### PR TITLE
L1 state declarations

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -678,7 +678,6 @@ struct TempoAccountState {
 
 /// @notice Complete Tempo state declaration for a transaction
 struct TempoStateDeclaration {
-    uint64 tempoBlockNumber;            // Tempo block this declaration is valid for
     TempoAccountState[] accountStates;  // Declared state per account
 }
 ```
@@ -694,15 +693,16 @@ Transactions using Tempo state declarations use a new transaction type. The form
 Where `tempoStateDeclaration` is:
 
 ```
-[[tempoBlockNumber], [[account1, [[slot1, value1], [slot2, value2], ...]], [account2, [[slot1, value1], ...]], ...]]
+[[[account1, [[slot1, value1], [slot2, value2], ...]], [account2, [[slot1, value1], ...]], ...]]
 ```
 
 **Validation rules:**
 
-1. `tempoBlockNumber` must match the zone's current finalized Tempo block (from `TempoState.tempoBlockNumber()`)
-2. All declared values must match actual Tempo state at that block
-3. Execution must not read any Tempo state not covered by the declaration
-4. Transactions that fail any check are **invalid** and cannot be included in a block (the zone block itself becomes invalid)
+1. All declared values must match current Tempo state (at the zone's finalized Tempo block)
+2. Execution must not read any Tempo state not covered by the declaration
+3. Transactions that fail either check are **invalid** and cannot be included in a block (the zone block itself becomes invalid)
+
+By not including a block number in the declaration, transactions remain valid as long as the declared values match current Tempo state. They only become invalid when the actual state changes, not just because a new Tempo block was finalized. This makes transactions more robust and reduces unnecessary invalidation.
 
 **Gas costs (similar to EIP-2930):**
 
@@ -736,7 +736,6 @@ const tx = {
   data: isAuthorizedCalldata,
   accessList: [],
   tempoStateDeclaration: {
-    tempoBlockNumber: currentTempoBlock,
     accountStates: [{
       account: tempoPolicyContractAddress,
       storageEntries: [

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -786,16 +786,8 @@ bytes32 recipientSetSlot = keccak256(abi.encode(to, innerSlotFrom));
   - `1` (true) if WHITELIST policy (assume recipient is whitelisted)
   - `0` (false) if BLACKLIST policy (assume recipient is not blacklisted)
 
-**Benefits:**
-- ✅ Wallets can sign normal Ethereum transactions without modifications
-- ✅ No need for wallet support for transaction type `0x7A`
-- ✅ No need for `eth_getTempoStateDeclaration` RPC call
-- ✅ Transactions are automatically valid for authorized users
-- ✅ Invalid assumptions simply make the transaction invalid (no security risk)
-
 **Special cases:**
 - Policy ID 0 (always-reject) and 1 (always-allow) don't need state declarations (hardcoded behavior)
-- For policy ID ≥ 2, the sequencer reads Tempo state to infer the declarations
 
 #### TIP-403 registry
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -653,6 +653,100 @@ The TempoState stores the Tempo wrapper fields and the inner fields needed by th
 
 Tempo state staleness depends on how frequently the sequencer calls `finalizeTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed during the batch.
 
+#### Tempo state declarations (transaction type `0x7A`)
+
+Zone transactions that read Tempo state must include a **Tempo state declaration**—an extension of EIP-2930 access lists that includes the actual values. This enables the sequencer to validate transactions without blocking on Tempo state fetches.
+
+**Format (analogous to EIP-2930):**
+
+| EIP-2930 Access List | Tempo State Declaration |
+|---------------------|-------------------------|
+| `[[address, [slot, ...]], ...]` | `[[address, [[slot, value], ...]], ...]` |
+
+```solidity
+/// @notice A single storage slot and its declared value
+struct TempoStorageEntry {
+    bytes32 slot;   // Storage slot key
+    bytes32 value;  // Declared value at this slot
+}
+
+/// @notice Tempo state for a single account (contract)
+struct TempoAccountState {
+    address account;                    // Tempo contract address
+    TempoStorageEntry[] storageEntries; // Declared storage slots and values
+}
+
+/// @notice Complete Tempo state declaration for a transaction
+struct TempoStateDeclaration {
+    uint64 tempoBlockNumber;            // Tempo block this declaration is valid for
+    TempoAccountState[] accountStates;  // Declared state per account
+}
+```
+
+**Transaction type:** `0x7A` ('z' for zone)
+
+Transactions using Tempo state declarations use a new transaction type. The format extends EIP-1559 (type 2) transactions:
+
+```
+0x7A || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, tempoStateDeclaration, signatureYParity, signatureR, signatureS])
+```
+
+Where `tempoStateDeclaration` is:
+
+```
+[[tempoBlockNumber], [[account1, [[slot1, value1], [slot2, value2], ...]], [account2, [[slot1, value1], ...]], ...]]
+```
+
+**Validation rules:**
+
+1. `tempoBlockNumber` must match the zone's current finalized Tempo block (from `TempoState.tempoBlockNumber()`)
+2. All declared values must match actual Tempo state at that block
+3. Execution must not read any Tempo state not covered by the declaration
+4. Transactions that fail any check are **invalid** and cannot be included in a block (the zone block itself becomes invalid)
+
+**Gas costs (similar to EIP-2930):**
+
+| Operation | Gas Cost |
+|-----------|----------|
+| Declare account | 2,400 |
+| Declare storage slot | 1,900 |
+| Read declared slot during execution | 100 (warm read) |
+
+**Benefits:**
+
+- **Non-blocking mempool**: The sequencer can validate and order transactions without fetching Tempo state synchronously
+- **User responsibility**: Wallets/dapps fetch and declare state, shifting work off the critical path
+- **Early rejection**: Invalid declarations are rejected before execution, saving gas
+- **Proof efficiency**: The batch proof only needs to verify the declared state matches Tempo, not trace all storage accesses
+
+**Example usage:**
+
+A transaction calling `TIP403Registry.isAuthorized()` (which reads Tempo state internally) must declare the policy storage slots it will access:
+
+```javascript
+const tx = {
+  type: 0x7a,
+  chainId: zoneChainId,
+  nonce: 0,
+  maxPriorityFeePerGas: 0,
+  maxFeePerGas: 1000000000,
+  gasLimit: 100000,
+  to: tip403RegistryAddress,
+  value: 0,
+  data: isAuthorizedCalldata,
+  accessList: [],
+  tempoStateDeclaration: {
+    tempoBlockNumber: currentTempoBlock,
+    accountStates: [{
+      account: tempoPolicyContractAddress,
+      storageEntries: [
+        { slot: policySlot, value: policyValue }
+      ]
+    }]
+  }
+};
+```
+
 #### TIP-403 registry
 
 The zone has a `TIP403Registry` contract deployed at the **same address** as Tempo. This contract is read-only—it does not support writing policies. Its `isAuthorized` function reads policy state from Tempo via the Tempo state reader precompile, so zone-side TIP-20 transfers enforce Tempo TIP-403 policies automatically.

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -712,40 +712,6 @@ By not including a block number in the declaration, transactions remain valid as
 | Declare storage slot | 1,900 |
 | Read declared slot during execution | 100 (warm read) |
 
-**Benefits:**
-
-- **Non-blocking mempool**: The sequencer can validate and order transactions without fetching Tempo state synchronously
-- **User responsibility**: Wallets/dapps fetch and declare state, shifting work off the critical path
-- **Early rejection**: Invalid declarations are rejected before execution, saving gas
-- **Proof efficiency**: The batch proof only needs to verify the declared state matches Tempo, not trace all storage accesses
-
-**Example usage:**
-
-A transaction calling `TIP403Registry.isAuthorized()` (which reads Tempo state internally) must declare the policy storage slots it will access:
-
-```javascript
-const tx = {
-  type: 0x7a,
-  chainId: zoneChainId,
-  nonce: 0,
-  maxPriorityFeePerGas: 0,
-  maxFeePerGas: 1000000000,
-  gasLimit: 100000,
-  to: tip403RegistryAddress,
-  value: 0,
-  data: isAuthorizedCalldata,
-  accessList: [],
-  tempoStateDeclaration: {
-    accountStates: [{
-      account: tempoPolicyContractAddress,
-      storageEntries: [
-        { slot: policySlot, value: policyValue }
-      ]
-    }]
-  }
-};
-```
-
 #### TIP-403 registry
 
 The zone has a `TIP403Registry` contract deployed at the **same address** as Tempo. This contract is read-only—it does not support writing policies. Its `isAuthorized` function reads policy state from Tempo via the Tempo state reader precompile, so zone-side TIP-20 transfers enforce Tempo TIP-403 policies automatically.

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -712,9 +712,95 @@ By not including a block number in the declaration, transactions remain valid as
 | Declare storage slot | 1,900 |
 | Read declared slot during execution | 100 (warm read) |
 
+**Transaction signing workflow:**
+
+Transactions that read Tempo state require coordination between the user's wallet and the sequencer:
+
+1. **User intent**: User initiates a transaction (e.g., a TIP-20 transfer that requires policy checks)
+2. **Create unsigned transaction**: Wallet creates the transaction without the `tempoStateDeclaration` field
+3. **Get declaration from sequencer**: Wallet calls `eth_getTempoStateDeclaration(tx)` on the sequencer's RPC. The sequencer simulates the transaction, traces all Tempo state reads, fetches the current values, and returns the required declaration.
+4. **Sign transaction**: Wallet adds the declaration to the transaction and prompts user to sign (tx type `0x7A`)
+5. **Send transaction**: Wallet submits the signed transaction to the sequencer
+
+```
+┌─────────┐                    ┌────────────┐                    ┌─────────┐
+│  User   │                    │   Wallet   │                    │Sequencer│
+└────┬────┘                    └─────┬──────┘                    └────┬────┘
+     │  Initiate transfer           │                                 │
+     │─────────────────────────────>│                                 │
+     │                              │                                 │
+     │                              │  eth_getTempoStateDeclaration   │
+     │                              │────────────────────────────────>│
+     │                              │                                 │
+     │                              │  TempoStateDeclaration          │
+     │                              │<────────────────────────────────│
+     │                              │                                 │
+     │  Sign tx (type 0x7A)?        │                                 │
+     │<─────────────────────────────│                                 │
+     │                              │                                 │
+     │  Signature                   │                                 │
+     │─────────────────────────────>│                                 │
+     │                              │                                 │
+     │                              │  eth_sendRawTransaction         │
+     │                              │────────────────────────────────>│
+     │                              │                                 │
+```
+
+If Tempo state changes between steps 3 and 5, the sequencer will reject the transaction as invalid (declared values don't match). The wallet can retry from step 3.
+
 #### TIP-403 registry
 
-The zone has a `TIP403Registry` contract deployed at the **same address** as Tempo. This contract is read-only—it does not support writing policies. Its `isAuthorized` function reads policy state from Tempo via the Tempo state reader precompile, so zone-side TIP-20 transfers enforce Tempo TIP-403 policies automatically.
+The zone has a `ZoneTIP403Registry` contract deployed at the **same address** as Tempo's `TIP403Registry`. This contract is read-only—it does not support writing policies. Its `isAuthorized` function reads policy state from Tempo via the `TempoState` precompile, so zone-side TIP-20 transfers enforce Tempo TIP-403 policies automatically.
+
+```solidity
+/// @title ZoneTIP403Registry
+/// @notice Read-only TIP-403 policy registry for zones
+/// @dev Deployed at the SAME ADDRESS as Tempo's TIP403Registry.
+///      Transactions calling this contract MUST use tx type 0x7A with
+///      a TempoStateDeclaration that declares the required policy slots.
+contract ZoneTIP403Registry {
+    address public constant TEMPO_STATE = 0x1c00000000000000000000000000000000000000;
+    address public immutable TEMPO_REGISTRY; // = address(this)
+
+    /// @notice Checks if a user is authorized under a policy on Tempo
+    /// @dev Reads _policyData[policyId] and policySet[policyId][user] from Tempo
+    function isAuthorized(uint64 policyId, address user) public view returns (bool) {
+        // Special policies: 0 = always-reject, 1 = always-allow
+        if (policyId < 2) return policyId == 1;
+
+        // Read policy type from Tempo
+        (PolicyType policyType, ) = policyData(policyId);
+
+        // Read whether user is in the policy set from Tempo
+        bool inPolicySet = _isInPolicySet(policyId, user);
+
+        // Whitelist: authorized if in set; Blacklist: authorized if NOT in set
+        return policyType == PolicyType.WHITELIST ? inPolicySet : !inPolicySet;
+    }
+
+    function _readTempoSlot(bytes32 slot) internal view returns (bytes32) {
+        // Calls TempoState.readTempoStorageSlot(TEMPO_REGISTRY, slot)
+        // Reverts if slot not in transaction's TempoStateDeclaration
+    }
+
+    // Write functions revert: "read-only on zones, manage policies on Tempo"
+}
+```
+
+**Storage slot calculation for declarations:**
+
+When calling `isAuthorized(policyId, user)`, the transaction must declare these Tempo storage slots:
+
+```solidity
+// 1. Policy data: _policyData[policyId]
+bytes32 policyDataSlot = keccak256(abi.encode(policyId, uint256(1)));
+
+// 2. Policy set membership: policySet[policyId][user]
+bytes32 innerSlot = keccak256(abi.encode(policyId, uint256(2)));
+bytes32 policySetSlot = keccak256(abi.encode(user, innerSlot));
+```
+
+The sequencer's `eth_getTempoStateDeclaration` RPC handles this automatically.
 
 #### Zone inbox
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -748,6 +748,55 @@ Transactions that read Tempo state require coordination between the user's walle
 
 If Tempo state changes between steps 3 and 5, the sequencer will reject the transaction as invalid (declared values don't match). The wallet can retry from step 3.
 
+**TIP-20 transfer inference (simplified workflow):**
+
+For TIP-20 `transfer` and `transferFrom` transactions, the sequencer can **automatically infer** the required state declarations, allowing wallets to sign regular Ethereum/Tempo transactions (type 0 or 2) without explicit state declarations:
+
+1. **Detect TIP-20 transfer**: Sequencer identifies `transfer(to, amount)` or `transferFrom(from, to, amount)` calls to TIP-20 contracts
+2. **Read token policy**: Sequencer reads the token's `transferPolicyId` from Tempo L1
+3. **Read policy type**: Sequencer reads the policy data to determine if it's a WHITELIST or BLACKLIST
+4. **Infer authorization assumptions**:
+   - For WHITELIST policies: Assume both `from` and `to` are IN the policy set (whitelisted)
+   - For BLACKLIST policies: Assume both `from` and `to` are NOT IN the policy set (not blacklisted)
+5. **Add inferred declarations**: Sequencer adds the required Tempo state slots with the assumed values to the transaction's state declaration
+6. **Validate execution**: Transaction executes. If assumptions are wrong, transaction is invalid (which is acceptable—it wouldn't have succeeded anyway)
+
+**Required state declarations for inferred transfers:**
+
+For a transfer from address `from` to address `to` on token with `transferPolicyId`:
+
+```solidity
+// 1. Policy data: _policyData[transferPolicyId]
+bytes32 policyDataSlot = keccak256(abi.encode(transferPolicyId, uint256(1)));
+
+// 2. Policy set for sender: policySet[transferPolicyId][from]
+bytes32 innerSlotFrom = keccak256(abi.encode(transferPolicyId, uint256(2)));
+bytes32 senderSetSlot = keccak256(abi.encode(from, innerSlotFrom));
+
+// 3. Policy set for recipient: policySet[transferPolicyId][to]
+bytes32 recipientSetSlot = keccak256(abi.encode(to, innerSlotFrom));
+```
+
+**Values to declare:**
+- `policyDataSlot`: The policy data (contains type: WHITELIST or BLACKLIST)
+- `senderSetSlot`:
+  - `1` (true) if WHITELIST policy (assume sender is whitelisted)
+  - `0` (false) if BLACKLIST policy (assume sender is not blacklisted)
+- `recipientSetSlot`:
+  - `1` (true) if WHITELIST policy (assume recipient is whitelisted)
+  - `0` (false) if BLACKLIST policy (assume recipient is not blacklisted)
+
+**Benefits:**
+- ✅ Wallets can sign normal Ethereum transactions without modifications
+- ✅ No need for wallet support for transaction type `0x7A`
+- ✅ No need for `eth_getTempoStateDeclaration` RPC call
+- ✅ Transactions are automatically valid for authorized users
+- ✅ Invalid assumptions simply make the transaction invalid (no security risk)
+
+**Special cases:**
+- Policy ID 0 (always-reject) and 1 (always-allow) don't need state declarations (hardcoded behavior)
+- For policy ID ≥ 2, the sequencer reads Tempo state to infer the declarations
+
 #### TIP-403 registry
 
 The zone has a `ZoneTIP403Registry` contract deployed at the **same address** as Tempo's `TIP403Registry`. This contract is read-only—it does not support writing policies. Its `isAuthorized` function reads policy state from Tempo via the `TempoState` precompile, so zone-side TIP-20 transfers enforce Tempo TIP-403 policies automatically.

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -284,15 +284,18 @@ struct TempoAccountState {
 /// @notice Complete Tempo state declaration for a transaction
 /// @dev A transaction includes this to declare all Tempo state it will access.
 ///      The zone node validates that:
-///      1. All declared values match the actual Tempo state at the reference block
+///      1. All declared values match the current Tempo state (at the zone's finalized block)
 ///      2. All Tempo state reads during execution are covered by the declaration
 ///      Transactions that fail either check are invalid.
+///
+///      By not including a block number, transactions remain valid as long as the
+///      declared values match current state - they only become invalid when the
+///      actual Tempo state changes, not just because a new block was finalized.
 ///
 ///      Format mirrors EIP-2930 access lists:
 ///      - EIP-2930: [[address, [slot, ...]], ...]
 ///      - This:     [[address, [[slot, value], ...]], ...]
 struct TempoStateDeclaration {
-    uint64 tempoBlockNumber;            // Tempo block this declaration is valid for
     TempoAccountState[] accountStates;  // Declared state per account
 }
 

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -262,6 +262,49 @@ struct LastBatch {
     uint64 withdrawalBatchIndex;
 }
 
+/*//////////////////////////////////////////////////////////////
+                    TEMPO STATE DECLARATIONS
+//////////////////////////////////////////////////////////////*/
+
+/// @notice A single storage slot and its declared value
+/// @dev Analogous to a storage key in EIP-2930, but includes the value.
+///      Used in Tempo state declarations for zone transactions.
+struct TempoStorageEntry {
+    bytes32 slot;   // Storage slot key
+    bytes32 value;  // Declared value at this slot
+}
+
+/// @notice Tempo state for a single account (contract)
+/// @dev Analogous to AccessListEntry in EIP-2930
+struct TempoAccountState {
+    address account;                    // Tempo contract address
+    TempoStorageEntry[] storageEntries; // Declared storage slots and values
+}
+
+/// @notice Complete Tempo state declaration for a transaction
+/// @dev A transaction includes this to declare all Tempo state it will access.
+///      The zone node validates that:
+///      1. All declared values match the actual Tempo state at the reference block
+///      2. All Tempo state reads during execution are covered by the declaration
+///      Transactions that fail either check are invalid.
+///
+///      Format mirrors EIP-2930 access lists:
+///      - EIP-2930: [[address, [slot, ...]], ...]
+///      - This:     [[address, [[slot, value], ...]], ...]
+struct TempoStateDeclaration {
+    uint64 tempoBlockNumber;            // Tempo block this declaration is valid for
+    TempoAccountState[] accountStates;  // Declared state per account
+}
+
+/// @notice Transaction type for zone transactions with Tempo state declarations
+/// @dev 'z' for zone - extends EIP-1559 with tempoStateDeclaration field
+uint8 constant ZONE_TX_TYPE_TEMPO_STATE = 0x7A;
+
+/// @notice Gas costs for Tempo state declarations (analogous to EIP-2930 costs)
+uint64 constant TEMPO_DECLARATION_ACCOUNT_COST = 2400;  // Per declared account
+uint64 constant TEMPO_DECLARATION_SLOT_COST = 1900;     // Per declared slot
+uint64 constant TEMPO_DECLARED_SLOT_READ_COST = 100;    // Warm read during execution
+
 /// @title ITempoState
 /// @notice Interface for zone-side Tempo state verification predeploy
 /// @dev Deployed at 0x1c00000000000000000000000000000000000000

--- a/docs/specs/src/zone/TempoState.sol
+++ b/docs/specs/src/zone/TempoState.sol
@@ -134,11 +134,21 @@ contract TempoState is ITempoState {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Read a storage slot from a Tempo contract
-    /// @dev In production, this is a precompile that reads from proven Tempo state.
+    /// @dev In production, this is a precompile that reads from the transaction's
+    ///      Tempo state declaration (type 0x7A transactions).
+    ///
+    ///      The precompile:
+    ///      1. Looks up (account, slot) in the transaction's TempoStateDeclaration
+    ///      2. If found, returns the declared value (already validated at tx submission)
+    ///      3. If not found, the transaction is INVALID (block cannot include it)
+    ///
+    ///      This enables the sequencer to validate transactions without blocking
+    ///      on Tempo state fetches - users declare state upfront, sequencer verifies.
+    ///
     ///      This stub reverts - actual implementation is in the zone node.
     /// @param account The Tempo contract address
     /// @param slot The storage slot to read
-    /// @return value The storage value (stub always reverts)
+    /// @return value The storage value from the declaration (stub always reverts)
     function readTempoStorageSlot(address account, bytes32 slot) external view returns (bytes32) {
         // Silence unused variable warnings
         account; slot;
@@ -146,11 +156,14 @@ contract TempoState is ITempoState {
     }
 
     /// @notice Read multiple storage slots from a Tempo contract
-    /// @dev In production, this is a precompile that reads from proven Tempo state.
+    /// @dev In production, this is a precompile that reads from the transaction's
+    ///      Tempo state declaration (type 0x7A transactions).
+    ///
+    ///      See readTempoStorageSlot for details on how declarations work.
     ///      This stub reverts - actual implementation is in the zone node.
     /// @param account The Tempo contract address
     /// @param slots The storage slots to read
-    /// @return values The storage values (stub always reverts)
+    /// @return values The storage values from the declaration (stub always reverts)
     function readTempoStorageSlots(address account, bytes32[] calldata slots) external view returns (bytes32[] memory) {
         // Silence unused variable warnings
         account; slots;

--- a/docs/specs/src/zone/ZoneTIP403Registry.sol
+++ b/docs/specs/src/zone/ZoneTIP403Registry.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { ITIP403Registry } from "../interfaces/ITIP403Registry.sol";
+
+/// @title ZoneTIP403Registry
+/// @notice Read-only TIP-403 policy registry for zones that reads state from Tempo
+/// @dev This contract is deployed at the SAME ADDRESS as the Tempo TIP403Registry.
+///      It provides read-only access to Tempo's policy state via the TempoState precompile.
+///      Zone-side TIP-20 contracts call isAuthorized() to enforce Tempo TIP-403 policies.
+///
+///      IMPORTANT: Transactions calling this contract MUST include a TempoStateDeclaration
+///      (tx type 0x7A) that declares the policy storage slots they will read.
+///      Transactions without proper declarations are invalid.
+///
+///      Storage layout matches Tempo's TIP403Registry:
+///      - slot 0: policyIdCounter (uint64)
+///      - mapping(_policyData): keccak256(policyId, 1) → PolicyData
+///      - mapping(policySet): keccak256(account, keccak256(policyId, 2)) → bool
+contract ZoneTIP403Registry {
+    /// @notice The TempoState predeploy for reading Tempo storage
+    address public constant TEMPO_STATE = 0x1c00000000000000000000000000000000000000;
+
+    /// @notice The address of the TIP403Registry on Tempo (same as this contract's address)
+    /// @dev This contract MUST be deployed at the same address as the Tempo registry
+    address public immutable TEMPO_REGISTRY;
+
+    /// @notice Storage slot constants matching Tempo's TIP403Registry layout
+    uint256 private constant SLOT_POLICY_ID_COUNTER = 0;
+    uint256 private constant SLOT_POLICY_DATA_MAPPING = 1;
+    uint256 private constant SLOT_POLICY_SET_MAPPING = 2;
+
+    /// @notice Policy types (must match Tempo's ITIP403Registry.PolicyType)
+    enum PolicyType {
+        WHITELIST,
+        BLACKLIST
+    }
+
+    error PolicyNotFound();
+
+    constructor() {
+        // This contract must be deployed at the same address as Tempo's TIP403Registry
+        TEMPO_REGISTRY = address(this);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            READ-ONLY QUERIES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Returns the current policy ID counter from Tempo
+    /// @dev Reads slot 0 from Tempo's TIP403Registry
+    function policyIdCounter() public view returns (uint64) {
+        bytes32 value = _readTempoSlot(bytes32(SLOT_POLICY_ID_COUNTER));
+        return uint64(uint256(value));
+    }
+
+    /// @notice Returns whether a policy exists on Tempo
+    /// @param policyId The ID of the policy to check
+    /// @return True if the policy exists, false otherwise
+    function policyExists(uint64 policyId) public view returns (bool) {
+        // Special policies 0 and 1 always exist
+        if (policyId < 2) {
+            return true;
+        }
+        // Check if policy ID is within the range of created policies
+        return policyId < policyIdCounter();
+    }
+
+    /// @notice Checks if a user is authorized under a specific policy on Tempo
+    /// @dev This is the main entry point for zone TIP-20 contracts to enforce policies.
+    ///      The calling transaction MUST declare the required Tempo storage slots.
+    /// @param policyId The ID of the policy to check against
+    /// @param user The address to check authorization for
+    /// @return True if the user is authorized, false otherwise
+    function isAuthorized(uint64 policyId, address user) public view returns (bool) {
+        // Special case for the "always-allow" and "always-reject" policies
+        if (policyId < 2) {
+            // policyId == 0 is the "always-reject" policy
+            // policyId == 1 is the "always-allow" policy
+            return policyId == 1;
+        }
+
+        // Read policy data from Tempo
+        (PolicyType policyType, ) = policyData(policyId);
+
+        // Read whether user is in the policy set
+        bool inPolicySet = _isInPolicySet(policyId, user);
+
+        // For whitelist: authorized if in set
+        // For blacklist: authorized if NOT in set
+        return policyType == PolicyType.WHITELIST ? inPolicySet : !inPolicySet;
+    }
+
+    /// @notice Returns the policy data for a given policy ID from Tempo
+    /// @param policyId The ID of the policy to query
+    /// @return policyType The type of the policy (whitelist or blacklist)
+    /// @return admin The admin address of the policy
+    function policyData(uint64 policyId)
+        public
+        view
+        returns (PolicyType policyType, address admin)
+    {
+        if (!policyExists(policyId)) revert PolicyNotFound();
+
+        // Calculate storage slot for _policyData[policyId]
+        // mapping slot = keccak256(key, baseSlot)
+        bytes32 slot = keccak256(abi.encode(policyId, SLOT_POLICY_DATA_MAPPING));
+        bytes32 value = _readTempoSlot(slot);
+
+        // PolicyData is packed: policyType (uint8) in low bits, admin (address) in next 160 bits
+        // Solidity packs structs tightly: PolicyType (1 byte) + admin (20 bytes) = 21 bytes in slot
+        policyType = PolicyType(uint8(uint256(value)));
+        admin = address(uint160(uint256(value) >> 8));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            INTERNAL HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Check if an account is in a policy's set on Tempo
+    /// @dev Reads from the policySet mapping: policySet[policyId][account]
+    function _isInPolicySet(uint64 policyId, address account) internal view returns (bool) {
+        // Calculate storage slot for policySet[policyId][account]
+        // Nested mapping: keccak256(innerKey, keccak256(outerKey, baseSlot))
+        bytes32 innerSlot = keccak256(abi.encode(policyId, SLOT_POLICY_SET_MAPPING));
+        bytes32 slot = keccak256(abi.encode(account, innerSlot));
+        bytes32 value = _readTempoSlot(slot);
+        return value != bytes32(0);
+    }
+
+    /// @notice Read a storage slot from Tempo via the TempoState precompile
+    /// @dev This call will revert if the slot was not declared in the transaction's
+    ///      TempoStateDeclaration, making the transaction invalid.
+    function _readTempoSlot(bytes32 slot) internal view returns (bytes32) {
+        // Call TempoState.readTempoStorageSlot(TEMPO_REGISTRY, slot)
+        (bool success, bytes memory result) = TEMPO_STATE.staticcall(
+            abi.encodeWithSignature(
+                "readTempoStorageSlot(address,bytes32)",
+                TEMPO_REGISTRY,
+                slot
+            )
+        );
+        require(success, "Tempo state read failed");
+        return abi.decode(result, (bytes32));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        WRITE FUNCTIONS (DISABLED)
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Write functions are disabled on zones - policies are managed on Tempo
+    function createPolicy(address, PolicyType) external pure returns (uint64) {
+        revert("ZoneTIP403Registry: read-only on zones, manage policies on Tempo");
+    }
+
+    function createPolicyWithAccounts(address, PolicyType, address[] calldata)
+        external
+        pure
+        returns (uint64)
+    {
+        revert("ZoneTIP403Registry: read-only on zones, manage policies on Tempo");
+    }
+
+    function setPolicyAdmin(uint64, address) external pure {
+        revert("ZoneTIP403Registry: read-only on zones, manage policies on Tempo");
+    }
+
+    function modifyPolicyWhitelist(uint64, address, bool) external pure {
+        revert("ZoneTIP403Registry: read-only on zones, manage policies on Tempo");
+    }
+
+    function modifyPolicyBlacklist(uint64, address, bool) external pure {
+        revert("ZoneTIP403Registry: read-only on zones, manage policies on Tempo");
+    }
+}


### PR DESCRIPTION
Specify how L1 state reads can work via L1 state declarations. In this version, all transactions have to declare all L1 state they read (keys and values), and fail if the declaration is incomplete or wrong. This means:
1. Transactions cannot initiate unexpected L1 storage reads. This ensures that the sequencer can request all declared state from an RPC at the start of block building and is not dependent on RPC latency during block building
2. L2 state can be reconstructed from history without having to run L1 state in parallel or needing low latency access to an archive node.

The downsides of this design are:
1. It isn't generally possible to sign transactions without access to a zone RPC
   - can be mitigated by predicting TIP-403 access patterns, which is the most common case, and assuming that the account is not blacklisted
2. Wallets need to implement this new transaction type in order to be able to use tempo zones
   - We could special case this by allowing inference of the TIP-403 generated state access pattern allowing TIP-20 transfers without the state declaration