### PR TITLE
Rename "gas token" to "zone token"

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -580,7 +580,7 @@ The receiver must return `IWithdrawalReceiver.onWithdrawalReceived.selector` to 
 
 ### Zone predeploys
 
-#### Zone zone token
+#### Zone token
 
 The zone's zone token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -582,7 +582,7 @@ The receiver must return `IWithdrawalReceiver.onWithdrawalReceived.selector` to 
 
 #### Zone token
 
-The zone's zone token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
+The zone token is the only bridged TIP-20 from Tempo allowed on the zone. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
 
 #### TempoState predeploy
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -6,7 +6,7 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 - Create a Tempo-native validium called a zone.
 - Each zone has exactly one permissioned sequencer.
-- Each zone bridges exactly one TIP-20 token, which is also the zone gas token.
+- Each zone bridges exactly one TIP-20 token, which is also the zone zone token.
 - Settlement uses fast validity proofs or TEE attestations (ZK or TEE). Data availability is fully trusted to the sequencer.
 - Cross-chain operations are Tempo-centric: bridge in (simple deposit), bridge out (with optional callback to receiver contracts for Tempo composability).
 - Verifier is abstracted behind a minimal `IVerifier` interface.
@@ -22,8 +22,8 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 - Tempo: the base chain.
 - Zone: the validium chain anchored to Tempo.
-- Gas token: the zone's only TIP-20, bridged from Tempo.
-- Portal: the Tempo-side contract that escrows the gas token and finalizes exits.
+- Zone token: the zone's only TIP-20, bridged from Tempo.
+- Portal: the Tempo-side contract that escrows the zone token and finalizes exits.
 - Batch: a sequencer-produced commitment covering one or more zone blocks. The batch **must** end with a single `finalizeWithdrawalBatch()` call in the final block, and intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The sequencer controls batch frequency.
 
 ## System overview
@@ -37,7 +37,7 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 ### Tempo contracts
 
 - `ZoneFactory`: creates zones and registers parameters.
-- `ZonePortal`: per-zone portal that escrows the gas token on Tempo and finalizes exits.
+- `ZonePortal`: per-zone portal that escrows the zone token on Tempo and finalizes exits.
 
 ### Zone components (off-chain or zone-side)
 
@@ -49,12 +49,12 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 A zone is created via `ZoneFactory.createZone(...)` with:
 
-- `token`: the Tempo TIP-20 address to bridge. This is the only bridged token and the gas token.
+- `token`: the Tempo TIP-20 address to bridge. This is the only bridged token and the zone token.
 - `sequencer`: permissioned sequencer address.
 - `verifier`: `IVerifier` implementation for proof or attestation.
 - `zoneParams`: initial configuration (genesis block hash, genesis Tempo block hash/number).
 
-The factory deploys a `ZonePortal` that escrows the gas token on Tempo. The zone genesis includes the portal address and the gas token configuration.
+The factory deploys a `ZonePortal` that escrows the zone token on Tempo. The zone genesis includes the portal address and the zone token configuration.
 
 ### Sequencer transfer
 
@@ -68,8 +68,8 @@ This applies to all zone contracts: `ZonePortal` (Tempo-side), `ZoneInbox`, `Zon
 ## Execution and fees
 
 - The zone reuses Tempo's fee units and accounting model.
-- The fee token is always the gas token. There is no fee token selection.
-- Transactions use Tempo transaction semantics for fee payer, max fee per gas, and gas limit. The fee token field is fixed to the gas token.
+- The fee token is always the zone token. There is no fee token selection.
+- Transactions use Tempo transaction semantics for fee payer, max fee per gas, and gas limit. The fee token field is fixed to the zone token.
 
 ### Deposit fees
 
@@ -279,7 +279,7 @@ This section defines the functions and interfaces used by the design. The signat
 ### Common types
 
 ```solidity
-/// @notice Interface for the zone's gas token (TIP-20 with mint/burn for system)
+/// @notice Interface for the zone's zone token (TIP-20 with mint/burn for system)
 interface IZoneGasToken {
     function mint(address to, uint256 amount) external;
     function burn(address from, uint256 amount) external;
@@ -497,7 +497,7 @@ interface IZonePortal {
     /// @notice Set the sequencer's public key. Only callable by the sequencer.
     function setSequencerPubkey(bytes32 pubkey) external;
 
-    /// @notice Deposit gas token into the zone. Returns the new current deposit queue hash.
+    /// @notice Deposit zone token into the zone. Returns the new current deposit queue hash.
     function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
 
     /// @notice Process the next withdrawal from the queue. Only callable by the sequencer.
@@ -523,14 +523,14 @@ interface IZonePortal {
 
 #### Zone messenger (Tempo)
 
-Each zone has a dedicated messenger contract on Tempo. The portal gives the messenger max approval for the gas token. Withdrawal callbacks originate from this contract, not the portal.
+Each zone has a dedicated messenger contract on Tempo. The portal gives the messenger max approval for the zone token. Withdrawal callbacks originate from this contract, not the portal.
 
 ```solidity
 interface IZoneMessenger {
     /// @notice Returns the zone's portal address
     function portal() external view returns (address);
 
-    /// @notice Returns the gas token address
+    /// @notice Returns the zone token address
     function token() external view returns (address);
 
     /// @notice Returns the L2 sender during callback execution
@@ -580,9 +580,9 @@ The receiver must return `IWithdrawalReceiver.onWithdrawalReceived.selector` to 
 
 ### Zone predeploys
 
-#### Zone gas token
+#### Zone zone token
 
-The zone's gas token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
+The zone's zone token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
 
 #### TempoState predeploy
 
@@ -687,7 +687,7 @@ interface IZoneInbox {
     /// @notice The TempoState predeploy address.
     function tempoState() external view returns (TempoState);
 
-    /// @notice The gas token (TIP-20 at same address as Tempo).
+    /// @notice The zone token (TIP-20 at same address as Tempo).
     function gasToken() external view returns (IZoneGasToken);
 
     /// @notice Current sequencer address.
@@ -719,7 +719,7 @@ interface IZoneInbox {
 The sequencer observes `DepositMade` events on the Tempo portal and relays them to the zone via `advanceTempo`. This function:
 
 1. Calls `TempoState.finalizeTempo(header)` to advance the zone's view of Tempo
-2. Processes deposits in order, building the hash chain and minting gas tokens
+2. Processes deposits in order, building the hash chain and minting zone tokens
 3. Reads `currentDepositQueueHash` from the Tempo portal's storage via `TempoState.readTempoStorageSlot()`
 4. Validates the resulting hash matches Tempo's current state
 
@@ -727,7 +727,7 @@ This combined approach ensures Tempo state advancement and deposit processing ar
 
 #### Zone outbox
 
-The zone outbox handles withdrawal requests. Users approve the outbox to spend their gas tokens, then call `requestWithdrawal`. The outbox stores pending withdrawals in an array. When the sequencer is ready to finalize a **batch**, it calls `finalizeWithdrawalBatch(count)` as a system transaction at the end of the **final block** in that batch. This constructs the withdrawal queue hash on-chain and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to storage. Intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The call is required even if there are zero withdrawals (use `count = 0`) so the withdrawal batch index advances. The event is emitted for observability, but the proof reads from state (via the `lastBatch` storage) rather than parsing event logs.
+The zone outbox handles withdrawal requests. Users approve the outbox to spend their zone tokens, then call `requestWithdrawal`. The outbox stores pending withdrawals in an array. When the sequencer is ready to finalize a **batch**, it calls `finalizeWithdrawalBatch(count)` as a system transaction at the end of the **final block** in that batch. This constructs the withdrawal queue hash on-chain and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to storage. Intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The call is required even if there are zero withdrawals (use `count = 0`) so the withdrawal batch index advances. The event is emitted for observability, but the proof reads from state (via the `lastBatch` storage) rather than parsing event logs.
 
 ```solidity
 /// @notice Withdrawal batch parameters stored in state for proof access
@@ -764,7 +764,7 @@ interface IZoneOutbox {
     event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
 
-    /// @notice The gas token (same as Tempo portal's token).
+    /// @notice The zone token (same as Tempo portal's token).
     function gasToken() external view returns (IZoneGasToken);
 
     /// @notice Current sequencer address.
@@ -804,7 +804,7 @@ interface IZoneOutbox {
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo.
-    /// @dev Caller must have approved the outbox to spend `amount + fee` of gas tokens.
+    /// @dev Caller must have approved the outbox to spend `amount + fee` of zone tokens.
     ///      Tokens are burned immediately and withdrawal is stored in pending array.
     /// @param to The Tempo recipient address.
     /// @param amount Amount to send to recipient (fee is additional).
@@ -945,8 +945,8 @@ The key insight: structure the hash chain so the **on-chain operation touches th
 ## Bridging in (Tempo to zone)
 
 1. User calls `ZonePortal.deposit(to, amount, memo)` on Tempo.
-2. `ZonePortal` transfers `amount` of the gas token into escrow and appends a deposit to the queue: `currentDepositQueueHash = keccak256(abi.encode(deposit, currentDepositQueueHash))`.
-3. The sequencer observes `DepositMade` events and processes deposits in order via `ZoneInbox.advanceTempo()`, crediting `to` with `amount` of the gas token (TIP-20 balance). Deposits always succeed—there is no callback or bounce mechanism.
+2. `ZonePortal` transfers `amount` of the zone token into escrow and appends a deposit to the queue: `currentDepositQueueHash = keccak256(abi.encode(deposit, currentDepositQueueHash))`.
+3. The sequencer observes `DepositMade` events and processes deposits in order via `ZoneInbox.advanceTempo()`, crediting `to` with `amount` of the zone token (TIP-20 balance). Deposits always succeed—there is no callback or bounce mechanism.
 4. A batch proof/attestation must prove the zone correctly processed deposits by validating the Tempo state read inside the proof.
 5. After the batch is accepted, `lastSyncedTempoBlockNumber` is updated to record how far Tempo state was synced.
 
@@ -1048,7 +1048,7 @@ Withdrawals can fail for various reasons. The system handles failures gracefully
 Withdrawals can fail due to:
 - **Transfer failure**: `transfer` or `transferFrom` reverts (includes gasLimit = 0 cases)
 - **TIP-403 policy**: Recipient not authorized under the token's transfer policy
-- **Token paused**: The gas token is globally paused
+- **Token paused**: The zone token is globally paused
 - **Callback revert**: The receiver contract reverts (out of gas, logic error, etc.)
 - **Callback rejection**: Receiver returns wrong selector
 
@@ -1066,7 +1066,7 @@ Tempo TIP-20 tokens use TIP-403 for transfer authorization:
 - Policy types: WHITELIST (must be in set) or BLACKLIST (must not be in set)
 - Policy ID 1 is "always-allow" (default for most tokens)
 
-Zone creators SHOULD choose gas tokens with `transferPolicyId == 1` to avoid complexity. If using restricted policies:
+Zone creators SHOULD choose zone tokens with `transferPolicyId == 1` to avoid complexity. If using restricted policies:
 - The portal address MUST be whitelisted
 - Users should set `fallbackRecipient` to an address they control
 
@@ -1077,8 +1077,8 @@ Zone creators SHOULD choose gas tokens with `transferPolicyId == 1` to avoid com
 - Withdrawals with callbacks go through the zone messenger with a user-specified gas limit. The messenger does `transferFrom` + callback atomically; any transfer or callback failure triggers a bounce-back to `fallbackRecipient`.
 - Deposits are locked on Tempo until a verified batch consumes them.
 - **Bounce-back guarantees**: Failed withdrawals bounce back to zone `fallbackRecipient`. Users always retain their funds.
-- **TIP-403 policy changes**: If the gas token's policy restricts the portal, withdrawals will fail and bounce back.
-- **Token pause**: If the gas token is paused, withdrawals bounce back to zone.
+- **TIP-403 policy changes**: If the zone token's policy restricts the portal, withdrawals will fail and bounce back.
+- **Token pause**: If the zone token is paused, withdrawals bounce back to zone.
 
 ## Implementation architecture
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -6,7 +6,7 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 - Create a Tempo-native validium called a zone.
 - Each zone has exactly one permissioned sequencer.
-- Each zone bridges exactly one TIP-20 token, which is also the zone zone token.
+- Each zone bridges exactly one TIP-20 token, which is called its *zone token*. The zone token also serves as the gas token for the chain.
 - Settlement uses fast validity proofs or TEE attestations (ZK or TEE). Data availability is fully trusted to the sequencer.
 - Cross-chain operations are Tempo-centric: bridge in (simple deposit), bridge out (with optional callback to receiver contracts for Tempo composability).
 - Verifier is abstracted behind a minimal `IVerifier` interface.

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-/// @title IZoneGasToken
-/// @notice Interface for the zone's gas token (TIP-20 with mint/burn for system)
-interface IZoneGasToken {
+/// @title IZoneToken
+/// @notice Interface for the zone's zone token (TIP-20 with mint/burn for system)
+interface IZoneToken {
     function mint(address to, uint256 amount) external;
     function burn(address from, uint256 amount) external;
     function transfer(address to, uint256 amount) external returns (bool);
@@ -220,7 +220,7 @@ interface IZoneMessenger {
     /// @notice Returns the zone's portal address
     function portal() external view returns (address);
 
-    /// @notice Returns the gas token address
+    /// @notice Returns the zone token address
     function token() external view returns (address);
 
     /// @notice Returns the L2 sender during callback execution
@@ -351,8 +351,8 @@ interface IZoneInbox {
     /// @notice The TempoState predeploy address
     function tempoState() external view returns (ITempoState);
 
-    /// @notice The gas token (TIP-20 at same address as Tempo)
-    function gasToken() external view returns (IZoneGasToken);
+    /// @notice The zone token (TIP-20 at same address as Tempo)
+    function gasToken() external view returns (IZoneToken);
 
     /// @notice Current sequencer address
     function sequencer() external view returns (address);
@@ -409,8 +409,8 @@ interface IZoneOutbox {
     event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
 
-    /// @notice The gas token (same as Tempo portal's token)
-    function gasToken() external view returns (IZoneGasToken);
+    /// @notice The zone token (same as Tempo portal's token)
+    function gasToken() external view returns (IZoneToken);
 
     /// @notice Current sequencer address
     function sequencer() external view returns (address);

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Deposit, IZoneGasToken, IZoneInbox, ITempoState } from "./IZone.sol";
+import { Deposit, IZoneToken, IZoneInbox, ITempoState } from "./IZone.sol";
 import { TempoState } from "./TempoState.sol";
 
 /// @title ZoneInbox
@@ -19,8 +19,8 @@ contract ZoneInbox is IZoneInbox {
     /// @notice The TempoState predeploy address (stored as concrete type for internal use)
     TempoState internal immutable _tempoState;
 
-    /// @notice The gas token (TIP-20 at same address as Tempo)
-    IZoneGasToken public immutable gasToken;
+    /// @notice The zone token (TIP-20 at same address as Tempo)
+    IZoneToken public immutable gasToken;
 
     /// @notice Current sequencer address
     address public sequencer;
@@ -54,7 +54,7 @@ contract ZoneInbox is IZoneInbox {
     ) {
         tempoPortal = _tempoPortalAddr;
         _tempoState = TempoState(_tempoStateAddr);
-        gasToken = IZoneGasToken(_gasToken);
+        gasToken = IZoneToken(_gasToken);
         sequencer = _sequencer;
     }
 
@@ -113,7 +113,7 @@ contract ZoneInbox is IZoneInbox {
             // Advance the hash chain (matches Tempo's deposit queue structure)
             currentHash = keccak256(abi.encode(d, currentHash));
 
-            // Mint gas tokens to the recipient
+            // Mint zone tokens to the recipient
             gasToken.mint(d.to, d.amount);
 
             emit DepositProcessed(currentHash, d.sender, d.to, d.amount, d.memo);

--- a/docs/specs/src/zone/ZoneMessenger.sol
+++ b/docs/specs/src/zone/ZoneMessenger.sol
@@ -7,7 +7,7 @@ import { IZoneMessenger, IWithdrawalReceiver } from "./IZone.sol";
 /// @title ZoneMessenger
 /// @notice Per-zone messenger that handles withdrawal callbacks
 /// @dev Deployed by ZoneFactory for each zone. The portal gives the messenger max approval
-///      for the gas token. Withdrawal callbacks originate from this contract, not the portal.
+///      for the zone token. Withdrawal callbacks originate from this contract, not the portal.
 contract ZoneMessenger is IZoneMessenger {
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -16,7 +16,7 @@ contract ZoneMessenger is IZoneMessenger {
     /// @notice The zone's portal address
     address public immutable portal;
 
-    /// @notice The gas token address
+    /// @notice The zone token address
     address public immutable token;
 
     /// @notice The L2 sender during callback execution (transient)

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { IZoneOutbox, IZoneGasToken, Withdrawal, LastBatch } from "./IZone.sol";
+import { IZoneOutbox, IZoneToken, Withdrawal, LastBatch } from "./IZone.sol";
 import { EMPTY_SENTINEL } from "./WithdrawalQueueLib.sol";
 
 /// @title ZoneOutbox
 /// @notice Zone-side predeploy for requesting withdrawals back to Tempo
-/// @dev Burns gas tokens and stores pending withdrawals. Sequencer calls finalizeWithdrawalBatch()
+/// @dev Burns zone tokens and stores pending withdrawals. Sequencer calls finalizeWithdrawalBatch()
 ///      at the end of a block to construct withdrawal queue hash on-chain.
 contract ZoneOutbox is IZoneOutbox {
     /*//////////////////////////////////////////////////////////////
@@ -21,8 +21,8 @@ contract ZoneOutbox is IZoneOutbox {
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The gas token (TIP-20 at same address as Tempo)
-    IZoneGasToken public immutable gasToken;
+    /// @notice The zone token (TIP-20 at same address as Tempo)
+    IZoneToken public immutable gasToken;
 
     /// @notice Current sequencer address
     address public sequencer;
@@ -30,11 +30,11 @@ contract ZoneOutbox is IZoneOutbox {
     /// @notice Pending sequencer for two-step transfer
     address public pendingSequencer;
 
-    /// @notice Base fee for withdrawal processing (in gas token units)
+    /// @notice Base fee for withdrawal processing (in zone token units)
     /// @dev Covers fixed costs of processWithdrawal on Tempo
     uint128 public withdrawalBaseFee;
 
-    /// @notice Fee per unit of gasLimit (in gas token units)
+    /// @notice Fee per unit of gasLimit (in zone token units)
     /// @dev Covers callback execution costs on Tempo: fee = baseFee + gasLimit * gasFeeRate
     uint128 public withdrawalGasFeeRate;
 
@@ -71,7 +71,7 @@ contract ZoneOutbox is IZoneOutbox {
         address _gasToken,
         address _sequencer
     ) {
-        gasToken = IZoneGasToken(_gasToken);
+        gasToken = IZoneToken(_gasToken);
         sequencer = _sequencer;
     }
 
@@ -121,7 +121,7 @@ contract ZoneOutbox is IZoneOutbox {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Request a withdrawal from the zone back to Tempo
-    /// @dev Caller must have approved the outbox to spend `amount + fee` of gas tokens.
+    /// @dev Caller must have approved the outbox to spend `amount + fee` of zone tokens.
     ///      The outbox burns the tokens and stores the withdrawal. The sequencer
     ///      calls finalizeWithdrawalBatch() to construct the withdrawal queue hash.
     /// @param to The Tempo recipient address

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -17,7 +17,7 @@ import { WithdrawalQueue, WithdrawalQueueLib } from "./WithdrawalQueueLib.sol";
 import { BLOCKHASH_HISTORY, IBlockHashHistory } from "./BlockHashHistory.sol";
 
 /// @title ZonePortal
-/// @notice Per-zone portal that escrows gas tokens on Tempo and manages deposits/withdrawals
+/// @notice Per-zone portal that escrows zone tokens on Tempo and manages deposits/withdrawals
 contract ZonePortal is IZonePortal {
     using WithdrawalQueueLib for WithdrawalQueue;
 
@@ -71,7 +71,7 @@ contract ZonePortal is IZonePortal {
         blockHash = _genesisBlockHash;
         genesisTempoBlockNumber = _genesisTempoBlockNumber;
 
-        // Give messenger max approval for the gas token
+        // Give messenger max approval for the zone token
         ITIP20(_token).approve(_messenger, type(uint256).max);
     }
 
@@ -132,7 +132,7 @@ contract ZonePortal is IZonePortal {
                                DEPOSITS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Deposit gas token into the zone. Returns the new current deposit queue hash.
+    /// @notice Deposit zone token into the zone. Returns the new current deposit queue hash.
     function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash) {
         // TIP-20 transfers revert on failure, so no boolean check is needed here.
         ITIP20(token).transferFrom(msg.sender, address(this), amount);


### PR DESCRIPTION
Rename all references from "gas token" to "zone token" throughout the codebase

The name reflects the function of being the token for all payments on the zone not just gas