### PR TITLE
feat(zones): Phase 1 - Zone contracts for Tempo validium

### DIFF
--- a/docs/specs/src/zones/MockVerifier.sol
+++ b/docs/specs/src/zones/MockVerifier.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IVerifier} from "./interfaces/IVerifier.sol";
+
+/// @title MockVerifier
+/// @notice A mock verifier that always returns true (for testing only)
+contract MockVerifier is IVerifier {
+    /// @inheritdoc IVerifier
+    function verify(bytes32, bytes calldata) external pure returns (bool) {
+        return true;
+    }
+}

--- a/docs/specs/src/zones/MockVerifier.sol
+++ b/docs/specs/src/zones/MockVerifier.sol
@@ -7,7 +7,16 @@ import {IVerifier} from "./interfaces/IVerifier.sol";
 /// @notice A mock verifier that always returns true (for testing only)
 contract MockVerifier is IVerifier {
     /// @inheritdoc IVerifier
-    function verify(bytes32, bytes calldata) external pure returns (bool) {
+    function verify(
+        bytes32,
+        bytes32,
+        bytes32,
+        bytes32,
+        bytes32,
+        bytes32,
+        bytes32,
+        bytes calldata
+    ) external pure returns (bool) {
         return true;
     }
 }

--- a/docs/specs/src/zones/ZoneFactory.sol
+++ b/docs/specs/src/zones/ZoneFactory.sol
@@ -35,8 +35,7 @@ contract ZoneFactory is IZoneFactory {
             params.sequencer,
             params.verifier,
             params.genesisStateRoot,
-            address(registry),
-            address(this)
+            address(registry)
         ));
 
         ZoneInfo memory info = ZoneInfo({

--- a/docs/specs/src/zones/ZoneFactory.sol
+++ b/docs/specs/src/zones/ZoneFactory.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZoneFactory} from "./interfaces/IZoneFactory.sol";
+import {IZoneRegistry} from "./interfaces/IZoneRegistry.sol";
+import {ZonePortal} from "./ZonePortal.sol";
+
+/// @title ZoneFactory
+/// @notice Factory for creating new zones
+contract ZoneFactory is IZoneFactory {
+    /// @notice The zone registry
+    IZoneRegistry public immutable registry;
+
+    /// @notice The next zone ID
+    uint64 private _nextZoneId;
+
+    /// @notice Zone info by zone ID
+    mapping(uint64 => ZoneInfo) private _zones;
+
+    /// @notice Portal address to zone ID
+    mapping(address => uint64) private _portalToZone;
+
+    constructor(address registry_) {
+        registry = IZoneRegistry(registry_);
+        _nextZoneId = 1;
+    }
+
+    /// @inheritdoc IZoneFactory
+    function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal) {
+        zoneId = _nextZoneId++;
+
+        portal = address(new ZonePortal(
+            zoneId,
+            params.gasToken,
+            params.sequencer,
+            params.verifier,
+            params.genesisStateRoot,
+            address(registry),
+            address(this)
+        ));
+
+        ZoneInfo memory info = ZoneInfo({
+            zoneId: zoneId,
+            portal: portal,
+            gasToken: params.gasToken,
+            sequencer: params.sequencer,
+            verifier: params.verifier,
+            genesisStateRoot: params.genesisStateRoot
+        });
+
+        _zones[zoneId] = info;
+        _portalToZone[portal] = zoneId;
+
+        registry.registerZone(info);
+
+        emit ZoneCreated(
+            zoneId,
+            portal,
+            params.gasToken,
+            params.sequencer,
+            params.verifier,
+            params.genesisStateRoot
+        );
+    }
+
+    /// @inheritdoc IZoneFactory
+    function zoneCount() external view returns (uint64) {
+        return _nextZoneId - 1;
+    }
+
+    /// @inheritdoc IZoneFactory
+    function zones(uint64 zoneId) external view returns (ZoneInfo memory) {
+        return _zones[zoneId];
+    }
+
+    /// @inheritdoc IZoneFactory
+    function isZonePortal(address portal) external view returns (bool) {
+        return _portalToZone[portal] != 0;
+    }
+}

--- a/docs/specs/src/zones/ZoneOutbox.sol
+++ b/docs/specs/src/zones/ZoneOutbox.sol
@@ -2,183 +2,74 @@
 pragma solidity ^0.8.13;
 
 import {IZoneOutbox} from "./interfaces/IZoneOutbox.sol";
-import {IZoneTypes} from "./interfaces/IZoneTypes.sol";
 
 /// @title ZoneOutbox
-/// @notice Zone predeploy for exit intent management
-/// @dev This contract is deployed as a predeploy on the zone. Its storage root
-///      is committed to the zone block header's withdrawals_root field.
+/// @notice Zone predeploy for withdrawal management
+/// @dev This contract is deployed as a predeploy on the zone. Withdrawals are
+///      accumulated and committed to by the zone prover, then processed on Tempo.
 contract ZoneOutbox is IZoneOutbox {
+    /// @notice The zone ID
+    uint64 public immutable zoneId;
+
     /// @notice The zone's gas token (TIP-20)
     address public immutable gasToken;
 
     /// @inheritdoc IZoneOutbox
-    uint64 public nextExitIndex;
+    uint64 public nextWithdrawalIndex;
 
-    /// @notice Exit intents by index
-    mapping(uint64 => ExitIntent) private _exits;
+    /// @notice Withdrawals by index
+    mapping(uint64 => Withdrawal) private _withdrawals;
 
-    constructor(address gasToken_) {
+    constructor(uint64 zoneId_, address gasToken_) {
+        zoneId = zoneId_;
         gasToken = gasToken_;
     }
 
     /// @inheritdoc IZoneOutbox
-    function exitByIndex(uint64 exitIndex) external view returns (ExitIntent memory) {
-        return _exits[exitIndex];
+    function withdrawalByIndex(uint64 index) external view returns (Withdrawal memory) {
+        return _withdrawals[index];
     }
 
     /// @inheritdoc IZoneOutbox
-    function requestTransferExit(
-        address recipient,
+    function requestWithdrawal(
+        address to,
         uint128 amount,
-        bytes32 memo
-    ) external returns (bytes32 exitId) {
-        if (amount == 0) {
-            revert InvalidAmount();
-        }
+        uint64 gasLimit,
+        address fallbackRecipient,
+        bytes calldata data
+    ) external returns (bytes32 withdrawalId) {
+        if (amount == 0) revert InvalidAmount();
 
         _burnGasToken(msg.sender, amount);
 
-        uint64 exitIndex = nextExitIndex++;
+        uint64 withdrawalIndex = nextWithdrawalIndex++;
 
-        ExitIntent memory intent = ExitIntent({
-            kind: ExitKind.Transfer,
-            exitIndex: exitIndex,
+        Withdrawal memory w = Withdrawal({
             sender: msg.sender,
-            transfer: TransferExit({
-                recipient: recipient,
-                amount: amount
-            }),
-            swap: SwapExit({
-                recipient: address(0),
-                tokenOut: address(0),
-                amountIn: 0,
-                minAmountOut: 0
-            }),
-            swapAndDeposit: SwapAndDepositExit({
-                tokenOut: address(0),
-                amountIn: 0,
-                minAmountOut: 0,
-                destinationZoneId: 0,
-                destinationRecipient: address(0)
-            }),
-            memo: memo
+            to: to,
+            amount: amount,
+            gasLimit: gasLimit,
+            fallbackRecipient: fallbackRecipient,
+            data: data
         });
 
-        _exits[exitIndex] = intent;
-        exitId = _computeExitId(exitIndex, intent);
+        _withdrawals[withdrawalIndex] = w;
+        withdrawalId = keccak256(abi.encode(zoneId, withdrawalIndex, w));
 
-        emit ExitRequested(exitId, exitIndex, ExitKind.Transfer);
-    }
-
-    /// @inheritdoc IZoneOutbox
-    function requestSwapExit(
-        address tokenOut,
-        uint128 amountIn,
-        uint128 minAmountOut,
-        address recipient,
-        bytes32 memo
-    ) external returns (bytes32 exitId) {
-        if (amountIn == 0) {
-            revert InvalidAmount();
-        }
-
-        _burnGasToken(msg.sender, amountIn);
-
-        uint64 exitIndex = nextExitIndex++;
-
-        ExitIntent memory intent = ExitIntent({
-            kind: ExitKind.Swap,
-            exitIndex: exitIndex,
-            sender: msg.sender,
-            transfer: TransferExit({
-                recipient: address(0),
-                amount: 0
-            }),
-            swap: SwapExit({
-                recipient: recipient,
-                tokenOut: tokenOut,
-                amountIn: amountIn,
-                minAmountOut: minAmountOut
-            }),
-            swapAndDeposit: SwapAndDepositExit({
-                tokenOut: address(0),
-                amountIn: 0,
-                minAmountOut: 0,
-                destinationZoneId: 0,
-                destinationRecipient: address(0)
-            }),
-            memo: memo
-        });
-
-        _exits[exitIndex] = intent;
-        exitId = _computeExitId(exitIndex, intent);
-
-        emit ExitRequested(exitId, exitIndex, ExitKind.Swap);
-    }
-
-    /// @inheritdoc IZoneOutbox
-    function requestSwapAndDepositExit(
-        address tokenOut,
-        uint128 amountIn,
-        uint128 minAmountOut,
-        uint64 destinationZoneId,
-        address destinationRecipient,
-        bytes32 memo
-    ) external returns (bytes32 exitId) {
-        if (amountIn == 0) {
-            revert InvalidAmount();
-        }
-
-        _burnGasToken(msg.sender, amountIn);
-
-        uint64 exitIndex = nextExitIndex++;
-
-        ExitIntent memory intent = ExitIntent({
-            kind: ExitKind.SwapAndDeposit,
-            exitIndex: exitIndex,
-            sender: msg.sender,
-            transfer: TransferExit({
-                recipient: address(0),
-                amount: 0
-            }),
-            swap: SwapExit({
-                recipient: address(0),
-                tokenOut: address(0),
-                amountIn: 0,
-                minAmountOut: 0
-            }),
-            swapAndDeposit: SwapAndDepositExit({
-                tokenOut: tokenOut,
-                amountIn: amountIn,
-                minAmountOut: minAmountOut,
-                destinationZoneId: destinationZoneId,
-                destinationRecipient: destinationRecipient
-            }),
-            memo: memo
-        });
-
-        _exits[exitIndex] = intent;
-        exitId = _computeExitId(exitIndex, intent);
-
-        emit ExitRequested(exitId, exitIndex, ExitKind.SwapAndDeposit);
+        emit WithdrawalRequested(withdrawalId, withdrawalIndex);
     }
 
     function _burnGasToken(address from, uint128 amount) internal {
-        (bool success, bytes memory data) = gasToken.call(
+        (bool success, bytes memory returnData) = gasToken.call(
             abi.encodeWithSignature("transferFrom(address,address,uint256)", from, address(this), uint256(amount))
         );
 
-        if (!success || (data.length > 0 && !abi.decode(data, (bool)))) {
+        if (!success || (returnData.length > 0 && !abi.decode(returnData, (bool)))) {
             revert InsufficientBalance();
         }
 
         (success,) = gasToken.call(
             abi.encodeWithSignature("burn(uint256)", uint256(amount))
         );
-    }
-
-    function _computeExitId(uint64 exitIndex, ExitIntent memory intent) internal pure returns (bytes32) {
-        return keccak256(abi.encode(exitIndex, intent));
     }
 }

--- a/docs/specs/src/zones/ZoneOutbox.sol
+++ b/docs/specs/src/zones/ZoneOutbox.sol
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZoneOutbox} from "./interfaces/IZoneOutbox.sol";
+import {IZoneTypes} from "./interfaces/IZoneTypes.sol";
+
+/// @title ZoneOutbox
+/// @notice Zone predeploy for exit intent management
+/// @dev This contract is deployed as a predeploy on the zone. Its storage root
+///      is committed to the zone block header's withdrawals_root field.
+contract ZoneOutbox is IZoneOutbox {
+    /// @notice The zone's gas token (TIP-20)
+    address public immutable gasToken;
+
+    /// @inheritdoc IZoneOutbox
+    uint64 public nextExitIndex;
+
+    /// @notice Exit intents by index
+    mapping(uint64 => ExitIntent) private _exits;
+
+    constructor(address gasToken_) {
+        gasToken = gasToken_;
+    }
+
+    /// @inheritdoc IZoneOutbox
+    function exitByIndex(uint64 exitIndex) external view returns (ExitIntent memory) {
+        return _exits[exitIndex];
+    }
+
+    /// @inheritdoc IZoneOutbox
+    function requestTransferExit(
+        address recipient,
+        uint128 amount,
+        bytes32 memo
+    ) external returns (bytes32 exitId) {
+        if (amount == 0) {
+            revert InvalidAmount();
+        }
+
+        _burnGasToken(msg.sender, amount);
+
+        uint64 exitIndex = nextExitIndex++;
+
+        ExitIntent memory intent = ExitIntent({
+            kind: ExitKind.Transfer,
+            exitIndex: exitIndex,
+            sender: msg.sender,
+            transfer: TransferExit({
+                recipient: recipient,
+                amount: amount
+            }),
+            swap: SwapExit({
+                recipient: address(0),
+                tokenOut: address(0),
+                amountIn: 0,
+                minAmountOut: 0
+            }),
+            swapAndDeposit: SwapAndDepositExit({
+                tokenOut: address(0),
+                amountIn: 0,
+                minAmountOut: 0,
+                destinationZoneId: 0,
+                destinationRecipient: address(0)
+            }),
+            memo: memo
+        });
+
+        _exits[exitIndex] = intent;
+        exitId = _computeExitId(exitIndex, intent);
+
+        emit ExitRequested(exitId, exitIndex, ExitKind.Transfer);
+    }
+
+    /// @inheritdoc IZoneOutbox
+    function requestSwapExit(
+        address tokenOut,
+        uint128 amountIn,
+        uint128 minAmountOut,
+        address recipient,
+        bytes32 memo
+    ) external returns (bytes32 exitId) {
+        if (amountIn == 0) {
+            revert InvalidAmount();
+        }
+
+        _burnGasToken(msg.sender, amountIn);
+
+        uint64 exitIndex = nextExitIndex++;
+
+        ExitIntent memory intent = ExitIntent({
+            kind: ExitKind.Swap,
+            exitIndex: exitIndex,
+            sender: msg.sender,
+            transfer: TransferExit({
+                recipient: address(0),
+                amount: 0
+            }),
+            swap: SwapExit({
+                recipient: recipient,
+                tokenOut: tokenOut,
+                amountIn: amountIn,
+                minAmountOut: minAmountOut
+            }),
+            swapAndDeposit: SwapAndDepositExit({
+                tokenOut: address(0),
+                amountIn: 0,
+                minAmountOut: 0,
+                destinationZoneId: 0,
+                destinationRecipient: address(0)
+            }),
+            memo: memo
+        });
+
+        _exits[exitIndex] = intent;
+        exitId = _computeExitId(exitIndex, intent);
+
+        emit ExitRequested(exitId, exitIndex, ExitKind.Swap);
+    }
+
+    /// @inheritdoc IZoneOutbox
+    function requestSwapAndDepositExit(
+        address tokenOut,
+        uint128 amountIn,
+        uint128 minAmountOut,
+        uint64 destinationZoneId,
+        address destinationRecipient,
+        bytes32 memo
+    ) external returns (bytes32 exitId) {
+        if (amountIn == 0) {
+            revert InvalidAmount();
+        }
+
+        _burnGasToken(msg.sender, amountIn);
+
+        uint64 exitIndex = nextExitIndex++;
+
+        ExitIntent memory intent = ExitIntent({
+            kind: ExitKind.SwapAndDeposit,
+            exitIndex: exitIndex,
+            sender: msg.sender,
+            transfer: TransferExit({
+                recipient: address(0),
+                amount: 0
+            }),
+            swap: SwapExit({
+                recipient: address(0),
+                tokenOut: address(0),
+                amountIn: 0,
+                minAmountOut: 0
+            }),
+            swapAndDeposit: SwapAndDepositExit({
+                tokenOut: tokenOut,
+                amountIn: amountIn,
+                minAmountOut: minAmountOut,
+                destinationZoneId: destinationZoneId,
+                destinationRecipient: destinationRecipient
+            }),
+            memo: memo
+        });
+
+        _exits[exitIndex] = intent;
+        exitId = _computeExitId(exitIndex, intent);
+
+        emit ExitRequested(exitId, exitIndex, ExitKind.SwapAndDeposit);
+    }
+
+    function _burnGasToken(address from, uint128 amount) internal {
+        (bool success, bytes memory data) = gasToken.call(
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", from, address(this), uint256(amount))
+        );
+
+        if (!success || (data.length > 0 && !abi.decode(data, (bool)))) {
+            revert InsufficientBalance();
+        }
+
+        (success,) = gasToken.call(
+            abi.encodeWithSignature("burn(uint256)", uint256(amount))
+        );
+    }
+
+    function _computeExitId(uint64 exitIndex, ExitIntent memory intent) internal pure returns (bytes32) {
+        return keccak256(abi.encode(exitIndex, intent));
+    }
+}

--- a/docs/specs/src/zones/ZonePortal.sol
+++ b/docs/specs/src/zones/ZonePortal.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZonePortal} from "./interfaces/IZonePortal.sol";
+import {IZoneRegistry} from "./interfaces/IZoneRegistry.sol";
+import {IVerifier} from "./interfaces/IVerifier.sol";
+import {IZoneTypes} from "./interfaces/IZoneTypes.sol";
+import {ITIP20} from "../interfaces/ITIP20.sol";
+import {IStablecoinDEX} from "../interfaces/IStablecoinDEX.sol";
+
+/// @title ZonePortal
+/// @notice Per-zone portal that escrows the gas token and finalizes exits
+contract ZonePortal is IZonePortal {
+    /// @notice The Tempo Stablecoin DEX address
+    address public constant DEX = 0xDEc0000000000000000000000000000000000000;
+
+    /// @inheritdoc IZonePortal
+    uint64 public immutable zoneId;
+
+    /// @inheritdoc IZonePortal
+    address public immutable gasToken;
+
+    /// @inheritdoc IZonePortal
+    address public immutable sequencer;
+
+    /// @inheritdoc IZonePortal
+    address public immutable verifier;
+
+    /// @notice The zone registry
+    IZoneRegistry public immutable registry;
+
+    /// @notice The zone factory
+    address public immutable factory;
+
+    /// @inheritdoc IZonePortal
+    uint64 public nextDepositIndex;
+
+    /// @inheritdoc IZonePortal
+    bytes32 public stateRoot;
+
+    /// @inheritdoc IZonePortal
+    uint64 public batchIndex;
+
+    /// @inheritdoc IZonePortal
+    bytes32 public exitRoot;
+
+    /// @notice Deposits by index
+    mapping(uint64 => Deposit) private _deposits;
+
+    /// @notice Claimed exits
+    mapping(bytes32 => bool) private _exitClaimed;
+
+    /// @notice Batch exit roots by batch index
+    mapping(uint64 => bytes32) private _batchExitRoots;
+
+    constructor(
+        uint64 zoneId_,
+        address gasToken_,
+        address sequencer_,
+        address verifier_,
+        bytes32 genesisStateRoot_,
+        address registry_,
+        address factory_
+    ) {
+        zoneId = zoneId_;
+        gasToken = gasToken_;
+        sequencer = sequencer_;
+        verifier = verifier_;
+        stateRoot = genesisStateRoot_;
+        registry = IZoneRegistry(registry_);
+        factory = factory_;
+    }
+
+    /// @inheritdoc IZonePortal
+    function deposits(uint64 index) external view returns (Deposit memory) {
+        return _deposits[index];
+    }
+
+    /// @inheritdoc IZonePortal
+    function exitClaimed(bytes32 exitId) external view returns (bool) {
+        return _exitClaimed[exitId];
+    }
+
+    /// @inheritdoc IZonePortal
+    function deposit(address to, uint256 amount, bytes32 memo) external returns (uint64 depositIndex) {
+        ITIP20(gasToken).transferFrom(msg.sender, address(this), amount);
+
+        depositIndex = nextDepositIndex++;
+        _deposits[depositIndex] = Deposit({
+            sender: msg.sender,
+            to: to,
+            amount: amount,
+            memo: memo
+        });
+
+        emit DepositEnqueued(zoneId, depositIndex, msg.sender, to, amount, memo);
+    }
+
+    /// @inheritdoc IZonePortal
+    function submitBatch(BatchCommitment calldata commitment, bytes calldata proof) external {
+        if (msg.sender != sequencer) {
+            revert OnlySequencer();
+        }
+        if (commitment.zoneId != zoneId) {
+            revert InvalidBatchIndex();
+        }
+        if (commitment.batchIndex != batchIndex + 1) {
+            revert InvalidBatchIndex();
+        }
+        if (commitment.prevStateRoot != stateRoot) {
+            revert InvalidPrevStateRoot();
+        }
+
+        bytes32 commitmentHash = keccak256(abi.encode(commitment));
+        if (!IVerifier(verifier).verify(commitmentHash, proof)) {
+            revert InvalidProof();
+        }
+
+        batchIndex = commitment.batchIndex;
+        stateRoot = commitment.newStateRoot;
+        exitRoot = commitment.exitRoot;
+        _batchExitRoots[commitment.batchIndex] = commitment.exitRoot;
+
+        registry.updateBatchHead(zoneId, batchIndex, stateRoot, exitRoot);
+
+        emit BatchAccepted(
+            zoneId,
+            commitment.batchIndex,
+            commitment.prevStateRoot,
+            commitment.newStateRoot,
+            commitment.depositIndex,
+            commitment.exitRoot,
+            commitment.batchHash
+        );
+    }
+
+    /// @inheritdoc IZonePortal
+    function finalizeTransferExit(ExitIntent calldata intent, ExitProof calldata proof) external {
+        _validateAndClaimExit(intent, proof);
+
+        ITIP20(gasToken).transfer(intent.transfer.recipient, intent.transfer.amount);
+
+        emit ExitFinalized(_exitId(intent), zoneId, ExitKind.Transfer);
+    }
+
+    /// @inheritdoc IZonePortal
+    function finalizeSwapExit(ExitIntent calldata intent, ExitProof calldata proof) external {
+        _validateAndClaimExit(intent, proof);
+
+        ITIP20(gasToken).approve(DEX, intent.swap.amountIn);
+
+        uint128 amountOut = IStablecoinDEX(DEX).swapExactAmountIn(
+            gasToken,
+            intent.swap.tokenOut,
+            intent.swap.amountIn,
+            intent.swap.minAmountOut
+        );
+
+        IStablecoinDEX(DEX).withdraw(intent.swap.tokenOut, amountOut);
+        ITIP20(intent.swap.tokenOut).transfer(intent.swap.recipient, amountOut);
+
+        emit ExitFinalized(_exitId(intent), zoneId, ExitKind.Swap);
+    }
+
+    /// @inheritdoc IZonePortal
+    function finalizeSwapAndDepositExit(ExitIntent calldata intent, ExitProof calldata proof) external {
+        _validateAndClaimExit(intent, proof);
+
+        ITIP20(gasToken).approve(DEX, intent.swapAndDeposit.amountIn);
+
+        uint128 amountOut = IStablecoinDEX(DEX).swapExactAmountIn(
+            gasToken,
+            intent.swapAndDeposit.tokenOut,
+            intent.swapAndDeposit.amountIn,
+            intent.swapAndDeposit.minAmountOut
+        );
+
+        IStablecoinDEX(DEX).withdraw(intent.swapAndDeposit.tokenOut, amountOut);
+
+        IZoneTypes.ZoneInfo memory destZone = registry.getZone(intent.swapAndDeposit.destinationZoneId);
+        if (destZone.portal == address(0)) {
+            revert DestinationZoneNotFound();
+        }
+
+        ITIP20(intent.swapAndDeposit.tokenOut).approve(destZone.portal, amountOut);
+        IZonePortal(destZone.portal).deposit(
+            intent.swapAndDeposit.destinationRecipient,
+            amountOut,
+            intent.memo
+        );
+
+        emit ExitFinalized(_exitId(intent), zoneId, ExitKind.SwapAndDeposit);
+    }
+
+    function _validateAndClaimExit(ExitIntent calldata intent, ExitProof calldata proof) internal {
+        bytes32 exitId = _exitId(intent);
+
+        if (_exitClaimed[exitId]) {
+            revert ExitAlreadyClaimed();
+        }
+
+        bytes32 batchExitRoot = _batchExitRoots[proof.batchIndex];
+        if (batchExitRoot == bytes32(0)) {
+            revert InvalidProof();
+        }
+
+        bytes32 leaf = keccak256(abi.encode(intent));
+        if (!_verifyMerkleProof(proof.merkleProof, batchExitRoot, leaf)) {
+            revert InvalidProof();
+        }
+
+        _exitClaimed[exitId] = true;
+    }
+
+    function _exitId(ExitIntent calldata intent) internal view returns (bytes32) {
+        return keccak256(abi.encode(zoneId, intent.exitIndex, intent));
+    }
+
+    function _verifyMerkleProof(
+        bytes32[] calldata proof,
+        bytes32 root,
+        bytes32 leaf
+    ) internal pure returns (bool) {
+        bytes32 computedHash = leaf;
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 proofElement = proof[i];
+
+            if (computedHash <= proofElement) {
+                computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+            } else {
+                computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+            }
+        }
+
+        return computedHash == root;
+    }
+}

--- a/docs/specs/src/zones/ZonePortal.sol
+++ b/docs/specs/src/zones/ZonePortal.sol
@@ -4,16 +4,12 @@ pragma solidity ^0.8.13;
 import {IZonePortal} from "./interfaces/IZonePortal.sol";
 import {IZoneRegistry} from "./interfaces/IZoneRegistry.sol";
 import {IVerifier} from "./interfaces/IVerifier.sol";
-import {IZoneTypes} from "./interfaces/IZoneTypes.sol";
+import {IExitReceiver} from "./interfaces/IExitReceiver.sol";
 import {ITIP20} from "../interfaces/ITIP20.sol";
-import {IStablecoinDEX} from "../interfaces/IStablecoinDEX.sol";
 
 /// @title ZonePortal
-/// @notice Per-zone portal that escrows the gas token and finalizes exits
+/// @notice Per-zone portal that escrows the gas token and processes withdrawals
 contract ZonePortal is IZonePortal {
-    /// @notice The Tempo Stablecoin DEX address
-    address public constant DEX = 0xDEc0000000000000000000000000000000000000;
-
     /// @inheritdoc IZonePortal
     uint64 public immutable zoneId;
 
@@ -29,29 +25,31 @@ contract ZonePortal is IZonePortal {
     /// @notice The zone registry
     IZoneRegistry public immutable registry;
 
-    /// @notice The zone factory
-    address public immutable factory;
-
     /// @inheritdoc IZonePortal
-    uint64 public nextDepositIndex;
-
-    /// @inheritdoc IZonePortal
-    bytes32 public stateRoot;
+    bytes32 public sequencerPubkey;
 
     /// @inheritdoc IZonePortal
     uint64 public batchIndex;
 
     /// @inheritdoc IZonePortal
-    bytes32 public exitRoot;
+    bytes32 public stateRoot;
 
-    /// @notice Deposits by index
-    mapping(uint64 => Deposit) private _deposits;
+    /// @inheritdoc IZonePortal
+    bytes32 public currentDepositsHash;
 
-    /// @notice Claimed exits
-    mapping(bytes32 => bool) private _exitClaimed;
+    /// @inheritdoc IZonePortal
+    bytes32 public checkpointedDepositsHash;
 
-    /// @notice Batch exit roots by batch index
-    mapping(uint64 => bytes32) private _batchExitRoots;
+    /// @inheritdoc IZonePortal
+    bytes32 public withdrawalQueue1;
+
+    /// @inheritdoc IZonePortal
+    bytes32 public withdrawalQueue2;
+
+    modifier onlySequencer() {
+        if (msg.sender != sequencer) revert OnlySequencer();
+        _;
+    }
 
     constructor(
         uint64 zoneId_,
@@ -59,8 +57,7 @@ contract ZonePortal is IZonePortal {
         address sequencer_,
         address verifier_,
         bytes32 genesisStateRoot_,
-        address registry_,
-        address factory_
+        address registry_
     ) {
         zoneId = zoneId_;
         gasToken = gasToken_;
@@ -68,171 +65,154 @@ contract ZonePortal is IZonePortal {
         verifier = verifier_;
         stateRoot = genesisStateRoot_;
         registry = IZoneRegistry(registry_);
-        factory = factory_;
     }
 
     /// @inheritdoc IZonePortal
-    function deposits(uint64 index) external view returns (Deposit memory) {
-        return _deposits[index];
+    function setSequencerPubkey(bytes32 pubkey) external onlySequencer {
+        sequencerPubkey = pubkey;
     }
 
     /// @inheritdoc IZonePortal
-    function exitClaimed(bytes32 exitId) external view returns (bool) {
-        return _exitClaimed[exitId];
-    }
-
-    /// @inheritdoc IZonePortal
-    function deposit(address to, uint256 amount, bytes32 memo) external returns (uint64 depositIndex) {
+    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositsHash) {
         ITIP20(gasToken).transferFrom(msg.sender, address(this), amount);
 
-        depositIndex = nextDepositIndex++;
-        _deposits[depositIndex] = Deposit({
+        Deposit memory dep = Deposit({
+            l1BlockHash: blockhash(block.number - 1),
+            l1BlockNumber: uint64(block.number),
+            l1Timestamp: uint64(block.timestamp),
             sender: msg.sender,
             to: to,
             amount: amount,
             memo: memo
         });
 
-        emit DepositEnqueued(zoneId, depositIndex, msg.sender, to, amount, memo);
-    }
+        newCurrentDepositsHash = keccak256(abi.encode(dep, currentDepositsHash));
+        currentDepositsHash = newCurrentDepositsHash;
 
-    /// @inheritdoc IZonePortal
-    function submitBatch(BatchCommitment calldata commitment, bytes calldata proof) external {
-        if (msg.sender != sequencer) {
-            revert OnlySequencer();
-        }
-        if (commitment.zoneId != zoneId) {
-            revert InvalidBatchIndex();
-        }
-        if (commitment.batchIndex != batchIndex + 1) {
-            revert InvalidBatchIndex();
-        }
-        if (commitment.prevStateRoot != stateRoot) {
-            revert InvalidPrevStateRoot();
-        }
-
-        bytes32 commitmentHash = keccak256(abi.encode(commitment));
-        if (!IVerifier(verifier).verify(commitmentHash, proof)) {
-            revert InvalidProof();
-        }
-
-        batchIndex = commitment.batchIndex;
-        stateRoot = commitment.newStateRoot;
-        exitRoot = commitment.exitRoot;
-        _batchExitRoots[commitment.batchIndex] = commitment.exitRoot;
-
-        registry.updateBatchHead(zoneId, batchIndex, stateRoot, exitRoot);
-
-        emit BatchAccepted(
+        emit DepositEnqueued(
             zoneId,
-            commitment.batchIndex,
-            commitment.prevStateRoot,
+            newCurrentDepositsHash,
+            msg.sender,
+            to,
+            amount,
+            memo,
+            dep.l1BlockHash,
+            dep.l1BlockNumber,
+            dep.l1Timestamp
+        );
+    }
+
+    /// @inheritdoc IZonePortal
+    function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) external onlySequencer {
+        if (withdrawalQueue1 == bytes32(0)) {
+            if (withdrawalQueue2 == bytes32(0)) revert NoWithdrawals();
+            withdrawalQueue1 = withdrawalQueue2;
+            withdrawalQueue2 = bytes32(0);
+        }
+
+        if (keccak256(abi.encode(w, remainingQueue)) != withdrawalQueue1) {
+            revert InvalidWithdrawal();
+        }
+
+        _executeWithdrawal(w);
+
+        if (remainingQueue == bytes32(0)) {
+            withdrawalQueue1 = withdrawalQueue2;
+            withdrawalQueue2 = bytes32(0);
+        } else {
+            withdrawalQueue1 = remainingQueue;
+        }
+    }
+
+    /// @inheritdoc IZonePortal
+    function submitBatch(
+        BatchCommitment calldata commitment,
+        bytes32 expectedQueue2,
+        bytes32 updatedQueue2,
+        bytes32 newWithdrawalsOnly,
+        bytes calldata proof
+    ) external onlySequencer {
+        bool valid = IVerifier(verifier).verify(
+            checkpointedDepositsHash,
+            commitment.newProcessedDepositsHash,
+            stateRoot,
             commitment.newStateRoot,
-            commitment.depositIndex,
-            commitment.exitRoot,
-            commitment.batchHash
+            expectedQueue2,
+            updatedQueue2,
+            newWithdrawalsOnly,
+            proof
+        );
+
+        if (!valid) revert InvalidProof();
+
+        if (withdrawalQueue2 == expectedQueue2) {
+            withdrawalQueue2 = updatedQueue2;
+        } else if (withdrawalQueue2 == bytes32(0)) {
+            withdrawalQueue2 = newWithdrawalsOnly;
+        } else {
+            revert UnexpectedQueue2State();
+        }
+
+        checkpointedDepositsHash = commitment.newProcessedDepositsHash;
+        stateRoot = commitment.newStateRoot;
+        batchIndex++;
+
+        registry.updateBatchHead(zoneId, batchIndex, stateRoot);
+
+        emit BatchSubmitted(
+            zoneId,
+            batchIndex,
+            commitment.newProcessedDepositsHash,
+            commitment.newStateRoot
         );
     }
 
-    /// @inheritdoc IZonePortal
-    function finalizeTransferExit(ExitIntent calldata intent, ExitProof calldata proof) external {
-        _validateAndClaimExit(intent, proof);
+    function _executeWithdrawal(Withdrawal calldata w) internal {
+        ITIP20(gasToken).transfer(w.to, w.amount);
 
-        ITIP20(gasToken).transfer(intent.transfer.recipient, intent.transfer.amount);
+        emit WithdrawalProcessed(zoneId, w.to, w.amount);
 
-        emit ExitFinalized(_exitId(intent), zoneId, ExitKind.Transfer);
-    }
-
-    /// @inheritdoc IZonePortal
-    function finalizeSwapExit(ExitIntent calldata intent, ExitProof calldata proof) external {
-        _validateAndClaimExit(intent, proof);
-
-        ITIP20(gasToken).approve(DEX, intent.swap.amountIn);
-
-        uint128 amountOut = IStablecoinDEX(DEX).swapExactAmountIn(
-            gasToken,
-            intent.swap.tokenOut,
-            intent.swap.amountIn,
-            intent.swap.minAmountOut
-        );
-
-        IStablecoinDEX(DEX).withdraw(intent.swap.tokenOut, amountOut);
-        ITIP20(intent.swap.tokenOut).transfer(intent.swap.recipient, amountOut);
-
-        emit ExitFinalized(_exitId(intent), zoneId, ExitKind.Swap);
-    }
-
-    /// @inheritdoc IZonePortal
-    function finalizeSwapAndDepositExit(ExitIntent calldata intent, ExitProof calldata proof) external {
-        _validateAndClaimExit(intent, proof);
-
-        ITIP20(gasToken).approve(DEX, intent.swapAndDeposit.amountIn);
-
-        uint128 amountOut = IStablecoinDEX(DEX).swapExactAmountIn(
-            gasToken,
-            intent.swapAndDeposit.tokenOut,
-            intent.swapAndDeposit.amountIn,
-            intent.swapAndDeposit.minAmountOut
-        );
-
-        IStablecoinDEX(DEX).withdraw(intent.swapAndDeposit.tokenOut, amountOut);
-
-        IZoneTypes.ZoneInfo memory destZone = registry.getZone(intent.swapAndDeposit.destinationZoneId);
-        if (destZone.portal == address(0)) {
-            revert DestinationZoneNotFound();
-        }
-
-        ITIP20(intent.swapAndDeposit.tokenOut).approve(destZone.portal, amountOut);
-        IZonePortal(destZone.portal).deposit(
-            intent.swapAndDeposit.destinationRecipient,
-            amountOut,
-            intent.memo
-        );
-
-        emit ExitFinalized(_exitId(intent), zoneId, ExitKind.SwapAndDeposit);
-    }
-
-    function _validateAndClaimExit(ExitIntent calldata intent, ExitProof calldata proof) internal {
-        bytes32 exitId = _exitId(intent);
-
-        if (_exitClaimed[exitId]) {
-            revert ExitAlreadyClaimed();
-        }
-
-        bytes32 batchExitRoot = _batchExitRoots[proof.batchIndex];
-        if (batchExitRoot == bytes32(0)) {
-            revert InvalidProof();
-        }
-
-        bytes32 leaf = keccak256(abi.encode(intent));
-        if (!_verifyMerkleProof(proof.merkleProof, batchExitRoot, leaf)) {
-            revert InvalidProof();
-        }
-
-        _exitClaimed[exitId] = true;
-    }
-
-    function _exitId(ExitIntent calldata intent) internal view returns (bytes32) {
-        return keccak256(abi.encode(zoneId, intent.exitIndex, intent));
-    }
-
-    function _verifyMerkleProof(
-        bytes32[] calldata proof,
-        bytes32 root,
-        bytes32 leaf
-    ) internal pure returns (bool) {
-        bytes32 computedHash = leaf;
-
-        for (uint256 i = 0; i < proof.length; i++) {
-            bytes32 proofElement = proof[i];
-
-            if (computedHash <= proofElement) {
-                computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
-            } else {
-                computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+        if (w.gasLimit > 0) {
+            try IExitReceiver(w.to).onExitReceived{gas: w.gasLimit}(
+                w.sender,
+                w.amount,
+                w.data
+            ) returns (bytes4 selector) {
+                if (selector != IExitReceiver.onExitReceived.selector) {
+                    _enqueueBounceBack(w.amount, w.fallbackRecipient);
+                }
+            } catch {
+                _enqueueBounceBack(w.amount, w.fallbackRecipient);
             }
         }
+    }
 
-        return computedHash == root;
+    function _enqueueBounceBack(uint128 amount, address fallbackRecipient) internal {
+        Deposit memory dep = Deposit({
+            l1BlockHash: blockhash(block.number - 1),
+            l1BlockNumber: uint64(block.number),
+            l1Timestamp: uint64(block.timestamp),
+            sender: address(this),
+            to: fallbackRecipient,
+            amount: amount,
+            memo: bytes32(0)
+        });
+
+        bytes32 newHash = keccak256(abi.encode(dep, currentDepositsHash));
+        currentDepositsHash = newHash;
+
+        emit WithdrawalBouncedBack(zoneId, fallbackRecipient, amount);
+
+        emit DepositEnqueued(
+            zoneId,
+            newHash,
+            address(this),
+            fallbackRecipient,
+            amount,
+            bytes32(0),
+            dep.l1BlockHash,
+            dep.l1BlockNumber,
+            dep.l1Timestamp
+        );
     }
 }

--- a/docs/specs/src/zones/ZoneRegistry.sol
+++ b/docs/specs/src/zones/ZoneRegistry.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZoneRegistry} from "./interfaces/IZoneRegistry.sol";
+import {IZoneTypes} from "./interfaces/IZoneTypes.sol";
+
+/// @title ZoneRegistry
+/// @notice Registry for zone metadata and batch heads
+contract ZoneRegistry is IZoneRegistry {
+    /// @notice Zone info by zone ID
+    mapping(uint64 => ZoneInfo) private _zones;
+
+    /// @notice Batch head by zone ID
+    mapping(uint64 => BatchHead) private _batchHeads;
+
+    /// @notice Portal address to zone ID mapping
+    mapping(address => uint64) private _portalToZone;
+
+    struct BatchHead {
+        uint64 batchIndex;
+        bytes32 stateRoot;
+        bytes32 exitRoot;
+    }
+
+    /// @inheritdoc IZoneRegistry
+    function registerZone(ZoneInfo calldata info) external {
+        if (_zones[info.zoneId].portal != address(0)) {
+            revert ZoneAlreadyRegistered();
+        }
+
+        _zones[info.zoneId] = info;
+        _portalToZone[info.portal] = info.zoneId;
+        _batchHeads[info.zoneId] = BatchHead({
+            batchIndex: 0,
+            stateRoot: info.genesisStateRoot,
+            exitRoot: bytes32(0)
+        });
+
+        emit ZoneRegistered(info.zoneId, info.portal);
+    }
+
+    /// @inheritdoc IZoneRegistry
+    function getZone(uint64 zoneId) external view returns (ZoneInfo memory) {
+        if (_zones[zoneId].portal == address(0)) {
+            revert ZoneNotFound();
+        }
+        return _zones[zoneId];
+    }
+
+    /// @inheritdoc IZoneRegistry
+    function batchHead(uint64 zoneId)
+        external
+        view
+        returns (uint64 batchIndex, bytes32 stateRoot, bytes32 exitRoot)
+    {
+        BatchHead storage head = _batchHeads[zoneId];
+        return (head.batchIndex, head.stateRoot, head.exitRoot);
+    }
+
+    /// @inheritdoc IZoneRegistry
+    function updateBatchHead(
+        uint64 zoneId,
+        uint64 batchIndex_,
+        bytes32 stateRoot,
+        bytes32 exitRoot
+    ) external {
+        ZoneInfo storage info = _zones[zoneId];
+        if (info.portal == address(0)) {
+            revert ZoneNotFound();
+        }
+        if (msg.sender != info.portal) {
+            revert OnlyPortal();
+        }
+
+        _batchHeads[zoneId] = BatchHead({
+            batchIndex: batchIndex_,
+            stateRoot: stateRoot,
+            exitRoot: exitRoot
+        });
+
+        emit BatchHeadUpdated(zoneId, batchIndex_, stateRoot, exitRoot);
+    }
+}

--- a/docs/specs/src/zones/ZoneRegistry.sol
+++ b/docs/specs/src/zones/ZoneRegistry.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import {IZoneRegistry} from "./interfaces/IZoneRegistry.sol";
-import {IZoneTypes} from "./interfaces/IZoneTypes.sol";
 
 /// @title ZoneRegistry
 /// @notice Registry for zone metadata and batch heads
@@ -19,7 +18,6 @@ contract ZoneRegistry is IZoneRegistry {
     struct BatchHead {
         uint64 batchIndex;
         bytes32 stateRoot;
-        bytes32 exitRoot;
     }
 
     /// @inheritdoc IZoneRegistry
@@ -32,8 +30,7 @@ contract ZoneRegistry is IZoneRegistry {
         _portalToZone[info.portal] = info.zoneId;
         _batchHeads[info.zoneId] = BatchHead({
             batchIndex: 0,
-            stateRoot: info.genesisStateRoot,
-            exitRoot: bytes32(0)
+            stateRoot: info.genesisStateRoot
         });
 
         emit ZoneRegistered(info.zoneId, info.portal);
@@ -48,22 +45,13 @@ contract ZoneRegistry is IZoneRegistry {
     }
 
     /// @inheritdoc IZoneRegistry
-    function batchHead(uint64 zoneId)
-        external
-        view
-        returns (uint64 batchIndex, bytes32 stateRoot, bytes32 exitRoot)
-    {
+    function batchHead(uint64 zoneId) external view returns (uint64 batchIndex, bytes32 stateRoot) {
         BatchHead storage head = _batchHeads[zoneId];
-        return (head.batchIndex, head.stateRoot, head.exitRoot);
+        return (head.batchIndex, head.stateRoot);
     }
 
     /// @inheritdoc IZoneRegistry
-    function updateBatchHead(
-        uint64 zoneId,
-        uint64 batchIndex_,
-        bytes32 stateRoot,
-        bytes32 exitRoot
-    ) external {
+    function updateBatchHead(uint64 zoneId, uint64 batchIndex_, bytes32 stateRoot) external {
         ZoneInfo storage info = _zones[zoneId];
         if (info.portal == address(0)) {
             revert ZoneNotFound();
@@ -74,10 +62,9 @@ contract ZoneRegistry is IZoneRegistry {
 
         _batchHeads[zoneId] = BatchHead({
             batchIndex: batchIndex_,
-            stateRoot: stateRoot,
-            exitRoot: exitRoot
+            stateRoot: stateRoot
         });
 
-        emit BatchHeadUpdated(zoneId, batchIndex_, stateRoot, exitRoot);
+        emit BatchHeadUpdated(zoneId, batchIndex_, stateRoot);
     }
 }

--- a/docs/specs/src/zones/interfaces/IExitReceiver.sol
+++ b/docs/specs/src/zones/interfaces/IExitReceiver.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title IExitReceiver
+/// @notice Interface for contracts that receive withdrawal callbacks
+interface IExitReceiver {
+    /// @notice Called by the portal when a withdrawal targets this contract
+    /// @param sender The address that initiated the withdrawal on the zone
+    /// @param amount The amount of gas tokens transferred
+    /// @param data User-provided data from the withdrawal
+    /// @return selector Must return IExitReceiver.onExitReceived.selector to accept
+    function onExitReceived(
+        address sender,
+        uint128 amount,
+        bytes calldata data
+    ) external returns (bytes4);
+}

--- a/docs/specs/src/zones/interfaces/IVerifier.sol
+++ b/docs/specs/src/zones/interfaces/IVerifier.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title IVerifier
+/// @notice Abstract verifier interface for ZK proofs or TEE attestations
+interface IVerifier {
+    /// @notice Verify a batch commitment
+    /// @param batchCommitment The hash of the batch commitment
+    /// @param proof The proof or attestation data
+    /// @return True if the proof is valid
+    function verify(bytes32 batchCommitment, bytes calldata proof) external view returns (bool);
+}

--- a/docs/specs/src/zones/interfaces/IVerifier.sol
+++ b/docs/specs/src/zones/interfaces/IVerifier.sol
@@ -4,9 +4,24 @@ pragma solidity ^0.8.13;
 /// @title IVerifier
 /// @notice Abstract verifier interface for ZK proofs or TEE attestations
 interface IVerifier {
-    /// @notice Verify a batch commitment
-    /// @param batchCommitment The hash of the batch commitment
-    /// @param proof The proof or attestation data
+    /// @notice Verify a batch state transition
+    /// @param checkpointedDepositsHash Where proof starts (from portal state)
+    /// @param newProcessedDepositsHash Where zone processed up to (from batch)
+    /// @param prevStateRoot Previous state root
+    /// @param newStateRoot New state root after execution
+    /// @param expectedQueue2 What proof assumed queue2 was
+    /// @param updatedQueue2 Queue2 with new withdrawals added to innermost
+    /// @param newWithdrawalsOnly New withdrawals only (if queue2 was empty)
+    /// @param proof The validity proof or TEE attestation
     /// @return True if the proof is valid
-    function verify(bytes32 batchCommitment, bytes calldata proof) external view returns (bool);
+    function verify(
+        bytes32 checkpointedDepositsHash,
+        bytes32 newProcessedDepositsHash,
+        bytes32 prevStateRoot,
+        bytes32 newStateRoot,
+        bytes32 expectedQueue2,
+        bytes32 updatedQueue2,
+        bytes32 newWithdrawalsOnly,
+        bytes calldata proof
+    ) external view returns (bool);
 }

--- a/docs/specs/src/zones/interfaces/IZoneFactory.sol
+++ b/docs/specs/src/zones/interfaces/IZoneFactory.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZoneTypes} from "./IZoneTypes.sol";
+
+/// @title IZoneFactory
+/// @notice Factory for creating new zones
+interface IZoneFactory is IZoneTypes {
+    /// @notice Parameters for creating a new zone
+    struct CreateZoneParams {
+        address gasToken;
+        address sequencer;
+        address verifier;
+        bytes32 genesisStateRoot;
+    }
+
+    /// @notice Emitted when a new zone is created
+    event ZoneCreated(
+        uint64 indexed zoneId,
+        address indexed portal,
+        address indexed gasToken,
+        address sequencer,
+        address verifier,
+        bytes32 genesisStateRoot
+    );
+
+    /// @notice Create a new zone
+    /// @param params The zone creation parameters
+    /// @return zoneId The ID of the newly created zone
+    /// @return portal The address of the zone's portal contract
+    function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
+
+    /// @notice Get the total number of zones created
+    /// @return The zone count
+    function zoneCount() external view returns (uint64);
+
+    /// @notice Get zone info by ID
+    /// @param zoneId The zone ID
+    /// @return The zone info
+    function zones(uint64 zoneId) external view returns (ZoneInfo memory);
+
+    /// @notice Check if an address is a zone portal
+    /// @param portal The address to check
+    /// @return True if the address is a zone portal
+    function isZonePortal(address portal) external view returns (bool);
+}

--- a/docs/specs/src/zones/interfaces/IZoneOutbox.sol
+++ b/docs/specs/src/zones/interfaces/IZoneOutbox.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZoneTypes} from "./IZoneTypes.sol";
+
+/// @title IZoneOutbox
+/// @notice Zone predeploy for exit intent management
+interface IZoneOutbox is IZoneTypes {
+    /// @notice Emitted when an exit is requested
+    event ExitRequested(bytes32 indexed exitId, uint64 indexed exitIndex, ExitKind kind);
+
+    error InsufficientBalance();
+    error InvalidAmount();
+
+    /// @notice Get the next exit index
+    function nextExitIndex() external view returns (uint64);
+
+    /// @notice Get an exit intent by index
+    function exitByIndex(uint64 exitIndex) external view returns (ExitIntent memory);
+
+    /// @notice Request a transfer exit
+    /// @param recipient The Tempo recipient address
+    /// @param amount The amount to transfer
+    /// @param memo Optional memo
+    /// @return exitId The exit intent ID
+    function requestTransferExit(address recipient, uint128 amount, bytes32 memo) external returns (bytes32 exitId);
+
+    /// @notice Request a swap exit
+    /// @param tokenOut The output token address on Tempo
+    /// @param amountIn The input amount (gas token)
+    /// @param minAmountOut Minimum output amount (slippage protection)
+    /// @param recipient The recipient on Tempo
+    /// @param memo Optional memo
+    /// @return exitId The exit intent ID
+    function requestSwapExit(
+        address tokenOut,
+        uint128 amountIn,
+        uint128 minAmountOut,
+        address recipient,
+        bytes32 memo
+    ) external returns (bytes32 exitId);
+
+    /// @notice Request a swap and deposit exit
+    /// @param tokenOut The output token (must be destination zone's gas token)
+    /// @param amountIn The input amount (gas token)
+    /// @param minAmountOut Minimum output amount
+    /// @param destinationZoneId The destination zone ID
+    /// @param destinationRecipient The recipient on the destination zone
+    /// @param memo Optional memo
+    /// @return exitId The exit intent ID
+    function requestSwapAndDepositExit(
+        address tokenOut,
+        uint128 amountIn,
+        uint128 minAmountOut,
+        uint64 destinationZoneId,
+        address destinationRecipient,
+        bytes32 memo
+    ) external returns (bytes32 exitId);
+}

--- a/docs/specs/src/zones/interfaces/IZoneOutbox.sol
+++ b/docs/specs/src/zones/interfaces/IZoneOutbox.sol
@@ -4,56 +4,32 @@ pragma solidity ^0.8.13;
 import {IZoneTypes} from "./IZoneTypes.sol";
 
 /// @title IZoneOutbox
-/// @notice Zone predeploy for exit intent management
+/// @notice Zone predeploy for withdrawal management
 interface IZoneOutbox is IZoneTypes {
-    /// @notice Emitted when an exit is requested
-    event ExitRequested(bytes32 indexed exitId, uint64 indexed exitIndex, ExitKind kind);
+    /// @notice Emitted when a withdrawal is requested
+    event WithdrawalRequested(bytes32 indexed withdrawalId, uint64 indexed withdrawalIndex);
 
     error InsufficientBalance();
     error InvalidAmount();
 
-    /// @notice Get the next exit index
-    function nextExitIndex() external view returns (uint64);
+    /// @notice Get the next withdrawal index
+    function nextWithdrawalIndex() external view returns (uint64);
 
-    /// @notice Get an exit intent by index
-    function exitByIndex(uint64 exitIndex) external view returns (ExitIntent memory);
+    /// @notice Get a withdrawal by index
+    function withdrawalByIndex(uint64 index) external view returns (Withdrawal memory);
 
-    /// @notice Request a transfer exit
-    /// @param recipient The Tempo recipient address
-    /// @param amount The amount to transfer
-    /// @param memo Optional memo
-    /// @return exitId The exit intent ID
-    function requestTransferExit(address recipient, uint128 amount, bytes32 memo) external returns (bytes32 exitId);
-
-    /// @notice Request a swap exit
-    /// @param tokenOut The output token address on Tempo
-    /// @param amountIn The input amount (gas token)
-    /// @param minAmountOut Minimum output amount (slippage protection)
-    /// @param recipient The recipient on Tempo
-    /// @param memo Optional memo
-    /// @return exitId The exit intent ID
-    function requestSwapExit(
-        address tokenOut,
-        uint128 amountIn,
-        uint128 minAmountOut,
-        address recipient,
-        bytes32 memo
-    ) external returns (bytes32 exitId);
-
-    /// @notice Request a swap and deposit exit
-    /// @param tokenOut The output token (must be destination zone's gas token)
-    /// @param amountIn The input amount (gas token)
-    /// @param minAmountOut Minimum output amount
-    /// @param destinationZoneId The destination zone ID
-    /// @param destinationRecipient The recipient on the destination zone
-    /// @param memo Optional memo
-    /// @return exitId The exit intent ID
-    function requestSwapAndDepositExit(
-        address tokenOut,
-        uint128 amountIn,
-        uint128 minAmountOut,
-        uint64 destinationZoneId,
-        address destinationRecipient,
-        bytes32 memo
-    ) external returns (bytes32 exitId);
+    /// @notice Request a withdrawal from the zone to Tempo
+    /// @param to The Tempo recipient address
+    /// @param amount The amount to withdraw
+    /// @param gasLimit Max gas for IExitReceiver callback (0 = no callback)
+    /// @param fallbackRecipient Zone address for bounce-back if callback fails
+    /// @param data Calldata for IExitReceiver (if gasLimit > 0)
+    /// @return withdrawalId The withdrawal ID
+    function requestWithdrawal(
+        address to,
+        uint128 amount,
+        uint64 gasLimit,
+        address fallbackRecipient,
+        bytes calldata data
+    ) external returns (bytes32 withdrawalId);
 }

--- a/docs/specs/src/zones/interfaces/IZonePortal.sol
+++ b/docs/specs/src/zones/interfaces/IZonePortal.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZoneTypes} from "./IZoneTypes.sol";
+
+/// @title IZonePortal
+/// @notice Per-zone portal that escrows the gas token and finalizes exits
+interface IZonePortal is IZoneTypes {
+    /// @notice Emitted when a deposit is enqueued
+    event DepositEnqueued(
+        uint64 indexed zoneId,
+        uint64 indexed depositIndex,
+        address indexed sender,
+        address to,
+        uint256 amount,
+        bytes32 memo
+    );
+
+    /// @notice Emitted when a batch is accepted
+    event BatchAccepted(
+        uint64 indexed zoneId,
+        uint64 indexed batchIndex,
+        bytes32 prevStateRoot,
+        bytes32 newStateRoot,
+        uint64 depositIndex,
+        bytes32 exitRoot,
+        bytes32 batchHash
+    );
+
+    /// @notice Emitted when an exit is finalized
+    event ExitFinalized(bytes32 indexed exitId, uint64 indexed zoneId, ExitKind kind);
+
+    error InvalidBatchIndex();
+    error InvalidDepositIndex();
+    error InvalidPrevStateRoot();
+    error InvalidProof();
+    error ExitAlreadyClaimed();
+    error OnlySequencer();
+    error SwapFailed();
+    error DestinationZoneNotFound();
+
+    /// @notice Get the zone ID
+    function zoneId() external view returns (uint64);
+
+    /// @notice Get the gas token address
+    function gasToken() external view returns (address);
+
+    /// @notice Get the sequencer address
+    function sequencer() external view returns (address);
+
+    /// @notice Get the verifier address
+    function verifier() external view returns (address);
+
+    /// @notice Get the next deposit index
+    function nextDepositIndex() external view returns (uint64);
+
+    /// @notice Get a deposit by index
+    function deposits(uint64 index) external view returns (Deposit memory);
+
+    /// @notice Get the current state root
+    function stateRoot() external view returns (bytes32);
+
+    /// @notice Get the current batch index
+    function batchIndex() external view returns (uint64);
+
+    /// @notice Get the current exit root
+    function exitRoot() external view returns (bytes32);
+
+    /// @notice Deposit tokens into the zone
+    /// @param to The recipient on the zone
+    /// @param amount The amount to deposit
+    /// @param memo Optional memo for the deposit
+    /// @return depositIndex The index of the deposit
+    function deposit(address to, uint256 amount, bytes32 memo) external returns (uint64 depositIndex);
+
+    /// @notice Submit a batch commitment with proof
+    /// @param commitment The batch commitment
+    /// @param proof The validity proof
+    function submitBatch(BatchCommitment calldata commitment, bytes calldata proof) external;
+
+    /// @notice Check if an exit has been claimed
+    function exitClaimed(bytes32 exitId) external view returns (bool);
+
+    /// @notice Finalize a transfer exit
+    function finalizeTransferExit(ExitIntent calldata intent, ExitProof calldata proof) external;
+
+    /// @notice Finalize a swap exit
+    function finalizeSwapExit(ExitIntent calldata intent, ExitProof calldata proof) external;
+
+    /// @notice Finalize a swap and deposit exit
+    function finalizeSwapAndDepositExit(ExitIntent calldata intent, ExitProof calldata proof) external;
+}

--- a/docs/specs/src/zones/interfaces/IZonePortal.sol
+++ b/docs/specs/src/zones/interfaces/IZonePortal.sol
@@ -4,89 +4,88 @@ pragma solidity ^0.8.13;
 import {IZoneTypes} from "./IZoneTypes.sol";
 
 /// @title IZonePortal
-/// @notice Per-zone portal that escrows the gas token and finalizes exits
+/// @notice Per-zone portal that escrows the gas token and processes withdrawals
 interface IZonePortal is IZoneTypes {
     /// @notice Emitted when a deposit is enqueued
     event DepositEnqueued(
         uint64 indexed zoneId,
-        uint64 indexed depositIndex,
+        bytes32 indexed newCurrentDepositsHash,
         address indexed sender,
         address to,
-        uint256 amount,
-        bytes32 memo
+        uint128 amount,
+        bytes32 memo,
+        bytes32 l1BlockHash,
+        uint64 l1BlockNumber,
+        uint64 l1Timestamp
     );
 
-    /// @notice Emitted when a batch is accepted
-    event BatchAccepted(
+    /// @notice Emitted when a batch is submitted
+    event BatchSubmitted(
         uint64 indexed zoneId,
         uint64 indexed batchIndex,
-        bytes32 prevStateRoot,
-        bytes32 newStateRoot,
-        uint64 depositIndex,
-        bytes32 exitRoot,
-        bytes32 batchHash
+        bytes32 newProcessedDepositsHash,
+        bytes32 newStateRoot
     );
 
-    /// @notice Emitted when an exit is finalized
-    event ExitFinalized(bytes32 indexed exitId, uint64 indexed zoneId, ExitKind kind);
+    /// @notice Emitted when a withdrawal is processed
+    event WithdrawalProcessed(
+        uint64 indexed zoneId,
+        address indexed to,
+        uint128 amount
+    );
 
-    error InvalidBatchIndex();
-    error InvalidDepositIndex();
-    error InvalidPrevStateRoot();
-    error InvalidProof();
-    error ExitAlreadyClaimed();
+    /// @notice Emitted when a withdrawal bounces back
+    event WithdrawalBouncedBack(
+        uint64 indexed zoneId,
+        address indexed fallbackRecipient,
+        uint128 amount
+    );
+
     error OnlySequencer();
-    error SwapFailed();
-    error DestinationZoneNotFound();
+    error InvalidProof();
+    error InvalidWithdrawal();
+    error NoWithdrawals();
+    error UnexpectedQueue2State();
+    error WithdrawalRejected();
 
-    /// @notice Get the zone ID
     function zoneId() external view returns (uint64);
-
-    /// @notice Get the gas token address
     function gasToken() external view returns (address);
-
-    /// @notice Get the sequencer address
     function sequencer() external view returns (address);
-
-    /// @notice Get the verifier address
+    function sequencerPubkey() external view returns (bytes32);
     function verifier() external view returns (address);
-
-    /// @notice Get the next deposit index
-    function nextDepositIndex() external view returns (uint64);
-
-    /// @notice Get a deposit by index
-    function deposits(uint64 index) external view returns (Deposit memory);
-
-    /// @notice Get the current state root
-    function stateRoot() external view returns (bytes32);
-
-    /// @notice Get the current batch index
     function batchIndex() external view returns (uint64);
+    function stateRoot() external view returns (bytes32);
+    function currentDepositsHash() external view returns (bytes32);
+    function checkpointedDepositsHash() external view returns (bytes32);
+    function withdrawalQueue1() external view returns (bytes32);
+    function withdrawalQueue2() external view returns (bytes32);
 
-    /// @notice Get the current exit root
-    function exitRoot() external view returns (bytes32);
+    /// @notice Set the sequencer's public key. Only callable by the sequencer.
+    function setSequencerPubkey(bytes32 pubkey) external;
 
-    /// @notice Deposit tokens into the zone
+    /// @notice Deposit gas token into the zone
     /// @param to The recipient on the zone
     /// @param amount The amount to deposit
     /// @param memo Optional memo for the deposit
-    /// @return depositIndex The index of the deposit
-    function deposit(address to, uint256 amount, bytes32 memo) external returns (uint64 depositIndex);
+    /// @return newCurrentDepositsHash The new deposits hash chain head
+    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositsHash);
 
-    /// @notice Submit a batch commitment with proof
-    /// @param commitment The batch commitment
-    /// @param proof The validity proof
-    function submitBatch(BatchCommitment calldata commitment, bytes calldata proof) external;
+    /// @notice Process the next withdrawal from queue1. Only callable by the sequencer.
+    /// @param w The withdrawal to process (must be at the head of queue1)
+    /// @param remainingQueue The hash of the remaining queue after this withdrawal
+    function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) external;
 
-    /// @notice Check if an exit has been claimed
-    function exitClaimed(bytes32 exitId) external view returns (bool);
-
-    /// @notice Finalize a transfer exit
-    function finalizeTransferExit(ExitIntent calldata intent, ExitProof calldata proof) external;
-
-    /// @notice Finalize a swap exit
-    function finalizeSwapExit(ExitIntent calldata intent, ExitProof calldata proof) external;
-
-    /// @notice Finalize a swap and deposit exit
-    function finalizeSwapAndDepositExit(ExitIntent calldata intent, ExitProof calldata proof) external;
+    /// @notice Submit a batch and verify the proof. Only callable by the sequencer.
+    /// @param commitment The batch commitment (new state root and processed deposits hash)
+    /// @param expectedQueue2 The queue2 value the proof assumed during generation
+    /// @param updatedQueue2 New queue2 if expectedQueue2 matches current queue2
+    /// @param newWithdrawalsOnly New queue2 if current queue2 is empty (swap occurred)
+    /// @param proof The validity proof or TEE attestation
+    function submitBatch(
+        BatchCommitment calldata commitment,
+        bytes32 expectedQueue2,
+        bytes32 updatedQueue2,
+        bytes32 newWithdrawalsOnly,
+        bytes calldata proof
+    ) external;
 }

--- a/docs/specs/src/zones/interfaces/IZoneRegistry.sol
+++ b/docs/specs/src/zones/interfaces/IZoneRegistry.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {IZoneTypes} from "./IZoneTypes.sol";
+
+/// @title IZoneRegistry
+/// @notice Optional registry for zone metadata and batch heads
+interface IZoneRegistry is IZoneTypes {
+    /// @notice Emitted when a zone is registered
+    event ZoneRegistered(uint64 indexed zoneId, address indexed portal);
+
+    /// @notice Emitted when a batch head is updated
+    event BatchHeadUpdated(
+        uint64 indexed zoneId,
+        uint64 indexed batchIndex,
+        bytes32 stateRoot,
+        bytes32 exitRoot
+    );
+
+    error ZoneAlreadyRegistered();
+    error ZoneNotFound();
+    error OnlyPortal();
+
+    /// @notice Register a zone
+    function registerZone(ZoneInfo calldata info) external;
+
+    /// @notice Get zone info by ID
+    function getZone(uint64 zoneId) external view returns (ZoneInfo memory);
+
+    /// @notice Get the batch head for a zone
+    /// @return batchIndex The current batch index
+    /// @return stateRoot The current state root
+    /// @return exitRoot The current exit root
+    function batchHead(uint64 zoneId) external view returns (uint64 batchIndex, bytes32 stateRoot, bytes32 exitRoot);
+
+    /// @notice Update the batch head (called by portal)
+    function updateBatchHead(uint64 zoneId, uint64 batchIndex, bytes32 stateRoot, bytes32 exitRoot) external;
+}

--- a/docs/specs/src/zones/interfaces/IZoneRegistry.sol
+++ b/docs/specs/src/zones/interfaces/IZoneRegistry.sol
@@ -10,12 +10,7 @@ interface IZoneRegistry is IZoneTypes {
     event ZoneRegistered(uint64 indexed zoneId, address indexed portal);
 
     /// @notice Emitted when a batch head is updated
-    event BatchHeadUpdated(
-        uint64 indexed zoneId,
-        uint64 indexed batchIndex,
-        bytes32 stateRoot,
-        bytes32 exitRoot
-    );
+    event BatchHeadUpdated(uint64 indexed zoneId, uint64 indexed batchIndex, bytes32 stateRoot);
 
     error ZoneAlreadyRegistered();
     error ZoneNotFound();
@@ -30,9 +25,8 @@ interface IZoneRegistry is IZoneTypes {
     /// @notice Get the batch head for a zone
     /// @return batchIndex The current batch index
     /// @return stateRoot The current state root
-    /// @return exitRoot The current exit root
-    function batchHead(uint64 zoneId) external view returns (uint64 batchIndex, bytes32 stateRoot, bytes32 exitRoot);
+    function batchHead(uint64 zoneId) external view returns (uint64 batchIndex, bytes32 stateRoot);
 
     /// @notice Update the batch head (called by portal)
-    function updateBatchHead(uint64 zoneId, uint64 batchIndex, bytes32 stateRoot, bytes32 exitRoot) external;
+    function updateBatchHead(uint64 zoneId, uint64 batchIndex, bytes32 stateRoot) external;
 }

--- a/docs/specs/src/zones/interfaces/IZoneTypes.sol
+++ b/docs/specs/src/zones/interfaces/IZoneTypes.sol
@@ -4,13 +4,6 @@ pragma solidity ^0.8.13;
 /// @title Zone Types
 /// @notice Common types used across Zone contracts
 interface IZoneTypes {
-    /// @notice Exit intent types for bridging out of a zone
-    enum ExitKind {
-        Transfer,
-        Swap,
-        SwapAndDeposit
-    }
-
     /// @notice Zone metadata stored in the registry
     struct ZoneInfo {
         uint64 zoneId;
@@ -21,62 +14,30 @@ interface IZoneTypes {
         bytes32 genesisStateRoot;
     }
 
-    /// @notice Batch commitment posted by the sequencer
+    /// @notice Batch commitment for state transition
     struct BatchCommitment {
-        uint64 zoneId;
-        uint64 batchIndex;
-        bytes32 prevStateRoot;
+        bytes32 newProcessedDepositsHash;
         bytes32 newStateRoot;
-        uint64 depositIndex;
-        bytes32 exitRoot;
-        bytes32 batchHash;
     }
 
-    /// @notice Deposit from Tempo into a zone
+    /// @notice Deposit from Tempo into a zone (includes L1 block info)
     struct Deposit {
+        bytes32 l1BlockHash;
+        uint64 l1BlockNumber;
+        uint64 l1Timestamp;
         address sender;
         address to;
-        uint256 amount;
-        bytes32 memo;
-    }
-
-    /// @notice Transfer exit: release gas token to a Tempo recipient
-    struct TransferExit {
-        address recipient;
         uint128 amount;
-    }
-
-    /// @notice Swap exit: release gas token, swap on DEX, send output to recipient
-    struct SwapExit {
-        address recipient;
-        address tokenOut;
-        uint128 amountIn;
-        uint128 minAmountOut;
-    }
-
-    /// @notice Swap and deposit exit: swap then deposit into another zone
-    struct SwapAndDepositExit {
-        address tokenOut;
-        uint128 amountIn;
-        uint128 minAmountOut;
-        uint64 destinationZoneId;
-        address destinationRecipient;
-    }
-
-    /// @notice Full exit intent with all possible exit data
-    struct ExitIntent {
-        ExitKind kind;
-        uint64 exitIndex;
-        address sender;
-        TransferExit transfer;
-        SwapExit swap;
-        SwapAndDepositExit swapAndDeposit;
         bytes32 memo;
     }
 
-    /// @notice Merkle proof for exit finalization
-    struct ExitProof {
-        uint64 batchIndex;
-        bytes32[] merkleProof;
+    /// @notice Withdrawal from zone to Tempo
+    struct Withdrawal {
+        address sender;
+        address to;
+        uint128 amount;
+        uint64 gasLimit;
+        address fallbackRecipient;
+        bytes data;
     }
 }

--- a/docs/specs/src/zones/interfaces/IZoneTypes.sol
+++ b/docs/specs/src/zones/interfaces/IZoneTypes.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title Zone Types
+/// @notice Common types used across Zone contracts
+interface IZoneTypes {
+    /// @notice Exit intent types for bridging out of a zone
+    enum ExitKind {
+        Transfer,
+        Swap,
+        SwapAndDeposit
+    }
+
+    /// @notice Zone metadata stored in the registry
+    struct ZoneInfo {
+        uint64 zoneId;
+        address portal;
+        address gasToken;
+        address sequencer;
+        address verifier;
+        bytes32 genesisStateRoot;
+    }
+
+    /// @notice Batch commitment posted by the sequencer
+    struct BatchCommitment {
+        uint64 zoneId;
+        uint64 batchIndex;
+        bytes32 prevStateRoot;
+        bytes32 newStateRoot;
+        uint64 depositIndex;
+        bytes32 exitRoot;
+        bytes32 batchHash;
+    }
+
+    /// @notice Deposit from Tempo into a zone
+    struct Deposit {
+        address sender;
+        address to;
+        uint256 amount;
+        bytes32 memo;
+    }
+
+    /// @notice Transfer exit: release gas token to a Tempo recipient
+    struct TransferExit {
+        address recipient;
+        uint128 amount;
+    }
+
+    /// @notice Swap exit: release gas token, swap on DEX, send output to recipient
+    struct SwapExit {
+        address recipient;
+        address tokenOut;
+        uint128 amountIn;
+        uint128 minAmountOut;
+    }
+
+    /// @notice Swap and deposit exit: swap then deposit into another zone
+    struct SwapAndDepositExit {
+        address tokenOut;
+        uint128 amountIn;
+        uint128 minAmountOut;
+        uint64 destinationZoneId;
+        address destinationRecipient;
+    }
+
+    /// @notice Full exit intent with all possible exit data
+    struct ExitIntent {
+        ExitKind kind;
+        uint64 exitIndex;
+        address sender;
+        TransferExit transfer;
+        SwapExit swap;
+        SwapAndDepositExit swapAndDeposit;
+        bytes32 memo;
+    }
+
+    /// @notice Merkle proof for exit finalization
+    struct ExitProof {
+        uint64 batchIndex;
+        bytes32[] merkleProof;
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of Tempo Zones - Solidity contracts for the validium L2 system.

## What's included

### Interfaces
- `IZoneTypes` - Common types: `ExitKind`, `ZoneInfo`, `BatchCommitment`, `Deposit`, exit structs
- `IVerifier` - Abstract verifier interface for ZK/TEE proofs
- `IZoneFactory` - Factory interface for creating zones
- `IZonePortal` - Per-zone portal interface (escrow, deposits, exits)
- `IZoneRegistry` - Registry interface for zone metadata
- `IZoneOutbox` - Zone predeploy interface for exit intents

### Implementations
- `ZoneRegistry` - Zone metadata and batch head storage
- `ZoneFactory` - Creates zones and deploys ZonePortal instances
- `ZonePortal` - Escrow, batch submission, exit finalization with DEX integration
- `ZoneOutbox` - Exit intent storage (predeploy for zone side)
- `MockVerifier` - Test verifier for development

## Features
- **Deposits**: Users deposit TIP-20 tokens from Tempo into zones
- **Exits**: Three exit types supported:
  - `Transfer` - Direct token release to Tempo recipient
  - `Swap` - Swap on Tempo DEX then send to recipient
  - `SwapAndDeposit` - Swap then deposit into another zone
- **Batch verification**: Sequencer submits batches with proofs via `IVerifier`
- **Merkle proofs**: Exit finalization uses merkle proofs against `exitRoot`

## Based on
- `tempo-validium-spec.md` (dr/validium-spec branch)
- `tempo-validium-zone-design.md` (dr/validium-spec branch)

## Next phases
- Phase 2: Wire ZoneOutbox as predeploy, commit `withdrawals_root` in headers
- Phase 3: Deposit tx `0x7E` and L1 Block Info system tx
- Phase 4: TIP-20 gas token per zone
- Phase 5: Integration tests

## Testing
```bash
cd docs/specs && forge build --contracts src/zones
```
