### PR TITLE
feat(zone): centralize L1 sequencer management and restrict Tempo state reads

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -701,7 +701,7 @@ interface ITempoState {
 
     /// @notice Finalize a Tempo block header. Only callable by ZoneInbox.
     /// @dev Validates chain continuity (parent hash must match, number must be +1).
-    ///      Called by ZoneInbox.advanceTempo(). Protocol enforces advanceTempo() runs as system transaction.
+    ///      Called by ZoneInbox.advanceTempo(). Executor enforces ZoneInbox-only access.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external;
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -58,12 +58,12 @@ The factory deploys a `ZonePortal` that escrows the zone token on Tempo. The zon
 
 ### Sequencer transfer
 
-The sequencer can transfer control to a new address via a two-step process:
+The sequencer can transfer control to a new address via a two-step process on **Tempo L1 only**:
 
-1. Current sequencer calls `transferSequencer(newSequencer)` to nominate a new sequencer
-2. New sequencer calls `acceptSequencer()` to accept the transfer
+1. Current sequencer calls `ZonePortal.transferSequencer(newSequencer)` to nominate a new sequencer
+2. New sequencer calls `ZonePortal.acceptSequencer()` to accept the transfer
 
-This applies to all zone contracts: `ZonePortal` (Tempo-side), `ZoneInbox`, `ZoneOutbox`, and `TempoState` (zone-side). The two-step pattern prevents accidental transfers to incorrect addresses.
+**Sequencer management is centralized on L1 (Tempo).** Zone-side system contracts (`ZoneInbox`, `ZoneOutbox`) read the sequencer from L1 via `ZoneConfig`, which queries `TempoState` to get the sequencer address from the finalized `ZonePortal` storage. This eliminates duplicate sequencer management logic and ensures L1 is the single source of truth. The two-step pattern prevents accidental transfers to incorrect addresses.
 
 ## Execution and fees
 
@@ -633,22 +633,44 @@ The receiver must return `IWithdrawalReceiver.onWithdrawalReceived.selector` to 
 
 The zone's zone token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
 
-#### TempoState predeploy
+#### ZoneConfig predeploy
 
-The TempoState predeploy allows zones to verify they have a correct view of Tempo state. It stores the Tempo wrapper fields and selected inner Ethereum header fields, and provides storage reading functionality.
+ZoneConfig is the central zone configuration contract that provides access to zone metadata and reads the sequencer from L1. It is deployed at **0x1c00000000000000000000000000000000000003**.
 
 ```solidity
-// Predeploy address: 0x1c00000000000000000000000000000000000000
-interface ITempoState {
-    event TempoBlockFinalized(bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot);
-    event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
-    event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+interface IZoneConfig {
+    /// @notice Zone token address (TIP-20 at same address as Tempo)
+    function zoneToken() external view returns (address);
 
-    /// @notice Current sequencer address
+    /// @notice L1 ZonePortal address
+    function tempoPortal() external view returns (address);
+
+    /// @notice TempoState predeploy for L1 reads
+    function tempoState() external view returns (ITempoState);
+
+    /// @notice Get current sequencer by reading from L1 ZonePortal
     function sequencer() external view returns (address);
 
-    /// @notice Pending sequencer for two-step transfer
+    /// @notice Get pending sequencer by reading from L1 ZonePortal
     function pendingSequencer() external view returns (address);
+
+    /// @notice Check if an address is the current sequencer
+    function isSequencer(address account) external view returns (bool);
+
+    /// @notice Get zone token as IZoneToken interface
+    function getZoneToken() external view returns (IZoneToken);
+}
+```
+
+ZoneConfig reads the sequencer address from the finalized L1 `ZonePortal` storage via `TempoState.readTempoStorageSlot()`. This makes L1 the **single source of truth** for sequencer management, eliminating duplicate sequencer logic on zone-side contracts. Zone system contracts (`ZoneInbox`, `ZoneOutbox`) reference `ZoneConfig` for sequencer checks.
+
+#### TempoState predeploy
+
+The TempoState predeploy allows zones to verify they have a correct view of Tempo state. It stores the Tempo wrapper fields and selected inner Ethereum header fields, and provides storage reading functionality for system contracts. Deployed at **0x1c00000000000000000000000000000000000000**.
+
+```solidity
+interface ITempoState {
+    event TempoBlockFinalized(bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot);
 
     /// @notice Current finalized Tempo block hash (keccak256 of RLP-encoded header)
     function tempoBlockHash() external view returns (bytes32);
@@ -670,24 +692,19 @@ interface ITempoState {
     function tempoTimestampMillis() external view returns (uint64);
     function tempoPrevRandao() external view returns (bytes32);
 
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external;
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external;
-
-    /// @notice Finalize a Tempo block header. Only callable by sequencer.
-    /// @dev Validates chain continuity (parent hash must match, number must be +1)
+    /// @notice Finalize a Tempo block header. System transaction only.
+    /// @dev Validates chain continuity (parent hash must match, number must be +1).
+    ///      Called by ZoneInbox.advanceTempo(). Executor enforces system-only access.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external;
 
     /// @notice Read a storage slot from a Tempo contract
-    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig).
     ///      Used to read ZonePortal and TIP-403 policy state from Tempo.
     function readTempoStorageSlot(address account, bytes32 slot) external view returns (bytes32);
 
     /// @notice Read multiple storage slots from a Tempo contract
-    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig).
     function readTempoStorageSlots(address account, bytes32[] calldata slots) external view returns (bytes32[] memory);
 }
 ```
@@ -698,21 +715,22 @@ The TempoState stores the Tempo wrapper fields and the inner fields needed by th
 
 **How it works:**
 
-1. The sequencer submits Tempo block headers via `finalizeTempo()`, which decodes the RLP header, validates chain continuity, and stores the wrapper fields and selected inner fields.
+1. ZoneInbox calls `finalizeTempo()` at the start of each block, which decodes the RLP header, validates chain continuity, and stores the wrapper fields and selected inner fields.
 2. When submitting a batch, the prover specifies a `tempoBlockNumber` and optionally a `recentTempoBlockNumber`. The portal reads the hash for `anchorBlockNumber` via the EIP-2935 block hash history precompile.
 3. The proof must demonstrate that the zone's `tempoBlockHash` (from TempoState) matches the portal's `anchorBlockHash` in direct mode, or that the parent-hash chain from `tempoBlockNumber` reaches `anchorBlockHash` in ancestry mode.
-4. The `readTempoStorageSlot` functions are **precompile stubs restricted to system contracts only** - actual implementation is in the zone node, validated against `tempoStateRoot`. Only ZoneInbox (0x1c00...0001) and ZoneOutbox (0x1c00...0002) can call these functions. User transactions cannot directly read Tempo state.
+4. The `readTempoStorageSlot` functions are **precompile stubs restricted to system contracts only** - actual implementation is in the zone node, validated against `tempoStateRoot`. Only ZoneInbox (0x1c00...0001), ZoneOutbox (0x1c00...0002), and ZoneConfig (0x1c00...0003) can call these functions. User transactions cannot directly read Tempo state.
 
 **Access restrictions:**
 
-Tempo state reads are restricted to zone system contracts (ZoneInbox, ZoneOutbox) to maintain simplicity and security:
-- **ZoneInbox** reads ZonePortal storage for deposit queue hash and encryption keys
+Tempo state reads are restricted to zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig) to maintain simplicity and security:
+- **ZoneConfig** reads ZonePortal storage for sequencer address (L1 is single source of truth)
+- **ZoneInbox** reads ZonePortal storage for deposit queue hash
 - **ZoneOutbox** may read ZonePortal storage for withdrawal processing
 - **TIP-403 enforcement** is handled by TIP-20 transfers reading policy state indirectly through system contracts
 
 User transactions **cannot** directly read Tempo state. This eliminates the complexity of state subscriptions and per-transaction state declarations while still allowing the zone to maintain its view of critical Tempo state for system operations.
 
-Tempo state staleness depends on how frequently the sequencer calls `finalizeTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed by system contracts during the batch.
+Tempo state staleness depends on how frequently ZoneInbox calls `finalizeTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed by system contracts during the batch.
 
 #### TIP-403 registry
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -629,6 +629,13 @@ The receiver must return `IWithdrawalReceiver.onWithdrawalReceived.selector` to 
 
 ### Zone predeploys
 
+Zones have four system contract predeploys at fixed addresses:
+
+- **TempoState** (0x1c00000000000000000000000000000000000000) - Stores finalized Tempo state and provides storage read access
+- **ZoneInbox** (0x1c00000000000000000000000000000000000001) - Advances Tempo state and processes deposits
+- **ZoneOutbox** (0x1c00000000000000000000000000000000000002) - Handles withdrawal requests back to Tempo
+- **ZoneConfig** (0x1c00000000000000000000000000000000000003) - Central configuration that reads sequencer from L1
+
 #### Zone zone token
 
 The zone's zone token is the bridged TIP-20 from Tempo. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -692,9 +692,9 @@ interface ITempoState {
     function tempoTimestampMillis() external view returns (uint64);
     function tempoPrevRandao() external view returns (bytes32);
 
-    /// @notice Finalize a Tempo block header. System transaction only.
+    /// @notice Finalize a Tempo block header. Only callable by ZoneInbox.
     /// @dev Validates chain continuity (parent hash must match, number must be +1).
-    ///      Called by ZoneInbox.advanceTempo(). Executor enforces system-only access.
+    ///      Called by ZoneInbox.advanceTempo(). Protocol enforces advanceTempo() runs as system transaction.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external;
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -722,7 +722,7 @@ The TempoState stores the Tempo wrapper fields and the inner fields needed by th
 
 **How it works:**
 
-1. ZoneInbox calls `finalizeTempo()` at the start of each block, which decodes the RLP header, validates chain continuity, and stores the wrapper fields and selected inner fields.
+1. ZoneInbox calls `finalizeTempo()` when the sequencer chooses to advance Tempo for a block, which decodes the RLP header, validates chain continuity, and stores the wrapper fields and selected inner fields. If a block omits `advanceTempo`, the Tempo binding carries over from the previous block.
 2. When submitting a batch, the prover specifies a `tempoBlockNumber` and optionally a `recentTempoBlockNumber`. The portal reads the hash for `anchorBlockNumber` via the EIP-2935 block hash history precompile.
 3. The proof must demonstrate that the zone's `tempoBlockHash` (from TempoState) matches the portal's `anchorBlockHash` in direct mode, or that the parent-hash chain from `tempoBlockNumber` reaches `anchorBlockHash` in ancestry mode.
 4. The `readTempoStorageSlot` functions are **precompile stubs restricted to system contracts only** - actual implementation is in the zone node, validated against `tempoStateRoot`. Only ZoneInbox (0x1c00...0001), ZoneOutbox (0x1c00...0002), and ZoneConfig (0x1c00...0003) can call these functions. User transactions cannot directly read Tempo state.
@@ -745,7 +745,7 @@ The zone has a `TIP403Registry` contract deployed at the **same address** as Tem
 
 #### Zone inbox
 
-The zone inbox is a system contract that advances Tempo state and processes deposits from Tempo in a single atomic operation. It is called by the sequencer at the start of each block.
+The zone inbox is a system contract that advances Tempo state and processes deposits from Tempo in a single atomic operation. It is called by the sequencer at the start of a block when Tempo is advanced; blocks may omit this call and carry forward the existing Tempo binding.
 
 ```solidity
 interface IZoneInbox {
@@ -1195,10 +1195,10 @@ Each zone runs as an ExEx (Execution Extension) attached to a Tempo node. There 
 - **Zone block hash**: Computed from the zone block header after execution. The zone block header is a simplified Ethereum header that includes:
   - `parentHash`, `beneficiary`, `stateRoot`, `transactionsRoot`, `receiptsRoot`, `number`, `timestamp`
   - **Omitted fields**: `gasLimit`, `gasUsed` (zones have no hard gas limit), `logsBloom`, `extraData` (not needed for proofs)
-- **Transactions/receipts roots**: Computed over the full ordered list `[advanceTempo, user txs..., finalizeWithdrawalBatch?]`.
+- **Transactions/receipts roots**: Computed over the full ordered list `[advanceTempo?, user txs..., finalizeWithdrawalBatch?]`.
 - **Transactions root**: Committed in the block hash but not proven on-chain. This prevents sequencer revisionism (claiming different transactions led to the state) while avoiding expensive transaction proof verification.
 - **Receipts root**: Committed in the block hash but not proven on-chain. Batch parameters are read from `lastBatch` state storage instead of event logs.
-- **Tempo anchoring**: The zone maintains its view of Tempo state via the TempoState predeploy. Each zone block starts with a sequencer-only call to `ZoneInbox.advanceTempo()`, which internally calls `TempoState.finalizeTempo()` with the Tempo block header. When submitting a batch, the prover specifies a `tempoBlockNumber` and an `anchorBlockNumber`; the proof must demonstrate the zone committed to `tempoBlockNumber` and that the anchor hash matches either the same block (direct mode) or a verified ancestry chain (ancestry mode) ending at `anchorBlockHash` from the EIP-2935 history precompile.
+- **Tempo anchoring**: The zone maintains its view of Tempo state via the TempoState predeploy. A zone block may start with a sequencer-only call to `ZoneInbox.advanceTempo()`, which internally calls `TempoState.finalizeTempo()` with the Tempo block header; if omitted, the binding carries over from the previous block. When submitting a batch, the prover specifies a `tempoBlockNumber` and an `anchorBlockNumber`; the proof must demonstrate the zone committed to `tempoBlockNumber` and that the anchor hash matches either the same block (direct mode) or a verified ancestry chain (ancestry mode) ending at `anchorBlockHash` from the EIP-2935 history precompile.
 
 #### Block header field coverage
 
@@ -1238,7 +1238,7 @@ The portal provides `blockHash` and `withdrawalBatchIndex` as the previous batch
 ### Deposits and withdrawals
 
 - **Deposit contract**: Tempo portal escrows TIP-20 tokens. The ExEx watches `DepositMade` events and queues deposits for zone processing.
-- **Combined sequencer call**: Each zone block starts with a sequencer-only call to `ZoneInbox.advanceTempo(header, deposits)`. This atomically advances the zone's Tempo view and processes pending deposits, validating the deposit hash against Tempo state.
+- **Combined sequencer call**: A zone block may start with a sequencer-only call to `ZoneInbox.advanceTempo(header, deposits)`. This atomically advances the zone's Tempo view and processes pending deposits, validating the deposit hash against Tempo state. If omitted, no deposits are processed and the Tempo binding is unchanged for that block.
 - **Withdrawal requests**: Users trigger withdrawals on the zone via RPC. The withdrawal is added to the pending exits and included in the next batch's exit list.
 
 ### RPC interface

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -682,9 +682,12 @@ interface ITempoState {
     function finalizeTempo(bytes calldata header) external;
 
     /// @notice Read a storage slot from a Tempo contract
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
+    ///      Used to read ZonePortal and TIP-403 policy state from Tempo.
     function readTempoStorageSlot(address account, bytes32 slot) external view returns (bytes32);
 
     /// @notice Read multiple storage slots from a Tempo contract
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
     function readTempoStorageSlots(address account, bytes32[] calldata slots) external view returns (bytes32[] memory);
 }
 ```
@@ -698,9 +701,18 @@ The TempoState stores the Tempo wrapper fields and the inner fields needed by th
 1. The sequencer submits Tempo block headers via `finalizeTempo()`, which decodes the RLP header, validates chain continuity, and stores the wrapper fields and selected inner fields.
 2. When submitting a batch, the prover specifies a `tempoBlockNumber` and optionally a `recentTempoBlockNumber`. The portal reads the hash for `anchorBlockNumber` via the EIP-2935 block hash history precompile.
 3. The proof must demonstrate that the zone's `tempoBlockHash` (from TempoState) matches the portal's `anchorBlockHash` in direct mode, or that the parent-hash chain from `tempoBlockNumber` reaches `anchorBlockHash` in ancestry mode.
-4. The `readTempoStorageSlot` functions are precompile stubs - actual implementation is in the zone node, validated against `tempoStateRoot`.
+4. The `readTempoStorageSlot` functions are **precompile stubs restricted to system contracts only** - actual implementation is in the zone node, validated against `tempoStateRoot`. Only ZoneInbox (0x1c00...0001) and ZoneOutbox (0x1c00...0002) can call these functions. User transactions cannot directly read Tempo state.
 
-Tempo state staleness depends on how frequently the sequencer calls `finalizeTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed during the batch.
+**Access restrictions:**
+
+Tempo state reads are restricted to zone system contracts (ZoneInbox, ZoneOutbox) to maintain simplicity and security:
+- **ZoneInbox** reads ZonePortal storage for deposit queue hash and encryption keys
+- **ZoneOutbox** may read ZonePortal storage for withdrawal processing
+- **TIP-403 enforcement** is handled by TIP-20 transfers reading policy state indirectly through system contracts
+
+User transactions **cannot** directly read Tempo state. This eliminates the complexity of state subscriptions and per-transaction state declarations while still allowing the zone to maintain its view of critical Tempo state for system operations.
+
+Tempo state staleness depends on how frequently the sequencer calls `finalizeTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed by system contracts during the batch.
 
 #### TIP-403 registry
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -727,17 +727,7 @@ The TempoState stores the Tempo wrapper fields and the inner fields needed by th
 3. The proof must demonstrate that the zone's `tempoBlockHash` (from TempoState) matches the portal's `anchorBlockHash` in direct mode, or that the parent-hash chain from `tempoBlockNumber` reaches `anchorBlockHash` in ancestry mode.
 4. The `readTempoStorageSlot` functions are **precompile stubs restricted to system contracts only** - actual implementation is in the zone node, validated against `tempoStateRoot`. Only ZoneInbox (0x1c00...0001), ZoneOutbox (0x1c00...0002), and ZoneConfig (0x1c00...0003) can call these functions. User transactions cannot directly read Tempo state.
 
-**Access restrictions:**
-
-Tempo state reads are restricted to zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig) to maintain simplicity and security:
-- **ZoneConfig** reads ZonePortal storage for sequencer address (L1 is single source of truth)
-- **ZoneInbox** reads ZonePortal storage for deposit queue hash
-- **ZoneOutbox** may read ZonePortal storage for withdrawal processing
-- **TIP-403 enforcement** is handled by TIP-20 transfers reading policy state indirectly through system contracts
-
-User transactions **cannot** directly read Tempo state. This eliminates the complexity of state subscriptions and per-transaction state declarations while still allowing the zone to maintain its view of critical Tempo state for system operations.
-
-Tempo state staleness depends on how frequently ZoneInbox calls `finalizeTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed by system contracts during the batch.
+Tempo state staleness depends on how frequently the sequencer updates tempo state using `advanceTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed by system contracts during the batch.
 
 #### TIP-403 registry
 

--- a/docs/pages/protocol/privacy/prover-design.md
+++ b/docs/pages/protocol/privacy/prover-design.md
@@ -114,10 +114,11 @@ pub struct ZoneBlock {
     /// Beneficiary (must match registered sequencer)
     pub beneficiary: Address,
 
-    /// Tempo header RLP used by the call (ZoneInbox.advanceTempo)
-    pub tempo_header_rlp: Vec<u8>,
+    /// Tempo header RLP used by the call (ZoneInbox.advanceTempo).
+    /// If None, the block does not advance Tempo and the binding carries over.
+    pub tempo_header_rlp: Option<Vec<u8>>,
 
-    /// Deposits processed by the call (oldest first)
+    /// Deposits processed by the call (oldest first). Must be empty if tempo_header_rlp is None.
     pub deposits: Vec<Deposit>,
 
     /// Sequencer-only: finalize a batch (only in final block, must be last)
@@ -130,13 +131,15 @@ pub struct ZoneBlock {
 ```
 
 Each zone block contains an ordered list of user transactions executed using `revm`. The sequencer
-calls `ZoneInbox.advanceTempo` at the start of the block to advance Tempo state and process deposits,
-and (only in the final block of a batch) calls `ZoneOutbox.finalizeWithdrawalBatch` at the end.
+may call `ZoneInbox.advanceTempo` at the start of the block to advance Tempo state and process deposits,
+and (only in the final block of a batch) calls `ZoneOutbox.finalizeWithdrawalBatch` at the end. If
+`advanceTempo` is omitted for a block, the Tempo binding carries over from the previous block.
 
 User transactions **must not** call the system contract predeploys
 (`TempoState`, `ZoneInbox`, `ZoneOutbox`, `ZoneConfig`). The executor must reject any
-non-sequencer call to these addresses, enforce one `advanceTempo` at the start of each block,
-and enforce `finalizeWithdrawalBatch` only in the final block of the batch. Tempo state reads
+non-sequencer call to these addresses, enforce at most one `advanceTempo` at the start of each block
+(or zero, for blocks that do not advance Tempo), and enforce `finalizeWithdrawalBatch` only in the
+final block of the batch. Tempo state reads
 via `TempoState` are restricted to system contracts only.
 The block hash is computed from the simplified zone header:
 `parentHash`, `beneficiary`, `stateRoot`, `transactionsRoot`, `receiptsRoot`, `number`, `timestamp`.
@@ -187,7 +190,7 @@ pub struct BatchStateProof {
 
 pub struct L1StateRead {
     /// Which zone block performed this read
-    pub zone_block_index: u32,
+    pub zone_block_index: u64,
 
     /// Which Tempo block to read from (must match TempoState for this block)
     pub tempo_block_number: u64,
@@ -431,22 +434,26 @@ fn execute_zone_block(
         )
         .build();
 
-    // Sequencer calls advanceTempo at the start of the block.
+    // Sequencer may call advanceTempo at the start of the block.
     // The TempoState precompile must bind reads during this call to the newly
     // finalized Tempo header, and reject any unbound reads.
-    evm.transact_commit(sequencer_tx_advance_tempo(
-        &block.tempo_header_rlp,
-        &block.deposits,
-    ))
-    .map_err(|e| Error::ExecutionError(e.to_string()))?;
+    if let Some(tempo_header_rlp) = &block.tempo_header_rlp {
+        evm.transact_commit(sequencer_tx_advance_tempo(
+            tempo_header_rlp,
+            &block.deposits,
+        ))
+        .map_err(|e| Error::ExecutionError(e.to_string()))?;
 
-    let tempo_number = zone_state.tempo_state_block_number()?;
-    tempo_state.bind_block(block_index, tempo_number)?;
+        let tempo_number = zone_state.tempo_state_block_number()?;
+        tempo_state.bind_block(block_index, tempo_number)?;
 
-    let expected_tempo_hash = tempo_state
-        .block_hash(tempo_number)
-        .ok_or(Error::InvalidProof)?;
-    if expected_tempo_hash != keccak256(&block.tempo_header_rlp) {
+        let expected_tempo_hash = tempo_state
+            .block_hash(tempo_number)
+            .ok_or(Error::InvalidProof)?;
+        if expected_tempo_hash != keccak256(tempo_header_rlp) {
+            return Err(Error::InconsistentState);
+        }
+    } else if !block.deposits.is_empty() {
         return Err(Error::InconsistentState);
     }
 

--- a/docs/pages/protocol/privacy/prover-design.md
+++ b/docs/pages/protocol/privacy/prover-design.md
@@ -135,13 +135,9 @@ may call `ZoneInbox.advanceTempo` at the start of the block to advance Tempo sta
 and (only in the final block of a batch) calls `ZoneOutbox.finalizeWithdrawalBatch` at the end. If
 `advanceTempo` is omitted for a block, the Tempo binding carries over from the previous block.
 
-User transactions **must not** call the system contract predeploys
-(`TempoState`, `ZoneInbox`, `ZoneOutbox`, `ZoneConfig`). The executor must reject any
-non-sequencer call to these addresses, enforce at most one `advanceTempo` at the start of each block
+The executor must enforce at most one `advanceTempo` at the start of each block
 (or zero, for blocks that do not advance Tempo), and enforce `finalizeWithdrawalBatch` only in the
-final block of the batch. Tempo state reads
-via `TempoState` are restricted to system contracts only.
-The block hash is computed from the simplified zone header:
+final block of the batch. The block hash is computed from the simplified zone header:
 `parentHash`, `beneficiary`, `stateRoot`, `transactionsRoot`, `receiptsRoot`, `number`, `timestamp`.
 The transactions and receipts roots are computed over the full ordered list of zone transactions.
 

--- a/docs/pages/protocol/privacy/prover-design.md
+++ b/docs/pages/protocol/privacy/prover-design.md
@@ -133,10 +133,11 @@ Each zone block contains an ordered list of user transactions executed using `re
 calls `ZoneInbox.advanceTempo` at the start of the block to advance Tempo state and process deposits,
 and (only in the final block of a batch) calls `ZoneOutbox.finalizeWithdrawalBatch` at the end.
 
-User transactions may call the `TempoState` precompile to read Tempo state. User transactions
-**must not** call `ZoneInbox` or `ZoneOutbox`; those are sequencer-only predeploys. The executor
-must reject any non-sequencer call to these addresses and enforce that `finalize_withdrawal_batch_count`
-is set at most once, only in the final block, and only after all user transactions.
+User transactions **must not** call the system contract predeploys
+(`TempoState`, `ZoneInbox`, `ZoneOutbox`, `ZoneConfig`). The executor must reject any
+non-sequencer call to these addresses, enforce one `advanceTempo` at the start of each block,
+and enforce `finalizeWithdrawalBatch` only in the final block of the batch. Tempo state reads
+via `TempoState` are restricted to system contracts only.
 The block hash is computed from the simplified zone header:
 `parentHash`, `beneficiary`, `stateRoot`, `transactionsRoot`, `receiptsRoot`, `number`, `timestamp`.
 The transactions and receipts roots are computed over the full ordered list of zone transactions.

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -78,6 +78,10 @@ struct Withdrawal {
                     ZONE SYSTEM CONTRACTS
 //////////////////////////////////////////////////////////////*/
 
+/// @notice TempoState predeploy address
+/// @dev Predeploy at 0x1c00000000000000000000000000000000000000
+address constant TEMPO_STATE = 0x1c00000000000000000000000000000000000000;
+
 /// @notice ZoneInbox system contract address
 /// @dev Predeploy at 0x1c00000000000000000000000000000000000001
 address constant ZONE_INBOX = 0x1c00000000000000000000000000000000000001;
@@ -337,6 +341,7 @@ interface ITempoState {
     error InvalidParentHash();
     error InvalidBlockNumber();
     error InvalidRlpData();
+    error OnlyZoneInbox();
 
     /// @notice Current finalized Tempo block hash (keccak256 of RLP-encoded header)
     function tempoBlockHash() external view returns (bytes32);
@@ -358,7 +363,7 @@ interface ITempoState {
     function tempoTimestampMillis() external view returns (uint64);
     function tempoPrevRandao() external view returns (bytes32);
 
-    /// @notice Finalize a Tempo block header. Sequencer-only call via ZoneInbox.
+    /// @notice Finalize a Tempo block header. Only callable by ZoneInbox.
     /// @dev Validates chain continuity (parent hash must match, number must be +1).
     ///      Called by ZoneInbox.advanceTempo(). Executor enforces ZoneInbox-only access.
     /// @param header RLP-encoded Tempo header

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -330,7 +330,8 @@ struct LastBatch {
 /// @title ITempoState
 /// @notice Interface for zone-side Tempo state verification predeploy
 /// @dev Deployed at 0x1c00000000000000000000000000000000000000
-///      System-only contract. Executor must enforce that only ZoneInbox can call finalizeTempo.
+///      System-only contract. Only ZoneInbox can call finalizeTempo().
+///      Only ZoneInbox, ZoneOutbox, and ZoneConfig can call readTempoStorageSlot(s).
 interface ITempoState {
     event TempoBlockFinalized(
         bytes32 indexed blockHash,

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -74,6 +74,22 @@ struct Withdrawal {
     bytes callbackData; // calldata for IWithdrawalReceiver (if gasLimit > 0)
 }
 
+/*//////////////////////////////////////////////////////////////
+                    ZONE SYSTEM CONTRACTS
+//////////////////////////////////////////////////////////////*/
+
+/// @notice ZoneInbox system contract address
+/// @dev Predeploy at 0x1c00000000000000000000000000000000000001
+address constant ZONE_INBOX = 0x1c00000000000000000000000000000000000001;
+
+/// @notice ZoneOutbox system contract address
+/// @dev Predeploy at 0x1c00000000000000000000000000000000000002
+address constant ZONE_OUTBOX = 0x1c00000000000000000000000000000000000002;
+
+/// @notice ZoneConfig system contract address
+/// @dev Predeploy at 0x1c00000000000000000000000000000000000003
+address constant ZONE_CONFIG = 0x1c00000000000000000000000000000000000003;
+
 /// @title IVerifier
 /// @notice Interface for zone proof/attestation verification
 interface IVerifier {
@@ -310,27 +326,17 @@ struct LastBatch {
 /// @title ITempoState
 /// @notice Interface for zone-side Tempo state verification predeploy
 /// @dev Deployed at 0x1c00000000000000000000000000000000000000
+///      System-only contract. Executor must enforce that only ZoneInbox can call finalizeTempo.
 interface ITempoState {
-
     event TempoBlockFinalized(
-        bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot
+        bytes32 indexed blockHash,
+        uint64 indexed blockNumber,
+        bytes32 stateRoot
     );
-    event SequencerTransferStarted(
-        address indexed currentSequencer, address indexed pendingSequencer
-    );
-    event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
 
-    error OnlySequencer();
-    error NotPendingSequencer();
     error InvalidParentHash();
     error InvalidBlockNumber();
     error InvalidRlpData();
-
-    /// @notice Current sequencer address
-    function sequencer() external view returns (address);
-
-    /// @notice Pending sequencer for two-step transfer
-    function pendingSequencer() external view returns (address);
 
     /// @notice Current finalized Tempo block hash (keccak256 of RLP-encoded header)
     function tempoBlockHash() external view returns (bytes32);
@@ -352,14 +358,9 @@ interface ITempoState {
     function tempoTimestampMillis() external view returns (uint64);
     function tempoPrevRandao() external view returns (bytes32);
 
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external;
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external;
-
-    /// @notice Finalize a Tempo block header. Only callable by sequencer.
-    /// @dev Validates chain continuity (parent hash must match, number must be +1)
+    /// @notice Finalize a Tempo block header. Sequencer-only call via ZoneInbox.
+    /// @dev Validates chain continuity (parent hash must match, number must be +1).
+    ///      Called by ZoneInbox.advanceTempo(). Executor enforces ZoneInbox-only access.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external;
 
@@ -396,14 +397,11 @@ interface IZoneInbox {
         bytes32 memo
     );
 
-    event SequencerTransferStarted(
-        address indexed currentSequencer, address indexed pendingSequencer
-    );
-    event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
-
     error OnlySequencer();
-    error NotPendingSequencer();
     error InvalidDepositQueueHash();
+
+    /// @notice Zone configuration (reads sequencer from L1)
+    function config() external view returns (IZoneConfig);
 
     /// @notice The Tempo portal address (for reading deposit queue hash)
     function tempoPortal() external view returns (address);
@@ -414,20 +412,8 @@ interface IZoneInbox {
     /// @notice The zone token (TIP-20 at same address as Tempo)
     function gasToken() external view returns (IZoneToken);
 
-    /// @notice Current sequencer address
-    function sequencer() external view returns (address);
-
-    /// @notice Pending sequencer for two-step transfer
-    function pendingSequencer() external view returns (address);
-
     /// @notice The zone's last processed deposit queue hash
     function processedDepositQueueHash() external view returns (bytes32);
-
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external;
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external;
 
     /// @notice Advance Tempo state and process deposits in a single sequencer-only call.
     /// @dev This is the main entry point for the sequencer at block start.
@@ -468,19 +454,11 @@ interface IZoneOutbox {
     /// @dev Kept for observability. Proof reads from lastBatch storage instead.
     event BatchFinalized(bytes32 indexed withdrawalQueueHash, uint64 withdrawalBatchIndex);
 
-    event SequencerTransferStarted(
-        address indexed currentSequencer, address indexed pendingSequencer
-    );
-    event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+    /// @notice Zone configuration (reads sequencer from L1)
+    function config() external view returns (IZoneConfig);
 
     /// @notice The zone token (same as Tempo portal's token)
     function gasToken() external view returns (IZoneToken);
-
-    /// @notice Current sequencer address
-    function sequencer() external view returns (address);
-
-    /// @notice Pending sequencer for two-step transfer
-    function pendingSequencer() external view returns (address);
 
     /// @notice Tempo gas rate (gas token units per gas unit on Tempo)
     /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
@@ -497,12 +475,6 @@ interface IZoneOutbox {
 
     /// @notice Number of pending withdrawals
     function pendingWithdrawalsCount() external view returns (uint256);
-
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external;
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external;
 
     /// @notice Set Tempo gas rate. Only callable by sequencer.
     /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price fluctuations.
@@ -532,4 +504,38 @@ interface IZoneOutbox {
     /// @return withdrawalQueueHash The hash chain (0 if no withdrawals)
     function finalizeWithdrawalBatch(uint256 count) external returns (bytes32 withdrawalQueueHash);
 
+}
+
+/// @title IZoneConfig
+/// @notice Interface for zone configuration and L1 state access
+/// @dev System contract predeploy at 0x1c00000000000000000000000000000000000003
+///      Provides centralized access to zone metadata and reads sequencer from L1.
+interface IZoneConfig {
+    error NotSequencer();
+
+    /// @notice Zone token address (TIP-20 at same address as Tempo)
+    function zoneToken() external view returns (address);
+
+    /// @notice L1 ZonePortal address
+    function tempoPortal() external view returns (address);
+
+    /// @notice TempoState predeploy for L1 reads
+    function tempoState() external view returns (ITempoState);
+
+    /// @notice Get current sequencer by reading from L1 ZonePortal
+    /// @dev Reads from finalized Tempo state. L1 is single source of truth.
+    function sequencer() external view returns (address);
+
+    /// @notice Get pending sequencer by reading from L1 ZonePortal
+    function pendingSequencer() external view returns (address);
+
+    /// @notice Get sequencer's encryption public key by reading from L1 ZonePortal
+    /// @dev Used for encrypted deposits (ECIES).
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+
+    /// @notice Check if an address is the current sequencer
+    function isSequencer(address account) external view returns (bool);
+
+    /// @notice Get zone token as IZoneToken interface
+    function getZoneToken() external view returns (IZoneToken);
 }

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -78,20 +78,16 @@ struct Withdrawal {
                     ZONE SYSTEM CONTRACTS
 //////////////////////////////////////////////////////////////*/
 
-/// @notice TempoState predeploy address
-/// @dev Predeploy at 0x1c00000000000000000000000000000000000000
-address constant TEMPO_STATE = 0x1c00000000000000000000000000000000000000;
+// TempoState predeploy address (0x1c00...0000)
+address constant TEMPO_STATE = 0x1C00000000000000000000000000000000000000;
 
-/// @notice ZoneInbox system contract address
-/// @dev Predeploy at 0x1c00000000000000000000000000000000000001
+// ZoneInbox system contract address (0x1c00...0001)
 address constant ZONE_INBOX = 0x1c00000000000000000000000000000000000001;
 
-/// @notice ZoneOutbox system contract address
-/// @dev Predeploy at 0x1c00000000000000000000000000000000000002
+// ZoneOutbox system contract address (0x1c00...0002)
 address constant ZONE_OUTBOX = 0x1c00000000000000000000000000000000000002;
 
-/// @notice ZoneConfig system contract address
-/// @dev Predeploy at 0x1c00000000000000000000000000000000000003
+// ZoneConfig system contract address (0x1c00...0003)
 address constant ZONE_CONFIG = 0x1c00000000000000000000000000000000000003;
 
 /// @title IVerifier
@@ -333,10 +329,9 @@ struct LastBatch {
 ///      System-only contract. Only ZoneInbox can call finalizeTempo().
 ///      Only ZoneInbox, ZoneOutbox, and ZoneConfig can call readTempoStorageSlot(s).
 interface ITempoState {
+
     event TempoBlockFinalized(
-        bytes32 indexed blockHash,
-        uint64 indexed blockNumber,
-        bytes32 stateRoot
+        bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot
     );
 
     error InvalidParentHash();
@@ -517,6 +512,7 @@ interface IZoneOutbox {
 /// @dev System contract predeploy at 0x1c00000000000000000000000000000000000003
 ///      Provides centralized access to zone metadata and reads sequencer from L1.
 interface IZoneConfig {
+
     error NotSequencer();
 
     /// @notice Zone token address (TIP-20 at same address as Tempo)
@@ -544,4 +540,5 @@ interface IZoneConfig {
 
     /// @notice Get zone token as IZoneToken interface
     function getZoneToken() external view returns (IZoneToken);
+
 }

--- a/docs/specs/src/zone/TempoState.sol
+++ b/docs/specs/src/zone/TempoState.sol
@@ -130,7 +130,15 @@ contract TempoState is ITempoState {
     /// @param account The Tempo contract address (ZonePortal or TIP-403)
     /// @param slot The storage slot to read
     /// @return value The storage value (stub always reverts)
-    function readTempoStorageSlot(address account, bytes32 slot) external view onlySystemContract returns (bytes32) {
+    function readTempoStorageSlot(
+        address account,
+        bytes32 slot
+    )
+        external
+        view
+        onlySystemContract
+        returns (bytes32)
+    {
         // Silence unused variable warnings
         account;
         slot;

--- a/docs/specs/src/zone/TempoState.sol
+++ b/docs/specs/src/zone/TempoState.sol
@@ -14,12 +14,6 @@ contract TempoState is ITempoState {
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Current sequencer address
-    address public sequencer;
-
-    /// @notice Pending sequencer for two-step transfer
-    address public pendingSequencer;
-
     /// @notice Current finalized Tempo block hash (keccak256 of RLP-encoded header)
     bytes32 public tempoBlockHash;
 
@@ -75,33 +69,10 @@ contract TempoState is ITempoState {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Initialize with genesis Tempo block
-    /// @param _sequencer The sequencer address
     /// @param _genesisHeader RLP-encoded genesis Tempo header
-    constructor(address _sequencer, bytes memory _genesisHeader) {
-        sequencer = _sequencer;
-
+    constructor(bytes memory _genesisHeader) {
         // Decode and store genesis header
         _decodeAndStoreHeader(_genesisHeader);
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                         SEQUENCER MANAGEMENT
-    //////////////////////////////////////////////////////////////*/
-
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external {
-        if (msg.sender != sequencer) revert OnlySequencer();
-        pendingSequencer = newSequencer;
-        emit SequencerTransferStarted(sequencer, newSequencer);
-    }
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external {
-        if (msg.sender != pendingSequencer) revert NotPendingSequencer();
-        address previousSequencer = sequencer;
-        sequencer = pendingSequencer;
-        pendingSequencer = address(0);
-        emit SequencerTransferred(previousSequencer, sequencer);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -109,12 +80,12 @@ contract TempoState is ITempoState {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Finalize a Tempo block header
-    /// @dev Validates chain continuity (parent hash must match stored hash, number must be +1)
+    /// @dev Validates chain continuity (parent hash must match stored hash, number must be +1).
     ///      The header is RLP-encoded as: rlp([general_gas_limit, shared_gas_limit, timestamp_millis_part, inner])
     ///      where inner is a standard Ethereum header.
+    ///      Called by ZoneInbox.advanceTempo() as a system transaction. Executor enforces system-only access.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external {
-        if (msg.sender != sequencer) revert OnlySequencer();
 
         // Store previous values for validation
         bytes32 prevBlockHash = tempoBlockHash;
@@ -138,10 +109,11 @@ contract TempoState is ITempoState {
     /// @dev These contracts need access to read from ZonePortal and TIP-403 on Tempo
     address private constant ZONE_INBOX = 0x1c00000000000000000000000000000000000001;
     address private constant ZONE_OUTBOX = 0x1c00000000000000000000000000000000000002;
+    address private constant ZONE_CONFIG = 0x1c00000000000000000000000000000000000003;
 
     /// @notice Check if caller is a zone system contract
     modifier onlySystemContract() {
-        if (msg.sender != ZONE_INBOX && msg.sender != ZONE_OUTBOX) {
+        if (msg.sender != ZONE_INBOX && msg.sender != ZONE_OUTBOX && msg.sender != ZONE_CONFIG) {
             revert("TempoState: only zone system contracts can read Tempo state");
         }
         _;

--- a/docs/specs/src/zone/TempoState.sol
+++ b/docs/specs/src/zone/TempoState.sol
@@ -83,9 +83,11 @@ contract TempoState is ITempoState {
     /// @dev Validates chain continuity (parent hash must match stored hash, number must be +1).
     ///      The header is RLP-encoded as: rlp([general_gas_limit, shared_gas_limit, timestamp_millis_part, inner])
     ///      where inner is a standard Ethereum header.
-    ///      Called by ZoneInbox.advanceTempo() as a system transaction. Executor enforces system-only access.
+    ///      Only callable by ZoneInbox. Protocol enforces ZoneInbox.advanceTempo() runs as system transaction.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external {
+        // Only ZoneInbox can call this function
+        if (msg.sender != ZONE_INBOX) revert OnlyZoneInbox();
 
         // Store previous values for validation
         bytes32 prevBlockHash = tempoBlockHash;

--- a/docs/specs/src/zone/TempoState.sol
+++ b/docs/specs/src/zone/TempoState.sol
@@ -83,7 +83,7 @@ contract TempoState is ITempoState {
     /// @dev Validates chain continuity (parent hash must match stored hash, number must be +1).
     ///      The header is RLP-encoded as: rlp([general_gas_limit, shared_gas_limit, timestamp_millis_part, inner])
     ///      where inner is a standard Ethereum header.
-    ///      Only callable by ZoneInbox. Protocol enforces ZoneInbox.advanceTempo() runs as system transaction.
+    ///      Only callable by ZoneInbox. Executor enforces ZoneInbox-only access.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external {
         // Only ZoneInbox can call this function

--- a/docs/specs/src/zone/TempoState.sol
+++ b/docs/specs/src/zone/TempoState.sol
@@ -122,7 +122,7 @@ contract TempoState is ITempoState {
     }
 
     /// @notice Read a storage slot from a Tempo contract
-    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig).
     ///      In production, this is a precompile that reads from proven Tempo state.
     ///      Used to read ZonePortal state (deposit queue, encryption keys) and TIP-403
     ///      policy state for the zone token.
@@ -138,7 +138,7 @@ contract TempoState is ITempoState {
     }
 
     /// @notice Read multiple storage slots from a Tempo contract
-    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig).
     ///      In production, this is a precompile that reads from proven Tempo state.
     ///      This stub reverts - actual implementation is in the zone node.
     /// @param account The Tempo contract address (ZonePortal or TIP-403)

--- a/docs/specs/src/zone/TempoState.sol
+++ b/docs/specs/src/zone/TempoState.sol
@@ -131,16 +131,32 @@ contract TempoState is ITempoState {
     }
 
     /*//////////////////////////////////////////////////////////////
-                          STORAGE READING STUBS
+                    TEMPO STORAGE READING (SYSTEM ONLY)
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Zone system contract addresses that are allowed to read Tempo state
+    /// @dev These contracts need access to read from ZonePortal and TIP-403 on Tempo
+    address private constant ZONE_INBOX = 0x1c00000000000000000000000000000000000001;
+    address private constant ZONE_OUTBOX = 0x1c00000000000000000000000000000000000002;
+
+    /// @notice Check if caller is a zone system contract
+    modifier onlySystemContract() {
+        if (msg.sender != ZONE_INBOX && msg.sender != ZONE_OUTBOX) {
+            revert("TempoState: only zone system contracts can read Tempo state");
+        }
+        _;
+    }
+
     /// @notice Read a storage slot from a Tempo contract
-    /// @dev In production, this is a precompile that reads from proven Tempo state.
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
+    ///      In production, this is a precompile that reads from proven Tempo state.
+    ///      Used to read ZonePortal state (deposit queue, encryption keys) and TIP-403
+    ///      policy state for the zone token.
     ///      This stub reverts - actual implementation is in the zone node.
-    /// @param account The Tempo contract address
+    /// @param account The Tempo contract address (ZonePortal or TIP-403)
     /// @param slot The storage slot to read
     /// @return value The storage value (stub always reverts)
-    function readTempoStorageSlot(address account, bytes32 slot) external view returns (bytes32) {
+    function readTempoStorageSlot(address account, bytes32 slot) external view onlySystemContract returns (bytes32) {
         // Silence unused variable warnings
         account;
         slot;
@@ -148,9 +164,10 @@ contract TempoState is ITempoState {
     }
 
     /// @notice Read multiple storage slots from a Tempo contract
-    /// @dev In production, this is a precompile that reads from proven Tempo state.
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox).
+    ///      In production, this is a precompile that reads from proven Tempo state.
     ///      This stub reverts - actual implementation is in the zone node.
-    /// @param account The Tempo contract address
+    /// @param account The Tempo contract address (ZonePortal or TIP-403)
     /// @param slots The storage slots to read
     /// @return values The storage values (stub always reverts)
     function readTempoStorageSlots(
@@ -159,6 +176,7 @@ contract TempoState is ITempoState {
     )
         external
         view
+        onlySystemContract
         returns (bytes32[] memory)
     {
         // Silence unused variable warnings

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { IZoneToken, ITempoState } from "./IZone.sol";
+import { ITempoState, IZoneToken } from "./IZone.sol";
 
 /// @title ZoneConfig
 /// @notice Central zone metadata and L1 state references
@@ -9,6 +9,7 @@ import { IZoneToken, ITempoState } from "./IZone.sol";
 ///      Provides single source of truth for zone configuration.
 ///      Reads sequencer from L1 ZonePortal, eliminating duplicate sequencer management.
 contract ZoneConfig {
+
     /*//////////////////////////////////////////////////////////////
                                IMMUTABLES
     //////////////////////////////////////////////////////////////*/
@@ -50,11 +51,7 @@ contract ZoneConfig {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(
-        address _zoneToken,
-        address _tempoPortal,
-        address _tempoState
-    ) {
+    constructor(address _zoneToken, address _tempoPortal, address _tempoState) {
         zoneToken = _zoneToken;
         tempoPortal = _tempoPortal;
         tempoState = ITempoState(_tempoState);
@@ -122,4 +119,5 @@ contract ZoneConfig {
     function getZoneToken() external view returns (IZoneToken) {
         return IZoneToken(zoneToken);
     }
+
 }

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { IZoneToken, ITempoState } from "./IZone.sol";
+
+/// @title ZoneConfig
+/// @notice Central zone metadata and L1 state references
+/// @dev System contract predeploy at 0x1c00000000000000000000000000000000000003
+///      Provides single source of truth for zone configuration.
+///      Reads sequencer from L1 ZonePortal, eliminating duplicate sequencer management.
+contract ZoneConfig {
+    /*//////////////////////////////////////////////////////////////
+                               IMMUTABLES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Zone token address (TIP-20 at same address as Tempo)
+    address public immutable zoneToken;
+
+    /// @notice L1 ZonePortal address
+    address public immutable tempoPortal;
+
+    /// @notice TempoState predeploy for L1 reads
+    ITempoState public immutable tempoState;
+
+    /*//////////////////////////////////////////////////////////////
+                           STORAGE SLOT CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Storage slot for sequencer in ZonePortal
+    /// @dev ZonePortal storage layout (non-immutable variables):
+    ///      slot 0: sequencer (address)
+    ///      slot 1: pendingSequencer (address)
+    ///      slot 2: sequencerPubkey (bytes32)
+    ///      ...
+    bytes32 internal constant SEQUENCER_SLOT = bytes32(uint256(0));
+
+    /// @notice Storage slot for pendingSequencer in ZonePortal
+    bytes32 internal constant PENDING_SEQUENCER_SLOT = bytes32(uint256(1));
+
+    /// @notice Storage slot for sequencerPubkey in ZonePortal (X coordinate)
+    bytes32 internal constant SEQUENCER_PUBKEY_SLOT = bytes32(uint256(2));
+
+    /*//////////////////////////////////////////////////////////////
+                               ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error NotSequencer();
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(
+        address _zoneToken,
+        address _tempoPortal,
+        address _tempoState
+    ) {
+        zoneToken = _zoneToken;
+        tempoPortal = _tempoPortal;
+        tempoState = ITempoState(_tempoState);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          L1 STATE ACCESSORS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Get current sequencer by reading from L1 ZonePortal
+    /// @dev Reads portal's sequencer slot from finalized Tempo state.
+    ///      L1 ZonePortal is the single source of truth for sequencer.
+    ///      Sequencer changes on L1 become visible after Tempo block finalization.
+    /// @return Current sequencer address
+    function sequencer() external view returns (address) {
+        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, SEQUENCER_SLOT);
+        return address(uint160(uint256(value)));
+    }
+
+    /// @notice Get pending sequencer by reading from L1 ZonePortal
+    /// @dev Reads portal's pendingSequencer slot from finalized Tempo state.
+    /// @return Pending sequencer address (0 if none)
+    function pendingSequencer() external view returns (address) {
+        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, PENDING_SEQUENCER_SLOT);
+        return address(uint160(uint256(value)));
+    }
+
+    /// @notice Get sequencer's encryption public key by reading from L1 ZonePortal
+    /// @dev Reads portal's sequencerPubkey slot from finalized Tempo state.
+    ///      Used for encrypted deposits (ECIES).
+    /// @return x X-coordinate of sequencer's secp256k1 public key
+    /// @return yParity Y-coordinate parity (0 or 1)
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity) {
+        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, SEQUENCER_PUBKEY_SLOT);
+        // Public key is stored as: x (bytes32) with yParity in the first byte
+        yParity = uint8(uint256(value) >> 248);
+        x = bytes32(uint256(value) & ((1 << 248) - 1));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              MODIFIERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Modifier to restrict access to current sequencer
+    /// @dev Reads sequencer from L1 via ZonePortal for each check.
+    ///      L1 is the single source of truth.
+    modifier onlySequencer() {
+        if (msg.sender != this.sequencer()) revert NotSequencer();
+        _;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          CONVENIENCE FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Check if an address is the current sequencer
+    /// @param account Address to check
+    /// @return True if account is the current sequencer
+    function isSequencer(address account) external view returns (bool) {
+        return account == this.sequencer();
+    }
+
+    /// @notice Get zone token as IZoneToken interface
+    /// @return Zone token interface
+    function getZoneToken() external view returns (IZoneToken) {
+        return IZoneToken(zoneToken);
+    }
+}

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Deposit, IZoneConfig, IZoneInbox, IZoneToken, ITempoState } from "./IZone.sol";
+import { Deposit, ITempoState, IZoneConfig, IZoneInbox, IZoneToken } from "./IZone.sol";
 import { TempoState } from "./TempoState.sol";
 
 /// @title ZoneInbox
@@ -69,10 +69,7 @@ contract ZoneInbox is IZoneInbox {
     ///      Protocol and proof enforce this runs at the start of each block.
     /// @param header RLP-encoded Tempo block header
     /// @param deposits Array of deposits to process (oldest first, must be contiguous from processedDepositQueueHash)
-    function advanceTempo(
-        bytes calldata header,
-        Deposit[] calldata deposits
-    ) external {
+    function advanceTempo(bytes calldata header, Deposit[] calldata deposits) external {
         if (msg.sender != config.sequencer()) revert OnlySequencer();
 
         // Step 1: Advance Tempo state (validates chain continuity internally)

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Deposit, ITempoState, IZoneInbox, IZoneToken } from "./IZone.sol";
+import { Deposit, IZoneConfig, IZoneInbox, IZoneToken, ITempoState } from "./IZone.sol";
 import { TempoState } from "./TempoState.sol";
 
 /// @title ZoneInbox
@@ -14,6 +14,9 @@ contract ZoneInbox is IZoneInbox {
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Zone configuration (reads sequencer from L1)
+    IZoneConfig public immutable config;
+
     /// @notice The Tempo portal address (for reading deposit queue hash)
     address public immutable tempoPortal;
 
@@ -22,12 +25,6 @@ contract ZoneInbox is IZoneInbox {
 
     /// @notice The zone token (TIP-20 at same address as Tempo)
     IZoneToken public immutable gasToken;
-
-    /// @notice Current sequencer address
-    address public sequencer;
-
-    /// @notice Pending sequencer for two-step transfer
-    address public pendingSequencer;
 
     /// @notice Last processed deposit queue hash (validated against Tempo state)
     bytes32 public processedDepositQueueHash;
@@ -48,45 +45,21 @@ contract ZoneInbox is IZoneInbox {
     //////////////////////////////////////////////////////////////*/
 
     constructor(
+        address _config,
         address _tempoPortalAddr,
         address _tempoStateAddr,
-        address _gasToken,
-        address _sequencer
+        address _gasToken
     ) {
+        config = IZoneConfig(_config);
         tempoPortal = _tempoPortalAddr;
         _tempoState = TempoState(_tempoStateAddr);
         gasToken = IZoneToken(_gasToken);
-        sequencer = _sequencer;
     }
 
     /// @notice The TempoState predeploy address
     function tempoState() external view returns (ITempoState) {
         return _tempoState;
     }
-
-    /*//////////////////////////////////////////////////////////////
-                         SEQUENCER MANAGEMENT
-    //////////////////////////////////////////////////////////////*/
-
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external {
-        if (msg.sender != sequencer) revert OnlySequencer();
-        pendingSequencer = newSequencer;
-        emit SequencerTransferStarted(sequencer, newSequencer);
-    }
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external {
-        if (msg.sender != pendingSequencer) revert NotPendingSequencer();
-        address previousSequencer = sequencer;
-        sequencer = pendingSequencer;
-        pendingSequencer = address(0);
-        emit SequencerTransferred(previousSequencer, sequencer);
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                         SYSTEM TRANSACTION
-    //////////////////////////////////////////////////////////////*/
 
     /// @notice Advance Tempo state and process deposits in a single sequencer-only call
     /// @dev This is the main entry point for the sequencer at block start.
@@ -96,8 +69,11 @@ contract ZoneInbox is IZoneInbox {
     ///      Protocol and proof enforce this runs at the start of each block.
     /// @param header RLP-encoded Tempo block header
     /// @param deposits Array of deposits to process (oldest first, must be contiguous from processedDepositQueueHash)
-    function advanceTempo(bytes calldata header, Deposit[] calldata deposits) external {
-        if (msg.sender != sequencer) revert OnlySequencer();
+    function advanceTempo(
+        bytes calldata header,
+        Deposit[] calldata deposits
+    ) external {
+        if (msg.sender != config.sequencer()) revert OnlySequencer();
 
         // Step 1: Advance Tempo state (validates chain continuity internally)
         _tempoState.finalizeTempo(header);

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -62,11 +62,11 @@ contract ZoneInbox is IZoneInbox {
     }
 
     /// @notice Advance Tempo state and process deposits in a single sequencer-only call
-    /// @dev This is the main entry point for the sequencer at block start.
+    /// @dev This is the main entry point for the sequencer at block start when Tempo is advanced.
     ///      1. Advances the zone's view of Tempo by processing the header
     ///      2. Processes deposits from the deposit queue
     ///      3. Validates the resulting hash against Tempo's currentDepositQueueHash
-    ///      Protocol and proof enforce this runs at the start of each block.
+    ///      Protocol and proof enforce at most one call at the start of a block (or zero if skipping).
     /// @param header RLP-encoded Tempo block header
     /// @param deposits Array of deposits to process (oldest first, must be contiguous from processedDepositQueueHash)
     function advanceTempo(bytes calldata header, Deposit[] calldata deposits) external {

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { IZoneOutbox, IZoneToken, LastBatch, Withdrawal } from "./IZone.sol";
+import { IZoneConfig, IZoneOutbox, IZoneToken, LastBatch, Withdrawal } from "./IZone.sol";
 import { EMPTY_SENTINEL } from "./WithdrawalQueueLib.sol";
 
 /// @title ZoneOutbox
@@ -26,14 +26,11 @@ contract ZoneOutbox is IZoneOutbox {
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Zone configuration (reads sequencer from L1)
+    IZoneConfig public immutable config;
+
     /// @notice The zone token (TIP-20 at same address as Tempo)
     IZoneToken public immutable gasToken;
-
-    /// @notice Current sequencer address
-    address public sequencer;
-
-    /// @notice Pending sequencer for two-step transfer
-    address public pendingSequencer;
 
     /// @notice Tempo gas rate (zone token units per gas unit on Tempo)
     /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price changes.
@@ -63,35 +60,17 @@ contract ZoneOutbox is IZoneOutbox {
     error CallbackDataTooLarge();
     error TransferFailed();
     error OnlySequencer();
-    error NotPendingSequencer();
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address _gasToken, address _sequencer) {
+    constructor(
+        address _config,
+        address _gasToken
+    ) {
+        config = IZoneConfig(_config);
         gasToken = IZoneToken(_gasToken);
-        sequencer = _sequencer;
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                         SEQUENCER MANAGEMENT
-    //////////////////////////////////////////////////////////////*/
-
-    /// @notice Start a sequencer transfer. Only callable by current sequencer.
-    function transferSequencer(address newSequencer) external {
-        if (msg.sender != sequencer) revert OnlySequencer();
-        pendingSequencer = newSequencer;
-        emit SequencerTransferStarted(sequencer, newSequencer);
-    }
-
-    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
-    function acceptSequencer() external {
-        if (msg.sender != pendingSequencer) revert NotPendingSequencer();
-        address previousSequencer = sequencer;
-        sequencer = pendingSequencer;
-        pendingSequencer = address(0);
-        emit SequencerTransferred(previousSequencer, sequencer);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -104,7 +83,7 @@ contract ZoneOutbox is IZoneOutbox {
     ///      If actual Tempo gas is lower, sequencer keeps the surplus.
     /// @param _tempoGasRate Zone token units per gas unit on Tempo
     function setTempoGasRate(uint128 _tempoGasRate) external {
-        if (msg.sender != sequencer) revert OnlySequencer();
+        if (msg.sender != config.sequencer()) revert OnlySequencer();
         tempoGasRate = _tempoGasRate;
         emit TempoGasRateUpdated(_tempoGasRate);
     }
@@ -200,7 +179,7 @@ contract ZoneOutbox is IZoneOutbox {
     /// @param count Max number of withdrawals to process (avoids unbounded loops)
     /// @return withdrawalQueueHash The hash chain (0 if no withdrawals)
     function finalizeWithdrawalBatch(uint256 count) external returns (bytes32 withdrawalQueueHash) {
-        if (msg.sender != sequencer) revert OnlySequencer();
+        if (msg.sender != config.sequencer()) revert OnlySequencer();
 
         uint256 pending = _pendingWithdrawals.length - _pendingWithdrawalsHead;
 

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -65,10 +65,7 @@ contract ZoneOutbox is IZoneOutbox {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(
-        address _config,
-        address _gasToken
-    ) {
+    constructor(address _config, address _gasToken) {
         config = IZoneConfig(_config);
         gasToken = IZoneToken(_gasToken);
     }

--- a/docs/specs/test/zone/TempoState.t.sol
+++ b/docs/specs/test/zone/TempoState.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { ITempoState } from "../../src/zone/IZone.sol";
+import { ITempoState, ZONE_INBOX } from "../../src/zone/IZone.sol";
 import { TempoState } from "../../src/zone/TempoState.sol";
 import { Test } from "forge-std/Test.sol";
 
@@ -11,8 +11,8 @@ contract TempoStateTest is Test {
 
     TempoState public tempoState;
 
-    address public sequencer = address(0x1);
-    address public notSequencer = address(0x2);
+    address public zoneInbox = ZONE_INBOX;
+    address public notZoneInbox = address(0x2);
 
     // Genesis values - we'll use a real encoded header
     uint64 constant GENESIS_BLOCK_NUMBER = 100;
@@ -39,7 +39,7 @@ contract TempoStateTest is Test {
         );
         genesisBlockHash = keccak256(genesisHeader);
 
-        tempoState = new TempoState(sequencer, genesisHeader);
+        tempoState = new TempoState(genesisHeader);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -47,7 +47,6 @@ contract TempoStateTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_constructor_initializesState() public view {
-        assertEq(tempoState.sequencer(), sequencer);
         assertEq(tempoState.tempoBlockHash(), genesisBlockHash);
         assertEq(tempoState.tempoBlockNumber(), GENESIS_BLOCK_NUMBER);
         assertEq(tempoState.tempoTimestamp(), GENESIS_TIMESTAMP);
@@ -79,7 +78,7 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 12
         );
 
-        vm.prank(sequencer);
+        vm.prank(zoneInbox);
         tempoState.finalizeTempo(header);
 
         // Verify state was updated
@@ -105,7 +104,7 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 12
         );
 
-        vm.prank(sequencer);
+        vm.prank(zoneInbox);
         tempoState.finalizeTempo(header1);
 
         bytes32 block101Hash = keccak256(header1);
@@ -123,7 +122,7 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 24
         );
 
-        vm.prank(sequencer);
+        vm.prank(zoneInbox);
         tempoState.finalizeTempo(header2);
 
         bytes32 block102Hash = keccak256(header2);
@@ -143,7 +142,7 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 12
         );
 
-        vm.prank(sequencer);
+        vm.prank(zoneInbox);
         vm.expectRevert(ITempoState.InvalidParentHash.selector);
         tempoState.finalizeTempo(header);
     }
@@ -159,7 +158,7 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 12
         );
 
-        vm.prank(sequencer);
+        vm.prank(zoneInbox);
         vm.expectRevert(ITempoState.InvalidBlockNumber.selector);
         tempoState.finalizeTempo(header);
     }
@@ -175,12 +174,12 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 12
         );
 
-        vm.prank(sequencer);
+        vm.prank(zoneInbox);
         vm.expectRevert(ITempoState.InvalidBlockNumber.selector);
         tempoState.finalizeTempo(header);
     }
 
-    function test_finalizeTempo_revertsIfNotSequencer() public {
+    function test_finalizeTempo_revertsIfNotZoneInbox() public {
         bytes memory header = _buildTempoHeader(
             genesisBlockHash,
             keccak256("stateRoot"),
@@ -191,8 +190,8 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 12
         );
 
-        vm.prank(notSequencer);
-        vm.expectRevert(ITempoState.OnlySequencer.selector);
+        vm.prank(notZoneInbox);
+        vm.expectRevert(ITempoState.OnlyZoneInbox.selector);
         tempoState.finalizeTempo(header);
     }
 
@@ -208,7 +207,7 @@ contract TempoStateTest is Test {
             GENESIS_TIMESTAMP + 12
         );
 
-        vm.prank(sequencer);
+        vm.prank(zoneInbox);
         vm.expectEmit(true, true, false, true);
         emit ITempoState.TempoBlockFinalized(
             keccak256(header), GENESIS_BLOCK_NUMBER + 1, newStateRoot
@@ -221,6 +220,7 @@ contract TempoStateTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_readTempoStorageSlot_revertsAsStub() public {
+        vm.prank(zoneInbox);
         vm.expectRevert("TempoState: readTempoStorageSlot is a precompile stub");
         tempoState.readTempoStorageSlot(address(0x1234), bytes32(0));
     }
@@ -230,6 +230,7 @@ contract TempoStateTest is Test {
         slots[0] = bytes32(uint256(1));
         slots[1] = bytes32(uint256(2));
 
+        vm.prank(zoneInbox);
         vm.expectRevert("TempoState: readTempoStorageSlots is a precompile stub");
         tempoState.readTempoStorageSlots(address(0x1234), slots);
     }

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -15,6 +15,7 @@ import {
     ZoneParams
 } from "../../src/zone/IZone.sol";
 import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
 import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
@@ -71,6 +72,7 @@ contract ZoneBridgeTest is BaseTest {
 
     MockZoneGasToken public l2GasToken;
     MockTempoState public l2TempoState;
+    ZoneConfig public l2Config;
     ZoneInbox public l2Inbox;
     ZoneOutbox public l2Outbox;
 
@@ -150,12 +152,20 @@ contract ZoneBridgeTest is BaseTest {
         // TempoState mock for testing
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
 
+        // Zone config (reads sequencer from L1 portal via Tempo state)
+        l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
+        l2TempoState.setMockStorageValue(
+            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+        );
+
         // Zone inbox (advances Tempo state and processes deposits)
-        l2Inbox = new ZoneInbox(portalAddr, address(l2TempoState), address(l2GasToken), admin);
+        l2Inbox = new ZoneInbox(
+            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
+        );
         l2GasToken.setMinter(address(l2Inbox), true);
 
         // Zone outbox (handles withdrawals)
-        l2Outbox = new ZoneOutbox(address(l2GasToken), admin);
+        l2Outbox = new ZoneOutbox(address(l2Config), address(l2GasToken));
         l2GasToken.setBurner(address(l2Outbox), true);
 
         // Initialize zone block hash

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { Deposit, IZoneInbox } from "../../src/zone/IZone.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
 import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
@@ -11,6 +12,7 @@ import { Test } from "forge-std/Test.sol";
 /// @notice Tests for ZoneInbox covering edge cases
 contract ZoneInboxTest is Test {
 
+    ZoneConfig public config;
     ZoneInbox public inbox;
     MockZoneGasToken public gasToken;
     MockTempoState public tempoState;
@@ -31,7 +33,11 @@ contract ZoneInboxTest is Test {
         gasToken = new MockZoneGasToken("Zone USD", "zUSD");
         tempoState =
             new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
-        inbox = new ZoneInbox(mockPortal, address(tempoState), address(gasToken), sequencer);
+        config = new ZoneConfig(address(gasToken), mockPortal, address(tempoState));
+        tempoState.setMockStorageValue(
+            mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
+        );
+        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(gasToken));
 
         gasToken.setMinter(address(inbox), true);
     }
@@ -272,10 +278,10 @@ contract ZoneInboxTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_immutableGetters() public view {
+        assertEq(address(inbox.config()), address(config));
         assertEq(inbox.tempoPortal(), mockPortal);
         assertEq(address(inbox.tempoState()), address(tempoState));
         assertEq(address(inbox.gasToken()), address(gasToken));
-        assertEq(inbox.sequencer(), sequencer);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -14,6 +14,7 @@ import {
     ZoneParams
 } from "../../src/zone/IZone.sol";
 import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
 import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
@@ -57,6 +58,7 @@ contract ZoneIntegrationTest is BaseTest {
     // L2 contracts
     MockZoneGasToken public l2GasToken;
     MockTempoState public l2TempoState;
+    ZoneConfig public l2Config;
     ZoneInbox public l2Inbox;
     ZoneOutbox public l2Outbox;
 
@@ -107,8 +109,14 @@ contract ZoneIntegrationTest is BaseTest {
         // L2 setup
         l2GasToken = new MockZoneGasToken("Zone USD", "zUSD");
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
-        l2Inbox = new ZoneInbox(portalAddr, address(l2TempoState), address(l2GasToken), admin);
-        l2Outbox = new ZoneOutbox(address(l2GasToken), admin);
+        l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
+        l2TempoState.setMockStorageValue(
+            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+        );
+        l2Inbox = new ZoneInbox(
+            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
+        );
+        l2Outbox = new ZoneOutbox(address(l2Config), address(l2GasToken));
 
         l2GasToken.setMinter(address(l2Inbox), true);
         l2GasToken.setBurner(address(l2Outbox), true);

--- a/docs/specs/test/zone/ZoneOutbox.t.sol
+++ b/docs/specs/test/zone/ZoneOutbox.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import { IZoneOutbox, LastBatch, Withdrawal } from "../../src/zone/IZone.sol";
 import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
 import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
@@ -13,6 +14,7 @@ import { Test } from "forge-std/Test.sol";
 /// @notice Tests for ZoneOutbox finalizeWithdrawalBatch() functionality and withdrawal storage
 contract ZoneOutboxTest is Test {
 
+    ZoneConfig public config;
     ZoneOutbox public outbox;
     ZoneInbox public inbox;
     MockZoneGasToken public gasToken;
@@ -31,8 +33,12 @@ contract ZoneOutboxTest is Test {
         gasToken = new MockZoneGasToken("Zone USD", "zUSD");
         tempoState =
             new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
-        inbox = new ZoneInbox(mockPortal, address(tempoState), address(gasToken), sequencer);
-        outbox = new ZoneOutbox(address(gasToken), sequencer);
+        config = new ZoneConfig(address(gasToken), mockPortal, address(tempoState));
+        tempoState.setMockStorageValue(
+            mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
+        );
+        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(gasToken));
+        outbox = new ZoneOutbox(address(config), address(gasToken));
 
         // Grant minter role to inbox and burner role to outbox
         gasToken.setMinter(address(inbox), true);
@@ -784,7 +790,8 @@ contract ZoneOutboxTest is Test {
 
     function test_immutableGetters() public view {
         assertEq(address(outbox.gasToken()), address(gasToken));
-        assertEq(outbox.sequencer(), sequencer);
+        assertEq(address(outbox.config()), address(config));
+        assertEq(config.sequencer(), sequencer);
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Centralizes sequencer management on L1 (Tempo) via a new ZoneConfig system contract and restricts Tempo state access to only zone system contracts. This eliminates duplicate sequencer logic across zone contracts and prevents user transactions from reading arbitrary L1 state.

## Changes

### ZoneConfig System Contract
- **New predeploy at 0x1c00...0003**: Centralizes zone configuration and L1 state access
- **Single source of truth**: Reads sequencer from L1 ZonePortal via TempoState
- **Provides**: `sequencer()`, `pendingSequencer()`, `sequencerEncryptionKey()`, `isSequencer()`
- **Benefits**: Eliminates ~100 lines of duplicate sequencer management per contract

### Updated Zone System Contracts
- **ZoneInbox & ZoneOutbox**: Removed local sequencer storage, now use `config.sequencer()`
- **TempoState**: Removed sequencer management, added ZoneConfig to system contract allowlist
- **Access control consistency**: Added explicit `onlyZoneInbox` check to `TempoState.finalizeTempo()`

### Tempo State Access Restrictions
- **TempoState.sol**: `onlySystemContract` modifier restricts `readTempoStorageSlot()` and `readTempoStorageSlots()` to:
  - `ZONE_INBOX` (0x1c00...0001)
  - `ZONE_OUTBOX` (0x1c00...0002)
  - `ZONE_CONFIG` (0x1c00...0003)
- **TempoState.finalizeTempo()**: Only callable by `ZONE_INBOX` for consistency with other system contracts

### Documentation
- **IZone.sol**: Added system contract constants, IZoneConfig interface, updated all interfaces
- **overview.md**: Documented ZoneConfig predeploy, L1-based sequencer management, access restrictions

## Rationale

**Centralized L1 management**: L1 ZonePortal is the single source of truth for sequencer. Changes on L1 become visible to zone contracts after Tempo block finalization. This eliminates the risk of zone-side and L1-side sequencer state diverging.

**Access control consistency**: All zone system contracts now use explicit `msg.sender` checks with the same pattern, making the security model clear and uniform.

**Simplified state access**: User transactions cannot directly read arbitrary L1 state, reducing complexity while maintaining necessary system operations.

## Related

- Incorporates sequencer centralization from #17
- Builds on Tempo state verification infrastructure from #13
- Separate from encrypted deposits work

🤖 Generated with [Claude Code](https://claude.com/claude-code)