### PR TITLE
Proposal for gas rate on zone deposit/withdrawals

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -73,17 +73,26 @@ This applies to all zone contracts: `ZonePortal` (Tempo-side), `ZoneInbox`, `Zon
 
 ### Deposit fees
 
-> **TODO**: Deposit fee mechanism is undecided. Options include: minimum deposit amount (spam prevention), fixed fee deducted from deposit, or no fee (sequencer absorbs zone-side gas costs). Zone gas should be cheap due to no data availability costs.
+Deposits incur a processing fee to compensate the sequencer for zone-side gas costs:
+
+- **Zone gas rate**: Sequencer publishes `zoneGasRate` (gas token units per gas unit)
+- **Gas estimate**: Fixed `DEPOSIT_GAS_ESTIMATE` constant (e.g., 50,000 gas for minting)
+- **Total fee**: `DEPOSIT_GAS_ESTIMATE * zoneGasRate`
+
+The sequencer configures `zoneGasRate` via `ZonePortal.setZoneGasRate()` and takes the risk on zone gas price fluctuations. If actual zone gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
+
+The fee is deducted from the deposit amount and paid to the sequencer immediately on Tempo. The deposit queue stores the net amount (`amount - fee`) which is minted on the zone.
 
 ### Withdrawal processing fees
 
 Withdrawals incur a processing fee to compensate the sequencer for Tempo-side gas costs:
 
-- **Base fee**: Fixed cost per withdrawal (covers `processWithdrawal` overhead)
-- **Gas fee**: Proportional to `gasLimit` (covers callback execution)
-- **Total fee**: `baseFee + gasLimit * gasFeeRate`
+- **Tempo gas rate**: Sequencer publishes `tempoGasRate` (gas token units per gas unit)
+- **Base gas**: Fixed `WITHDRAWAL_BASE_GAS` constant (e.g., 50,000 gas for `processWithdrawal` overhead)
+- **Callback gas**: User-specified `gasLimit` for callback execution
+- **Total fee**: `(WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate`
 
-The sequencer configures these parameters via `ZoneOutbox.setWithdrawalFees(baseFee, gasFeeRate)`. The fee is calculated and locked in at request time, stored in the `Withdrawal.fee` field, and paid to the sequencer when the withdrawal is processed on Tempo (regardless of success or failure).
+The sequencer configures `tempoGasRate` via `ZoneOutbox.setTempoGasRate()` and takes the risk on Tempo gas price fluctuations. If actual Tempo gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
 
 Users burn `amount + fee` when requesting a withdrawal. On success, `amount` goes to the recipient and `fee` goes to the sequencer. On failure (bounce-back), only `amount` is re-deposited to `fallbackRecipient`; the sequencer keeps the fee.
 
@@ -445,7 +454,8 @@ interface IZonePortal {
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
         address to,
-        uint128 amount,
+        uint128 netAmount,
+        uint128 fee,
         bytes32 memo
     );
 
@@ -470,6 +480,10 @@ interface IZonePortal {
 
     event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+    event ZoneGasRateUpdated(uint128 zoneGasRate);
+
+    /// @notice Estimated gas cost for processing a deposit on the zone.
+    function DEPOSIT_GAS_ESTIMATE() external view returns (uint64);
 
     function zoneId() external view returns (uint64);
     function token() external view returns (address);
@@ -477,6 +491,7 @@ interface IZonePortal {
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);
     function sequencerPubkey() external view returns (bytes32);
+    function zoneGasRate() external view returns (uint128);
     function verifier() external view returns (address);
     function genesisTempoBlockNumber() external view returns (uint64);
     function withdrawalBatchIndex() external view returns (uint64);
@@ -497,7 +512,14 @@ interface IZonePortal {
     /// @notice Set the sequencer's public key. Only callable by the sequencer.
     function setSequencerPubkey(bytes32 pubkey) external;
 
-    /// @notice Deposit gas token into the zone. Returns the new current deposit queue hash.
+    /// @notice Set zone gas rate. Only callable by sequencer.
+    function setZoneGasRate(uint128 _zoneGasRate) external;
+
+    /// @notice Calculate the fee for a deposit.
+    function calculateDepositFee() external view returns (uint128 fee);
+
+    /// @notice Deposit gas token into the zone. Fee is deducted from amount.
+    /// @dev Returns the new current deposit queue hash.
     function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
 
     /// @notice Process the next withdrawal from the queue. Only callable by the sequencer.
@@ -752,7 +774,7 @@ interface IZoneOutbox {
         bytes data
     );
 
-    event WithdrawalFeesUpdated(uint128 baseFee, uint128 gasFeeRate);
+    event TempoGasRateUpdated(uint128 tempoGasRate);
 
     /// @notice Emitted when sequencer finalizes a batch at end of block.
     /// @dev Kept for observability. Proof reads from lastBatch storage instead.
@@ -773,11 +795,11 @@ interface IZoneOutbox {
     /// @notice Pending sequencer for two-step transfer.
     function pendingSequencer() external view returns (address);
 
-    /// @notice Base fee for withdrawal processing.
-    function withdrawalBaseFee() external view returns (uint128);
+    /// @notice Base gas cost for processing a withdrawal on Tempo (excluding callback).
+    function WITHDRAWAL_BASE_GAS() external view returns (uint64);
 
-    /// @notice Fee per unit of gasLimit.
-    function withdrawalGasFeeRate() external view returns (uint128);
+    /// @notice Tempo gas rate (gas token units per gas unit on Tempo).
+    function tempoGasRate() external view returns (uint128);
 
     /// @notice Next withdrawal index (monotonically increasing).
     function nextWithdrawalIndex() external view returns (uint64);
@@ -797,10 +819,11 @@ interface IZoneOutbox {
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
     function acceptSequencer() external;
 
-    /// @notice Set withdrawal fee parameters. Only callable by sequencer.
-    function setWithdrawalFees(uint128 baseFee, uint128 gasFeeRate) external;
+    /// @notice Set Tempo gas rate. Only callable by sequencer.
+    function setTempoGasRate(uint128 _tempoGasRate) external;
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit.
+    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo.

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -73,13 +73,13 @@ This applies to all zone contracts: `ZonePortal` (Tempo-side), `ZoneInbox`, `Zon
 
 ### Deposit fees
 
-Deposits incur a processing fee to compensate the sequencer for zone-side gas costs:
+Deposits incur a processing fee to compensate the sequencer for zone-side processing costs:
 
 - **Zone gas rate**: Sequencer publishes `zoneGasRate` (zone token units per gas unit)
-- **Gas estimate**: Fixed `DEPOSIT_GAS_ESTIMATE` constant (e.g., 50,000 gas for minting)
-- **Total fee**: `DEPOSIT_GAS_ESTIMATE * zoneGasRate`
+- **Fixed gas value**: `FIXED_DEPOSIT_GAS` is fixed at 100,000 gas
+- **Total fee**: `FIXED_DEPOSIT_GAS * zoneGasRate` = `100,000 * zoneGasRate`
 
-The sequencer configures `zoneGasRate` via `ZonePortal.setZoneGasRate()` and takes the risk on zone gas price fluctuations. If actual zone gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
+The sequencer configures `zoneGasRate` via `ZonePortal.setZoneGasRate()`. The fixed gas value of 100,000 provides a stable pricing basis for deposits while allowing the sequencer flexibility to adjust the rate based on operational costs and future deposit mechanism variations.
 
 The fee is deducted from the deposit amount and paid to the sequencer immediately on Tempo. The deposit queue stores the net amount (`amount - fee`) which is minted on the zone.
 
@@ -481,8 +481,8 @@ interface IZonePortal {
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
     event ZoneGasRateUpdated(uint128 zoneGasRate);
 
-    /// @notice Estimated gas cost for processing a deposit on the zone.
-    function DEPOSIT_GAS_ESTIMATE() external view returns (uint64);
+    /// @notice Fixed gas value for deposit fee calculation (100,000 gas).
+    function FIXED_DEPOSIT_GAS() external view returns (uint64);
 
     function zoneId() external view returns (uint64);
     function token() external view returns (address);

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -88,11 +88,10 @@ The fee is deducted from the deposit amount and paid to the sequencer immediatel
 Withdrawals incur a processing fee to compensate the sequencer for Tempo-side gas costs:
 
 - **Tempo gas rate**: Sequencer publishes `tempoGasRate` (gas token units per gas unit)
-- **Base gas**: Fixed `WITHDRAWAL_BASE_GAS` constant (e.g., 50,000 gas for `processWithdrawal` overhead)
-- **Callback gas**: User-specified `gasLimit` for callback execution
-- **Total fee**: `(WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate`
+- **Gas limit**: User specifies `gasLimit` covering all execution costs (processing + callback)
+- **Total fee**: `gasLimit * tempoGasRate`
 
-The sequencer configures `tempoGasRate` via `ZoneOutbox.setTempoGasRate()` and takes the risk on Tempo gas price fluctuations. If actual Tempo gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
+The user must estimate total gas needed for their withdrawal, including `processWithdrawal` overhead and any callback. The sequencer configures `tempoGasRate` via `ZoneOutbox.setTempoGasRate()` and takes the risk on Tempo gas price fluctuations. If actual Tempo gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
 
 Users burn `amount + fee` when requesting a withdrawal. On success, `amount` goes to the recipient and `fee` goes to the sequencer. On failure (bounce-back), only `amount` is re-deposited to `fallbackRecipient`; the sequencer keeps the fee.
 
@@ -795,10 +794,8 @@ interface IZoneOutbox {
     /// @notice Pending sequencer for two-step transfer.
     function pendingSequencer() external view returns (address);
 
-    /// @notice Base gas cost for processing a withdrawal on Tempo (excluding callback).
-    function WITHDRAWAL_BASE_GAS() external view returns (uint64);
-
     /// @notice Tempo gas rate (gas token units per gas unit on Tempo).
+    /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
     function tempoGasRate() external view returns (uint128);
 
     /// @notice Next withdrawal index (monotonically increasing).
@@ -823,7 +820,7 @@ interface IZoneOutbox {
     function setTempoGasRate(uint128 _tempoGasRate) external;
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit.
-    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
+    /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo.

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -144,7 +144,8 @@ interface IZonePortal {
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
         address to,
-        uint128 amount,
+        uint128 netAmount,
+        uint128 fee,
         bytes32 memo
     );
 
@@ -169,12 +170,17 @@ interface IZonePortal {
 
     event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+    event ZoneGasRateUpdated(uint128 zoneGasRate);
 
     error NotSequencer();
     error NotPendingSequencer();
     error InvalidProof();
     error InvalidTempoBlockNumber();
     error CallbackRejected();
+    error DepositTooSmall();
+
+    /// @notice Estimated gas cost for processing a deposit on the zone
+    function DEPOSIT_GAS_ESTIMATE() external view returns (uint64);
 
     function zoneId() external view returns (uint64);
     function token() external view returns (address);
@@ -182,6 +188,7 @@ interface IZonePortal {
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);
     function sequencerPubkey() external view returns (bytes32);
+    function zoneGasRate() external view returns (uint128);
     function verifier() external view returns (address);
     function withdrawalBatchIndex() external view returns (uint64);
     function blockHash() external view returns (bytes32);
@@ -202,6 +209,14 @@ interface IZonePortal {
     function acceptSequencer() external;
 
     function setSequencerPubkey(bytes32 pubkey) external;
+
+    /// @notice Set zone gas rate. Only callable by sequencer.
+    /// @param _zoneGasRate Gas token units per gas unit on the zone
+    function setZoneGasRate(uint128 _zoneGasRate) external;
+
+    /// @notice Calculate the fee for a deposit
+    function calculateDepositFee() external view returns (uint128 fee);
+
     function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
     function submitBatch(
@@ -385,6 +400,9 @@ interface IZoneOutbox {
     /// @notice Maximum callback data size (1KB)
     function MAX_CALLBACK_DATA_SIZE() external view returns (uint256);
 
+    /// @notice Base gas cost for processing a withdrawal on Tempo (excluding callback)
+    function WITHDRAWAL_BASE_GAS() external view returns (uint64);
+
     event WithdrawalRequested(
         uint64 indexed withdrawalIndex,
         address indexed sender,
@@ -397,7 +415,7 @@ interface IZoneOutbox {
         bytes data
     );
 
-    event WithdrawalFeesUpdated(uint128 baseFee, uint128 gasFeeRate);
+    event TempoGasRateUpdated(uint128 tempoGasRate);
 
     /// @notice Emitted when sequencer finalizes a batch at end of block
     /// @dev Kept for observability. Proof reads from lastBatch storage instead.
@@ -418,11 +436,9 @@ interface IZoneOutbox {
     /// @notice Pending sequencer for two-step transfer
     function pendingSequencer() external view returns (address);
 
-    /// @notice Base fee for withdrawal processing
-    function withdrawalBaseFee() external view returns (uint128);
-
-    /// @notice Fee per unit of gasLimit
-    function withdrawalGasFeeRate() external view returns (uint128);
+    /// @notice Tempo gas rate (gas token units per gas unit on Tempo)
+    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
+    function tempoGasRate() external view returns (uint128);
 
     /// @notice Next withdrawal index (monotonically increasing)
     function nextWithdrawalIndex() external view returns (uint64);
@@ -442,10 +458,13 @@ interface IZoneOutbox {
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
     function acceptSequencer() external;
 
-    /// @notice Set withdrawal fee parameters. Only callable by sequencer.
-    function setWithdrawalFees(uint128 baseFee, uint128 gasFeeRate) external;
+    /// @notice Set Tempo gas rate. Only callable by sequencer.
+    /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price fluctuations.
+    /// @param _tempoGasRate Gas token units per gas unit on Tempo
+    function setTempoGasRate(uint128 _tempoGasRate) external;
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit
+    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -400,9 +400,6 @@ interface IZoneOutbox {
     /// @notice Maximum callback data size (1KB)
     function MAX_CALLBACK_DATA_SIZE() external view returns (uint256);
 
-    /// @notice Base gas cost for processing a withdrawal on Tempo (excluding callback)
-    function WITHDRAWAL_BASE_GAS() external view returns (uint64);
-
     event WithdrawalRequested(
         uint64 indexed withdrawalIndex,
         address indexed sender,
@@ -437,7 +434,7 @@ interface IZoneOutbox {
     function pendingSequencer() external view returns (address);
 
     /// @notice Tempo gas rate (gas token units per gas unit on Tempo)
-    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
+    /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
     function tempoGasRate() external view returns (uint128);
 
     /// @notice Next withdrawal index (monotonically increasing)
@@ -464,7 +461,7 @@ interface IZoneOutbox {
     function setTempoGasRate(uint128 _tempoGasRate) external;
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit
-    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
+    /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -179,8 +179,8 @@ interface IZonePortal {
     error CallbackRejected();
     error DepositTooSmall();
 
-    /// @notice Estimated gas cost for processing a deposit on the zone
-    function DEPOSIT_GAS_ESTIMATE() external view returns (uint64);
+    /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
+    function FIXED_DEPOSIT_GAS() external view returns (uint64);
 
     function zoneId() external view returns (uint64);
     function token() external view returns (address);

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -17,6 +17,10 @@ contract ZoneOutbox is IZoneOutbox {
     /// @dev Limits storage costs and hash computation overhead
     uint256 public constant MAX_CALLBACK_DATA_SIZE = 1024;
 
+    /// @notice Base gas cost for processing a withdrawal on Tempo (excluding callback)
+    /// @dev Covers processWithdrawal overhead: queue dequeue, transfer, event emission
+    uint64 public constant WITHDRAWAL_BASE_GAS = 50000;
+
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -30,13 +34,10 @@ contract ZoneOutbox is IZoneOutbox {
     /// @notice Pending sequencer for two-step transfer
     address public pendingSequencer;
 
-    /// @notice Base fee for withdrawal processing (in gas token units)
-    /// @dev Covers fixed costs of processWithdrawal on Tempo
-    uint128 public withdrawalBaseFee;
-
-    /// @notice Fee per unit of gasLimit (in gas token units)
-    /// @dev Covers callback execution costs on Tempo: fee = baseFee + gasLimit * gasFeeRate
-    uint128 public withdrawalGasFeeRate;
+    /// @notice Tempo gas rate (gas token units per gas unit)
+    /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price changes.
+    ///      Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
+    uint128 public tempoGasRate;
 
     /// @notice Next withdrawal index (monotonically increasing)
     uint64 public nextWithdrawalIndex;
@@ -99,21 +100,23 @@ contract ZoneOutbox is IZoneOutbox {
                             FEE CONFIGURATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Set withdrawal fee parameters. Only callable by sequencer.
-    /// @param baseFee Base fee for each withdrawal (covers processWithdrawal overhead)
-    /// @param gasFeeRate Fee per unit of gasLimit (covers callback execution)
-    function setWithdrawalFees(uint128 baseFee, uint128 gasFeeRate) external {
+    /// @notice Set Tempo gas rate. Only callable by sequencer.
+    /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price fluctuations.
+    ///      If actual Tempo gas is higher, sequencer covers the difference.
+    ///      If actual Tempo gas is lower, sequencer keeps the surplus.
+    /// @param _tempoGasRate Gas token units per gas unit on Tempo
+    function setTempoGasRate(uint128 _tempoGasRate) external {
         if (msg.sender != sequencer) revert OnlySequencer();
-        withdrawalBaseFee = baseFee;
-        withdrawalGasFeeRate = gasFeeRate;
-        emit WithdrawalFeesUpdated(baseFee, gasFeeRate);
+        tempoGasRate = _tempoGasRate;
+        emit TempoGasRateUpdated(_tempoGasRate);
     }
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit
+    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
     /// @param gasLimit The gas limit for the callback (0 if no callback)
-    /// @return fee The total fee (baseFee + gasLimit * gasFeeRate)
+    /// @return fee The total fee in gas token units
     function calculateWithdrawalFee(uint64 gasLimit) public view returns (uint128 fee) {
-        fee = withdrawalBaseFee + uint128(gasLimit) * withdrawalGasFeeRate;
+        fee = uint128(WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -149,6 +152,7 @@ contract ZoneOutbox is IZoneOutbox {
         }
 
         // Calculate processing fee (locked in at request time)
+        // Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
         uint128 fee = calculateWithdrawalFee(gasLimit);
         uint128 totalBurn = amount + fee;
 

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -17,10 +17,6 @@ contract ZoneOutbox is IZoneOutbox {
     /// @dev Limits storage costs and hash computation overhead
     uint256 public constant MAX_CALLBACK_DATA_SIZE = 1024;
 
-    /// @notice Base gas cost for processing a withdrawal on Tempo (excluding callback)
-    /// @dev Covers processWithdrawal overhead: queue dequeue, transfer, event emission
-    uint64 public constant WITHDRAWAL_BASE_GAS = 50000;
-
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -36,7 +32,7 @@ contract ZoneOutbox is IZoneOutbox {
 
     /// @notice Tempo gas rate (gas token units per gas unit)
     /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price changes.
-    ///      Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
+    ///      Fee = gasLimit * tempoGasRate. User must include all gas costs in gasLimit.
     uint128 public tempoGasRate;
 
     /// @notice Next withdrawal index (monotonically increasing)
@@ -112,11 +108,11 @@ contract ZoneOutbox is IZoneOutbox {
     }
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit
-    /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
-    /// @param gasLimit The gas limit for the callback (0 if no callback)
+    /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
+    /// @param gasLimit Total gas limit (must cover processWithdrawal + any callback)
     /// @return fee The total fee in gas token units
     function calculateWithdrawalFee(uint64 gasLimit) public view returns (uint128 fee) {
-        fee = uint128(WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate;
+        fee = uint128(gasLimit) * tempoGasRate;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -22,6 +22,14 @@ contract ZonePortal is IZonePortal {
     using WithdrawalQueueLib for WithdrawalQueue;
 
     /*//////////////////////////////////////////////////////////////
+                               CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Estimated gas cost for processing a deposit on the zone
+    /// @dev Covers ZoneInbox.advanceTempo processing: hash computation, token minting, event emission
+    uint64 public constant DEPOSIT_GAS_ESTIMATE = 50000;
+
+    /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
@@ -37,7 +45,15 @@ contract ZonePortal is IZonePortal {
     /// @notice Pending sequencer for two-step transfer
     address public pendingSequencer;
 
+    /// @notice Sequencer's public key for encrypting messages (e.g., deposit memos)
+    /// @dev Future functionality: allows users to encrypt data only the sequencer can read
     bytes32 public sequencerPubkey;
+
+    /// @notice Zone gas rate (gas token units per gas unit on the zone)
+    /// @dev Sequencer publishes this rate and takes the risk on zone gas costs.
+    ///      Deposit fee = DEPOSIT_GAS_ESTIMATE * zoneGasRate
+    uint128 public zoneGasRate;
+
     uint64 public withdrawalBatchIndex;
     bytes32 public blockHash;
 
@@ -108,6 +124,16 @@ contract ZonePortal is IZonePortal {
         sequencerPubkey = pubkey;
     }
 
+    /// @notice Set zone gas rate. Only callable by sequencer.
+    /// @dev Sequencer publishes this rate and takes the risk on zone gas costs.
+    ///      If actual zone gas is higher, sequencer covers the difference.
+    ///      If actual zone gas is lower, sequencer keeps the surplus.
+    /// @param _zoneGasRate Gas token units per gas unit on the zone
+    function setZoneGasRate(uint128 _zoneGasRate) external onlySequencer {
+        zoneGasRate = _zoneGasRate;
+        emit ZoneGasRateUpdated(_zoneGasRate);
+    }
+
     /*//////////////////////////////////////////////////////////////
                            QUEUE ACCESSORS
     //////////////////////////////////////////////////////////////*/
@@ -132,16 +158,39 @@ contract ZonePortal is IZonePortal {
                                DEPOSITS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Calculate the fee for a deposit
+    /// @dev Fee = DEPOSIT_GAS_ESTIMATE * zoneGasRate
+    /// @return fee The deposit fee in gas token units
+    function calculateDepositFee() public view returns (uint128 fee) {
+        fee = uint128(DEPOSIT_GAS_ESTIMATE) * zoneGasRate;
+    }
+
     /// @notice Deposit gas token into the zone. Returns the new current deposit queue hash.
+    /// @dev Fee is deducted from amount and paid to sequencer. Net amount is credited on zone.
+    /// @param to Recipient address on the zone
+    /// @param amount Total amount to deposit (fee will be deducted)
+    /// @param memo User-provided context
+    /// @return newCurrentDepositQueueHash The new deposit queue hash after this deposit
     function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash) {
+        // Calculate deposit fee
+        uint128 fee = calculateDepositFee();
+        if (amount <= fee) revert DepositTooSmall();
+        uint128 netAmount = amount - fee;
+
+        // Transfer full amount from sender to this contract
         // TIP-20 transfers revert on failure, so no boolean check is needed here.
         ITIP20(token).transferFrom(msg.sender, address(this), amount);
 
-        // Build deposit struct
+        // Transfer fee to sequencer
+        if (fee > 0) {
+            ITIP20(token).transfer(sequencer, fee);
+        }
+
+        // Build deposit struct with net amount (fee already paid to sequencer on Tempo)
         Deposit memory depositData = Deposit({
             sender: msg.sender,
             to: to,
-            amount: amount,
+            amount: netAmount,
             memo: memo
         });
 
@@ -153,7 +202,8 @@ contract ZonePortal is IZonePortal {
             newCurrentDepositQueueHash,
             msg.sender,
             to,
-            amount,
+            netAmount,
+            fee,
             memo
         );
     }

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -25,9 +25,11 @@ contract ZonePortal is IZonePortal {
                                CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Estimated gas cost for processing a deposit on the zone
-    /// @dev Covers ZoneInbox.advanceTempo processing: hash computation, token minting, event emission
-    uint64 public constant DEPOSIT_GAS_ESTIMATE = 50000;
+    /// @notice Fixed gas value for deposit fee calculation
+    /// @dev Set to 100,000 gas. Deposit fee = FIXED_DEPOSIT_GAS * zoneGasRate.
+    ///      This provides a stable pricing basis for deposits while allowing sequencer
+    ///      flexibility to adjust the zoneGasRate based on operational costs.
+    uint64 public constant FIXED_DEPOSIT_GAS = 100000;
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -159,10 +161,10 @@ contract ZonePortal is IZonePortal {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Calculate the fee for a deposit
-    /// @dev Fee = DEPOSIT_GAS_ESTIMATE * zoneGasRate
+    /// @dev Fee = FIXED_DEPOSIT_GAS * zoneGasRate
     /// @return fee The deposit fee in zone token units
     function calculateDepositFee() public view returns (uint128 fee) {
-        fee = uint128(DEPOSIT_GAS_ESTIMATE) * zoneGasRate;
+        fee = uint128(FIXED_DEPOSIT_GAS) * zoneGasRate;
     }
 
     /// @notice Deposit zone token into the zone. Returns the new current deposit queue hash.


### PR DESCRIPTION
## Summary

 - Gas on deposits is charged according to `zoneGasRate` set by sequencer in portal contract
 - Gas on withdrawals is charged according to `tempoGasRate` set by sequencer inside zone

## Withdrawals (Zone → Tempo)

- Rename `withdrawalGasFeeRate` to `tempoGasRate`
- Fee formula: `gasLimit * tempoGasRate`
- Sequencer publishes `tempoGasRate` via `setTempoGasRate()`
- Sequencer takes the risk: if actual Tempo gas is higher, they cover; if lower, they profit

## Deposits (Tempo → Zone)

- Add `DEPOSIT_GAS_ESTIMATE` constant (50,000 gas for minting on zone)
- Add `zoneGasRate` to ZonePortal
- Fee formula: `DEPOSIT_GAS_ESTIMATE * zoneGasRate`
- Fee is deducted from deposit amount and paid to sequencer immediately on Tempo
- Deposit queue stores net amount (`amount - fee`)
- Sequencer publishes `zoneGasRate` via `setZoneGasRate()`
- Sequencer takes the risk on zone gas costs