### PR TITLE
feat(zone): add encrypted deposits for privacy

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1034,6 +1034,59 @@ Notes:
 - Tempo state advancement is combined with deposit processing in `ZoneInbox.advanceTempo()`, which calls `TempoState.finalizeTempo()` internally.
 - The proof validates an exact match to `currentDepositQueueHash` from Tempo state, ensuring it cannot claim to process fake deposits. TODO: implement a recursive ancestor check in the proof or on-chain as a fallback.
 
+### Encrypted deposits
+
+For privacy-sensitive use cases, users can make **encrypted deposits** where the recipient and memo are encrypted using the sequencer's public key. Only the sequencer can decrypt and credit the correct recipient on the zone.
+
+**Encryption scheme**: ECIES with secp256k1
+
+1. Sequencer publishes a secp256k1 encryption public key via `setSequencerEncryptionKey(x, yParity)`
+2. User generates an ephemeral keypair and derives a shared secret via ECDH
+3. User encrypts `(to || memo)` with AES-256-GCM using the derived key
+4. User calls `depositEncrypted(amount, encryptedPayload)` on the portal
+
+```solidity
+/// @notice Encrypted deposit payload
+struct EncryptedDepositPayload {
+    bytes32 ephemeralPubkeyX;     // Ephemeral public key X coordinate (for ECDH)
+    uint8 ephemeralPubkeyYParity; // Y coordinate parity (0x02 or 0x03)
+    bytes ciphertext;             // AES-256-GCM encrypted (to || memo || padding)
+    bytes12 nonce;                // GCM nonce
+    bytes16 tag;                  // GCM authentication tag
+}
+
+/// @notice Encrypted deposit stored in the queue
+struct EncryptedDeposit {
+    address sender;              // Depositor (public, for refunds)
+    uint128 amount;              // Amount (public, for accounting)
+    EncryptedDepositPayload encrypted; // Encrypted (to, memo)
+}
+```
+
+**What's public vs. private:**
+
+| Field | Visibility | Reason |
+|-------|------------|--------|
+| `sender` | Public | Needed for potential refunds if decryption fails |
+| `amount` | Public | Needed for on-chain accounting/escrow |
+| `to` | Encrypted | Privacy - only sequencer knows recipient |
+| `memo` | Encrypted | Privacy - only sequencer knows payment context |
+
+**Processing flow:**
+
+1. User calls `depositEncrypted(amount, encrypted)` on Tempo portal
+2. Portal escrows funds and emits `EncryptedDepositMade` (no recipient revealed)
+3. Sequencer decrypts the payload off-chain using their private key
+4. Sequencer calls `advanceTempoWithEncrypted()` on zone, providing decrypted values
+5. Zone credits the decrypted recipient with the deposited amount
+
+**Security considerations:**
+
+- **Sequencer trust**: Users trust the sequencer to decrypt correctly and credit the right recipient. A malicious sequencer could steal encrypted deposits.
+- **Decryption proof**: For ZK-based verification, the proof must validate that the sequencer's decryption is correct. For TEE-based verification, the TEE performs decryption.
+- **Key rotation**: If the sequencer rotates their encryption key, in-flight encrypted deposits using the old key must still be decryptable (sequencer should retain old keys).
+- **Malformed ciphertext**: If decryption fails, the sequencer may refund to `sender` or hold funds pending resolution.
+
 ## Bridging out (zone to Tempo)
 
 Users withdraw by creating a withdrawal on the zone. Withdrawals are processed in two steps:

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -516,7 +516,6 @@ interface IZonePortal {
     function messenger() external view returns (address);
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);
-    function sequencerPubkey() external view returns (bytes32);
     function zoneGasRate() external view returns (uint128);
     function verifier() external view returns (address);
     function genesisTempoBlockNumber() external view returns (uint64);
@@ -534,9 +533,6 @@ interface IZonePortal {
 
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
     function acceptSequencer() external;
-
-    /// @notice Set the sequencer's public key. Only callable by the sequencer.
-    function setSequencerPubkey(bytes32 pubkey) external;
 
     /// @notice Set zone gas rate. Only callable by sequencer.
     function setZoneGasRate(uint128 _zoneGasRate) external;

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1254,8 +1254,9 @@ bytes32 aesKey = _hkdfSha256(
 );
 
 // Step 4: Verify decrypted plaintext matches claimed (to, memo)
+// Plaintext is packed as [address(20 bytes)][memo(32 bytes)][padding(12 bytes)]
 if (valid && decryptedPlaintext.length >= 52) {
-    (address decryptedTo, bytes32 decryptedMemo) = abi.decode(decryptedPlaintext, (address, bytes32));
+    (address decryptedTo, bytes32 decryptedMemo) = EncryptedDepositLib.decodePlaintext(decryptedPlaintext);
     valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);
 } else {
     valid = false;

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1115,9 +1115,10 @@ The zone can verify encrypted deposit decryption on-chain without the sequencer 
 
 ```solidity
 struct DecryptionData {
-    bytes32 sharedSecret;  // ECDH shared secret (sequencerPriv * ephemeralPub)
-    address to;            // Decrypted recipient
-    bytes32 memo;          // Decrypted memo
+    bytes32 sharedSecret;       // ECDH shared secret (sequencerPriv * ephemeralPub)
+    address to;                 // Decrypted recipient
+    bytes32 memo;               // Decrypted memo
+    ChaumPedersenProof cpProof; // Proof of correct shared secret derivation
 }
 ```
 
@@ -1140,25 +1141,28 @@ The sequencer provides a Chaum-Pedersen proof that proves: "I know `privSeq` suc
 This proof allows on-chain verification without revealing the private key:
 
 ```solidity
-// Step 1: Verify Chaum-Pedersen proof of correct shared secret derivation
+// Step 1: Look up sequencer's public key from on-chain key history
+(bytes32 seqPubX, uint8 seqPubYParity) = _readEncryptionKey(ed.keyIndex);
+
+// Step 2: Verify Chaum-Pedersen proof of correct shared secret derivation
 bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
     ed.encrypted.ephemeralPubX,
     ed.encrypted.ephemeralPubYParity,
     dec.sharedSecret,
-    dec.sequencerPubX,
-    dec.sequencerPubYParity,
+    seqPubX,          // looked up on-chain, not from dec
+    seqPubYParity,    // looked up on-chain, not from dec
     dec.cpProof
 );
 if (!proofValid) revert InvalidSharedSecretProof();
 
-// Step 2: Derive AES key using HKDF-SHA256 (in Solidity)
+// Step 3: Derive AES key using HKDF-SHA256 (in Solidity)
 // Note: Encryption key validity is already validated on Tempo side in ZonePortal.depositEncrypted()
 bytes32 aesKey = _hkdfSha256(dec.sharedSecret, "ecies-aes-key", "");
 
-// Step 3: Try to decrypt using AES-GCM precompile
+// Step 4: Try to decrypt using AES-GCM precompile
 (bytes memory plaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(...);
 
-// Step 4: If decryption fails, return funds to sender (don't block chain)
+// Step 5: If decryption fails, return funds to sender (don't block chain)
 if (!valid) {
     gasToken.mint(ed.sender, ed.amount);
     emit EncryptedDepositFailed(...);
@@ -1226,25 +1230,28 @@ interface IAesGcmDecrypt {
 Usage in `ZoneInbox.advanceTempo()`:
 
 ```solidity
-// Step 1: Verify Chaum-Pedersen proof of correct shared secret derivation
+// Step 1: Look up sequencer's public key from on-chain key history
+(bytes32 seqPubX, uint8 seqPubYParity) = _readEncryptionKey(ed.keyIndex);
+
+// Step 2: Verify Chaum-Pedersen proof of correct shared secret derivation
 bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
     ed.encrypted.ephemeralPubX,
     ed.encrypted.ephemeralPubYParity,
     dec.sharedSecret,
-    dec.sequencerPubX,
-    dec.sequencerPubYParity,
+    seqPubX,          // looked up on-chain, not from dec
+    seqPubYParity,    // looked up on-chain, not from dec
     dec.cpProof
 );
 if (!proofValid) revert InvalidSharedSecretProof();
 
-// Step 2: Derive AES key from shared secret using HKDF-SHA256 (in Solidity)
+// Step 3: Derive AES key from shared secret using HKDF-SHA256 (in Solidity)
 bytes32 aesKey = _hkdfSha256(
     dec.sharedSecret,
     "ecies-aes-key",  // salt
     ""                // info (empty)
 );
 
-// Step 3: Decrypt using AES-256-GCM precompile
+// Step 4: Decrypt using AES-256-GCM precompile
 (bytes memory decryptedPlaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(
     aesKey,
     ed.encrypted.nonce,
@@ -1253,7 +1260,7 @@ bytes32 aesKey = _hkdfSha256(
     ed.encrypted.tag
 );
 
-// Step 4: Verify decrypted plaintext matches claimed (to, memo)
+// Step 5: Verify decrypted plaintext matches claimed (to, memo)
 // Plaintext is packed as [address(20 bytes)][memo(32 bytes)][padding(12 bytes)]
 if (valid && decryptedPlaintext.length >= 52) {
     (address decryptedTo, bytes32 decryptedMemo) = EncryptedDepositLib.decodePlaintext(decryptedPlaintext);
@@ -1262,7 +1269,7 @@ if (valid && decryptedPlaintext.length >= 52) {
     valid = false;
 }
 
-// Step 5: Handle success or failure
+// Step 6: Handle success or failure
 if (!valid) {
     // Decryption failed - return funds to sender
     gasToken.mint(ed.sender, ed.amount);

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1100,9 +1100,73 @@ This ensures deposits are processed in the exact order they were made, regardles
 **Security considerations:**
 
 - **Sequencer trust**: Users trust the sequencer to decrypt correctly and credit the right recipient. A malicious sequencer could steal encrypted deposits.
-- **Decryption proof**: For ZK-based verification, the proof must validate that the sequencer's decryption is correct. For TEE-based verification, the TEE performs decryption.
+- **On-chain verification**: The sequencer provides the ECDH shared secret, which enables on-chain decryption verification via GCM tag validation without revealing the private key. See "On-chain decryption verification" below.
 - **Key rotation**: The portal maintains a history of encryption keys. Each encrypted deposit includes the `keyIndex` the user encrypted to, allowing the prover to look up the correct key for decryption. See "Encryption key history" below.
 - **Malformed ciphertext**: If decryption fails, the sequencer may refund to `sender` or hold funds pending resolution.
+
+**On-chain decryption verification:**
+
+The zone can verify encrypted deposit decryption on-chain without the sequencer revealing their private key. The sequencer provides the ECDH shared secret alongside the decrypted data:
+
+```solidity
+struct DecryptionData {
+    bytes32 sharedSecret;  // ECDH shared secret (sequencerPriv * ephemeralPub)
+    address to;            // Decrypted recipient
+    bytes32 memo;          // Decrypted memo
+}
+```
+
+Verification works by leveraging the AES-GCM authentication tag:
+
+1. Sequencer computes: `sharedSecret = ECDH(sequencerPriv, ephemeralPub)`
+2. On-chain, derive AES key from `sharedSecret` using HKDF-SHA256
+3. Attempt to decrypt the ciphertext with AES-256-GCM
+4. **The GCM tag will only validate if the shared secret is correct**
+5. If tag validates, the decrypted `(to, memo)` are cryptographically proven authentic
+
+This is implemented via the ECIES verification precompile at `0x1c00000000000000000000000000000000000100`:
+
+```solidity
+interface IEciesVerify {
+    /// @notice Verify that sharedSecret correctly decrypts the encrypted payload to plaintext
+    /// @dev Uses HKDF-SHA256 to derive AES key from sharedSecret, then verifies GCM tag.
+    ///      The GCM tag proves the shared secret is correct without revealing private keys.
+    /// @param sharedSecret The ECDH shared secret (sequencerPriv * ephemeralPub)
+    /// @param encrypted The encrypted payload (ephemeralPub, ciphertext, nonce, tag)
+    /// @param plaintext The claimed decrypted data to verify
+    /// @return valid True if the shared secret correctly decrypts to the plaintext
+    function verifyDecryption(
+        bytes32 sharedSecret,
+        EncryptedDepositPayload calldata encrypted,
+        bytes calldata plaintext
+    ) external view returns (bool valid);
+}
+```
+
+Usage in `ZoneInbox.advanceTempo()`:
+
+```solidity
+// Verify decryption on-chain using ECIES precompile
+bytes memory plaintext = abi.encode(dec.to, dec.memo);
+bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(
+    dec.sharedSecret,
+    ed.encrypted,
+    plaintext
+);
+if (!valid) revert InvalidDecryption();
+```
+
+**Key properties:**
+- **No private key exposure**: Sequencer only reveals the shared secret, not their private key
+- **Cryptographic proof**: GCM tag validation proves decryption correctness
+- **On-chain verification**: No reliance on proof/TEE for this specific check
+- **Standard crypto**: Uses well-established ECIES, ECDH, HKDF-SHA256, and AES-256-GCM
+
+**Precompile implementation notes:**
+- Derive AES key: `aesKey = HKDF-SHA256(sharedSecret, salt="ecies-aes-key", info="")`
+- Decrypt: `plaintext = AES-256-GCM-Decrypt(aesKey, nonce, ciphertext, aad="", tag)`
+- Return `true` if tag validates and decryption succeeds, `false` otherwise
+- Gas cost: ~5000 gas for HKDF + ~1000 per 32 bytes of ciphertext for AES-GCM
 
 **Encryption key history:**
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1074,17 +1074,34 @@ struct EncryptedDeposit {
 
 **Processing flow:**
 
-1. User calls `depositEncrypted(amount, encrypted)` on Tempo portal
-2. Portal escrows funds and emits `EncryptedDepositMade` (no recipient revealed)
+1. User calls `depositEncrypted(amount, keyIndex, encrypted)` on Tempo portal
+2. Portal escrows funds, adds to the **unified deposit queue**, and emits `EncryptedDepositMade`
 3. Sequencer decrypts the payload off-chain using their private key
-4. Sequencer calls `advanceTempoWithEncrypted()` on zone, providing decrypted values
-5. Zone credits the decrypted recipient with the deposited amount
+4. When processing the zone block, sequencer calls `advanceTempo()` with deposits from the unified queue
+5. For each encrypted deposit, sequencer provides decrypted `(to, memo)` alongside the encrypted data
+6. Zone/proof validates decryption and credits the recipient
+
+**Unified deposit queue:**
+
+Regular and encrypted deposits share a single ordered queue with a type discriminator in the hash chain:
+
+```solidity
+enum DepositType { Regular, Encrypted }
+
+// Regular deposit hash:
+keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
+
+// Encrypted deposit hash:
+keccak256(abi.encode(DepositType.Encrypted, encryptedDeposit, prevHash))
+```
+
+This ensures deposits are processed in the exact order they were made, regardless of type.
 
 **Security considerations:**
 
 - **Sequencer trust**: Users trust the sequencer to decrypt correctly and credit the right recipient. A malicious sequencer could steal encrypted deposits.
 - **Decryption proof**: For ZK-based verification, the proof must validate that the sequencer's decryption is correct. For TEE-based verification, the TEE performs decryption.
-- **Key rotation**: The portal maintains a history of encryption keys with their activation block numbers. Each encrypted deposit records the `tempoBlockNumber` when it was made, allowing the prover to determine which key was valid at that time. See "Encryption key history" below.
+- **Key rotation**: The portal maintains a history of encryption keys. Each encrypted deposit includes the `keyIndex` the user encrypted to, allowing the prover to look up the correct key for decryption. See "Encryption key history" below.
 - **Malformed ciphertext**: If decryption fails, the sequencer may refund to `sender` or hold funds pending resolution.
 
 **Encryption key history:**

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1041,7 +1041,7 @@ For privacy-sensitive use cases, users can make **encrypted deposits** where the
 
 **Encryption scheme**: ECIES with secp256k1
 
-1. Sequencer publishes a secp256k1 encryption public key via `setSequencerEncryptionKey(x, yParity)`
+1. Sequencer publishes a secp256k1 encryption public key via `setSequencerEncryptionKey(x, yParity, popV, popR, popS)` with a proof of possession
 2. User generates an ephemeral keypair and derives a shared secret via ECDH
 3. User encrypts `(to || memo)` with AES-256-GCM using the derived key
 4. User calls `depositEncrypted(amount, keyIndex, encryptedPayload)` on the portal
@@ -1340,7 +1340,7 @@ function depositEncrypted(
 
 Key management functions:
 
-- `setSequencerEncryptionKey(x, yParity)` - Appends a new key to history, active from current Tempo block
+- `setSequencerEncryptionKey(x, yParity, popV, popR, popS)` - Appends a new key to history, active from current Tempo block. Requires a proof of possession (ECDSA signature over `keccak256(abi.encode(portalAddress, x, yParity))` by the corresponding private key)
 - `encryptionKeyCount()` - Returns total number of keys in history
 - `encryptionKeyAt(index)` - Returns a historical key entry by index
 - `encryptionKeyAtBlock(tempoBlockNumber)` - Returns the key that was active at a specific block

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1121,6 +1121,7 @@ Key management functions:
 - `encryptionKeyCount()` - Returns total number of keys in history
 - `encryptionKeyAt(index)` - Returns a historical key entry by index
 - `encryptionKeyAtBlock(tempoBlockNumber)` - Returns the key that was active at a specific block
+- `isEncryptionKeyValid(keyIndex)` - Check if a key can still be used for new deposits
 
 **Why keyIndex instead of block number:**
 
@@ -1129,10 +1130,33 @@ The user specifies `keyIndex` at signing time (when they know which key they're 
 - The portal can validate that `keyIndex` is a valid historical key
 - The prover looks up `encryptionKeyAt(keyIndex)` to get the decryption key
 
+**Key expiration:**
+
+Old encryption keys expire after a grace period to limit how long the sequencer must retain old private keys:
+
+```solidity
+/// 1 day at 1 second block time = 86400 blocks
+uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
+
+error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
+```
+
+- When a new key is set, the previous key remains valid for `ENCRYPTION_KEY_GRACE_PERIOD` blocks
+- After that, deposits using the old key are rejected with `EncryptionKeyExpired`
+- Users should call `isEncryptionKeyValid(keyIndex)` before signing to check if their key is still valid
+- The current (latest) key never expires
+
+Example timeline:
+1. Block 1000: Key 0 is set (current)
+2. Block 5000: Key 1 is set (current), Key 0 expires at block 5000 + 86400 = 91400
+3. Block 91400: Deposits with Key 0 start being rejected
+4. Sequencer can delete Key 0's private key after block 91400
+
 This allows:
 1. Users to verify they're encrypting to the current key before signing
 2. The prover to determine which key to use for any deposit via explicit `keyIndex`
-3. Seamless key rotation without invalidating in-flight transactions
+3. Seamless key rotation with a grace period for in-flight transactions
+4. Sequencer to safely delete old private keys after expiration
 
 ## Bridging out (zone to Tempo)
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -638,7 +638,7 @@ Zones have four system contract predeploys at fixed addresses:
 
 #### Zone token
 
-The zone's zone token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
+The zone token is the only bridged TIP-20 from Tempo allowed on the zone. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
 
 #### ZoneConfig predeploy
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1152,6 +1152,7 @@ bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
 if (!proofValid) revert InvalidSharedSecretProof();
 
 // Step 2: Derive AES key using HKDF-SHA256 (in Solidity)
+// Note: Encryption key validity is already validated on Tempo side in ZonePortal.depositEncrypted()
 bytes32 aesKey = _hkdfSha256(dec.sharedSecret, "ecies-aes-key", "");
 
 // Step 3: Try to decrypt using AES-GCM precompile

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1151,10 +1151,13 @@ bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
 );
 if (!proofValid) revert InvalidSharedSecretProof();
 
-// Step 2: Try to decrypt
-bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(...);
+// Step 2: Derive AES key using HKDF-SHA256 (in Solidity)
+bytes32 aesKey = _hkdfSha256(dec.sharedSecret, "ecies-aes-key", "");
 
-// Step 3: If decryption fails, return funds to sender (don't block chain)
+// Step 3: Try to decrypt using AES-GCM precompile
+(bytes memory plaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(...);
+
+// Step 4: If decryption fails, return funds to sender (don't block chain)
 if (!valid) {
     gasToken.mint(ed.sender, ed.amount);
     emit EncryptedDepositFailed(...);
@@ -1194,22 +1197,28 @@ interface IChaumPedersenVerify {
 }
 ```
 
-**ECIES verification precompile** (at `0x1c00000000000000000000000000000000000101`):
+**AES-GCM decryption precompile** (at `0x1c00000000000000000000000000000000000101`):
+
+This is a minimal precompile that only performs AES-256-GCM decryption. HKDF-SHA256 key derivation is implemented in Solidity using the existing SHA256 precompile (0x02), making the precompile simpler and more auditable.
 
 ```solidity
-interface IEciesVerify {
-    /// @notice Verify that sharedSecret correctly decrypts the encrypted payload to plaintext
-    /// @dev Uses HKDF-SHA256 to derive AES key from sharedSecret, then verifies GCM tag.
-    ///      The GCM tag proves the shared secret is correct without revealing private keys.
-    /// @param sharedSecret The ECDH shared secret (sequencerPriv * ephemeralPub)
-    /// @param encrypted The encrypted payload (ephemeralPub, ciphertext, nonce, tag)
-    /// @param plaintext The claimed decrypted data to verify
-    /// @return valid True if the shared secret correctly decrypts to the plaintext
-    function verifyDecryption(
-        bytes32 sharedSecret,
-        EncryptedDepositPayload calldata encrypted,
-        bytes calldata plaintext
-    ) external view returns (bool valid);
+interface IAesGcmDecrypt {
+    /// @notice Decrypt AES-256-GCM ciphertext and verify authentication tag
+    /// @dev Returns empty bytes and false if tag verification fails.
+    /// @param key AES-256 key (32 bytes)
+    /// @param nonce GCM nonce (12 bytes)
+    /// @param ciphertext The encrypted data
+    /// @param aad Additional authenticated data (empty for ECIES)
+    /// @param tag GCM authentication tag (16 bytes)
+    /// @return plaintext The decrypted data (empty if verification fails)
+    /// @return valid True if the tag verifies and decryption succeeds
+    function decrypt(
+        bytes32 key,
+        bytes12 nonce,
+        bytes calldata ciphertext,
+        bytes calldata aad,
+        bytes16 tag
+    ) external view returns (bytes memory plaintext, bool valid);
 }
 ```
 
@@ -1227,15 +1236,31 @@ bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
 );
 if (!proofValid) revert InvalidSharedSecretProof();
 
-// Step 2: Verify the decryption using ECIES precompile
-bytes memory plaintext = abi.encode(dec.to, dec.memo);
-bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(
+// Step 2: Derive AES key from shared secret using HKDF-SHA256 (in Solidity)
+bytes32 aesKey = _hkdfSha256(
     dec.sharedSecret,
-    ed.encrypted,
-    plaintext
+    "ecies-aes-key",  // salt
+    ""                // info (empty)
 );
 
-// Step 3: Handle success or failure
+// Step 3: Decrypt using AES-256-GCM precompile
+(bytes memory decryptedPlaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(
+    aesKey,
+    ed.encrypted.nonce,
+    ed.encrypted.ciphertext,
+    "",  // empty AAD
+    ed.encrypted.tag
+);
+
+// Step 4: Verify decrypted plaintext matches claimed (to, memo)
+if (valid && decryptedPlaintext.length >= 52) {
+    (address decryptedTo, bytes32 decryptedMemo) = abi.decode(decryptedPlaintext, (address, bytes32));
+    valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);
+} else {
+    valid = false;
+}
+
+// Step 5: Handle success or failure
 if (!valid) {
     // Decryption failed - return funds to sender
     gasToken.mint(ed.sender, ed.amount);
@@ -1265,11 +1290,20 @@ if (!valid) {
 - Verify: `c == c'`
 - Gas cost: ~8000 gas (2 point multiplications + 2 point additions + hash)
 
-*ECIES Verify (`0x1c00000000000000000000000000000000000101`):*
-- Derive AES key: `aesKey = HKDF-SHA256(sharedSecret, salt="ecies-aes-key", info="")`
-- Decrypt: `plaintext = AES-256-GCM-Decrypt(aesKey, nonce, ciphertext, aad="", tag)`
-- Return `true` if tag validates and decryption succeeds, `false` otherwise
-- Gas cost: ~5000 gas for HKDF + ~1000 per 32 bytes of ciphertext for AES-GCM
+*AES-GCM Decrypt (`0x1c00000000000000000000000000000000000101`):*
+- Input: AES key (32 bytes), nonce (12 bytes), ciphertext, AAD, tag (16 bytes)
+- Decrypt: `plaintext = AES-256-GCM-Decrypt(key, nonce, ciphertext, aad, tag)`
+- Return decrypted plaintext and `true` if tag validates, or empty bytes and `false` otherwise
+- Gas cost: ~1000 gas base + ~500 per 32 bytes of ciphertext
+- Much simpler than full ECIES precompile - only handles symmetric encryption
+
+*HKDF-SHA256 (implemented in Solidity):*
+- Uses existing SHA256 precompile (0x02) to implement HMAC-SHA256 and HKDF
+- HMAC-SHA256: `HMAC(key, msg) = SHA256((key ⊕ opad) || SHA256((key ⊕ ipad) || msg))`
+- HKDF-Extract: `PRK = HMAC-SHA256(salt, IKM)`
+- HKDF-Expand: `OKM = HMAC-SHA256(PRK, info || 0x01)`
+- Gas cost: ~5-10k gas for full HKDF (depends on message sizes, dominated by SHA256 calls)
+- Tradeoff: Higher gas cost than native implementation, but keeps precompile minimal and auditable
 
 **Encryption key history:**
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -636,7 +636,7 @@ Zones have four system contract predeploys at fixed addresses:
 - **ZoneOutbox** (0x1c00000000000000000000000000000000000002) - Handles withdrawal requests back to Tempo
 - **ZoneConfig** (0x1c00000000000000000000000000000000000003) - Central configuration that reads sequencer from L1
 
-#### Zone zone token
+#### Zone token
 
 The zone's zone token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -6,7 +6,7 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 - Create a Tempo-native validium called a zone.
 - Each zone has exactly one permissioned sequencer.
-- Each zone bridges exactly one TIP-20 token, which is also the zone zone token.
+- Each zone bridges exactly one TIP-20 token, which is called its *zone token*. The zone token also serves as the gas token for the chain.
 - Settlement uses fast validity proofs or TEE attestations (ZK or TEE). Data availability is fully trusted to the sequencer.
 - Cross-chain operations are Tempo-centric: bridge in (simple deposit), bridge out (with optional callback to receiver contracts for Tempo composability).
 - Verifier is abstracted behind a minimal `IVerifier` interface.

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -506,7 +506,40 @@ interface IZonePortal {
 
     event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+
+    /// @notice Emitted when an encrypted deposit is made (recipient/memo not revealed)
+    event EncryptedDepositMade(
+        bytes32 indexed newCurrentDepositQueueHash,
+        address indexed sender,
+        uint128 netAmount,
+        uint128 fee,
+        uint256 keyIndex,
+        bytes32 ephemeralPubkeyX,
+        uint8 ephemeralPubkeyYParity,
+        bytes ciphertext,
+        bytes12 nonce,
+        bytes16 tag
+    );
+
+    /// @notice Emitted when sequencer updates their encryption key
+    event SequencerEncryptionKeyUpdated(
+        bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock
+    );
     event ZoneGasRateUpdated(uint128 zoneGasRate);
+
+    error NotSequencer();
+    error NotPendingSequencer();
+    error InvalidProof();
+    error InvalidTempoBlockNumber();
+    error CallbackRejected();
+    error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
+    error InvalidEncryptionKeyIndex(uint256 keyIndex);
+    error NoEncryptionKeySet();
+    error NoEncryptionKeyAtBlock(uint64 blockNumber);
+    error InvalidEphemeralPubkey();
+    error InvalidCiphertextLength(uint256 actual, uint256 expected);
+    error InvalidProofOfPossession();
+    error DepositTooSmall();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas).
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
@@ -541,19 +574,44 @@ interface IZonePortal {
     function calculateDepositFee() external view returns (uint128 fee);
 
     /// @notice Deposit zone token into the zone. Fee is deducted from amount.
-    /// @dev Returns the new current deposit queue hash.
     function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
 
+    /// @notice Deposit with encrypted recipient and memo. Fee is deducted from amount.
+    function depositEncrypted(
+        uint128 amount,
+        uint256 keyIndex,
+        EncryptedDepositPayload calldata encrypted
+    ) external returns (bytes32 newCurrentDepositQueueHash);
+
+    /// @notice Get the current sequencer encryption key.
+    /// @dev Reverts with NoEncryptionKeySet() if no key has been set.
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+
+    /// @notice Set sequencer encryption key with proof of possession.
+    /// @dev Requires ECDSA signature proving control of the corresponding private key.
+    function setSequencerEncryptionKey(
+        bytes32 x, uint8 yParity, uint8 popV, bytes32 popR, bytes32 popS
+    ) external;
+
+    /// @notice Number of encryption keys in history.
+    function encryptionKeyCount() external view returns (uint256);
+
+    /// @notice Get a historical encryption key entry by index.
+    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory);
+
+    /// @notice Get the encryption key active at a specific block.
+    /// @dev Reverts with NoEncryptionKeyAtBlock() if no key was active at that block.
+    function encryptionKeyAtBlock(uint64 tempoBlockNumber)
+        external view returns (bytes32 x, uint8 yParity, uint256 keyIndex);
+
+    /// @notice Check if an encryption key is still valid for new deposits.
+    function isEncryptionKeyValid(uint256 keyIndex)
+        external view returns (bool valid, uint64 expiresAtBlock);
+
     /// @notice Process the next withdrawal from the queue. Only callable by the sequencer.
-    /// @dev Fee is paid to sequencer regardless of success/failure.
-    /// @param withdrawal The withdrawal to process (must be at the head of the current slot).
-    /// @param remainingQueue The hash of the remaining withdrawals in this slot (0 if last).
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
 
     /// @notice Submit a batch and verify the proof. Only callable by the sequencer.
-    /// @dev Verifies prevBlockHash == blockHash, then calls the verifier.
-    ///      On success updates withdrawalBatchIndex, blockHash, lastSyncedTempoBlockNumber,
-    ///      and adds withdrawals to the queue.
     function submitBatch(
         uint64 tempoBlockNumber,
         uint64 recentTempoBlockNumber,
@@ -642,6 +700,9 @@ ZoneConfig is the central zone configuration contract that provides access to zo
 
 ```solidity
 interface IZoneConfig {
+    error NotSequencer();
+    error NoEncryptionKeySet();
+
     /// @notice Zone token address (TIP-20 at same address as Tempo)
     function zoneToken() external view returns (address);
 
@@ -656,6 +717,10 @@ interface IZoneConfig {
 
     /// @notice Get pending sequencer by reading from L1 ZonePortal
     function pendingSequencer() external view returns (address);
+
+    /// @notice Get sequencer's encryption public key by reading from L1 ZonePortal
+    /// @dev Reverts with NoEncryptionKeySet() if no key has been set.
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
 
     /// @notice Check if an address is the current sequencer
     function isSequencer(address account) external view returns (bool);
@@ -750,32 +815,40 @@ interface IZoneInbox {
         bytes32 memo
     );
 
-    event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
-    event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+    /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
+    event EncryptedDepositProcessed(
+        bytes32 indexed depositHash,
+        address indexed sender,
+        address indexed to,
+        uint128 amount,
+        bytes32 memo
+    );
+
+    /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
+    event EncryptedDepositFailed(
+        bytes32 indexed depositHash, address indexed sender, uint128 amount
+    );
+
+    error OnlySequencer();
+    error InvalidDepositQueueHash();
+    error MissingDecryptionData();
+    error ExtraDecryptionData();
+    error InvalidSharedSecretProof();
+
+    /// @notice Zone configuration (reads sequencer from L1)
+    function config() external view returns (IZoneConfig);
 
     /// @notice The Tempo portal address (for reading deposit queue hash).
     function tempoPortal() external view returns (address);
 
     /// @notice The TempoState predeploy address.
-    function tempoState() external view returns (TempoState);
+    function tempoState() external view returns (ITempoState);
 
     /// @notice The zone token (TIP-20 at same address as Tempo).
     function gasToken() external view returns (IZoneGasToken);
 
-    /// @notice Current sequencer address.
-    function sequencer() external view returns (address);
-
-    /// @notice Pending sequencer for two-step transfer.
-    function pendingSequencer() external view returns (address);
-
     /// @notice The zone's last processed deposit queue hash.
     function processedDepositQueueHash() external view returns (bytes32);
-
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external;
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external;
 
     /// @notice Advance Tempo state and process deposits in a single sequencer-only call.
     /// @dev This is the main entry point for the sequencer at block start.
@@ -1257,8 +1330,8 @@ bytes32 aesKey = _hkdfSha256(
 );
 
 // Step 5: Verify decrypted plaintext matches claimed (to, memo)
-// Plaintext is packed as [address(20 bytes)][memo(32 bytes)][padding(12 bytes)]
-if (valid && decryptedPlaintext.length >= 52) {
+// Plaintext is packed as [address(20 bytes)][memo(32 bytes)][padding(12 bytes)] = 64 bytes
+if (valid && decryptedPlaintext.length == ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
     (address decryptedTo, bytes32 decryptedMemo) = EncryptedDepositLib.decodePlaintext(decryptedPlaintext);
     valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);
 } else {

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -6,7 +6,7 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 - Create a Tempo-native validium called a zone.
 - Each zone has exactly one permissioned sequencer.
-- Each zone bridges exactly one TIP-20 token, which is called its *zone token*. The zone token also serves as the gas token for the chain.
+- Each zone bridges exactly one TIP-20 token, which is called its *zone token*. The zone token is used to pay transaction fees on the zone.
 - Settlement uses fast validity proofs or TEE attestations (ZK or TEE). Data availability is fully trusted to the sequencer.
 - Cross-chain operations are Tempo-centric: bridge in (simple deposit), bridge out (with optional callback to receiver contracts for Tempo composability).
 - Verifier is abstracted behind a minimal `IVerifier` interface.

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1089,7 +1089,7 @@ struct EncryptedDeposit {
 
 **Encryption key history:**
 
-To support key rotation, the portal stores all historical encryption keys with their activation blocks:
+To support key rotation, the portal stores all historical encryption keys. Users explicitly specify which key index they encrypted to, solving the race condition where a key might rotate between transaction signing and block inclusion.
 
 ```solidity
 /// @notice Historical record of an encryption key with its activation block
@@ -1099,13 +1099,20 @@ struct EncryptionKeyEntry {
     uint64 activationBlock; // Tempo block number when this key became active
 }
 
-/// @notice Encrypted deposit includes the block number for key lookup
+/// @notice Encrypted deposit includes the key index used for encryption
 struct EncryptedDeposit {
     address sender;              // Depositor (public, for refunds)
     uint128 amount;              // Amount (public, for accounting)
-    uint64 tempoBlockNumber;     // Tempo block when deposit was made (for key lookup)
+    uint256 keyIndex;            // Index of encryption key used (specified by depositor)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
 }
+
+/// @notice Deposit function requires explicit key index
+function depositEncrypted(
+    uint128 amount,
+    uint256 keyIndex,                      // User specifies which key they encrypted to
+    EncryptedDepositPayload calldata encrypted
+) external returns (bytes32 newCurrentDepositQueueHash);
 ```
 
 Key management functions:
@@ -1113,12 +1120,19 @@ Key management functions:
 - `setSequencerEncryptionKey(x, yParity)` - Appends a new key to history, active from current Tempo block
 - `encryptionKeyCount()` - Returns total number of keys in history
 - `encryptionKeyAt(index)` - Returns a historical key entry by index
-- `encryptionKeyAtBlock(tempoBlockNumber)` - Returns the key that was active at a specific block (binary search)
+- `encryptionKeyAtBlock(tempoBlockNumber)` - Returns the key that was active at a specific block
+
+**Why keyIndex instead of block number:**
+
+The user specifies `keyIndex` at signing time (when they know which key they're encrypting to). This avoids race conditions:
+- If key rotates *after* signing but *before* inclusion, the deposit still references the correct key
+- The portal can validate that `keyIndex` is a valid historical key
+- The prover looks up `encryptionKeyAt(keyIndex)` to get the decryption key
 
 This allows:
-1. Users to verify they're encrypting to the current key
-2. The prover to determine which key was valid for any deposit based on `tempoBlockNumber`
-3. Seamless key rotation without losing ability to decrypt in-flight deposits
+1. Users to verify they're encrypting to the current key before signing
+2. The prover to determine which key to use for any deposit via explicit `keyIndex`
+3. Seamless key rotation without invalidating in-flight transactions
 
 ## Bridging out (zone to Tempo)
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1129,7 +1129,72 @@ Verification works by leveraging the AES-GCM authentication tag:
 4. **The GCM tag will only validate if the shared secret is correct**
 5. If tag validates, the decrypted `(to, memo)` are cryptographically proven authentic
 
-This is implemented via the ECIES verification precompile at `0x1c00000000000000000000000000000000000100`:
+**Griefing attack prevention:**
+
+Without additional checks, a malicious user could submit an encrypted deposit with invalid ciphertext (garbage data or encrypted to the wrong key). The sequencer wouldn't be able to decrypt it, but also couldn't prove it's invalid, blocking chain progress.
+
+**Solution**: Use a **Chaum-Pedersen zero-knowledge proof** to prove the shared secret was correctly derived, without exposing the sequencer's private key to the EVM.
+
+The sequencer provides a Chaum-Pedersen proof that proves: "I know `privSeq` such that `pubSeq = privSeq * G` AND `sharedSecretPoint = privSeq * ephemeralPub`"
+
+This proof allows on-chain verification without revealing the private key:
+
+```solidity
+// Step 1: Verify Chaum-Pedersen proof of correct shared secret derivation
+bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
+    ed.encrypted.ephemeralPubX,
+    ed.encrypted.ephemeralPubYParity,
+    dec.sharedSecret,
+    dec.sequencerPubX,
+    dec.sequencerPubYParity,
+    dec.cpProof
+);
+if (!proofValid) revert InvalidSharedSecretProof();
+
+// Step 2: Try to decrypt
+bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(...);
+
+// Step 3: If decryption fails, return funds to sender (don't block chain)
+if (!valid) {
+    gasToken.mint(ed.sender, ed.amount);
+    emit EncryptedDepositFailed(...);
+}
+```
+
+This prevents griefing: users can't block the chain with invalid encryptions, and the sequencer's private key never touches the EVM.
+
+**Chaum-Pedersen proof protocol:**
+
+1. **Prover (sequencer) computes off-chain:**
+   - Pick random `r`
+   - `R1 = r * G`
+   - `R2 = r * ephemeralPub`
+   - `c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)` (Fiat-Shamir challenge)
+   - `s = r + c * privSeq (mod n)`
+   - Proof is `(s, c)`
+
+2. **Verifier (on-chain) checks:**
+   - Reconstruct: `R1 = s*G - c*pubSeq`
+   - Reconstruct: `R2 = s*ephemeralPub - c*sharedSecretPoint`
+   - Recompute: `c' = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)`
+   - Verify: `c == c'`
+
+**Chaum-Pedersen verification precompile** (at `0x1c00000000000000000000000000000000000100`):
+
+```solidity
+interface IChaumPedersenVerify {
+    function verifyProof(
+        bytes32 ephemeralPubX,
+        uint8 ephemeralPubYParity,
+        bytes32 sharedSecret,
+        bytes32 sequencerPubX,
+        uint8 sequencerPubYParity,
+        ChaumPedersenProof calldata proof
+    ) external view returns (bool valid);
+}
+```
+
+**ECIES verification precompile** (at `0x1c00000000000000000000000000000000000101`):
 
 ```solidity
 interface IEciesVerify {
@@ -1151,23 +1216,56 @@ interface IEciesVerify {
 Usage in `ZoneInbox.advanceTempo()`:
 
 ```solidity
-// Verify decryption on-chain using ECIES precompile
+// Step 1: Verify Chaum-Pedersen proof of correct shared secret derivation
+bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
+    ed.encrypted.ephemeralPubX,
+    ed.encrypted.ephemeralPubYParity,
+    dec.sharedSecret,
+    dec.sequencerPubX,
+    dec.sequencerPubYParity,
+    dec.cpProof
+);
+if (!proofValid) revert InvalidSharedSecretProof();
+
+// Step 2: Verify the decryption using ECIES precompile
 bytes memory plaintext = abi.encode(dec.to, dec.memo);
 bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(
     dec.sharedSecret,
     ed.encrypted,
     plaintext
 );
-if (!valid) revert InvalidDecryption();
+
+// Step 3: Handle success or failure
+if (!valid) {
+    // Decryption failed - return funds to sender
+    gasToken.mint(ed.sender, ed.amount);
+    emit EncryptedDepositFailed(currentHash, ed.sender, ed.amount);
+} else {
+    // Decryption succeeded - mint to decrypted recipient
+    gasToken.mint(dec.to, ed.amount);
+    emit DepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
+}
 ```
 
 **Key properties:**
-- **No private key exposure**: Sequencer only reveals the shared secret, not their private key
+- **Zero-knowledge security**: Chaum-Pedersen proof verifies shared secret without exposing sequencer's private key to EVM
+- **Griefing resistance**: Invalid encryptions can be detected and rejected, preventing chain blockage
+- **Graceful failure**: Invalid encrypted deposits return funds to sender instead of reverting
 - **Cryptographic proof**: GCM tag validation proves decryption correctness
-- **On-chain verification**: No reliance on proof/TEE for this specific check
-- **Standard crypto**: Uses well-established ECIES, ECDH, HKDF-SHA256, and AES-256-GCM
+- **On-chain verification**: All verification happens on-chain via precompiles
+- **Standard crypto**: Uses well-established ECIES, ECDH, Chaum-Pedersen, HKDF-SHA256, and AES-256-GCM
 
 **Precompile implementation notes:**
+
+*Chaum-Pedersen Verify (`0x1c00000000000000000000000000000000000100`):*
+- Input: ephemeralPub, sharedSecret, sequencerPub, proof (s, c)
+- Reconstruct commitments: `R1 = s*G - c*pubSeq`, `R2 = s*ephemeralPub - c*sharedSecretPoint`
+- where `sharedSecretPoint` is derived by lifting sharedSecret to curve (requires Y-coordinate recovery)
+- Recompute challenge: `c' = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)`
+- Verify: `c == c'`
+- Gas cost: ~8000 gas (2 point multiplications + 2 point additions + hash)
+
+*ECIES Verify (`0x1c00000000000000000000000000000000000101`):*
 - Derive AES key: `aesKey = HKDF-SHA256(sharedSecret, salt="ecies-aes-key", info="")`
 - Decrypt: `plaintext = AES-256-GCM-Decrypt(aesKey, nonce, ciphertext, aad="", tag)`
 - Return `true` if tag validates and decryption succeeds, `false` otherwise

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1084,8 +1084,41 @@ struct EncryptedDeposit {
 
 - **Sequencer trust**: Users trust the sequencer to decrypt correctly and credit the right recipient. A malicious sequencer could steal encrypted deposits.
 - **Decryption proof**: For ZK-based verification, the proof must validate that the sequencer's decryption is correct. For TEE-based verification, the TEE performs decryption.
-- **Key rotation**: If the sequencer rotates their encryption key, in-flight encrypted deposits using the old key must still be decryptable (sequencer should retain old keys).
+- **Key rotation**: The portal maintains a history of encryption keys with their activation block numbers. Each encrypted deposit records the `tempoBlockNumber` when it was made, allowing the prover to determine which key was valid at that time. See "Encryption key history" below.
 - **Malformed ciphertext**: If decryption fails, the sequencer may refund to `sender` or hold funds pending resolution.
+
+**Encryption key history:**
+
+To support key rotation, the portal stores all historical encryption keys with their activation blocks:
+
+```solidity
+/// @notice Historical record of an encryption key with its activation block
+struct EncryptionKeyEntry {
+    bytes32 x;              // X coordinate of the public key
+    uint8 yParity;          // Y coordinate parity (0x02 or 0x03)
+    uint64 activationBlock; // Tempo block number when this key became active
+}
+
+/// @notice Encrypted deposit includes the block number for key lookup
+struct EncryptedDeposit {
+    address sender;              // Depositor (public, for refunds)
+    uint128 amount;              // Amount (public, for accounting)
+    uint64 tempoBlockNumber;     // Tempo block when deposit was made (for key lookup)
+    EncryptedDepositPayload encrypted; // Encrypted (to, memo)
+}
+```
+
+Key management functions:
+
+- `setSequencerEncryptionKey(x, yParity)` - Appends a new key to history, active from current Tempo block
+- `encryptionKeyCount()` - Returns total number of keys in history
+- `encryptionKeyAt(index)` - Returns a historical key entry by index
+- `encryptionKeyAtBlock(tempoBlockNumber)` - Returns the key that was active at a specific block (binary search)
+
+This allows:
+1. Users to verify they're encrypting to the current key
+2. The prover to determine which key was valid for any deposit based on `tempoBlockNumber`
+3. Seamless key rotation without losing ability to decrypt in-flight deposits
 
 ## Bridging out (zone to Tempo)
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -784,11 +784,16 @@ interface IZoneInbox {
     /// @notice Advance Tempo state and process deposits in a single sequencer-only call.
     /// @dev This is the main entry point for the sequencer at block start.
     ///      1. Advances the zone's view of Tempo by processing the header
-    ///      2. Processes deposits from the deposit queue
+    ///      2. Processes deposits from the unified deposit queue (regular + encrypted)
     ///      3. Validates the resulting hash against Tempo's currentDepositQueueHash
     /// @param header RLP-encoded Tempo block header
-    /// @param deposits Array of deposits to process (oldest first, must be contiguous from processedDepositQueueHash)
-    function advanceTempo(bytes calldata header, Deposit[] calldata deposits) external;
+    /// @param deposits Array of queued deposits to process (oldest first, must be contiguous)
+    /// @param decryptions Decryption data for encrypted deposits (1:1 with encrypted deposits, in order)
+    function advanceTempo(
+        bytes calldata header,
+        QueuedDeposit[] calldata deposits,
+        DecryptionData[] calldata decryptions
+    ) external;
 }
 ```
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -22,7 +22,7 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 - Tempo: the base chain.
 - Zone: the validium chain anchored to Tempo.
-- Gas token: the zone's only TIP-20, bridged from Tempo.
+- Zone token: the zone's only TIP-20, bridged from Tempo.
 - Portal: the Tempo-side contract that escrows the zone token and finalizes exits.
 - Batch: a sequencer-produced commitment covering one or more zone blocks. The batch **must** end with a single `finalizeWithdrawalBatch()` call in the final block, and intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The sequencer controls batch frequency.
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -1048,7 +1048,7 @@ For privacy-sensitive use cases, users can make **encrypted deposits** where the
 1. Sequencer publishes a secp256k1 encryption public key via `setSequencerEncryptionKey(x, yParity)`
 2. User generates an ephemeral keypair and derives a shared secret via ECDH
 3. User encrypts `(to || memo)` with AES-256-GCM using the derived key
-4. User calls `depositEncrypted(amount, encryptedPayload)` on the portal
+4. User calls `depositEncrypted(amount, keyIndex, encryptedPayload)` on the portal
 
 ```solidity
 /// @notice Encrypted deposit payload

--- a/docs/pages/protocol/privacy/prover-design.md
+++ b/docs/pages/protocol/privacy/prover-design.md
@@ -118,8 +118,13 @@ pub struct ZoneBlock {
     /// If None, the block does not advance Tempo and the binding carries over.
     pub tempo_header_rlp: Option<Vec<u8>>,
 
-    /// Deposits processed by the call (oldest first). Must be empty if tempo_header_rlp is None.
-    pub deposits: Vec<Deposit>,
+    /// Deposits processed by the system tx (oldest first, unified queue).
+    /// Must be empty if tempo_header_rlp is None.
+    pub deposits: Vec<QueuedDeposit>,
+
+    /// Decryption data for encrypted deposits in the system tx.
+    /// Must be empty if tempo_header_rlp is None.
+    pub decryptions: Vec<DecryptionData>,
 
     /// Sequencer-only: finalize a batch (only in final block, must be last)
     /// Required for the final block in a batch; must be absent in intermediate blocks.
@@ -130,10 +135,11 @@ pub struct ZoneBlock {
 }
 ```
 
-Each zone block contains an ordered list of user transactions executed using `revm`. The sequencer
-may call `ZoneInbox.advanceTempo` at the start of the block to advance Tempo state and process deposits,
-and (only in the final block of a batch) calls `ZoneOutbox.finalizeWithdrawalBatch` at the end. If
-`advanceTempo` is omitted for a block, the Tempo binding carries over from the previous block.
+Each zone block contains the required system transactions plus user transactions that will be executed using `revm`.
+The system transactions must mirror the Solidity reference implementation:
+- `ZoneInbox.advanceTempo(tempo_header_rlp, deposits, decryptions)` at the start of the block
+- `ZoneOutbox.finalizeWithdrawalBatch(count)` at the end of the block **only if this is the final block of the batch**
+If `advanceTempo` is omitted for a block, the Tempo binding carries over from the previous block.
 
 The executor must enforce at most one `advanceTempo` at the start of each block
 (or zero, for blocks that do not advance Tempo), and enforce `finalizeWithdrawalBatch` only in the
@@ -430,13 +436,14 @@ fn execute_zone_block(
         )
         .build();
 
-    // Sequencer may call advanceTempo at the start of the block.
-    // The TempoState precompile must bind reads during this call to the newly
-    // finalized Tempo header, and reject any unbound reads.
+    // System tx: advance Tempo and process deposits.
+    // The TempoState precompile must bind reads during this call to the newly finalized
+    // Tempo header, and reject any unbound reads.
     if let Some(tempo_header_rlp) = &block.tempo_header_rlp {
-        evm.transact_commit(sequencer_tx_advance_tempo(
+        evm.transact_commit(system_tx_advance_tempo(
             tempo_header_rlp,
             &block.deposits,
+            &block.decryptions,
         ))
         .map_err(|e| Error::ExecutionError(e.to_string()))?;
 
@@ -449,7 +456,7 @@ fn execute_zone_block(
         if expected_tempo_hash != keccak256(tempo_header_rlp) {
             return Err(Error::InconsistentState);
         }
-    } else if !block.deposits.is_empty() {
+    } else if !block.deposits.is_empty() || !block.decryptions.is_empty() {
         return Err(Error::InconsistentState);
     }
 

--- a/docs/pages/protocol/privacy/prover-design.md
+++ b/docs/pages/protocol/privacy/prover-design.md
@@ -78,6 +78,14 @@ pub struct LastBatchCommitment {
     pub withdrawal_batch_index: u64,
 }
 
+/// Mirrors the Solidity `LastBatch` struct from ZoneOutbox.
+/// Used internally when reading from zone state; fields are split across
+/// `WithdrawalQueueTransition` (hash) and `LastBatchCommitment` (index) in output.
+pub struct LastBatch {
+    pub withdrawal_queue_hash: B256,
+    pub withdrawal_batch_index: u64,
+}
+
 pub struct ZoneHeader {
     pub parent_hash: B256,
     pub beneficiary: Address,
@@ -128,10 +136,40 @@ pub struct ZoneBlock {
 
     /// Sequencer-only: finalize a batch (only in final block, must be last)
     /// Required for the final block in a batch; must be absent in intermediate blocks.
-    pub finalize_withdrawal_batch_count: Option<u64>,
+    /// Uses U256 to match Solidity `finalizeWithdrawalBatch(uint256 count)`.
+    pub finalize_withdrawal_batch_count: Option<U256>,
 
     /// Transactions to execute
     pub transactions: Vec<Transaction>,
+}
+```
+
+### Deposit and Decryption Types
+
+```rust
+/// Mirrors the Solidity `QueuedDeposit` struct from IZone.sol
+pub struct QueuedDeposit {
+    pub deposit_type: DepositType,
+    pub deposit_data: Vec<u8>, // abi.encode(Deposit) or abi.encode(EncryptedDeposit)
+}
+
+pub enum DepositType {
+    Plain,
+    Encrypted,
+}
+
+/// Mirrors the Solidity `DecryptionData` struct from IZone.sol
+/// Provided by the sequencer for each encrypted deposit
+pub struct DecryptionData {
+    pub shared_secret: B256,  // ECDH shared secret (x-coordinate)
+    pub to: Address,          // Decrypted recipient
+    pub memo: B256,           // Decrypted memo
+    pub cp_proof: ChaumPedersenProof, // Proof of correct shared secret derivation
+}
+
+pub struct ChaumPedersenProof {
+    pub s: B256, // Response: s = r + c * privSeq (mod n)
+    pub c: B256, // Challenge: c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)
 }
 ```
 
@@ -312,6 +350,7 @@ pub fn prove_zone_batch(witness: BatchWitness) -> Result<BatchOutput, Error> {
         if block.number != prev_header.number + 1 {
             return Err(Error::InconsistentState);
         }
+        // Timestamps must be non-decreasing (equal is allowed, matching EVM rules)
         if block.timestamp < prev_header.timestamp {
             return Err(Error::InconsistentState);
         }

--- a/docs/specs/src/zone/DepositQueueLib.sol
+++ b/docs/specs/src/zone/DepositQueueLib.sol
@@ -1,29 +1,42 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Deposit } from "./IZone.sol";
+import { Deposit, EncryptedDeposit, DepositType } from "./IZone.sol";
 
 /// @title DepositQueueLib
 /// @notice Library for managing the deposit queue hash chain
 /// @dev The Tempo portal only tracks `currentDepositQueueHash` (where new deposits land).
 ///      The zone tracks its own `processedDepositQueueHash` in EVM state, and the proof
 ///      validates deposit processing by reading `currentDepositQueueHash` from Tempo state.
+///
+///      The queue supports both regular and encrypted deposits. The hash chain includes
+///      a type discriminator to distinguish between them:
+///      - Regular:   keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
+///      - Encrypted: keccak256(abi.encode(DepositType.Encrypted, encryptedDeposit, prevHash))
 library DepositQueueLib {
-
-    /// @notice Enqueue a new deposit into the queue (on-chain operation)
-    /// @dev Hash chain: newHash = keccak256(abi.encode(deposit, prevHash))
+    /// @notice Enqueue a regular deposit into the queue
+    /// @dev Hash chain: newHash = keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
     /// @param currentHash The current head of the deposit queue
     /// @param depositData The deposit to enqueue
     /// @return newHash The new head of the deposit queue
     function enqueue(
         bytes32 currentHash,
         Deposit memory depositData
-    )
-        internal
-        pure
-        returns (bytes32 newHash)
-    {
-        newHash = keccak256(abi.encode(depositData, currentHash));
+    ) internal pure returns (bytes32 newHash) {
+        newHash = keccak256(abi.encode(DepositType.Regular, depositData, currentHash));
+    }
+
+    /// @notice Enqueue an encrypted deposit into the queue
+    /// @dev Hash chain: newHash = keccak256(abi.encode(DepositType.Encrypted, encryptedDeposit, prevHash))
+    /// @param currentHash The current head of the deposit queue
+    /// @param encryptedDepositData The encrypted deposit to enqueue
+    /// @return newHash The new head of the deposit queue
+    function enqueueEncrypted(
+        bytes32 currentHash,
+        EncryptedDeposit memory encryptedDepositData
+    ) internal pure returns (bytes32 newHash) {
+        newHash = keccak256(abi.encode(DepositType.Encrypted, encryptedDepositData, currentHash));
+    }
     }
 
 }

--- a/docs/specs/src/zone/DepositQueueLib.sol
+++ b/docs/specs/src/zone/DepositQueueLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Deposit, EncryptedDeposit, DepositType } from "./IZone.sol";
+import { Deposit, DepositType, EncryptedDeposit } from "./IZone.sol";
 
 /// @title DepositQueueLib
 /// @notice Library for managing the deposit queue hash chain
@@ -14,6 +14,7 @@ import { Deposit, EncryptedDeposit, DepositType } from "./IZone.sol";
 ///      - Regular:   keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
 ///      - Encrypted: keccak256(abi.encode(DepositType.Encrypted, encryptedDeposit, prevHash))
 library DepositQueueLib {
+
     /// @notice Enqueue a regular deposit into the queue
     /// @dev Hash chain: newHash = keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
     /// @param currentHash The current head of the deposit queue
@@ -22,7 +23,11 @@ library DepositQueueLib {
     function enqueue(
         bytes32 currentHash,
         Deposit memory depositData
-    ) internal pure returns (bytes32 newHash) {
+    )
+        internal
+        pure
+        returns (bytes32 newHash)
+    {
         newHash = keccak256(abi.encode(DepositType.Regular, depositData, currentHash));
     }
 
@@ -34,9 +39,12 @@ library DepositQueueLib {
     function enqueueEncrypted(
         bytes32 currentHash,
         EncryptedDeposit memory encryptedDepositData
-    ) internal pure returns (bytes32 newHash) {
+    )
+        internal
+        pure
+        returns (bytes32 newHash)
+    {
         newHash = keccak256(abi.encode(DepositType.Encrypted, encryptedDepositData, currentHash));
-    }
     }
 
 }

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-/// @title Encrypted Deposit Types and Interface
+import {EncryptedDepositPayload, EncryptedDeposit, EncryptionKeyEntry} from "./IZone.sol";
+
+/// @title Encrypted Deposit Helpers
 /// @notice Enables privacy-preserving deposits where recipient and memo are encrypted
 /// @dev Users encrypt (to, memo) using the sequencer's public key. Only the sequencer
 ///      can decrypt and credit the correct recipient on the zone.
@@ -11,40 +13,9 @@ pragma solidity ^0.8.13;
 ///      - User generates ephemeral keypair, derives shared secret via ECDH
 ///      - Plaintext (to || memo) is encrypted with AES-256-GCM using derived key
 ///      - Ciphertext includes ephemeral public key for sequencer to derive same shared secret
-
-/*//////////////////////////////////////////////////////////////
-                        ENCRYPTED DEPOSIT TYPES
-//////////////////////////////////////////////////////////////*/
-
-/// @notice Encrypted deposit payload
-/// @dev Contains the ciphertext of (recipient address, memo) encrypted to the sequencer's pubkey
-struct EncryptedDepositPayload {
-    bytes32 ephemeralPubkeyX;   // Ephemeral public key X coordinate (for ECDH)
-    uint8 ephemeralPubkeyYParity; // Y coordinate parity (0x02 or 0x03)
-    bytes ciphertext;           // AES-256-GCM encrypted (to || memo || padding)
-    bytes12 nonce;              // GCM nonce
-    bytes16 tag;                // GCM authentication tag
-}
-
-/// @notice Encrypted deposit stored in the queue
-/// @dev The sender, amount, and key index are public; recipient and memo are encrypted.
-///      The keyIndex specifies which encryption key the user used, allowing the prover
-///      to look up the correct key for decryption even after key rotations.
-struct EncryptedDeposit {
-    address sender;             // Depositor (public, needed for refunds)
-    uint128 amount;             // Deposit amount (public, needed for accounting)
-    uint256 keyIndex;           // Index of encryption key used (specified by depositor)
-    EncryptedDepositPayload encrypted; // Encrypted (to, memo)
-}
-
-/// @notice Decrypted deposit (after sequencer decryption)
-/// @dev This is what the sequencer works with internally
-struct DecryptedDeposit {
-    address sender;
-    address to;
-    uint128 amount;
-    bytes32 memo;
-}
+///
+///      Types (EncryptedDepositPayload, EncryptedDeposit, EncryptionKeyEntry) are defined in IZone.sol.
+///      Portal interface (depositEncrypted, key management) is in IZonePortal.
 
 /*//////////////////////////////////////////////////////////////
                         ENCRYPTION CONSTANTS
@@ -58,58 +29,17 @@ uint256 constant ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE = 64;
 uint256 constant MIN_CIPHERTEXT_SIZE = 64;
 
 /*//////////////////////////////////////////////////////////////
-                        PORTAL INTERFACE EXTENSION
-//////////////////////////////////////////////////////////////*/
-
-/// @title IEncryptedDeposits
-/// @notice Extension interface for encrypted deposits on ZonePortal
-interface IEncryptedDeposits {
-    /// @notice Emitted when an encrypted deposit is made
-    /// @dev Recipient and memo are NOT included - they're encrypted
-    event EncryptedDepositMade(
-        bytes32 indexed newCurrentDepositQueueHash,
-        address indexed sender,
-        uint128 amount,
-        uint256 keyIndex,
-        bytes32 ephemeralPubkeyX,
-        uint8 ephemeralPubkeyYParity
-    );
-
-    /// @notice Thrown when trying to use an expired encryption key
-    /// @param keyIndex The expired key index
-    /// @param activationBlock When the key became active
-    /// @param supersededAtBlock When the next key was activated (key expired at this + grace period)
-    error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
-
-    /// @notice Thrown when keyIndex doesn't exist
-    error InvalidEncryptionKeyIndex(uint256 keyIndex);
-
-    /// @notice Deposit with encrypted recipient and memo
-    /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key
-    ///      at the specified keyIndex. The user must specify which key they encrypted to,
-    ///      ensuring correct decryption even if the key rotates before inclusion.
-    ///      Reverts if the key has expired (superseded for longer than ENCRYPTION_KEY_GRACE_PERIOD).
-    ///      If the sequencer cannot decrypt (malformed), they may reject or refund.
-    /// @param amount Amount to deposit
-    /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
-    /// @param encrypted The encrypted payload (recipient and memo)
-    /// @return newCurrentDepositQueueHash The new deposit queue hash
-    function depositEncrypted(
-        uint128 amount,
-        uint256 keyIndex,
-        EncryptedDepositPayload calldata encrypted
-    ) external returns (bytes32 newCurrentDepositQueueHash);
-
-    /// @notice Check if an encryption key is still valid for new deposits
-    /// @param keyIndex The key index to check
-    /// @return valid True if the key can be used for new deposits
-    /// @return expiresAtBlock Block number when this key expires (0 if current key)
-    function isEncryptionKeyValid(uint256 keyIndex) external view returns (bool valid, uint64 expiresAtBlock);
-}
-
-/*//////////////////////////////////////////////////////////////
                         ENCRYPTION HELPERS
 //////////////////////////////////////////////////////////////*/
+
+/// @notice Decrypted deposit (after sequencer decryption)
+/// @dev This is what the sequencer works with internally on the zone
+struct DecryptedDeposit {
+    address sender;
+    address to;
+    uint128 amount;
+    bytes32 memo;
+}
 
 /// @title EncryptedDepositLib
 /// @notice Library for working with encrypted deposits
@@ -143,82 +73,6 @@ library EncryptedDepositLib {
             memo := mload(add(plaintext, 52))
         }
     }
-}
-
-/*//////////////////////////////////////////////////////////////
-                        SEQUENCER KEY MANAGEMENT
-//////////////////////////////////////////////////////////////*/
-
-/// @notice Sequencer public key format for ECIES
-/// @dev Compressed secp256k1 public key: 1 byte prefix (0x02/0x03) + 32 bytes X coordinate
-///      Stored as bytes32 (X) + uint8 (parity) to save gas
-struct SequencerEncryptionKey {
-    bytes32 x;      // X coordinate of the public key
-    uint8 yParity;  // 0x02 for even Y, 0x03 for odd Y
-}
-
-/// @notice Historical record of an encryption key with its activation block
-/// @dev Used to track key rotations so the prover can determine which key
-///      was valid when a deposit was made
-struct EncryptionKeyEntry {
-    bytes32 x;              // X coordinate of the public key
-    uint8 yParity;          // Y coordinate parity (0x02 or 0x03)
-    uint64 activationBlock; // Tempo block number when this key became active
-}
-
-/// Grace period after key rotation during which old keys are still accepted
-/// After this period, deposits using the old key are rejected.
-/// 1 day at 1 second block time = 86400 blocks
-uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
-
-/// @title ISequencerEncryptionKey
-/// @notice Interface for managing sequencer encryption keys with history
-/// @dev Key history is maintained so that:
-///      1. Users can verify they're encrypting to the current key
-///      2. The prover can determine which key was valid for any deposit
-///      3. Deposits made with old keys (during rotation) can still be decrypted
-interface ISequencerEncryptionKey {
-    /// @notice Emitted when sequencer updates their encryption key
-    /// @param x The X coordinate of the new key
-    /// @param yParity The Y coordinate parity (0x02 or 0x03)
-    /// @param keyIndex The index of this key in the history array
-    /// @param activationBlock The Tempo block when this key becomes active
-    event SequencerEncryptionKeyUpdated(
-        bytes32 x, 
-        uint8 yParity, 
-        uint256 keyIndex,
-        uint64 activationBlock
-    );
-
-    /// @notice Get the sequencer's current encryption public key
-    /// @return x The X coordinate
-    /// @return yParity The Y coordinate parity (0x02 or 0x03)
-    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
-
-    /// @notice Set the sequencer's encryption public key
-    /// @dev Only callable by the sequencer. Appends to key history.
-    ///      The new key becomes active at the current Tempo block.
-    /// @param x The X coordinate
-    /// @param yParity The Y coordinate parity (0x02 or 0x03)
-    function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external;
-
-    /// @notice Get the number of keys in the history
-    /// @return The total count of keys (including current)
-    function encryptionKeyCount() external view returns (uint256);
-
-    /// @notice Get a historical encryption key by index
-    /// @param index The index in the key history (0 = first key)
-    /// @return entry The key entry with activation block
-    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry);
-
-    /// @notice Get the encryption key that was active at a specific Tempo block
-    /// @dev Binary search through key history to find the correct key
-    /// @param tempoBlockNumber The Tempo block number to query
-    /// @return x The X coordinate of the active key
-    /// @return yParity The Y coordinate parity
-    /// @return keyIndex The index of this key in history
-    function encryptionKeyAtBlock(uint64 tempoBlockNumber) 
-        external view returns (bytes32 x, uint8 yParity, uint256 keyIndex);
 }
 
 /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { DepositType, EncryptedDeposit, EncryptedDepositPayload, EncryptionKeyEntry } from "./IZone.sol";
+import {
+    DepositType,
+    EncryptedDeposit,
+    EncryptedDepositPayload,
+    EncryptionKeyEntry
+} from "./IZone.sol";
 
 /*
 Encrypted Deposit Helpers

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title Encrypted Deposit Types and Interface
+/// @notice Enables privacy-preserving deposits where recipient and memo are encrypted
+/// @dev Users encrypt (to, memo) using the sequencer's public key. Only the sequencer
+///      can decrypt and credit the correct recipient on the zone.
+///
+///      Encryption scheme: ECIES with secp256k1
+///      - Sequencer publishes a secp256k1 public key (compressed, 33 bytes stored as bytes32 + 1 byte)
+///      - User generates ephemeral keypair, derives shared secret via ECDH
+///      - Plaintext (to || memo) is encrypted with AES-256-GCM using derived key
+///      - Ciphertext includes ephemeral public key for sequencer to derive same shared secret
+
+/*//////////////////////////////////////////////////////////////
+                        ENCRYPTED DEPOSIT TYPES
+//////////////////////////////////////////////////////////////*/
+
+/// @notice Encrypted deposit payload
+/// @dev Contains the ciphertext of (recipient address, memo) encrypted to the sequencer's pubkey
+struct EncryptedDepositPayload {
+    bytes32 ephemeralPubkeyX;   // Ephemeral public key X coordinate (for ECDH)
+    uint8 ephemeralPubkeyYParity; // Y coordinate parity (0x02 or 0x03)
+    bytes ciphertext;           // AES-256-GCM encrypted (to || memo || padding)
+    bytes12 nonce;              // GCM nonce
+    bytes16 tag;                // GCM authentication tag
+}
+
+/// @notice Encrypted deposit stored in the queue
+/// @dev The sender and amount are public; recipient and memo are encrypted
+struct EncryptedDeposit {
+    address sender;             // Depositor (public, needed for refunds)
+    uint128 amount;             // Deposit amount (public, needed for accounting)
+    EncryptedDepositPayload encrypted; // Encrypted (to, memo)
+}
+
+/// @notice Decrypted deposit (after sequencer decryption)
+/// @dev This is what the sequencer works with internally
+struct DecryptedDeposit {
+    address sender;
+    address to;
+    uint128 amount;
+    bytes32 memo;
+}
+
+/*//////////////////////////////////////////////////////////////
+                        ENCRYPTION CONSTANTS
+//////////////////////////////////////////////////////////////*/
+
+/// Size of the plaintext: 20 bytes (address) + 32 bytes (memo) = 52 bytes
+/// Padded to 64 bytes for AES block alignment
+uint256 constant ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE = 64;
+
+/// Minimum ciphertext size (plaintext size, GCM doesn't expand)
+uint256 constant MIN_CIPHERTEXT_SIZE = 64;
+
+/*//////////////////////////////////////////////////////////////
+                        PORTAL INTERFACE EXTENSION
+//////////////////////////////////////////////////////////////*/
+
+/// @title IEncryptedDeposits
+/// @notice Extension interface for encrypted deposits on ZonePortal
+interface IEncryptedDeposits {
+    /// @notice Emitted when an encrypted deposit is made
+    /// @dev Recipient and memo are NOT included - they're encrypted
+    event EncryptedDepositMade(
+        bytes32 indexed newCurrentDepositQueueHash,
+        address indexed sender,
+        uint128 amount,
+        bytes32 ephemeralPubkeyX,
+        uint8 ephemeralPubkeyYParity
+    );
+
+    /// @notice Deposit with encrypted recipient and memo
+    /// @dev The encrypted payload contains (to, memo) encrypted to sequencerPubkey.
+    ///      Only the sequencer can decrypt and credit the correct recipient.
+    ///      If the sequencer cannot decrypt (malformed), they may reject or refund.
+    /// @param amount Amount to deposit
+    /// @param encrypted The encrypted payload (recipient and memo)
+    /// @return newCurrentDepositQueueHash The new deposit queue hash
+    function depositEncrypted(
+        uint128 amount,
+        EncryptedDepositPayload calldata encrypted
+    ) external returns (bytes32 newCurrentDepositQueueHash);
+}
+
+/*//////////////////////////////////////////////////////////////
+                        ENCRYPTION HELPERS
+//////////////////////////////////////////////////////////////*/
+
+/// @title EncryptedDepositLib
+/// @notice Library for working with encrypted deposits
+/// @dev These are reference implementations - actual encryption happens off-chain
+library EncryptedDepositLib {
+    /// @notice Compute the hash of an encrypted deposit for the queue
+    /// @dev Uses the encrypted form, not the decrypted form
+    function hash(EncryptedDeposit memory deposit) internal pure returns (bytes32) {
+        return keccak256(abi.encode(deposit));
+    }
+
+    /// @notice Encode plaintext for encryption
+    /// @dev Packs (to, memo) into 64 bytes for encryption
+    function encodePlaintext(address to, bytes32 memo) internal pure returns (bytes memory) {
+        bytes memory plaintext = new bytes(64);
+        assembly {
+            // Store address at offset 0 (left-padded to 32 bytes, we take last 20)
+            mstore(add(plaintext, 32), shl(96, to))
+            // Store memo at offset 20
+            mstore(add(plaintext, 52), memo)
+        }
+        return plaintext;
+    }
+
+    /// @notice Decode plaintext after decryption
+    /// @dev Unpacks (to, memo) from 64 bytes
+    function decodePlaintext(bytes memory plaintext) internal pure returns (address to, bytes32 memo) {
+        require(plaintext.length >= 52, "Invalid plaintext length");
+        assembly {
+            to := shr(96, mload(add(plaintext, 32)))
+            memo := mload(add(plaintext, 52))
+        }
+    }
+}
+
+/*//////////////////////////////////////////////////////////////
+                        SEQUENCER KEY MANAGEMENT
+//////////////////////////////////////////////////////////////*/
+
+/// @notice Sequencer public key format for ECIES
+/// @dev Compressed secp256k1 public key: 1 byte prefix (0x02/0x03) + 32 bytes X coordinate
+///      Stored as bytes32 (X) + uint8 (parity) to save gas
+struct SequencerEncryptionKey {
+    bytes32 x;      // X coordinate of the public key
+    uint8 yParity;  // 0x02 for even Y, 0x03 for odd Y
+}
+
+/// @title ISequencerEncryptionKey
+/// @notice Interface for managing sequencer encryption keys
+interface ISequencerEncryptionKey {
+    /// @notice Emitted when sequencer updates their encryption key
+    event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity);
+
+    /// @notice Get the sequencer's current encryption public key
+    /// @return x The X coordinate
+    /// @return yParity The Y coordinate parity (0x02 or 0x03)
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+
+    /// @notice Set the sequencer's encryption public key
+    /// @dev Only callable by the sequencer
+    /// @param x The X coordinate
+    /// @param yParity The Y coordinate parity (0x02 or 0x03)
+    function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external;
+}
+
+/*//////////////////////////////////////////////////////////////
+                        ZONE INBOX EXTENSION
+//////////////////////////////////////////////////////////////*/
+
+/// @title IEncryptedDepositProcessor
+/// @notice Extension interface for ZoneInbox to process encrypted deposits
+interface IEncryptedDepositProcessor {
+    /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
+    event EncryptedDepositProcessed(
+        bytes32 indexed depositHash,
+        address indexed sender,
+        address indexed to,  // Now revealed after decryption
+        uint128 amount,
+        bytes32 memo         // Now revealed after decryption
+    );
+
+    /// @notice Advance Tempo state and process deposits including encrypted ones
+    /// @dev The sequencer provides decrypted versions of encrypted deposits.
+    ///      The proof must validate that decryptions are correct (or use TEE attestation).
+    /// @param header RLP-encoded Tempo block header
+    /// @param deposits Array of regular deposits
+    /// @param encryptedDeposits Array of encrypted deposits (from Tempo)
+    /// @param decryptedRecipients Decrypted recipients for encrypted deposits (same order)
+    /// @param decryptedMemos Decrypted memos for encrypted deposits (same order)
+    function advanceTempoWithEncrypted(
+        bytes calldata header,
+        /* regular Deposit[] */ bytes calldata deposits,
+        EncryptedDeposit[] calldata encryptedDeposits,
+        address[] calldata decryptedRecipients,
+        bytes32[] calldata decryptedMemos
+    ) external;
+}

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -27,12 +27,13 @@ struct EncryptedDepositPayload {
 }
 
 /// @notice Encrypted deposit stored in the queue
-/// @dev The sender, amount, and deposit block are public; recipient and memo are encrypted.
-///      The tempoBlockNumber is recorded so the prover knows which encryption key was valid.
+/// @dev The sender, amount, and key index are public; recipient and memo are encrypted.
+///      The keyIndex specifies which encryption key the user used, allowing the prover
+///      to look up the correct key for decryption even after key rotations.
 struct EncryptedDeposit {
     address sender;             // Depositor (public, needed for refunds)
     uint128 amount;             // Deposit amount (public, needed for accounting)
-    uint64 tempoBlockNumber;    // Tempo block when deposit was made (for key lookup)
+    uint256 keyIndex;           // Index of encryption key used (specified by depositor)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
 }
 
@@ -74,14 +75,17 @@ interface IEncryptedDeposits {
     );
 
     /// @notice Deposit with encrypted recipient and memo
-    /// @dev The encrypted payload contains (to, memo) encrypted to sequencerPubkey.
-    ///      Only the sequencer can decrypt and credit the correct recipient.
+    /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key
+    ///      at the specified keyIndex. The user must specify which key they encrypted to,
+    ///      ensuring correct decryption even if the key rotates before inclusion.
     ///      If the sequencer cannot decrypt (malformed), they may reject or refund.
     /// @param amount Amount to deposit
+    /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
     function depositEncrypted(
         uint128 amount,
+        uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
     ) external returns (bytes32 newCurrentDepositQueueHash);
 }

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -1,31 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {EncryptedDepositPayload, EncryptedDeposit, EncryptionKeyEntry} from "./IZone.sol";
+import { EncryptedDeposit, EncryptedDepositPayload, EncryptionKeyEntry } from "./IZone.sol";
 
-/// @title Encrypted Deposit Helpers
-/// @notice Enables privacy-preserving deposits where recipient and memo are encrypted
-/// @dev Users encrypt (to, memo) using the sequencer's public key. Only the sequencer
-///      can decrypt and credit the correct recipient on the zone.
-///
-///      Encryption scheme: ECIES with secp256k1
-///      - Sequencer publishes a secp256k1 public key (compressed, 33 bytes stored as bytes32 + 1 byte)
-///      - User generates ephemeral keypair, derives shared secret via ECDH
-///      - Plaintext (to || memo) is encrypted with AES-256-GCM using derived key
-///      - Ciphertext includes ephemeral public key for sequencer to derive same shared secret
-///
-///      Types (EncryptedDepositPayload, EncryptedDeposit, EncryptionKeyEntry) are defined in IZone.sol.
-///      Portal interface (depositEncrypted, key management) is in IZonePortal.
+/*
+Encrypted Deposit Helpers
+
+Enables privacy-preserving deposits where recipient and memo are encrypted.
+Users encrypt (to, memo) using the sequencer's public key. Only the sequencer
+can decrypt and credit the correct recipient on the zone.
+
+Encryption scheme: ECIES with secp256k1
+- Sequencer publishes a secp256k1 public key (compressed, 33 bytes stored as bytes32 + 1 byte)
+- User generates ephemeral keypair, derives shared secret via ECDH
+- Plaintext (to || memo) is encrypted with AES-256-GCM using derived key
+- Ciphertext includes ephemeral public key for sequencer to derive same shared secret
+
+Types (EncryptedDepositPayload, EncryptedDeposit, EncryptionKeyEntry) are defined in IZone.sol.
+Portal interface (depositEncrypted, key management) is in IZonePortal.
+*/
 
 /*//////////////////////////////////////////////////////////////
                         ENCRYPTION CONSTANTS
 //////////////////////////////////////////////////////////////*/
 
-/// Size of the plaintext: 20 bytes (address) + 32 bytes (memo) = 52 bytes
-/// Padded to 64 bytes for AES block alignment
+// Size of the plaintext: 20 bytes (address) + 32 bytes (memo) = 52 bytes
+// Padded to 64 bytes for AES block alignment
 uint256 constant ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE = 64;
 
-/// Minimum ciphertext size (plaintext size, GCM doesn't expand)
+// Minimum ciphertext size (plaintext size, GCM doesn't expand)
 uint256 constant MIN_CIPHERTEXT_SIZE = 64;
 
 /*//////////////////////////////////////////////////////////////
@@ -45,6 +48,7 @@ struct DecryptedDeposit {
 /// @notice Library for working with encrypted deposits
 /// @dev These are reference implementations - actual encryption happens off-chain
 library EncryptedDepositLib {
+
     /// @notice Compute the hash of an encrypted deposit for the queue
     /// @dev Uses the encrypted form, not the decrypted form
     function hash(EncryptedDeposit memory deposit) internal pure returns (bytes32) {
@@ -66,13 +70,18 @@ library EncryptedDepositLib {
 
     /// @notice Decode plaintext after decryption
     /// @dev Unpacks (to, memo) from 64 bytes
-    function decodePlaintext(bytes memory plaintext) internal pure returns (address to, bytes32 memo) {
+    function decodePlaintext(bytes memory plaintext)
+        internal
+        pure
+        returns (address to, bytes32 memo)
+    {
         require(plaintext.length >= 52, "Invalid plaintext length");
         assembly {
             to := shr(96, mload(add(plaintext, 32)))
             memo := mload(add(plaintext, 52))
         }
     }
+
 }
 
 /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -54,6 +54,9 @@ struct DecryptedDeposit {
 /// @dev These are reference implementations - actual encryption happens off-chain
 library EncryptedDepositLib {
 
+    /// @notice Thrown when decrypted plaintext does not have the expected length
+    error InvalidPlaintextLength(uint256 actual, uint256 expected);
+
     /// @notice Compute the queue hash for an encrypted deposit
     /// @dev Matches the queue hash chain format used in DepositQueueLib:
     ///      keccak256(abi.encode(DepositType.Encrypted, deposit, prevHash))
@@ -82,13 +85,16 @@ library EncryptedDepositLib {
     }
 
     /// @notice Decode plaintext after decryption
-    /// @dev Unpacks (to, memo) from 64 bytes
+    /// @dev Unpacks (to, memo) from exactly ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE (64) bytes.
+    ///      Layout: [address(20 bytes)][memo(32 bytes)][zero-padding(12 bytes)]
     function decodePlaintext(bytes memory plaintext)
         internal
         pure
         returns (address to, bytes32 memo)
     {
-        require(plaintext.length >= 52, "Invalid plaintext length");
+        if (plaintext.length != ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
+            revert InvalidPlaintextLength(plaintext.length, ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE);
+        }
         assembly {
             to := shr(96, mload(add(plaintext, 32)))
             memo := mload(add(plaintext, 52))

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -79,7 +79,6 @@ library EncryptedDepositLib {
                     UNIFIED DEPOSIT QUEUE PROCESSING
 //////////////////////////////////////////////////////////////*/
 
-/// @notice Wrapper for processing deposits from the unified queue
 /// @dev The deposit queue on Tempo contains both regular and encrypted deposits
 ///      in a single ordered sequence. The sequencer must provide decryption data
 ///      for encrypted deposits when processing the queue on the zone.
@@ -91,21 +90,5 @@ library EncryptedDepositLib {
 ///      The zone's advanceTempo() processes deposits in order. For encrypted deposits,
 ///      the sequencer provides the decrypted (to, memo) alongside the encrypted data.
 ///      The proof/TEE validates that decryptions are correct.
-
-/// @notice A deposit entry in the unified queue (for zone-side processing)
-/// @dev Used by the sequencer when calling advanceTempo with mixed deposit types
-struct QueuedDeposit {
-    DepositType depositType;
-    // For Regular: decode as Deposit
-    // For Encrypted: decode as EncryptedDeposit + decrypted values provided separately
-    bytes depositData;
-}
-
-/// @notice Decryption data provided by sequencer for encrypted deposits
-/// @dev Must match 1:1 with encrypted deposits in the queue (in order)
-struct DecryptionData {
-    address to;      // Decrypted recipient
-    bytes32 memo;    // Decrypted memo
-}
-
-import {DepositType} from "./IZone.sol";
+///
+///      Types QueuedDeposit and DecryptionData are defined in IZone.sol.

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -76,34 +76,36 @@ library EncryptedDepositLib {
 }
 
 /*//////////////////////////////////////////////////////////////
-                        ZONE INBOX EXTENSION
+                    UNIFIED DEPOSIT QUEUE PROCESSING
 //////////////////////////////////////////////////////////////*/
 
-/// @title IEncryptedDepositProcessor
-/// @notice Extension interface for ZoneInbox to process encrypted deposits
-interface IEncryptedDepositProcessor {
-    /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
-    event EncryptedDepositProcessed(
-        bytes32 indexed depositHash,
-        address indexed sender,
-        address indexed to,  // Now revealed after decryption
-        uint128 amount,
-        bytes32 memo         // Now revealed after decryption
-    );
+/// @notice Wrapper for processing deposits from the unified queue
+/// @dev The deposit queue on Tempo contains both regular and encrypted deposits
+///      in a single ordered sequence. The sequencer must provide decryption data
+///      for encrypted deposits when processing the queue on the zone.
+///
+///      Queue hash chain includes type discriminator:
+///      - Regular:   keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
+///      - Encrypted: keccak256(abi.encode(DepositType.Encrypted, encryptedDeposit, prevHash))
+///
+///      The zone's advanceTempo() processes deposits in order. For encrypted deposits,
+///      the sequencer provides the decrypted (to, memo) alongside the encrypted data.
+///      The proof/TEE validates that decryptions are correct.
 
-    /// @notice Advance Tempo state and process deposits including encrypted ones
-    /// @dev The sequencer provides decrypted versions of encrypted deposits.
-    ///      The proof must validate that decryptions are correct (or use TEE attestation).
-    /// @param header RLP-encoded Tempo block header
-    /// @param deposits Array of regular deposits
-    /// @param encryptedDeposits Array of encrypted deposits (from Tempo)
-    /// @param decryptedRecipients Decrypted recipients for encrypted deposits (same order)
-    /// @param decryptedMemos Decrypted memos for encrypted deposits (same order)
-    function advanceTempoWithEncrypted(
-        bytes calldata header,
-        /* regular Deposit[] */ bytes calldata deposits,
-        EncryptedDeposit[] calldata encryptedDeposits,
-        address[] calldata decryptedRecipients,
-        bytes32[] calldata decryptedMemos
-    ) external;
+/// @notice A deposit entry in the unified queue (for zone-side processing)
+/// @dev Used by the sequencer when calling advanceTempo with mixed deposit types
+struct QueuedDeposit {
+    DepositType depositType;
+    // For Regular: decode as Deposit
+    // For Encrypted: decode as EncryptedDeposit + decrypted values provided separately
+    bytes depositData;
 }
+
+/// @notice Decryption data provided by sequencer for encrypted deposits
+/// @dev Must match 1:1 with encrypted deposits in the queue (in order)
+struct DecryptionData {
+    address to;      // Decrypted recipient
+    bytes32 memo;    // Decrypted memo
+}
+
+import {DepositType} from "./IZone.sol";

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -27,10 +27,12 @@ struct EncryptedDepositPayload {
 }
 
 /// @notice Encrypted deposit stored in the queue
-/// @dev The sender and amount are public; recipient and memo are encrypted
+/// @dev The sender, amount, and deposit block are public; recipient and memo are encrypted.
+///      The tempoBlockNumber is recorded so the prover knows which encryption key was valid.
 struct EncryptedDeposit {
     address sender;             // Depositor (public, needed for refunds)
     uint128 amount;             // Deposit amount (public, needed for accounting)
+    uint64 tempoBlockNumber;    // Tempo block when deposit was made (for key lookup)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
 }
 
@@ -134,11 +136,33 @@ struct SequencerEncryptionKey {
     uint8 yParity;  // 0x02 for even Y, 0x03 for odd Y
 }
 
+/// @notice Historical record of an encryption key with its activation block
+/// @dev Used to track key rotations so the prover can determine which key
+///      was valid when a deposit was made
+struct EncryptionKeyEntry {
+    bytes32 x;              // X coordinate of the public key
+    uint8 yParity;          // Y coordinate parity (0x02 or 0x03)
+    uint64 activationBlock; // Tempo block number when this key became active
+}
+
 /// @title ISequencerEncryptionKey
-/// @notice Interface for managing sequencer encryption keys
+/// @notice Interface for managing sequencer encryption keys with history
+/// @dev Key history is maintained so that:
+///      1. Users can verify they're encrypting to the current key
+///      2. The prover can determine which key was valid for any deposit
+///      3. Deposits made with old keys (during rotation) can still be decrypted
 interface ISequencerEncryptionKey {
     /// @notice Emitted when sequencer updates their encryption key
-    event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity);
+    /// @param x The X coordinate of the new key
+    /// @param yParity The Y coordinate parity (0x02 or 0x03)
+    /// @param keyIndex The index of this key in the history array
+    /// @param activationBlock The Tempo block when this key becomes active
+    event SequencerEncryptionKeyUpdated(
+        bytes32 x, 
+        uint8 yParity, 
+        uint256 keyIndex,
+        uint64 activationBlock
+    );
 
     /// @notice Get the sequencer's current encryption public key
     /// @return x The X coordinate
@@ -146,10 +170,29 @@ interface ISequencerEncryptionKey {
     function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
 
     /// @notice Set the sequencer's encryption public key
-    /// @dev Only callable by the sequencer
+    /// @dev Only callable by the sequencer. Appends to key history.
+    ///      The new key becomes active at the current Tempo block.
     /// @param x The X coordinate
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
     function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external;
+
+    /// @notice Get the number of keys in the history
+    /// @return The total count of keys (including current)
+    function encryptionKeyCount() external view returns (uint256);
+
+    /// @notice Get a historical encryption key by index
+    /// @param index The index in the key history (0 = first key)
+    /// @return entry The key entry with activation block
+    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry);
+
+    /// @notice Get the encryption key that was active at a specific Tempo block
+    /// @dev Binary search through key history to find the correct key
+    /// @param tempoBlockNumber The Tempo block number to query
+    /// @return x The X coordinate of the active key
+    /// @return yParity The Y coordinate parity
+    /// @return keyIndex The index of this key in history
+    function encryptionKeyAtBlock(uint64 tempoBlockNumber) 
+        external view returns (bytes32 x, uint8 yParity, uint256 keyIndex);
 }
 
 /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { EncryptedDeposit, EncryptedDepositPayload, EncryptionKeyEntry } from "./IZone.sol";
+import { DepositType, EncryptedDeposit, EncryptedDepositPayload, EncryptionKeyEntry } from "./IZone.sol";
 
 /*
 Encrypted Deposit Helpers
@@ -49,10 +49,18 @@ struct DecryptedDeposit {
 /// @dev These are reference implementations - actual encryption happens off-chain
 library EncryptedDepositLib {
 
-    /// @notice Compute the hash of an encrypted deposit for the queue
-    /// @dev Uses the encrypted form, not the decrypted form
-    function hash(EncryptedDeposit memory deposit) internal pure returns (bytes32) {
-        return keccak256(abi.encode(deposit));
+    /// @notice Compute the queue hash for an encrypted deposit
+    /// @dev Matches the queue hash chain format used in DepositQueueLib:
+    ///      keccak256(abi.encode(DepositType.Encrypted, deposit, prevHash))
+    function queueHash(
+        EncryptedDeposit memory deposit,
+        bytes32 prevHash
+    )
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encode(DepositType.Encrypted, deposit, prevHash));
     }
 
     /// @notice Encode plaintext for encryption

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -70,14 +70,25 @@ interface IEncryptedDeposits {
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
         uint128 amount,
+        uint256 keyIndex,
         bytes32 ephemeralPubkeyX,
         uint8 ephemeralPubkeyYParity
     );
+
+    /// @notice Thrown when trying to use an expired encryption key
+    /// @param keyIndex The expired key index
+    /// @param activationBlock When the key became active
+    /// @param supersededAtBlock When the next key was activated (key expired at this + grace period)
+    error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
+
+    /// @notice Thrown when keyIndex doesn't exist
+    error InvalidEncryptionKeyIndex(uint256 keyIndex);
 
     /// @notice Deposit with encrypted recipient and memo
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key
     ///      at the specified keyIndex. The user must specify which key they encrypted to,
     ///      ensuring correct decryption even if the key rotates before inclusion.
+    ///      Reverts if the key has expired (superseded for longer than ENCRYPTION_KEY_GRACE_PERIOD).
     ///      If the sequencer cannot decrypt (malformed), they may reject or refund.
     /// @param amount Amount to deposit
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
@@ -88,6 +99,12 @@ interface IEncryptedDeposits {
         uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
     ) external returns (bytes32 newCurrentDepositQueueHash);
+
+    /// @notice Check if an encryption key is still valid for new deposits
+    /// @param keyIndex The key index to check
+    /// @return valid True if the key can be used for new deposits
+    /// @return expiresAtBlock Block number when this key expires (0 if current key)
+    function isEncryptionKeyValid(uint256 keyIndex) external view returns (bool valid, uint64 expiresAtBlock);
 }
 
 /*//////////////////////////////////////////////////////////////
@@ -148,6 +165,11 @@ struct EncryptionKeyEntry {
     uint8 yParity;          // Y coordinate parity (0x02 or 0x03)
     uint64 activationBlock; // Tempo block number when this key became active
 }
+
+/// Grace period after key rotation during which old keys are still accepted
+/// After this period, deposits using the old key are rejected.
+/// 1 day at 1 second block time = 86400 blocks
+uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
 
 /// @title ISequencerEncryptionKey
 /// @notice Interface for managing sequencer encryption keys with history

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -109,6 +109,25 @@ struct EncryptionKeyEntry {
 /// 1 day at 1 second block time = 86400 blocks
 uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
 
+/*//////////////////////////////////////////////////////////////
+                    UNIFIED DEPOSIT QUEUE TYPES
+//////////////////////////////////////////////////////////////*/
+
+/// @notice A deposit entry in the unified queue (for zone-side processing)
+/// @dev Used by the sequencer when calling advanceTempo with mixed deposit types.
+///      The depositData is ABI-encoded Deposit or EncryptedDeposit depending on type.
+struct QueuedDeposit {
+    DepositType depositType;
+    bytes depositData;  // abi.encode(Deposit) or abi.encode(EncryptedDeposit)
+}
+
+/// @notice Decryption data provided by sequencer for encrypted deposits
+/// @dev Must match 1:1 with encrypted deposits in the queue (in order of appearance)
+struct DecryptionData {
+    address to;      // Decrypted recipient
+    bytes32 memo;    // Decrypted memo
+}
+
 struct Withdrawal {
     address sender; // who initiated the withdrawal on the zone
     address to; // Tempo recipient
@@ -518,6 +537,14 @@ interface IZoneInbox {
         bytes32 memo
     );
 
+    /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
+    event EncryptedDepositProcessed(
+        bytes32 indexed depositHash,
+        address indexed sender,
+        address indexed to,      // Revealed after decryption
+        uint128 amount,
+        bytes32 memo             // Revealed after decryption
+    );
     error OnlySequencer();
     error InvalidDepositQueueHash();
 
@@ -539,12 +566,20 @@ interface IZoneInbox {
     /// @notice Advance Tempo state and process deposits in a single sequencer-only call.
     /// @dev This is the main entry point for the sequencer at block start.
     ///      1. Advances the zone's view of Tempo by processing the header
-    ///      2. Processes deposits from the deposit queue
+    ///      2. Processes deposits from the unified queue (regular and encrypted)
     ///      3. Validates the resulting hash against Tempo's currentDepositQueueHash
+    ///
+    ///      For encrypted deposits, the sequencer provides DecryptionData with the
+    ///      decrypted (to, memo) values. The proof/TEE validates correctness.
+    ///
     /// @param header RLP-encoded Tempo block header
-    /// @param deposits Array of deposits to process (oldest first, must be contiguous from processedDepositQueueHash)
-    function advanceTempo(bytes calldata header, Deposit[] calldata deposits) external;
-
+    /// @param deposits Array of queued deposits to process (oldest first, must be contiguous)
+    /// @param decryptions Decryption data for encrypted deposits (1:1 with encrypted deposits, in order)
+    function advanceTempo(
+        bytes calldata header,
+        QueuedDeposit[] calldata deposits,
+        DecryptionData[] calldata decryptions
+    ) external;
 }
 
 /// @title IZoneOutbox

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -97,6 +97,11 @@ struct EncryptionKeyEntry {
     uint64 activationBlock; // Tempo block number when this key became active
 }
 
+/// Grace period after key rotation during which old keys are still accepted.
+/// After this period, deposits using the old key are rejected.
+/// 1 day at 1 second block time = 86400 blocks
+uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
+
 struct Withdrawal {
     address sender; // who initiated the withdrawal on the zone
     address to; // Tempo recipient
@@ -240,6 +245,7 @@ interface IZonePortal {
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
         uint128 amount,
+        uint256 keyIndex,
         bytes32 ephemeralPubkeyX,
         uint8 ephemeralPubkeyYParity
     );
@@ -262,6 +268,8 @@ interface IZonePortal {
     error InvalidProof();
     error InvalidTempoBlockNumber();
     error CallbackRejected();
+    error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
+    error InvalidEncryptionKeyIndex(uint256 keyIndex);
     error DepositTooSmall();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
@@ -330,6 +338,17 @@ interface IZonePortal {
 
     /// @notice Calculate the fee for a deposit
     function calculateDepositFee() external view returns (uint128 fee);
+
+    /// @notice Check if an encryption key is still valid for new deposits
+    /// @dev A key is valid if it's the current key OR if it was superseded less than
+    ///      ENCRYPTION_KEY_GRACE_PERIOD blocks ago
+    /// @param keyIndex The key index to check
+    /// @return valid True if the key can be used for new deposits
+    /// @return expiresAtBlock Block number when this key expires (0 if current key, never expires)
+    function isEncryptionKeyValid(uint256 keyIndex)
+        external
+        view
+        returns (bool valid, uint64 expiresAtBlock);
 
     function deposit(address to, uint128 amount, bytes32 memo)
         external

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -121,23 +121,70 @@ struct QueuedDeposit {
     bytes depositData;  // abi.encode(Deposit) or abi.encode(EncryptedDeposit)
 }
 
+/// @notice Chaum-Pedersen proof for ECDH shared secret derivation
+/// @dev Proves knowledge of privSeq such that:
+///      - pubSeq = privSeq * G (sequencer's key pair)
+///      - sharedSecretPoint = privSeq * ephemeralPub (ECDH computation)
+///      Uses Fiat-Shamir heuristic for non-interactive proof.
+struct ChaumPedersenProof {
+    bytes32 s;  // Response: s = r + c * privSeq (mod n)
+    bytes32 c;  // Challenge: c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)
+}
+
 /// @notice Decryption data provided by sequencer for encrypted deposits
 /// @dev Must match 1:1 with encrypted deposits in the queue (in order of appearance).
-///      The sharedSecret enables on-chain verification via GCM tag validation without
-///      revealing the sequencer's private key.
+///      Includes a Chaum-Pedersen proof to verify the shared secret was correctly derived
+///      without exposing the sequencer's private key.
 struct DecryptionData {
-    bytes32 sharedSecret;  // ECDH shared secret (sequencerPriv * ephemeralPub)
-    address to;            // Decrypted recipient
-    bytes32 memo;          // Decrypted memo
+    bytes32 sharedSecret;        // ECDH shared secret (x-coordinate of privSeq * ephemeralPub)
+    address to;                  // Decrypted recipient
+    bytes32 memo;                // Decrypted memo
+    bytes32 sequencerPubX;       // Sequencer's public key X (must match keyIndex from deposit)
+    uint8 sequencerPubYParity;   // Sequencer's public key Y parity
+    ChaumPedersenProof cpProof;  // Proof of correct shared secret derivation
 }
 
 /*//////////////////////////////////////////////////////////////
-                    ECIES VERIFICATION PRECOMPILE
+                    CRYPTOGRAPHIC PRECOMPILES
 //////////////////////////////////////////////////////////////*/
 
-/// @notice Precompile address for ECIES decryption verification
+/// @notice Precompile address for Chaum-Pedersen proof verification
 /// @dev Predeploy at 0x1c00000000000000000000000000000000000100
-address constant ECIES_VERIFY = 0x1c00000000000000000000000000000000000100;
+address constant CHAUM_PEDERSEN_VERIFY = 0x1c00000000000000000000000000000000000100;
+
+/// @notice Precompile address for ECIES decryption verification
+/// @dev Predeploy at 0x1c00000000000000000000000000000000000101
+address constant ECIES_VERIFY = 0x1c00000000000000000000000000000000000101;
+
+/// @title IChaumPedersenVerify
+/// @notice Precompile for verifying Chaum-Pedersen proofs of ECDH shared secret derivation
+/// @dev Verifies that the sequencer knows privSeq such that:
+///      - pubSeq = privSeq * G (their public key)
+///      - sharedSecretPoint = privSeq * ephemeralPub (the ECDH computation)
+///      This proves correct derivation without revealing the private key.
+interface IChaumPedersenVerify {
+    /// @notice Verify a Chaum-Pedersen proof for ECDH shared secret derivation
+    /// @dev Verification equations:
+    ///      - R1 = s*G - c*pubSeq
+    ///      - R2 = s*ephemeralPub - c*sharedSecretPoint
+    ///      - c' = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)
+    ///      - Check: c == c'
+    /// @param ephemeralPubX The X coordinate of the ephemeral public key
+    /// @param ephemeralPubYParity The Y coordinate parity (0x02 or 0x03)
+    /// @param sharedSecret The claimed shared secret (x-coordinate)
+    /// @param sequencerPubX The sequencer's public key X coordinate
+    /// @param sequencerPubYParity The sequencer's public key Y parity
+    /// @param proof The Chaum-Pedersen proof (s, c)
+    /// @return valid True if the proof verifies correctly
+    function verifyProof(
+        bytes32 ephemeralPubX,
+        uint8 ephemeralPubYParity,
+        bytes32 sharedSecret,
+        bytes32 sequencerPubX,
+        uint8 sequencerPubYParity,
+        ChaumPedersenProof calldata proof
+    ) external view returns (bool valid);
+}
 
 /// @title IEciesVerify
 /// @notice Precompile for verifying ECIES (secp256k1 + AES-256-GCM) decryption
@@ -575,10 +622,18 @@ interface IZoneInbox {
         uint128 amount,
         bytes32 memo             // Revealed after decryption
     );
+
+    /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
+    event EncryptedDepositFailed(
+        bytes32 indexed depositHash,
+        address indexed sender,
+        uint128 amount
+    );
     error OnlySequencer();
     error InvalidDepositQueueHash();
     error MissingDecryptionData();
     error ExtraDecryptionData();
+    error InvalidSharedSecretProof();
     error InvalidDecryption();
 
     /// @notice Zone configuration (reads sequencer from L1)

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -63,6 +63,28 @@ struct Deposit {
     bytes32 memo;
 }
 
+/*//////////////////////////////////////////////////////////////
+                        ENCRYPTED DEPOSITS
+//////////////////////////////////////////////////////////////*/
+
+/// @notice Encrypted deposit payload (recipient and memo encrypted to sequencer)
+/// @dev Uses ECIES with secp256k1: ephemeral ECDH + AES-256-GCM
+struct EncryptedDepositPayload {
+    bytes32 ephemeralPubkeyX;     // Ephemeral public key X coordinate (for ECDH)
+    uint8 ephemeralPubkeyYParity; // Y coordinate parity (0x02 or 0x03)
+    bytes ciphertext;             // AES-256-GCM encrypted (to || memo || padding)
+    bytes12 nonce;                // GCM nonce
+    bytes16 tag;                  // GCM authentication tag
+}
+
+/// @notice Encrypted deposit stored in the queue
+/// @dev Sender and amount are public; recipient and memo are encrypted
+struct EncryptedDeposit {
+    address sender;              // Depositor (public, for refunds)
+    uint128 amount;              // Amount (public, for accounting)
+    EncryptedDepositPayload encrypted; // Encrypted (to, memo)
+}
+
 struct Withdrawal {
     address sender; // who initiated the withdrawal on the zone
     address to; // Tempo recipient
@@ -200,6 +222,18 @@ interface IZonePortal {
         address indexed currentSequencer, address indexed pendingSequencer
     );
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+
+    /// @notice Emitted when an encrypted deposit is made (recipient/memo not revealed)
+    event EncryptedDepositMade(
+        bytes32 indexed newCurrentDepositQueueHash,
+        address indexed sender,
+        uint128 amount,
+        bytes32 ephemeralPubkeyX,
+        uint8 ephemeralPubkeyYParity
+    );
+
+    /// @notice Emitted when sequencer updates their encryption key
+    event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity);
     event ZoneGasRateUpdated(uint128 zoneGasRate);
 
     error NotSequencer();
@@ -240,6 +274,16 @@ interface IZonePortal {
 
     function setSequencerPubkey(bytes32 pubkey) external;
 
+    /// @notice Get the sequencer's encryption public key for encrypted deposits
+    /// @return x The X coordinate of the secp256k1 public key
+    /// @return yParity The Y coordinate parity (0x02 or 0x03)
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+
+    /// @notice Set the sequencer's encryption public key. Only callable by sequencer.
+    /// @param x The X coordinate of the secp256k1 public key
+    /// @param yParity The Y coordinate parity (0x02 or 0x03)
+    function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external;
+
     /// @notice Set zone gas rate. Only callable by sequencer.
     /// @param _zoneGasRate Gas token units per gas unit on the zone
     function setZoneGasRate(uint128 _zoneGasRate) external;
@@ -247,13 +291,20 @@ interface IZonePortal {
     /// @notice Calculate the fee for a deposit
     function calculateDepositFee() external view returns (uint128 fee);
 
-    function deposit(
-        address to,
-        uint128 amount,
-        bytes32 memo
-    )
+    function deposit(address to, uint128 amount, bytes32 memo)
         external
         returns (bytes32 newCurrentDepositQueueHash);
+
+    /// @notice Deposit with encrypted recipient and memo
+    /// @dev The encrypted payload contains (to, memo) encrypted to sequencerEncryptionKey.
+    ///      Only the sequencer can decrypt and credit the correct recipient on the zone.
+    /// @param amount Amount to deposit
+    /// @param encrypted The encrypted payload (recipient and memo)
+    /// @return newCurrentDepositQueueHash The new deposit queue hash
+    function depositEncrypted(
+        uint128 amount,
+        EncryptedDepositPayload calldata encrypted
+    ) external returns (bytes32 newCurrentDepositQueueHash);
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
     function submitBatch(
         uint64 tempoBlockNumber,

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -4,13 +4,11 @@ pragma solidity ^0.8.13;
 /// @title IZoneToken
 /// @notice Interface for the zone's zone token (TIP-20 with mint/burn for system)
 interface IZoneToken {
-
     function mint(address to, uint256 amount) external;
     function burn(address from, uint256 amount) external;
     function transfer(address to, uint256 amount) external returns (bool);
     function transferFrom(address from, address to, uint256 amount) external returns (bool);
     function balanceOf(address account) external view returns (uint256);
-
 }
 
 /// @notice Common types for the Zone protocol
@@ -167,7 +165,6 @@ address constant SHA256 = 0x0000000000000000000000000000000000000002;
 ///      - sharedSecretPoint = privSeq * ephemeralPub (the ECDH computation)
 ///      This proves correct derivation without revealing the private key.
 interface IChaumPedersenVerify {
-
     /// @notice Verify a Chaum-Pedersen proof for ECDH shared secret derivation
     /// @dev Verification equations:
     ///      - R1 = s*G - c*pubSeq
@@ -188,11 +185,7 @@ interface IChaumPedersenVerify {
         bytes32 sequencerPubX,
         uint8 sequencerPubYParity,
         ChaumPedersenProof calldata proof
-    )
-        external
-        view
-        returns (bool valid);
-
+    ) external view returns (bool valid);
 }
 
 /// @title IAesGcmDecrypt
@@ -200,7 +193,6 @@ interface IChaumPedersenVerify {
 /// @dev Decrypts ciphertext and verifies the GCM authentication tag.
 ///      HKDF-SHA256 key derivation is done in Solidity using the SHA256 precompile.
 interface IAesGcmDecrypt {
-
     /// @notice Decrypt AES-256-GCM ciphertext and verify authentication tag
     /// @dev Returns empty bytes and false if tag verification fails.
     ///      AAD (Additional Authenticated Data) is typically empty for ECIES.
@@ -211,17 +203,10 @@ interface IAesGcmDecrypt {
     /// @param tag GCM authentication tag (16 bytes)
     /// @return plaintext The decrypted data (empty if verification fails)
     /// @return valid True if the tag verifies and decryption succeeds
-    function decrypt(
-        bytes32 key,
-        bytes12 nonce,
-        bytes calldata ciphertext,
-        bytes calldata aad,
-        bytes16 tag
-    )
+    function decrypt(bytes32 key, bytes12 nonce, bytes calldata ciphertext, bytes calldata aad, bytes16 tag)
         external
         view
         returns (bytes memory plaintext, bool valid);
-
 }
 
 struct Withdrawal {
@@ -254,7 +239,6 @@ address constant ZONE_CONFIG = 0x1c00000000000000000000000000000000000003;
 /// @title IVerifier
 /// @notice Interface for zone proof/attestation verification
 interface IVerifier {
-
     /// @notice Verify a batch proof
     /// @dev The proof validates:
     ///      1. Valid state transition from prevBlockHash to nextBlockHash
@@ -286,17 +270,12 @@ interface IVerifier {
         WithdrawalQueueTransition calldata withdrawalQueueTransition,
         bytes calldata verifierConfig,
         bytes calldata proof
-    )
-        external
-        view
-        returns (bool);
-
+    ) external view returns (bool);
 }
 
 /// @title IZoneFactory
 /// @notice Interface for creating zones
 interface IZoneFactory {
-
     struct CreateZoneParams {
         address token;
         address sequencer;
@@ -320,19 +299,15 @@ interface IZoneFactory {
     error InvalidSequencer();
     error InvalidVerifier();
 
-    function createZone(CreateZoneParams calldata params)
-        external
-        returns (uint64 zoneId, address portal);
+    function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
     function zoneCount() external view returns (uint64);
     function zones(uint64 zoneId) external view returns (ZoneInfo memory);
     function isZonePortal(address portal) external view returns (bool);
-
 }
 
 /// @title IZonePortal
 /// @notice Interface for zone portal on Tempo
 interface IZonePortal {
-
     event DepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
@@ -351,15 +326,9 @@ interface IZonePortal {
 
     event WithdrawalProcessed(address indexed to, uint128 amount, bool callbackSuccess);
 
-    event BounceBack(
-        bytes32 indexed newCurrentDepositQueueHash,
-        address indexed fallbackRecipient,
-        uint128 amount
-    );
+    event BounceBack(bytes32 indexed newCurrentDepositQueueHash, address indexed fallbackRecipient, uint128 amount);
 
-    event SequencerTransferStarted(
-        address indexed currentSequencer, address indexed pendingSequencer
-    );
+    event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
 
     /// @notice Emitted when an encrypted deposit is made (recipient/memo not revealed)
@@ -377,9 +346,7 @@ interface IZonePortal {
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
     /// @param keyIndex The index of this key in the history array
     /// @param activationBlock The Tempo block when this key becomes active
-    event SequencerEncryptionKeyUpdated(
-        bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock
-    );
+    event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock);
     event ZoneGasRateUpdated(uint128 zoneGasRate);
 
     error NotSequencer();
@@ -400,7 +367,6 @@ interface IZonePortal {
     function messenger() external view returns (address);
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);
-    function sequencerPubkey() external view returns (bytes32);
     function zoneGasRate() external view returns (uint128);
     function verifier() external view returns (address);
     function withdrawalBatchIndex() external view returns (uint64);
@@ -420,8 +386,6 @@ interface IZonePortal {
 
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
     function acceptSequencer() external;
-
-    function setSequencerPubkey(bytes32 pubkey) external;
 
     /// @notice Get the sequencer's current encryption public key for encrypted deposits
     /// @return x The X coordinate of the secp256k1 public key
@@ -467,18 +431,9 @@ interface IZonePortal {
     /// @param keyIndex The key index to check
     /// @return valid True if the key can be used for new deposits
     /// @return expiresAtBlock Block number when this key expires (0 if current key, never expires)
-    function isEncryptionKeyValid(uint256 keyIndex)
-        external
-        view
-        returns (bool valid, uint64 expiresAtBlock);
+    function isEncryptionKeyValid(uint256 keyIndex) external view returns (bool valid, uint64 expiresAtBlock);
 
-    function deposit(
-        address to,
-        uint128 amount,
-        bytes32 memo
-    )
-        external
-        returns (bytes32 newCurrentDepositQueueHash);
+    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
 
     /// @notice Deposit with encrypted recipient and memo
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key
@@ -488,11 +443,7 @@ interface IZonePortal {
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
-    function depositEncrypted(
-        uint128 amount,
-        uint256 keyIndex,
-        EncryptedDepositPayload calldata encrypted
-    )
+    function depositEncrypted(uint128 amount, uint256 keyIndex, EncryptedDepositPayload calldata encrypted)
         external
         returns (bytes32 newCurrentDepositQueueHash);
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
@@ -504,15 +455,12 @@ interface IZonePortal {
         WithdrawalQueueTransition calldata withdrawalQueueTransition,
         bytes calldata verifierConfig,
         bytes calldata proof
-    )
-        external;
-
+    ) external;
 }
 
 /// @title IZoneMessenger
 /// @notice Interface for zone messenger on Tempo (handles withdrawal callbacks)
 interface IZoneMessenger {
-
     /// @notice Returns the zone's portal address
     function portal() external view returns (address);
 
@@ -531,29 +479,13 @@ interface IZoneMessenger {
     /// @param amount Tokens to transfer from portal to target
     /// @param gasLimit Max gas for the callback
     /// @param data Calldata for the target
-    function relayMessage(
-        address sender,
-        address target,
-        uint128 amount,
-        uint64 gasLimit,
-        bytes calldata data
-    )
-        external;
-
+    function relayMessage(address sender, address target, uint128 amount, uint64 gasLimit, bytes calldata data) external;
 }
 
 /// @title IWithdrawalReceiver
 /// @notice Interface for contracts that receive withdrawals with callbacks
 interface IWithdrawalReceiver {
-
-    function onWithdrawalReceived(
-        address sender,
-        uint128 amount,
-        bytes calldata callbackData
-    )
-        external
-        returns (bytes4);
-
+    function onWithdrawalReceived(address sender, uint128 amount, bytes calldata callbackData) external returns (bytes4);
 }
 
 /// @notice Withdrawal batch parameters stored in state for proof access
@@ -570,10 +502,7 @@ struct LastBatch {
 ///      System-only contract. Only ZoneInbox can call finalizeTempo().
 ///      Only ZoneInbox, ZoneOutbox, and ZoneConfig can call readTempoStorageSlot(s).
 interface ITempoState {
-
-    event TempoBlockFinalized(
-        bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot
-    );
+    event TempoBlockFinalized(bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot);
 
     error InvalidParentHash();
     error InvalidBlockNumber();
@@ -610,20 +539,12 @@ interface ITempoState {
     function readTempoStorageSlot(address account, bytes32 slot) external view returns (bytes32);
 
     /// @notice Read multiple storage slots from a Tempo contract
-    function readTempoStorageSlots(
-        address account,
-        bytes32[] calldata slots
-    )
-        external
-        view
-        returns (bytes32[] memory);
-
+    function readTempoStorageSlots(address account, bytes32[] calldata slots) external view returns (bytes32[] memory);
 }
 
 /// @title IZoneInbox
 /// @notice Interface for zone-side system contract that advances Tempo state and processes deposits
 interface IZoneInbox {
-
     event TempoAdvanced(
         bytes32 indexed tempoBlockHash,
         uint64 indexed tempoBlockNumber,
@@ -632,11 +553,7 @@ interface IZoneInbox {
     );
 
     event DepositProcessed(
-        bytes32 indexed depositHash,
-        address indexed sender,
-        address indexed to,
-        uint128 amount,
-        bytes32 memo
+        bytes32 indexed depositHash, address indexed sender, address indexed to, uint128 amount, bytes32 memo
     );
 
     /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
@@ -649,9 +566,7 @@ interface IZoneInbox {
     );
 
     /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
-    event EncryptedDepositFailed(
-        bytes32 indexed depositHash, address indexed sender, uint128 amount
-    );
+    event EncryptedDepositFailed(bytes32 indexed depositHash, address indexed sender, uint128 amount);
     error OnlySequencer();
     error InvalidDepositQueueHash();
     error MissingDecryptionData();
@@ -690,15 +605,12 @@ interface IZoneInbox {
         bytes calldata header,
         QueuedDeposit[] calldata deposits,
         DecryptionData[] calldata decryptions
-    )
-        external;
-
+    ) external;
 }
 
 /// @title IZoneOutbox
 /// @notice Interface for zone outbox on the zone
 interface IZoneOutbox {
-
     /// @notice Maximum callback data size (1KB)
     function MAX_CALLBACK_DATA_SIZE() external view returns (uint256);
 
@@ -763,8 +675,7 @@ interface IZoneOutbox {
         uint64 gasLimit,
         address fallbackRecipient,
         bytes calldata data
-    )
-        external;
+    ) external;
 
     /// @notice Finalize batch at end of block - build withdrawal hash and write to state
     /// @dev Only callable by sequencer. Required per batch (count may be 0).
@@ -772,7 +683,6 @@ interface IZoneOutbox {
     /// @param count Max number of withdrawals to process
     /// @return withdrawalQueueHash The hash chain (0 if no withdrawals)
     function finalizeWithdrawalBatch(uint256 count) external returns (bytes32 withdrawalQueueHash);
-
 }
 
 /// @title IZoneConfig
@@ -780,7 +690,6 @@ interface IZoneOutbox {
 /// @dev System contract predeploy at 0x1c00000000000000000000000000000000000003
 ///      Provides centralized access to zone metadata and reads sequencer from L1.
 interface IZoneConfig {
-
     error NotSequencer();
 
     /// @notice Zone token address (TIP-20 at same address as Tempo)
@@ -808,5 +717,4 @@ interface IZoneConfig {
 
     /// @notice Get zone token as IZoneToken interface
     function getZoneToken() external view returns (IZoneToken);
-
 }

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -389,6 +389,7 @@ interface IZonePortal {
     error CallbackRejected();
     error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
     error InvalidEncryptionKeyIndex(uint256 keyIndex);
+    error InvalidEphemeralPubkey();
     error DepositTooSmall();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -1,4 +1,4 @@
-                                                                                                                                                                                // SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 /// @title IZoneToken
@@ -59,8 +59,8 @@ struct WithdrawalQueueTransition {
 /// @notice Deposit type discriminator for the unified deposit queue
 /// @dev Used in hash chain: keccak256(abi.encode(depositType, depositData, prevHash))
 enum DepositType {
-    Regular,    // Standard deposit with plaintext recipient and memo
-    Encrypted   // Encrypted deposit with hidden recipient and memo
+    Regular, // Standard deposit with plaintext recipient and memo
+    Encrypted // Encrypted deposit with hidden recipient and memo
 }
 
 struct Deposit {
@@ -77,11 +77,11 @@ struct Deposit {
 /// @notice Encrypted deposit payload (recipient and memo encrypted to sequencer)
 /// @dev Uses ECIES with secp256k1: ephemeral ECDH + AES-256-GCM
 struct EncryptedDepositPayload {
-    bytes32 ephemeralPubkeyX;     // Ephemeral public key X coordinate (for ECDH)
+    bytes32 ephemeralPubkeyX; // Ephemeral public key X coordinate (for ECDH)
     uint8 ephemeralPubkeyYParity; // Y coordinate parity (0x02 or 0x03)
-    bytes ciphertext;             // AES-256-GCM encrypted (to || memo || padding)
-    bytes12 nonce;                // GCM nonce
-    bytes16 tag;                  // GCM authentication tag
+    bytes ciphertext; // AES-256-GCM encrypted (to || memo || padding)
+    bytes12 nonce; // GCM nonce
+    bytes16 tag; // GCM authentication tag
 }
 
 /// @notice Encrypted deposit stored in the queue
@@ -89,9 +89,9 @@ struct EncryptedDepositPayload {
 ///      The keyIndex specifies which encryption key the user used, allowing the prover
 ///      to look up the correct key for decryption even after key rotations.
 struct EncryptedDeposit {
-    address sender;              // Depositor (public, for refunds)
-    uint128 amount;              // Amount (public, for accounting)
-    uint256 keyIndex;            // Index of encryption key used (specified by depositor)
+    address sender; // Depositor (public, for refunds)
+    uint128 amount; // Amount (public, for accounting)
+    uint256 keyIndex; // Index of encryption key used (specified by depositor)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
 }
 
@@ -99,15 +99,15 @@ struct EncryptedDeposit {
 /// @dev Used to track key rotations so the prover can determine which key
 ///      was valid when a deposit was made
 struct EncryptionKeyEntry {
-    bytes32 x;              // X coordinate of the public key
-    uint8 yParity;          // Y coordinate parity (0x02 or 0x03)
+    bytes32 x; // X coordinate of the public key
+    uint8 yParity; // Y coordinate parity (0x02 or 0x03)
     uint64 activationBlock; // Tempo block number when this key became active
 }
 
-/// Grace period after key rotation during which old keys are still accepted.
-/// After this period, deposits using the old key are rejected.
-/// 1 day at 1 second block time = 86400 blocks
-uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
+// Grace period after key rotation during which old keys are still accepted.
+// After this period, deposits using the old key are rejected.
+// 1 day at 1 second block time = 86400 blocks
+uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86_400;
 
 /*//////////////////////////////////////////////////////////////
                     UNIFIED DEPOSIT QUEUE TYPES
@@ -118,7 +118,7 @@ uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
 ///      The depositData is ABI-encoded Deposit or EncryptedDeposit depending on type.
 struct QueuedDeposit {
     DepositType depositType;
-    bytes depositData;  // abi.encode(Deposit) or abi.encode(EncryptedDeposit)
+    bytes depositData; // abi.encode(Deposit) or abi.encode(EncryptedDeposit)
 }
 
 /// @notice Chaum-Pedersen proof for ECDH shared secret derivation
@@ -127,8 +127,8 @@ struct QueuedDeposit {
 ///      - sharedSecretPoint = privSeq * ephemeralPub (ECDH computation)
 ///      Uses Fiat-Shamir heuristic for non-interactive proof.
 struct ChaumPedersenProof {
-    bytes32 s;  // Response: s = r + c * privSeq (mod n)
-    bytes32 c;  // Challenge: c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)
+    bytes32 s; // Response: s = r + c * privSeq (mod n)
+    bytes32 c; // Challenge: c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)
 }
 
 /// @notice Decryption data provided by sequencer for encrypted deposits
@@ -136,28 +136,28 @@ struct ChaumPedersenProof {
 ///      Includes a Chaum-Pedersen proof to verify the shared secret was correctly derived
 ///      without exposing the sequencer's private key.
 struct DecryptionData {
-    bytes32 sharedSecret;        // ECDH shared secret (x-coordinate of privSeq * ephemeralPub)
-    address to;                  // Decrypted recipient
-    bytes32 memo;                // Decrypted memo
-    bytes32 sequencerPubX;       // Sequencer's public key X (must match keyIndex from deposit)
-    uint8 sequencerPubYParity;   // Sequencer's public key Y parity
-    ChaumPedersenProof cpProof;  // Proof of correct shared secret derivation
+    bytes32 sharedSecret; // ECDH shared secret (x-coordinate of privSeq * ephemeralPub)
+    address to; // Decrypted recipient
+    bytes32 memo; // Decrypted memo
+    bytes32 sequencerPubX; // Sequencer's public key X (must match keyIndex from deposit)
+    uint8 sequencerPubYParity; // Sequencer's public key Y parity
+    ChaumPedersenProof cpProof; // Proof of correct shared secret derivation
 }
 
 /*//////////////////////////////////////////////////////////////
                     CRYPTOGRAPHIC PRECOMPILES
 //////////////////////////////////////////////////////////////*/
 
-/// @notice Precompile address for Chaum-Pedersen proof verification
-/// @dev Predeploy at 0x1c00000000000000000000000000000000000100
-address constant CHAUM_PEDERSEN_VERIFY = 0x1c00000000000000000000000000000000000100;
+// Precompile address for Chaum-Pedersen proof verification
+// Predeploy at 0x1c00000000000000000000000000000000000100
+address constant CHAUM_PEDERSEN_VERIFY = 0x1C00000000000000000000000000000000000100;
 
-/// @notice Precompile address for AES-256-GCM decryption
-/// @dev Predeploy at 0x1c00000000000000000000000000000000000101
-address constant AES_GCM_DECRYPT = 0x1c00000000000000000000000000000000000101;
+// Precompile address for AES-256-GCM decryption
+// Predeploy at 0x1c00000000000000000000000000000000000101
+address constant AES_GCM_DECRYPT = 0x1C00000000000000000000000000000000000101;
 
-/// @notice Precompile address for SHA256 (standard Ethereum precompile)
-/// @dev Used for HKDF-SHA256 implementation in Solidity
+// Precompile address for SHA256 (standard Ethereum precompile)
+// Used for HKDF-SHA256 implementation in Solidity
 address constant SHA256 = 0x0000000000000000000000000000000000000002;
 
 /// @title IChaumPedersenVerify
@@ -167,6 +167,7 @@ address constant SHA256 = 0x0000000000000000000000000000000000000002;
 ///      - sharedSecretPoint = privSeq * ephemeralPub (the ECDH computation)
 ///      This proves correct derivation without revealing the private key.
 interface IChaumPedersenVerify {
+
     /// @notice Verify a Chaum-Pedersen proof for ECDH shared secret derivation
     /// @dev Verification equations:
     ///      - R1 = s*G - c*pubSeq
@@ -187,7 +188,11 @@ interface IChaumPedersenVerify {
         bytes32 sequencerPubX,
         uint8 sequencerPubYParity,
         ChaumPedersenProof calldata proof
-    ) external view returns (bool valid);
+    )
+        external
+        view
+        returns (bool valid);
+
 }
 
 /// @title IAesGcmDecrypt
@@ -195,6 +200,7 @@ interface IChaumPedersenVerify {
 /// @dev Decrypts ciphertext and verifies the GCM authentication tag.
 ///      HKDF-SHA256 key derivation is done in Solidity using the SHA256 precompile.
 interface IAesGcmDecrypt {
+
     /// @notice Decrypt AES-256-GCM ciphertext and verify authentication tag
     /// @dev Returns empty bytes and false if tag verification fails.
     ///      AAD (Additional Authenticated Data) is typically empty for ECIES.
@@ -211,7 +217,11 @@ interface IAesGcmDecrypt {
         bytes calldata ciphertext,
         bytes calldata aad,
         bytes16 tag
-    ) external view returns (bytes memory plaintext, bool valid);
+    )
+        external
+        view
+        returns (bytes memory plaintext, bool valid);
+
 }
 
 struct Withdrawal {
@@ -368,10 +378,7 @@ interface IZonePortal {
     /// @param keyIndex The index of this key in the history array
     /// @param activationBlock The Tempo block when this key becomes active
     event SequencerEncryptionKeyUpdated(
-        bytes32 x,
-        uint8 yParity,
-        uint256 keyIndex,
-        uint64 activationBlock
+        bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock
     );
     event ZoneGasRateUpdated(uint128 zoneGasRate);
 
@@ -442,7 +449,9 @@ interface IZonePortal {
     /// @return yParity The Y coordinate parity
     /// @return keyIndex The index of this key in history
     function encryptionKeyAtBlock(uint64 tempoBlockNumber)
-        external view returns (bytes32 x, uint8 yParity, uint256 keyIndex);
+        external
+        view
+        returns (bytes32 x, uint8 yParity, uint256 keyIndex);
 
     /// @notice Set zone gas rate. Only callable by sequencer.
     /// @param _zoneGasRate Gas token units per gas unit on the zone
@@ -462,7 +471,11 @@ interface IZonePortal {
         view
         returns (bool valid, uint64 expiresAtBlock);
 
-    function deposit(address to, uint128 amount, bytes32 memo)
+    function deposit(
+        address to,
+        uint128 amount,
+        bytes32 memo
+    )
         external
         returns (bytes32 newCurrentDepositQueueHash);
 
@@ -478,7 +491,9 @@ interface IZonePortal {
         uint128 amount,
         uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
-    ) external returns (bytes32 newCurrentDepositQueueHash);
+    )
+        external
+        returns (bytes32 newCurrentDepositQueueHash);
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
     function submitBatch(
         uint64 tempoBlockNumber,
@@ -627,16 +642,14 @@ interface IZoneInbox {
     event EncryptedDepositProcessed(
         bytes32 indexed depositHash,
         address indexed sender,
-        address indexed to,      // Revealed after decryption
+        address indexed to, // Revealed after decryption
         uint128 amount,
-        bytes32 memo             // Revealed after decryption
+        bytes32 memo // Revealed after decryption
     );
 
     /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
     event EncryptedDepositFailed(
-        bytes32 indexed depositHash,
-        address indexed sender,
-        uint128 amount
+        bytes32 indexed depositHash, address indexed sender, uint128 amount
     );
     error OnlySequencer();
     error InvalidDepositQueueHash();
@@ -676,7 +689,9 @@ interface IZoneInbox {
         bytes calldata header,
         QueuedDeposit[] calldata deposits,
         DecryptionData[] calldata decryptions
-    ) external;
+    )
+        external;
+
 }
 
 /// @title IZoneOutbox

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -78,12 +78,13 @@ struct EncryptedDepositPayload {
 }
 
 /// @notice Encrypted deposit stored in the queue
-/// @dev Sender, amount, and deposit block are public; recipient and memo are encrypted.
-///      The tempoBlockNumber is recorded so the prover knows which encryption key was valid.
+/// @dev Sender, amount, and key index are public; recipient and memo are encrypted.
+///      The keyIndex specifies which encryption key the user used, allowing the prover
+///      to look up the correct key for decryption even after key rotations.
 struct EncryptedDeposit {
     address sender;              // Depositor (public, for refunds)
     uint128 amount;              // Amount (public, for accounting)
-    uint64 tempoBlockNumber;     // Tempo block when deposit was made (for key lookup)
+    uint256 keyIndex;            // Index of encryption key used (specified by depositor)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
 }
 
@@ -335,13 +336,16 @@ interface IZonePortal {
         returns (bytes32 newCurrentDepositQueueHash);
 
     /// @notice Deposit with encrypted recipient and memo
-    /// @dev The encrypted payload contains (to, memo) encrypted to sequencerEncryptionKey.
-    ///      Only the sequencer can decrypt and credit the correct recipient on the zone.
+    /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key
+    ///      at the specified keyIndex. The user must specify which key they encrypted to,
+    ///      ensuring correct decryption even if the key rotates before inclusion.
     /// @param amount Amount to deposit
+    /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
     function depositEncrypted(
         uint128 amount,
+        uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
     ) external returns (bytes32 newCurrentDepositQueueHash);
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -388,10 +388,14 @@ interface IZonePortal {
     event EncryptedDepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
-        uint128 amount,
+        uint128 netAmount,
+        uint128 fee,
         uint256 keyIndex,
         bytes32 ephemeralPubkeyX,
-        uint8 ephemeralPubkeyYParity
+        uint8 ephemeralPubkeyYParity,
+        bytes ciphertext,
+        bytes12 nonce,
+        bytes16 tag
     );
 
     /// @notice Emitted when sequencer updates their encryption key

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+                                                                                                                                                                                // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
 /// @title IZoneToken

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -56,6 +56,13 @@ struct WithdrawalQueueTransition {
     bytes32 withdrawalQueueHash; // hash chain of withdrawals for this batch (0 if none)
 }
 
+/// @notice Deposit type discriminator for the unified deposit queue
+/// @dev Used in hash chain: keccak256(abi.encode(depositType, depositData, prevHash))
+enum DepositType {
+    Regular,    // Standard deposit with plaintext recipient and memo
+    Encrypted   // Encrypted deposit with hidden recipient and memo
+}
+
 struct Deposit {
     address sender;
     address to;

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -4,11 +4,13 @@ pragma solidity ^0.8.13;
 /// @title IZoneToken
 /// @notice Interface for the zone's zone token (TIP-20 with mint/burn for system)
 interface IZoneToken {
+
     function mint(address to, uint256 amount) external;
     function burn(address from, uint256 amount) external;
     function transfer(address to, uint256 amount) external returns (bool);
     function transferFrom(address from, address to, uint256 amount) external returns (bool);
     function balanceOf(address account) external view returns (uint256);
+
 }
 
 /// @notice Common types for the Zone protocol
@@ -165,6 +167,7 @@ address constant SHA256 = 0x0000000000000000000000000000000000000002;
 ///      - sharedSecretPoint = privSeq * ephemeralPub (the ECDH computation)
 ///      This proves correct derivation without revealing the private key.
 interface IChaumPedersenVerify {
+
     /// @notice Verify a Chaum-Pedersen proof for ECDH shared secret derivation
     /// @dev Verification equations:
     ///      - R1 = s*G - c*pubSeq
@@ -185,7 +188,11 @@ interface IChaumPedersenVerify {
         bytes32 sequencerPubX,
         uint8 sequencerPubYParity,
         ChaumPedersenProof calldata proof
-    ) external view returns (bool valid);
+    )
+        external
+        view
+        returns (bool valid);
+
 }
 
 /// @title IAesGcmDecrypt
@@ -193,6 +200,7 @@ interface IChaumPedersenVerify {
 /// @dev Decrypts ciphertext and verifies the GCM authentication tag.
 ///      HKDF-SHA256 key derivation is done in Solidity using the SHA256 precompile.
 interface IAesGcmDecrypt {
+
     /// @notice Decrypt AES-256-GCM ciphertext and verify authentication tag
     /// @dev Returns empty bytes and false if tag verification fails.
     ///      AAD (Additional Authenticated Data) is typically empty for ECIES.
@@ -203,10 +211,17 @@ interface IAesGcmDecrypt {
     /// @param tag GCM authentication tag (16 bytes)
     /// @return plaintext The decrypted data (empty if verification fails)
     /// @return valid True if the tag verifies and decryption succeeds
-    function decrypt(bytes32 key, bytes12 nonce, bytes calldata ciphertext, bytes calldata aad, bytes16 tag)
+    function decrypt(
+        bytes32 key,
+        bytes12 nonce,
+        bytes calldata ciphertext,
+        bytes calldata aad,
+        bytes16 tag
+    )
         external
         view
         returns (bytes memory plaintext, bool valid);
+
 }
 
 struct Withdrawal {
@@ -236,9 +251,32 @@ address constant ZONE_OUTBOX = 0x1c00000000000000000000000000000000000002;
 // ZoneConfig system contract address (0x1c00...0003)
 address constant ZONE_CONFIG = 0x1c00000000000000000000000000000000000003;
 
+/*//////////////////////////////////////////////////////////////
+                ZONE PORTAL STORAGE SLOT CONSTANTS
+//////////////////////////////////////////////////////////////*/
+
+// ZonePortal storage layout (non-immutable variables only):
+//   slot 0: sequencer (address)
+//   slot 1: pendingSequencer (address)
+//   slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+//   slot 3: blockHash (bytes32)
+//   slot 4: currentDepositQueueHash (bytes32)
+//   slot 5: lastSyncedTempoBlockNumber (uint64)
+//   slot 6: _encryptionKeys (EncryptionKeyEntry[])
+//
+// These constants are the single source of truth for cross-domain reads.
+// ZoneConfig and ZoneInbox use them to read portal state via
+// TempoState.readTempoStorageSlot(). If the portal layout changes,
+// update these constants and the vm.load regression tests will catch mismatches.
+bytes32 constant PORTAL_SEQUENCER_SLOT = bytes32(uint256(0));
+bytes32 constant PORTAL_PENDING_SEQUENCER_SLOT = bytes32(uint256(1));
+bytes32 constant PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
+bytes32 constant PORTAL_ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
+
 /// @title IVerifier
 /// @notice Interface for zone proof/attestation verification
 interface IVerifier {
+
     /// @notice Verify a batch proof
     /// @dev The proof validates:
     ///      1. Valid state transition from prevBlockHash to nextBlockHash
@@ -270,12 +308,17 @@ interface IVerifier {
         WithdrawalQueueTransition calldata withdrawalQueueTransition,
         bytes calldata verifierConfig,
         bytes calldata proof
-    ) external view returns (bool);
+    )
+        external
+        view
+        returns (bool);
+
 }
 
 /// @title IZoneFactory
 /// @notice Interface for creating zones
 interface IZoneFactory {
+
     struct CreateZoneParams {
         address token;
         address sequencer;
@@ -299,15 +342,19 @@ interface IZoneFactory {
     error InvalidSequencer();
     error InvalidVerifier();
 
-    function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
+    function createZone(CreateZoneParams calldata params)
+        external
+        returns (uint64 zoneId, address portal);
     function zoneCount() external view returns (uint64);
     function zones(uint64 zoneId) external view returns (ZoneInfo memory);
     function isZonePortal(address portal) external view returns (bool);
+
 }
 
 /// @title IZonePortal
 /// @notice Interface for zone portal on Tempo
 interface IZonePortal {
+
     event DepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
@@ -326,9 +373,15 @@ interface IZonePortal {
 
     event WithdrawalProcessed(address indexed to, uint128 amount, bool callbackSuccess);
 
-    event BounceBack(bytes32 indexed newCurrentDepositQueueHash, address indexed fallbackRecipient, uint128 amount);
+    event BounceBack(
+        bytes32 indexed newCurrentDepositQueueHash,
+        address indexed fallbackRecipient,
+        uint128 amount
+    );
 
-    event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
+    event SequencerTransferStarted(
+        address indexed currentSequencer, address indexed pendingSequencer
+    );
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
 
     /// @notice Emitted when an encrypted deposit is made (recipient/memo not revealed)
@@ -346,7 +399,9 @@ interface IZonePortal {
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
     /// @param keyIndex The index of this key in the history array
     /// @param activationBlock The Tempo block when this key becomes active
-    event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock);
+    event SequencerEncryptionKeyUpdated(
+        bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock
+    );
     event ZoneGasRateUpdated(uint128 zoneGasRate);
 
     error NotSequencer();
@@ -431,9 +486,18 @@ interface IZonePortal {
     /// @param keyIndex The key index to check
     /// @return valid True if the key can be used for new deposits
     /// @return expiresAtBlock Block number when this key expires (0 if current key, never expires)
-    function isEncryptionKeyValid(uint256 keyIndex) external view returns (bool valid, uint64 expiresAtBlock);
+    function isEncryptionKeyValid(uint256 keyIndex)
+        external
+        view
+        returns (bool valid, uint64 expiresAtBlock);
 
-    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
+    function deposit(
+        address to,
+        uint128 amount,
+        bytes32 memo
+    )
+        external
+        returns (bytes32 newCurrentDepositQueueHash);
 
     /// @notice Deposit with encrypted recipient and memo
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key
@@ -443,7 +507,11 @@ interface IZonePortal {
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
-    function depositEncrypted(uint128 amount, uint256 keyIndex, EncryptedDepositPayload calldata encrypted)
+    function depositEncrypted(
+        uint128 amount,
+        uint256 keyIndex,
+        EncryptedDepositPayload calldata encrypted
+    )
         external
         returns (bytes32 newCurrentDepositQueueHash);
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
@@ -455,12 +523,15 @@ interface IZonePortal {
         WithdrawalQueueTransition calldata withdrawalQueueTransition,
         bytes calldata verifierConfig,
         bytes calldata proof
-    ) external;
+    )
+        external;
+
 }
 
 /// @title IZoneMessenger
 /// @notice Interface for zone messenger on Tempo (handles withdrawal callbacks)
 interface IZoneMessenger {
+
     /// @notice Returns the zone's portal address
     function portal() external view returns (address);
 
@@ -479,13 +550,29 @@ interface IZoneMessenger {
     /// @param amount Tokens to transfer from portal to target
     /// @param gasLimit Max gas for the callback
     /// @param data Calldata for the target
-    function relayMessage(address sender, address target, uint128 amount, uint64 gasLimit, bytes calldata data) external;
+    function relayMessage(
+        address sender,
+        address target,
+        uint128 amount,
+        uint64 gasLimit,
+        bytes calldata data
+    )
+        external;
+
 }
 
 /// @title IWithdrawalReceiver
 /// @notice Interface for contracts that receive withdrawals with callbacks
 interface IWithdrawalReceiver {
-    function onWithdrawalReceived(address sender, uint128 amount, bytes calldata callbackData) external returns (bytes4);
+
+    function onWithdrawalReceived(
+        address sender,
+        uint128 amount,
+        bytes calldata callbackData
+    )
+        external
+        returns (bytes4);
+
 }
 
 /// @notice Withdrawal batch parameters stored in state for proof access
@@ -502,7 +589,10 @@ struct LastBatch {
 ///      System-only contract. Only ZoneInbox can call finalizeTempo().
 ///      Only ZoneInbox, ZoneOutbox, and ZoneConfig can call readTempoStorageSlot(s).
 interface ITempoState {
-    event TempoBlockFinalized(bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot);
+
+    event TempoBlockFinalized(
+        bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot
+    );
 
     error InvalidParentHash();
     error InvalidBlockNumber();
@@ -539,12 +629,20 @@ interface ITempoState {
     function readTempoStorageSlot(address account, bytes32 slot) external view returns (bytes32);
 
     /// @notice Read multiple storage slots from a Tempo contract
-    function readTempoStorageSlots(address account, bytes32[] calldata slots) external view returns (bytes32[] memory);
+    function readTempoStorageSlots(
+        address account,
+        bytes32[] calldata slots
+    )
+        external
+        view
+        returns (bytes32[] memory);
+
 }
 
 /// @title IZoneInbox
 /// @notice Interface for zone-side system contract that advances Tempo state and processes deposits
 interface IZoneInbox {
+
     event TempoAdvanced(
         bytes32 indexed tempoBlockHash,
         uint64 indexed tempoBlockNumber,
@@ -553,7 +651,11 @@ interface IZoneInbox {
     );
 
     event DepositProcessed(
-        bytes32 indexed depositHash, address indexed sender, address indexed to, uint128 amount, bytes32 memo
+        bytes32 indexed depositHash,
+        address indexed sender,
+        address indexed to,
+        uint128 amount,
+        bytes32 memo
     );
 
     /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
@@ -566,7 +668,9 @@ interface IZoneInbox {
     );
 
     /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
-    event EncryptedDepositFailed(bytes32 indexed depositHash, address indexed sender, uint128 amount);
+    event EncryptedDepositFailed(
+        bytes32 indexed depositHash, address indexed sender, uint128 amount
+    );
     error OnlySequencer();
     error InvalidDepositQueueHash();
     error MissingDecryptionData();
@@ -605,12 +709,15 @@ interface IZoneInbox {
         bytes calldata header,
         QueuedDeposit[] calldata deposits,
         DecryptionData[] calldata decryptions
-    ) external;
+    )
+        external;
+
 }
 
 /// @title IZoneOutbox
 /// @notice Interface for zone outbox on the zone
 interface IZoneOutbox {
+
     /// @notice Maximum callback data size (1KB)
     function MAX_CALLBACK_DATA_SIZE() external view returns (uint256);
 
@@ -675,7 +782,8 @@ interface IZoneOutbox {
         uint64 gasLimit,
         address fallbackRecipient,
         bytes calldata data
-    ) external;
+    )
+        external;
 
     /// @notice Finalize batch at end of block - build withdrawal hash and write to state
     /// @dev Only callable by sequencer. Required per batch (count may be 0).
@@ -683,6 +791,7 @@ interface IZoneOutbox {
     /// @param count Max number of withdrawals to process
     /// @return withdrawalQueueHash The hash chain (0 if no withdrawals)
     function finalizeWithdrawalBatch(uint256 count) external returns (bytes32 withdrawalQueueHash);
+
 }
 
 /// @title IZoneConfig
@@ -690,6 +799,7 @@ interface IZoneOutbox {
 /// @dev System contract predeploy at 0x1c00000000000000000000000000000000000003
 ///      Provides centralized access to zone metadata and reads sequencer from L1.
 interface IZoneConfig {
+
     error NotSequencer();
 
     /// @notice Zone token address (TIP-20 at same address as Tempo)
@@ -717,4 +827,5 @@ interface IZoneConfig {
 
     /// @notice Get zone token as IZoneToken interface
     function getZoneToken() external view returns (IZoneToken);
+
 }

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -152,9 +152,13 @@ struct DecryptionData {
 /// @dev Predeploy at 0x1c00000000000000000000000000000000000100
 address constant CHAUM_PEDERSEN_VERIFY = 0x1c00000000000000000000000000000000000100;
 
-/// @notice Precompile address for ECIES decryption verification
+/// @notice Precompile address for AES-256-GCM decryption
 /// @dev Predeploy at 0x1c00000000000000000000000000000000000101
-address constant ECIES_VERIFY = 0x1c00000000000000000000000000000000000101;
+address constant AES_GCM_DECRYPT = 0x1c00000000000000000000000000000000000101;
+
+/// @notice Precompile address for SHA256 (standard Ethereum precompile)
+/// @dev Used for HKDF-SHA256 implementation in Solidity
+address constant SHA256 = 0x0000000000000000000000000000000000000002;
 
 /// @title IChaumPedersenVerify
 /// @notice Precompile for verifying Chaum-Pedersen proofs of ECDH shared secret derivation
@@ -186,23 +190,28 @@ interface IChaumPedersenVerify {
     ) external view returns (bool valid);
 }
 
-/// @title IEciesVerify
-/// @notice Precompile for verifying ECIES (secp256k1 + AES-256-GCM) decryption
-/// @dev Validates that a given shared secret correctly decrypts a ciphertext by checking
-///      the GCM authentication tag. Does not require the sequencer's private key.
-interface IEciesVerify {
-    /// @notice Verify that sharedSecret correctly decrypts the encrypted payload to plaintext
-    /// @dev Uses HKDF-SHA256 to derive AES key from sharedSecret, then verifies GCM tag.
-    ///      The GCM tag proves the shared secret is correct without revealing private keys.
-    /// @param sharedSecret The ECDH shared secret (sequencerPriv * ephemeralPub)
-    /// @param encrypted The encrypted payload (ephemeralPub, ciphertext, nonce, tag)
-    /// @param plaintext The claimed decrypted data to verify
-    /// @return valid True if the shared secret correctly decrypts to the plaintext
-    function verifyDecryption(
-        bytes32 sharedSecret,
-        EncryptedDepositPayload calldata encrypted,
-        bytes calldata plaintext
-    ) external view returns (bool valid);
+/// @title IAesGcmDecrypt
+/// @notice Minimal precompile for AES-256-GCM decryption with authentication
+/// @dev Decrypts ciphertext and verifies the GCM authentication tag.
+///      HKDF-SHA256 key derivation is done in Solidity using the SHA256 precompile.
+interface IAesGcmDecrypt {
+    /// @notice Decrypt AES-256-GCM ciphertext and verify authentication tag
+    /// @dev Returns empty bytes and false if tag verification fails.
+    ///      AAD (Additional Authenticated Data) is typically empty for ECIES.
+    /// @param key AES-256 key (32 bytes)
+    /// @param nonce GCM nonce (12 bytes)
+    /// @param ciphertext The encrypted data
+    /// @param aad Additional authenticated data (use empty bytes if none)
+    /// @param tag GCM authentication tag (16 bytes)
+    /// @return plaintext The decrypted data (empty if verification fails)
+    /// @return valid True if the tag verifies and decryption succeeds
+    function decrypt(
+        bytes32 key,
+        bytes12 nonce,
+        bytes calldata ciphertext,
+        bytes calldata aad,
+        bytes16 tag
+    ) external view returns (bytes memory plaintext, bool valid);
 }
 
 struct Withdrawal {

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -547,6 +547,8 @@ interface IZoneInbox {
     );
     error OnlySequencer();
     error InvalidDepositQueueHash();
+    error MissingDecryptionData();
+    error ExtraDecryptionData();
 
     /// @notice Zone configuration (reads sequencer from L1)
     function config() external view returns (IZoneConfig);

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -415,6 +415,8 @@ interface IZonePortal {
     error CallbackRejected();
     error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
     error InvalidEncryptionKeyIndex(uint256 keyIndex);
+    error NoEncryptionKeySet();
+    error NoEncryptionKeyAtBlock(uint64 blockNumber);
     error InvalidEphemeralPubkey();
     error InvalidCiphertextLength(uint256 actual, uint256 expected);
     error InvalidProofOfPossession();
@@ -692,7 +694,6 @@ interface IZoneInbox {
     error MissingDecryptionData();
     error ExtraDecryptionData();
     error InvalidSharedSecretProof();
-    error InvalidDecryption();
 
     /// @notice Zone configuration (reads sequencer from L1)
     function config() external view returns (IZoneConfig);
@@ -817,6 +818,7 @@ interface IZoneOutbox {
 interface IZoneConfig {
 
     error NotSequencer();
+    error NoEncryptionKeySet();
 
     /// @notice Zone token address (TIP-20 at same address as Tempo)
     function zoneToken() external view returns (address);

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -135,12 +135,12 @@ struct ChaumPedersenProof {
 /// @dev Must match 1:1 with encrypted deposits in the queue (in order of appearance).
 ///      Includes a Chaum-Pedersen proof to verify the shared secret was correctly derived
 ///      without exposing the sequencer's private key.
+///      The sequencer's public key is looked up from the deposit's keyIndex on-chain,
+///      so it does not need to be included here.
 struct DecryptionData {
     bytes32 sharedSecret; // ECDH shared secret (x-coordinate of privSeq * ephemeralPub)
     address to; // Decrypted recipient
     bytes32 memo; // Decrypted memo
-    bytes32 sequencerPubX; // Sequencer's public key X (must match keyIndex from deposit)
-    uint8 sequencerPubYParity; // Sequencer's public key Y parity
     ChaumPedersenProof cpProof; // Proof of correct shared secret derivation
 }
 

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -78,11 +78,22 @@ struct EncryptedDepositPayload {
 }
 
 /// @notice Encrypted deposit stored in the queue
-/// @dev Sender and amount are public; recipient and memo are encrypted
+/// @dev Sender, amount, and deposit block are public; recipient and memo are encrypted.
+///      The tempoBlockNumber is recorded so the prover knows which encryption key was valid.
 struct EncryptedDeposit {
     address sender;              // Depositor (public, for refunds)
     uint128 amount;              // Amount (public, for accounting)
+    uint64 tempoBlockNumber;     // Tempo block when deposit was made (for key lookup)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
+}
+
+/// @notice Historical record of an encryption key with its activation block
+/// @dev Used to track key rotations so the prover can determine which key
+///      was valid when a deposit was made
+struct EncryptionKeyEntry {
+    bytes32 x;              // X coordinate of the public key
+    uint8 yParity;          // Y coordinate parity (0x02 or 0x03)
+    uint64 activationBlock; // Tempo block number when this key became active
 }
 
 struct Withdrawal {
@@ -233,7 +244,16 @@ interface IZonePortal {
     );
 
     /// @notice Emitted when sequencer updates their encryption key
-    event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity);
+    /// @param x The X coordinate of the new key
+    /// @param yParity The Y coordinate parity (0x02 or 0x03)
+    /// @param keyIndex The index of this key in the history array
+    /// @param activationBlock The Tempo block when this key becomes active
+    event SequencerEncryptionKeyUpdated(
+        bytes32 x,
+        uint8 yParity,
+        uint256 keyIndex,
+        uint64 activationBlock
+    );
     event ZoneGasRateUpdated(uint128 zoneGasRate);
 
     error NotSequencer();
@@ -274,15 +294,34 @@ interface IZonePortal {
 
     function setSequencerPubkey(bytes32 pubkey) external;
 
-    /// @notice Get the sequencer's encryption public key for encrypted deposits
+    /// @notice Get the sequencer's current encryption public key for encrypted deposits
     /// @return x The X coordinate of the secp256k1 public key
     /// @return yParity The Y coordinate parity (0x02 or 0x03)
     function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
 
     /// @notice Set the sequencer's encryption public key. Only callable by sequencer.
+    /// @dev Appends to key history. The new key becomes active at the current Tempo block.
     /// @param x The X coordinate of the secp256k1 public key
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
     function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external;
+
+    /// @notice Get the number of encryption keys in the history
+    /// @return The total count of keys (including current)
+    function encryptionKeyCount() external view returns (uint256);
+
+    /// @notice Get a historical encryption key by index
+    /// @param index The index in the key history (0 = first key)
+    /// @return entry The key entry with activation block
+    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry);
+
+    /// @notice Get the encryption key that was active at a specific Tempo block
+    /// @dev Binary search through key history to find the correct key
+    /// @param tempoBlockNumber The Tempo block number to query
+    /// @return x The X coordinate of the active key
+    /// @return yParity The Y coordinate parity
+    /// @return keyIndex The index of this key in history
+    function encryptionKeyAtBlock(uint64 tempoBlockNumber)
+        external view returns (bytes32 x, uint8 yParity, uint256 keyIndex);
 
     /// @notice Set zone gas rate. Only callable by sequencer.
     /// @param _zoneGasRate Gas token units per gas unit on the zone

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -412,6 +412,7 @@ interface IZonePortal {
     error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
     error InvalidEncryptionKeyIndex(uint256 keyIndex);
     error InvalidEphemeralPubkey();
+    error InvalidCiphertextLength(uint256 actual, uint256 expected);
     error DepositTooSmall();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -413,6 +413,7 @@ interface IZonePortal {
     error InvalidEncryptionKeyIndex(uint256 keyIndex);
     error InvalidEphemeralPubkey();
     error InvalidCiphertextLength(uint256 actual, uint256 expected);
+    error InvalidProofOfPossession();
     error DepositTooSmall();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
@@ -452,7 +453,17 @@ interface IZonePortal {
     /// @dev Appends to key history. The new key becomes active at the current Tempo block.
     /// @param x The X coordinate of the secp256k1 public key
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
-    function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external;
+    /// @param popV Recovery id of the proof-of-possession signature
+    /// @param popR R component of the proof-of-possession signature
+    /// @param popS S component of the proof-of-possession signature
+    function setSequencerEncryptionKey(
+        bytes32 x,
+        uint8 yParity,
+        uint8 popV,
+        bytes32 popR,
+        bytes32 popS
+    )
+        external;
 
     /// @notice Get the number of encryption keys in the history
     /// @return The total count of keys (including current)

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -122,10 +122,40 @@ struct QueuedDeposit {
 }
 
 /// @notice Decryption data provided by sequencer for encrypted deposits
-/// @dev Must match 1:1 with encrypted deposits in the queue (in order of appearance)
+/// @dev Must match 1:1 with encrypted deposits in the queue (in order of appearance).
+///      The sharedSecret enables on-chain verification via GCM tag validation without
+///      revealing the sequencer's private key.
 struct DecryptionData {
-    address to;      // Decrypted recipient
-    bytes32 memo;    // Decrypted memo
+    bytes32 sharedSecret;  // ECDH shared secret (sequencerPriv * ephemeralPub)
+    address to;            // Decrypted recipient
+    bytes32 memo;          // Decrypted memo
+}
+
+/*//////////////////////////////////////////////////////////////
+                    ECIES VERIFICATION PRECOMPILE
+//////////////////////////////////////////////////////////////*/
+
+/// @notice Precompile address for ECIES decryption verification
+/// @dev Predeploy at 0x1c00000000000000000000000000000000000100
+address constant ECIES_VERIFY = 0x1c00000000000000000000000000000000000100;
+
+/// @title IEciesVerify
+/// @notice Precompile for verifying ECIES (secp256k1 + AES-256-GCM) decryption
+/// @dev Validates that a given shared secret correctly decrypts a ciphertext by checking
+///      the GCM authentication tag. Does not require the sequencer's private key.
+interface IEciesVerify {
+    /// @notice Verify that sharedSecret correctly decrypts the encrypted payload to plaintext
+    /// @dev Uses HKDF-SHA256 to derive AES key from sharedSecret, then verifies GCM tag.
+    ///      The GCM tag proves the shared secret is correct without revealing private keys.
+    /// @param sharedSecret The ECDH shared secret (sequencerPriv * ephemeralPub)
+    /// @param encrypted The encrypted payload (ephemeralPub, ciphertext, nonce, tag)
+    /// @param plaintext The claimed decrypted data to verify
+    /// @return valid True if the shared secret correctly decrypts to the plaintext
+    function verifyDecryption(
+        bytes32 sharedSecret,
+        EncryptedDepositPayload calldata encrypted,
+        bytes calldata plaintext
+    ) external view returns (bool valid);
 }
 
 struct Withdrawal {
@@ -549,6 +579,7 @@ interface IZoneInbox {
     error InvalidDepositQueueHash();
     error MissingDecryptionData();
     error ExtraDecryptionData();
+    error InvalidDecryption();
 
     /// @notice Zone configuration (reads sequencer from L1)
     function config() external view returns (IZoneConfig);

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -79,7 +79,7 @@ contract ZoneConfig is IZoneConfig {
         uint256 length =
             uint256(tempoState.readTempoStorageSlot(tempoPortal, PORTAL_ENCRYPTION_KEYS_SLOT));
 
-        if (length == 0) return (bytes32(0), 0);
+        if (length == 0) revert NoEncryptionKeySet();
 
         // Compute the storage base for array data: keccak256(abi.encode(slot))
         uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ITempoState, IZoneToken } from "./IZone.sol";
+import {ITempoState, IZoneToken} from "./IZone.sol";
 
 /// @title ZoneConfig
 /// @notice Central zone metadata and L1 state references
@@ -9,7 +9,6 @@ import { ITempoState, IZoneToken } from "./IZone.sol";
 ///      Provides single source of truth for zone configuration.
 ///      Reads sequencer from L1 ZonePortal, eliminating duplicate sequencer management.
 contract ZoneConfig {
-
     /*//////////////////////////////////////////////////////////////
                                IMMUTABLES
     //////////////////////////////////////////////////////////////*/
@@ -31,12 +30,11 @@ contract ZoneConfig {
     /// @dev ZonePortal storage layout (non-immutable variables):
     ///      slot 0: sequencer (address)
     ///      slot 1: pendingSequencer (address)
-    ///      slot 2: sequencerPubkey (bytes32, legacy)
-    ///      slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
-    ///      slot 4: blockHash (bytes32)
-    ///      slot 5: currentDepositQueueHash (bytes32)
-    ///      slot 6: lastSyncedTempoBlockNumber (uint64)
-    ///      slot 7: _encryptionKeys (EncryptionKeyEntry[])
+    ///      slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+    ///      slot 3: blockHash (bytes32)
+    ///      slot 4: currentDepositQueueHash (bytes32)
+    ///      slot 5: lastSyncedTempoBlockNumber (uint64)
+    ///      slot 6: _encryptionKeys (EncryptionKeyEntry[])
     bytes32 internal constant SEQUENCER_SLOT = bytes32(uint256(0));
 
     /// @notice Storage slot for pendingSequencer in ZonePortal
@@ -46,8 +44,8 @@ contract ZoneConfig {
     /// @dev Each EncryptionKeyEntry occupies 2 storage slots:
     ///      slot base + (index * 2):     x (bytes32)
     ///      slot base + (index * 2) + 1: yParity (uint8) + activationBlock (uint64) [packed]
-    ///      where base = keccak256(abi.encode(7))
-    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
+    ///      where base = keccak256(abi.encode(6))
+    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
 
     /*//////////////////////////////////////////////////////////////
                                ERRORS
@@ -142,5 +140,4 @@ contract ZoneConfig {
     function getZoneToken() external view returns (IZoneToken) {
         return IZoneToken(zoneToken);
     }
-
 }

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -31,15 +31,23 @@ contract ZoneConfig {
     /// @dev ZonePortal storage layout (non-immutable variables):
     ///      slot 0: sequencer (address)
     ///      slot 1: pendingSequencer (address)
-    ///      slot 2: sequencerPubkey (bytes32)
-    ///      ...
+    ///      slot 2: sequencerPubkey (bytes32, legacy)
+    ///      slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+    ///      slot 4: blockHash (bytes32)
+    ///      slot 5: currentDepositQueueHash (bytes32)
+    ///      slot 6: lastSyncedTempoBlockNumber (uint64)
+    ///      slot 7: _encryptionKeys (EncryptionKeyEntry[])
     bytes32 internal constant SEQUENCER_SLOT = bytes32(uint256(0));
 
     /// @notice Storage slot for pendingSequencer in ZonePortal
     bytes32 internal constant PENDING_SEQUENCER_SLOT = bytes32(uint256(1));
 
-    /// @notice Storage slot for sequencerPubkey in ZonePortal (X coordinate)
-    bytes32 internal constant SEQUENCER_PUBKEY_SLOT = bytes32(uint256(2));
+    /// @notice Storage slot for _encryptionKeys dynamic array in ZonePortal
+    /// @dev Each EncryptionKeyEntry occupies 2 storage slots:
+    ///      slot base + (index * 2):     x (bytes32)
+    ///      slot base + (index * 2) + 1: yParity (uint8) + activationBlock (uint64) [packed]
+    ///      where base = keccak256(abi.encode(7))
+    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
 
     /*//////////////////////////////////////////////////////////////
                                ERRORS
@@ -79,16 +87,31 @@ contract ZoneConfig {
         return address(uint160(uint256(value)));
     }
 
-    /// @notice Get sequencer's encryption public key by reading from L1 ZonePortal
-    /// @dev Reads portal's sequencerPubkey slot from finalized Tempo state.
-    ///      Used for encrypted deposits (ECIES).
+    /// @notice Get sequencer's current encryption public key by reading from L1 ZonePortal
+    /// @dev Reads the last entry from the _encryptionKeys dynamic array (slot 7).
+    ///      Each EncryptionKeyEntry occupies 2 storage slots:
+    ///        slot base + (index * 2):     x (bytes32)
+    ///        slot base + (index * 2) + 1: yParity (uint8) + activationBlock (uint64) [packed]
+    ///      where base = keccak256(abi.encode(7))
     /// @return x X-coordinate of sequencer's secp256k1 public key
     /// @return yParity Y-coordinate parity (0 or 1)
     function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity) {
-        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, SEQUENCER_PUBKEY_SLOT);
-        // Public key is stored as: x (bytes32) with yParity in the first byte
-        yParity = uint8(uint256(value) >> 248);
-        x = bytes32(uint256(value) & ((1 << 248) - 1));
+        // Read the array length from the array's base slot
+        uint256 length = uint256(tempoState.readTempoStorageSlot(tempoPortal, ENCRYPTION_KEYS_SLOT));
+
+        if (length == 0) return (bytes32(0), 0);
+
+        // Compute the storage base for array data: keccak256(abi.encode(slot))
+        uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
+
+        // Read the last entry (2 slots per EncryptionKeyEntry)
+        uint256 lastIndex = length - 1;
+        uint256 slotX = base + (lastIndex * 2);
+        uint256 slotMeta = slotX + 1;
+
+        x = tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotX));
+        bytes32 metaSlot = tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotMeta));
+        yParity = uint8(uint256(metaSlot) & 0xff);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {ITempoState, IZoneToken} from "./IZone.sol";
+import {
+    ITempoState,
+    IZoneToken,
+    PORTAL_ENCRYPTION_KEYS_SLOT,
+    PORTAL_PENDING_SEQUENCER_SLOT,
+    PORTAL_SEQUENCER_SLOT
+} from "./IZone.sol";
 
 /// @title ZoneConfig
 /// @notice Central zone metadata and L1 state references
@@ -9,6 +15,7 @@ import {ITempoState, IZoneToken} from "./IZone.sol";
 ///      Provides single source of truth for zone configuration.
 ///      Reads sequencer from L1 ZonePortal, eliminating duplicate sequencer management.
 contract ZoneConfig {
+
     /*//////////////////////////////////////////////////////////////
                                IMMUTABLES
     //////////////////////////////////////////////////////////////*/
@@ -21,31 +28,6 @@ contract ZoneConfig {
 
     /// @notice TempoState predeploy for L1 reads
     ITempoState public immutable tempoState;
-
-    /*//////////////////////////////////////////////////////////////
-                           STORAGE SLOT CONSTANTS
-    //////////////////////////////////////////////////////////////*/
-
-    /// @notice Storage slot for sequencer in ZonePortal
-    /// @dev ZonePortal storage layout (non-immutable variables):
-    ///      slot 0: sequencer (address)
-    ///      slot 1: pendingSequencer (address)
-    ///      slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
-    ///      slot 3: blockHash (bytes32)
-    ///      slot 4: currentDepositQueueHash (bytes32)
-    ///      slot 5: lastSyncedTempoBlockNumber (uint64)
-    ///      slot 6: _encryptionKeys (EncryptionKeyEntry[])
-    bytes32 internal constant SEQUENCER_SLOT = bytes32(uint256(0));
-
-    /// @notice Storage slot for pendingSequencer in ZonePortal
-    bytes32 internal constant PENDING_SEQUENCER_SLOT = bytes32(uint256(1));
-
-    /// @notice Storage slot for _encryptionKeys dynamic array in ZonePortal
-    /// @dev Each EncryptionKeyEntry occupies 2 storage slots:
-    ///      slot base + (index * 2):     x (bytes32)
-    ///      slot base + (index * 2) + 1: yParity (uint8) + activationBlock (uint64) [packed]
-    ///      where base = keccak256(abi.encode(6))
-    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
 
     /*//////////////////////////////////////////////////////////////
                                ERRORS
@@ -73,7 +55,7 @@ contract ZoneConfig {
     ///      Sequencer changes on L1 become visible after Tempo block finalization.
     /// @return Current sequencer address
     function sequencer() external view returns (address) {
-        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, SEQUENCER_SLOT);
+        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, PORTAL_SEQUENCER_SLOT);
         return address(uint160(uint256(value)));
     }
 
@@ -81,7 +63,7 @@ contract ZoneConfig {
     /// @dev Reads portal's pendingSequencer slot from finalized Tempo state.
     /// @return Pending sequencer address (0 if none)
     function pendingSequencer() external view returns (address) {
-        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, PENDING_SEQUENCER_SLOT);
+        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, PORTAL_PENDING_SEQUENCER_SLOT);
         return address(uint160(uint256(value)));
     }
 
@@ -95,12 +77,13 @@ contract ZoneConfig {
     /// @return yParity Y-coordinate parity (0 or 1)
     function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity) {
         // Read the array length from the array's base slot
-        uint256 length = uint256(tempoState.readTempoStorageSlot(tempoPortal, ENCRYPTION_KEYS_SLOT));
+        uint256 length =
+            uint256(tempoState.readTempoStorageSlot(tempoPortal, PORTAL_ENCRYPTION_KEYS_SLOT));
 
         if (length == 0) return (bytes32(0), 0);
 
         // Compute the storage base for array data: keccak256(abi.encode(slot))
-        uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
 
         // Read the last entry (2 slots per EncryptionKeyEntry)
         uint256 lastIndex = length - 1;
@@ -140,4 +123,5 @@ contract ZoneConfig {
     function getZoneToken() external view returns (IZoneToken) {
         return IZoneToken(zoneToken);
     }
+
 }

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {
     ITempoState,
+    IZoneConfig,
     IZoneToken,
     PORTAL_ENCRYPTION_KEYS_SLOT,
     PORTAL_PENDING_SEQUENCER_SLOT,
@@ -14,7 +15,7 @@ import {
 /// @dev System contract predeploy at 0x1c00000000000000000000000000000000000003
 ///      Provides single source of truth for zone configuration.
 ///      Reads sequencer from L1 ZonePortal, eliminating duplicate sequencer management.
-contract ZoneConfig {
+contract ZoneConfig is IZoneConfig {
 
     /*//////////////////////////////////////////////////////////////
                                IMMUTABLES
@@ -32,8 +33,6 @@ contract ZoneConfig {
     /*//////////////////////////////////////////////////////////////
                                ERRORS
     //////////////////////////////////////////////////////////////*/
-
-    error NotSequencer();
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -10,7 +10,9 @@ import {
     ITempoState,
     IZoneConfig,
     IZoneInbox,
-    IZoneToken
+    IZoneToken,
+    ECIES_VERIFY,
+    IEciesVerify
 } from "./IZone.sol";
 import { TempoState } from "./TempoState.sol";
 
@@ -116,11 +118,20 @@ contract ZoneInbox is IZoneInbox {
                 if (decryptionIndex >= decryptions.length) revert MissingDecryptionData();
                 DecryptionData calldata dec = decryptions[decryptionIndex++];
 
+                // Verify decryption on-chain using ECIES precompile
+                // The GCM tag proves the shared secret is correct without revealing private key
+                bytes memory plaintext = abi.encode(dec.to, dec.memo);
+                bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(
+                    dec.sharedSecret,
+                    ed.encrypted,
+                    plaintext
+                );
+                if (!valid) revert InvalidDecryption();
+
                 // Advance the hash chain with type discriminator
                 currentHash = keccak256(abi.encode(DepositType.Encrypted, ed, currentHash));
 
                 // Mint zone tokens to the decrypted recipient
-                // Note: Proof/TEE validates the decryption is correct
                 gasToken.mint(dec.to, ed.amount);
 
                 emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,7 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Deposit, ITempoState, IZoneConfig, IZoneInbox, IZoneToken } from "./IZone.sol";
+import {
+    Deposit,
+    EncryptedDeposit,
+    DepositType,
+    QueuedDeposit,
+    DecryptionData,
+    ITempoState,
+    IZoneConfig,
+    IZoneInbox,
+    IZoneToken
+} from "./IZone.sol";
 import { TempoState } from "./TempoState.sol";
 
 /// @title ZoneInbox
@@ -64,12 +74,17 @@ contract ZoneInbox is IZoneInbox {
     /// @notice Advance Tempo state and process deposits in a single sequencer-only call
     /// @dev This is the main entry point for the sequencer at block start when Tempo is advanced.
     ///      1. Advances the zone's view of Tempo by processing the header
-    ///      2. Processes deposits from the deposit queue
+    ///      2. Processes deposits from the unified queue (regular + encrypted)
     ///      3. Validates the resulting hash against Tempo's currentDepositQueueHash
     ///      Protocol and proof enforce at most one call at the start of a block (or zero if skipping).
     /// @param header RLP-encoded Tempo block header
-    /// @param deposits Array of deposits to process (oldest first, must be contiguous from processedDepositQueueHash)
-    function advanceTempo(bytes calldata header, Deposit[] calldata deposits) external {
+    /// @param deposits Array of queued deposits to process (oldest first, must be contiguous)
+    /// @param decryptions Decryption data for encrypted deposits (1:1 with encrypted deposits, in order)
+    function advanceTempo(
+        bytes calldata header,
+        QueuedDeposit[] calldata deposits,
+        DecryptionData[] calldata decryptions
+    ) external {
         if (msg.sender != config.sequencer()) revert OnlySequencer();
 
         // Step 1: Advance Tempo state (validates chain continuity internally)
@@ -77,18 +92,43 @@ contract ZoneInbox is IZoneInbox {
 
         // Step 2: Process deposits and build hash chain
         bytes32 currentHash = processedDepositQueueHash;
+        uint256 decryptionIndex = 0;
 
         for (uint256 i = 0; i < deposits.length; i++) {
-            Deposit calldata d = deposits[i];
+            QueuedDeposit calldata qd = deposits[i];
 
-            // Advance the hash chain (matches Tempo's deposit queue structure)
-            currentHash = keccak256(abi.encode(d, currentHash));
+            if (qd.depositType == DepositType.Regular) {
+                // Decode regular deposit
+                Deposit memory d = abi.decode(qd.depositData, (Deposit));
 
-            // Mint zone tokens to the recipient
-            gasToken.mint(d.to, d.amount);
+                // Advance the hash chain with type discriminator
+                currentHash = keccak256(abi.encode(DepositType.Regular, d, currentHash));
 
-            emit DepositProcessed(currentHash, d.sender, d.to, d.amount, d.memo);
+                // Mint zone tokens to the recipient
+                gasToken.mint(d.to, d.amount);
+
+                emit DepositProcessed(currentHash, d.sender, d.to, d.amount, d.memo);
+            } else {
+                // Decode encrypted deposit
+                EncryptedDeposit memory ed = abi.decode(qd.depositData, (EncryptedDeposit));
+
+                // Sequencer must provide decryption for this encrypted deposit
+                if (decryptionIndex >= decryptions.length) revert MissingDecryptionData();
+                DecryptionData calldata dec = decryptions[decryptionIndex++];
+
+                // Advance the hash chain with type discriminator
+                currentHash = keccak256(abi.encode(DepositType.Encrypted, ed, currentHash));
+
+                // Mint zone tokens to the decrypted recipient
+                // Note: Proof/TEE validates the decryption is correct
+                gasToken.mint(dec.to, ed.amount);
+
+                emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
+            }
         }
+
+        // Verify all decryption data was consumed
+        if (decryptionIndex != decryptions.length) revert ExtraDecryptionData();
 
         // Step 3: Validate against Tempo state
         // Read currentDepositQueueHash from the portal's storage using the new Tempo state

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -11,6 +11,8 @@ import {
     IZoneConfig,
     IZoneInbox,
     IZoneToken,
+    CHAUM_PEDERSEN_VERIFY,
+    IChaumPedersenVerify,
     ECIES_VERIFY,
     IEciesVerify
 } from "./IZone.sol";
@@ -118,28 +120,45 @@ contract ZoneInbox is IZoneInbox {
                 if (decryptionIndex >= decryptions.length) revert MissingDecryptionData();
                 DecryptionData calldata dec = decryptions[decryptionIndex++];
 
-                // Verify decryption on-chain using ECIES precompile
-                // The GCM tag proves the shared secret is correct without revealing private key
-                //
-                // ALTERNATIVE: Instead of this precompile, we could hash the encrypted data
-                // and include that hash in the EncryptedDepositPayload. The sequencer would
-                // provide the hash during decryption, allowing verification that the correct
-                // data was encrypted without the cost of the precompile.
+                // Step 1: Verify Chaum-Pedersen proof of correct shared secret derivation
+                // This prevents griefing attacks where users encrypt with wrong keys,
+                // without exposing the sequencer's private key to the EVM.
+                // The proof verifies that sharedSecret = privSeq * ephemeralPub without revealing privSeq.
+                bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
+                    ed.encrypted.ephemeralPubX,
+                    ed.encrypted.ephemeralPubYParity,
+                    dec.sharedSecret,
+                    dec.sequencerPubX,
+                    dec.sequencerPubYParity,
+                    dec.cpProof
+                );
+                if (!proofValid) revert InvalidSharedSecretProof();
+
+                // TODO: Verify dec.sequencerPubX/YParity matches the key at ed.keyIndex
+                // This ensures the sequencer used the correct historical key
+
+                // Step 3: Verify the decryption using ECIES precompile
+                // The GCM tag proves the plaintext matches the ciphertext for this shared secret
                 bytes memory plaintext = abi.encode(dec.to, dec.memo);
                 bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(
                     dec.sharedSecret,
                     ed.encrypted,
                     plaintext
                 );
-                if (!valid) revert InvalidDecryption();
 
                 // Advance the hash chain with type discriminator
                 currentHash = keccak256(abi.encode(DepositType.Encrypted, ed, currentHash));
 
-                // Mint zone tokens to the decrypted recipient
-                gasToken.mint(dec.to, ed.amount);
-
-                emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
+                if (!valid) {
+                    // Decryption failed (user encrypted garbage or corrupted data)
+                    // Return funds to sender instead of blocking chain progress
+                    gasToken.mint(ed.sender, ed.amount);
+                    emit EncryptedDepositFailed(currentHash, ed.sender, ed.amount);
+                } else {
+                    // Decryption succeeded - mint to the decrypted recipient
+                    gasToken.mint(dec.to, ed.amount);
+                    emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
+                }
             }
         }
 

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {EncryptedDepositLib} from "./EncryptedDeposit.sol";
+import { EncryptedDepositLib } from "./EncryptedDeposit.sol";
 import {
     AES_GCM_DECRYPT,
     CHAUM_PEDERSEN_VERIFY,
@@ -15,15 +15,18 @@ import {
     IZoneConfig,
     IZoneInbox,
     IZoneToken,
+    PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
+    PORTAL_ENCRYPTION_KEYS_SLOT,
     QueuedDeposit
 } from "./IZone.sol";
-import {TempoState} from "./TempoState.sol";
+import { TempoState } from "./TempoState.sol";
 
 /// @title ZoneInbox
 /// @notice Zone-side system contract for advancing Tempo state and processing deposits
 /// @dev Called by sequencer. Combines Tempo header advancement
 ///      with deposit queue processing in a single atomic operation.
 contract ZoneInbox is IZoneInbox {
+
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -43,23 +46,16 @@ contract ZoneInbox is IZoneInbox {
     /// @notice Last processed deposit queue hash (validated against Tempo state)
     bytes32 public processedDepositQueueHash;
 
-    /// @notice Storage slot for currentDepositQueueHash in ZonePortal
-    /// @dev ZonePortal storage layout (non-immutable variables only):
-    ///      slot 0: sequencer (address)
-    ///      slot 1: pendingSequencer (address)
-    ///      slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
-    ///      slot 3: blockHash (bytes32)
-    ///      slot 4: currentDepositQueueHash (bytes32)
-    ///      slot 5: lastSyncedTempoBlockNumber (uint64)
-    ///      slot 6: _encryptionKeys (EncryptionKeyEntry[])
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
-    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
-
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address _config, address _tempoPortalAddr, address _tempoStateAddr, address _gasToken) {
+    constructor(
+        address _config,
+        address _tempoPortalAddr,
+        address _tempoStateAddr,
+        address _gasToken
+    ) {
         config = IZoneConfig(_config);
         tempoPortal = _tempoPortalAddr;
         _tempoState = TempoState(_tempoStateAddr);
@@ -81,7 +77,14 @@ contract ZoneInbox is IZoneInbox {
     /// @param key The HMAC key (will be padded/hashed if longer than 64 bytes)
     /// @param message The message to authenticate
     /// @return result The 32-byte HMAC-SHA256 output
-    function _hmacSha256(bytes memory key, bytes memory message) internal view returns (bytes32 result) {
+    function _hmacSha256(
+        bytes memory key,
+        bytes memory message
+    )
+        internal
+        view
+        returns (bytes32 result)
+    {
         // SHA256 block size is 64 bytes
         bytes memory paddedKey = new bytes(64);
 
@@ -122,7 +125,15 @@ contract ZoneInbox is IZoneInbox {
     /// @param salt Salt value (use "ecies-aes-key" for ECIES)
     /// @param info Context-specific info (typically empty for ECIES)
     /// @return okm Output key material (32 bytes for AES-256)
-    function _hkdfSha256(bytes32 ikm, bytes memory salt, bytes memory info) internal view returns (bytes32 okm) {
+    function _hkdfSha256(
+        bytes32 ikm,
+        bytes memory salt,
+        bytes memory info
+    )
+        internal
+        view
+        returns (bytes32 okm)
+    {
         // HKDF-Extract: PRK = HMAC-SHA256(salt, IKM)
         bytes32 prk = _hmacSha256(salt, abi.encodePacked(ikm));
 
@@ -133,7 +144,7 @@ contract ZoneInbox is IZoneInbox {
     }
 
     function _readEncryptionKey(uint256 keyIndex) internal view returns (bytes32 x, uint8 yParity) {
-        uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
         uint256 slotX = base + (keyIndex * 2);
         uint256 slotMeta = slotX + 1;
         bytes32 xSlot = _tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotX));
@@ -159,7 +170,9 @@ contract ZoneInbox is IZoneInbox {
         bytes calldata header,
         QueuedDeposit[] calldata deposits,
         DecryptionData[] calldata decryptions
-    ) external {
+    )
+        external
+    {
         if (msg.sender != config.sequencer()) revert OnlySequencer();
 
         // Step 1: Advance Tempo state (validates chain continuity internally)
@@ -250,7 +263,9 @@ contract ZoneInbox is IZoneInbox {
                 } else {
                     // Decryption succeeded - mint to the decrypted recipient
                     gasToken.mint(dec.to, ed.amount);
-                    emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
+                    emit EncryptedDepositProcessed(
+                        currentHash, ed.sender, dec.to, ed.amount, dec.memo
+                    );
                 }
             }
         }
@@ -260,7 +275,8 @@ contract ZoneInbox is IZoneInbox {
 
         // Step 3: Validate against Tempo state
         // Read currentDepositQueueHash from the portal's storage using the new Tempo state
-        bytes32 tempoCurrentHash = _tempoState.readTempoStorageSlot(tempoPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
+        bytes32 tempoCurrentHash =
+            _tempoState.readTempoStorageSlot(tempoPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
 
         // Our processed hash must match Tempo's current hash for now.
         // TODO: Implement recursive ancestor check in proof or on-chain as a fallback.
@@ -271,6 +287,12 @@ contract ZoneInbox is IZoneInbox {
         // Step 4: Update state
         processedDepositQueueHash = currentHash;
 
-        emit TempoAdvanced(_tempoState.tempoBlockHash(), _tempoState.tempoBlockNumber(), deposits.length, currentHash);
+        emit TempoAdvanced(
+            _tempoState.tempoBlockHash(),
+            _tempoState.tempoBlockNumber(),
+            deposits.length,
+            currentHash
+        );
     }
+
 }

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -48,14 +48,13 @@ contract ZoneInbox is IZoneInbox {
     ///      slot 0: sequencer (address)
     ///      slot 1: pendingSequencer (address)
     ///      slot 2: sequencerPubkey (bytes32)
-    ///      slot 3: withdrawalBatchIndex (uint64)
+    ///      slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
     ///      slot 4: blockHash (bytes32)
     ///      slot 5: currentDepositQueueHash (bytes32)
     ///      slot 6: lastSyncedTempoBlockNumber (uint64)
-    ///      slot 7: zoneGasRate (uint128)
-    ///      slot 8: _encryptionKeys (EncryptionKeyEntry[])
+    ///      slot 7: _encryptionKeys (EncryptionKeyEntry[])
     bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
-    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(8));
+    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -50,8 +50,9 @@ contract ZoneInbox is IZoneInbox {
     ///      slot 2: sequencerPubkey (bytes32)
     ///      slot 3: withdrawalBatchIndex (uint64)
     ///      slot 4: blockHash (bytes32)
-    ///      slot 5: currentDepositQueueHash (bytes32) ← this one
+    ///      slot 5: currentDepositQueueHash (bytes32)
     ///      slot 6: lastSyncedTempoBlockNumber (uint64)
+    ///      slot 7: zoneGasRate (uint128)
     bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
 
     /*//////////////////////////////////////////////////////////////
@@ -193,6 +194,7 @@ contract ZoneInbox is IZoneInbox {
                 // This prevents griefing attacks where users encrypt with wrong keys,
                 // without exposing the sequencer's private key to the EVM.
                 // The proof verifies that sharedSecret = privSeq * ephemeralPub without revealing privSeq.
+                // Note: Encryption key validity is already checked on Tempo side in ZonePortal.depositEncrypted()
                 bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
                     ed.encrypted.ephemeralPubX,
                     ed.encrypted.ephemeralPubYParity,
@@ -202,9 +204,6 @@ contract ZoneInbox is IZoneInbox {
                     dec.cpProof
                 );
                 if (!proofValid) revert InvalidSharedSecretProof();
-
-                // TODO: Verify dec.sequencerPubX/YParity matches the key at ed.keyIndex
-                // This ensures the sequencer used the correct historical key
 
                 // Step 2: Derive AES key from shared secret using HKDF-SHA256
                 // This is done in Solidity using the SHA256 precompile (0x02)

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -71,10 +71,18 @@ contract ZoneInbox is IZoneInbox {
                          CRYPTOGRAPHIC HELPERS
     //////////////////////////////////////////////////////////////*/
 
+    /// @dev HMAC ipad constant (0x36 repeated 32 times)
+    bytes32 private constant _IPAD =
+        0x3636363636363636363636363636363636363636363636363636363636363636;
+    /// @dev HMAC opad constant (0x5c repeated 32 times)
+    bytes32 private constant _OPAD =
+        0x5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c5c;
+
     /// @notice HMAC-SHA256 implementation using the SHA256 precompile
     /// @dev HMAC(key, message) = SHA256((key ⊕ opad) || SHA256((key ⊕ ipad) || message))
-    ///      where ipad = 0x36 repeated, opad = 0x5c repeated
-    /// @param key The HMAC key (will be padded/hashed if longer than 64 bytes)
+    ///      where ipad = 0x36 repeated, opad = 0x5c repeated.
+    ///      Uses word-level XOR instead of byte-by-byte loops for ~95% gas reduction.
+    /// @param key The HMAC key (will be hashed if longer than 64 bytes)
     /// @param message The message to authenticate
     /// @return result The 32-byte HMAC-SHA256 output
     function _hmacSha256(
@@ -85,37 +93,39 @@ contract ZoneInbox is IZoneInbox {
         view
         returns (bytes32 result)
     {
-        // SHA256 block size is 64 bytes
-        bytes memory paddedKey = new bytes(64);
+        // Load key into two 32-byte words (SHA256 block size = 64 bytes = 2 words)
+        bytes32 keyWord0;
+        bytes32 keyWord1;
 
         if (key.length > 64) {
-            // If key is longer than block size, hash it first
-            bytes32 hashedKey = sha256(key);
-            assembly {
-                mstore(add(paddedKey, 32), hashedKey)
-            }
+            // Key longer than block size: hash it first (result goes in first word, second is zero)
+            keyWord0 = sha256(key);
         } else {
-            // Copy key and pad with zeros
-            for (uint256 i = 0; i < key.length; i++) {
-                paddedKey[i] = key[i];
+            assembly {
+                let keyLen := mload(key)
+                keyWord0 := mload(add(key, 32))
+                // Load second word only if key > 32 bytes
+                switch gt(keyLen, 32)
+                case 1 { keyWord1 := mload(add(key, 64)) }
+                default { keyWord1 := 0 }
+                // Zero out bytes beyond key length in first word
+                if lt(keyLen, 32) {
+                    let shift := mul(sub(32, keyLen), 8)
+                    keyWord0 := and(keyWord0, not(sub(shl(shift, 1), 1)))
+                }
+                // Zero out bytes beyond key length in second word
+                if and(gt(keyLen, 32), lt(keyLen, 64)) {
+                    let shift := mul(sub(64, keyLen), 8)
+                    keyWord1 := and(keyWord1, not(sub(shl(shift, 1), 1)))
+                }
             }
-        }
-
-        // Compute inner and outer padded keys
-        bytes memory innerKey = new bytes(64);
-        bytes memory outerKey = new bytes(64);
-        for (uint256 i = 0; i < 64; i++) {
-            innerKey[i] = bytes1(uint8(paddedKey[i]) ^ 0x36);
-            outerKey[i] = bytes1(uint8(paddedKey[i]) ^ 0x5c);
         }
 
         // Inner hash: SHA256((key ⊕ ipad) || message)
-        bytes memory innerData = bytes.concat(innerKey, message);
-        bytes32 innerHash = sha256(innerData);
+        bytes32 innerHash = sha256(abi.encodePacked(keyWord0 ^ _IPAD, keyWord1 ^ _IPAD, message));
 
         // Outer hash: SHA256((key ⊕ opad) || innerHash)
-        bytes memory outerData = bytes.concat(outerKey, abi.encodePacked(innerHash));
-        result = sha256(outerData);
+        result = sha256(abi.encodePacked(keyWord0 ^ _OPAD, keyWord1 ^ _OPAD, innerHash));
     }
 
     /// @notice HKDF-SHA256 key derivation (simplified single-output version)

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -219,18 +219,16 @@ contract ZoneInbox is IZoneInbox {
                 // This prevents griefing attacks where users encrypt with wrong keys,
                 // without exposing the sequencer's private key to the EVM.
                 // The proof verifies that sharedSecret = privSeq * ephemeralPub without revealing privSeq.
-                (bytes32 expectedPubX, uint8 expectedYParity) = _readEncryptionKey(ed.keyIndex);
-                if (dec.sequencerPubX != expectedPubX || dec.sequencerPubYParity != expectedYParity)
-                {
-                    revert InvalidSharedSecretProof();
-                }
+                // The sequencer's public key is looked up on-chain from the deposit's keyIndex,
+                // so it doesn't need to be in DecryptionData (saves calldata).
+                (bytes32 seqPubX, uint8 seqPubYParity) = _readEncryptionKey(ed.keyIndex);
                 bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY)
                     .verifyProof(
                         ed.encrypted.ephemeralPubkeyX,
                         ed.encrypted.ephemeralPubkeyYParity,
                         dec.sharedSecret,
-                        dec.sequencerPubX,
-                        dec.sequencerPubYParity,
+                        seqPubX,
+                        seqPubYParity,
                         dec.cpProof
                     );
                 if (!proofValid) revert InvalidSharedSecretProof();

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -53,7 +53,9 @@ contract ZoneInbox is IZoneInbox {
     ///      slot 5: currentDepositQueueHash (bytes32)
     ///      slot 6: lastSyncedTempoBlockNumber (uint64)
     ///      slot 7: zoneGasRate (uint128)
+    ///      slot 8: _encryptionKeys (EncryptionKeyEntry[])
     bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
+    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(8));
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
@@ -152,6 +154,16 @@ contract ZoneInbox is IZoneInbox {
         okm = _hmacSha256(abi.encodePacked(prk), expandInput);
     }
 
+    function _readEncryptionKey(uint256 keyIndex) internal view returns (bytes32 x, uint8 yParity) {
+        uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
+        uint256 slotX = base + (keyIndex * 2);
+        uint256 slotMeta = slotX + 1;
+        bytes32 xSlot = _tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotX));
+        if (xSlot == bytes32(0)) revert InvalidSharedSecretProof();
+        bytes32 metaSlot = _tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotMeta));
+        return (xSlot, uint8(uint256(metaSlot) & 0xff));
+    }
+
     /*//////////////////////////////////////////////////////////////
                          SYSTEM TRANSACTION
     //////////////////////////////////////////////////////////////*/
@@ -207,7 +219,11 @@ contract ZoneInbox is IZoneInbox {
                 // This prevents griefing attacks where users encrypt with wrong keys,
                 // without exposing the sequencer's private key to the EVM.
                 // The proof verifies that sharedSecret = privSeq * ephemeralPub without revealing privSeq.
-                // Note: Encryption key validity is already checked on Tempo side in ZonePortal.depositEncrypted()
+                (bytes32 expectedPubX, uint8 expectedYParity) = _readEncryptionKey(ed.keyIndex);
+                if (dec.sequencerPubX != expectedPubX || dec.sequencerPubYParity != expectedYParity)
+                {
+                    revert InvalidSharedSecretProof();
+                }
                 bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY)
                     .verifyProof(
                         ed.encrypted.ephemeralPubkeyX,

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -120,6 +120,11 @@ contract ZoneInbox is IZoneInbox {
 
                 // Verify decryption on-chain using ECIES precompile
                 // The GCM tag proves the shared secret is correct without revealing private key
+                //
+                // ALTERNATIVE: Instead of this precompile, we could hash the encrypted data
+                // and include that hash in the EncryptedDepositPayload. The sequencer would
+                // provide the hash during decryption, allowing verification that the correct
+                // data was encrypted without the cost of the precompile.
                 bytes memory plaintext = abi.encode(dec.to, dec.memo);
                 bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(
                     dec.sharedSecret,

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { EncryptedDepositLib } from "./EncryptedDeposit.sol";
+import { ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE, EncryptedDepositLib } from "./EncryptedDeposit.sol";
 import {
     AES_GCM_DECRYPT,
     CHAUM_PEDERSEN_VERIFY,
@@ -243,8 +243,8 @@ contract ZoneInbox is IZoneInbox {
 
                 // Step 4: Verify decrypted plaintext matches claimed (to, memo)
                 // Plaintext is packed as [address(20 bytes)][memo(32 bytes)][padding(12 bytes)]
-                // Must use packed decoding (not abi.decode which expects 32-byte padded fields)
-                if (valid && decryptedPlaintext.length >= 52) {
+                // Must be exactly ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE (64) bytes
+                if (valid && decryptedPlaintext.length == ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
                     (address decryptedTo, bytes32 decryptedMemo) =
                         EncryptedDepositLib.decodePlaintext(decryptedPlaintext);
                     valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { EncryptedDepositLib } from "./EncryptedDeposit.sol";
+import {EncryptedDepositLib} from "./EncryptedDeposit.sol";
 import {
     AES_GCM_DECRYPT,
     CHAUM_PEDERSEN_VERIFY,
@@ -17,14 +17,13 @@ import {
     IZoneToken,
     QueuedDeposit
 } from "./IZone.sol";
-import { TempoState } from "./TempoState.sol";
+import {TempoState} from "./TempoState.sol";
 
 /// @title ZoneInbox
 /// @notice Zone-side system contract for advancing Tempo state and processing deposits
 /// @dev Called by sequencer. Combines Tempo header advancement
 ///      with deposit queue processing in a single atomic operation.
 contract ZoneInbox is IZoneInbox {
-
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -48,25 +47,19 @@ contract ZoneInbox is IZoneInbox {
     /// @dev ZonePortal storage layout (non-immutable variables only):
     ///      slot 0: sequencer (address)
     ///      slot 1: pendingSequencer (address)
-    ///      slot 2: sequencerPubkey (bytes32)
-    ///      slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
-    ///      slot 4: blockHash (bytes32)
-    ///      slot 5: currentDepositQueueHash (bytes32)
-    ///      slot 6: lastSyncedTempoBlockNumber (uint64)
-    ///      slot 7: _encryptionKeys (EncryptionKeyEntry[])
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
-    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
+    ///      slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+    ///      slot 3: blockHash (bytes32)
+    ///      slot 4: currentDepositQueueHash (bytes32)
+    ///      slot 5: lastSyncedTempoBlockNumber (uint64)
+    ///      slot 6: _encryptionKeys (EncryptionKeyEntry[])
+    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
+    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(
-        address _config,
-        address _tempoPortalAddr,
-        address _tempoStateAddr,
-        address _gasToken
-    ) {
+    constructor(address _config, address _tempoPortalAddr, address _tempoStateAddr, address _gasToken) {
         config = IZoneConfig(_config);
         tempoPortal = _tempoPortalAddr;
         _tempoState = TempoState(_tempoStateAddr);
@@ -88,14 +81,7 @@ contract ZoneInbox is IZoneInbox {
     /// @param key The HMAC key (will be padded/hashed if longer than 64 bytes)
     /// @param message The message to authenticate
     /// @return result The 32-byte HMAC-SHA256 output
-    function _hmacSha256(
-        bytes memory key,
-        bytes memory message
-    )
-        internal
-        view
-        returns (bytes32 result)
-    {
+    function _hmacSha256(bytes memory key, bytes memory message) internal view returns (bytes32 result) {
         // SHA256 block size is 64 bytes
         bytes memory paddedKey = new bytes(64);
 
@@ -136,15 +122,7 @@ contract ZoneInbox is IZoneInbox {
     /// @param salt Salt value (use "ecies-aes-key" for ECIES)
     /// @param info Context-specific info (typically empty for ECIES)
     /// @return okm Output key material (32 bytes for AES-256)
-    function _hkdfSha256(
-        bytes32 ikm,
-        bytes memory salt,
-        bytes memory info
-    )
-        internal
-        view
-        returns (bytes32 okm)
-    {
+    function _hkdfSha256(bytes32 ikm, bytes memory salt, bytes memory info) internal view returns (bytes32 okm) {
         // HKDF-Extract: PRK = HMAC-SHA256(salt, IKM)
         bytes32 prk = _hmacSha256(salt, abi.encodePacked(ikm));
 
@@ -181,9 +159,7 @@ contract ZoneInbox is IZoneInbox {
         bytes calldata header,
         QueuedDeposit[] calldata deposits,
         DecryptionData[] calldata decryptions
-    )
-        external
-    {
+    ) external {
         if (msg.sender != config.sequencer()) revert OnlySequencer();
 
         // Step 1: Advance Tempo state (validates chain continuity internally)
@@ -274,9 +250,7 @@ contract ZoneInbox is IZoneInbox {
                 } else {
                     // Decryption succeeded - mint to the decrypted recipient
                     gasToken.mint(dec.to, ed.amount);
-                    emit EncryptedDepositProcessed(
-                        currentHash, ed.sender, dec.to, ed.amount, dec.memo
-                    );
+                    emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
                 }
             }
         }
@@ -286,8 +260,7 @@ contract ZoneInbox is IZoneInbox {
 
         // Step 3: Validate against Tempo state
         // Read currentDepositQueueHash from the portal's storage using the new Tempo state
-        bytes32 tempoCurrentHash =
-            _tempoState.readTempoStorageSlot(tempoPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
+        bytes32 tempoCurrentHash = _tempoState.readTempoStorageSlot(tempoPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
 
         // Our processed hash must match Tempo's current hash for now.
         // TODO: Implement recursive ancestor check in proof or on-chain as a fallback.
@@ -298,12 +271,6 @@ contract ZoneInbox is IZoneInbox {
         // Step 4: Update state
         processedDepositQueueHash = currentHash;
 
-        emit TempoAdvanced(
-            _tempoState.tempoBlockHash(),
-            _tempoState.tempoBlockNumber(),
-            deposits.length,
-            currentHash
-        );
+        emit TempoAdvanced(_tempoState.tempoBlockHash(), _tempoState.tempoBlockNumber(), deposits.length, currentHash);
     }
-
 }

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -2,19 +2,19 @@
 pragma solidity ^0.8.13;
 
 import {
-    Deposit,
-    EncryptedDeposit,
-    DepositType,
-    QueuedDeposit,
+    AES_GCM_DECRYPT,
+    CHAUM_PEDERSEN_VERIFY,
     DecryptionData,
+    Deposit,
+    DepositType,
+    EncryptedDeposit,
+    IAesGcmDecrypt,
+    IChaumPedersenVerify,
     ITempoState,
     IZoneConfig,
     IZoneInbox,
     IZoneToken,
-    CHAUM_PEDERSEN_VERIFY,
-    IChaumPedersenVerify,
-    AES_GCM_DECRYPT,
-    IAesGcmDecrypt
+    QueuedDeposit
 } from "./IZone.sol";
 import { TempoState } from "./TempoState.sol";
 
@@ -86,7 +86,14 @@ contract ZoneInbox is IZoneInbox {
     /// @param key The HMAC key (will be padded/hashed if longer than 64 bytes)
     /// @param message The message to authenticate
     /// @return result The 32-byte HMAC-SHA256 output
-    function _hmacSha256(bytes memory key, bytes memory message) internal view returns (bytes32 result) {
+    function _hmacSha256(
+        bytes memory key,
+        bytes memory message
+    )
+        internal
+        view
+        returns (bytes32 result)
+    {
         // SHA256 block size is 64 bytes
         bytes memory paddedKey = new bytes(64);
 
@@ -131,7 +138,11 @@ contract ZoneInbox is IZoneInbox {
         bytes32 ikm,
         bytes memory salt,
         bytes memory info
-    ) internal view returns (bytes32 okm) {
+    )
+        internal
+        view
+        returns (bytes32 okm)
+    {
         // HKDF-Extract: PRK = HMAC-SHA256(salt, IKM)
         bytes32 prk = _hmacSha256(salt, abi.encodePacked(ikm));
 
@@ -158,7 +169,9 @@ contract ZoneInbox is IZoneInbox {
         bytes calldata header,
         QueuedDeposit[] calldata deposits,
         DecryptionData[] calldata decryptions
-    ) external {
+    )
+        external
+    {
         if (msg.sender != config.sequencer()) revert OnlySequencer();
 
         // Step 1: Advance Tempo state (validates chain continuity internally)
@@ -195,38 +208,41 @@ contract ZoneInbox is IZoneInbox {
                 // without exposing the sequencer's private key to the EVM.
                 // The proof verifies that sharedSecret = privSeq * ephemeralPub without revealing privSeq.
                 // Note: Encryption key validity is already checked on Tempo side in ZonePortal.depositEncrypted()
-                bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
-                    ed.encrypted.ephemeralPubX,
-                    ed.encrypted.ephemeralPubYParity,
-                    dec.sharedSecret,
-                    dec.sequencerPubX,
-                    dec.sequencerPubYParity,
-                    dec.cpProof
-                );
+                bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY)
+                    .verifyProof(
+                        ed.encrypted.ephemeralPubkeyX,
+                        ed.encrypted.ephemeralPubkeyYParity,
+                        dec.sharedSecret,
+                        dec.sequencerPubX,
+                        dec.sequencerPubYParity,
+                        dec.cpProof
+                    );
                 if (!proofValid) revert InvalidSharedSecretProof();
 
                 // Step 2: Derive AES key from shared secret using HKDF-SHA256
                 // This is done in Solidity using the SHA256 precompile (0x02)
                 bytes32 aesKey = _hkdfSha256(
                     dec.sharedSecret,
-                    "ecies-aes-key",  // salt
-                    ""                // info (empty)
+                    "ecies-aes-key", // salt
+                    "" // info (empty)
                 );
 
                 // Step 3: Decrypt using AES-256-GCM precompile
                 // The GCM tag proves the plaintext matches the ciphertext for this shared secret
-                (bytes memory decryptedPlaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(
-                    aesKey,
-                    ed.encrypted.nonce,
-                    ed.encrypted.ciphertext,
-                    "",  // empty AAD
-                    ed.encrypted.tag
-                );
+                (bytes memory decryptedPlaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT)
+                    .decrypt(
+                        aesKey,
+                        ed.encrypted.nonce,
+                        ed.encrypted.ciphertext,
+                        "", // empty AAD
+                        ed.encrypted.tag
+                    );
 
                 // Step 4: Verify decrypted plaintext matches claimed (to, memo)
                 if (valid && decryptedPlaintext.length >= 52) {
                     // Decode decrypted plaintext and compare
-                    (address decryptedTo, bytes32 decryptedMemo) = abi.decode(decryptedPlaintext, (address, bytes32));
+                    (address decryptedTo, bytes32 decryptedMemo) =
+                        abi.decode(decryptedPlaintext, (address, bytes32));
                     valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);
                 } else {
                     valid = false;
@@ -243,7 +259,9 @@ contract ZoneInbox is IZoneInbox {
                 } else {
                     // Decryption succeeded - mint to the decrypted recipient
                     gasToken.mint(dec.to, ed.amount);
-                    emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
+                    emit EncryptedDepositProcessed(
+                        currentHash, ed.sender, dec.to, ed.amount, dec.memo
+                    );
                 }
             }
         }

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import { EncryptedDepositLib } from "./EncryptedDeposit.sol";
 import {
     AES_GCM_DECRYPT,
     CHAUM_PEDERSEN_VERIFY,
@@ -16,7 +17,6 @@ import {
     IZoneToken,
     QueuedDeposit
 } from "./IZone.sol";
-import { EncryptedDepositLib } from "./EncryptedDeposit.sol";
 import { TempoState } from "./TempoState.sol";
 
 /// @title ZoneInbox

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -16,6 +16,7 @@ import {
     IZoneToken,
     QueuedDeposit
 } from "./IZone.sol";
+import { EncryptedDepositLib } from "./EncryptedDeposit.sol";
 import { TempoState } from "./TempoState.sol";
 
 /// @title ZoneInbox
@@ -254,10 +255,11 @@ contract ZoneInbox is IZoneInbox {
                     );
 
                 // Step 4: Verify decrypted plaintext matches claimed (to, memo)
+                // Plaintext is packed as [address(20 bytes)][memo(32 bytes)][padding(12 bytes)]
+                // Must use packed decoding (not abi.decode which expects 32-byte padded fields)
                 if (valid && decryptedPlaintext.length >= 52) {
-                    // Decode decrypted plaintext and compare
                     (address decryptedTo, bytes32 decryptedMemo) =
-                        abi.decode(decryptedPlaintext, (address, bytes32));
+                        EncryptedDepositLib.decodePlaintext(decryptedPlaintext);
                     valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);
                 } else {
                     valid = false;

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -13,8 +13,8 @@ import {
     IZoneToken,
     CHAUM_PEDERSEN_VERIFY,
     IChaumPedersenVerify,
-    ECIES_VERIFY,
-    IEciesVerify
+    AES_GCM_DECRYPT,
+    IAesGcmDecrypt
 } from "./IZone.sol";
 import { TempoState } from "./TempoState.sol";
 
@@ -75,8 +75,77 @@ contract ZoneInbox is IZoneInbox {
         return _tempoState;
     }
 
-    /// @notice Advance Tempo state and process deposits in a single sequencer-only call
-    /// @dev This is the main entry point for the sequencer at block start when Tempo is advanced.
+    /*//////////////////////////////////////////////////////////////
+                         CRYPTOGRAPHIC HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice HMAC-SHA256 implementation using the SHA256 precompile
+    /// @dev HMAC(key, message) = SHA256((key ⊕ opad) || SHA256((key ⊕ ipad) || message))
+    ///      where ipad = 0x36 repeated, opad = 0x5c repeated
+    /// @param key The HMAC key (will be padded/hashed if longer than 64 bytes)
+    /// @param message The message to authenticate
+    /// @return result The 32-byte HMAC-SHA256 output
+    function _hmacSha256(bytes memory key, bytes memory message) internal view returns (bytes32 result) {
+        // SHA256 block size is 64 bytes
+        bytes memory paddedKey = new bytes(64);
+
+        if (key.length > 64) {
+            // If key is longer than block size, hash it first
+            bytes32 hashedKey = sha256(key);
+            assembly {
+                mstore(add(paddedKey, 32), hashedKey)
+            }
+        } else {
+            // Copy key and pad with zeros
+            for (uint256 i = 0; i < key.length; i++) {
+                paddedKey[i] = key[i];
+            }
+        }
+
+        // Compute inner and outer padded keys
+        bytes memory innerKey = new bytes(64);
+        bytes memory outerKey = new bytes(64);
+        for (uint256 i = 0; i < 64; i++) {
+            innerKey[i] = bytes1(uint8(paddedKey[i]) ^ 0x36);
+            outerKey[i] = bytes1(uint8(paddedKey[i]) ^ 0x5c);
+        }
+
+        // Inner hash: SHA256((key ⊕ ipad) || message)
+        bytes memory innerData = bytes.concat(innerKey, message);
+        bytes32 innerHash = sha256(innerData);
+
+        // Outer hash: SHA256((key ⊕ opad) || innerHash)
+        bytes memory outerData = bytes.concat(outerKey, abi.encodePacked(innerHash));
+        result = sha256(outerData);
+    }
+
+    /// @notice HKDF-SHA256 key derivation (simplified single-output version)
+    /// @dev Implements HKDF-Extract and HKDF-Expand to derive a 32-byte key
+    ///      from the input key material (shared secret).
+    /// @param ikm Input key material (the ECDH shared secret)
+    /// @param salt Salt value (use "ecies-aes-key" for ECIES)
+    /// @param info Context-specific info (typically empty for ECIES)
+    /// @return okm Output key material (32 bytes for AES-256)
+    function _hkdfSha256(
+        bytes32 ikm,
+        bytes memory salt,
+        bytes memory info
+    ) internal view returns (bytes32 okm) {
+        // HKDF-Extract: PRK = HMAC-SHA256(salt, IKM)
+        bytes32 prk = _hmacSha256(salt, abi.encodePacked(ikm));
+
+        // HKDF-Expand: OKM = HMAC-SHA256(PRK, info || 0x01)
+        // We only need 32 bytes (one block), so N=1 and we append 0x01
+        bytes memory expandInput = bytes.concat(info, hex"01");
+        okm = _hmacSha256(abi.encodePacked(prk), expandInput);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         SYSTEM TRANSACTION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Advance Tempo state and process deposits in a single system transaction
+    /// @dev This is the main entry point for the sequencer's system transaction.
     ///      1. Advances the zone's view of Tempo by processing the header
     ///      2. Processes deposits from the unified queue (regular + encrypted)
     ///      3. Validates the resulting hash against Tempo's currentDepositQueueHash
@@ -137,14 +206,32 @@ contract ZoneInbox is IZoneInbox {
                 // TODO: Verify dec.sequencerPubX/YParity matches the key at ed.keyIndex
                 // This ensures the sequencer used the correct historical key
 
-                // Step 3: Verify the decryption using ECIES precompile
-                // The GCM tag proves the plaintext matches the ciphertext for this shared secret
-                bytes memory plaintext = abi.encode(dec.to, dec.memo);
-                bool valid = IEciesVerify(ECIES_VERIFY).verifyDecryption(
+                // Step 2: Derive AES key from shared secret using HKDF-SHA256
+                // This is done in Solidity using the SHA256 precompile (0x02)
+                bytes32 aesKey = _hkdfSha256(
                     dec.sharedSecret,
-                    ed.encrypted,
-                    plaintext
+                    "ecies-aes-key",  // salt
+                    ""                // info (empty)
                 );
+
+                // Step 3: Decrypt using AES-256-GCM precompile
+                // The GCM tag proves the plaintext matches the ciphertext for this shared secret
+                (bytes memory decryptedPlaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(
+                    aesKey,
+                    ed.encrypted.nonce,
+                    ed.encrypted.ciphertext,
+                    "",  // empty AAD
+                    ed.encrypted.tag
+                );
+
+                // Step 4: Verify decrypted plaintext matches claimed (to, memo)
+                if (valid && decryptedPlaintext.length >= 52) {
+                    // Decode decrypted plaintext and compare
+                    (address decryptedTo, bytes32 decryptedMemo) = abi.decode(decryptedPlaintext, (address, bytes32));
+                    valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);
+                } else {
+                    valid = false;
+                }
 
                 // Advance the hash chain with type discriminator
                 currentHash = keccak256(abi.encode(DepositType.Encrypted, ed, currentHash));

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -269,6 +269,40 @@ contract ZonePortal is IZonePortal {
     }
 
     /*//////////////////////////////////////////////////////////////
+                       EPHEMERAL KEY VALIDATION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice secp256k1 field prime
+    uint256 internal constant SECP256K1_P =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+
+    /// @notice (SECP256K1_P - 1) / 2 for Euler's criterion
+    uint256 internal constant SECP256K1_HALF_PM1 =
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFE17;
+
+    /// @notice Validate that an X coordinate corresponds to a valid secp256k1 point
+    /// @dev Uses Euler's criterion via the MODEXP precompile (0x05):
+    ///      x³ + 7 is a quadratic residue mod p iff (x³+7)^((p-1)/2) ≡ 1 (mod p)
+    function _isValidSecp256k1X(bytes32 x) internal view returns (bool) {
+        uint256 px = uint256(x);
+        if (px == 0 || px >= SECP256K1_P) return false;
+
+        // rhs = x³ + 7 mod p
+        uint256 rhs = addmod(mulmod(mulmod(px, px, SECP256K1_P), px, SECP256K1_P), 7, SECP256K1_P);
+
+        // Call MODEXP precompile: rhs^((p-1)/2) mod p
+        // Input format: Bsize(32) || Esize(32) || Msize(32) || B || E || M
+        bytes memory input = abi.encodePacked(
+            uint256(32), uint256(32), uint256(32), rhs, SECP256K1_HALF_PM1, SECP256K1_P
+        );
+
+        (bool success, bytes memory result) = address(0x05).staticcall(input);
+        if (!success || result.length != 32) return false;
+
+        return uint256(bytes32(result)) == 1;
+    }
+
+    /*//////////////////////////////////////////////////////////////
                                DEPOSITS
     //////////////////////////////////////////////////////////////*/
 
@@ -334,6 +368,16 @@ contract ZonePortal is IZonePortal {
         external
         returns (bytes32 newCurrentDepositQueueHash)
     {
+        // Validate ephemeral public key is a valid secp256k1 point
+        // Prevents griefing: invalid points make Chaum-Pedersen proofs impossible,
+        // which would block chain progress on the zone side.
+        if (
+            encrypted.ephemeralPubkeyYParity != 0x02 && encrypted.ephemeralPubkeyYParity != 0x03
+        ) {
+            revert InvalidEphemeralPubkey();
+        }
+        if (!_isValidSecp256k1X(encrypted.ephemeralPubkeyX)) revert InvalidEphemeralPubkey();
+
         // Validate encryption key
         (bool valid, uint64 expiresAtBlock) = isEncryptionKeyValid(keyIndex);
         if (!valid) {

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -174,11 +174,38 @@ contract ZonePortal is IZonePortal {
         return (current.x, current.yParity);
     }
 
-    /// @notice Set the sequencer's encryption public key
+    /// @notice Set the sequencer's encryption public key with proof of possession
     /// @dev Only callable by the sequencer. Appends to key history.
-    /// @param x The X coordinate
+    ///      Requires a valid ECDSA signature over keccak256(abi.encode(address(this), x, yParity))
+    ///      produced by the private key corresponding to (x, yParity). This prevents accidental
+    ///      registration of keys the sequencer cannot decrypt with.
+    /// @param x The X coordinate (must be valid secp256k1 point)
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
-    function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external onlySequencer {
+    /// @param popV Recovery id of the proof-of-possession signature
+    /// @param popR R component of the proof-of-possession signature
+    /// @param popS S component of the proof-of-possession signature
+    function setSequencerEncryptionKey(
+        bytes32 x,
+        uint8 yParity,
+        uint8 popV,
+        bytes32 popR,
+        bytes32 popS
+    )
+        external
+        onlySequencer
+    {
+        // Validate yParity
+        if (yParity != 0x02 && yParity != 0x03) revert InvalidEphemeralPubkey();
+
+        // Validate x is on the secp256k1 curve
+        if (!_isValidSecp256k1X(x)) revert InvalidEphemeralPubkey();
+
+        // Verify proof of possession: the sequencer must sign with the encryption key's private key
+        bytes32 message = keccak256(abi.encode(address(this), x, yParity));
+        address recovered = ecrecover(message, popV, popR, popS);
+        address expected = _deriveAddressFromPubKey(x, yParity);
+        if (recovered == address(0) || recovered != expected) revert InvalidProofOfPossession();
+
         uint64 activationBlock = uint64(block.number);
         _encryptionKeys.push(
             EncryptionKeyEntry({ x: x, yParity: yParity, activationBlock: activationBlock })
@@ -274,6 +301,10 @@ contract ZonePortal is IZonePortal {
     uint256 internal constant SECP256K1_HALF_PM1 =
         0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFE17;
 
+    /// @notice (SECP256K1_P + 1) / 4 for modular square root (p ≡ 3 mod 4)
+    uint256 internal constant SECP256K1_SQRT_EXP =
+        0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFBFFFFF0C;
+
     /// @notice Validate that an X coordinate corresponds to a valid secp256k1 point
     /// @dev Uses Euler's criterion via the MODEXP precompile (0x05):
     ///      x³ + 7 is a quadratic residue mod p iff (x³+7)^((p-1)/2) ≡ 1 (mod p)
@@ -294,6 +325,41 @@ contract ZonePortal is IZonePortal {
         if (!success || result.length != 32) return false;
 
         return uint256(bytes32(result)) == 1;
+    }
+
+    /// @notice Derive the Ethereum address corresponding to a compressed secp256k1 public key
+    /// @dev Computes y from x using modular square root, then keccak256(x || y)
+    /// @param x The X coordinate (must be a valid secp256k1 x-coordinate)
+    /// @param yParity 0x02 (even y) or 0x03 (odd y)
+    /// @return addr The derived Ethereum address
+    function _deriveAddressFromPubKey(
+        bytes32 x,
+        uint8 yParity
+    )
+        internal
+        view
+        returns (address addr)
+    {
+        uint256 px = uint256(x);
+
+        // Compute y² = x³ + 7 mod p
+        uint256 rhs = addmod(mulmod(mulmod(px, px, SECP256K1_P), px, SECP256K1_P), 7, SECP256K1_P);
+
+        // Compute y = rhs^((p+1)/4) mod p (valid because p ≡ 3 mod 4)
+        bytes memory modexpInput = abi.encodePacked(
+            uint256(32), uint256(32), uint256(32), rhs, SECP256K1_SQRT_EXP, SECP256K1_P
+        );
+        (bool success, bytes memory modexpResult) = address(0x05).staticcall(modexpInput);
+        require(success && modexpResult.length == 32, "modexp failed");
+        uint256 y = uint256(bytes32(modexpResult));
+
+        // Select correct y based on parity: 0x02 = even, 0x03 = odd
+        if ((y % 2 == 0) != (yParity == 0x02)) {
+            y = SECP256K1_P - y;
+        }
+
+        // Address = last 20 bytes of keccak256(uncompressed public key)
+        addr = address(uint160(uint256(keccak256(abi.encodePacked(px, y)))));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {ITIP20} from "../interfaces/ITIP20.sol";
+import { ITIP20 } from "../interfaces/ITIP20.sol";
 
-import {BLOCKHASH_HISTORY, IBlockHashHistory} from "./BlockHashHistory.sol";
-import {DepositQueueLib} from "./DepositQueueLib.sol";
+import { BLOCKHASH_HISTORY, IBlockHashHistory } from "./BlockHashHistory.sol";
+import { DepositQueueLib } from "./DepositQueueLib.sol";
 import {
     BlockTransition,
     Deposit,
@@ -21,11 +21,12 @@ import {
     Withdrawal,
     WithdrawalQueueTransition
 } from "./IZone.sol";
-import {WithdrawalQueue, WithdrawalQueueLib} from "./WithdrawalQueueLib.sol";
+import { WithdrawalQueue, WithdrawalQueueLib } from "./WithdrawalQueueLib.sol";
 
 /// @title ZonePortal
 /// @notice Per-zone portal that escrows zone tokens on Tempo and manages deposits/withdrawals
 contract ZonePortal is IZonePortal {
+
     using WithdrawalQueueLib for WithdrawalQueue;
 
     /*//////////////////////////////////////////////////////////////
@@ -69,7 +70,7 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Historical encryption keys with activation blocks
     /// @dev Users specify which key they encrypted to (by index). Maintained for key rotation.
-    ///      Stored at slot 7 in the ZonePortal storage layout.
+    ///      Stored at slot 6 in the ZonePortal storage layout.
     EncryptionKeyEntry[] internal _encryptionKeys;
 
     /// @notice Withdrawal queue (zone→Tempo): unbounded buffer
@@ -178,7 +179,9 @@ contract ZonePortal is IZonePortal {
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
     function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external onlySequencer {
         uint64 activationBlock = uint64(block.number);
-        _encryptionKeys.push(EncryptionKeyEntry({x: x, yParity: yParity, activationBlock: activationBlock}));
+        _encryptionKeys.push(
+            EncryptionKeyEntry({ x: x, yParity: yParity, activationBlock: activationBlock })
+        );
         emit SequencerEncryptionKeyUpdated(x, yParity, _encryptionKeys.length - 1, activationBlock);
     }
 
@@ -190,7 +193,11 @@ contract ZonePortal is IZonePortal {
     /// @notice Get a historical encryption key by index
     /// @param index The index in the key history (0 = first key)
     /// @return entry The key entry with activation block
-    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry) {
+    function encryptionKeyAt(uint256 index)
+        external
+        view
+        returns (EncryptionKeyEntry memory entry)
+    {
         if (index >= _encryptionKeys.length) {
             revert InvalidEncryptionKeyIndex(index);
         }
@@ -232,7 +239,11 @@ contract ZonePortal is IZonePortal {
     /// @param keyIndex The key index to check
     /// @return valid True if the key can be used for new deposits
     /// @return expiresAtBlock Block number when this key expires (0 if current key)
-    function isEncryptionKeyValid(uint256 keyIndex) public view returns (bool valid, uint64 expiresAtBlock) {
+    function isEncryptionKeyValid(uint256 keyIndex)
+        public
+        view
+        returns (bool valid, uint64 expiresAtBlock)
+    {
         if (keyIndex >= _encryptionKeys.length) {
             return (false, 0);
         }
@@ -255,10 +266,12 @@ contract ZonePortal is IZonePortal {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice secp256k1 field prime
-    uint256 internal constant SECP256K1_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+    uint256 internal constant SECP256K1_P =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
 
     /// @notice (SECP256K1_P - 1) / 2 for Euler's criterion
-    uint256 internal constant SECP256K1_HALF_PM1 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFE17;
+    uint256 internal constant SECP256K1_HALF_PM1 =
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFE17;
 
     /// @notice Validate that an X coordinate corresponds to a valid secp256k1 point
     /// @dev Uses Euler's criterion via the MODEXP precompile (0x05):
@@ -272,8 +285,9 @@ contract ZonePortal is IZonePortal {
 
         // Call MODEXP precompile: rhs^((p-1)/2) mod p
         // Input format: Bsize(32) || Esize(32) || Msize(32) || B || E || M
-        bytes memory input =
-            abi.encodePacked(uint256(32), uint256(32), uint256(32), rhs, SECP256K1_HALF_PM1, SECP256K1_P);
+        bytes memory input = abi.encodePacked(
+            uint256(32), uint256(32), uint256(32), rhs, SECP256K1_HALF_PM1, SECP256K1_P
+        );
 
         (bool success, bytes memory result) = address(0x05).staticcall(input);
         if (!success || result.length != 32) return false;
@@ -298,7 +312,14 @@ contract ZonePortal is IZonePortal {
     /// @param amount Total amount to deposit (fee will be deducted)
     /// @param memo User-provided context
     /// @return newCurrentDepositQueueHash The new deposit queue hash after this deposit
-    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash) {
+    function deposit(
+        address to,
+        uint128 amount,
+        bytes32 memo
+    )
+        external
+        returns (bytes32 newCurrentDepositQueueHash)
+    {
         // Calculate deposit fee
         uint128 fee = calculateDepositFee();
         if (amount <= fee) revert DepositTooSmall();
@@ -314,7 +335,8 @@ contract ZonePortal is IZonePortal {
         }
 
         // Build deposit struct with net amount (fee already paid to sequencer on Tempo)
-        Deposit memory depositData = Deposit({sender: msg.sender, to: to, amount: netAmount, memo: memo});
+        Deposit memory depositData =
+            Deposit({ sender: msg.sender, to: to, amount: netAmount, memo: memo });
 
         // Insert deposit into queue
         newCurrentDepositQueueHash = DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
@@ -331,7 +353,11 @@ contract ZonePortal is IZonePortal {
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
-    function depositEncrypted(uint128 amount, uint256 keyIndex, EncryptedDepositPayload calldata encrypted)
+    function depositEncrypted(
+        uint128 amount,
+        uint256 keyIndex,
+        EncryptedDepositPayload calldata encrypted
+    )
         external
         returns (bytes32 newCurrentDepositQueueHash)
     {
@@ -365,11 +391,13 @@ contract ZonePortal is IZonePortal {
         }
 
         // Build encrypted deposit struct
-        EncryptedDeposit memory depositData =
-            EncryptedDeposit({sender: msg.sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted});
+        EncryptedDeposit memory depositData = EncryptedDeposit({
+            sender: msg.sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted
+        });
 
         // Insert encrypted deposit into queue
-        newCurrentDepositQueueHash = DepositQueueLib.enqueueEncrypted(currentDepositQueueHash, depositData);
+        newCurrentDepositQueueHash =
+            DepositQueueLib.enqueueEncrypted(currentDepositQueueHash, depositData);
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
         emit EncryptedDepositMade(
@@ -389,7 +417,13 @@ contract ZonePortal is IZonePortal {
     /// @notice Process the next withdrawal from the queue. Only callable by the sequencer.
     /// @dev Fee is always paid to sequencer regardless of success/failure.
     ///      On failure, only the amount (not fee) is bounced back.
-    function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external onlySequencer {
+    function processWithdrawal(
+        Withdrawal calldata withdrawal,
+        bytes32 remainingQueue
+    )
+        external
+        onlySequencer
+    {
         // Pop from withdrawal queue (library handles swap and hash verification)
         _withdrawalQueue.dequeue(withdrawal, remainingQueue);
 
@@ -421,7 +455,11 @@ contract ZonePortal is IZonePortal {
         // Try callback via messenger; revert is treated as failure
         try IZoneMessenger(messenger)
             .relayMessage(
-                withdrawal.sender, withdrawal.to, withdrawal.amount, withdrawal.gasLimit, withdrawal.callbackData
+                withdrawal.sender,
+                withdrawal.to,
+                withdrawal.amount,
+                withdrawal.gasLimit,
+                withdrawal.callbackData
             ) {
             emit WithdrawalProcessed(withdrawal.to, withdrawal.amount, true);
         } catch {
@@ -433,10 +471,12 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Enqueue a bounce-back deposit for failed callback
     function _enqueueBounceBack(uint128 amount, address fallbackRecipient) internal {
-        Deposit memory depositData =
-            Deposit({sender: address(this), to: fallbackRecipient, amount: amount, memo: bytes32(0)});
+        Deposit memory depositData = Deposit({
+            sender: address(this), to: fallbackRecipient, amount: amount, memo: bytes32(0)
+        });
 
-        bytes32 newCurrentDepositQueueHash = DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
+        bytes32 newCurrentDepositQueueHash =
+            DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
         emit BounceBack(newCurrentDepositQueueHash, fallbackRecipient, amount);
@@ -457,7 +497,10 @@ contract ZonePortal is IZonePortal {
         WithdrawalQueueTransition calldata withdrawalQueueTransition,
         bytes calldata verifierConfig,
         bytes calldata proof
-    ) external onlySequencer {
+    )
+        external
+        onlySequencer
+    {
         if (blockTransition.prevBlockHash != blockHash) {
             revert InvalidProof();
         }
@@ -482,7 +525,8 @@ contract ZonePortal is IZonePortal {
             if (recentTempoBlockNumber > block.number) revert InvalidTempoBlockNumber();
 
             anchorBlockNumber = recentTempoBlockNumber;
-            anchorBlockHash = IBlockHashHistory(BLOCKHASH_HISTORY).getBlockHash(recentTempoBlockNumber);
+            anchorBlockHash =
+                IBlockHashHistory(BLOCKHASH_HISTORY).getBlockHash(recentTempoBlockNumber);
             if (anchorBlockHash == bytes32(0)) revert InvalidTempoBlockNumber();
         }
 
@@ -519,4 +563,5 @@ contract ZonePortal is IZonePortal {
             withdrawalQueueTransition.withdrawalQueueHash
         );
     }
+
 }

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -6,12 +6,18 @@ import { ITIP20 } from "../interfaces/ITIP20.sol";
 import { BLOCKHASH_HISTORY, IBlockHashHistory } from "./BlockHashHistory.sol";
 import { DepositQueueLib } from "./DepositQueueLib.sol";
 import {
+    IZonePortal,
+    IZoneMessenger,
+    IVerifier,
     BlockTransition,
     Deposit,
+    EncryptedDeposit,
+    EncryptedDepositPayload,
+    DepositType,
+    QueuedDeposit,
+    EncryptionKeyEntry,
+    ENCRYPTION_KEY_GRACE_PERIOD,
     DepositQueueTransition,
-    IVerifier,
-    IZoneMessenger,
-    IZonePortal,
     Withdrawal,
     WithdrawalQueueTransition
 } from "./IZone.sol";
@@ -49,9 +55,10 @@ contract ZonePortal is IZonePortal {
     /// @notice Pending sequencer for two-step transfer
     address public pendingSequencer;
 
-    /// @notice Sequencer's public key for encrypting messages (e.g., deposit memos)
-    /// @dev Future functionality: allows users to encrypt data only the sequencer can read
-    bytes32 public sequencerPubkey;
+    /// @notice Historical encryption keys with activation blocks
+    /// @dev Users specify which key they encrypted to (by index). Maintained for key rotation.
+    ///      This is stored at slot 8 in the storage layout.
+    EncryptionKeyEntry[] internal _encryptionKeys;
 
     /// @notice Zone gas rate (zone token units per gas unit on the zone)
     /// @dev Sequencer publishes this rate and takes the risk on zone gas costs.
@@ -158,6 +165,68 @@ contract ZonePortal is IZonePortal {
     }
 
     /*//////////////////////////////////////////////////////////////
+                        ENCRYPTION KEY MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Get the sequencer's current encryption public key
+    /// @return x The X coordinate
+    /// @return yParity The Y coordinate parity (0x02 or 0x03)
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity) {
+        if (_encryptionKeys.length == 0) return (bytes32(0), 0);
+        EncryptionKeyEntry storage current = _encryptionKeys[_encryptionKeys.length - 1];
+        return (current.x, current.yParity);
+    }
+
+    /// @notice Set the sequencer's encryption public key
+    /// @dev Only callable by the sequencer. Appends to key history.
+    /// @param x The X coordinate
+    /// @param yParity The Y coordinate parity (0x02 or 0x03)
+    function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external onlySequencer {
+        uint64 activationBlock = uint64(block.number);
+        _encryptionKeys.push(EncryptionKeyEntry({
+            x: x,
+            yParity: yParity,
+            activationBlock: activationBlock
+        }));
+        emit SequencerEncryptionKeyUpdated(x, yParity, _encryptionKeys.length - 1, activationBlock);
+    }
+
+    /// @notice Get the number of keys in the history
+    function encryptionKeyCount() external view returns (uint256) {
+        return _encryptionKeys.length;
+    }
+
+    /// @notice Get a historical encryption key by index
+    /// @param index The index in the key history (0 = first key)
+    /// @return entry The key entry with activation block
+    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry) {
+        if (index >= _encryptionKeys.length) revert InvalidEncryptionKeyIndex(index);
+        return _encryptionKeys[index];
+    }
+
+    /// @notice Check if an encryption key is still valid for new deposits
+    /// @param keyIndex The key index to check
+    /// @return valid True if the key can be used for new deposits
+    /// @return expiresAtBlock Block number when this key expires (0 if current key)
+    function isEncryptionKeyValid(uint256 keyIndex) public view returns (bool valid, uint64 expiresAtBlock) {
+        if (keyIndex >= _encryptionKeys.length) {
+            return (false, 0);
+        }
+
+        // Current key (latest) never expires
+        if (keyIndex == _encryptionKeys.length - 1) {
+            return (true, 0);
+        }
+
+        // Old keys are valid during grace period after supersession
+        EncryptionKeyEntry storage nextKey = _encryptionKeys[keyIndex + 1];
+        uint64 expiration = nextKey.activationBlock + ENCRYPTION_KEY_GRACE_PERIOD;
+
+        valid = block.number < expiration;
+        expiresAtBlock = expiration;
+    }
+
+    /*//////////////////////////////////////////////////////////////
                                DEPOSITS
     //////////////////////////////////////////////////////////////*/
 
@@ -205,6 +274,59 @@ contract ZonePortal is IZonePortal {
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
         emit DepositMade(newCurrentDepositQueueHash, msg.sender, to, netAmount, fee, memo);
+    }
+
+    /// @notice Deposit with encrypted recipient and memo
+    /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key.
+    ///      Validates that keyIndex is valid (exists and not expired).
+    ///      Fee is NOT charged for encrypted deposits (no amount deduction).
+    /// @param amount Amount to deposit (full amount, no fee deducted)
+    /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
+    /// @param encrypted The encrypted payload (recipient and memo)
+    /// @return newCurrentDepositQueueHash The new deposit queue hash
+    function depositEncrypted(
+        uint128 amount,
+        uint256 keyIndex,
+        EncryptedDepositPayload calldata encrypted
+    ) external returns (bytes32 newCurrentDepositQueueHash) {
+        // Validate encryption key
+        (bool valid, uint64 expiresAtBlock) = isEncryptionKeyValid(keyIndex);
+        if (!valid) {
+            if (keyIndex >= _encryptionKeys.length) {
+                revert InvalidEncryptionKeyIndex(keyIndex);
+            }
+            EncryptionKeyEntry storage key = _encryptionKeys[keyIndex];
+            EncryptionKeyEntry storage nextKey = _encryptionKeys[keyIndex + 1];
+            revert EncryptionKeyExpired(keyIndex, key.activationBlock, nextKey.activationBlock);
+        }
+
+        // Transfer full amount from sender to this contract (no fee for encrypted deposits)
+        ITIP20(token).transferFrom(msg.sender, address(this), amount);
+
+        // Build encrypted deposit struct
+        EncryptedDeposit memory depositData = EncryptedDeposit({
+            sender: msg.sender,
+            amount: amount,
+            keyIndex: keyIndex,
+            encrypted: encrypted
+        });
+
+        // Insert encrypted deposit into queue with type discriminator
+        newCurrentDepositQueueHash = keccak256(abi.encode(
+            DepositType.Encrypted,
+            depositData,
+            currentDepositQueueHash
+        ));
+        currentDepositQueueHash = newCurrentDepositQueueHash;
+
+        emit EncryptedDepositMade(
+            newCurrentDepositQueueHash,
+            msg.sender,
+            amount,
+            keyIndex,
+            encrypted.ephemeralPubkeyX,
+            encrypted.ephemeralPubkeyYParity
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -6,18 +6,18 @@ import { ITIP20 } from "../interfaces/ITIP20.sol";
 import { BLOCKHASH_HISTORY, IBlockHashHistory } from "./BlockHashHistory.sol";
 import { DepositQueueLib } from "./DepositQueueLib.sol";
 import {
-    IZonePortal,
-    IZoneMessenger,
-    IVerifier,
     BlockTransition,
     Deposit,
+    DepositQueueTransition,
+    DepositType,
+    ENCRYPTION_KEY_GRACE_PERIOD,
     EncryptedDeposit,
     EncryptedDepositPayload,
-    DepositType,
-    QueuedDeposit,
     EncryptionKeyEntry,
-    ENCRYPTION_KEY_GRACE_PERIOD,
-    DepositQueueTransition,
+    IVerifier,
+    IZoneMessenger,
+    IZonePortal,
+    QueuedDeposit,
     Withdrawal,
     WithdrawalQueueTransition
 } from "./IZone.sol";
@@ -54,6 +54,9 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Pending sequencer for two-step transfer
     address public pendingSequencer;
+
+    /// @notice Sequencer public key (legacy field for compatibility)
+    bytes32 public sequencerPubkey;
 
     /// @notice Historical encryption keys with activation blocks
     /// @dev Users specify which key they encrypted to (by index). Maintained for key rotation.
@@ -183,11 +186,9 @@ contract ZonePortal is IZonePortal {
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
     function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external onlySequencer {
         uint64 activationBlock = uint64(block.number);
-        _encryptionKeys.push(EncryptionKeyEntry({
-            x: x,
-            yParity: yParity,
-            activationBlock: activationBlock
-        }));
+        _encryptionKeys.push(
+            EncryptionKeyEntry({ x: x, yParity: yParity, activationBlock: activationBlock })
+        );
         emit SequencerEncryptionKeyUpdated(x, yParity, _encryptionKeys.length - 1, activationBlock);
     }
 
@@ -199,16 +200,57 @@ contract ZonePortal is IZonePortal {
     /// @notice Get a historical encryption key by index
     /// @param index The index in the key history (0 = first key)
     /// @return entry The key entry with activation block
-    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry) {
-        if (index >= _encryptionKeys.length) revert InvalidEncryptionKeyIndex(index);
+    function encryptionKeyAt(uint256 index)
+        external
+        view
+        returns (EncryptionKeyEntry memory entry)
+    {
+        if (index >= _encryptionKeys.length) {
+            revert InvalidEncryptionKeyIndex(index);
+        }
         return _encryptionKeys[index];
+    }
+
+    /// @notice Get the encryption key that was active at a specific Tempo block
+    /// @dev Binary search through key history to find the correct key
+    /// @param tempoBlockNumber The Tempo block number to query
+    /// @return x The X coordinate of the active key
+    /// @return yParity The Y coordinate parity
+    /// @return keyIndex The index of this key in history
+    function encryptionKeyAtBlock(uint64 tempoBlockNumber)
+        external
+        view
+        returns (bytes32 x, uint8 yParity, uint256 keyIndex)
+    {
+        uint256 len = _encryptionKeys.length;
+        if (len == 0 || tempoBlockNumber < _encryptionKeys[0].activationBlock) {
+            revert InvalidEncryptionKeyIndex(0);
+        }
+
+        uint256 low = 0;
+        uint256 high = len - 1;
+        while (low < high) {
+            uint256 mid = (low + high + 1) / 2;
+            if (_encryptionKeys[mid].activationBlock <= tempoBlockNumber) {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+
+        EncryptionKeyEntry storage entry = _encryptionKeys[low];
+        return (entry.x, entry.yParity, low);
     }
 
     /// @notice Check if an encryption key is still valid for new deposits
     /// @param keyIndex The key index to check
     /// @return valid True if the key can be used for new deposits
     /// @return expiresAtBlock Block number when this key expires (0 if current key)
-    function isEncryptionKeyValid(uint256 keyIndex) public view returns (bool valid, uint64 expiresAtBlock) {
+    function isEncryptionKeyValid(uint256 keyIndex)
+        public
+        view
+        returns (bool valid, uint64 expiresAtBlock)
+    {
         if (keyIndex >= _encryptionKeys.length) {
             return (false, 0);
         }
@@ -288,7 +330,10 @@ contract ZonePortal is IZonePortal {
         uint128 amount,
         uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
-    ) external returns (bytes32 newCurrentDepositQueueHash) {
+    )
+        external
+        returns (bytes32 newCurrentDepositQueueHash)
+    {
         // Validate encryption key
         (bool valid, uint64 expiresAtBlock) = isEncryptionKeyValid(keyIndex);
         if (!valid) {
@@ -305,18 +350,12 @@ contract ZonePortal is IZonePortal {
 
         // Build encrypted deposit struct
         EncryptedDeposit memory depositData = EncryptedDeposit({
-            sender: msg.sender,
-            amount: amount,
-            keyIndex: keyIndex,
-            encrypted: encrypted
+            sender: msg.sender, amount: amount, keyIndex: keyIndex, encrypted: encrypted
         });
 
         // Insert encrypted deposit into queue with type discriminator
-        newCurrentDepositQueueHash = keccak256(abi.encode(
-            DepositType.Encrypted,
-            depositData,
-            currentDepositQueueHash
-        ));
+        newCurrentDepositQueueHash =
+            keccak256(abi.encode(DepositType.Encrypted, depositData, currentDepositQueueHash));
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
         emit EncryptedDepositMade(

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -58,11 +58,6 @@ contract ZonePortal is IZonePortal {
     /// @notice Sequencer public key (legacy field for compatibility)
     bytes32 public sequencerPubkey;
 
-    /// @notice Historical encryption keys with activation blocks
-    /// @dev Users specify which key they encrypted to (by index). Maintained for key rotation.
-    ///      This is stored at slot 8 in the storage layout.
-    EncryptionKeyEntry[] internal _encryptionKeys;
-
     /// @notice Zone gas rate (zone token units per gas unit on the zone)
     /// @dev Sequencer publishes this rate and takes the risk on zone gas costs.
     ///      Deposit fee = FIXED_DEPOSIT_GAS * zoneGasRate
@@ -75,6 +70,11 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Last Tempo block number the zone has synced to
     uint64 public lastSyncedTempoBlockNumber;
+
+    /// @notice Historical encryption keys with activation blocks
+    /// @dev Users specify which key they encrypted to (by index). Maintained for key rotation.
+    ///      Stored at slot 7 in the ZonePortal storage layout.
+    EncryptionKeyEntry[] internal _encryptionKeys;
 
     /// @notice Withdrawal queue (zone→Tempo): unbounded buffer
     WithdrawalQueue internal _withdrawalQueue;

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -404,9 +404,9 @@ contract ZonePortal is IZonePortal {
             sender: msg.sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted
         });
 
-        // Insert encrypted deposit into queue with type discriminator
+        // Insert encrypted deposit into queue
         newCurrentDepositQueueHash =
-            keccak256(abi.encode(DepositType.Encrypted, depositData, currentDepositQueueHash));
+            DepositQueueLib.enqueueEncrypted(currentDepositQueueHash, depositData);
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
         emit EncryptedDepositMade(

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -321,8 +321,8 @@ contract ZonePortal is IZonePortal {
     /// @notice Deposit with encrypted recipient and memo
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key.
     ///      Validates that keyIndex is valid (exists and not expired).
-    ///      Fee is NOT charged for encrypted deposits (no amount deduction).
-    /// @param amount Amount to deposit (full amount, no fee deducted)
+    ///      Charges the same deposit fee as regular deposits.
+    /// @param amount Amount to deposit (fee deducted from this amount)
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
@@ -345,12 +345,19 @@ contract ZonePortal is IZonePortal {
             revert EncryptionKeyExpired(keyIndex, key.activationBlock, nextKey.activationBlock);
         }
 
-        // Transfer full amount from sender to this contract (no fee for encrypted deposits)
+        uint128 fee = calculateDepositFee();
+        if (amount <= fee) revert DepositTooSmall();
+        uint128 netAmount = amount - fee;
+
+        // Transfer full amount from sender to this contract
         ITIP20(token).transferFrom(msg.sender, address(this), amount);
+        if (fee > 0) {
+            ITIP20(token).transfer(sequencer, fee);
+        }
 
         // Build encrypted deposit struct
         EncryptedDeposit memory depositData = EncryptedDeposit({
-            sender: msg.sender, amount: amount, keyIndex: keyIndex, encrypted: encrypted
+            sender: msg.sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted
         });
 
         // Insert encrypted deposit into queue with type discriminator
@@ -361,7 +368,7 @@ contract ZonePortal is IZonePortal {
         emit EncryptedDepositMade(
             newCurrentDepositQueueHash,
             msg.sender,
-            amount,
+            netAmount,
             keyIndex,
             encrypted.ephemeralPubkeyX,
             encrypted.ephemeralPubkeyYParity

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -479,9 +479,13 @@ contract ZonePortal is IZonePortal {
             newCurrentDepositQueueHash,
             msg.sender,
             netAmount,
+            fee,
             keyIndex,
             encrypted.ephemeralPubkeyX,
-            encrypted.ephemeralPubkeyYParity
+            encrypted.ephemeralPubkeyYParity,
+            encrypted.ciphertext,
+            encrypted.nonce,
+            encrypted.tag
         );
     }
 

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -371,9 +371,7 @@ contract ZonePortal is IZonePortal {
         // Validate ephemeral public key is a valid secp256k1 point
         // Prevents griefing: invalid points make Chaum-Pedersen proofs impossible,
         // which would block chain progress on the zone side.
-        if (
-            encrypted.ephemeralPubkeyYParity != 0x02 && encrypted.ephemeralPubkeyYParity != 0x03
-        ) {
+        if (encrypted.ephemeralPubkeyYParity != 0x02 && encrypted.ephemeralPubkeyYParity != 0x03) {
             revert InvalidEphemeralPubkey();
         }
         if (!_isValidSecp256k1X(encrypted.ephemeralPubkeyX)) revert InvalidEphemeralPubkey();

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -169,7 +169,7 @@ contract ZonePortal is IZonePortal {
     /// @return x The X coordinate
     /// @return yParity The Y coordinate parity (0x02 or 0x03)
     function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity) {
-        if (_encryptionKeys.length == 0) return (bytes32(0), 0);
+        if (_encryptionKeys.length == 0) revert NoEncryptionKeySet();
         EncryptionKeyEntry storage current = _encryptionKeys[_encryptionKeys.length - 1];
         return (current.x, current.yParity);
     }
@@ -245,7 +245,7 @@ contract ZonePortal is IZonePortal {
     {
         uint256 len = _encryptionKeys.length;
         if (len == 0 || tempoBlockNumber < _encryptionKeys[0].activationBlock) {
-            revert InvalidEncryptionKeyIndex(0);
+            revert NoEncryptionKeyAtBlock(tempoBlockNumber);
         }
 
         uint256 low = 0;

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -5,6 +5,7 @@ import { ITIP20 } from "../interfaces/ITIP20.sol";
 
 import { BLOCKHASH_HISTORY, IBlockHashHistory } from "./BlockHashHistory.sol";
 import { DepositQueueLib } from "./DepositQueueLib.sol";
+import { ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE } from "./EncryptedDeposit.sol";
 import {
     BlockTransition,
     Deposit,
@@ -368,6 +369,14 @@ contract ZonePortal is IZonePortal {
             revert InvalidEphemeralPubkey();
         }
         if (!_isValidSecp256k1X(encrypted.ephemeralPubkeyX)) revert InvalidEphemeralPubkey();
+
+        // Validate ciphertext length — GCM ciphertext == plaintext length (tag is separate)
+        // Prevents DoS: oversized ciphertexts inflate zone-side AES-GCM processing cost
+        if (encrypted.ciphertext.length != ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
+            revert InvalidCiphertextLength(
+                encrypted.ciphertext.length, ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE
+            );
+        }
 
         // Validate encryption key
         (bool valid, uint64 expiresAtBlock) = isEncryptionKeyValid(keyIndex);

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ITIP20 } from "../interfaces/ITIP20.sol";
+import {ITIP20} from "../interfaces/ITIP20.sol";
 
-import { BLOCKHASH_HISTORY, IBlockHashHistory } from "./BlockHashHistory.sol";
-import { DepositQueueLib } from "./DepositQueueLib.sol";
+import {BLOCKHASH_HISTORY, IBlockHashHistory} from "./BlockHashHistory.sol";
+import {DepositQueueLib} from "./DepositQueueLib.sol";
 import {
     BlockTransition,
     Deposit,
@@ -21,12 +21,11 @@ import {
     Withdrawal,
     WithdrawalQueueTransition
 } from "./IZone.sol";
-import { WithdrawalQueue, WithdrawalQueueLib } from "./WithdrawalQueueLib.sol";
+import {WithdrawalQueue, WithdrawalQueueLib} from "./WithdrawalQueueLib.sol";
 
 /// @title ZonePortal
 /// @notice Per-zone portal that escrows zone tokens on Tempo and manages deposits/withdrawals
 contract ZonePortal is IZonePortal {
-
     using WithdrawalQueueLib for WithdrawalQueue;
 
     /*//////////////////////////////////////////////////////////////
@@ -54,9 +53,6 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Pending sequencer for two-step transfer
     address public pendingSequencer;
-
-    /// @notice Sequencer public key (legacy field for compatibility)
-    bytes32 public sequencerPubkey;
 
     /// @notice Zone gas rate (zone token units per gas unit on the zone)
     /// @dev Sequencer publishes this rate and takes the risk on zone gas costs.
@@ -133,10 +129,6 @@ contract ZonePortal is IZonePortal {
         emit SequencerTransferred(previousSequencer, sequencer);
     }
 
-    function setSequencerPubkey(bytes32 pubkey) external onlySequencer {
-        sequencerPubkey = pubkey;
-    }
-
     /// @notice Set zone gas rate. Only callable by sequencer.
     /// @dev Sequencer publishes this rate and takes the risk on zone gas costs.
     ///      If actual zone gas is higher, sequencer covers the difference.
@@ -186,9 +178,7 @@ contract ZonePortal is IZonePortal {
     /// @param yParity The Y coordinate parity (0x02 or 0x03)
     function setSequencerEncryptionKey(bytes32 x, uint8 yParity) external onlySequencer {
         uint64 activationBlock = uint64(block.number);
-        _encryptionKeys.push(
-            EncryptionKeyEntry({ x: x, yParity: yParity, activationBlock: activationBlock })
-        );
+        _encryptionKeys.push(EncryptionKeyEntry({x: x, yParity: yParity, activationBlock: activationBlock}));
         emit SequencerEncryptionKeyUpdated(x, yParity, _encryptionKeys.length - 1, activationBlock);
     }
 
@@ -200,11 +190,7 @@ contract ZonePortal is IZonePortal {
     /// @notice Get a historical encryption key by index
     /// @param index The index in the key history (0 = first key)
     /// @return entry The key entry with activation block
-    function encryptionKeyAt(uint256 index)
-        external
-        view
-        returns (EncryptionKeyEntry memory entry)
-    {
+    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry) {
         if (index >= _encryptionKeys.length) {
             revert InvalidEncryptionKeyIndex(index);
         }
@@ -246,11 +232,7 @@ contract ZonePortal is IZonePortal {
     /// @param keyIndex The key index to check
     /// @return valid True if the key can be used for new deposits
     /// @return expiresAtBlock Block number when this key expires (0 if current key)
-    function isEncryptionKeyValid(uint256 keyIndex)
-        public
-        view
-        returns (bool valid, uint64 expiresAtBlock)
-    {
+    function isEncryptionKeyValid(uint256 keyIndex) public view returns (bool valid, uint64 expiresAtBlock) {
         if (keyIndex >= _encryptionKeys.length) {
             return (false, 0);
         }
@@ -273,12 +255,10 @@ contract ZonePortal is IZonePortal {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice secp256k1 field prime
-    uint256 internal constant SECP256K1_P =
-        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+    uint256 internal constant SECP256K1_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
 
     /// @notice (SECP256K1_P - 1) / 2 for Euler's criterion
-    uint256 internal constant SECP256K1_HALF_PM1 =
-        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFE17;
+    uint256 internal constant SECP256K1_HALF_PM1 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF7FFFFE17;
 
     /// @notice Validate that an X coordinate corresponds to a valid secp256k1 point
     /// @dev Uses Euler's criterion via the MODEXP precompile (0x05):
@@ -292,9 +272,8 @@ contract ZonePortal is IZonePortal {
 
         // Call MODEXP precompile: rhs^((p-1)/2) mod p
         // Input format: Bsize(32) || Esize(32) || Msize(32) || B || E || M
-        bytes memory input = abi.encodePacked(
-            uint256(32), uint256(32), uint256(32), rhs, SECP256K1_HALF_PM1, SECP256K1_P
-        );
+        bytes memory input =
+            abi.encodePacked(uint256(32), uint256(32), uint256(32), rhs, SECP256K1_HALF_PM1, SECP256K1_P);
 
         (bool success, bytes memory result) = address(0x05).staticcall(input);
         if (!success || result.length != 32) return false;
@@ -319,14 +298,7 @@ contract ZonePortal is IZonePortal {
     /// @param amount Total amount to deposit (fee will be deducted)
     /// @param memo User-provided context
     /// @return newCurrentDepositQueueHash The new deposit queue hash after this deposit
-    function deposit(
-        address to,
-        uint128 amount,
-        bytes32 memo
-    )
-        external
-        returns (bytes32 newCurrentDepositQueueHash)
-    {
+    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash) {
         // Calculate deposit fee
         uint128 fee = calculateDepositFee();
         if (amount <= fee) revert DepositTooSmall();
@@ -342,8 +314,7 @@ contract ZonePortal is IZonePortal {
         }
 
         // Build deposit struct with net amount (fee already paid to sequencer on Tempo)
-        Deposit memory depositData =
-            Deposit({ sender: msg.sender, to: to, amount: netAmount, memo: memo });
+        Deposit memory depositData = Deposit({sender: msg.sender, to: to, amount: netAmount, memo: memo});
 
         // Insert deposit into queue
         newCurrentDepositQueueHash = DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
@@ -360,11 +331,7 @@ contract ZonePortal is IZonePortal {
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
-    function depositEncrypted(
-        uint128 amount,
-        uint256 keyIndex,
-        EncryptedDepositPayload calldata encrypted
-    )
+    function depositEncrypted(uint128 amount, uint256 keyIndex, EncryptedDepositPayload calldata encrypted)
         external
         returns (bytes32 newCurrentDepositQueueHash)
     {
@@ -398,13 +365,11 @@ contract ZonePortal is IZonePortal {
         }
 
         // Build encrypted deposit struct
-        EncryptedDeposit memory depositData = EncryptedDeposit({
-            sender: msg.sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted
-        });
+        EncryptedDeposit memory depositData =
+            EncryptedDeposit({sender: msg.sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted});
 
         // Insert encrypted deposit into queue
-        newCurrentDepositQueueHash =
-            DepositQueueLib.enqueueEncrypted(currentDepositQueueHash, depositData);
+        newCurrentDepositQueueHash = DepositQueueLib.enqueueEncrypted(currentDepositQueueHash, depositData);
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
         emit EncryptedDepositMade(
@@ -424,13 +389,7 @@ contract ZonePortal is IZonePortal {
     /// @notice Process the next withdrawal from the queue. Only callable by the sequencer.
     /// @dev Fee is always paid to sequencer regardless of success/failure.
     ///      On failure, only the amount (not fee) is bounced back.
-    function processWithdrawal(
-        Withdrawal calldata withdrawal,
-        bytes32 remainingQueue
-    )
-        external
-        onlySequencer
-    {
+    function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external onlySequencer {
         // Pop from withdrawal queue (library handles swap and hash verification)
         _withdrawalQueue.dequeue(withdrawal, remainingQueue);
 
@@ -462,11 +421,7 @@ contract ZonePortal is IZonePortal {
         // Try callback via messenger; revert is treated as failure
         try IZoneMessenger(messenger)
             .relayMessage(
-                withdrawal.sender,
-                withdrawal.to,
-                withdrawal.amount,
-                withdrawal.gasLimit,
-                withdrawal.callbackData
+                withdrawal.sender, withdrawal.to, withdrawal.amount, withdrawal.gasLimit, withdrawal.callbackData
             ) {
             emit WithdrawalProcessed(withdrawal.to, withdrawal.amount, true);
         } catch {
@@ -478,12 +433,10 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Enqueue a bounce-back deposit for failed callback
     function _enqueueBounceBack(uint128 amount, address fallbackRecipient) internal {
-        Deposit memory depositData = Deposit({
-            sender: address(this), to: fallbackRecipient, amount: amount, memo: bytes32(0)
-        });
+        Deposit memory depositData =
+            Deposit({sender: address(this), to: fallbackRecipient, amount: amount, memo: bytes32(0)});
 
-        bytes32 newCurrentDepositQueueHash =
-            DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
+        bytes32 newCurrentDepositQueueHash = DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
         emit BounceBack(newCurrentDepositQueueHash, fallbackRecipient, amount);
@@ -504,10 +457,7 @@ contract ZonePortal is IZonePortal {
         WithdrawalQueueTransition calldata withdrawalQueueTransition,
         bytes calldata verifierConfig,
         bytes calldata proof
-    )
-        external
-        onlySequencer
-    {
+    ) external onlySequencer {
         if (blockTransition.prevBlockHash != blockHash) {
             revert InvalidProof();
         }
@@ -532,8 +482,7 @@ contract ZonePortal is IZonePortal {
             if (recentTempoBlockNumber > block.number) revert InvalidTempoBlockNumber();
 
             anchorBlockNumber = recentTempoBlockNumber;
-            anchorBlockHash =
-                IBlockHashHistory(BLOCKHASH_HISTORY).getBlockHash(recentTempoBlockNumber);
+            anchorBlockHash = IBlockHashHistory(BLOCKHASH_HISTORY).getBlockHash(recentTempoBlockNumber);
             if (anchorBlockHash == bytes32(0)) revert InvalidTempoBlockNumber();
         }
 
@@ -570,5 +519,4 @@ contract ZonePortal is IZonePortal {
             withdrawalQueueTransition.withdrawalQueueHash
         );
     }
-
 }

--- a/docs/specs/test/zone/DepositQueueLib.t.sol
+++ b/docs/specs/test/zone/DepositQueueLib.t.sol
@@ -2,7 +2,12 @@
 pragma solidity ^0.8.13;
 
 import { DepositQueueLib } from "../../src/zone/DepositQueueLib.sol";
-import { Deposit, DepositType } from "../../src/zone/IZone.sol";
+import {
+    Deposit,
+    DepositType,
+    EncryptedDeposit,
+    EncryptedDepositPayload
+} from "../../src/zone/IZone.sol";
 import { Test } from "forge-std/Test.sol";
 
 /// @title DepositQueueLibTest
@@ -105,6 +110,89 @@ contract DepositQueueLibTest is Test {
         bytes32 h2 = DepositQueueLib.enqueue(bytes32(uint256(1)), d);
 
         assertTrue(h1 != h2);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    ENQUEUE ENCRYPTED TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_enqueueEncrypted_singleDeposit() public pure {
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: address(0x200),
+            amount: 100e6,
+            keyIndex: 0,
+            encrypted: EncryptedDepositPayload({
+                ephemeralPubkeyX: bytes32(uint256(1)),
+                ephemeralPubkeyYParity: 0x02,
+                ciphertext: new bytes(64),
+                nonce: bytes12(0),
+                tag: bytes16(0)
+            })
+        });
+
+        bytes32 newHash = DepositQueueLib.enqueueEncrypted(bytes32(0), ed);
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
+        assertEq(newHash, expectedHash);
+    }
+
+    function test_enqueueEncrypted_mixedQueue() public pure {
+        Deposit memory d1 = Deposit({
+            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("d1")
+        });
+
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: address(0x300),
+            amount: 200e6,
+            keyIndex: 0,
+            encrypted: EncryptedDepositPayload({
+                ephemeralPubkeyX: bytes32(uint256(1)),
+                ephemeralPubkeyYParity: 0x02,
+                ciphertext: new bytes(64),
+                nonce: bytes12(0),
+                tag: bytes16(0)
+            })
+        });
+
+        Deposit memory d2 = Deposit({
+            sender: address(0x200), to: address(0x200), amount: 300e6, memo: bytes32("d3")
+        });
+
+        bytes32 h1 = DepositQueueLib.enqueue(bytes32(0), d1);
+        bytes32 h2 = DepositQueueLib.enqueueEncrypted(h1, ed);
+        bytes32 h3 = DepositQueueLib.enqueue(h2, d2);
+
+        bytes32 expected1 = keccak256(abi.encode(DepositType.Regular, d1, bytes32(0)));
+        bytes32 expected2 = keccak256(abi.encode(DepositType.Encrypted, ed, expected1));
+        bytes32 expected3 = keccak256(abi.encode(DepositType.Regular, d2, expected2));
+
+        assertEq(h1, expected1);
+        assertEq(h2, expected2);
+        assertEq(h3, expected3);
+    }
+
+    function test_enqueue_typeDiscriminatorPreventsCollision() public pure {
+        // Same sender/amount but different type discriminators produce different hashes
+        Deposit memory d = Deposit({
+            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("memo")
+        });
+
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: address(0x200),
+            amount: 100e6,
+            keyIndex: 0,
+            encrypted: EncryptedDepositPayload({
+                ephemeralPubkeyX: bytes32(0),
+                ephemeralPubkeyYParity: 0,
+                ciphertext: "",
+                nonce: bytes12(0),
+                tag: bytes16(0)
+            })
+        });
+
+        bytes32 regularHash = DepositQueueLib.enqueue(bytes32(0), d);
+        bytes32 encryptedHash = DepositQueueLib.enqueueEncrypted(bytes32(0), ed);
+
+        assertTrue(regularHash != encryptedHash);
     }
 
 }

--- a/docs/specs/test/zone/DepositQueueLib.t.sol
+++ b/docs/specs/test/zone/DepositQueueLib.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { DepositQueueLib } from "../../src/zone/DepositQueueLib.sol";
-import { Deposit } from "../../src/zone/IZone.sol";
+import { Deposit, DepositType } from "../../src/zone/IZone.sol";
 import { Test } from "forge-std/Test.sol";
 
 /// @title DepositQueueLibTest
@@ -23,7 +23,7 @@ contract DepositQueueLibTest is Test {
 
         bytes32 newHash = DepositQueueLib.enqueue(bytes32(0), d);
 
-        bytes32 expectedHash = keccak256(abi.encode(d, bytes32(0)));
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
         assertEq(newHash, expectedHash);
     }
 
@@ -43,9 +43,9 @@ contract DepositQueueLibTest is Test {
         bytes32 h3 = DepositQueueLib.enqueue(h2, d3);
 
         // Verify hash chain structure
-        bytes32 expected1 = keccak256(abi.encode(d1, bytes32(0)));
-        bytes32 expected2 = keccak256(abi.encode(d2, expected1));
-        bytes32 expected3 = keccak256(abi.encode(d3, expected2));
+        bytes32 expected1 = keccak256(abi.encode(DepositType.Regular, d1, bytes32(0)));
+        bytes32 expected2 = keccak256(abi.encode(DepositType.Regular, d2, expected1));
+        bytes32 expected3 = keccak256(abi.encode(DepositType.Regular, d3, expected2));
 
         assertEq(h1, expected1);
         assertEq(h2, expected2);
@@ -65,7 +65,7 @@ contract DepositQueueLibTest is Test {
         bytes32 h2 = DepositQueueLib.enqueue(h1, d2);
 
         // h2 should wrap h1
-        assertEq(h2, keccak256(abi.encode(d2, h1)));
+        assertEq(h2, keccak256(abi.encode(DepositType.Regular, d2, h1)));
     }
 
     function test_enqueue_emptyToEmpty() public pure {
@@ -74,7 +74,7 @@ contract DepositQueueLibTest is Test {
             Deposit({ sender: address(0), to: address(0), amount: 0, memo: bytes32(0) });
 
         bytes32 h = DepositQueueLib.enqueue(bytes32(0), d);
-        bytes32 expected = keccak256(abi.encode(d, bytes32(0)));
+        bytes32 expected = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
         assertEq(h, expected);
         assertTrue(h != bytes32(0)); // Hash of something is non-zero
     }

--- a/docs/specs/test/zone/DepositQueueLib.t.sol
+++ b/docs/specs/test/zone/DepositQueueLib.t.sol
@@ -3,12 +3,25 @@ pragma solidity ^0.8.13;
 
 import { DepositQueueLib } from "../../src/zone/DepositQueueLib.sol";
 import {
+    ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE,
+    EncryptedDepositLib
+} from "../../src/zone/EncryptedDeposit.sol";
+import {
     Deposit,
     DepositType,
     EncryptedDeposit,
     EncryptedDepositPayload
 } from "../../src/zone/IZone.sol";
 import { Test } from "forge-std/Test.sol";
+
+/// @notice External wrapper to test EncryptedDepositLib.decodePlaintext (which is internal)
+contract PlaintextDecoder {
+
+    function decode(bytes memory plaintext) external pure returns (address to, bytes32 memo) {
+        return EncryptedDepositLib.decodePlaintext(plaintext);
+    }
+
+}
 
 /// @title DepositQueueLibTest
 /// @notice Direct tests for DepositQueueLib functionality
@@ -193,6 +206,115 @@ contract DepositQueueLibTest is Test {
         bytes32 encryptedHash = DepositQueueLib.enqueueEncrypted(bytes32(0), ed);
 
         assertTrue(regularHash != encryptedHash);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    PLAINTEXT ENCODE / DECODE TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    PlaintextDecoder internal decoder;
+
+    function _ensureDecoder() internal {
+        if (address(decoder) == address(0)) {
+            decoder = new PlaintextDecoder();
+        }
+    }
+
+    /// @notice Round-trip: encodePlaintext → decodePlaintext recovers original values
+    function test_plaintext_roundTrip() public {
+        _ensureDecoder();
+        address to = address(0x1234567890AbcdEF1234567890aBcdef12345678);
+        bytes32 memo = bytes32("hello world");
+
+        bytes memory encoded = EncryptedDepositLib.encodePlaintext(to, memo);
+        assertEq(encoded.length, ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE, "encoded should be 64 bytes");
+
+        (address decodedTo, bytes32 decodedMemo) = decoder.decode(encoded);
+        assertEq(decodedTo, to, "decoded address mismatch");
+        assertEq(decodedMemo, memo, "decoded memo mismatch");
+    }
+
+    /// @notice decodePlaintext rejects plaintext shorter than 64 bytes (e.g. 52 bytes)
+    /// @dev Previously the check was >= 52, allowing out-of-bounds assembly reads
+    function test_plaintext_rejectsTooShort() public {
+        _ensureDecoder();
+        bytes memory short = new bytes(52);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                EncryptedDepositLib.InvalidPlaintextLength.selector,
+                uint256(52),
+                ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE
+            )
+        );
+        decoder.decode(short);
+    }
+
+    /// @notice decodePlaintext rejects empty plaintext
+    function test_plaintext_rejectsEmpty() public {
+        _ensureDecoder();
+        bytes memory empty = new bytes(0);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                EncryptedDepositLib.InvalidPlaintextLength.selector,
+                uint256(0),
+                ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE
+            )
+        );
+        decoder.decode(empty);
+    }
+
+    /// @notice decodePlaintext rejects plaintext longer than 64 bytes
+    /// @dev Trailing bytes beyond 64 were previously silently ignored
+    function test_plaintext_rejectsTooLong() public {
+        _ensureDecoder();
+        bytes memory long = new bytes(65);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                EncryptedDepositLib.InvalidPlaintextLength.selector,
+                uint256(65),
+                ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE
+            )
+        );
+        decoder.decode(long);
+    }
+
+    /// @notice decodePlaintext rejects 63-byte plaintext (off-by-one boundary)
+    function test_plaintext_rejects63Bytes() public {
+        _ensureDecoder();
+        bytes memory almostRight = new bytes(63);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                EncryptedDepositLib.InvalidPlaintextLength.selector,
+                uint256(63),
+                ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE
+            )
+        );
+        decoder.decode(almostRight);
+    }
+
+    /// @notice decodePlaintext accepts exactly 64 bytes (boundary test)
+    function test_plaintext_acceptsExact64Bytes() public {
+        _ensureDecoder();
+        bytes memory exact = new bytes(64);
+        (address to, bytes32 memo) = decoder.decode(exact);
+        assertEq(to, address(0), "zero-filled plaintext should decode to zero address");
+        assertEq(memo, bytes32(0), "zero-filled plaintext should decode to zero memo");
+    }
+
+    /// @notice Fuzz test: decodePlaintext always reverts for length != 64
+    function testFuzz_plaintext_rejectsWrongLength(uint256 len) public {
+        _ensureDecoder();
+        vm.assume(len != ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE);
+        vm.assume(len <= 256); // keep allocation reasonable
+        bytes memory data = new bytes(len);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                EncryptedDepositLib.InvalidPlaintextLength.selector,
+                len,
+                ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE
+            )
+        );
+        decoder.decode(data);
     }
 
 }

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -2,17 +2,26 @@
 pragma solidity ^0.8.13;
 
 import { TIP20 } from "../../src/TIP20.sol";
+import { EncryptedDepositLib } from "../../src/zone/EncryptedDeposit.sol";
 import {
+    AES_GCM_DECRYPT,
     BlockTransition,
+    CHAUM_PEDERSEN_VERIFY,
+    ChaumPedersenProof,
     DecryptionData,
     Deposit,
     DepositQueueTransition,
     DepositType,
+    EncryptedDeposit,
+    EncryptedDepositPayload,
+    IAesGcmDecrypt,
+    IChaumPedersenVerify,
     IWithdrawalReceiver,
     IZoneFactory,
     IZoneInbox,
     IZonePortal,
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
+    PORTAL_ENCRYPTION_KEYS_SLOT,
     QueuedDeposit,
     Withdrawal,
     WithdrawalQueueTransition,
@@ -28,6 +37,7 @@ import { BaseTest } from "../BaseTest.t.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
 import { MockVerifier } from "./mocks/MockVerifier.sol";
 import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import { Vm } from "forge-std/Vm.sol";
 
 /// @notice Mock withdrawal receiver for callback tests
 contract MockWithdrawalReceiver is IWithdrawalReceiver {
@@ -764,6 +774,536 @@ contract ZoneBridgeTest is BaseTest {
 
         // Sanity: value should be non-zero after deposit
         assertTrue(fromSlot != bytes32(0), "deposit queue hash should be non-zero after deposit");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+            ENCRYPTED DEPOSIT INTEGRATION TESTS — HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    // secp256k1 generator point X (known valid point on curve)
+    bytes32 internal constant VALID_SECP256K1_X =
+        0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+
+    // Test private keys for encryption key PoP
+    uint256 internal constant ENC_KEY_1 = 1;
+    uint256 internal constant ENC_KEY_2 = 2;
+
+    /// @notice Observed encrypted deposit from L1 (simulating sequencer watching events)
+    struct ObservedEncryptedDeposit {
+        EncryptedDeposit encDeposit;
+        bytes32 newCurrentDepositQueueHash;
+    }
+
+    /// @notice Pending encrypted deposit observations
+    ObservedEncryptedDeposit[] internal pendingEncryptedDeposits;
+
+    /// @notice Helper: set encryption key on L1 portal with proof of possession
+    function _setEncKeyOnL1(uint256 privateKey) internal returns (bytes32 x, uint8 yParity) {
+        Vm.Wallet memory w = vm.createWallet(privateKey);
+        x = bytes32(w.publicKeyX);
+        yParity = w.publicKeyY % 2 == 0 ? 0x02 : 0x03;
+        bytes32 message = keccak256(abi.encode(address(l1Portal), x, yParity));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(w.privateKey, message);
+        l1Portal.setSequencerEncryptionKey(x, yParity, v, r, s);
+    }
+
+    /// @notice Helper: create an encrypted deposit payload
+    function _makeEncryptedPayload() internal pure returns (EncryptedDepositPayload memory) {
+        return EncryptedDepositPayload({
+            ephemeralPubkeyX: VALID_SECP256K1_X,
+            ephemeralPubkeyYParity: 0x02,
+            ciphertext: new bytes(64),
+            nonce: bytes12(0),
+            tag: bytes16(0)
+        });
+    }
+
+    /// @notice Simulate sequencer observing an encrypted deposit event on L1
+    function _sequencerObserveEncryptedDeposit(
+        address sender,
+        uint128 netAmount,
+        uint256 keyIndex,
+        EncryptedDepositPayload memory encrypted
+    )
+        internal
+        returns (bytes32 newHash)
+    {
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted
+        });
+
+        // Calculate the new hash (matches what portal computes via DepositQueueLib)
+        bytes32 prevHash;
+        if (pendingDeposits.length > 0) {
+            prevHash = pendingDeposits[pendingDeposits.length - 1].newCurrentDepositQueueHash;
+        } else if (pendingEncryptedDeposits.length > 0) {
+            prevHash =
+            pendingEncryptedDeposits[pendingEncryptedDeposits.length - 1].newCurrentDepositQueueHash;
+        } else {
+            prevHash = l2Inbox.processedDepositQueueHash();
+        }
+
+        newHash = keccak256(abi.encode(DepositType.Encrypted, ed, prevHash));
+        pendingEncryptedDeposits.push(
+            ObservedEncryptedDeposit({ encDeposit: ed, newCurrentDepositQueueHash: newHash })
+        );
+    }
+
+    /// @notice Set up encryption key mock storage on zone side so ZoneInbox._readEncryptionKey works
+    function _setupEncryptionKeyMockOnZone(
+        uint256 keyIndex,
+        bytes32 keyX,
+        uint8 keyYParity
+    )
+        internal
+    {
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
+        uint256 slotX = base + (keyIndex * 2);
+        uint256 slotMeta = slotX + 1;
+        l2TempoState.setMockStorageValue(address(l1Portal), bytes32(slotX), keyX);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), bytes32(slotMeta), bytes32(uint256(keyYParity))
+        );
+    }
+
+    /// @notice Set up precompile mocks for successful encrypted deposit decryption
+    function _setupPrecompileMocksSuccess(address recipient, bytes32 memo) internal {
+        vm.etch(CHAUM_PEDERSEN_VERIFY, hex"00");
+        vm.etch(AES_GCM_DECRYPT, hex"00");
+
+        // Mock Chaum-Pedersen to return valid
+        vm.mockCall(
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
+        );
+
+        // Mock AES-GCM to return expected plaintext
+        bytes memory plaintext = EncryptedDepositLib.encodePlaintext(recipient, memo);
+        vm.mockCall(
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(plaintext, true)
+        );
+    }
+
+    /// @notice Set up precompile mocks for failed AES-GCM decryption (bounce)
+    function _setupPrecompileMocksFail() internal {
+        vm.etch(CHAUM_PEDERSEN_VERIFY, hex"00");
+        vm.etch(AES_GCM_DECRYPT, hex"00");
+
+        // Mock Chaum-Pedersen to return valid (proof is fine, decryption fails)
+        vm.mockCall(
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
+        );
+
+        // Mock AES-GCM to return failure
+        vm.mockCall(
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(new bytes(0), false)
+        );
+    }
+
+    /// @notice Simulate sequencer relaying a single encrypted deposit to the zone
+    /// @dev Handles all the mock setup, builds the unified queue entries, and calls advanceTempo
+    function _sequencerRelayEncryptedDepositsToL2(
+        address decryptedTo,
+        bytes32 decryptedMemo,
+        bool shouldSucceed
+    )
+        internal
+        returns (bytes32 newProcessedHash)
+    {
+        require(pendingEncryptedDeposits.length > 0, "no encrypted deposits to relay");
+        require(
+            pendingDeposits.length == 0, "use _sequencerRelayMixedDepositsToL2 for mixed queues"
+        );
+
+        // Build queued deposits array
+        QueuedDeposit[] memory queued = new QueuedDeposit[](pendingEncryptedDeposits.length);
+        DecryptionData[] memory decs = new DecryptionData[](pendingEncryptedDeposits.length);
+
+        for (uint256 i = 0; i < pendingEncryptedDeposits.length; i++) {
+            queued[i] = QueuedDeposit({
+                depositType: DepositType.Encrypted,
+                depositData: abi.encode(pendingEncryptedDeposits[i].encDeposit)
+            });
+            decs[i] = DecryptionData({
+                sharedSecret: bytes32(uint256(0xDEAD)),
+                to: decryptedTo,
+                memo: decryptedMemo,
+                cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+            });
+        }
+
+        // Get expected final hash
+        newProcessedHash =
+        pendingEncryptedDeposits[pendingEncryptedDeposits.length - 1].newCurrentDepositQueueHash;
+
+        // Set up mock: TempoState will return this hash when reading from portal
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, newProcessedHash
+        );
+
+        // Mock precompiles
+        if (shouldSucceed) {
+            _setupPrecompileMocksSuccess(decryptedTo, decryptedMemo);
+        } else {
+            _setupPrecompileMocksFail();
+        }
+
+        // Process on zone via advanceTempo
+        vm.prank(admin);
+        l2Inbox.advanceTempo("", queued, decs);
+
+        // Clear pending
+        delete pendingEncryptedDeposits;
+
+        // Update zone block hash (simulated)
+        l2BlockHash = keccak256(abi.encode(l2BlockHash, "enc-deposits", newProcessedHash));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+            ENCRYPTED DEPOSIT INTEGRATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Full lifecycle: encrypted deposit on L1 → relay to zone → mint to decrypted recipient
+    function test_fullFlow_encryptedDepositAndMint() public {
+        // === STEP 1: Sequencer sets encryption key on L1 ===
+        (bytes32 encKeyX, uint8 encKeyYParity) = _setEncKeyOnL1(ENC_KEY_1);
+
+        // === STEP 2: Alice makes encrypted deposit on L1 ===
+        uint128 depositAmount = 1000e6;
+        uint128 fee = l1Portal.calculateDepositFee();
+        uint128 netAmount = depositAmount - fee;
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(l1Portal), depositAmount);
+        bytes32 l1DepositHash = l1Portal.depositEncrypted(depositAmount, 0, payload);
+        vm.stopPrank();
+
+        // Verify L1 state
+        assertEq(l1Portal.currentDepositQueueHash(), l1DepositHash, "L1 queue hash mismatch");
+        assertEq(
+            pathUSD.balanceOf(address(l1Portal)),
+            depositAmount - fee,
+            "Portal should hold net amount"
+        );
+
+        // === STEP 3: Sequencer observes encrypted deposit event ===
+        _sequencerObserveEncryptedDeposit(alice, netAmount, 0, payload);
+
+        // Verify our local hash matches L1
+        assertEq(
+            pendingEncryptedDeposits[0].newCurrentDepositQueueHash,
+            l1DepositHash,
+            "Observed hash must match L1 hash"
+        );
+
+        // === STEP 4: Set up zone-side encryption key mock and relay ===
+        _setupEncryptionKeyMockOnZone(0, encKeyX, encKeyYParity);
+
+        address decryptedRecipient = bob;
+        bytes32 decryptedMemo = bytes32("secret memo");
+        bytes32 newProcessedHash =
+            _sequencerRelayEncryptedDepositsToL2(decryptedRecipient, decryptedMemo, true);
+
+        // Verify zone state — tokens minted to decrypted recipient
+        assertEq(
+            l2GasToken.balanceOf(decryptedRecipient), netAmount, "Recipient should receive tokens"
+        );
+        assertEq(l2GasToken.balanceOf(alice), 0, "Sender should not receive tokens");
+        assertEq(
+            l2Inbox.processedDepositQueueHash(), newProcessedHash, "Zone processed hash mismatch"
+        );
+
+        // === STEP 5: Submit batch to L1 ===
+        _sequencerSubmitBatch(newProcessedHash);
+
+        // Verify L1 batch state updated
+        assertEq(l1Portal.withdrawalBatchIndex(), 1, "Batch index should advance");
+        assertEq(l1Portal.blockHash(), l2BlockHash, "Block hash should update");
+    }
+
+    /// @notice Full lifecycle: encrypted deposit → decryption failure → funds returned to sender
+    function test_fullFlow_encryptedDepositBounce() public {
+        // === STEP 1: Sequencer sets encryption key on L1 ===
+        (bytes32 encKeyX, uint8 encKeyYParity) = _setEncKeyOnL1(ENC_KEY_1);
+
+        // === STEP 2: Alice makes encrypted deposit on L1 ===
+        uint128 depositAmount = 1000e6;
+        uint128 fee = l1Portal.calculateDepositFee();
+        uint128 netAmount = depositAmount - fee;
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(l1Portal), depositAmount);
+        l1Portal.depositEncrypted(depositAmount, 0, payload);
+        vm.stopPrank();
+
+        // === STEP 3: Sequencer observes and relays with FAILED decryption ===
+        _sequencerObserveEncryptedDeposit(alice, netAmount, 0, payload);
+        _setupEncryptionKeyMockOnZone(0, encKeyX, encKeyYParity);
+
+        // Even with shouldSucceed=false, we need a to/memo for DecryptionData (values don't matter)
+        bytes32 newProcessedHash =
+            _sequencerRelayEncryptedDepositsToL2(address(0xBEEF), bytes32("wrong"), false);
+
+        // Verify zone state — tokens bounced back to sender (alice), not to any recipient
+        assertEq(l2GasToken.balanceOf(alice), netAmount, "Sender should get bounced tokens");
+        assertEq(l2GasToken.balanceOf(address(0xBEEF)), 0, "Failed recipient should get nothing");
+        assertEq(
+            l2Inbox.processedDepositQueueHash(), newProcessedHash, "Zone processed hash mismatch"
+        );
+
+        // === STEP 4: Submit batch to L1 ===
+        _sequencerSubmitBatch(newProcessedHash);
+        assertEq(l1Portal.withdrawalBatchIndex(), 1, "Batch index should advance");
+    }
+
+    /// @notice Mixed queue: regular deposit + encrypted deposit in single advanceTempo
+    function test_fullFlow_mixedRegularAndEncryptedDeposits() public {
+        // === STEP 1: Set up encryption key ===
+        (bytes32 encKeyX, uint8 encKeyYParity) = _setEncKeyOnL1(ENC_KEY_1);
+
+        uint128 depositAmount = 1000e6;
+        uint128 fee = l1Portal.calculateDepositFee();
+        uint128 netAmount = depositAmount - fee;
+
+        // === STEP 2: Alice makes a regular deposit ===
+        vm.startPrank(alice);
+        pathUSD.approve(address(l1Portal), depositAmount * 2);
+        bytes32 h1 = l1Portal.deposit(alice, depositAmount, bytes32("regular"));
+        vm.stopPrank();
+
+        // === STEP 3: Bob makes an encrypted deposit ===
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+        vm.startPrank(bob);
+        pathUSD.approve(address(l1Portal), depositAmount);
+        bytes32 h2 = l1Portal.depositEncrypted(depositAmount, 0, payload);
+        vm.stopPrank();
+
+        // === STEP 4: Carol makes another regular deposit ===
+        address carol = address(0x600);
+        vm.prank(pathUSDAdmin);
+        pathUSD.mint(carol, 100_000e6);
+        vm.startPrank(carol);
+        pathUSD.approve(address(l1Portal), depositAmount);
+        bytes32 h3 = l1Portal.deposit(carol, depositAmount, bytes32("carol"));
+        vm.stopPrank();
+
+        assertEq(l1Portal.currentDepositQueueHash(), h3, "L1 hash should be after 3rd deposit");
+
+        // === STEP 5: Sequencer observes all deposits and manually builds the unified queue ===
+        // We need to compute hashes in the same order the portal did
+
+        // Regular deposit from alice
+        Deposit memory d1 =
+            Deposit({ sender: alice, to: alice, amount: depositAmount, memo: bytes32("regular") });
+        bytes32 prevHash = l2Inbox.processedDepositQueueHash();
+        bytes32 hash1 = keccak256(abi.encode(DepositType.Regular, d1, prevHash));
+        assertEq(hash1, h1, "hash1 must match L1");
+
+        // Encrypted deposit from bob
+        EncryptedDeposit memory ed =
+            EncryptedDeposit({ sender: bob, amount: netAmount, keyIndex: 0, encrypted: payload });
+        bytes32 hash2 = keccak256(abi.encode(DepositType.Encrypted, ed, hash1));
+        assertEq(hash2, h2, "hash2 must match L1");
+
+        // Regular deposit from carol
+        Deposit memory d3 =
+            Deposit({ sender: carol, to: carol, amount: depositAmount, memo: bytes32("carol") });
+        bytes32 hash3 = keccak256(abi.encode(DepositType.Regular, d3, hash2));
+        assertEq(hash3, h3, "hash3 must match L1");
+
+        // === STEP 6: Build the mixed queue and relay to zone ===
+        QueuedDeposit[] memory queued = new QueuedDeposit[](3);
+        queued[0] = QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d1) });
+        queued[1] =
+            QueuedDeposit({ depositType: DepositType.Encrypted, depositData: abi.encode(ed) });
+        queued[2] = QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d3) });
+
+        // Decryption data (only 1 encrypted deposit)
+        address decryptedTo = address(0x700);
+        bytes32 decryptedMemo = bytes32("bob-secret");
+        DecryptionData[] memory decs = new DecryptionData[](1);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xDEAD)),
+            to: decryptedTo,
+            memo: decryptedMemo,
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+
+        // Set up zone-side state
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, hash3
+        );
+        _setupEncryptionKeyMockOnZone(0, encKeyX, encKeyYParity);
+        _setupPrecompileMocksSuccess(decryptedTo, decryptedMemo);
+
+        vm.prank(admin);
+        l2Inbox.advanceTempo("", queued, decs);
+
+        // === STEP 7: Verify all balances ===
+        assertEq(l2GasToken.balanceOf(alice), depositAmount, "Alice gets regular deposit");
+        assertEq(
+            l2GasToken.balanceOf(decryptedTo), netAmount, "Bob's encrypted recipient gets tokens"
+        );
+        assertEq(l2GasToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
+        assertEq(l2GasToken.balanceOf(carol), depositAmount, "Carol gets regular deposit");
+        assertEq(l2Inbox.processedDepositQueueHash(), hash3, "Zone processed hash matches L1");
+
+        // Total supply = alice_regular + bob_encrypted_net + carol_regular
+        assertEq(
+            l2GasToken.totalSupply(),
+            depositAmount + netAmount + depositAmount,
+            "Total supply should equal all deposits"
+        );
+
+        // === STEP 8: Submit batch to L1 ===
+        l2BlockHash = keccak256(abi.encode(l2BlockHash, "mixed-deposits", hash3));
+        _sequencerSubmitBatch(hash3);
+        assertEq(l1Portal.withdrawalBatchIndex(), 1, "Batch index should advance");
+    }
+
+    /// @notice Key rotation: two encrypted deposits using different encryption keys
+    function test_fullFlow_keyRotationWithPendingDeposits() public {
+        // === STEP 1: Sequencer sets first encryption key ===
+        (bytes32 keyX1, uint8 keyYParity1) = _setEncKeyOnL1(ENC_KEY_1);
+
+        // === STEP 2: Alice deposits with keyIndex=0 ===
+        uint128 depositAmount = 1000e6;
+        uint128 fee = l1Portal.calculateDepositFee();
+        uint128 netAmount = depositAmount - fee;
+        EncryptedDepositPayload memory payload1 = _makeEncryptedPayload();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(l1Portal), depositAmount);
+        bytes32 h1 = l1Portal.depositEncrypted(depositAmount, 0, payload1);
+        vm.stopPrank();
+
+        // === STEP 3: Sequencer rotates to second encryption key ===
+        vm.roll(block.number + 100);
+        (bytes32 keyX2, uint8 keyYParity2) = _setEncKeyOnL1(ENC_KEY_2);
+
+        // === STEP 4: Bob deposits with keyIndex=1 ===
+        EncryptedDepositPayload memory payload2 = _makeEncryptedPayload();
+
+        vm.startPrank(bob);
+        pathUSD.approve(address(l1Portal), depositAmount);
+        bytes32 h2 = l1Portal.depositEncrypted(depositAmount, 1, payload2);
+        vm.stopPrank();
+
+        assertEq(l1Portal.currentDepositQueueHash(), h2, "L1 hash after both deposits");
+
+        // === STEP 5: Compute expected hashes ===
+        bytes32 prevHash = l2Inbox.processedDepositQueueHash();
+        EncryptedDeposit memory ed1 = EncryptedDeposit({
+            sender: alice, amount: netAmount, keyIndex: 0, encrypted: payload1
+        });
+        bytes32 hash1 = keccak256(abi.encode(DepositType.Encrypted, ed1, prevHash));
+        assertEq(hash1, h1, "hash1 must match L1");
+
+        EncryptedDeposit memory ed2 =
+            EncryptedDeposit({ sender: bob, amount: netAmount, keyIndex: 1, encrypted: payload2 });
+        bytes32 hash2 = keccak256(abi.encode(DepositType.Encrypted, ed2, hash1));
+        assertEq(hash2, h2, "hash2 must match L1");
+
+        // === STEP 6: Build queue and relay ===
+        QueuedDeposit[] memory queued = new QueuedDeposit[](2);
+        queued[0] =
+            QueuedDeposit({ depositType: DepositType.Encrypted, depositData: abi.encode(ed1) });
+        queued[1] =
+            QueuedDeposit({ depositType: DepositType.Encrypted, depositData: abi.encode(ed2) });
+
+        address aliceRecipient = address(0x700);
+        bytes32 aliceMemo = bytes32("alice-secret");
+        address bobRecipient = address(0x800);
+        bytes32 bobMemo = bytes32("bob-secret");
+
+        DecryptionData[] memory decs = new DecryptionData[](2);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xDEAD)),
+            to: aliceRecipient,
+            memo: aliceMemo,
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+        decs[1] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xBEEF)),
+            to: bobRecipient,
+            memo: bobMemo,
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(3)), c: bytes32(uint256(4)) })
+        });
+
+        // Set up zone-side mocks: both keys in storage
+        _setupEncryptionKeyMockOnZone(0, keyX1, keyYParity1);
+        _setupEncryptionKeyMockOnZone(1, keyX2, keyYParity2);
+
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, hash2
+        );
+
+        // Mock precompiles — we use broad mocks since vm.mockCall matches any input
+        // For the success path, we need AES-GCM to return the correct plaintext.
+        // Since vm.mockCall with just the selector matches ALL calls, we mock for the LAST
+        // decryption (bobRecipient). For aliceRecipient we set up mock before advanceTempo,
+        // but vm.mockCall replaces: we need a workaround.
+        //
+        // Since Foundry's vm.mockCall uses last-registered-wins for the same address+selector,
+        // and encrypted deposits are processed sequentially, we can't differentiate two calls
+        // to the same precompile with different expected outputs using selector-only mocking.
+        //
+        // Workaround: mock both precompiles to return bobRecipient's plaintext.
+        // Alice's deposit will fail the plaintext check (dec.to != decryptedTo), causing a bounce.
+        // We test a simpler scenario: mock for aliceRecipient so BOTH succeed with the same plaintext.
+        //
+        // Actually, the cleanest approach: make both deposits decrypt to the same recipient/memo.
+        // This tests key rotation without needing differentiated mocks.
+
+        // Use same recipient/memo for both decryptions
+        address sharedRecipient = address(0x700);
+        bytes32 sharedMemo = bytes32("shared-secret");
+        decs[0].to = sharedRecipient;
+        decs[0].memo = sharedMemo;
+        decs[1].to = sharedRecipient;
+        decs[1].memo = sharedMemo;
+
+        vm.etch(CHAUM_PEDERSEN_VERIFY, hex"00");
+        vm.etch(AES_GCM_DECRYPT, hex"00");
+        vm.mockCall(
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
+        );
+        bytes memory plaintext = EncryptedDepositLib.encodePlaintext(sharedRecipient, sharedMemo);
+        vm.mockCall(
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(plaintext, true)
+        );
+
+        vm.prank(admin);
+        l2Inbox.advanceTempo("", queued, decs);
+
+        // === STEP 7: Verify ===
+        // Both deposits go to sharedRecipient
+        assertEq(
+            l2GasToken.balanceOf(sharedRecipient),
+            netAmount * 2,
+            "Recipient should receive both deposits"
+        );
+        assertEq(l2GasToken.balanceOf(alice), 0, "Alice (sender) should not receive tokens");
+        assertEq(l2GasToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
+        assertEq(l2Inbox.processedDepositQueueHash(), hash2, "Zone processed hash matches L1");
+
+        // === STEP 8: Submit batch ===
+        l2BlockHash = keccak256(abi.encode(l2BlockHash, "key-rotation", hash2));
+        _sequencerSubmitBatch(hash2);
+        assertEq(l1Portal.withdrawalBatchIndex(), 1, "Batch index should advance");
     }
 
 }

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {TIP20} from "../../src/TIP20.sol";
+import { TIP20 } from "../../src/TIP20.sol";
 import {
     BlockTransition,
     DecryptionData,
@@ -12,24 +12,26 @@ import {
     IZoneFactory,
     IZoneInbox,
     IZonePortal,
+    PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     QueuedDeposit,
     Withdrawal,
     WithdrawalQueueTransition,
     ZoneParams
 } from "../../src/zone/IZone.sol";
-import {EMPTY_SENTINEL} from "../../src/zone/WithdrawalQueueLib.sol";
-import {ZoneConfig} from "../../src/zone/ZoneConfig.sol";
-import {ZoneFactory} from "../../src/zone/ZoneFactory.sol";
-import {ZoneInbox} from "../../src/zone/ZoneInbox.sol";
-import {ZoneOutbox} from "../../src/zone/ZoneOutbox.sol";
-import {ZonePortal} from "../../src/zone/ZonePortal.sol";
-import {BaseTest} from "../BaseTest.t.sol";
-import {MockTempoState} from "./mocks/MockTempoState.sol";
-import {MockVerifier} from "./mocks/MockVerifier.sol";
-import {MockZoneGasToken} from "./mocks/MockZoneGasToken.sol";
+import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
+import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
+import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
+import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
+import { ZonePortal } from "../../src/zone/ZonePortal.sol";
+import { BaseTest } from "../BaseTest.t.sol";
+import { MockTempoState } from "./mocks/MockTempoState.sol";
+import { MockVerifier } from "./mocks/MockVerifier.sol";
+import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
 
 /// @notice Mock withdrawal receiver for callback tests
 contract MockWithdrawalReceiver is IWithdrawalReceiver {
+
     bool public shouldAccept = true;
     address public lastSender;
     uint128 public lastAmount;
@@ -39,7 +41,11 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         shouldAccept = _accept;
     }
 
-    function onWithdrawalReceived(address sender, uint128 amount, bytes calldata callbackData)
+    function onWithdrawalReceived(
+        address sender,
+        uint128 amount,
+        bytes calldata callbackData
+    )
         external
         returns (bytes4)
     {
@@ -48,12 +54,14 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         lastCallbackData = callbackData;
         return shouldAccept ? IWithdrawalReceiver.onWithdrawalReceived.selector : bytes4(0);
     }
+
 }
 
 /// @title ZoneBridgeTest
 /// @notice Tests the full L1<->zone state machine with mocked message passing
 /// @dev Simulates sequencer relaying data between chains asynchronously
 contract ZoneBridgeTest is BaseTest {
+
     /*//////////////////////////////////////////////////////////////
                               L1 CONTRACTS
     //////////////////////////////////////////////////////////////*/
@@ -82,11 +90,6 @@ contract ZoneBridgeTest is BaseTest {
     bytes32 constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
     uint64 public genesisTempoBlockNumber;
-
-    /// @notice Storage slot for currentDepositQueueHash in ZonePortal
-    /// @dev Layout: sequencer(0), pendingSequencer(1), zoneGasRate+withdrawalBatchIndex(2),
-    ///      blockHash(3), currentDepositQueueHash(4), lastSyncedTempoBlockNumber(5), _encryptionKeys(6)
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
 
     /// @notice Represents an observed deposit from Tempo (simulating sequencer watching events)
     struct ObservedDeposit {
@@ -151,10 +154,14 @@ contract ZoneBridgeTest is BaseTest {
 
         // Zone config (reads sequencer from L1 portal via Tempo state)
         l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
-        l2TempoState.setMockStorageValue(portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin))));
+        l2TempoState.setMockStorageValue(
+            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+        );
 
         // Zone inbox (advances Tempo state and processes deposits)
-        l2Inbox = new ZoneInbox(address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken));
+        l2Inbox = new ZoneInbox(
+            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
+        );
         l2GasToken.setMinter(address(l2Inbox), true);
 
         // Zone outbox (handles withdrawals)
@@ -170,12 +177,17 @@ contract ZoneBridgeTest is BaseTest {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Simulate sequencer observing a deposit event on Tempo
-    function _sequencerObserveDeposit(address sender, address to, uint128 amount, bytes32 memo)
+    function _sequencerObserveDeposit(
+        address sender,
+        address to,
+        uint128 amount,
+        bytes32 memo
+    )
         internal
         returns (bytes32 newHash)
     {
         // Record the deposit
-        Deposit memory d = Deposit({sender: sender, to: to, amount: amount, memo: memo});
+        Deposit memory d = Deposit({ sender: sender, to: to, amount: amount, memo: memo });
 
         // Calculate the new hash (matches what Tempo portal computes)
         bytes32 prevHash = pendingDeposits.length > 0
@@ -184,7 +196,7 @@ contract ZoneBridgeTest is BaseTest {
 
         newHash = keccak256(abi.encode(DepositType.Regular, d, prevHash));
 
-        pendingDeposits.push(ObservedDeposit({deposit: d, newCurrentDepositQueueHash: newHash}));
+        pendingDeposits.push(ObservedDeposit({ deposit: d, newCurrentDepositQueueHash: newHash }));
     }
 
     /// @notice Simulate sequencer relaying deposits to the zone (sequencer-only call)
@@ -201,7 +213,9 @@ contract ZoneBridgeTest is BaseTest {
         newProcessedHash = pendingDeposits[pendingDeposits.length - 1].newCurrentDepositQueueHash;
 
         // Set up mock: TempoState will return this hash when reading from portal
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, newProcessedHash);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, newProcessedHash
+        );
 
         // Process on zone via advanceTempo (sequencer-only call)
         // Empty header since MockTempoState just advances block number
@@ -215,10 +229,16 @@ contract ZoneBridgeTest is BaseTest {
         l2BlockHash = keccak256(abi.encode(l2BlockHash, "deposits", newProcessedHash));
     }
 
-    function _wrapDeposits(Deposit[] memory deposits) internal pure returns (QueuedDeposit[] memory queued) {
+    function _wrapDeposits(Deposit[] memory deposits)
+        internal
+        pure
+        returns (QueuedDeposit[] memory queued)
+    {
         queued = new QueuedDeposit[](deposits.length);
         for (uint256 i = 0; i < deposits.length; i++) {
-            queued[i] = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(deposits[i])});
+            queued[i] = QueuedDeposit({
+                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
+            });
         }
     }
 
@@ -232,7 +252,9 @@ contract ZoneBridgeTest is BaseTest {
         uint64 gasLimit,
         address fallbackRecipient,
         bytes memory data
-    ) internal {
+    )
+        internal
+    {
         pendingWithdrawals.push(
             ObservedWithdrawal({
                 index: index,
@@ -279,9 +301,11 @@ contract ZoneBridgeTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: l2BlockHash}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: newProcessedDepositQueueHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: withdrawalQueueHash}),
+            BlockTransition({ prevBlockHash: l1Portal.blockHash(), nextBlockHash: l2BlockHash }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: newProcessedDepositQueueHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalQueueHash }),
             "",
             ""
         );
@@ -495,7 +519,14 @@ contract ZoneBridgeTest is BaseTest {
 
         // Sequencer observes and submits
         _sequencerObserveWithdrawal(
-            0, alice, address(withdrawalReceiver), 500e6, bytes32(0), 100_000, alice, "callback_data"
+            0,
+            alice,
+            address(withdrawalReceiver),
+            500e6,
+            bytes32(0),
+            100_000,
+            alice,
+            "callback_data"
         );
         l2BlockHash = keccak256(abi.encode(l2BlockHash, "callback_withdrawal"));
         _sequencerSubmitBatch(processedHash);
@@ -546,7 +577,9 @@ contract ZoneBridgeTest is BaseTest {
         vm.stopPrank();
 
         // Sequencer observes and submits
-        _sequencerObserveWithdrawal(0, alice, address(withdrawalReceiver), 500e6, bytes32(0), 100_000, alice, "");
+        _sequencerObserveWithdrawal(
+            0, alice, address(withdrawalReceiver), 500e6, bytes32(0), 100_000, alice, ""
+        );
         l2BlockHash = keccak256(abi.encode(l2BlockHash, "failing_callback"));
         _sequencerSubmitBatch(processedHash);
 
@@ -645,7 +678,9 @@ contract ZoneBridgeTest is BaseTest {
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
 
         // Set up mock with wrong hash
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32("wrong hash"));
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32("wrong hash")
+        );
 
         Deposit[] memory deposits = new Deposit[](1);
         deposits[0] = pendingDeposits[0].deposit;
@@ -690,7 +725,9 @@ contract ZoneBridgeTest is BaseTest {
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
 
         bytes32 expectedHash = pendingDeposits[0].newCurrentDepositQueueHash;
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         Deposit[] memory deposits = new Deposit[](1);
         deposits[0] = pendingDeposits[0].deposit;
@@ -705,7 +742,7 @@ contract ZoneBridgeTest is BaseTest {
                     STORAGE LAYOUT VERIFICATION TESTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Verify CURRENT_DEPOSIT_QUEUE_HASH_SLOT matches the actual ZonePortal storage layout.
+    /// @notice Verify PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT matches the actual ZonePortal storage layout.
     /// @dev This is a critical regression test. If ZonePortal's storage layout changes,
     ///      this test will fail, preventing silent slot mismatches.
     function test_storageLayout_currentDepositQueueHashSlot() public {
@@ -716,16 +753,17 @@ contract ZoneBridgeTest is BaseTest {
         vm.stopPrank();
 
         // Read via vm.load using our constant
-        bytes32 fromSlot = vm.load(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
+        bytes32 fromSlot = vm.load(address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
 
         // Compare against the public getter
         assertEq(
             fromSlot,
             l1Portal.currentDepositQueueHash(),
-            "CURRENT_DEPOSIT_QUEUE_HASH_SLOT does not match actual storage position"
+            "PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT does not match actual storage position"
         );
 
         // Sanity: value should be non-zero after deposit
         assertTrue(fromSlot != bytes32(0), "deposit queue hash should be non-zero after deposit");
     }
+
 }

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { TIP20 } from "../../src/TIP20.sol";
+import {TIP20} from "../../src/TIP20.sol";
 import {
     BlockTransition,
     DecryptionData,
@@ -17,20 +17,19 @@ import {
     WithdrawalQueueTransition,
     ZoneParams
 } from "../../src/zone/IZone.sol";
-import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
-import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
-import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
-import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
-import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
-import { ZonePortal } from "../../src/zone/ZonePortal.sol";
-import { BaseTest } from "../BaseTest.t.sol";
-import { MockTempoState } from "./mocks/MockTempoState.sol";
-import { MockVerifier } from "./mocks/MockVerifier.sol";
-import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import {EMPTY_SENTINEL} from "../../src/zone/WithdrawalQueueLib.sol";
+import {ZoneConfig} from "../../src/zone/ZoneConfig.sol";
+import {ZoneFactory} from "../../src/zone/ZoneFactory.sol";
+import {ZoneInbox} from "../../src/zone/ZoneInbox.sol";
+import {ZoneOutbox} from "../../src/zone/ZoneOutbox.sol";
+import {ZonePortal} from "../../src/zone/ZonePortal.sol";
+import {BaseTest} from "../BaseTest.t.sol";
+import {MockTempoState} from "./mocks/MockTempoState.sol";
+import {MockVerifier} from "./mocks/MockVerifier.sol";
+import {MockZoneGasToken} from "./mocks/MockZoneGasToken.sol";
 
 /// @notice Mock withdrawal receiver for callback tests
 contract MockWithdrawalReceiver is IWithdrawalReceiver {
-
     bool public shouldAccept = true;
     address public lastSender;
     uint128 public lastAmount;
@@ -40,11 +39,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         shouldAccept = _accept;
     }
 
-    function onWithdrawalReceived(
-        address sender,
-        uint128 amount,
-        bytes calldata callbackData
-    )
+    function onWithdrawalReceived(address sender, uint128 amount, bytes calldata callbackData)
         external
         returns (bytes4)
     {
@@ -53,14 +48,12 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         lastCallbackData = callbackData;
         return shouldAccept ? IWithdrawalReceiver.onWithdrawalReceived.selector : bytes4(0);
     }
-
 }
 
 /// @title ZoneBridgeTest
 /// @notice Tests the full L1<->zone state machine with mocked message passing
 /// @dev Simulates sequencer relaying data between chains asynchronously
 contract ZoneBridgeTest is BaseTest {
-
     /*//////////////////////////////////////////////////////////////
                               L1 CONTRACTS
     //////////////////////////////////////////////////////////////*/
@@ -91,8 +84,9 @@ contract ZoneBridgeTest is BaseTest {
     uint64 public genesisTempoBlockNumber;
 
     /// @notice Storage slot for currentDepositQueueHash in ZonePortal
-    /// @dev Layout: sequencerPubkey(0), withdrawalBatchIndex(1), blockHash(2), currentDepositQueueHash(3)
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
+    /// @dev Layout: sequencer(0), pendingSequencer(1), zoneGasRate+withdrawalBatchIndex(2),
+    ///      blockHash(3), currentDepositQueueHash(4), lastSyncedTempoBlockNumber(5), _encryptionKeys(6)
+    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
 
     /// @notice Represents an observed deposit from Tempo (simulating sequencer watching events)
     struct ObservedDeposit {
@@ -157,14 +151,10 @@ contract ZoneBridgeTest is BaseTest {
 
         // Zone config (reads sequencer from L1 portal via Tempo state)
         l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
-        l2TempoState.setMockStorageValue(
-            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
-        );
+        l2TempoState.setMockStorageValue(portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin))));
 
         // Zone inbox (advances Tempo state and processes deposits)
-        l2Inbox = new ZoneInbox(
-            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
-        );
+        l2Inbox = new ZoneInbox(address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken));
         l2GasToken.setMinter(address(l2Inbox), true);
 
         // Zone outbox (handles withdrawals)
@@ -180,17 +170,12 @@ contract ZoneBridgeTest is BaseTest {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Simulate sequencer observing a deposit event on Tempo
-    function _sequencerObserveDeposit(
-        address sender,
-        address to,
-        uint128 amount,
-        bytes32 memo
-    )
+    function _sequencerObserveDeposit(address sender, address to, uint128 amount, bytes32 memo)
         internal
         returns (bytes32 newHash)
     {
         // Record the deposit
-        Deposit memory d = Deposit({ sender: sender, to: to, amount: amount, memo: memo });
+        Deposit memory d = Deposit({sender: sender, to: to, amount: amount, memo: memo});
 
         // Calculate the new hash (matches what Tempo portal computes)
         bytes32 prevHash = pendingDeposits.length > 0
@@ -199,7 +184,7 @@ contract ZoneBridgeTest is BaseTest {
 
         newHash = keccak256(abi.encode(DepositType.Regular, d, prevHash));
 
-        pendingDeposits.push(ObservedDeposit({ deposit: d, newCurrentDepositQueueHash: newHash }));
+        pendingDeposits.push(ObservedDeposit({deposit: d, newCurrentDepositQueueHash: newHash}));
     }
 
     /// @notice Simulate sequencer relaying deposits to the zone (sequencer-only call)
@@ -216,9 +201,7 @@ contract ZoneBridgeTest is BaseTest {
         newProcessedHash = pendingDeposits[pendingDeposits.length - 1].newCurrentDepositQueueHash;
 
         // Set up mock: TempoState will return this hash when reading from portal
-        l2TempoState.setMockStorageValue(
-            address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, newProcessedHash
-        );
+        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, newProcessedHash);
 
         // Process on zone via advanceTempo (sequencer-only call)
         // Empty header since MockTempoState just advances block number
@@ -232,16 +215,10 @@ contract ZoneBridgeTest is BaseTest {
         l2BlockHash = keccak256(abi.encode(l2BlockHash, "deposits", newProcessedHash));
     }
 
-    function _wrapDeposits(Deposit[] memory deposits)
-        internal
-        pure
-        returns (QueuedDeposit[] memory queued)
-    {
+    function _wrapDeposits(Deposit[] memory deposits) internal pure returns (QueuedDeposit[] memory queued) {
         queued = new QueuedDeposit[](deposits.length);
         for (uint256 i = 0; i < deposits.length; i++) {
-            queued[i] = QueuedDeposit({
-                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
-            });
+            queued[i] = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(deposits[i])});
         }
     }
 
@@ -255,9 +232,7 @@ contract ZoneBridgeTest is BaseTest {
         uint64 gasLimit,
         address fallbackRecipient,
         bytes memory data
-    )
-        internal
-    {
+    ) internal {
         pendingWithdrawals.push(
             ObservedWithdrawal({
                 index: index,
@@ -304,11 +279,9 @@ contract ZoneBridgeTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: l1Portal.blockHash(), nextBlockHash: l2BlockHash }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: newProcessedDepositQueueHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalQueueHash }),
+            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: l2BlockHash}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: newProcessedDepositQueueHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: withdrawalQueueHash}),
             "",
             ""
         );
@@ -522,14 +495,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Sequencer observes and submits
         _sequencerObserveWithdrawal(
-            0,
-            alice,
-            address(withdrawalReceiver),
-            500e6,
-            bytes32(0),
-            100_000,
-            alice,
-            "callback_data"
+            0, alice, address(withdrawalReceiver), 500e6, bytes32(0), 100_000, alice, "callback_data"
         );
         l2BlockHash = keccak256(abi.encode(l2BlockHash, "callback_withdrawal"));
         _sequencerSubmitBatch(processedHash);
@@ -580,9 +546,7 @@ contract ZoneBridgeTest is BaseTest {
         vm.stopPrank();
 
         // Sequencer observes and submits
-        _sequencerObserveWithdrawal(
-            0, alice, address(withdrawalReceiver), 500e6, bytes32(0), 100_000, alice, ""
-        );
+        _sequencerObserveWithdrawal(0, alice, address(withdrawalReceiver), 500e6, bytes32(0), 100_000, alice, "");
         l2BlockHash = keccak256(abi.encode(l2BlockHash, "failing_callback"));
         _sequencerSubmitBatch(processedHash);
 
@@ -681,9 +645,7 @@ contract ZoneBridgeTest is BaseTest {
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
 
         // Set up mock with wrong hash
-        l2TempoState.setMockStorageValue(
-            address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32("wrong hash")
-        );
+        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32("wrong hash"));
 
         Deposit[] memory deposits = new Deposit[](1);
         deposits[0] = pendingDeposits[0].deposit;
@@ -728,9 +690,7 @@ contract ZoneBridgeTest is BaseTest {
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
 
         bytes32 expectedHash = pendingDeposits[0].newCurrentDepositQueueHash;
-        l2TempoState.setMockStorageValue(
-            address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
-        );
+        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
 
         Deposit[] memory deposits = new Deposit[](1);
         deposits[0] = pendingDeposits[0].deposit;
@@ -741,4 +701,31 @@ contract ZoneBridgeTest is BaseTest {
         l2Inbox.advanceTempo("", _wrapDeposits(deposits), new DecryptionData[](0));
     }
 
+    /*//////////////////////////////////////////////////////////////
+                    STORAGE LAYOUT VERIFICATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Verify CURRENT_DEPOSIT_QUEUE_HASH_SLOT matches the actual ZonePortal storage layout.
+    /// @dev This is a critical regression test. If ZonePortal's storage layout changes,
+    ///      this test will fail, preventing silent slot mismatches.
+    function test_storageLayout_currentDepositQueueHashSlot() public {
+        // Make a deposit to get a non-zero currentDepositQueueHash
+        vm.startPrank(alice);
+        pathUSD.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(alice, 1000e6, bytes32("layout-test"));
+        vm.stopPrank();
+
+        // Read via vm.load using our constant
+        bytes32 fromSlot = vm.load(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
+
+        // Compare against the public getter
+        assertEq(
+            fromSlot,
+            l1Portal.currentDepositQueueHash(),
+            "CURRENT_DEPOSIT_QUEUE_HASH_SLOT does not match actual storage position"
+        );
+
+        // Sanity: value should be non-zero after deposit
+        assertTrue(fromSlot != bytes32(0), "deposit queue hash should be non-zero after deposit");
+    }
 }

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -4,12 +4,15 @@ pragma solidity ^0.8.13;
 import { TIP20 } from "../../src/TIP20.sol";
 import {
     BlockTransition,
+    DecryptionData,
     Deposit,
     DepositQueueTransition,
+    DepositType,
     IWithdrawalReceiver,
     IZoneFactory,
     IZoneInbox,
     IZonePortal,
+    QueuedDeposit,
     Withdrawal,
     WithdrawalQueueTransition,
     ZoneParams
@@ -194,7 +197,7 @@ contract ZoneBridgeTest is BaseTest {
             ? pendingDeposits[pendingDeposits.length - 1].newCurrentDepositQueueHash
             : l2Inbox.processedDepositQueueHash();
 
-        newHash = keccak256(abi.encode(d, prevHash));
+        newHash = keccak256(abi.encode(DepositType.Regular, d, prevHash));
 
         pendingDeposits.push(ObservedDeposit({ deposit: d, newCurrentDepositQueueHash: newHash }));
     }
@@ -220,13 +223,26 @@ contract ZoneBridgeTest is BaseTest {
         // Process on zone via advanceTempo (sequencer-only call)
         // Empty header since MockTempoState just advances block number
         vm.prank(admin);
-        l2Inbox.advanceTempo("", deposits);
+        l2Inbox.advanceTempo("", _wrapDeposits(deposits), new DecryptionData[](0));
 
         // Clear pending
         delete pendingDeposits;
 
         // Update zone block hash (simulated)
         l2BlockHash = keccak256(abi.encode(l2BlockHash, "deposits", newProcessedHash));
+    }
+
+    function _wrapDeposits(Deposit[] memory deposits)
+        internal
+        pure
+        returns (QueuedDeposit[] memory queued)
+    {
+        queued = new QueuedDeposit[](deposits.length);
+        for (uint256 i = 0; i < deposits.length; i++) {
+            queued[i] = QueuedDeposit({
+                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
+            });
+        }
     }
 
     /// @notice Simulate sequencer observing a withdrawal event on the zone
@@ -675,7 +691,7 @@ contract ZoneBridgeTest is BaseTest {
         // Should revert because hash doesn't match
         vm.prank(admin);
         vm.expectRevert(IZoneInbox.InvalidDepositQueueHash.selector);
-        l2Inbox.advanceTempo("", deposits);
+        l2Inbox.advanceTempo("", _wrapDeposits(deposits), new DecryptionData[](0));
     }
 
     function test_l2_callbackRequiresFallbackRecipient() public {
@@ -722,7 +738,7 @@ contract ZoneBridgeTest is BaseTest {
         // Non-sequencer tries to advance
         vm.prank(alice);
         vm.expectRevert(IZoneInbox.OnlySequencer.selector);
-        l2Inbox.advanceTempo("", deposits);
+        l2Inbox.advanceTempo("", _wrapDeposits(deposits), new DecryptionData[](0));
     }
 
 }

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import { EncryptedDepositLib } from "../../src/zone/EncryptedDeposit.sol";
 import {
+    AES_GCM_DECRYPT,
+    CHAUM_PEDERSEN_VERIFY,
+    ChaumPedersenProof,
     DecryptionData,
     Deposit,
     DepositType,
+    EncryptedDeposit,
+    EncryptedDepositPayload,
+    IAesGcmDecrypt,
+    IChaumPedersenVerify,
     IZoneInbox,
     QueuedDeposit
 } from "../../src/zone/IZone.sol";
@@ -332,6 +340,294 @@ contract ZoneInboxTest is Test {
         // Calculate expected balance: sum of 1 + 2 + ... + 50 = 50 * 51 / 2 = 1275
         uint256 expectedBalance = (numDeposits * (numDeposits + 1) / 2) * 1e6;
         assertEq(gasToken.balanceOf(bob), expectedBalance);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    ENCRYPTED DEPOSIT TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Storage slot for _encryptionKeys in ZonePortal
+    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
+
+    /// @notice Set up encryption key mock storage for a given key index
+    function _setupEncryptionKeyMock(uint256 keyIndex, bytes32 keyX, uint8 keyYParity) internal {
+        uint256 base = uint256(keccak256(abi.encode(uint256(7))));
+        uint256 slotX = base + (keyIndex * 2);
+        uint256 slotMeta = slotX + 1;
+        tempoState.setMockStorageValue(mockPortal, bytes32(slotX), keyX);
+        tempoState.setMockStorageValue(mockPortal, bytes32(slotMeta), bytes32(uint256(keyYParity)));
+    }
+
+    /// @notice Build an EncryptedDeposit and its QueuedDeposit wrapper
+    function _makeEncryptedDeposit(
+        address sender,
+        uint128 amount,
+        uint256 keyIndex
+    )
+        internal
+        pure
+        returns (QueuedDeposit memory qd, EncryptedDeposit memory ed)
+    {
+        ed = EncryptedDeposit({
+            sender: sender,
+            amount: amount,
+            keyIndex: keyIndex,
+            encrypted: EncryptedDepositPayload({
+                ephemeralPubkeyX: bytes32(uint256(0x1234)),
+                ephemeralPubkeyYParity: 0x02,
+                ciphertext: new bytes(64),
+                nonce: bytes12(0),
+                tag: bytes16(0)
+            })
+        });
+        qd = QueuedDeposit({ depositType: DepositType.Encrypted, depositData: abi.encode(ed) });
+    }
+
+    /// @notice Set up precompile mocks for successful encrypted deposit processing
+    function _setupPrecompileMocks(address recipient, bytes32 memo) internal {
+        // Deploy dummy code so high-level Solidity calls pass extcodesize check
+        vm.etch(CHAUM_PEDERSEN_VERIFY, hex"00");
+        vm.etch(AES_GCM_DECRYPT, hex"00");
+
+        // Mock Chaum-Pedersen to return valid
+        vm.mockCall(
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
+        );
+
+        // Mock AES-GCM to return expected plaintext
+        bytes memory plaintext = EncryptedDepositLib.encodePlaintext(recipient, memo);
+        vm.mockCall(
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(plaintext, true)
+        );
+    }
+
+    function test_advanceTempo_encryptedDeposit_success() public {
+        address recipient = address(0x500);
+        bytes32 memo = bytes32("secret memo");
+        uint128 amount = 1000e6;
+
+        // Set up encryption key in mock Tempo storage
+        bytes32 seqKeyX = keccak256("sequencer-key-x");
+        uint8 seqKeyYParity = 0x03;
+        _setupEncryptionKeyMock(0, seqKeyX, seqKeyYParity);
+
+        // Set up precompile mocks
+        _setupPrecompileMocks(recipient, memo);
+
+        // Build encrypted deposit
+        (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
+            _makeEncryptedDeposit(alice, amount, 0);
+
+        // Compute expected hash and set in mock storage
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
+        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+
+        // Build deposits and decryptions arrays
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
+        deposits[0] = qd;
+
+        DecryptionData[] memory decs = new DecryptionData[](1);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xdeadbeef)),
+            to: recipient,
+            memo: memo,
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs);
+
+        // Verify minting to the decrypted recipient
+        assertEq(gasToken.balanceOf(recipient), amount);
+        assertEq(inbox.processedDepositQueueHash(), expectedHash);
+    }
+
+    function test_advanceTempo_encryptedDeposit_decryptionFails() public {
+        uint128 amount = 1000e6;
+
+        // Set up encryption key
+        _setupEncryptionKeyMock(0, keccak256("seq-key"), 0x03);
+
+        // Deploy dummy code at precompile addresses
+        vm.etch(CHAUM_PEDERSEN_VERIFY, hex"00");
+        vm.etch(AES_GCM_DECRYPT, hex"00");
+
+        // Mock CP to return valid
+        vm.mockCall(
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
+        );
+
+        // Mock AES-GCM to return FAILURE
+        vm.mockCall(
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(new bytes(0), false)
+        );
+
+        // Build encrypted deposit
+        (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
+            _makeEncryptedDeposit(alice, amount, 0);
+
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
+        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
+        deposits[0] = qd;
+
+        DecryptionData[] memory decs = new DecryptionData[](1);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xdeadbeef)),
+            to: address(0x500),
+            memo: bytes32("memo"),
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs);
+
+        // Funds should go to sender (alice), not the decrypted recipient
+        assertEq(gasToken.balanceOf(alice), amount);
+        assertEq(gasToken.balanceOf(address(0x500)), 0);
+        assertEq(inbox.processedDepositQueueHash(), expectedHash);
+    }
+
+    function test_advanceTempo_mixedRegularAndEncryptedDeposits() public {
+        address recipient = address(0x500);
+        bytes32 encMemo = bytes32("encrypted memo");
+
+        // Set up encryption key
+        _setupEncryptionKeyMock(0, keccak256("seq-key"), 0x03);
+        _setupPrecompileMocks(recipient, encMemo);
+
+        // Build regular deposit
+        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
+        QueuedDeposit memory qdRegular =
+            QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
+
+        // Build encrypted deposit
+        (QueuedDeposit memory qdEnc, EncryptedDeposit memory ed) =
+            _makeEncryptedDeposit(bob, 200e6, 0);
+
+        // Compute expected hash chain: regular first, then encrypted
+        bytes32 h1 = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
+        bytes32 h2 = keccak256(abi.encode(DepositType.Encrypted, ed, h1));
+
+        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
+
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](2);
+        deposits[0] = qdRegular;
+        deposits[1] = qdEnc;
+
+        DecryptionData[] memory decs = new DecryptionData[](1);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xabcd)),
+            to: recipient,
+            memo: encMemo,
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs);
+
+        // Regular deposit: bob gets 100e6
+        // Encrypted deposit: recipient gets 200e6
+        assertEq(gasToken.balanceOf(bob), 100e6);
+        assertEq(gasToken.balanceOf(recipient), 200e6);
+        assertEq(inbox.processedDepositQueueHash(), h2);
+    }
+
+    function test_advanceTempo_missingDecryptionData() public {
+        // Set up encryption key
+        _setupEncryptionKeyMock(0, keccak256("seq-key"), 0x03);
+
+        // Build encrypted deposit but provide NO decryption data
+        (QueuedDeposit memory qd,) = _makeEncryptedDeposit(alice, 1000e6, 0);
+
+        // We need to set the current hash to something - doesn't matter since we expect revert
+        tempoState.setMockStorageValue(
+            mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever")
+        );
+
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
+        deposits[0] = qd;
+
+        DecryptionData[] memory emptyDecs = new DecryptionData[](0);
+
+        vm.prank(sequencer);
+        vm.expectRevert(IZoneInbox.MissingDecryptionData.selector);
+        inbox.advanceTempo("", deposits, emptyDecs);
+    }
+
+    function test_advanceTempo_extraDecryptionData() public {
+        // Build a regular deposit only (no encrypted deposits)
+        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
+        QueuedDeposit memory qd =
+            QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
+
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
+        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
+        deposits[0] = qd;
+
+        // Provide decryption data even though there are no encrypted deposits
+        DecryptionData[] memory decs = new DecryptionData[](1);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(1)),
+            to: address(0x500),
+            memo: bytes32("memo"),
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+
+        vm.prank(sequencer);
+        vm.expectRevert(IZoneInbox.ExtraDecryptionData.selector);
+        inbox.advanceTempo("", deposits, decs);
+    }
+
+    function test_advanceTempo_encryptedDeposit_invalidProof() public {
+        uint128 amount = 1000e6;
+
+        // Set up encryption key
+        _setupEncryptionKeyMock(0, keccak256("seq-key"), 0x03);
+
+        // Deploy dummy code at precompile addresses
+        vm.etch(CHAUM_PEDERSEN_VERIFY, hex"00");
+        vm.etch(AES_GCM_DECRYPT, hex"00");
+
+        // Mock CP to return INVALID
+        vm.mockCall(
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(false)
+        );
+
+        // Build encrypted deposit
+        (QueuedDeposit memory qd,) = _makeEncryptedDeposit(alice, amount, 0);
+
+        tempoState.setMockStorageValue(
+            mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever")
+        );
+
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
+        deposits[0] = qd;
+
+        DecryptionData[] memory decs = new DecryptionData[](1);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xbad)),
+            to: address(0x500),
+            memo: bytes32("memo"),
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+
+        vm.prank(sequencer);
+        vm.expectRevert(IZoneInbox.InvalidSharedSecretProof.selector);
+        inbox.advanceTempo("", deposits, decs);
     }
 
 }

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -590,6 +590,92 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
     }
 
+    /*//////////////////////////////////////////////////////////////
+                    ZONE CONFIG ENCRYPTION KEY TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Verify ZoneConfig.sequencerEncryptionKey() reads from the correct storage slot.
+    /// @dev Regression test for the bug where ZoneConfig read slot 2 (legacy sequencerPubkey)
+    ///      instead of the _encryptionKeys dynamic array at slot 7.
+    function test_zoneConfig_sequencerEncryptionKey_readsCorrectSlot() public {
+        bytes32 keyX = keccak256("config-test-key");
+        uint8 keyYParity = 0x03;
+
+        // Simulate the _encryptionKeys array at slot 7:
+        // Set array length = 1 at slot 7
+        uint256 arraySlot = 7;
+        tempoState.setMockStorageValue(mockPortal, bytes32(arraySlot), bytes32(uint256(1)));
+
+        // Set the key entry data at the derived slots
+        uint256 base = uint256(keccak256(abi.encode(arraySlot)));
+        tempoState.setMockStorageValue(mockPortal, bytes32(base), keyX);
+        tempoState.setMockStorageValue(mockPortal, bytes32(base + 1), bytes32(uint256(keyYParity)));
+
+        // Read via ZoneConfig — this should use slot 7, not slot 2
+        (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
+        assertEq(readX, keyX, "ZoneConfig should read key x from slot 7 array");
+        assertEq(readYParity, keyYParity, "ZoneConfig should read yParity from slot 7 array");
+    }
+
+    /// @notice Verify ZoneConfig.sequencerEncryptionKey() returns the LAST key when multiple exist.
+    function test_zoneConfig_sequencerEncryptionKey_returnsLatestKey() public {
+        bytes32 keyX1 = keccak256("old-key");
+        bytes32 keyX2 = keccak256("new-key");
+        uint8 yParity2 = 0x02;
+
+        // Simulate 2 entries in _encryptionKeys
+        uint256 arraySlot = 7;
+        tempoState.setMockStorageValue(mockPortal, bytes32(arraySlot), bytes32(uint256(2)));
+
+        uint256 base = uint256(keccak256(abi.encode(arraySlot)));
+
+        // Entry 0
+        tempoState.setMockStorageValue(mockPortal, bytes32(base), keyX1);
+        tempoState.setMockStorageValue(mockPortal, bytes32(base + 1), bytes32(uint256(0x03)));
+
+        // Entry 1 (latest)
+        tempoState.setMockStorageValue(mockPortal, bytes32(base + 2), keyX2);
+        tempoState.setMockStorageValue(mockPortal, bytes32(base + 3), bytes32(uint256(yParity2)));
+
+        (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
+        assertEq(readX, keyX2, "should return the latest key");
+        assertEq(readYParity, yParity2, "should return the latest yParity");
+    }
+
+    /// @notice Verify ZoneConfig.sequencerEncryptionKey() returns zeros when no keys exist.
+    function test_zoneConfig_sequencerEncryptionKey_emptyReturnsZero() public {
+        // Array length = 0 (default)
+        tempoState.setMockStorageValue(mockPortal, bytes32(uint256(7)), bytes32(uint256(0)));
+
+        (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
+        assertEq(readX, bytes32(0));
+        assertEq(readYParity, 0);
+    }
+
+    /// @notice Verify ZoneConfig and ZoneInbox read from the same encryption key slot.
+    /// @dev Both contracts define ENCRYPTION_KEYS_SLOT = 7 and must agree on derived slot computation.
+    function test_zoneConfig_and_zoneInbox_readSameEncryptionKey() public {
+        bytes32 keyX = keccak256("shared-key-test");
+        uint8 keyYParity = 0x02;
+
+        // Set up encryption key mock (same as _setupEncryptionKeyMock)
+        _setupEncryptionKeyMock(0, keyX, keyYParity);
+
+        // Also set the array length (ZoneConfig needs this, ZoneInbox._readEncryptionKey doesn't)
+        tempoState.setMockStorageValue(mockPortal, bytes32(uint256(7)), bytes32(uint256(1)));
+
+        // Read via ZoneConfig
+        (bytes32 configX, uint8 configYParity) = config.sequencerEncryptionKey();
+
+        // The values read by ZoneConfig must match what ZoneInbox._readEncryptionKey would get
+        assertEq(configX, keyX, "ZoneConfig and ZoneInbox must agree on key X");
+        assertEq(configYParity, keyYParity, "ZoneConfig and ZoneInbox must agree on yParity");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    ENCRYPTED DEPOSIT TESTS (continued)
+    //////////////////////////////////////////////////////////////*/
+
     function test_advanceTempo_encryptedDeposit_invalidProof() public {
         uint128 amount = 1000e6;
 

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -13,6 +13,7 @@ import {
     EncryptedDepositPayload,
     IAesGcmDecrypt,
     IChaumPedersenVerify,
+    IZoneConfig,
     IZoneInbox,
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     PORTAL_ENCRYPTION_KEYS_SLOT,
@@ -659,14 +660,13 @@ contract ZoneInboxTest is Test {
         assertEq(readYParity, yParity2, "should return the latest yParity");
     }
 
-    /// @notice Verify ZoneConfig.sequencerEncryptionKey() returns zeros when no keys exist.
-    function test_zoneConfig_sequencerEncryptionKey_emptyReturnsZero() public {
+    /// @notice Verify ZoneConfig.sequencerEncryptionKey() reverts when no keys exist.
+    function test_zoneConfig_sequencerEncryptionKey_revertsWhenEmpty() public {
         // Array length = 0 (default)
         tempoState.setMockStorageValue(mockPortal, PORTAL_ENCRYPTION_KEYS_SLOT, bytes32(uint256(0)));
 
-        (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
-        assertEq(readX, bytes32(0));
-        assertEq(readYParity, 0);
+        vm.expectRevert(IZoneConfig.NoEncryptionKeySet.selector);
+        config.sequencerEncryptionKey();
     }
 
     /// @notice Verify ZoneConfig and ZoneInbox read from the same encryption key slot.

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Deposit, IZoneInbox } from "../../src/zone/IZone.sol";
+import {
+    DecryptionData,
+    Deposit,
+    DepositType,
+    IZoneInbox,
+    QueuedDeposit
+} from "../../src/zone/IZone.sol";
 import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
@@ -42,6 +48,23 @@ contract ZoneInboxTest is Test {
         gasToken.setMinter(address(inbox), true);
     }
 
+    function _wrapDeposits(Deposit[] memory deposits)
+        internal
+        pure
+        returns (QueuedDeposit[] memory queued)
+    {
+        queued = new QueuedDeposit[](deposits.length);
+        for (uint256 i = 0; i < deposits.length; i++) {
+            queued[i] = QueuedDeposit({
+                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
+            });
+        }
+    }
+
+    function _advanceTempo(Deposit[] memory deposits) internal {
+        inbox.advanceTempo("", _wrapDeposits(deposits), new DecryptionData[](0));
+    }
+
     /*//////////////////////////////////////////////////////////////
                           EMPTY DEPOSITS TESTS
     //////////////////////////////////////////////////////////////*/
@@ -53,7 +76,7 @@ contract ZoneInboxTest is Test {
         Deposit[] memory deposits = new Deposit[](0);
 
         vm.prank(sequencer);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         // State should remain at bytes32(0)
         assertEq(inbox.processedDepositQueueHash(), bytes32(0));
@@ -64,12 +87,12 @@ contract ZoneInboxTest is Test {
         deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
 
         // Calculate expected hash
-        bytes32 expectedHash = keccak256(abi.encode(deposits[0], bytes32(0)));
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
 
         vm.prank(sequencer);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         assertEq(inbox.processedDepositQueueHash(), expectedHash);
         assertEq(gasToken.balanceOf(bob), 1000e6);
@@ -83,14 +106,14 @@ contract ZoneInboxTest is Test {
 
         // Calculate expected hash chain
         bytes32 h0 = bytes32(0);
-        bytes32 h1 = keccak256(abi.encode(deposits[0], h0));
-        bytes32 h2 = keccak256(abi.encode(deposits[1], h1));
-        bytes32 h3 = keccak256(abi.encode(deposits[2], h2));
+        bytes32 h1 = keccak256(abi.encode(DepositType.Regular, deposits[0], h0));
+        bytes32 h2 = keccak256(abi.encode(DepositType.Regular, deposits[1], h1));
+        bytes32 h3 = keccak256(abi.encode(DepositType.Regular, deposits[2], h2));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h3);
 
         vm.prank(sequencer);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         assertEq(inbox.processedDepositQueueHash(), h3);
         assertEq(gasToken.balanceOf(alice), 100e6);
@@ -112,7 +135,7 @@ contract ZoneInboxTest is Test {
 
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.InvalidDepositQueueHash.selector);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
     }
 
     function test_advanceTempo_revertsOnPartialMismatch() public {
@@ -123,8 +146,8 @@ contract ZoneInboxTest is Test {
 
         // Set hash to be for both deposits
         bytes32 h0 = bytes32(0);
-        bytes32 h1 = keccak256(abi.encode(allDeposits[0], h0));
-        bytes32 h2 = keccak256(abi.encode(allDeposits[1], h1));
+        bytes32 h1 = keccak256(abi.encode(DepositType.Regular, allDeposits[0], h0));
+        bytes32 h2 = keccak256(abi.encode(DepositType.Regular, allDeposits[1], h1));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
 
@@ -134,7 +157,7 @@ contract ZoneInboxTest is Test {
 
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.InvalidDepositQueueHash.selector);
-        inbox.advanceTempo("", oneDeposit);
+        _advanceTempo(oneDeposit);
     }
 
     function test_advanceTempo_revertsOnWrongOrder() public {
@@ -149,15 +172,15 @@ contract ZoneInboxTest is Test {
         Deposit memory d2 = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
 
         bytes32 h0 = bytes32(0);
-        bytes32 h1 = keccak256(abi.encode(d1, h0));
-        bytes32 h2 = keccak256(abi.encode(d2, h1));
+        bytes32 h1 = keccak256(abi.encode(DepositType.Regular, d1, h0));
+        bytes32 h2 = keccak256(abi.encode(DepositType.Regular, d2, h1));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
 
         // Processing in wrong order should fail
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.InvalidDepositQueueHash.selector);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -172,11 +195,11 @@ contract ZoneInboxTest is Test {
         // Random user should fail
         vm.prank(alice);
         vm.expectRevert(IZoneInbox.OnlySequencer.selector);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         // Sequencer should succeed
         vm.prank(sequencer);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -190,13 +213,13 @@ contract ZoneInboxTest is Test {
         batch1[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
 
         bytes32 h0 = bytes32(0);
-        bytes32 h1 = keccak256(abi.encode(batch1[0], h0));
-        bytes32 h2 = keccak256(abi.encode(batch1[1], h1));
+        bytes32 h1 = keccak256(abi.encode(DepositType.Regular, batch1[0], h0));
+        bytes32 h2 = keccak256(abi.encode(DepositType.Regular, batch1[1], h1));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
 
         vm.prank(sequencer);
-        inbox.advanceTempo("", batch1);
+        _advanceTempo(batch1);
 
         assertEq(inbox.processedDepositQueueHash(), h2);
 
@@ -204,12 +227,12 @@ contract ZoneInboxTest is Test {
         Deposit[] memory batch2 = new Deposit[](1);
         batch2[0] = Deposit({ sender: alice, to: bob, amount: 500e6, memo: bytes32("d3") });
 
-        bytes32 h3 = keccak256(abi.encode(batch2[0], h2));
+        bytes32 h3 = keccak256(abi.encode(DepositType.Regular, batch2[0], h2));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h3);
 
         vm.prank(sequencer);
-        inbox.advanceTempo("", batch2);
+        _advanceTempo(batch2);
 
         assertEq(inbox.processedDepositQueueHash(), h3);
         assertEq(gasToken.balanceOf(alice), 100e6);
@@ -224,7 +247,7 @@ contract ZoneInboxTest is Test {
         Deposit[] memory deposits = new Deposit[](1);
         deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
 
-        bytes32 expectedHash = keccak256(abi.encode(deposits[0], bytes32(0)));
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
 
@@ -237,21 +260,21 @@ contract ZoneInboxTest is Test {
             1,
             expectedHash
         );
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
     }
 
     function test_advanceTempo_emitsDepositProcessedEvent() public {
         Deposit[] memory deposits = new Deposit[](1);
         deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
 
-        bytes32 expectedHash = keccak256(abi.encode(deposits[0], bytes32(0)));
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
 
         vm.prank(sequencer);
         vm.expectEmit(true, true, true, true);
         emit IZoneInbox.DepositProcessed(expectedHash, alice, bob, 1000e6, bytes32("payment"));
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -262,12 +285,12 @@ contract ZoneInboxTest is Test {
         Deposit[] memory deposits = new Deposit[](1);
         deposits[0] = Deposit({ sender: alice, to: bob, amount: 0, memo: bytes32("empty") });
 
-        bytes32 expectedHash = keccak256(abi.encode(deposits[0], bytes32(0)));
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
 
         vm.prank(sequencer);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         assertEq(inbox.processedDepositQueueHash(), expectedHash);
         assertEq(gasToken.balanceOf(bob), 0);
@@ -296,13 +319,13 @@ contract ZoneInboxTest is Test {
         for (uint256 i = 0; i < numDeposits; i++) {
             deposits[i] =
                 Deposit({ sender: alice, to: bob, amount: uint128(i + 1) * 1e6, memo: bytes32(i) });
-            currentHash = keccak256(abi.encode(deposits[i], currentHash));
+            currentHash = keccak256(abi.encode(DepositType.Regular, deposits[i], currentHash));
         }
 
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, currentHash);
 
         vm.prank(sequencer);
-        inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         assertEq(inbox.processedDepositQueueHash(), currentHash);
 

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {EncryptedDepositLib} from "../../src/zone/EncryptedDeposit.sol";
+import { EncryptedDepositLib } from "../../src/zone/EncryptedDeposit.sol";
 import {
     AES_GCM_DECRYPT,
     CHAUM_PEDERSEN_VERIFY,
@@ -14,17 +14,20 @@ import {
     IAesGcmDecrypt,
     IChaumPedersenVerify,
     IZoneInbox,
+    PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
+    PORTAL_ENCRYPTION_KEYS_SLOT,
     QueuedDeposit
 } from "../../src/zone/IZone.sol";
-import {ZoneConfig} from "../../src/zone/ZoneConfig.sol";
-import {ZoneInbox} from "../../src/zone/ZoneInbox.sol";
-import {MockTempoState} from "./mocks/MockTempoState.sol";
-import {MockZoneGasToken} from "./mocks/MockZoneGasToken.sol";
-import {Test} from "forge-std/Test.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
+import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
+import { MockTempoState } from "./mocks/MockTempoState.sol";
+import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import { Test } from "forge-std/Test.sol";
 
 /// @title ZoneInboxTest
 /// @notice Tests for ZoneInbox covering edge cases
 contract ZoneInboxTest is Test {
+
     ZoneConfig public config;
     ZoneInbox public inbox;
     MockZoneGasToken public gasToken;
@@ -38,24 +41,29 @@ contract ZoneInboxTest is Test {
     bytes32 constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
     uint64 constant GENESIS_TEMPO_BLOCK_NUMBER = 1;
 
-    /// @notice Storage slot for currentDepositQueueHash in ZonePortal
-    /// @dev Layout: sequencer(0), pendingSequencer(1), zoneGasRate+withdrawalBatchIndex(2), blockHash(3), currentDepositQueueHash(4), lastSyncedTempoBlockNumber(5), _encryptionKeys(6)
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
-
     function setUp() public {
         gasToken = new MockZoneGasToken("Zone USD", "zUSD");
-        tempoState = new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
+        tempoState =
+            new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
         config = new ZoneConfig(address(gasToken), mockPortal, address(tempoState));
-        tempoState.setMockStorageValue(mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer))));
+        tempoState.setMockStorageValue(
+            mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
+        );
         inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(gasToken));
 
         gasToken.setMinter(address(inbox), true);
     }
 
-    function _wrapDeposits(Deposit[] memory deposits) internal pure returns (QueuedDeposit[] memory queued) {
+    function _wrapDeposits(Deposit[] memory deposits)
+        internal
+        pure
+        returns (QueuedDeposit[] memory queued)
+    {
         queued = new QueuedDeposit[](deposits.length);
         for (uint256 i = 0; i < deposits.length; i++) {
-            queued[i] = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(deposits[i])});
+            queued[i] = QueuedDeposit({
+                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
+            });
         }
     }
 
@@ -69,7 +77,9 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_emptyDepositsArray() public {
         // Set mock to return bytes32(0) for currentDepositQueueHash (empty queue)
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32(0));
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32(0)
+        );
 
         Deposit[] memory deposits = new Deposit[](0);
 
@@ -82,12 +92,14 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_singleDeposit() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
+        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
 
         // Calculate expected hash
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         vm.prank(sequencer);
         _advanceTempo(deposits);
@@ -98,9 +110,9 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_multipleDeposits() public {
         Deposit[] memory deposits = new Deposit[](3);
-        deposits[0] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
-        deposits[1] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
-        deposits[2] = Deposit({sender: alice, to: bob, amount: 300e6, memo: bytes32("d3")});
+        deposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
+        deposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        deposits[2] = Deposit({ sender: alice, to: bob, amount: 300e6, memo: bytes32("d3") });
 
         // Calculate expected hash chain
         bytes32 h0 = bytes32(0);
@@ -108,7 +120,7 @@ contract ZoneInboxTest is Test {
         bytes32 h2 = keccak256(abi.encode(DepositType.Regular, deposits[1], h1));
         bytes32 h3 = keccak256(abi.encode(DepositType.Regular, deposits[2], h2));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h3);
+        tempoState.setMockStorageValue(mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h3);
 
         vm.prank(sequencer);
         _advanceTempo(deposits);
@@ -124,10 +136,12 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_revertsOnHashMismatch() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
+        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
 
         // Set wrong hash
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("wrongHash"));
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("wrongHash")
+        );
 
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.InvalidDepositQueueHash.selector);
@@ -137,15 +151,15 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_revertsOnPartialMismatch() public {
         // This tests that you can't claim a subset of deposits if the hash doesn't match
         Deposit[] memory allDeposits = new Deposit[](2);
-        allDeposits[0] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
-        allDeposits[1] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
+        allDeposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
+        allDeposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
 
         // Set hash to be for both deposits
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, allDeposits[0], h0));
         bytes32 h2 = keccak256(abi.encode(DepositType.Regular, allDeposits[1], h1));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
+        tempoState.setMockStorageValue(mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
 
         // Try to process only one deposit - should fail
         Deposit[] memory oneDeposit = new Deposit[](1);
@@ -159,18 +173,19 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_revertsOnWrongOrder() public {
         // Deposits must be processed in the correct order
         Deposit[] memory deposits = new Deposit[](2);
-        deposits[0] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
-        deposits[1] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
+        deposits[0] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        deposits[1] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
 
         // Set hash for correct order (alice first, then bob)
-        Deposit memory d1 = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
-        Deposit memory d2 = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
+        Deposit memory d1 =
+            Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
+        Deposit memory d2 = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
 
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, d1, h0));
         bytes32 h2 = keccak256(abi.encode(DepositType.Regular, d2, h1));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
+        tempoState.setMockStorageValue(mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
 
         // Processing in wrong order should fail
         vm.prank(sequencer);
@@ -183,7 +198,9 @@ contract ZoneInboxTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_advanceTempo_onlySequencer() public {
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32(0));
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, bytes32(0)
+        );
 
         Deposit[] memory deposits = new Deposit[](0);
 
@@ -204,14 +221,14 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_incrementalProcessing() public {
         // First batch of deposits
         Deposit[] memory batch1 = new Deposit[](2);
-        batch1[0] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
-        batch1[1] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
+        batch1[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
+        batch1[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
 
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, batch1[0], h0));
         bytes32 h2 = keccak256(abi.encode(DepositType.Regular, batch1[1], h1));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
+        tempoState.setMockStorageValue(mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
 
         vm.prank(sequencer);
         _advanceTempo(batch1);
@@ -220,11 +237,11 @@ contract ZoneInboxTest is Test {
 
         // Second batch of deposits
         Deposit[] memory batch2 = new Deposit[](1);
-        batch2[0] = Deposit({sender: alice, to: bob, amount: 500e6, memo: bytes32("d3")});
+        batch2[0] = Deposit({ sender: alice, to: bob, amount: 500e6, memo: bytes32("d3") });
 
         bytes32 h3 = keccak256(abi.encode(DepositType.Regular, batch2[0], h2));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h3);
+        tempoState.setMockStorageValue(mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h3);
 
         vm.prank(sequencer);
         _advanceTempo(batch2);
@@ -240,11 +257,13 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_emitsTempoAdvancedEvent() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
+        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         vm.prank(sequencer);
         vm.expectEmit(true, true, false, true);
@@ -260,11 +279,13 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_emitsDepositProcessedEvent() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
+        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         vm.prank(sequencer);
         vm.expectEmit(true, true, true, true);
@@ -278,11 +299,13 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_zeroAmountDeposit() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: bob, amount: 0, memo: bytes32("empty")});
+        deposits[0] = Deposit({ sender: alice, to: bob, amount: 0, memo: bytes32("empty") });
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         vm.prank(sequencer);
         _advanceTempo(deposits);
@@ -312,11 +335,14 @@ contract ZoneInboxTest is Test {
 
         bytes32 currentHash = bytes32(0);
         for (uint256 i = 0; i < numDeposits; i++) {
-            deposits[i] = Deposit({sender: alice, to: bob, amount: uint128(i + 1) * 1e6, memo: bytes32(i)});
+            deposits[i] =
+                Deposit({ sender: alice, to: bob, amount: uint128(i + 1) * 1e6, memo: bytes32(i) });
             currentHash = keccak256(abi.encode(DepositType.Regular, deposits[i], currentHash));
         }
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, currentHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, currentHash
+        );
 
         vm.prank(sequencer);
         _advanceTempo(deposits);
@@ -332,12 +358,9 @@ contract ZoneInboxTest is Test {
                     ENCRYPTED DEPOSIT TESTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Storage slot for _encryptionKeys in ZonePortal
-    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
-
     /// @notice Set up encryption key mock storage for a given key index
     function _setupEncryptionKeyMock(uint256 keyIndex, bytes32 keyX, uint8 keyYParity) internal {
-        uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
         uint256 slotX = base + (keyIndex * 2);
         uint256 slotMeta = slotX + 1;
         tempoState.setMockStorageValue(mockPortal, bytes32(slotX), keyX);
@@ -345,7 +368,11 @@ contract ZoneInboxTest is Test {
     }
 
     /// @notice Build an EncryptedDeposit and its QueuedDeposit wrapper
-    function _makeEncryptedDeposit(address sender, uint128 amount, uint256 keyIndex)
+    function _makeEncryptedDeposit(
+        address sender,
+        uint128 amount,
+        uint256 keyIndex
+    )
         internal
         pure
         returns (QueuedDeposit memory qd, EncryptedDeposit memory ed)
@@ -362,7 +389,7 @@ contract ZoneInboxTest is Test {
                 tag: bytes16(0)
             })
         });
-        qd = QueuedDeposit({depositType: DepositType.Encrypted, depositData: abi.encode(ed)});
+        qd = QueuedDeposit({ depositType: DepositType.Encrypted, depositData: abi.encode(ed) });
     }
 
     /// @notice Set up precompile mocks for successful encrypted deposit processing
@@ -373,13 +400,17 @@ contract ZoneInboxTest is Test {
 
         // Mock Chaum-Pedersen to return valid
         vm.mockCall(
-            CHAUM_PEDERSEN_VERIFY, abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector), abi.encode(true)
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
         );
 
         // Mock AES-GCM to return expected plaintext
         bytes memory plaintext = EncryptedDepositLib.encodePlaintext(recipient, memo);
         vm.mockCall(
-            AES_GCM_DECRYPT, abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector), abi.encode(plaintext, true)
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(plaintext, true)
         );
     }
 
@@ -397,11 +428,14 @@ contract ZoneInboxTest is Test {
         _setupPrecompileMocks(recipient, memo);
 
         // Build encrypted deposit
-        (QueuedDeposit memory qd, EncryptedDeposit memory ed) = _makeEncryptedDeposit(alice, amount, 0);
+        (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
+            _makeEncryptedDeposit(alice, amount, 0);
 
         // Compute expected hash and set in mock storage
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         // Build deposits and decryptions arrays
         QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
@@ -412,7 +446,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xdeadbeef)),
             to: recipient,
             memo: memo,
-            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
         });
 
         vm.prank(sequencer);
@@ -435,19 +469,26 @@ contract ZoneInboxTest is Test {
 
         // Mock CP to return valid
         vm.mockCall(
-            CHAUM_PEDERSEN_VERIFY, abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector), abi.encode(true)
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
         );
 
         // Mock AES-GCM to return FAILURE
         vm.mockCall(
-            AES_GCM_DECRYPT, abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector), abi.encode(new bytes(0), false)
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(new bytes(0), false)
         );
 
         // Build encrypted deposit
-        (QueuedDeposit memory qd, EncryptedDeposit memory ed) = _makeEncryptedDeposit(alice, amount, 0);
+        (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
+            _makeEncryptedDeposit(alice, amount, 0);
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
         deposits[0] = qd;
@@ -457,7 +498,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xdeadbeef)),
             to: address(0x500),
             memo: bytes32("memo"),
-            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
         });
 
         vm.prank(sequencer);
@@ -478,17 +519,19 @@ contract ZoneInboxTest is Test {
         _setupPrecompileMocks(recipient, encMemo);
 
         // Build regular deposit
-        Deposit memory d = Deposit({sender: alice, to: bob, amount: 100e6, memo: bytes32("d1")});
-        QueuedDeposit memory qdRegular = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(d)});
+        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
+        QueuedDeposit memory qdRegular =
+            QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
 
         // Build encrypted deposit
-        (QueuedDeposit memory qdEnc, EncryptedDeposit memory ed) = _makeEncryptedDeposit(bob, 200e6, 0);
+        (QueuedDeposit memory qdEnc, EncryptedDeposit memory ed) =
+            _makeEncryptedDeposit(bob, 200e6, 0);
 
         // Compute expected hash chain: regular first, then encrypted
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
         bytes32 h2 = keccak256(abi.encode(DepositType.Encrypted, ed, h1));
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
+        tempoState.setMockStorageValue(mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h2);
 
         QueuedDeposit[] memory deposits = new QueuedDeposit[](2);
         deposits[0] = qdRegular;
@@ -499,7 +542,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xabcd)),
             to: recipient,
             memo: encMemo,
-            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
         });
 
         vm.prank(sequencer);
@@ -520,7 +563,9 @@ contract ZoneInboxTest is Test {
         (QueuedDeposit memory qd,) = _makeEncryptedDeposit(alice, 1000e6, 0);
 
         // We need to set the current hash to something - doesn't matter since we expect revert
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever"));
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever")
+        );
 
         QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
         deposits[0] = qd;
@@ -534,11 +579,14 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_extraDecryptionData() public {
         // Build a regular deposit only (no encrypted deposits)
-        Deposit memory d = Deposit({sender: alice, to: bob, amount: 100e6, memo: bytes32("d1")});
-        QueuedDeposit memory qd = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(d)});
+        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
+        QueuedDeposit memory qd =
+            QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
 
         QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
         deposits[0] = qd;
@@ -549,7 +597,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(1)),
             to: address(0x500),
             memo: bytes32("memo"),
-            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
         });
 
         vm.prank(sequencer);
@@ -570,7 +618,7 @@ contract ZoneInboxTest is Test {
 
         // Simulate the _encryptionKeys array at slot 6:
         // Set array length = 1
-        uint256 arraySlot = uint256(ENCRYPTION_KEYS_SLOT);
+        uint256 arraySlot = uint256(PORTAL_ENCRYPTION_KEYS_SLOT);
         tempoState.setMockStorageValue(mockPortal, bytes32(arraySlot), bytes32(uint256(1)));
 
         // Set the key entry data at the derived slots
@@ -581,7 +629,9 @@ contract ZoneInboxTest is Test {
         // Read via ZoneConfig — this should use the _encryptionKeys array slot
         (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
         assertEq(readX, keyX, "ZoneConfig should read key x from encryption keys array");
-        assertEq(readYParity, keyYParity, "ZoneConfig should read yParity from encryption keys array");
+        assertEq(
+            readYParity, keyYParity, "ZoneConfig should read yParity from encryption keys array"
+        );
     }
 
     /// @notice Verify ZoneConfig.sequencerEncryptionKey() returns the LAST key when multiple exist.
@@ -591,7 +641,7 @@ contract ZoneInboxTest is Test {
         uint8 yParity2 = 0x02;
 
         // Simulate 2 entries in _encryptionKeys
-        uint256 arraySlot = uint256(ENCRYPTION_KEYS_SLOT);
+        uint256 arraySlot = uint256(PORTAL_ENCRYPTION_KEYS_SLOT);
         tempoState.setMockStorageValue(mockPortal, bytes32(arraySlot), bytes32(uint256(2)));
 
         uint256 base = uint256(keccak256(abi.encode(arraySlot)));
@@ -612,7 +662,7 @@ contract ZoneInboxTest is Test {
     /// @notice Verify ZoneConfig.sequencerEncryptionKey() returns zeros when no keys exist.
     function test_zoneConfig_sequencerEncryptionKey_emptyReturnsZero() public {
         // Array length = 0 (default)
-        tempoState.setMockStorageValue(mockPortal, ENCRYPTION_KEYS_SLOT, bytes32(uint256(0)));
+        tempoState.setMockStorageValue(mockPortal, PORTAL_ENCRYPTION_KEYS_SLOT, bytes32(uint256(0)));
 
         (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
         assertEq(readX, bytes32(0));
@@ -620,7 +670,7 @@ contract ZoneInboxTest is Test {
     }
 
     /// @notice Verify ZoneConfig and ZoneInbox read from the same encryption key slot.
-    /// @dev Both contracts define ENCRYPTION_KEYS_SLOT = 6 and must agree on derived slot computation.
+    /// @dev Both contracts import PORTAL_ENCRYPTION_KEYS_SLOT from IZone.sol and must agree on derived slot computation.
     function test_zoneConfig_and_zoneInbox_readSameEncryptionKey() public {
         bytes32 keyX = keccak256("shared-key-test");
         uint8 keyYParity = 0x02;
@@ -629,7 +679,7 @@ contract ZoneInboxTest is Test {
         _setupEncryptionKeyMock(0, keyX, keyYParity);
 
         // Also set the array length (ZoneConfig needs this, ZoneInbox._readEncryptionKey doesn't)
-        tempoState.setMockStorageValue(mockPortal, ENCRYPTION_KEYS_SLOT, bytes32(uint256(1)));
+        tempoState.setMockStorageValue(mockPortal, PORTAL_ENCRYPTION_KEYS_SLOT, bytes32(uint256(1)));
 
         // Read via ZoneConfig
         (bytes32 configX, uint8 configYParity) = config.sequencerEncryptionKey();
@@ -655,13 +705,17 @@ contract ZoneInboxTest is Test {
 
         // Mock CP to return INVALID
         vm.mockCall(
-            CHAUM_PEDERSEN_VERIFY, abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector), abi.encode(false)
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(false)
         );
 
         // Build encrypted deposit
         (QueuedDeposit memory qd,) = _makeEncryptedDeposit(alice, amount, 0);
 
-        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever"));
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever")
+        );
 
         QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
         deposits[0] = qd;
@@ -671,11 +725,12 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xbad)),
             to: address(0x500),
             memo: bytes32("memo"),
-            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
         });
 
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.InvalidSharedSecretProof.selector);
         inbox.advanceTempo("", deposits, decs);
     }
+
 }

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -733,4 +733,147 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
     }
 
+    /*//////////////////////////////////////////////////////////////
+                PLAINTEXT LENGTH VALIDATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Helper: set up an encrypted deposit flow where AES-GCM returns a specific plaintext
+    function _setupEncryptedDepositWithPlaintext(
+        bytes memory mockPlaintext,
+        bool aesValid,
+        address recipient,
+        bytes32 memo
+    )
+        internal
+        returns (QueuedDeposit[] memory deposits, DecryptionData[] memory decs)
+    {
+        uint128 amount = 1000e6;
+
+        // Set up encryption key
+        _setupEncryptionKeyMock(0, keccak256("seq-key"), 0x03);
+
+        // Deploy dummy code at precompile addresses
+        vm.etch(CHAUM_PEDERSEN_VERIFY, hex"00");
+        vm.etch(AES_GCM_DECRYPT, hex"00");
+
+        // Mock CP to return valid
+        vm.mockCall(
+            CHAUM_PEDERSEN_VERIFY,
+            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
+            abi.encode(true)
+        );
+
+        // Mock AES-GCM to return the specified plaintext
+        vm.mockCall(
+            AES_GCM_DECRYPT,
+            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
+            abi.encode(mockPlaintext, aesValid)
+        );
+
+        // Build encrypted deposit
+        (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
+            _makeEncryptedDeposit(alice, amount, 0);
+
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
+
+        deposits = new QueuedDeposit[](1);
+        deposits[0] = qd;
+
+        decs = new DecryptionData[](1);
+        decs[0] = DecryptionData({
+            sharedSecret: bytes32(uint256(0xdeadbeef)),
+            to: recipient,
+            memo: memo,
+            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+        });
+    }
+
+    /// @notice Verify that a too-short plaintext (52 bytes) causes the deposit to bounce
+    /// @dev This was the old boundary that used to pass (>= 52). Now requires exactly 64.
+    function test_advanceTempo_encryptedDeposit_plaintextTooShort_bounces() public {
+        address recipient = address(0x500);
+        bytes32 memo = bytes32("secret memo");
+
+        // Create a 52-byte plaintext (the old minimum that used to be accepted)
+        bytes memory shortPlaintext = new bytes(52);
+        // Write address and memo into the first 52 bytes (same layout as encodePlaintext but truncated)
+        assembly {
+            mstore(add(shortPlaintext, 32), shl(96, recipient))
+            mstore(add(shortPlaintext, 52), memo)
+        }
+
+        (QueuedDeposit[] memory deposits, DecryptionData[] memory decs) =
+            _setupEncryptedDepositWithPlaintext(shortPlaintext, true, recipient, memo);
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs);
+
+        // Deposit should bounce to sender (alice) because plaintext length != 64
+        assertEq(gasToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
+        assertEq(gasToken.balanceOf(recipient), 0, "recipient should get nothing");
+    }
+
+    /// @notice Verify that a too-long plaintext (65 bytes) causes the deposit to bounce
+    function test_advanceTempo_encryptedDeposit_plaintextTooLong_bounces() public {
+        address recipient = address(0x500);
+        bytes32 memo = bytes32("secret memo");
+
+        // Create a 65-byte plaintext (one byte too many)
+        bytes memory longPlaintext = new bytes(65);
+        assembly {
+            mstore(add(longPlaintext, 32), shl(96, recipient))
+            mstore(add(longPlaintext, 52), memo)
+        }
+
+        (QueuedDeposit[] memory deposits, DecryptionData[] memory decs) =
+            _setupEncryptedDepositWithPlaintext(longPlaintext, true, recipient, memo);
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs);
+
+        // Deposit should bounce to sender
+        assertEq(gasToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
+        assertEq(gasToken.balanceOf(recipient), 0, "recipient should get nothing");
+    }
+
+    /// @notice Verify that an empty plaintext (0 bytes) causes the deposit to bounce
+    function test_advanceTempo_encryptedDeposit_plaintextEmpty_bounces() public {
+        address recipient = address(0x500);
+        bytes32 memo = bytes32("secret memo");
+
+        bytes memory emptyPlaintext = new bytes(0);
+
+        (QueuedDeposit[] memory deposits, DecryptionData[] memory decs) =
+            _setupEncryptedDepositWithPlaintext(emptyPlaintext, true, recipient, memo);
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs);
+
+        // Deposit should bounce to sender
+        assertEq(gasToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
+        assertEq(gasToken.balanceOf(recipient), 0, "recipient should get nothing");
+    }
+
+    /// @notice Verify that exactly 64-byte plaintext with correct data succeeds
+    function test_advanceTempo_encryptedDeposit_plaintextExact64_succeeds() public {
+        address recipient = address(0x500);
+        bytes32 memo = bytes32("secret memo");
+
+        // Use the canonical encodePlaintext which produces exactly 64 bytes
+        bytes memory correctPlaintext = EncryptedDepositLib.encodePlaintext(recipient, memo);
+
+        (QueuedDeposit[] memory deposits, DecryptionData[] memory decs) =
+            _setupEncryptedDepositWithPlaintext(correctPlaintext, true, recipient, memo);
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs);
+
+        // Deposit should succeed — minted to the decrypted recipient
+        assertEq(gasToken.balanceOf(recipient), 1000e6, "recipient should receive funds");
+        assertEq(gasToken.balanceOf(alice), 0, "sender should get nothing (successful deposit)");
+    }
+
 }

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { EncryptedDepositLib } from "../../src/zone/EncryptedDeposit.sol";
+import {EncryptedDepositLib} from "../../src/zone/EncryptedDeposit.sol";
 import {
     AES_GCM_DECRYPT,
     CHAUM_PEDERSEN_VERIFY,
@@ -16,16 +16,15 @@ import {
     IZoneInbox,
     QueuedDeposit
 } from "../../src/zone/IZone.sol";
-import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
-import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
-import { MockTempoState } from "./mocks/MockTempoState.sol";
-import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
-import { Test } from "forge-std/Test.sol";
+import {ZoneConfig} from "../../src/zone/ZoneConfig.sol";
+import {ZoneInbox} from "../../src/zone/ZoneInbox.sol";
+import {MockTempoState} from "./mocks/MockTempoState.sol";
+import {MockZoneGasToken} from "./mocks/MockZoneGasToken.sol";
+import {Test} from "forge-std/Test.sol";
 
 /// @title ZoneInboxTest
 /// @notice Tests for ZoneInbox covering edge cases
 contract ZoneInboxTest is Test {
-
     ZoneConfig public config;
     ZoneInbox public inbox;
     MockZoneGasToken public gasToken;
@@ -40,32 +39,23 @@ contract ZoneInboxTest is Test {
     uint64 constant GENESIS_TEMPO_BLOCK_NUMBER = 1;
 
     /// @notice Storage slot for currentDepositQueueHash in ZonePortal
-    /// @dev Layout: sequencer(0), pendingSequencer(1), sequencerPubkey(2), withdrawalBatchIndex(3), blockHash(4), currentDepositQueueHash(5)
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
+    /// @dev Layout: sequencer(0), pendingSequencer(1), zoneGasRate+withdrawalBatchIndex(2), blockHash(3), currentDepositQueueHash(4), lastSyncedTempoBlockNumber(5), _encryptionKeys(6)
+    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
 
     function setUp() public {
         gasToken = new MockZoneGasToken("Zone USD", "zUSD");
-        tempoState =
-            new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
+        tempoState = new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
         config = new ZoneConfig(address(gasToken), mockPortal, address(tempoState));
-        tempoState.setMockStorageValue(
-            mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
-        );
+        tempoState.setMockStorageValue(mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer))));
         inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(gasToken));
 
         gasToken.setMinter(address(inbox), true);
     }
 
-    function _wrapDeposits(Deposit[] memory deposits)
-        internal
-        pure
-        returns (QueuedDeposit[] memory queued)
-    {
+    function _wrapDeposits(Deposit[] memory deposits) internal pure returns (QueuedDeposit[] memory queued) {
         queued = new QueuedDeposit[](deposits.length);
         for (uint256 i = 0; i < deposits.length; i++) {
-            queued[i] = QueuedDeposit({
-                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
-            });
+            queued[i] = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(deposits[i])});
         }
     }
 
@@ -92,7 +82,7 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_singleDeposit() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
 
         // Calculate expected hash
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
@@ -108,9 +98,9 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_multipleDeposits() public {
         Deposit[] memory deposits = new Deposit[](3);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        deposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
-        deposits[2] = Deposit({ sender: alice, to: bob, amount: 300e6, memo: bytes32("d3") });
+        deposits[0] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
+        deposits[1] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
+        deposits[2] = Deposit({sender: alice, to: bob, amount: 300e6, memo: bytes32("d3")});
 
         // Calculate expected hash chain
         bytes32 h0 = bytes32(0);
@@ -134,12 +124,10 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_revertsOnHashMismatch() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
 
         // Set wrong hash
-        tempoState.setMockStorageValue(
-            mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("wrongHash")
-        );
+        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("wrongHash"));
 
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.InvalidDepositQueueHash.selector);
@@ -149,8 +137,8 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_revertsOnPartialMismatch() public {
         // This tests that you can't claim a subset of deposits if the hash doesn't match
         Deposit[] memory allDeposits = new Deposit[](2);
-        allDeposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        allDeposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        allDeposits[0] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
+        allDeposits[1] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
 
         // Set hash to be for both deposits
         bytes32 h0 = bytes32(0);
@@ -171,13 +159,12 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_revertsOnWrongOrder() public {
         // Deposits must be processed in the correct order
         Deposit[] memory deposits = new Deposit[](2);
-        deposits[0] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
-        deposits[1] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
+        deposits[0] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
+        deposits[1] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
 
         // Set hash for correct order (alice first, then bob)
-        Deposit memory d1 =
-            Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        Deposit memory d2 = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        Deposit memory d1 = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
+        Deposit memory d2 = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
 
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, d1, h0));
@@ -217,8 +204,8 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_incrementalProcessing() public {
         // First batch of deposits
         Deposit[] memory batch1 = new Deposit[](2);
-        batch1[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        batch1[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        batch1[0] = Deposit({sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")});
+        batch1[1] = Deposit({sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")});
 
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, batch1[0], h0));
@@ -233,7 +220,7 @@ contract ZoneInboxTest is Test {
 
         // Second batch of deposits
         Deposit[] memory batch2 = new Deposit[](1);
-        batch2[0] = Deposit({ sender: alice, to: bob, amount: 500e6, memo: bytes32("d3") });
+        batch2[0] = Deposit({sender: alice, to: bob, amount: 500e6, memo: bytes32("d3")});
 
         bytes32 h3 = keccak256(abi.encode(DepositType.Regular, batch2[0], h2));
 
@@ -253,7 +240,7 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_emitsTempoAdvancedEvent() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
@@ -273,7 +260,7 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_emitsDepositProcessedEvent() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment")});
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
@@ -291,7 +278,7 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_zeroAmountDeposit() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 0, memo: bytes32("empty") });
+        deposits[0] = Deposit({sender: alice, to: bob, amount: 0, memo: bytes32("empty")});
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
@@ -325,8 +312,7 @@ contract ZoneInboxTest is Test {
 
         bytes32 currentHash = bytes32(0);
         for (uint256 i = 0; i < numDeposits; i++) {
-            deposits[i] =
-                Deposit({ sender: alice, to: bob, amount: uint128(i + 1) * 1e6, memo: bytes32(i) });
+            deposits[i] = Deposit({sender: alice, to: bob, amount: uint128(i + 1) * 1e6, memo: bytes32(i)});
             currentHash = keccak256(abi.encode(DepositType.Regular, deposits[i], currentHash));
         }
 
@@ -347,11 +333,11 @@ contract ZoneInboxTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Storage slot for _encryptionKeys in ZonePortal
-    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
+    bytes32 internal constant ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
 
     /// @notice Set up encryption key mock storage for a given key index
     function _setupEncryptionKeyMock(uint256 keyIndex, bytes32 keyX, uint8 keyYParity) internal {
-        uint256 base = uint256(keccak256(abi.encode(uint256(7))));
+        uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
         uint256 slotX = base + (keyIndex * 2);
         uint256 slotMeta = slotX + 1;
         tempoState.setMockStorageValue(mockPortal, bytes32(slotX), keyX);
@@ -359,11 +345,7 @@ contract ZoneInboxTest is Test {
     }
 
     /// @notice Build an EncryptedDeposit and its QueuedDeposit wrapper
-    function _makeEncryptedDeposit(
-        address sender,
-        uint128 amount,
-        uint256 keyIndex
-    )
+    function _makeEncryptedDeposit(address sender, uint128 amount, uint256 keyIndex)
         internal
         pure
         returns (QueuedDeposit memory qd, EncryptedDeposit memory ed)
@@ -380,7 +362,7 @@ contract ZoneInboxTest is Test {
                 tag: bytes16(0)
             })
         });
-        qd = QueuedDeposit({ depositType: DepositType.Encrypted, depositData: abi.encode(ed) });
+        qd = QueuedDeposit({depositType: DepositType.Encrypted, depositData: abi.encode(ed)});
     }
 
     /// @notice Set up precompile mocks for successful encrypted deposit processing
@@ -391,17 +373,13 @@ contract ZoneInboxTest is Test {
 
         // Mock Chaum-Pedersen to return valid
         vm.mockCall(
-            CHAUM_PEDERSEN_VERIFY,
-            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
-            abi.encode(true)
+            CHAUM_PEDERSEN_VERIFY, abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector), abi.encode(true)
         );
 
         // Mock AES-GCM to return expected plaintext
         bytes memory plaintext = EncryptedDepositLib.encodePlaintext(recipient, memo);
         vm.mockCall(
-            AES_GCM_DECRYPT,
-            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
-            abi.encode(plaintext, true)
+            AES_GCM_DECRYPT, abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector), abi.encode(plaintext, true)
         );
     }
 
@@ -419,8 +397,7 @@ contract ZoneInboxTest is Test {
         _setupPrecompileMocks(recipient, memo);
 
         // Build encrypted deposit
-        (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
-            _makeEncryptedDeposit(alice, amount, 0);
+        (QueuedDeposit memory qd, EncryptedDeposit memory ed) = _makeEncryptedDeposit(alice, amount, 0);
 
         // Compute expected hash and set in mock storage
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
@@ -435,7 +412,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xdeadbeef)),
             to: recipient,
             memo: memo,
-            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
         });
 
         vm.prank(sequencer);
@@ -458,21 +435,16 @@ contract ZoneInboxTest is Test {
 
         // Mock CP to return valid
         vm.mockCall(
-            CHAUM_PEDERSEN_VERIFY,
-            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
-            abi.encode(true)
+            CHAUM_PEDERSEN_VERIFY, abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector), abi.encode(true)
         );
 
         // Mock AES-GCM to return FAILURE
         vm.mockCall(
-            AES_GCM_DECRYPT,
-            abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector),
-            abi.encode(new bytes(0), false)
+            AES_GCM_DECRYPT, abi.encodeWithSelector(IAesGcmDecrypt.decrypt.selector), abi.encode(new bytes(0), false)
         );
 
         // Build encrypted deposit
-        (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
-            _makeEncryptedDeposit(alice, amount, 0);
+        (QueuedDeposit memory qd, EncryptedDeposit memory ed) = _makeEncryptedDeposit(alice, amount, 0);
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
@@ -485,7 +457,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xdeadbeef)),
             to: address(0x500),
             memo: bytes32("memo"),
-            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
         });
 
         vm.prank(sequencer);
@@ -506,13 +478,11 @@ contract ZoneInboxTest is Test {
         _setupPrecompileMocks(recipient, encMemo);
 
         // Build regular deposit
-        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
-        QueuedDeposit memory qdRegular =
-            QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
+        Deposit memory d = Deposit({sender: alice, to: bob, amount: 100e6, memo: bytes32("d1")});
+        QueuedDeposit memory qdRegular = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(d)});
 
         // Build encrypted deposit
-        (QueuedDeposit memory qdEnc, EncryptedDeposit memory ed) =
-            _makeEncryptedDeposit(bob, 200e6, 0);
+        (QueuedDeposit memory qdEnc, EncryptedDeposit memory ed) = _makeEncryptedDeposit(bob, 200e6, 0);
 
         // Compute expected hash chain: regular first, then encrypted
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
@@ -529,7 +499,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xabcd)),
             to: recipient,
             memo: encMemo,
-            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
         });
 
         vm.prank(sequencer);
@@ -550,9 +520,7 @@ contract ZoneInboxTest is Test {
         (QueuedDeposit memory qd,) = _makeEncryptedDeposit(alice, 1000e6, 0);
 
         // We need to set the current hash to something - doesn't matter since we expect revert
-        tempoState.setMockStorageValue(
-            mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever")
-        );
+        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever"));
 
         QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
         deposits[0] = qd;
@@ -566,9 +534,8 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_extraDecryptionData() public {
         // Build a regular deposit only (no encrypted deposits)
-        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
-        QueuedDeposit memory qd =
-            QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
+        Deposit memory d = Deposit({sender: alice, to: bob, amount: 100e6, memo: bytes32("d1")});
+        QueuedDeposit memory qd = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(d)});
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
         tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash);
@@ -582,7 +549,7 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(1)),
             to: address(0x500),
             memo: bytes32("memo"),
-            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
         });
 
         vm.prank(sequencer);
@@ -595,15 +562,15 @@ contract ZoneInboxTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Verify ZoneConfig.sequencerEncryptionKey() reads from the correct storage slot.
-    /// @dev Regression test for the bug where ZoneConfig read slot 2 (legacy sequencerPubkey)
-    ///      instead of the _encryptionKeys dynamic array at slot 7.
+    /// @dev Regression test for the bug where ZoneConfig read the wrong slot
+    ///      instead of the _encryptionKeys dynamic array at slot 6.
     function test_zoneConfig_sequencerEncryptionKey_readsCorrectSlot() public {
         bytes32 keyX = keccak256("config-test-key");
         uint8 keyYParity = 0x03;
 
-        // Simulate the _encryptionKeys array at slot 7:
-        // Set array length = 1 at slot 7
-        uint256 arraySlot = 7;
+        // Simulate the _encryptionKeys array at slot 6:
+        // Set array length = 1
+        uint256 arraySlot = uint256(ENCRYPTION_KEYS_SLOT);
         tempoState.setMockStorageValue(mockPortal, bytes32(arraySlot), bytes32(uint256(1)));
 
         // Set the key entry data at the derived slots
@@ -611,10 +578,10 @@ contract ZoneInboxTest is Test {
         tempoState.setMockStorageValue(mockPortal, bytes32(base), keyX);
         tempoState.setMockStorageValue(mockPortal, bytes32(base + 1), bytes32(uint256(keyYParity)));
 
-        // Read via ZoneConfig — this should use slot 7, not slot 2
+        // Read via ZoneConfig — this should use the _encryptionKeys array slot
         (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
-        assertEq(readX, keyX, "ZoneConfig should read key x from slot 7 array");
-        assertEq(readYParity, keyYParity, "ZoneConfig should read yParity from slot 7 array");
+        assertEq(readX, keyX, "ZoneConfig should read key x from encryption keys array");
+        assertEq(readYParity, keyYParity, "ZoneConfig should read yParity from encryption keys array");
     }
 
     /// @notice Verify ZoneConfig.sequencerEncryptionKey() returns the LAST key when multiple exist.
@@ -624,7 +591,7 @@ contract ZoneInboxTest is Test {
         uint8 yParity2 = 0x02;
 
         // Simulate 2 entries in _encryptionKeys
-        uint256 arraySlot = 7;
+        uint256 arraySlot = uint256(ENCRYPTION_KEYS_SLOT);
         tempoState.setMockStorageValue(mockPortal, bytes32(arraySlot), bytes32(uint256(2)));
 
         uint256 base = uint256(keccak256(abi.encode(arraySlot)));
@@ -645,7 +612,7 @@ contract ZoneInboxTest is Test {
     /// @notice Verify ZoneConfig.sequencerEncryptionKey() returns zeros when no keys exist.
     function test_zoneConfig_sequencerEncryptionKey_emptyReturnsZero() public {
         // Array length = 0 (default)
-        tempoState.setMockStorageValue(mockPortal, bytes32(uint256(7)), bytes32(uint256(0)));
+        tempoState.setMockStorageValue(mockPortal, ENCRYPTION_KEYS_SLOT, bytes32(uint256(0)));
 
         (bytes32 readX, uint8 readYParity) = config.sequencerEncryptionKey();
         assertEq(readX, bytes32(0));
@@ -653,7 +620,7 @@ contract ZoneInboxTest is Test {
     }
 
     /// @notice Verify ZoneConfig and ZoneInbox read from the same encryption key slot.
-    /// @dev Both contracts define ENCRYPTION_KEYS_SLOT = 7 and must agree on derived slot computation.
+    /// @dev Both contracts define ENCRYPTION_KEYS_SLOT = 6 and must agree on derived slot computation.
     function test_zoneConfig_and_zoneInbox_readSameEncryptionKey() public {
         bytes32 keyX = keccak256("shared-key-test");
         uint8 keyYParity = 0x02;
@@ -662,7 +629,7 @@ contract ZoneInboxTest is Test {
         _setupEncryptionKeyMock(0, keyX, keyYParity);
 
         // Also set the array length (ZoneConfig needs this, ZoneInbox._readEncryptionKey doesn't)
-        tempoState.setMockStorageValue(mockPortal, bytes32(uint256(7)), bytes32(uint256(1)));
+        tempoState.setMockStorageValue(mockPortal, ENCRYPTION_KEYS_SLOT, bytes32(uint256(1)));
 
         // Read via ZoneConfig
         (bytes32 configX, uint8 configYParity) = config.sequencerEncryptionKey();
@@ -688,17 +655,13 @@ contract ZoneInboxTest is Test {
 
         // Mock CP to return INVALID
         vm.mockCall(
-            CHAUM_PEDERSEN_VERIFY,
-            abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector),
-            abi.encode(false)
+            CHAUM_PEDERSEN_VERIFY, abi.encodeWithSelector(IChaumPedersenVerify.verifyProof.selector), abi.encode(false)
         );
 
         // Build encrypted deposit
         (QueuedDeposit memory qd,) = _makeEncryptedDeposit(alice, amount, 0);
 
-        tempoState.setMockStorageValue(
-            mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever")
-        );
+        tempoState.setMockStorageValue(mockPortal, CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever"));
 
         QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
         deposits[0] = qd;
@@ -708,12 +671,11 @@ contract ZoneInboxTest is Test {
             sharedSecret: bytes32(uint256(0xbad)),
             to: address(0x500),
             memo: bytes32("memo"),
-            cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+            cpProof: ChaumPedersenProof({s: bytes32(uint256(1)), c: bytes32(uint256(2))})
         });
 
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.InvalidSharedSecretProof.selector);
         inbox.advanceTempo("", deposits, decs);
     }
-
 }

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { TIP20 } from "../../src/TIP20.sol";
+import {TIP20} from "../../src/TIP20.sol";
 import {
     BlockTransition,
     DecryptionData,
@@ -16,43 +16,33 @@ import {
     WithdrawalQueueTransition,
     ZoneParams
 } from "../../src/zone/IZone.sol";
-import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
-import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
-import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
-import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
-import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
-import { ZonePortal } from "../../src/zone/ZonePortal.sol";
-import { BaseTest } from "../BaseTest.t.sol";
+import {EMPTY_SENTINEL} from "../../src/zone/WithdrawalQueueLib.sol";
+import {ZoneConfig} from "../../src/zone/ZoneConfig.sol";
+import {ZoneFactory} from "../../src/zone/ZoneFactory.sol";
+import {ZoneInbox} from "../../src/zone/ZoneInbox.sol";
+import {ZoneOutbox} from "../../src/zone/ZoneOutbox.sol";
+import {ZonePortal} from "../../src/zone/ZonePortal.sol";
+import {BaseTest} from "../BaseTest.t.sol";
 
-import { MockTempoState } from "./mocks/MockTempoState.sol";
-import { MockVerifier } from "./mocks/MockVerifier.sol";
-import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import {MockTempoState} from "./mocks/MockTempoState.sol";
+import {MockVerifier} from "./mocks/MockVerifier.sol";
+import {MockZoneGasToken} from "./mocks/MockZoneGasToken.sol";
 
 /// @notice Mock receiver that tracks received amounts
 contract TrackingReceiver is IWithdrawalReceiver {
-
     uint256 public totalReceived;
     uint256 public callCount;
 
-    function onWithdrawalReceived(
-        address,
-        uint128 amount,
-        bytes calldata
-    )
-        external
-        returns (bytes4)
-    {
+    function onWithdrawalReceived(address, uint128 amount, bytes calldata) external returns (bytes4) {
         totalReceived += amount;
         callCount++;
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }
-
 }
 
 /// @title ZoneIntegrationTest
 /// @notice Comprehensive integration tests for the full zone lifecycle
 contract ZoneIntegrationTest is BaseTest {
-
     // L1 contracts
     ZoneFactory public l1Factory;
     ZonePortal public l1Portal;
@@ -74,8 +64,9 @@ contract ZoneIntegrationTest is BaseTest {
     uint64 public genesisTempoBlockNumber;
 
     /// @notice Storage slot for currentDepositQueueHash in ZonePortal
-    /// @dev Layout: sequencerPubkey(0), withdrawalBatchIndex(1), blockHash(2), currentDepositQueueHash(3)
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
+    /// @dev Layout: sequencer(0), pendingSequencer(1), zoneGasRate+withdrawalBatchIndex(2),
+    ///      blockHash(3), currentDepositQueueHash(4), lastSyncedTempoBlockNumber(5), _encryptionKeys(6)
+    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
 
     function setUp() public override {
         super.setUp();
@@ -113,28 +104,18 @@ contract ZoneIntegrationTest is BaseTest {
         l2GasToken = new MockZoneGasToken("Zone USD", "zUSD");
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
         l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
-        l2TempoState.setMockStorageValue(
-            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
-        );
-        l2Inbox = new ZoneInbox(
-            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
-        );
+        l2TempoState.setMockStorageValue(portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin))));
+        l2Inbox = new ZoneInbox(address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken));
         l2Outbox = new ZoneOutbox(address(l2Config), address(l2GasToken));
 
         l2GasToken.setMinter(address(l2Inbox), true);
         l2GasToken.setBurner(address(l2Outbox), true);
     }
 
-    function _wrapDeposits(Deposit[] memory deposits)
-        internal
-        pure
-        returns (QueuedDeposit[] memory queued)
-    {
+    function _wrapDeposits(Deposit[] memory deposits) internal pure returns (QueuedDeposit[] memory queued) {
         queued = new QueuedDeposit[](deposits.length);
         for (uint256 i = 0; i < deposits.length; i++) {
-            queued[i] = QueuedDeposit({
-                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
-            });
+            queued[i] = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(deposits[i])});
         }
     }
 
@@ -166,11 +147,10 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Build deposit array
         Deposit[] memory deposits = new Deposit[](4);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 1000e6, memo: bytes32("alice1") });
-        deposits[1] = Deposit({ sender: alice, to: alice, amount: 2000e6, memo: bytes32("alice2") });
-        deposits[2] = Deposit({ sender: bob, to: bob, amount: 3000e6, memo: bytes32("bob1") });
-        deposits[3] =
-            Deposit({ sender: charlie, to: charlie, amount: 500e6, memo: bytes32("charlie1") });
+        deposits[0] = Deposit({sender: alice, to: alice, amount: 1000e6, memo: bytes32("alice1")});
+        deposits[1] = Deposit({sender: alice, to: alice, amount: 2000e6, memo: bytes32("alice2")});
+        deposits[2] = Deposit({sender: bob, to: bob, amount: 3000e6, memo: bytes32("bob1")});
+        deposits[3] = Deposit({sender: charlie, to: charlie, amount: 500e6, memo: bytes32("charlie1")});
 
         // Set up L2 mock
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h4);
@@ -200,7 +180,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process only first deposit
         Deposit[] memory batch1 = new Deposit[](1);
-        batch1[0] = Deposit({ sender: alice, to: alice, amount: 1000e6, memo: bytes32("d1") });
+        batch1[0] = Deposit({sender: alice, to: alice, amount: 1000e6, memo: bytes32("d1")});
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1);
         vm.prank(admin);
@@ -214,11 +194,9 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
-            }),
-            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: d1 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: d1}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -232,8 +210,8 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process remaining deposits
         Deposit[] memory batch2 = new Deposit[](2);
-        batch2[0] = Deposit({ sender: alice, to: alice, amount: 2000e6, memo: bytes32("d2") });
-        batch2[1] = Deposit({ sender: alice, to: alice, amount: 3000e6, memo: bytes32("d3") });
+        batch2[0] = Deposit({sender: alice, to: alice, amount: 2000e6, memo: bytes32("d2")});
+        batch2[1] = Deposit({sender: alice, to: alice, amount: 3000e6, memo: bytes32("d3")});
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3);
         vm.prank(admin);
@@ -255,20 +233,15 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process deposit on L2
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] =
-            Deposit({ sender: alice, to: alice, amount: 5000e6, memo: bytes32("deposit") });
-        l2TempoState.setMockStorageValue(
-            address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
-        );
+        deposits[0] = Deposit({sender: alice, to: alice, amount: 5000e6, memo: bytes32("deposit")});
+        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash);
         vm.prank(admin);
         _advanceTempo(deposits);
 
         // Alice requests withdrawal with callback
         vm.startPrank(alice);
         l2GasToken.approve(address(l2Outbox), 2000e6);
-        l2Outbox.requestWithdrawal(
-            address(receiver), 2000e6, bytes32("payment"), 100_000, alice, "callback"
-        );
+        l2Outbox.requestWithdrawal(address(receiver), 2000e6, bytes32("payment"), 100_000, alice, "callback");
         vm.stopPrank();
 
         // Finalize L2 batch
@@ -280,13 +253,9 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalHash }),
+            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: withdrawalHash}),
             "",
             ""
         );
@@ -323,11 +292,8 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process on L2
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] =
-            Deposit({ sender: alice, to: alice, amount: 50_000e6, memo: bytes32("big deposit") });
-        l2TempoState.setMockStorageValue(
-            address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
-        );
+        deposits[0] = Deposit({sender: alice, to: alice, amount: 50_000e6, memo: bytes32("big deposit")});
+        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash);
         vm.prank(admin);
         _advanceTempo(deposits);
 
@@ -344,13 +310,9 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash1 }),
+            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash1}),
             "",
             ""
         );
@@ -367,13 +329,9 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s2")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash2 }),
+            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s2")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash2}),
             "",
             ""
         );
@@ -390,13 +348,9 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s3")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash3 }),
+            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s3")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash3}),
             "",
             ""
         );
@@ -473,8 +427,8 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process both deposits
         Deposit[] memory deposits1 = new Deposit[](2);
-        deposits1[0] = Deposit({ sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1") });
-        deposits1[1] = Deposit({ sender: bob, to: bob, amount: 5000e6, memo: bytes32("d2") });
+        deposits1[0] = Deposit({sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1")});
+        deposits1[1] = Deposit({sender: bob, to: bob, amount: 5000e6, memo: bytes32("d2")});
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d2);
         vm.prank(admin);
@@ -505,19 +459,16 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
-            }),
-            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: d2 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: d2}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
 
         // Process new deposit
         Deposit[] memory deposits2 = new Deposit[](1);
-        deposits2[0] =
-            Deposit({ sender: charlie, to: charlie, amount: 7500e6, memo: bytes32("d3") });
+        deposits2[0] = Deposit({sender: charlie, to: charlie, amount: 7500e6, memo: bytes32("d3")});
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3);
         vm.prank(admin);
@@ -571,7 +522,7 @@ contract ZoneIntegrationTest is BaseTest {
         vm.stopPrank();
 
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1") });
+        deposits[0] = Deposit({sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1")});
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1);
         vm.prank(admin);
         _advanceTempo(deposits);
@@ -593,4 +544,30 @@ contract ZoneIntegrationTest is BaseTest {
         assertEq(l2GasToken.totalSupply(), 7000e6);
     }
 
+    /*//////////////////////////////////////////////////////////////
+                    STORAGE LAYOUT VERIFICATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Verify CURRENT_DEPOSIT_QUEUE_HASH_SLOT matches the actual ZonePortal storage layout.
+    /// @dev If ZonePortal's storage layout changes, this test will fail.
+    function test_storageLayout_currentDepositQueueHashSlot() public {
+        // Make a deposit to get a non-zero currentDepositQueueHash
+        vm.startPrank(alice);
+        pathUSD.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(alice, 1000e6, bytes32("layout-test"));
+        vm.stopPrank();
+
+        // Read via vm.load using our constant
+        bytes32 fromSlot = vm.load(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
+
+        // Compare against the public getter
+        assertEq(
+            fromSlot,
+            l1Portal.currentDepositQueueHash(),
+            "CURRENT_DEPOSIT_QUEUE_HASH_SLOT does not match actual storage position"
+        );
+
+        // Sanity: value should be non-zero after deposit
+        assertTrue(fromSlot != bytes32(0), "deposit queue hash should be non-zero after deposit");
+    }
 }

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -4,11 +4,14 @@ pragma solidity ^0.8.13;
 import { TIP20 } from "../../src/TIP20.sol";
 import {
     BlockTransition,
+    DecryptionData,
     Deposit,
     DepositQueueTransition,
+    DepositType,
     IWithdrawalReceiver,
     IZoneFactory,
     IZonePortal,
+    QueuedDeposit,
     Withdrawal,
     WithdrawalQueueTransition,
     ZoneParams
@@ -122,6 +125,23 @@ contract ZoneIntegrationTest is BaseTest {
         l2GasToken.setBurner(address(l2Outbox), true);
     }
 
+    function _wrapDeposits(Deposit[] memory deposits)
+        internal
+        pure
+        returns (QueuedDeposit[] memory queued)
+    {
+        queued = new QueuedDeposit[](deposits.length);
+        for (uint256 i = 0; i < deposits.length; i++) {
+            queued[i] = QueuedDeposit({
+                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
+            });
+        }
+    }
+
+    function _advanceTempo(Deposit[] memory deposits) internal {
+        l2Inbox.advanceTempo("", _wrapDeposits(deposits), new DecryptionData[](0));
+    }
+
     /*//////////////////////////////////////////////////////////////
                    MULTI-USER DEPOSIT FLOW TESTS
     //////////////////////////////////////////////////////////////*/
@@ -157,7 +177,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process on L2
         vm.prank(admin);
-        l2Inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         // Verify L2 balances
         assertEq(l2GasToken.balanceOf(alice), 3000e6);
@@ -184,7 +204,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1);
         vm.prank(admin);
-        l2Inbox.advanceTempo("", batch1);
+        _advanceTempo(batch1);
 
         assertEq(l2GasToken.balanceOf(alice), 1000e6);
         assertEq(l2Inbox.processedDepositQueueHash(), d1);
@@ -217,7 +237,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3);
         vm.prank(admin);
-        l2Inbox.advanceTempo("", batch2);
+        _advanceTempo(batch2);
 
         assertEq(l2GasToken.balanceOf(alice), 6000e6);
     }
@@ -241,7 +261,7 @@ contract ZoneIntegrationTest is BaseTest {
             address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
         );
         vm.prank(admin);
-        l2Inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         // Alice requests withdrawal with callback
         vm.startPrank(alice);
@@ -309,7 +329,7 @@ contract ZoneIntegrationTest is BaseTest {
             address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
         );
         vm.prank(admin);
-        l2Inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         // First batch: Alice withdraws to Bob
         vm.startPrank(alice);
@@ -458,7 +478,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d2);
         vm.prank(admin);
-        l2Inbox.advanceTempo("", deposits1);
+        _advanceTempo(deposits1);
 
         // Phase 2: Withdrawals
         vm.startPrank(alice);
@@ -501,7 +521,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3);
         vm.prank(admin);
-        l2Inbox.advanceTempo("", deposits2);
+        _advanceTempo(deposits2);
 
         // Verify all L2 balances
         assertEq(l2GasToken.balanceOf(alice), 10_000e6 - 2000e6);
@@ -554,7 +574,7 @@ contract ZoneIntegrationTest is BaseTest {
         deposits[0] = Deposit({ sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1") });
         l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1);
         vm.prank(admin);
-        l2Inbox.advanceTempo("", deposits);
+        _advanceTempo(deposits);
 
         assertEq(l2GasToken.totalSupply(), 10_000e6);
 

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {TIP20} from "../../src/TIP20.sol";
+import { TIP20 } from "../../src/TIP20.sol";
 import {
     BlockTransition,
     DecryptionData,
@@ -11,38 +11,49 @@ import {
     IWithdrawalReceiver,
     IZoneFactory,
     IZonePortal,
+    PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     QueuedDeposit,
     Withdrawal,
     WithdrawalQueueTransition,
     ZoneParams
 } from "../../src/zone/IZone.sol";
-import {EMPTY_SENTINEL} from "../../src/zone/WithdrawalQueueLib.sol";
-import {ZoneConfig} from "../../src/zone/ZoneConfig.sol";
-import {ZoneFactory} from "../../src/zone/ZoneFactory.sol";
-import {ZoneInbox} from "../../src/zone/ZoneInbox.sol";
-import {ZoneOutbox} from "../../src/zone/ZoneOutbox.sol";
-import {ZonePortal} from "../../src/zone/ZonePortal.sol";
-import {BaseTest} from "../BaseTest.t.sol";
+import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
+import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
+import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
+import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
+import { ZonePortal } from "../../src/zone/ZonePortal.sol";
+import { BaseTest } from "../BaseTest.t.sol";
 
-import {MockTempoState} from "./mocks/MockTempoState.sol";
-import {MockVerifier} from "./mocks/MockVerifier.sol";
-import {MockZoneGasToken} from "./mocks/MockZoneGasToken.sol";
+import { MockTempoState } from "./mocks/MockTempoState.sol";
+import { MockVerifier } from "./mocks/MockVerifier.sol";
+import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
 
 /// @notice Mock receiver that tracks received amounts
 contract TrackingReceiver is IWithdrawalReceiver {
+
     uint256 public totalReceived;
     uint256 public callCount;
 
-    function onWithdrawalReceived(address, uint128 amount, bytes calldata) external returns (bytes4) {
+    function onWithdrawalReceived(
+        address,
+        uint128 amount,
+        bytes calldata
+    )
+        external
+        returns (bytes4)
+    {
         totalReceived += amount;
         callCount++;
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }
+
 }
 
 /// @title ZoneIntegrationTest
 /// @notice Comprehensive integration tests for the full zone lifecycle
 contract ZoneIntegrationTest is BaseTest {
+
     // L1 contracts
     ZoneFactory public l1Factory;
     ZonePortal public l1Portal;
@@ -62,11 +73,6 @@ contract ZoneIntegrationTest is BaseTest {
     bytes32 constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
     uint64 public genesisTempoBlockNumber;
-
-    /// @notice Storage slot for currentDepositQueueHash in ZonePortal
-    /// @dev Layout: sequencer(0), pendingSequencer(1), zoneGasRate+withdrawalBatchIndex(2),
-    ///      blockHash(3), currentDepositQueueHash(4), lastSyncedTempoBlockNumber(5), _encryptionKeys(6)
-    bytes32 internal constant CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
 
     function setUp() public override {
         super.setUp();
@@ -104,18 +110,28 @@ contract ZoneIntegrationTest is BaseTest {
         l2GasToken = new MockZoneGasToken("Zone USD", "zUSD");
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
         l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
-        l2TempoState.setMockStorageValue(portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin))));
-        l2Inbox = new ZoneInbox(address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken));
+        l2TempoState.setMockStorageValue(
+            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+        );
+        l2Inbox = new ZoneInbox(
+            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
+        );
         l2Outbox = new ZoneOutbox(address(l2Config), address(l2GasToken));
 
         l2GasToken.setMinter(address(l2Inbox), true);
         l2GasToken.setBurner(address(l2Outbox), true);
     }
 
-    function _wrapDeposits(Deposit[] memory deposits) internal pure returns (QueuedDeposit[] memory queued) {
+    function _wrapDeposits(Deposit[] memory deposits)
+        internal
+        pure
+        returns (QueuedDeposit[] memory queued)
+    {
         queued = new QueuedDeposit[](deposits.length);
         for (uint256 i = 0; i < deposits.length; i++) {
-            queued[i] = QueuedDeposit({depositType: DepositType.Regular, depositData: abi.encode(deposits[i])});
+            queued[i] = QueuedDeposit({
+                depositType: DepositType.Regular, depositData: abi.encode(deposits[i])
+            });
         }
     }
 
@@ -147,13 +163,16 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Build deposit array
         Deposit[] memory deposits = new Deposit[](4);
-        deposits[0] = Deposit({sender: alice, to: alice, amount: 1000e6, memo: bytes32("alice1")});
-        deposits[1] = Deposit({sender: alice, to: alice, amount: 2000e6, memo: bytes32("alice2")});
-        deposits[2] = Deposit({sender: bob, to: bob, amount: 3000e6, memo: bytes32("bob1")});
-        deposits[3] = Deposit({sender: charlie, to: charlie, amount: 500e6, memo: bytes32("charlie1")});
+        deposits[0] = Deposit({ sender: alice, to: alice, amount: 1000e6, memo: bytes32("alice1") });
+        deposits[1] = Deposit({ sender: alice, to: alice, amount: 2000e6, memo: bytes32("alice2") });
+        deposits[2] = Deposit({ sender: bob, to: bob, amount: 3000e6, memo: bytes32("bob1") });
+        deposits[3] =
+            Deposit({ sender: charlie, to: charlie, amount: 500e6, memo: bytes32("charlie1") });
 
         // Set up L2 mock
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h4);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h4
+        );
 
         // Process on L2
         vm.prank(admin);
@@ -180,9 +199,11 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process only first deposit
         Deposit[] memory batch1 = new Deposit[](1);
-        batch1[0] = Deposit({sender: alice, to: alice, amount: 1000e6, memo: bytes32("d1")});
+        batch1[0] = Deposit({ sender: alice, to: alice, amount: 1000e6, memo: bytes32("d1") });
 
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1
+        );
         vm.prank(admin);
         _advanceTempo(batch1);
 
@@ -194,9 +215,11 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: d1}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({
+                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
+            }),
+            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: d1 }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -210,10 +233,12 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process remaining deposits
         Deposit[] memory batch2 = new Deposit[](2);
-        batch2[0] = Deposit({sender: alice, to: alice, amount: 2000e6, memo: bytes32("d2")});
-        batch2[1] = Deposit({sender: alice, to: alice, amount: 3000e6, memo: bytes32("d3")});
+        batch2[0] = Deposit({ sender: alice, to: alice, amount: 2000e6, memo: bytes32("d2") });
+        batch2[1] = Deposit({ sender: alice, to: alice, amount: 3000e6, memo: bytes32("d3") });
 
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3
+        );
         vm.prank(admin);
         _advanceTempo(batch2);
 
@@ -233,15 +258,20 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process deposit on L2
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: alice, amount: 5000e6, memo: bytes32("deposit")});
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash);
+        deposits[0] =
+            Deposit({ sender: alice, to: alice, amount: 5000e6, memo: bytes32("deposit") });
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
+        );
         vm.prank(admin);
         _advanceTempo(deposits);
 
         // Alice requests withdrawal with callback
         vm.startPrank(alice);
         l2GasToken.approve(address(l2Outbox), 2000e6);
-        l2Outbox.requestWithdrawal(address(receiver), 2000e6, bytes32("payment"), 100_000, alice, "callback");
+        l2Outbox.requestWithdrawal(
+            address(receiver), 2000e6, bytes32("payment"), 100_000, alice, "callback"
+        );
         vm.stopPrank();
 
         // Finalize L2 batch
@@ -253,9 +283,13 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: withdrawalHash}),
+            BlockTransition({
+                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalHash }),
             "",
             ""
         );
@@ -292,8 +326,11 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process on L2
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: alice, amount: 50_000e6, memo: bytes32("big deposit")});
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash);
+        deposits[0] =
+            Deposit({ sender: alice, to: alice, amount: 50_000e6, memo: bytes32("big deposit") });
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
+        );
         vm.prank(admin);
         _advanceTempo(deposits);
 
@@ -310,9 +347,13 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash1}),
+            BlockTransition({
+                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash1 }),
             "",
             ""
         );
@@ -329,9 +370,13 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s2")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash2}),
+            BlockTransition({
+                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s2")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash2 }),
             "",
             ""
         );
@@ -348,9 +393,13 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s3")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash3}),
+            BlockTransition({
+                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s3")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash3 }),
             "",
             ""
         );
@@ -427,10 +476,12 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process both deposits
         Deposit[] memory deposits1 = new Deposit[](2);
-        deposits1[0] = Deposit({sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1")});
-        deposits1[1] = Deposit({sender: bob, to: bob, amount: 5000e6, memo: bytes32("d2")});
+        deposits1[0] = Deposit({ sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1") });
+        deposits1[1] = Deposit({ sender: bob, to: bob, amount: 5000e6, memo: bytes32("d2") });
 
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d2);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d2
+        );
         vm.prank(admin);
         _advanceTempo(deposits1);
 
@@ -459,18 +510,23 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: d2}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({
+                prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
+            }),
+            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: d2 }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
 
         // Process new deposit
         Deposit[] memory deposits2 = new Deposit[](1);
-        deposits2[0] = Deposit({sender: charlie, to: charlie, amount: 7500e6, memo: bytes32("d3")});
+        deposits2[0] =
+            Deposit({ sender: charlie, to: charlie, amount: 7500e6, memo: bytes32("d3") });
 
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3);
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3
+        );
         vm.prank(admin);
         _advanceTempo(deposits2);
 
@@ -522,8 +578,10 @@ contract ZoneIntegrationTest is BaseTest {
         vm.stopPrank();
 
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1")});
-        l2TempoState.setMockStorageValue(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1);
+        deposits[0] = Deposit({ sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1") });
+        l2TempoState.setMockStorageValue(
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1
+        );
         vm.prank(admin);
         _advanceTempo(deposits);
 
@@ -548,7 +606,7 @@ contract ZoneIntegrationTest is BaseTest {
                     STORAGE LAYOUT VERIFICATION TESTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Verify CURRENT_DEPOSIT_QUEUE_HASH_SLOT matches the actual ZonePortal storage layout.
+    /// @notice Verify PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT matches the actual ZonePortal storage layout.
     /// @dev If ZonePortal's storage layout changes, this test will fail.
     function test_storageLayout_currentDepositQueueHashSlot() public {
         // Make a deposit to get a non-zero currentDepositQueueHash
@@ -558,16 +616,17 @@ contract ZoneIntegrationTest is BaseTest {
         vm.stopPrank();
 
         // Read via vm.load using our constant
-        bytes32 fromSlot = vm.load(address(l1Portal), CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
+        bytes32 fromSlot = vm.load(address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
 
         // Compare against the public getter
         assertEq(
             fromSlot,
             l1Portal.currentDepositQueueHash(),
-            "CURRENT_DEPOSIT_QUEUE_HASH_SLOT does not match actual storage position"
+            "PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT does not match actual storage position"
         );
 
         // Sanity: value should be non-zero after deposit
         assertTrue(fromSlot != bytes32(0), "deposit queue hash should be non-zero after deposit");
     }
+
 }

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -9,6 +9,7 @@ import {
     BlockTransition,
     Deposit,
     DepositQueueTransition,
+    DepositType,
     IWithdrawalReceiver,
     IZoneFactory,
     IZoneMessenger,
@@ -1615,7 +1616,8 @@ contract ZonePortalTest is BaseTest {
         // Deposit { sender: portal, to: bob, amount: 500e6, fee: 0, memo: 0 }
         Deposit memory expectedBounceBack =
             Deposit({ sender: address(portal), to: bob, amount: 500e6, memo: bytes32(0) });
-        bytes32 expectedHash = keccak256(abi.encode(expectedBounceBack, depositHashBefore));
+        bytes32 expectedHash =
+            keccak256(abi.encode(DepositType.Regular, expectedBounceBack, depositHashBefore));
         assertEq(newDepositHash, expectedHash);
     }
 
@@ -1689,6 +1691,7 @@ contract ZonePortalTest is BaseTest {
         uint128 netAmount = 500e6 - fee;
         bytes32 expectedHash = keccak256(
             abi.encode(
+                DepositType.Regular,
                 Deposit({ sender: alice, to: bob, amount: netAmount, memo: bytes32("test") }),
                 bytes32(0)
             )

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -1791,10 +1791,9 @@ contract ZonePortalTest is BaseTest {
         portal.setSequencerEncryptionKey(x, yParity, v, r, s);
     }
 
-    function test_sequencerEncryptionKey_emptyReturnsZero() public view {
-        (bytes32 x, uint8 yParity) = portal.sequencerEncryptionKey();
-        assertEq(x, bytes32(0));
-        assertEq(yParity, 0);
+    function test_sequencerEncryptionKey_revertsWhenEmpty() public {
+        vm.expectRevert(IZonePortal.NoEncryptionKeySet.selector);
+        portal.sequencerEncryptionKey();
     }
 
     function test_setSequencerEncryptionKey_success() public {

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -10,6 +10,10 @@ import {
     Deposit,
     DepositQueueTransition,
     DepositType,
+    ENCRYPTION_KEY_GRACE_PERIOD,
+    EncryptedDeposit,
+    EncryptedDepositPayload,
+    EncryptionKeyEntry,
     IWithdrawalReceiver,
     IZoneFactory,
     IZoneMessenger,
@@ -1788,6 +1792,379 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.sequencer(), admin);
         assertEq(portal.verifier(), address(mockVerifier));
         assertEq(portal.genesisTempoBlockNumber(), genesisTempoBlockNumber);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    ENCRYPTION KEY MANAGEMENT TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    // secp256k1 generator point X (known valid point on curve)
+    bytes32 internal constant VALID_SECP256K1_X =
+        0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+
+    function test_sequencerEncryptionKey_emptyReturnsZero() public view {
+        (bytes32 x, uint8 yParity) = portal.sequencerEncryptionKey();
+        assertEq(x, bytes32(0));
+        assertEq(yParity, 0);
+    }
+
+    function test_setSequencerEncryptionKey_success() public {
+        bytes32 x = keccak256("key1");
+        uint8 yParity = 0x02;
+
+        portal.setSequencerEncryptionKey(x, yParity);
+
+        (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
+        assertEq(storedX, x);
+        assertEq(storedYParity, yParity);
+        assertEq(portal.encryptionKeyCount(), 1);
+    }
+
+    function test_setSequencerEncryptionKey_onlySequencer() public {
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setSequencerEncryptionKey(keccak256("key"), 0x02);
+    }
+
+    function test_setSequencerEncryptionKey_multipleKeys() public {
+        bytes32 x1 = keccak256("key1");
+        bytes32 x2 = keccak256("key2");
+
+        portal.setSequencerEncryptionKey(x1, 0x02);
+        vm.roll(block.number + 100);
+        portal.setSequencerEncryptionKey(x2, 0x03);
+
+        assertEq(portal.encryptionKeyCount(), 2);
+
+        // sequencerEncryptionKey returns the latest key
+        (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
+        assertEq(storedX, x2);
+        assertEq(storedYParity, 0x03);
+    }
+
+    function test_setSequencerEncryptionKey_emitsEvent() public {
+        bytes32 x = keccak256("key1");
+        uint8 yParity = 0x02;
+
+        vm.expectEmit(true, true, true, true);
+        emit IZonePortal.SequencerEncryptionKeyUpdated(x, yParity, 0, uint64(block.number));
+        portal.setSequencerEncryptionKey(x, yParity);
+    }
+
+    function test_encryptionKeyAt_success() public {
+        bytes32 x1 = keccak256("key1");
+        portal.setSequencerEncryptionKey(x1, 0x02);
+
+        vm.roll(block.number + 50);
+        bytes32 x2 = keccak256("key2");
+        portal.setSequencerEncryptionKey(x2, 0x03);
+
+        EncryptionKeyEntry memory entry0 = portal.encryptionKeyAt(0);
+        assertEq(entry0.x, x1);
+        assertEq(entry0.yParity, 0x02);
+
+        EncryptionKeyEntry memory entry1 = portal.encryptionKeyAt(1);
+        assertEq(entry1.x, x2);
+        assertEq(entry1.yParity, 0x03);
+    }
+
+    function test_encryptionKeyAt_revertsOnInvalidIndex() public {
+        vm.expectRevert(abi.encodeWithSelector(IZonePortal.InvalidEncryptionKeyIndex.selector, 0));
+        portal.encryptionKeyAt(0);
+    }
+
+    function test_encryptionKeyAtBlock_binarySearch() public {
+        // Set key1 at block 10
+        vm.roll(10);
+        bytes32 x1 = keccak256("key1");
+        portal.setSequencerEncryptionKey(x1, 0x02);
+
+        // Set key2 at block 100
+        vm.roll(100);
+        bytes32 x2 = keccak256("key2");
+        portal.setSequencerEncryptionKey(x2, 0x03);
+
+        // Set key3 at block 200
+        vm.roll(200);
+        bytes32 x3 = keccak256("key3");
+        portal.setSequencerEncryptionKey(x3, 0x02);
+
+        // Query at block 10 -> key1
+        (bytes32 rx, uint8 ry, uint256 ri) = portal.encryptionKeyAtBlock(10);
+        assertEq(rx, x1);
+        assertEq(ry, 0x02);
+        assertEq(ri, 0);
+
+        // Query at block 50 -> key1 (still active)
+        (rx, ry, ri) = portal.encryptionKeyAtBlock(50);
+        assertEq(rx, x1);
+        assertEq(ri, 0);
+
+        // Query at block 100 -> key2
+        (rx, ry, ri) = portal.encryptionKeyAtBlock(100);
+        assertEq(rx, x2);
+        assertEq(ri, 1);
+
+        // Query at block 150 -> key2
+        (rx, ry, ri) = portal.encryptionKeyAtBlock(150);
+        assertEq(rx, x2);
+        assertEq(ri, 1);
+
+        // Query at block 200 -> key3
+        (rx, ry, ri) = portal.encryptionKeyAtBlock(200);
+        assertEq(rx, x3);
+        assertEq(ri, 2);
+
+        // Query at block 500 -> key3
+        (rx, ry, ri) = portal.encryptionKeyAtBlock(500);
+        assertEq(rx, x3);
+        assertEq(ri, 2);
+    }
+
+    function test_isEncryptionKeyValid_currentKeyNeverExpires() public {
+        portal.setSequencerEncryptionKey(keccak256("key"), 0x02);
+
+        (bool valid, uint64 expiresAt) = portal.isEncryptionKeyValid(0);
+        assertTrue(valid);
+        assertEq(expiresAt, 0);
+
+        // Still valid far in the future
+        vm.roll(block.number + 1_000_000);
+        (valid, expiresAt) = portal.isEncryptionKeyValid(0);
+        assertTrue(valid);
+        assertEq(expiresAt, 0);
+    }
+
+    function test_isEncryptionKeyValid_oldKeyValidDuringGrace() public {
+        portal.setSequencerEncryptionKey(keccak256("key1"), 0x02);
+
+        uint256 key2Block = block.number + 100;
+        vm.roll(key2Block);
+        portal.setSequencerEncryptionKey(keccak256("key2"), 0x03);
+
+        // Key 0 should be valid during grace period
+        vm.roll(key2Block + ENCRYPTION_KEY_GRACE_PERIOD - 1);
+        (bool valid,) = portal.isEncryptionKeyValid(0);
+        assertTrue(valid);
+    }
+
+    function test_isEncryptionKeyValid_oldKeyExpiredAfterGrace() public {
+        portal.setSequencerEncryptionKey(keccak256("key1"), 0x02);
+
+        uint256 key2Block = block.number + 100;
+        vm.roll(key2Block);
+        portal.setSequencerEncryptionKey(keccak256("key2"), 0x03);
+
+        // Key 0 should be expired after grace period
+        vm.roll(key2Block + ENCRYPTION_KEY_GRACE_PERIOD);
+        (bool valid,) = portal.isEncryptionKeyValid(0);
+        assertFalse(valid);
+    }
+
+    function test_isEncryptionKeyValid_invalidIndexReturnsFalse() public view {
+        (bool valid,) = portal.isEncryptionKeyValid(0);
+        assertFalse(valid);
+        (valid,) = portal.isEncryptionKeyValid(999);
+        assertFalse(valid);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                       ENCRYPTED DEPOSIT TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function _makeEncryptedPayload() internal pure returns (EncryptedDepositPayload memory) {
+        return EncryptedDepositPayload({
+            ephemeralPubkeyX: VALID_SECP256K1_X,
+            ephemeralPubkeyYParity: 0x02,
+            ciphertext: new bytes(64),
+            nonce: bytes12(0),
+            tag: bytes16(0)
+        });
+    }
+
+    function test_depositEncrypted_success() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        bytes32 hash = portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        vm.stopPrank();
+
+        assertEq(portal.currentDepositQueueHash(), hash);
+        assertTrue(hash != bytes32(0));
+    }
+
+    function test_depositEncrypted_hashChainMatchesLibrary() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        uint128 depositAmount = 1000e6;
+        uint128 fee = portal.calculateDepositFee();
+        uint128 netAmount = depositAmount - fee;
+
+        EncryptedDepositPayload memory encrypted = _makeEncryptedPayload();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        bytes32 hash = portal.depositEncrypted(depositAmount, 0, encrypted);
+        vm.stopPrank();
+
+        // Reconstruct expected hash using the same encoding as DepositQueueLib
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
+        });
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
+        assertEq(hash, expectedHash);
+    }
+
+    function test_depositEncrypted_mixedQueue() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        uint128 amount = 1000e6;
+
+        // Regular deposit from alice
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), amount * 3);
+        bytes32 h1 = portal.deposit(alice, amount, bytes32("memo"));
+
+        // Encrypted deposit from alice
+        bytes32 h2 = portal.depositEncrypted(amount, 0, _makeEncryptedPayload());
+        vm.stopPrank();
+
+        // Both should update the same queue
+        assertEq(portal.currentDepositQueueHash(), h2);
+        assertTrue(h1 != h2);
+        assertTrue(h2 != bytes32(0));
+    }
+
+    function test_depositEncrypted_deductsFee() public {
+        portal.setZoneGasRate(1); // 1 token per gas -> fee = 100_000
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        uint128 depositAmount = 1000e6;
+        uint128 expectedFee = uint128(100_000) * 1; // FIXED_DEPOSIT_GAS * zoneGasRate
+        uint256 aliceBefore = pathUSD.balanceOf(alice);
+        uint256 seqBefore = pathUSD.balanceOf(admin);
+        uint256 portalBefore = pathUSD.balanceOf(address(portal));
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        vm.stopPrank();
+
+        assertEq(pathUSD.balanceOf(alice), aliceBefore - depositAmount);
+        assertEq(pathUSD.balanceOf(admin), seqBefore + expectedFee);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBefore + depositAmount - expectedFee);
+    }
+
+    function test_depositEncrypted_emitsEvent() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        uint128 depositAmount = 1000e6;
+        uint128 fee = portal.calculateDepositFee();
+        uint128 netAmount = depositAmount - fee;
+
+        EncryptedDepositPayload memory encrypted = _makeEncryptedPayload();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+
+        // Build expected hash
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
+        });
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
+
+        vm.expectEmit(true, true, false, true);
+        emit IZonePortal.EncryptedDepositMade(
+            expectedHash, alice, netAmount, 0, VALID_SECP256K1_X, 0x02
+        );
+        portal.depositEncrypted(depositAmount, 0, encrypted);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnExpiredKey() public {
+        portal.setSequencerEncryptionKey(keccak256("key1"), 0x02);
+
+        // Rotate to key2
+        uint256 key2Block = block.number + 100;
+        vm.roll(key2Block);
+        portal.setSequencerEncryptionKey(keccak256("key2"), 0x03);
+
+        // Move past grace period for key1
+        vm.roll(key2Block + ENCRYPTION_KEY_GRACE_PERIOD);
+
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+
+        // Should revert with EncryptionKeyExpired for key index 0
+        vm.expectRevert();
+        portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnInvalidKeyIndex() public {
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+
+        // No keys set, index 0 is invalid
+        vm.expectRevert(abi.encodeWithSelector(IZonePortal.InvalidEncryptionKeyIndex.selector, 0));
+        portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnInvalidYParity() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+
+        EncryptedDepositPayload memory encrypted = EncryptedDepositPayload({
+            ephemeralPubkeyX: VALID_SECP256K1_X,
+            ephemeralPubkeyYParity: 0x04, // Invalid
+            ciphertext: new bytes(64),
+            nonce: bytes12(0),
+            tag: bytes16(0)
+        });
+
+        vm.expectRevert(IZonePortal.InvalidEphemeralPubkey.selector);
+        portal.depositEncrypted(depositAmount, 0, encrypted);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnInvalidEphemeralX() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+
+        EncryptedDepositPayload memory encrypted = EncryptedDepositPayload({
+            ephemeralPubkeyX: bytes32(0), // Invalid: zero
+            ephemeralPubkeyYParity: 0x02,
+            ciphertext: new bytes(64),
+            nonce: bytes12(0),
+            tag: bytes16(0)
+        });
+
+        vm.expectRevert(IZonePortal.InvalidEphemeralPubkey.selector);
+        portal.depositEncrypted(depositAmount, 0, encrypted);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnDepositTooSmall() public {
+        portal.setZoneGasRate(1); // fee = 100_000
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 100_000);
+
+        vm.expectRevert(IZonePortal.DepositTooSmall.selector);
+        portal.depositEncrypted(100_000, 0, _makeEncryptedPayload()); // amount == fee
+        vm.stopPrank();
     }
 
 }

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -2140,6 +2140,68 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
     }
 
+    function test_depositEncrypted_revertsOnCiphertextTooShort() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+        payload.ciphertext = new bytes(63); // one byte too short
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 63, 64)
+        );
+        portal.depositEncrypted(1000e6, 0, payload);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnCiphertextTooLong() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+        payload.ciphertext = new bytes(65); // one byte too long
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 65, 64)
+        );
+        portal.depositEncrypted(1000e6, 0, payload);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnEmptyCiphertext() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+        payload.ciphertext = new bytes(0);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+
+        vm.expectRevert(abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 0, 64));
+        portal.depositEncrypted(1000e6, 0, payload);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsOnOversizedCiphertext() public {
+        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+        payload.ciphertext = new bytes(1024); // large ciphertext (DoS vector)
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 1024, 64)
+        );
+        portal.depositEncrypted(1000e6, 0, payload);
+        vm.stopPrank();
+    }
+
     /*//////////////////////////////////////////////////////////////
                     STORAGE LAYOUT VERIFICATION TESTS
     //////////////////////////////////////////////////////////////*/

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -2167,4 +2167,199 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
     }
 
+    /*//////////////////////////////////////////////////////////////
+                    STORAGE LAYOUT VERIFICATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Verify that ZonePortal's storage layout matches the slot constants
+    ///         used by ZoneConfig and ZoneInbox for cross-domain reads.
+    /// @dev This is a critical regression test. If the ZonePortal storage layout changes
+    ///      (e.g. a variable is added/removed/reordered), this test will fail, preventing
+    ///      silent slot mismatches that corrupt zone-side reads.
+    ///
+    ///      The zone-side contracts (ZoneConfig, ZoneInbox) read ZonePortal storage via
+    ///      TempoState.readTempoStorageSlot() using hardcoded slot numbers. If those slot
+    ///      numbers drift from the actual layout, the zone reads garbage data.
+    ///
+    ///      Slot layout (non-immutable variables only):
+    ///        slot 0: sequencer (address)
+    ///        slot 1: pendingSequencer (address)
+    ///        slot 2: sequencerPubkey (bytes32)
+    ///        slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+    ///        slot 4: blockHash (bytes32)
+    ///        slot 5: currentDepositQueueHash (bytes32)
+    ///        slot 6: lastSyncedTempoBlockNumber (uint64)
+    ///        slot 7: _encryptionKeys.length (EncryptionKeyEntry[])
+    function test_storageLayout_slotPositions() public {
+        // --- Slot 0: sequencer ---
+        bytes32 slot0 = vm.load(address(portal), bytes32(uint256(0)));
+        assertEq(address(uint160(uint256(slot0))), portal.sequencer(), "slot 0: sequencer mismatch");
+
+        // --- Slot 1: pendingSequencer ---
+        // Transfer sequencer to get a non-zero pendingSequencer
+        portal.transferSequencer(alice);
+        bytes32 slot1 = vm.load(address(portal), bytes32(uint256(1)));
+        assertEq(
+            address(uint160(uint256(slot1))),
+            portal.pendingSequencer(),
+            "slot 1: pendingSequencer mismatch"
+        );
+
+        // --- Slot 2: sequencerPubkey ---
+        bytes32 testPubkey = keccak256("testPubkey");
+        portal.setSequencerPubkey(testPubkey);
+        bytes32 slot2 = vm.load(address(portal), bytes32(uint256(2)));
+        assertEq(slot2, testPubkey, "slot 2: sequencerPubkey mismatch");
+
+        // --- Slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) packed ---
+        uint128 testRate = 42;
+        portal.setZoneGasRate(testRate);
+        bytes32 slot3 = vm.load(address(portal), bytes32(uint256(3)));
+        // zoneGasRate is at the lowest 128 bits (uint128), withdrawalBatchIndex at bits 128-191
+        uint128 loadedRate = uint128(uint256(slot3));
+        assertEq(loadedRate, testRate, "slot 3: zoneGasRate mismatch");
+
+        // --- Slot 4: blockHash ---
+        bytes32 slot4 = vm.load(address(portal), bytes32(uint256(4)));
+        assertEq(slot4, portal.blockHash(), "slot 4: blockHash mismatch");
+
+        // --- Slot 5: currentDepositQueueHash ---
+        bytes32 slot5 = vm.load(address(portal), bytes32(uint256(5)));
+        assertEq(
+            slot5, portal.currentDepositQueueHash(), "slot 5: currentDepositQueueHash mismatch"
+        );
+
+        // --- Slot 6: lastSyncedTempoBlockNumber ---
+        bytes32 slot6 = vm.load(address(portal), bytes32(uint256(6)));
+        assertEq(
+            uint64(uint256(slot6)),
+            portal.lastSyncedTempoBlockNumber(),
+            "slot 6: lastSyncedTempoBlockNumber mismatch"
+        );
+
+        // --- Slot 7: _encryptionKeys array length ---
+        // Before adding keys, length should be 0
+        bytes32 slot7 = vm.load(address(portal), bytes32(uint256(7)));
+        assertEq(uint256(slot7), 0, "slot 7: _encryptionKeys length should be 0 initially");
+    }
+
+    /// @notice Verify that the _encryptionKeys dynamic array uses the expected slot layout.
+    /// @dev This ensures ZoneConfig and ZoneInbox both compute the correct storage slots
+    ///      when reading encryption keys via readTempoStorageSlot().
+    ///
+    ///      For a dynamic array at slot S:
+    ///        - slot S stores the array length
+    ///        - element data starts at keccak256(abi.encode(S))
+    ///        - each EncryptionKeyEntry occupies 2 slots:
+    ///            base + (index * 2):     x (bytes32)
+    ///            base + (index * 2) + 1: yParity (uint8) + activationBlock (uint64) [packed]
+    function test_storageLayout_encryptionKeysArray() public {
+        bytes32 keyX1 = keccak256("encryption-key-1");
+        uint8 keyYParity1 = 0x02;
+        bytes32 keyX2 = keccak256("encryption-key-2");
+        uint8 keyYParity2 = 0x03;
+
+        // Add two keys at different blocks
+        portal.setSequencerEncryptionKey(keyX1, keyYParity1);
+
+        vm.roll(block.number + 100);
+        portal.setSequencerEncryptionKey(keyX2, keyYParity2);
+
+        // Verify array length at slot 7
+        uint256 arraySlot = 7;
+        bytes32 lengthRaw = vm.load(address(portal), bytes32(arraySlot));
+        assertEq(uint256(lengthRaw), 2, "encryption keys array length should be 2");
+
+        // Compute the base slot for array data
+        uint256 base = uint256(keccak256(abi.encode(arraySlot)));
+
+        // --- Entry 0: verify raw storage matches the public getter ---
+        EncryptionKeyEntry memory entry0 = portal.encryptionKeyAt(0);
+        bytes32 loadedX1 = vm.load(address(portal), bytes32(base + 0));
+        assertEq(loadedX1, keyX1, "entry 0: x mismatch");
+        assertEq(loadedX1, entry0.x, "entry 0: x != getter");
+
+        bytes32 meta1 = vm.load(address(portal), bytes32(base + 1));
+        uint8 loadedYParity1 = uint8(uint256(meta1) & 0xff);
+        uint64 loadedActivation1 = uint64(uint256(meta1) >> 8);
+        assertEq(loadedYParity1, keyYParity1, "entry 0: yParity mismatch");
+        assertEq(loadedActivation1, entry0.activationBlock, "entry 0: activationBlock mismatch");
+
+        // --- Entry 1: verify raw storage matches the public getter ---
+        EncryptionKeyEntry memory entry1 = portal.encryptionKeyAt(1);
+        bytes32 loadedX2 = vm.load(address(portal), bytes32(base + 2));
+        assertEq(loadedX2, keyX2, "entry 1: x mismatch");
+        assertEq(loadedX2, entry1.x, "entry 1: x != getter");
+
+        bytes32 meta2 = vm.load(address(portal), bytes32(base + 3));
+        uint8 loadedYParity2 = uint8(uint256(meta2) & 0xff);
+        uint64 loadedActivation2 = uint64(uint256(meta2) >> 8);
+        assertEq(loadedYParity2, keyYParity2, "entry 1: yParity mismatch");
+        assertEq(loadedActivation2, entry1.activationBlock, "entry 1: activationBlock mismatch");
+
+        // Verify the two keys have different activation blocks (proves vm.roll worked)
+        assertTrue(
+            entry1.activationBlock > entry0.activationBlock, "key2 should be activated later"
+        );
+    }
+
+    /// @notice Verify that the slot constants used by ZoneInbox and ZoneConfig match
+    ///         the actual ZonePortal storage layout.
+    /// @dev This is the cross-contract consistency check. The test replicates the exact
+    ///      slot computation logic used by ZoneInbox._readEncryptionKey() and
+    ///      ZoneConfig.sequencerEncryptionKey() to ensure they both read the correct data.
+    function test_storageLayout_crossContractConsistency() public {
+        bytes32 keyX = keccak256("cross-contract-key");
+        uint8 keyYParity = 0x03;
+
+        portal.setSequencerEncryptionKey(keyX, keyYParity);
+
+        // These are the slot constants defined in ZoneInbox and ZoneConfig:
+        uint256 INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = 5;
+        uint256 INBOX_ENCRYPTION_KEYS_SLOT = 7;
+        // (ZoneConfig also uses ENCRYPTION_KEYS_SLOT = 7 after the fix)
+
+        // Verify currentDepositQueueHash slot
+        bytes32 queueHashFromSlot =
+            vm.load(address(portal), bytes32(INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT));
+        assertEq(
+            queueHashFromSlot,
+            portal.currentDepositQueueHash(),
+            "ZoneInbox CURRENT_DEPOSIT_QUEUE_HASH_SLOT reads wrong data"
+        );
+
+        // Verify encryption keys array length from slot 7
+        bytes32 arrayLenRaw = vm.load(address(portal), bytes32(INBOX_ENCRYPTION_KEYS_SLOT));
+        assertEq(
+            uint256(arrayLenRaw),
+            portal.encryptionKeyCount(),
+            "ZoneInbox/ZoneConfig ENCRYPTION_KEYS_SLOT reads wrong array length"
+        );
+
+        // Verify the derived slot computation matches actual key data
+        // This replicates the exact logic from ZoneInbox._readEncryptionKey():
+        //   uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
+        //   uint256 slotX = base + (keyIndex * 2);
+        //   uint256 slotMeta = slotX + 1;
+        uint256 base = uint256(keccak256(abi.encode(INBOX_ENCRYPTION_KEYS_SLOT)));
+        bytes32 loadedX = vm.load(address(portal), bytes32(base + 0));
+        bytes32 loadedMeta = vm.load(address(portal), bytes32(base + 1));
+
+        assertEq(loadedX, keyX, "derived slot for key x does not match actual storage");
+        assertEq(
+            uint8(uint256(loadedMeta) & 0xff),
+            keyYParity,
+            "derived slot for key yParity does not match actual storage"
+        );
+
+        // Also verify via the public getter for full round-trip confidence
+        EncryptionKeyEntry memory entry = portal.encryptionKeyAt(0);
+        assertEq(loadedX, entry.x, "vm.load x != encryptionKeyAt(0).x");
+        assertEq(
+            uint8(uint256(loadedMeta) & 0xff),
+            entry.yParity,
+            "vm.load yParity != encryptionKeyAt(0).yParity"
+        );
+    }
+
 }

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -2085,7 +2085,16 @@ contract ZonePortalTest is BaseTest {
 
         vm.expectEmit(true, true, false, true);
         emit IZonePortal.EncryptedDepositMade(
-            expectedHash, alice, netAmount, 0, VALID_SECP256K1_X, 0x02
+            expectedHash,
+            alice,
+            netAmount,
+            fee,
+            0,
+            VALID_SECP256K1_X,
+            0x02,
+            encrypted.ciphertext,
+            encrypted.nonce,
+            encrypted.tag
         );
         portal.depositEncrypted(depositAmount, 0, encrypted);
         vm.stopPrank();

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { TIP20 } from "../../src/TIP20.sol";
-import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
+import {TIP20} from "../../src/TIP20.sol";
+import {ITIP20} from "../../src/interfaces/ITIP20.sol";
 
-import { BLOCKHASH_HISTORY_WINDOW } from "../../src/zone/BlockHashHistory.sol";
+import {BLOCKHASH_HISTORY_WINDOW} from "../../src/zone/BlockHashHistory.sol";
 import {
     BlockTransition,
     Deposit,
@@ -23,17 +23,16 @@ import {
     ZoneInfo,
     ZoneParams
 } from "../../src/zone/IZone.sol";
-import { EMPTY_SENTINEL, WithdrawalQueueLib } from "../../src/zone/WithdrawalQueueLib.sol";
-import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
-import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
-import { ZonePortal } from "../../src/zone/ZonePortal.sol";
-import { BaseTest } from "../BaseTest.t.sol";
+import {EMPTY_SENTINEL, WithdrawalQueueLib} from "../../src/zone/WithdrawalQueueLib.sol";
+import {ZoneFactory} from "../../src/zone/ZoneFactory.sol";
+import {ZoneMessenger} from "../../src/zone/ZoneMessenger.sol";
+import {ZonePortal} from "../../src/zone/ZonePortal.sol";
+import {BaseTest} from "../BaseTest.t.sol";
 
-import { MockVerifier } from "./mocks/MockVerifier.sol";
+import {MockVerifier} from "./mocks/MockVerifier.sol";
 
 /// @notice Mock withdrawal receiver that accepts funds
 contract MockWithdrawalReceiver is IWithdrawalReceiver {
-
     bool public shouldAccept = true;
     bool public shouldRevert = false;
 
@@ -54,11 +53,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         shouldRevert = _shouldRevert;
     }
 
-    function onWithdrawalReceived(
-        address sender,
-        uint128 amount,
-        bytes calldata callbackData
-    )
+    function onWithdrawalReceived(address sender, uint128 amount, bytes calldata callbackData)
         external
         returns (bytes4)
     {
@@ -76,35 +71,29 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
             return bytes4(0xdeadbeef); // Wrong selector
         }
     }
-
 }
 
 /// @notice Mock receiver that consumes all gas
 contract GasConsumingReceiver is IWithdrawalReceiver {
-
     function onWithdrawalReceived(address, uint128, bytes calldata) external returns (bytes4) {
         // Infinite loop to consume all gas
-        while (true) { }
+        while (true) {}
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }
-
 }
 
 /// @notice Mock receiver that succeeds normally
 contract SuccessfulReceiver is IWithdrawalReceiver {
-
     uint256 public callCount;
 
     function onWithdrawalReceived(address, uint128, bytes calldata) external returns (bytes4) {
         callCount++;
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }
-
 }
 
 /// @notice Tests for ZonePortal - simulating L1/zone interface
 contract ZonePortalTest is BaseTest {
-
     ZoneFactory public zoneFactory;
     MockVerifier public mockVerifier;
     ZonePortal public portal;
@@ -285,11 +274,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: newStateRoot }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: newStateRoot}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -308,13 +295,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: keccak256("wrong"), nextBlockHash: keccak256("state")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: keccak256("wrong"), nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -331,11 +314,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -353,11 +334,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -397,13 +376,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("stateWithWithdrawal")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("stateWithWithdrawal")}),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalHash }),
+            WithdrawalQueueTransition({withdrawalQueueHash: withdrawalHash}),
             "",
             ""
         );
@@ -465,14 +442,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
             DepositQueueTransition({
-                    prevProcessedHash: bytes32(0),
-                    nextProcessedHash: portal.currentDepositQueueHash()
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: batchQueueHash }),
+                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: batchQueueHash}),
             "",
             ""
         );
@@ -523,14 +497,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
             DepositQueueTransition({
-                    prevProcessedHash: bytes32(0),
-                    nextProcessedHash: portal.currentDepositQueueHash()
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
+                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: w1Hash}),
             "",
             ""
         );
@@ -552,14 +523,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")}),
             DepositQueueTransition({
-                    prevProcessedHash: bytes32(0),
-                    nextProcessedHash: portal.currentDepositQueueHash()
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
+                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: w2Hash}),
             "",
             ""
         );
@@ -593,14 +561,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
             DepositQueueTransition({
-                    prevProcessedHash: bytes32(0),
-                    nextProcessedHash: portal.currentDepositQueueHash()
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }), // No withdrawals
+                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}), // No withdrawals
             "",
             ""
         );
@@ -641,14 +606,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
             DepositQueueTransition({
-                    prevProcessedHash: bytes32(0),
-                    nextProcessedHash: portal.currentDepositQueueHash()
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -696,13 +658,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -748,13 +706,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -803,13 +757,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -869,14 +819,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
             DepositQueueTransition({
-                    prevProcessedHash: bytes32(0),
-                    nextProcessedHash: portal.currentDepositQueueHash()
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -922,14 +869,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
             DepositQueueTransition({
-                    prevProcessedHash: bytes32(0),
-                    nextProcessedHash: portal.currentDepositQueueHash()
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -969,11 +913,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
-            }),
-            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: h1 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: h1}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -992,37 +934,6 @@ contract ZonePortalTest is BaseTest {
     }
 
     /*//////////////////////////////////////////////////////////////
-                     SEQUENCER PUBKEY TESTS
-    //////////////////////////////////////////////////////////////*/
-
-    function test_setSequencerPubkey_success() public {
-        bytes32 pubkey = keccak256("sequencerPubkey");
-
-        assertEq(portal.sequencerPubkey(), bytes32(0));
-
-        portal.setSequencerPubkey(pubkey);
-
-        assertEq(portal.sequencerPubkey(), pubkey);
-    }
-
-    function test_setSequencerPubkey_canUpdate() public {
-        bytes32 pubkey1 = keccak256("pubkey1");
-        bytes32 pubkey2 = keccak256("pubkey2");
-
-        portal.setSequencerPubkey(pubkey1);
-        assertEq(portal.sequencerPubkey(), pubkey1);
-
-        portal.setSequencerPubkey(pubkey2);
-        assertEq(portal.sequencerPubkey(), pubkey2);
-    }
-
-    function test_setSequencerPubkey_revertsIfNotSequencer() public {
-        vm.prank(alice);
-        vm.expectRevert(IZonePortal.NotSequencer.selector);
-        portal.setSequencerPubkey(keccak256("pubkey"));
-    }
-
-    /*//////////////////////////////////////////////////////////////
                       BATCH SUBMISSION VALIDATION
     //////////////////////////////////////////////////////////////*/
 
@@ -1032,11 +943,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             genesisTempoBlockNumber - 1, // Before genesis
             0,
-            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1050,11 +959,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number + 1), // In future
             0,
-            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1069,11 +976,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             genesisTempoBlockNumber, // Valid but beyond history window
             0,
-            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1089,13 +994,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             oldTempoBlockNumber,
             recentTempoBlockNumber,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1112,11 +1013,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             tempoBlockNumber,
             tempoBlockNumber,
-            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1133,11 +1032,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             tempoBlockNumber,
             futureTempoBlockNumber,
-            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1151,13 +1048,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             genesisTempoBlockNumber,
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
-            DepositQueueTransition({
-                    prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1189,14 +1082,12 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
-            }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
             DepositQueueTransition({
-                    prevProcessedHash: keccak256("wrongHash"), // This is ignored by implementation
-                    nextProcessedHash: depositHash
-                }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+                prevProcessedHash: keccak256("wrongHash"), // This is ignored by implementation
+                nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1220,11 +1111,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
-            }),
-            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: h1 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: h1}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1237,11 +1126,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({
-                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")
-            }),
-            DepositQueueTransition({ prevProcessedHash: h1, nextProcessedHash: h2 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")}),
+            DepositQueueTransition({prevProcessedHash: h1, nextProcessedHash: h2}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1282,11 +1169,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: w1Hash}),
             "",
             ""
         );
@@ -1313,11 +1198,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: w2Hash}),
             "",
             ""
         );
@@ -1346,11 +1229,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }), // No withdrawals
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}), // No withdrawals
             "",
             ""
         );
@@ -1389,11 +1270,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: w1Hash}),
             "",
             ""
         );
@@ -1414,11 +1293,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: w2Hash}),
             "",
             ""
         );
@@ -1464,11 +1341,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -1509,11 +1384,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -1555,11 +1428,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -1601,11 +1472,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -1618,10 +1487,8 @@ contract ZonePortalTest is BaseTest {
 
         // The bounce-back deposit should be:
         // Deposit { sender: portal, to: bob, amount: 500e6, fee: 0, memo: 0 }
-        Deposit memory expectedBounceBack =
-            Deposit({ sender: address(portal), to: bob, amount: 500e6, memo: bytes32(0) });
-        bytes32 expectedHash =
-            keccak256(abi.encode(DepositType.Regular, expectedBounceBack, depositHashBefore));
+        Deposit memory expectedBounceBack = Deposit({sender: address(portal), to: bob, amount: 500e6, memo: bytes32(0)});
+        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, expectedBounceBack, depositHashBefore));
         assertEq(newDepositHash, expectedHash);
     }
 
@@ -1643,11 +1510,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1657,11 +1522,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1671,11 +1534,9 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s3") }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
-            }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s3")}),
+            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
+            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
             "",
             ""
         );
@@ -1696,7 +1557,7 @@ contract ZonePortalTest is BaseTest {
         bytes32 expectedHash = keccak256(
             abi.encode(
                 DepositType.Regular,
-                Deposit({ sender: alice, to: bob, amount: netAmount, memo: bytes32("test") }),
+                Deposit({sender: alice, to: bob, amount: netAmount, memo: bytes32("test")}),
                 bytes32(0)
             )
         );
@@ -1729,11 +1590,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -1767,11 +1628,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
             "",
             ""
         );
@@ -1799,8 +1660,7 @@ contract ZonePortalTest is BaseTest {
     //////////////////////////////////////////////////////////////*/
 
     // secp256k1 generator point X (known valid point on curve)
-    bytes32 internal constant VALID_SECP256K1_X =
-        0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+    bytes32 internal constant VALID_SECP256K1_X = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
 
     function test_sequencerEncryptionKey_emptyReturnsZero() public view {
         (bytes32 x, uint8 yParity) = portal.sequencerEncryptionKey();
@@ -2010,9 +1870,8 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
 
         // Reconstruct expected hash using the same encoding as DepositQueueLib
-        EncryptedDeposit memory ed = EncryptedDeposit({
-            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
-        });
+        EncryptedDeposit memory ed =
+            EncryptedDeposit({sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted});
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
         assertEq(hash, expectedHash);
     }
@@ -2070,15 +1929,12 @@ contract ZonePortalTest is BaseTest {
         pathUSD.approve(address(portal), depositAmount);
 
         // Build expected hash
-        EncryptedDeposit memory ed = EncryptedDeposit({
-            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
-        });
+        EncryptedDeposit memory ed =
+            EncryptedDeposit({sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted});
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
 
         vm.expectEmit(true, true, false, true);
-        emit IZonePortal.EncryptedDepositMade(
-            expectedHash, alice, netAmount, 0, VALID_SECP256K1_X, 0x02
-        );
+        emit IZonePortal.EncryptedDepositMade(expectedHash, alice, netAmount, 0, VALID_SECP256K1_X, 0x02);
         portal.depositEncrypted(depositAmount, 0, encrypted);
         vm.stopPrank();
     }
@@ -2184,12 +2040,11 @@ contract ZonePortalTest is BaseTest {
     ///      Slot layout (non-immutable variables only):
     ///        slot 0: sequencer (address)
     ///        slot 1: pendingSequencer (address)
-    ///        slot 2: sequencerPubkey (bytes32)
-    ///        slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
-    ///        slot 4: blockHash (bytes32)
-    ///        slot 5: currentDepositQueueHash (bytes32)
-    ///        slot 6: lastSyncedTempoBlockNumber (uint64)
-    ///        slot 7: _encryptionKeys.length (EncryptionKeyEntry[])
+    ///        slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+    ///        slot 3: blockHash (bytes32)
+    ///        slot 4: currentDepositQueueHash (bytes32)
+    ///        slot 5: lastSyncedTempoBlockNumber (uint64)
+    ///        slot 6: _encryptionKeys.length (EncryptionKeyEntry[])
     function test_storageLayout_slotPositions() public {
         // --- Slot 0: sequencer ---
         bytes32 slot0 = vm.load(address(portal), bytes32(uint256(0)));
@@ -2199,48 +2054,34 @@ contract ZonePortalTest is BaseTest {
         // Transfer sequencer to get a non-zero pendingSequencer
         portal.transferSequencer(alice);
         bytes32 slot1 = vm.load(address(portal), bytes32(uint256(1)));
-        assertEq(
-            address(uint160(uint256(slot1))),
-            portal.pendingSequencer(),
-            "slot 1: pendingSequencer mismatch"
-        );
+        assertEq(address(uint160(uint256(slot1))), portal.pendingSequencer(), "slot 1: pendingSequencer mismatch");
 
-        // --- Slot 2: sequencerPubkey ---
-        bytes32 testPubkey = keccak256("testPubkey");
-        portal.setSequencerPubkey(testPubkey);
-        bytes32 slot2 = vm.load(address(portal), bytes32(uint256(2)));
-        assertEq(slot2, testPubkey, "slot 2: sequencerPubkey mismatch");
-
-        // --- Slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) packed ---
+        // --- Slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) packed ---
         uint128 testRate = 42;
         portal.setZoneGasRate(testRate);
-        bytes32 slot3 = vm.load(address(portal), bytes32(uint256(3)));
+        bytes32 slot2 = vm.load(address(portal), bytes32(uint256(2)));
         // zoneGasRate is at the lowest 128 bits (uint128), withdrawalBatchIndex at bits 128-191
-        uint128 loadedRate = uint128(uint256(slot3));
-        assertEq(loadedRate, testRate, "slot 3: zoneGasRate mismatch");
+        uint128 loadedRate = uint128(uint256(slot2));
+        assertEq(loadedRate, testRate, "slot 2: zoneGasRate mismatch");
 
-        // --- Slot 4: blockHash ---
+        // --- Slot 3: blockHash ---
+        bytes32 slot3 = vm.load(address(portal), bytes32(uint256(3)));
+        assertEq(slot3, portal.blockHash(), "slot 3: blockHash mismatch");
+
+        // --- Slot 4: currentDepositQueueHash ---
         bytes32 slot4 = vm.load(address(portal), bytes32(uint256(4)));
-        assertEq(slot4, portal.blockHash(), "slot 4: blockHash mismatch");
+        assertEq(slot4, portal.currentDepositQueueHash(), "slot 4: currentDepositQueueHash mismatch");
 
-        // --- Slot 5: currentDepositQueueHash ---
+        // --- Slot 5: lastSyncedTempoBlockNumber ---
         bytes32 slot5 = vm.load(address(portal), bytes32(uint256(5)));
         assertEq(
-            slot5, portal.currentDepositQueueHash(), "slot 5: currentDepositQueueHash mismatch"
+            uint64(uint256(slot5)), portal.lastSyncedTempoBlockNumber(), "slot 5: lastSyncedTempoBlockNumber mismatch"
         );
 
-        // --- Slot 6: lastSyncedTempoBlockNumber ---
-        bytes32 slot6 = vm.load(address(portal), bytes32(uint256(6)));
-        assertEq(
-            uint64(uint256(slot6)),
-            portal.lastSyncedTempoBlockNumber(),
-            "slot 6: lastSyncedTempoBlockNumber mismatch"
-        );
-
-        // --- Slot 7: _encryptionKeys array length ---
+        // --- Slot 6: _encryptionKeys array length ---
         // Before adding keys, length should be 0
-        bytes32 slot7 = vm.load(address(portal), bytes32(uint256(7)));
-        assertEq(uint256(slot7), 0, "slot 7: _encryptionKeys length should be 0 initially");
+        bytes32 slot6keys = vm.load(address(portal), bytes32(uint256(6)));
+        assertEq(uint256(slot6keys), 0, "slot 6: _encryptionKeys length should be 0 initially");
     }
 
     /// @notice Verify that the _encryptionKeys dynamic array uses the expected slot layout.
@@ -2265,8 +2106,8 @@ contract ZonePortalTest is BaseTest {
         vm.roll(block.number + 100);
         portal.setSequencerEncryptionKey(keyX2, keyYParity2);
 
-        // Verify array length at slot 7
-        uint256 arraySlot = 7;
+        // Verify array length at slot 6
+        uint256 arraySlot = 6;
         bytes32 lengthRaw = vm.load(address(portal), bytes32(arraySlot));
         assertEq(uint256(lengthRaw), 2, "encryption keys array length should be 2");
 
@@ -2298,9 +2139,7 @@ contract ZonePortalTest is BaseTest {
         assertEq(loadedActivation2, entry1.activationBlock, "entry 1: activationBlock mismatch");
 
         // Verify the two keys have different activation blocks (proves vm.roll worked)
-        assertTrue(
-            entry1.activationBlock > entry0.activationBlock, "key2 should be activated later"
-        );
+        assertTrue(entry1.activationBlock > entry0.activationBlock, "key2 should be activated later");
     }
 
     /// @notice Verify that the slot constants used by ZoneInbox and ZoneConfig match
@@ -2315,20 +2154,35 @@ contract ZonePortalTest is BaseTest {
         portal.setSequencerEncryptionKey(keyX, keyYParity);
 
         // These are the slot constants defined in ZoneInbox and ZoneConfig:
-        uint256 INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = 5;
-        uint256 INBOX_ENCRYPTION_KEYS_SLOT = 7;
-        // (ZoneConfig also uses ENCRYPTION_KEYS_SLOT = 7 after the fix)
+        uint256 CONFIG_SEQUENCER_SLOT = 0;
+        uint256 CONFIG_PENDING_SEQUENCER_SLOT = 1;
+        uint256 INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = 4;
+        uint256 INBOX_ENCRYPTION_KEYS_SLOT = 6;
+        // (ZoneConfig also uses ENCRYPTION_KEYS_SLOT = 6)
 
-        // Verify currentDepositQueueHash slot
-        bytes32 queueHashFromSlot =
-            vm.load(address(portal), bytes32(INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT));
+        // Verify sequencer slot (used by ZoneConfig)
+        bytes32 seqFromSlot = vm.load(address(portal), bytes32(CONFIG_SEQUENCER_SLOT));
+        assertEq(
+            address(uint160(uint256(seqFromSlot))), portal.sequencer(), "ZoneConfig SEQUENCER_SLOT reads wrong data"
+        );
+
+        // Verify pendingSequencer slot (used by ZoneConfig)
+        bytes32 pendingFromSlot = vm.load(address(portal), bytes32(CONFIG_PENDING_SEQUENCER_SLOT));
+        assertEq(
+            address(uint160(uint256(pendingFromSlot))),
+            portal.pendingSequencer(),
+            "ZoneConfig PENDING_SEQUENCER_SLOT reads wrong data"
+        );
+
+        // Verify currentDepositQueueHash slot (used by ZoneInbox)
+        bytes32 queueHashFromSlot = vm.load(address(portal), bytes32(INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT));
         assertEq(
             queueHashFromSlot,
             portal.currentDepositQueueHash(),
             "ZoneInbox CURRENT_DEPOSIT_QUEUE_HASH_SLOT reads wrong data"
         );
 
-        // Verify encryption keys array length from slot 7
+        // Verify encryption keys array length from slot 6
         bytes32 arrayLenRaw = vm.load(address(portal), bytes32(INBOX_ENCRYPTION_KEYS_SLOT));
         assertEq(
             uint256(arrayLenRaw),
@@ -2347,19 +2201,12 @@ contract ZonePortalTest is BaseTest {
 
         assertEq(loadedX, keyX, "derived slot for key x does not match actual storage");
         assertEq(
-            uint8(uint256(loadedMeta) & 0xff),
-            keyYParity,
-            "derived slot for key yParity does not match actual storage"
+            uint8(uint256(loadedMeta) & 0xff), keyYParity, "derived slot for key yParity does not match actual storage"
         );
 
         // Also verify via the public getter for full round-trip confidence
         EncryptionKeyEntry memory entry = portal.encryptionKeyAt(0);
         assertEq(loadedX, entry.x, "vm.load x != encryptionKeyAt(0).x");
-        assertEq(
-            uint8(uint256(loadedMeta) & 0xff),
-            entry.yParity,
-            "vm.load yParity != encryptionKeyAt(0).yParity"
-        );
+        assertEq(uint8(uint256(loadedMeta) & 0xff), entry.yParity, "vm.load yParity != encryptionKeyAt(0).yParity");
     }
-
 }

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {TIP20} from "../../src/TIP20.sol";
-import {ITIP20} from "../../src/interfaces/ITIP20.sol";
+import { TIP20 } from "../../src/TIP20.sol";
+import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
 
-import {BLOCKHASH_HISTORY_WINDOW} from "../../src/zone/BlockHashHistory.sol";
+import { BLOCKHASH_HISTORY_WINDOW } from "../../src/zone/BlockHashHistory.sol";
 import {
     BlockTransition,
     Deposit,
@@ -18,21 +18,26 @@ import {
     IZoneFactory,
     IZoneMessenger,
     IZonePortal,
+    PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
+    PORTAL_ENCRYPTION_KEYS_SLOT,
+    PORTAL_PENDING_SEQUENCER_SLOT,
+    PORTAL_SEQUENCER_SLOT,
     Withdrawal,
     WithdrawalQueueTransition,
     ZoneInfo,
     ZoneParams
 } from "../../src/zone/IZone.sol";
-import {EMPTY_SENTINEL, WithdrawalQueueLib} from "../../src/zone/WithdrawalQueueLib.sol";
-import {ZoneFactory} from "../../src/zone/ZoneFactory.sol";
-import {ZoneMessenger} from "../../src/zone/ZoneMessenger.sol";
-import {ZonePortal} from "../../src/zone/ZonePortal.sol";
-import {BaseTest} from "../BaseTest.t.sol";
+import { EMPTY_SENTINEL, WithdrawalQueueLib } from "../../src/zone/WithdrawalQueueLib.sol";
+import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
+import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
+import { ZonePortal } from "../../src/zone/ZonePortal.sol";
+import { BaseTest } from "../BaseTest.t.sol";
 
-import {MockVerifier} from "./mocks/MockVerifier.sol";
+import { MockVerifier } from "./mocks/MockVerifier.sol";
 
 /// @notice Mock withdrawal receiver that accepts funds
 contract MockWithdrawalReceiver is IWithdrawalReceiver {
+
     bool public shouldAccept = true;
     bool public shouldRevert = false;
 
@@ -53,7 +58,11 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         shouldRevert = _shouldRevert;
     }
 
-    function onWithdrawalReceived(address sender, uint128 amount, bytes calldata callbackData)
+    function onWithdrawalReceived(
+        address sender,
+        uint128 amount,
+        bytes calldata callbackData
+    )
         external
         returns (bytes4)
     {
@@ -71,29 +80,35 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
             return bytes4(0xdeadbeef); // Wrong selector
         }
     }
+
 }
 
 /// @notice Mock receiver that consumes all gas
 contract GasConsumingReceiver is IWithdrawalReceiver {
+
     function onWithdrawalReceived(address, uint128, bytes calldata) external returns (bytes4) {
         // Infinite loop to consume all gas
-        while (true) {}
+        while (true) { }
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }
+
 }
 
 /// @notice Mock receiver that succeeds normally
 contract SuccessfulReceiver is IWithdrawalReceiver {
+
     uint256 public callCount;
 
     function onWithdrawalReceived(address, uint128, bytes calldata) external returns (bytes4) {
         callCount++;
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }
+
 }
 
 /// @notice Tests for ZonePortal - simulating L1/zone interface
 contract ZonePortalTest is BaseTest {
+
     ZoneFactory public zoneFactory;
     MockVerifier public mockVerifier;
     ZonePortal public portal;
@@ -274,9 +289,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: newStateRoot}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: newStateRoot }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -295,9 +312,13 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: keccak256("wrong"), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({
+                prevBlockHash: keccak256("wrong"), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -314,9 +335,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -334,9 +357,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: nextStateRoot }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -376,11 +401,13 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("stateWithWithdrawal")}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("stateWithWithdrawal")
+            }),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: withdrawalHash}),
+            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalHash }),
             "",
             ""
         );
@@ -442,11 +469,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: batchQueueHash}),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash()
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: batchQueueHash }),
             "",
             ""
         );
@@ -497,11 +527,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: w1Hash}),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash()
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
             "",
             ""
         );
@@ -523,11 +556,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")}),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: w2Hash}),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash()
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
             "",
             ""
         );
@@ -561,11 +597,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}), // No withdrawals
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash()
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }), // No withdrawals
             "",
             ""
         );
@@ -606,11 +645,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash()
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -658,9 +700,13 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -706,9 +752,13 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -757,9 +807,13 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -819,11 +873,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash()
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -869,11 +926,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash()
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -913,9 +973,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: h1}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
+            }),
+            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: h1 }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -943,9 +1005,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             genesisTempoBlockNumber - 1, // Before genesis
             0,
-            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -959,9 +1023,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number + 1), // In future
             0,
-            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -976,9 +1042,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             genesisTempoBlockNumber, // Valid but beyond history window
             0,
-            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -994,9 +1062,13 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             oldTempoBlockNumber,
             recentTempoBlockNumber,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1013,9 +1085,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             tempoBlockNumber,
             tempoBlockNumber,
-            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1032,9 +1106,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             tempoBlockNumber,
             futureTempoBlockNumber,
-            BlockTransition({prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1048,9 +1124,13 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             genesisTempoBlockNumber,
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1082,12 +1162,14 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")}),
-            DepositQueueTransition({
-                prevProcessedHash: keccak256("wrongHash"), // This is ignored by implementation
-                nextProcessedHash: depositHash
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            DepositQueueTransition({
+                    prevProcessedHash: keccak256("wrongHash"), // This is ignored by implementation
+                    nextProcessedHash: depositHash
+                }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1111,9 +1193,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: h1}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
+            }),
+            DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: h1 }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1126,9 +1210,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")}),
-            DepositQueueTransition({prevProcessedHash: h1, nextProcessedHash: h2}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")
+            }),
+            DepositQueueTransition({ prevProcessedHash: h1, nextProcessedHash: h2 }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1169,9 +1255,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: w1Hash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
             "",
             ""
         );
@@ -1198,9 +1286,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: w2Hash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
             "",
             ""
         );
@@ -1229,9 +1319,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}), // No withdrawals
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }), // No withdrawals
             "",
             ""
         );
@@ -1270,9 +1362,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: w1Hash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
             "",
             ""
         );
@@ -1293,9 +1387,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: w2Hash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
             "",
             ""
         );
@@ -1341,9 +1437,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -1384,9 +1482,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -1428,9 +1528,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -1472,9 +1574,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore}),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -1487,8 +1591,10 @@ contract ZonePortalTest is BaseTest {
 
         // The bounce-back deposit should be:
         // Deposit { sender: portal, to: bob, amount: 500e6, fee: 0, memo: 0 }
-        Deposit memory expectedBounceBack = Deposit({sender: address(portal), to: bob, amount: 500e6, memo: bytes32(0)});
-        bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, expectedBounceBack, depositHashBefore));
+        Deposit memory expectedBounceBack =
+            Deposit({ sender: address(portal), to: bob, amount: 500e6, memo: bytes32(0) });
+        bytes32 expectedHash =
+            keccak256(abi.encode(DepositType.Regular, expectedBounceBack, depositHashBefore));
         assertEq(newDepositHash, expectedHash);
     }
 
@@ -1510,9 +1616,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1522,9 +1630,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1534,9 +1644,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s3")}),
-            DepositQueueTransition({prevProcessedHash: bytes32(0), nextProcessedHash: depositHash}),
-            WithdrawalQueueTransition({withdrawalQueueHash: bytes32(0)}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s3") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
+            }),
+            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
             "",
             ""
         );
@@ -1557,7 +1669,7 @@ contract ZonePortalTest is BaseTest {
         bytes32 expectedHash = keccak256(
             abi.encode(
                 DepositType.Regular,
-                Deposit({sender: alice, to: bob, amount: netAmount, memo: bytes32("test")}),
+                Deposit({ sender: alice, to: bob, amount: netAmount, memo: bytes32("test") }),
                 bytes32(0)
             )
         );
@@ -1590,11 +1702,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -1628,11 +1740,11 @@ contract ZonePortalTest is BaseTest {
         portal.submitBatch(
             uint64(block.number - 1),
             0,
-            BlockTransition({prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1")}),
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({withdrawalQueueHash: wHash}),
+            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
             "",
             ""
         );
@@ -1660,7 +1772,8 @@ contract ZonePortalTest is BaseTest {
     //////////////////////////////////////////////////////////////*/
 
     // secp256k1 generator point X (known valid point on curve)
-    bytes32 internal constant VALID_SECP256K1_X = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+    bytes32 internal constant VALID_SECP256K1_X =
+        0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
 
     function test_sequencerEncryptionKey_emptyReturnsZero() public view {
         (bytes32 x, uint8 yParity) = portal.sequencerEncryptionKey();
@@ -1870,8 +1983,9 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
 
         // Reconstruct expected hash using the same encoding as DepositQueueLib
-        EncryptedDeposit memory ed =
-            EncryptedDeposit({sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted});
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
+        });
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
         assertEq(hash, expectedHash);
     }
@@ -1929,12 +2043,15 @@ contract ZonePortalTest is BaseTest {
         pathUSD.approve(address(portal), depositAmount);
 
         // Build expected hash
-        EncryptedDeposit memory ed =
-            EncryptedDeposit({sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted});
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
+        });
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
 
         vm.expectEmit(true, true, false, true);
-        emit IZonePortal.EncryptedDepositMade(expectedHash, alice, netAmount, 0, VALID_SECP256K1_X, 0x02);
+        emit IZonePortal.EncryptedDepositMade(
+            expectedHash, alice, netAmount, 0, VALID_SECP256K1_X, 0x02
+        );
         portal.depositEncrypted(depositAmount, 0, encrypted);
         vm.stopPrank();
     }
@@ -2054,7 +2171,11 @@ contract ZonePortalTest is BaseTest {
         // Transfer sequencer to get a non-zero pendingSequencer
         portal.transferSequencer(alice);
         bytes32 slot1 = vm.load(address(portal), bytes32(uint256(1)));
-        assertEq(address(uint160(uint256(slot1))), portal.pendingSequencer(), "slot 1: pendingSequencer mismatch");
+        assertEq(
+            address(uint160(uint256(slot1))),
+            portal.pendingSequencer(),
+            "slot 1: pendingSequencer mismatch"
+        );
 
         // --- Slot 2: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) packed ---
         uint128 testRate = 42;
@@ -2070,12 +2191,16 @@ contract ZonePortalTest is BaseTest {
 
         // --- Slot 4: currentDepositQueueHash ---
         bytes32 slot4 = vm.load(address(portal), bytes32(uint256(4)));
-        assertEq(slot4, portal.currentDepositQueueHash(), "slot 4: currentDepositQueueHash mismatch");
+        assertEq(
+            slot4, portal.currentDepositQueueHash(), "slot 4: currentDepositQueueHash mismatch"
+        );
 
         // --- Slot 5: lastSyncedTempoBlockNumber ---
         bytes32 slot5 = vm.load(address(portal), bytes32(uint256(5)));
         assertEq(
-            uint64(uint256(slot5)), portal.lastSyncedTempoBlockNumber(), "slot 5: lastSyncedTempoBlockNumber mismatch"
+            uint64(uint256(slot5)),
+            portal.lastSyncedTempoBlockNumber(),
+            "slot 5: lastSyncedTempoBlockNumber mismatch"
         );
 
         // --- Slot 6: _encryptionKeys array length ---
@@ -2139,7 +2264,9 @@ contract ZonePortalTest is BaseTest {
         assertEq(loadedActivation2, entry1.activationBlock, "entry 1: activationBlock mismatch");
 
         // Verify the two keys have different activation blocks (proves vm.roll worked)
-        assertTrue(entry1.activationBlock > entry0.activationBlock, "key2 should be activated later");
+        assertTrue(
+            entry1.activationBlock > entry0.activationBlock, "key2 should be activated later"
+        );
     }
 
     /// @notice Verify that the slot constants used by ZoneInbox and ZoneConfig match
@@ -2153,60 +2280,64 @@ contract ZonePortalTest is BaseTest {
 
         portal.setSequencerEncryptionKey(keyX, keyYParity);
 
-        // These are the slot constants defined in ZoneInbox and ZoneConfig:
-        uint256 CONFIG_SEQUENCER_SLOT = 0;
-        uint256 CONFIG_PENDING_SEQUENCER_SLOT = 1;
-        uint256 INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = 4;
-        uint256 INBOX_ENCRYPTION_KEYS_SLOT = 6;
-        // (ZoneConfig also uses ENCRYPTION_KEYS_SLOT = 6)
+        // Use the shared constants from IZone.sol (single source of truth)
 
         // Verify sequencer slot (used by ZoneConfig)
-        bytes32 seqFromSlot = vm.load(address(portal), bytes32(CONFIG_SEQUENCER_SLOT));
+        bytes32 seqFromSlot = vm.load(address(portal), PORTAL_SEQUENCER_SLOT);
         assertEq(
-            address(uint160(uint256(seqFromSlot))), portal.sequencer(), "ZoneConfig SEQUENCER_SLOT reads wrong data"
+            address(uint160(uint256(seqFromSlot))),
+            portal.sequencer(),
+            "PORTAL_SEQUENCER_SLOT reads wrong data"
         );
 
         // Verify pendingSequencer slot (used by ZoneConfig)
-        bytes32 pendingFromSlot = vm.load(address(portal), bytes32(CONFIG_PENDING_SEQUENCER_SLOT));
+        bytes32 pendingFromSlot = vm.load(address(portal), PORTAL_PENDING_SEQUENCER_SLOT);
         assertEq(
             address(uint160(uint256(pendingFromSlot))),
             portal.pendingSequencer(),
-            "ZoneConfig PENDING_SEQUENCER_SLOT reads wrong data"
+            "PORTAL_PENDING_SEQUENCER_SLOT reads wrong data"
         );
 
         // Verify currentDepositQueueHash slot (used by ZoneInbox)
-        bytes32 queueHashFromSlot = vm.load(address(portal), bytes32(INBOX_CURRENT_DEPOSIT_QUEUE_HASH_SLOT));
+        bytes32 queueHashFromSlot = vm.load(address(portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
         assertEq(
             queueHashFromSlot,
             portal.currentDepositQueueHash(),
-            "ZoneInbox CURRENT_DEPOSIT_QUEUE_HASH_SLOT reads wrong data"
+            "PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT reads wrong data"
         );
 
         // Verify encryption keys array length from slot 6
-        bytes32 arrayLenRaw = vm.load(address(portal), bytes32(INBOX_ENCRYPTION_KEYS_SLOT));
+        bytes32 arrayLenRaw = vm.load(address(portal), PORTAL_ENCRYPTION_KEYS_SLOT);
         assertEq(
             uint256(arrayLenRaw),
             portal.encryptionKeyCount(),
-            "ZoneInbox/ZoneConfig ENCRYPTION_KEYS_SLOT reads wrong array length"
+            "PORTAL_ENCRYPTION_KEYS_SLOT reads wrong array length"
         );
 
         // Verify the derived slot computation matches actual key data
         // This replicates the exact logic from ZoneInbox._readEncryptionKey():
-        //   uint256 base = uint256(keccak256(abi.encode(uint256(ENCRYPTION_KEYS_SLOT))));
+        //   uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
         //   uint256 slotX = base + (keyIndex * 2);
         //   uint256 slotMeta = slotX + 1;
-        uint256 base = uint256(keccak256(abi.encode(INBOX_ENCRYPTION_KEYS_SLOT)));
+        uint256 base = uint256(keccak256(abi.encode(PORTAL_ENCRYPTION_KEYS_SLOT)));
         bytes32 loadedX = vm.load(address(portal), bytes32(base + 0));
         bytes32 loadedMeta = vm.load(address(portal), bytes32(base + 1));
 
         assertEq(loadedX, keyX, "derived slot for key x does not match actual storage");
         assertEq(
-            uint8(uint256(loadedMeta) & 0xff), keyYParity, "derived slot for key yParity does not match actual storage"
+            uint8(uint256(loadedMeta) & 0xff),
+            keyYParity,
+            "derived slot for key yParity does not match actual storage"
         );
 
         // Also verify via the public getter for full round-trip confidence
         EncryptionKeyEntry memory entry = portal.encryptionKeyAt(0);
         assertEq(loadedX, entry.x, "vm.load x != encryptionKeyAt(0).x");
-        assertEq(uint8(uint256(loadedMeta) & 0xff), entry.yParity, "vm.load yParity != encryptionKeyAt(0).yParity");
+        assertEq(
+            uint8(uint256(loadedMeta) & 0xff),
+            entry.yParity,
+            "vm.load yParity != encryptionKeyAt(0).yParity"
+        );
     }
+
 }

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -32,6 +32,7 @@ import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
 import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
 import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
+import { Vm } from "forge-std/Vm.sol";
 
 import { MockVerifier } from "./mocks/MockVerifier.sol";
 
@@ -1775,6 +1776,21 @@ contract ZonePortalTest is BaseTest {
     bytes32 internal constant VALID_SECP256K1_X =
         0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
 
+    // Well-known test private keys for secp256k1 PoP signatures
+    uint256 internal constant ENC_KEY_1 = 1; // pubkey = G (generator point)
+    uint256 internal constant ENC_KEY_2 = 2;
+    uint256 internal constant ENC_KEY_3 = 3;
+
+    /// @notice Helper: set encryption key with proof of possession using vm.createWallet + vm.sign
+    function _setEncKeyWithPoP(uint256 privateKey) internal returns (bytes32 x, uint8 yParity) {
+        Vm.Wallet memory w = vm.createWallet(privateKey);
+        x = bytes32(w.publicKeyX);
+        yParity = w.publicKeyY % 2 == 0 ? 0x02 : 0x03;
+        bytes32 message = keccak256(abi.encode(address(portal), x, yParity));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(w.privateKey, message);
+        portal.setSequencerEncryptionKey(x, yParity, v, r, s);
+    }
+
     function test_sequencerEncryptionKey_emptyReturnsZero() public view {
         (bytes32 x, uint8 yParity) = portal.sequencerEncryptionKey();
         assertEq(x, bytes32(0));
@@ -1782,10 +1798,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_setSequencerEncryptionKey_success() public {
-        bytes32 x = keccak256("key1");
-        uint8 yParity = 0x02;
-
-        portal.setSequencerEncryptionKey(x, yParity);
+        (bytes32 x, uint8 yParity) = _setEncKeyWithPoP(ENC_KEY_1);
 
         (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
         assertEq(storedX, x);
@@ -1796,49 +1809,47 @@ contract ZonePortalTest is BaseTest {
     function test_setSequencerEncryptionKey_onlySequencer() public {
         vm.prank(alice);
         vm.expectRevert(IZonePortal.NotSequencer.selector);
-        portal.setSequencerEncryptionKey(keccak256("key"), 0x02);
+        portal.setSequencerEncryptionKey(bytes32(uint256(1)), 0x02, 27, bytes32(0), bytes32(0));
     }
 
     function test_setSequencerEncryptionKey_multipleKeys() public {
-        bytes32 x1 = keccak256("key1");
-        bytes32 x2 = keccak256("key2");
-
-        portal.setSequencerEncryptionKey(x1, 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
         vm.roll(block.number + 100);
-        portal.setSequencerEncryptionKey(x2, 0x03);
+        (bytes32 x2, uint8 yParity2) = _setEncKeyWithPoP(ENC_KEY_2);
 
         assertEq(portal.encryptionKeyCount(), 2);
 
         // sequencerEncryptionKey returns the latest key
         (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
         assertEq(storedX, x2);
-        assertEq(storedYParity, 0x03);
+        assertEq(storedYParity, yParity2);
     }
 
     function test_setSequencerEncryptionKey_emitsEvent() public {
-        bytes32 x = keccak256("key1");
-        uint8 yParity = 0x02;
-
+        Vm.Wallet memory w = vm.createWallet(ENC_KEY_1);
+        bytes32 x = bytes32(w.publicKeyX);
+        uint8 yParity = w.publicKeyY % 2 == 0 ? 0x02 : 0x03;
         vm.expectEmit(true, true, true, true);
         emit IZonePortal.SequencerEncryptionKeyUpdated(x, yParity, 0, uint64(block.number));
-        portal.setSequencerEncryptionKey(x, yParity);
+        // can't use helper since expectEmit must come before the call
+        bytes32 message = keccak256(abi.encode(address(portal), x, yParity));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(w.privateKey, message);
+        portal.setSequencerEncryptionKey(x, yParity, v, r, s);
     }
 
     function test_encryptionKeyAt_success() public {
-        bytes32 x1 = keccak256("key1");
-        portal.setSequencerEncryptionKey(x1, 0x02);
+        (bytes32 x1, uint8 yParity1) = _setEncKeyWithPoP(ENC_KEY_1);
 
         vm.roll(block.number + 50);
-        bytes32 x2 = keccak256("key2");
-        portal.setSequencerEncryptionKey(x2, 0x03);
+        (bytes32 x2, uint8 yParity2) = _setEncKeyWithPoP(ENC_KEY_2);
 
         EncryptionKeyEntry memory entry0 = portal.encryptionKeyAt(0);
         assertEq(entry0.x, x1);
-        assertEq(entry0.yParity, 0x02);
+        assertEq(entry0.yParity, yParity1);
 
         EncryptionKeyEntry memory entry1 = portal.encryptionKeyAt(1);
         assertEq(entry1.x, x2);
-        assertEq(entry1.yParity, 0x03);
+        assertEq(entry1.yParity, yParity2);
     }
 
     function test_encryptionKeyAt_revertsOnInvalidIndex() public {
@@ -1849,23 +1860,20 @@ contract ZonePortalTest is BaseTest {
     function test_encryptionKeyAtBlock_binarySearch() public {
         // Set key1 at block 10
         vm.roll(10);
-        bytes32 x1 = keccak256("key1");
-        portal.setSequencerEncryptionKey(x1, 0x02);
+        (bytes32 x1, uint8 yParity1) = _setEncKeyWithPoP(ENC_KEY_1);
 
         // Set key2 at block 100
         vm.roll(100);
-        bytes32 x2 = keccak256("key2");
-        portal.setSequencerEncryptionKey(x2, 0x03);
+        (bytes32 x2,) = _setEncKeyWithPoP(ENC_KEY_2);
 
         // Set key3 at block 200
         vm.roll(200);
-        bytes32 x3 = keccak256("key3");
-        portal.setSequencerEncryptionKey(x3, 0x02);
+        (bytes32 x3,) = _setEncKeyWithPoP(ENC_KEY_3);
 
         // Query at block 10 -> key1
         (bytes32 rx, uint8 ry, uint256 ri) = portal.encryptionKeyAtBlock(10);
         assertEq(rx, x1);
-        assertEq(ry, 0x02);
+        assertEq(ry, yParity1);
         assertEq(ri, 0);
 
         // Query at block 50 -> key1 (still active)
@@ -1895,7 +1903,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_isEncryptionKeyValid_currentKeyNeverExpires() public {
-        portal.setSequencerEncryptionKey(keccak256("key"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         (bool valid, uint64 expiresAt) = portal.isEncryptionKeyValid(0);
         assertTrue(valid);
@@ -1909,11 +1917,11 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_isEncryptionKeyValid_oldKeyValidDuringGrace() public {
-        portal.setSequencerEncryptionKey(keccak256("key1"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint256 key2Block = block.number + 100;
         vm.roll(key2Block);
-        portal.setSequencerEncryptionKey(keccak256("key2"), 0x03);
+        _setEncKeyWithPoP(ENC_KEY_2);
 
         // Key 0 should be valid during grace period
         vm.roll(key2Block + ENCRYPTION_KEY_GRACE_PERIOD - 1);
@@ -1922,11 +1930,11 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_isEncryptionKeyValid_oldKeyExpiredAfterGrace() public {
-        portal.setSequencerEncryptionKey(keccak256("key1"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint256 key2Block = block.number + 100;
         vm.roll(key2Block);
-        portal.setSequencerEncryptionKey(keccak256("key2"), 0x03);
+        _setEncKeyWithPoP(ENC_KEY_2);
 
         // Key 0 should be expired after grace period
         vm.roll(key2Block + ENCRYPTION_KEY_GRACE_PERIOD);
@@ -1939,6 +1947,33 @@ contract ZonePortalTest is BaseTest {
         assertFalse(valid);
         (valid,) = portal.isEncryptionKeyValid(999);
         assertFalse(valid);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    PROOF-OF-POSSESSION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_setSequencerEncryptionKey_revertsOnInvalidPoP() public {
+        Vm.Wallet memory w = vm.createWallet(ENC_KEY_1);
+        bytes32 x = bytes32(w.publicKeyX);
+        uint8 yParity = w.publicKeyY % 2 == 0 ? 0x02 : 0x03;
+
+        // Sign with a DIFFERENT private key (wrong PoP)
+        bytes32 message = keccak256(abi.encode(address(portal), x, yParity));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ENC_KEY_2, message);
+
+        vm.expectRevert(IZonePortal.InvalidProofOfPossession.selector);
+        portal.setSequencerEncryptionKey(x, yParity, v, r, s);
+    }
+
+    function test_setSequencerEncryptionKey_revertsOnInvalidYParity() public {
+        vm.expectRevert(IZonePortal.InvalidEphemeralPubkey.selector);
+        portal.setSequencerEncryptionKey(bytes32(uint256(1)), 0x04, 27, bytes32(0), bytes32(0));
+    }
+
+    function test_setSequencerEncryptionKey_revertsOnInvalidX() public {
+        vm.expectRevert(IZonePortal.InvalidEphemeralPubkey.selector);
+        portal.setSequencerEncryptionKey(bytes32(0), 0x02, 27, bytes32(0), bytes32(0));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1956,7 +1991,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_success() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
@@ -1969,7 +2004,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_hashChainMatchesLibrary() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
         uint128 fee = portal.calculateDepositFee();
@@ -1991,7 +2026,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_mixedQueue() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 amount = 1000e6;
 
@@ -2012,7 +2047,7 @@ contract ZonePortalTest is BaseTest {
 
     function test_depositEncrypted_deductsFee() public {
         portal.setZoneGasRate(1); // 1 token per gas -> fee = 100_000
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
         uint128 expectedFee = uint128(100_000) * 1; // FIXED_DEPOSIT_GAS * zoneGasRate
@@ -2031,7 +2066,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_emitsEvent() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
         uint128 fee = portal.calculateDepositFee();
@@ -2057,12 +2092,12 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnExpiredKey() public {
-        portal.setSequencerEncryptionKey(keccak256("key1"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         // Rotate to key2
         uint256 key2Block = block.number + 100;
         vm.roll(key2Block);
-        portal.setSequencerEncryptionKey(keccak256("key2"), 0x03);
+        _setEncKeyWithPoP(ENC_KEY_2);
 
         // Move past grace period for key1
         vm.roll(key2Block + ENCRYPTION_KEY_GRACE_PERIOD);
@@ -2089,7 +2124,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnInvalidYParity() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
@@ -2109,7 +2144,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnInvalidEphemeralX() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
@@ -2130,7 +2165,7 @@ contract ZonePortalTest is BaseTest {
 
     function test_depositEncrypted_revertsOnDepositTooSmall() public {
         portal.setZoneGasRate(1); // fee = 100_000
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 100_000);
@@ -2141,7 +2176,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnCiphertextTooShort() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
         payload.ciphertext = new bytes(63); // one byte too short
@@ -2157,7 +2192,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnCiphertextTooLong() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
         payload.ciphertext = new bytes(65); // one byte too long
@@ -2173,7 +2208,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnEmptyCiphertext() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
         payload.ciphertext = new bytes(0);
@@ -2187,7 +2222,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnOversizedCiphertext() public {
-        portal.setSequencerEncryptionKey(keccak256("seqKey"), 0x02);
+        _setEncKeyWithPoP(ENC_KEY_1);
 
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
         payload.ciphertext = new bytes(1024); // large ciphertext (DoS vector)
@@ -2282,16 +2317,11 @@ contract ZonePortalTest is BaseTest {
     ///            base + (index * 2):     x (bytes32)
     ///            base + (index * 2) + 1: yParity (uint8) + activationBlock (uint64) [packed]
     function test_storageLayout_encryptionKeysArray() public {
-        bytes32 keyX1 = keccak256("encryption-key-1");
-        uint8 keyYParity1 = 0x02;
-        bytes32 keyX2 = keccak256("encryption-key-2");
-        uint8 keyYParity2 = 0x03;
-
         // Add two keys at different blocks
-        portal.setSequencerEncryptionKey(keyX1, keyYParity1);
+        (bytes32 keyX1, uint8 keyYParity1) = _setEncKeyWithPoP(ENC_KEY_1);
 
         vm.roll(block.number + 100);
-        portal.setSequencerEncryptionKey(keyX2, keyYParity2);
+        (bytes32 keyX2, uint8 keyYParity2) = _setEncKeyWithPoP(ENC_KEY_2);
 
         // Verify array length at slot 6
         uint256 arraySlot = 6;
@@ -2337,10 +2367,7 @@ contract ZonePortalTest is BaseTest {
     ///      slot computation logic used by ZoneInbox._readEncryptionKey() and
     ///      ZoneConfig.sequencerEncryptionKey() to ensure they both read the correct data.
     function test_storageLayout_crossContractConsistency() public {
-        bytes32 keyX = keccak256("cross-contract-key");
-        uint8 keyYParity = 0x03;
-
-        portal.setSequencerEncryptionKey(keyX, keyYParity);
+        (bytes32 keyX, uint8 keyYParity) = _setEncKeyWithPoP(ENC_KEY_1);
 
         // Use the shared constants from IZone.sol (single source of truth)
 


### PR DESCRIPTION
## Summary

- Add support for encrypted deposits where recipient and memo are encrypted using the sequencer's public key
- Only the sequencer can decrypt and credit the correct recipient on the zone

## Encryption scheme

ECIES with secp256k1:
1. Sequencer publishes secp256k1 encryption key via `setSequencerEncryptionKey()`
2. User generates ephemeral keypair, derives shared secret via ECDH
3. User encrypts `(to || memo)` with AES-256-GCM
4. Portal stores encrypted deposit; only `sender` and `amount` are public

## New types

- `EncryptedDepositPayload`: ephemeral pubkey + ciphertext + nonce + GCM tag
- `EncryptedDeposit`: sender + amount + encrypted payload

## New functions on IZonePortal

- `sequencerEncryptionKey() / setSequencerEncryptionKey()` - manage encryption key
- `depositEncrypted(amount, encryptedPayload)` - make encrypted deposit

## Privacy properties

| Field | Visibility | Reason |
|-------|------------|--------|
| `sender` | Public | Needed for refunds |
| `amount` | Public | Needed for accounting |
| `to` | **Encrypted** | Privacy |
| `memo` | **Encrypted** | Privacy |

## Security note

Encryption is not post quantum. Data might eventually be decipherable by anyone with quantum computers.



Made with [Cursor](https://cursor.com)