### PR TITLE
chore(zone): rename gasToken to zoneToken across codebase

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -314,7 +314,7 @@ This section defines the functions and interfaces used by the design. The signat
 
 ```solidity
 /// @notice Interface for the zone's zone token (TIP-20 with mint/burn for system)
-interface IZoneGasToken {
+interface IZoneToken {
     function mint(address to, uint256 amount) external;
     function burn(address from, uint256 amount) external;
     function transfer(address to, uint256 amount) external returns (bool);
@@ -845,7 +845,7 @@ interface IZoneInbox {
     function tempoState() external view returns (ITempoState);
 
     /// @notice The zone token (TIP-20 at same address as Tempo).
-    function gasToken() external view returns (IZoneGasToken);
+    function zoneToken() external view returns (IZoneToken);
 
     /// @notice The zone's last processed deposit queue hash.
     function processedDepositQueueHash() external view returns (bytes32);
@@ -915,7 +915,7 @@ interface IZoneOutbox {
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
 
     /// @notice The zone token (same as Tempo portal's token).
-    function gasToken() external view returns (IZoneGasToken);
+    function zoneToken() external view returns (IZoneToken);
 
     /// @notice Current sequencer address.
     function sequencer() external view returns (address);
@@ -1233,7 +1233,7 @@ bytes32 aesKey = _hkdfSha256(dec.sharedSecret, "ecies-aes-key", "");
 
 // Step 5: If decryption fails, return funds to sender (don't block chain)
 if (!valid) {
-    gasToken.mint(ed.sender, ed.amount);
+    zoneToken.mint(ed.sender, ed.amount);
     emit EncryptedDepositFailed(...);
 }
 ```
@@ -1341,11 +1341,11 @@ if (valid && decryptedPlaintext.length == ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
 // Step 6: Handle success or failure
 if (!valid) {
     // Decryption failed - return funds to sender
-    gasToken.mint(ed.sender, ed.amount);
+    zoneToken.mint(ed.sender, ed.amount);
     emit EncryptedDepositFailed(currentHash, ed.sender, ed.amount);
 } else {
     // Decryption succeeded - mint to decrypted recipient
-    gasToken.mint(dec.to, ed.amount);
+    zoneToken.mint(dec.to, ed.amount);
     emit DepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
 }
 ```

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -492,7 +492,7 @@ interface IZonePortal {
         returns (bytes32 x, uint8 yParity, uint256 keyIndex);
 
     /// @notice Set zone gas rate. Only callable by sequencer.
-    /// @param _zoneGasRate Gas token units per gas unit on the zone
+    /// @param _zoneGasRate Zone token units per gas unit on the zone
     function setZoneGasRate(uint128 _zoneGasRate) external;
 
     /// @notice Calculate the fee for a deposit
@@ -705,7 +705,7 @@ interface IZoneInbox {
     function tempoState() external view returns (ITempoState);
 
     /// @notice The zone token (TIP-20 at same address as Tempo)
-    function gasToken() external view returns (IZoneToken);
+    function zoneToken() external view returns (IZoneToken);
 
     /// @notice The zone's last processed deposit queue hash
     function processedDepositQueueHash() external view returns (bytes32);
@@ -763,9 +763,9 @@ interface IZoneOutbox {
     function config() external view returns (IZoneConfig);
 
     /// @notice The zone token (same as Tempo portal's token)
-    function gasToken() external view returns (IZoneToken);
+    function zoneToken() external view returns (IZoneToken);
 
-    /// @notice Tempo gas rate (gas token units per gas unit on Tempo)
+    /// @notice Tempo gas rate (zone token units per gas unit on Tempo)
     /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
     function tempoGasRate() external view returns (uint128);
 
@@ -783,7 +783,7 @@ interface IZoneOutbox {
 
     /// @notice Set Tempo gas rate. Only callable by sequencer.
     /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price fluctuations.
-    /// @param _tempoGasRate Gas token units per gas unit on Tempo
+    /// @param _tempoGasRate Zone token units per gas unit on Tempo
     function setTempoGasRate(uint128 _tempoGasRate) external;
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -41,7 +41,7 @@ contract ZoneInbox is IZoneInbox {
     TempoState internal immutable _tempoState;
 
     /// @notice The zone token (TIP-20 at same address as Tempo)
-    IZoneToken public immutable gasToken;
+    IZoneToken public immutable zoneToken;
 
     /// @notice Last processed deposit queue hash (validated against Tempo state)
     bytes32 public processedDepositQueueHash;
@@ -54,12 +54,12 @@ contract ZoneInbox is IZoneInbox {
         address _config,
         address _tempoPortalAddr,
         address _tempoStateAddr,
-        address _gasToken
+        address _zoneToken
     ) {
         config = IZoneConfig(_config);
         tempoPortal = _tempoPortalAddr;
         _tempoState = TempoState(_tempoStateAddr);
-        gasToken = IZoneToken(_gasToken);
+        zoneToken = IZoneToken(_zoneToken);
     }
 
     /// @notice The TempoState predeploy address
@@ -203,7 +203,7 @@ contract ZoneInbox is IZoneInbox {
                 currentHash = keccak256(abi.encode(DepositType.Regular, d, currentHash));
 
                 // Mint zone tokens to the recipient
-                gasToken.mint(d.to, d.amount);
+                zoneToken.mint(d.to, d.amount);
 
                 emit DepositProcessed(currentHash, d.sender, d.to, d.amount, d.memo);
             } else {
@@ -268,11 +268,11 @@ contract ZoneInbox is IZoneInbox {
                 if (!valid) {
                     // Decryption failed (user encrypted garbage or corrupted data)
                     // Return funds to sender instead of blocking chain progress
-                    gasToken.mint(ed.sender, ed.amount);
+                    zoneToken.mint(ed.sender, ed.amount);
                     emit EncryptedDepositFailed(currentHash, ed.sender, ed.amount);
                 } else {
                     // Decryption succeeded - mint to the decrypted recipient
-                    gasToken.mint(dec.to, ed.amount);
+                    zoneToken.mint(dec.to, ed.amount);
                     emit EncryptedDepositProcessed(
                         currentHash, ed.sender, dec.to, ed.amount, dec.memo
                     );

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -30,7 +30,7 @@ contract ZoneOutbox is IZoneOutbox {
     IZoneConfig public immutable config;
 
     /// @notice The zone token (TIP-20 at same address as Tempo)
-    IZoneToken public immutable gasToken;
+    IZoneToken public immutable zoneToken;
 
     /// @notice Tempo gas rate (zone token units per gas unit on Tempo)
     /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price changes.
@@ -65,9 +65,9 @@ contract ZoneOutbox is IZoneOutbox {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address _config, address _gasToken) {
+    constructor(address _config, address _zoneToken) {
         config = IZoneConfig(_config);
-        gasToken = IZoneToken(_gasToken);
+        zoneToken = IZoneToken(_zoneToken);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -133,13 +133,13 @@ contract ZoneOutbox is IZoneOutbox {
 
         // Transfer tokens from sender to this contract, then burn
         // (Using transferFrom so user must approve first)
-        if (!gasToken.transferFrom(msg.sender, address(this), totalBurn)) {
+        if (!zoneToken.transferFrom(msg.sender, address(this), totalBurn)) {
             revert TransferFailed();
         }
 
         // Burn the tokens (they'll be released on Tempo when withdrawal is processed)
         // Amount goes to recipient, fee goes to sequencer
-        gasToken.burn(address(this), totalBurn);
+        zoneToken.burn(address(this), totalBurn);
 
         // Store withdrawal in pending array
         _pendingWithdrawals.push(

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -36,7 +36,7 @@ import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
 import { MockVerifier } from "./mocks/MockVerifier.sol";
-import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import { MockZoneToken } from "./mocks/MockZoneToken.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 /// @notice Mock withdrawal receiver for callback tests
@@ -84,7 +84,7 @@ contract ZoneBridgeTest is BaseTest {
                              ZONE CONTRACTS
     //////////////////////////////////////////////////////////////*/
 
-    MockZoneGasToken public l2GasToken;
+    MockZoneToken public l2ZoneToken;
     MockTempoState public l2TempoState;
     ZoneConfig public l2Config;
     ZoneInbox public l2Inbox;
@@ -156,27 +156,27 @@ contract ZoneBridgeTest is BaseTest {
         l1Portal = ZonePortal(portalAddr);
 
         // === Deploy zone contracts ===
-        // Gas token on zone (same concept as pathUSD, deployed at "same address" conceptually)
-        l2GasToken = new MockZoneGasToken("Zone USD", "zUSD");
+        // Zone token (same concept as pathUSD, deployed at "same address" conceptually)
+        l2ZoneToken = new MockZoneToken("Zone USD", "zUSD");
 
         // TempoState mock for testing
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
 
         // Zone config (reads sequencer from L1 portal via Tempo state)
-        l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
+        l2Config = new ZoneConfig(address(l2ZoneToken), portalAddr, address(l2TempoState));
         l2TempoState.setMockStorageValue(
             portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
         );
 
         // Zone inbox (advances Tempo state and processes deposits)
         l2Inbox = new ZoneInbox(
-            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
+            address(l2Config), portalAddr, address(l2TempoState), address(l2ZoneToken)
         );
-        l2GasToken.setMinter(address(l2Inbox), true);
+        l2ZoneToken.setMinter(address(l2Inbox), true);
 
         // Zone outbox (handles withdrawals)
-        l2Outbox = new ZoneOutbox(address(l2Config), address(l2GasToken));
-        l2GasToken.setBurner(address(l2Outbox), true);
+        l2Outbox = new ZoneOutbox(address(l2Config), address(l2ZoneToken));
+        l2ZoneToken.setBurner(address(l2Outbox), true);
 
         // Initialize zone block hash
         l2BlockHash = GENESIS_BLOCK_HASH;
@@ -357,9 +357,9 @@ contract ZoneBridgeTest is BaseTest {
         bytes32 newProcessedHash = _sequencerRelayDepositsToL2();
 
         // Verify zone state
-        assertEq(l2GasToken.balanceOf(alice), depositAmount);
+        assertEq(l2ZoneToken.balanceOf(alice), depositAmount);
         assertEq(l2Inbox.processedDepositQueueHash(), newProcessedHash);
-        assertEq(l2GasToken.totalSupply(), depositAmount);
+        assertEq(l2ZoneToken.totalSupply(), depositAmount);
 
         // === STEP 4: Submit batch to L1 (no withdrawals yet) ===
         _sequencerSubmitBatch(newProcessedHash);
@@ -371,7 +371,7 @@ contract ZoneBridgeTest is BaseTest {
         // === STEP 5: Alice requests withdrawal on zone ===
         uint128 withdrawAmount = 400e6;
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), withdrawAmount);
+        l2ZoneToken.approve(address(l2Outbox), withdrawAmount);
         l2Outbox.requestWithdrawal(
             alice, // to (back to self on L1)
             withdrawAmount,
@@ -383,7 +383,7 @@ contract ZoneBridgeTest is BaseTest {
         vm.stopPrank();
 
         // Verify zone state - tokens burned
-        assertEq(l2GasToken.balanceOf(alice), depositAmount - withdrawAmount);
+        assertEq(l2ZoneToken.balanceOf(alice), depositAmount - withdrawAmount);
 
         // === STEP 6: Sequencer observes withdrawal event ===
         _sequencerObserveWithdrawal(0, alice, alice, withdrawAmount, bytes32(0), 0, alice, "");
@@ -441,20 +441,20 @@ contract ZoneBridgeTest is BaseTest {
         bytes32 processedHash = _sequencerRelayDepositsToL2();
 
         // Verify zone balances
-        assertEq(l2GasToken.balanceOf(alice), 2000e6);
-        assertEq(l2GasToken.balanceOf(bob), 3000e6);
+        assertEq(l2ZoneToken.balanceOf(alice), 2000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), 3000e6);
 
         // Submit batch
         _sequencerSubmitBatch(processedHash);
 
         // === Both request withdrawals ===
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 500e6);
+        l2ZoneToken.approve(address(l2Outbox), 500e6);
         l2Outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(bob);
-        l2GasToken.approve(address(l2Outbox), 1000e6);
+        l2ZoneToken.approve(address(l2Outbox), 1000e6);
         l2Outbox.requestWithdrawal(bob, 1000e6, bytes32(0), 0, bob, "");
         vm.stopPrank();
 
@@ -516,7 +516,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Request withdrawal with callback
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 500e6);
+        l2ZoneToken.approve(address(l2Outbox), 500e6);
         l2Outbox.requestWithdrawal(
             address(withdrawalReceiver), // to: receiver contract
             500e6,
@@ -575,7 +575,7 @@ contract ZoneBridgeTest is BaseTest {
         // Request withdrawal with callback that will fail
         withdrawalReceiver.setShouldAccept(false);
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 500e6);
+        l2ZoneToken.approve(address(l2Outbox), 500e6);
         l2Outbox.requestWithdrawal(
             address(withdrawalReceiver),
             500e6,
@@ -627,20 +627,20 @@ contract ZoneBridgeTest is BaseTest {
 
         // Alice transfers to Bob on zone
         vm.prank(alice);
-        l2GasToken.transfer(bob, 300e6);
+        l2ZoneToken.transfer(bob, 300e6);
 
         // Verify zone balances
-        assertEq(l2GasToken.balanceOf(alice), 700e6);
-        assertEq(l2GasToken.balanceOf(bob), 300e6);
+        assertEq(l2ZoneToken.balanceOf(alice), 700e6);
+        assertEq(l2ZoneToken.balanceOf(bob), 300e6);
 
         // Bob withdraws on zone
         vm.startPrank(bob);
-        l2GasToken.approve(address(l2Outbox), 300e6);
+        l2ZoneToken.approve(address(l2Outbox), 300e6);
         l2Outbox.requestWithdrawal(bob, 300e6, bytes32(0), 0, bob, "");
         vm.stopPrank();
 
         // Verify Bob's zone balance debited
-        assertEq(l2GasToken.balanceOf(bob), 0);
+        assertEq(l2ZoneToken.balanceOf(bob), 0);
         assertEq(l2Outbox.nextWithdrawalIndex(), 1);
     }
 
@@ -656,8 +656,8 @@ contract ZoneBridgeTest is BaseTest {
 
         // Alice tries to withdraw more than balance
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 2000e6);
-        vm.expectRevert(MockZoneGasToken.InsufficientBalance.selector);
+        l2ZoneToken.approve(address(l2Outbox), 2000e6);
+        vm.expectRevert(MockZoneToken.InsufficientBalance.selector);
         l2Outbox.requestWithdrawal(alice, 2000e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
     }
@@ -674,8 +674,8 @@ contract ZoneBridgeTest is BaseTest {
 
         // Alice tries to transfer more than balance
         vm.prank(alice);
-        vm.expectRevert(MockZoneGasToken.InsufficientBalance.selector);
-        l2GasToken.transfer(bob, 2000e6);
+        vm.expectRevert(MockZoneToken.InsufficientBalance.selector);
+        l2ZoneToken.transfer(bob, 2000e6);
     }
 
     function test_l2_invalidDepositHashReverts() public {
@@ -713,7 +713,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Try callback without fallback recipient
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 500e6);
+        l2ZoneToken.approve(address(l2Outbox), 500e6);
         vm.expectRevert(ZoneOutbox.InvalidFallbackRecipient.selector);
         l2Outbox.requestWithdrawal(
             address(withdrawalReceiver),
@@ -1014,9 +1014,9 @@ contract ZoneBridgeTest is BaseTest {
 
         // Verify zone state — tokens minted to decrypted recipient
         assertEq(
-            l2GasToken.balanceOf(decryptedRecipient), netAmount, "Recipient should receive tokens"
+            l2ZoneToken.balanceOf(decryptedRecipient), netAmount, "Recipient should receive tokens"
         );
-        assertEq(l2GasToken.balanceOf(alice), 0, "Sender should not receive tokens");
+        assertEq(l2ZoneToken.balanceOf(alice), 0, "Sender should not receive tokens");
         assertEq(
             l2Inbox.processedDepositQueueHash(), newProcessedHash, "Zone processed hash mismatch"
         );
@@ -1054,8 +1054,8 @@ contract ZoneBridgeTest is BaseTest {
             _sequencerRelayEncryptedDepositsToL2(address(0xBEEF), bytes32("wrong"), false);
 
         // Verify zone state — tokens bounced back to sender (alice), not to any recipient
-        assertEq(l2GasToken.balanceOf(alice), netAmount, "Sender should get bounced tokens");
-        assertEq(l2GasToken.balanceOf(address(0xBEEF)), 0, "Failed recipient should get nothing");
+        assertEq(l2ZoneToken.balanceOf(alice), netAmount, "Sender should get bounced tokens");
+        assertEq(l2ZoneToken.balanceOf(address(0xBEEF)), 0, "Failed recipient should get nothing");
         assertEq(
             l2Inbox.processedDepositQueueHash(), newProcessedHash, "Zone processed hash mismatch"
         );
@@ -1149,17 +1149,17 @@ contract ZoneBridgeTest is BaseTest {
         l2Inbox.advanceTempo("", queued, decs);
 
         // === STEP 7: Verify all balances ===
-        assertEq(l2GasToken.balanceOf(alice), depositAmount, "Alice gets regular deposit");
+        assertEq(l2ZoneToken.balanceOf(alice), depositAmount, "Alice gets regular deposit");
         assertEq(
-            l2GasToken.balanceOf(decryptedTo), netAmount, "Bob's encrypted recipient gets tokens"
+            l2ZoneToken.balanceOf(decryptedTo), netAmount, "Bob's encrypted recipient gets tokens"
         );
-        assertEq(l2GasToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
-        assertEq(l2GasToken.balanceOf(carol), depositAmount, "Carol gets regular deposit");
+        assertEq(l2ZoneToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
+        assertEq(l2ZoneToken.balanceOf(carol), depositAmount, "Carol gets regular deposit");
         assertEq(l2Inbox.processedDepositQueueHash(), hash3, "Zone processed hash matches L1");
 
         // Total supply = alice_regular + bob_encrypted_net + carol_regular
         assertEq(
-            l2GasToken.totalSupply(),
+            l2ZoneToken.totalSupply(),
             depositAmount + netAmount + depositAmount,
             "Total supply should equal all deposits"
         );
@@ -1292,12 +1292,12 @@ contract ZoneBridgeTest is BaseTest {
         // === STEP 7: Verify ===
         // Both deposits go to sharedRecipient
         assertEq(
-            l2GasToken.balanceOf(sharedRecipient),
+            l2ZoneToken.balanceOf(sharedRecipient),
             netAmount * 2,
             "Recipient should receive both deposits"
         );
-        assertEq(l2GasToken.balanceOf(alice), 0, "Alice (sender) should not receive tokens");
-        assertEq(l2GasToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
+        assertEq(l2ZoneToken.balanceOf(alice), 0, "Alice (sender) should not receive tokens");
+        assertEq(l2ZoneToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
         assertEq(l2Inbox.processedDepositQueueHash(), hash2, "Zone processed hash matches L1");
 
         // === STEP 8: Submit batch ===

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -22,7 +22,7 @@ import {
 import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
-import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import { MockZoneToken } from "./mocks/MockZoneToken.sol";
 import { Test } from "forge-std/Test.sol";
 
 /// @title ZoneInboxTest
@@ -31,7 +31,7 @@ contract ZoneInboxTest is Test {
 
     ZoneConfig public config;
     ZoneInbox public inbox;
-    MockZoneGasToken public gasToken;
+    MockZoneToken public zoneToken;
     MockTempoState public tempoState;
 
     address public sequencer = address(0x1);
@@ -43,16 +43,16 @@ contract ZoneInboxTest is Test {
     uint64 constant GENESIS_TEMPO_BLOCK_NUMBER = 1;
 
     function setUp() public {
-        gasToken = new MockZoneGasToken("Zone USD", "zUSD");
+        zoneToken = new MockZoneToken("Zone USD", "zUSD");
         tempoState =
             new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
-        config = new ZoneConfig(address(gasToken), mockPortal, address(tempoState));
+        config = new ZoneConfig(address(zoneToken), mockPortal, address(tempoState));
         tempoState.setMockStorageValue(
             mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
         );
-        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(gasToken));
+        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(zoneToken));
 
-        gasToken.setMinter(address(inbox), true);
+        zoneToken.setMinter(address(inbox), true);
     }
 
     function _wrapDeposits(Deposit[] memory deposits)
@@ -106,7 +106,7 @@ contract ZoneInboxTest is Test {
         _advanceTempo(deposits);
 
         assertEq(inbox.processedDepositQueueHash(), expectedHash);
-        assertEq(gasToken.balanceOf(bob), 1000e6);
+        assertEq(zoneToken.balanceOf(bob), 1000e6);
     }
 
     function test_advanceTempo_multipleDeposits() public {
@@ -127,8 +127,8 @@ contract ZoneInboxTest is Test {
         _advanceTempo(deposits);
 
         assertEq(inbox.processedDepositQueueHash(), h3);
-        assertEq(gasToken.balanceOf(alice), 100e6);
-        assertEq(gasToken.balanceOf(bob), 200e6 + 300e6);
+        assertEq(zoneToken.balanceOf(alice), 100e6);
+        assertEq(zoneToken.balanceOf(bob), 200e6 + 300e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -248,8 +248,8 @@ contract ZoneInboxTest is Test {
         _advanceTempo(batch2);
 
         assertEq(inbox.processedDepositQueueHash(), h3);
-        assertEq(gasToken.balanceOf(alice), 100e6);
-        assertEq(gasToken.balanceOf(bob), 200e6 + 500e6);
+        assertEq(zoneToken.balanceOf(alice), 100e6);
+        assertEq(zoneToken.balanceOf(bob), 200e6 + 500e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -312,7 +312,7 @@ contract ZoneInboxTest is Test {
         _advanceTempo(deposits);
 
         assertEq(inbox.processedDepositQueueHash(), expectedHash);
-        assertEq(gasToken.balanceOf(bob), 0);
+        assertEq(zoneToken.balanceOf(bob), 0);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -323,7 +323,7 @@ contract ZoneInboxTest is Test {
         assertEq(address(inbox.config()), address(config));
         assertEq(inbox.tempoPortal(), mockPortal);
         assertEq(address(inbox.tempoState()), address(tempoState));
-        assertEq(address(inbox.gasToken()), address(gasToken));
+        assertEq(address(inbox.zoneToken()), address(zoneToken));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -352,7 +352,7 @@ contract ZoneInboxTest is Test {
 
         // Calculate expected balance: sum of 1 + 2 + ... + 50 = 50 * 51 / 2 = 1275
         uint256 expectedBalance = (numDeposits * (numDeposits + 1) / 2) * 1e6;
-        assertEq(gasToken.balanceOf(bob), expectedBalance);
+        assertEq(zoneToken.balanceOf(bob), expectedBalance);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -454,7 +454,7 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
 
         // Verify minting to the decrypted recipient
-        assertEq(gasToken.balanceOf(recipient), amount);
+        assertEq(zoneToken.balanceOf(recipient), amount);
         assertEq(inbox.processedDepositQueueHash(), expectedHash);
     }
 
@@ -506,8 +506,8 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
 
         // Funds should go to sender (alice), not the decrypted recipient
-        assertEq(gasToken.balanceOf(alice), amount);
-        assertEq(gasToken.balanceOf(address(0x500)), 0);
+        assertEq(zoneToken.balanceOf(alice), amount);
+        assertEq(zoneToken.balanceOf(address(0x500)), 0);
         assertEq(inbox.processedDepositQueueHash(), expectedHash);
     }
 
@@ -551,8 +551,8 @@ contract ZoneInboxTest is Test {
 
         // Regular deposit: bob gets 100e6
         // Encrypted deposit: recipient gets 200e6
-        assertEq(gasToken.balanceOf(bob), 100e6);
-        assertEq(gasToken.balanceOf(recipient), 200e6);
+        assertEq(zoneToken.balanceOf(bob), 100e6);
+        assertEq(zoneToken.balanceOf(recipient), 200e6);
         assertEq(inbox.processedDepositQueueHash(), h2);
     }
 
@@ -812,8 +812,8 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
 
         // Deposit should bounce to sender (alice) because plaintext length != 64
-        assertEq(gasToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
-        assertEq(gasToken.balanceOf(recipient), 0, "recipient should get nothing");
+        assertEq(zoneToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
+        assertEq(zoneToken.balanceOf(recipient), 0, "recipient should get nothing");
     }
 
     /// @notice Verify that a too-long plaintext (65 bytes) causes the deposit to bounce
@@ -835,8 +835,8 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
 
         // Deposit should bounce to sender
-        assertEq(gasToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
-        assertEq(gasToken.balanceOf(recipient), 0, "recipient should get nothing");
+        assertEq(zoneToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
+        assertEq(zoneToken.balanceOf(recipient), 0, "recipient should get nothing");
     }
 
     /// @notice Verify that an empty plaintext (0 bytes) causes the deposit to bounce
@@ -853,8 +853,8 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
 
         // Deposit should bounce to sender
-        assertEq(gasToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
-        assertEq(gasToken.balanceOf(recipient), 0, "recipient should get nothing");
+        assertEq(zoneToken.balanceOf(alice), 1000e6, "sender should receive bounced funds");
+        assertEq(zoneToken.balanceOf(recipient), 0, "recipient should get nothing");
     }
 
     /// @notice Verify that exactly 64-byte plaintext with correct data succeeds
@@ -872,8 +872,8 @@ contract ZoneInboxTest is Test {
         inbox.advanceTempo("", deposits, decs);
 
         // Deposit should succeed — minted to the decrypted recipient
-        assertEq(gasToken.balanceOf(recipient), 1000e6, "recipient should receive funds");
-        assertEq(gasToken.balanceOf(alice), 0, "sender should get nothing (successful deposit)");
+        assertEq(zoneToken.balanceOf(recipient), 1000e6, "recipient should receive funds");
+        assertEq(zoneToken.balanceOf(alice), 0, "sender should get nothing (successful deposit)");
     }
 
 }

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -27,7 +27,7 @@ import { BaseTest } from "../BaseTest.t.sol";
 
 import { MockTempoState } from "./mocks/MockTempoState.sol";
 import { MockVerifier } from "./mocks/MockVerifier.sol";
-import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import { MockZoneToken } from "./mocks/MockZoneToken.sol";
 
 /// @notice Mock receiver that tracks received amounts
 contract TrackingReceiver is IWithdrawalReceiver {
@@ -60,7 +60,7 @@ contract ZoneIntegrationTest is BaseTest {
     MockVerifier public l1Verifier;
 
     // L2 contracts
-    MockZoneGasToken public l2GasToken;
+    MockZoneToken public l2ZoneToken;
     MockTempoState public l2TempoState;
     ZoneConfig public l2Config;
     ZoneInbox public l2Inbox;
@@ -107,19 +107,19 @@ contract ZoneIntegrationTest is BaseTest {
         l1Portal = ZonePortal(portalAddr);
 
         // L2 setup
-        l2GasToken = new MockZoneGasToken("Zone USD", "zUSD");
+        l2ZoneToken = new MockZoneToken("Zone USD", "zUSD");
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
-        l2Config = new ZoneConfig(address(l2GasToken), portalAddr, address(l2TempoState));
+        l2Config = new ZoneConfig(address(l2ZoneToken), portalAddr, address(l2TempoState));
         l2TempoState.setMockStorageValue(
             portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
         );
         l2Inbox = new ZoneInbox(
-            address(l2Config), portalAddr, address(l2TempoState), address(l2GasToken)
+            address(l2Config), portalAddr, address(l2TempoState), address(l2ZoneToken)
         );
-        l2Outbox = new ZoneOutbox(address(l2Config), address(l2GasToken));
+        l2Outbox = new ZoneOutbox(address(l2Config), address(l2ZoneToken));
 
-        l2GasToken.setMinter(address(l2Inbox), true);
-        l2GasToken.setBurner(address(l2Outbox), true);
+        l2ZoneToken.setMinter(address(l2Inbox), true);
+        l2ZoneToken.setBurner(address(l2Outbox), true);
     }
 
     function _wrapDeposits(Deposit[] memory deposits)
@@ -179,10 +179,10 @@ contract ZoneIntegrationTest is BaseTest {
         _advanceTempo(deposits);
 
         // Verify L2 balances
-        assertEq(l2GasToken.balanceOf(alice), 3000e6);
-        assertEq(l2GasToken.balanceOf(bob), 3000e6);
-        assertEq(l2GasToken.balanceOf(charlie), 500e6);
-        assertEq(l2GasToken.totalSupply(), 6500e6);
+        assertEq(l2ZoneToken.balanceOf(alice), 3000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), 3000e6);
+        assertEq(l2ZoneToken.balanceOf(charlie), 500e6);
+        assertEq(l2ZoneToken.totalSupply(), 6500e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -207,7 +207,7 @@ contract ZoneIntegrationTest is BaseTest {
         vm.prank(admin);
         _advanceTempo(batch1);
 
-        assertEq(l2GasToken.balanceOf(alice), 1000e6);
+        assertEq(l2ZoneToken.balanceOf(alice), 1000e6);
         assertEq(l2Inbox.processedDepositQueueHash(), d1);
 
         // Submit L1 batch for first deposit
@@ -242,7 +242,7 @@ contract ZoneIntegrationTest is BaseTest {
         vm.prank(admin);
         _advanceTempo(batch2);
 
-        assertEq(l2GasToken.balanceOf(alice), 6000e6);
+        assertEq(l2ZoneToken.balanceOf(alice), 6000e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -268,7 +268,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Alice requests withdrawal with callback
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 2000e6);
+        l2ZoneToken.approve(address(l2Outbox), 2000e6);
         l2Outbox.requestWithdrawal(
             address(receiver), 2000e6, bytes32("payment"), 100_000, alice, "callback"
         );
@@ -336,7 +336,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         // First batch: Alice withdraws to Bob
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 50_000e6);
+        l2ZoneToken.approve(address(l2Outbox), 50_000e6);
         l2Outbox.requestWithdrawal(bob, 1000e6, bytes32("to bob"), 0, alice, "");
         vm.stopPrank();
 
@@ -487,12 +487,12 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Phase 2: Withdrawals
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 5000e6);
+        l2ZoneToken.approve(address(l2Outbox), 5000e6);
         l2Outbox.requestWithdrawal(charlie, 2000e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(bob);
-        l2GasToken.approve(address(l2Outbox), 3000e6);
+        l2ZoneToken.approve(address(l2Outbox), 3000e6);
         l2Outbox.requestWithdrawal(charlie, 1500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -531,9 +531,9 @@ contract ZoneIntegrationTest is BaseTest {
         _advanceTempo(deposits2);
 
         // Verify all L2 balances
-        assertEq(l2GasToken.balanceOf(alice), 10_000e6 - 2000e6);
-        assertEq(l2GasToken.balanceOf(bob), 5000e6 - 1500e6);
-        assertEq(l2GasToken.balanceOf(charlie), 7500e6);
+        assertEq(l2ZoneToken.balanceOf(alice), 10_000e6 - 2000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), 5000e6 - 1500e6);
+        assertEq(l2ZoneToken.balanceOf(charlie), 7500e6);
 
         // Process withdrawals
         Withdrawal memory w1 = Withdrawal({
@@ -585,21 +585,21 @@ contract ZoneIntegrationTest is BaseTest {
         vm.prank(admin);
         _advanceTempo(deposits);
 
-        assertEq(l2GasToken.totalSupply(), 10_000e6);
+        assertEq(l2ZoneToken.totalSupply(), 10_000e6);
 
         // Withdraw 3000
         vm.startPrank(alice);
-        l2GasToken.approve(address(l2Outbox), 3000e6);
+        l2ZoneToken.approve(address(l2Outbox), 3000e6);
         l2Outbox.requestWithdrawal(bob, 3000e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
-        assertEq(l2GasToken.totalSupply(), 7000e6); // Tokens burned on withdrawal request
+        assertEq(l2ZoneToken.totalSupply(), 7000e6); // Tokens burned on withdrawal request
 
         // Transfer on L2 shouldn't change supply
         vm.prank(alice);
-        l2GasToken.transfer(bob, 2000e6);
+        l2ZoneToken.transfer(bob, 2000e6);
 
-        assertEq(l2GasToken.totalSupply(), 7000e6);
+        assertEq(l2ZoneToken.totalSupply(), 7000e6);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/test/zone/ZoneOutbox.t.sol
+++ b/docs/specs/test/zone/ZoneOutbox.t.sol
@@ -7,7 +7,7 @@ import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
 import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
-import { MockZoneGasToken } from "./mocks/MockZoneGasToken.sol";
+import { MockZoneToken } from "./mocks/MockZoneToken.sol";
 import { Test } from "forge-std/Test.sol";
 
 /// @title ZoneOutboxTest
@@ -17,7 +17,7 @@ contract ZoneOutboxTest is Test {
     ZoneConfig public config;
     ZoneOutbox public outbox;
     ZoneInbox public inbox;
-    MockZoneGasToken public gasToken;
+    MockZoneToken public zoneToken;
     MockTempoState public tempoState;
 
     address public sequencer = address(0x1);
@@ -30,25 +30,25 @@ contract ZoneOutboxTest is Test {
     uint64 constant GENESIS_TEMPO_BLOCK_NUMBER = 1;
 
     function setUp() public {
-        gasToken = new MockZoneGasToken("Zone USD", "zUSD");
+        zoneToken = new MockZoneToken("Zone USD", "zUSD");
         tempoState =
             new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
-        config = new ZoneConfig(address(gasToken), mockPortal, address(tempoState));
+        config = new ZoneConfig(address(zoneToken), mockPortal, address(tempoState));
         tempoState.setMockStorageValue(
             mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
         );
-        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(gasToken));
-        outbox = new ZoneOutbox(address(config), address(gasToken));
+        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(zoneToken));
+        outbox = new ZoneOutbox(address(config), address(zoneToken));
 
         // Grant minter role to inbox and burner role to outbox
-        gasToken.setMinter(address(inbox), true);
-        gasToken.setBurner(address(outbox), true);
+        zoneToken.setMinter(address(inbox), true);
+        zoneToken.setBurner(address(outbox), true);
 
         // Give alice and bob tokens
-        gasToken.setMinter(address(this), true);
-        gasToken.mint(alice, 10_000e6);
-        gasToken.mint(bob, 10_000e6);
-        gasToken.mint(charlie, 10_000e6);
+        zoneToken.setMinter(address(this), true);
+        zoneToken.mint(alice, 10_000e6);
+        zoneToken.mint(bob, 10_000e6);
+        zoneToken.mint(charlie, 10_000e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -57,14 +57,14 @@ contract ZoneOutboxTest is Test {
 
     function test_requestWithdrawal_storesInArray() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32("memo"), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 1);
 
         vm.startPrank(bob);
-        gasToken.approve(address(outbox), 300e6);
+        zoneToken.approve(address(outbox), 300e6);
         outbox.requestWithdrawal(bob, 300e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -86,7 +86,7 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_zeroCount_returnsZero() public {
         // Add a withdrawal
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -102,7 +102,7 @@ contract ZoneOutboxTest is Test {
 
     function test_finalizeWithdrawalBatch_singleWithdrawal_correctHash() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32("memo"), 0, alice, "");
         vm.stopPrank();
 
@@ -128,13 +128,13 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_multipleWithdrawals_correctHashChain() public {
         // Alice withdraws
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         // Bob withdraws
         vm.startPrank(bob);
-        gasToken.approve(address(outbox), 300e6);
+        zoneToken.approve(address(outbox), 300e6);
         outbox.requestWithdrawal(bob, 300e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -175,7 +175,7 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_clearsStorage() public {
         // Add withdrawals
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 1000e6);
+        zoneToken.approve(address(outbox), 1000e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
         outbox.requestWithdrawal(alice, 300e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
@@ -192,7 +192,7 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_partialBatch_processesOnlyCount() public {
         // Add 3 withdrawals
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 1500e6);
+        zoneToken.approve(address(outbox), 1500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32("w1"), 0, alice, "");
         outbox.requestWithdrawal(alice, 500e6, bytes32("w2"), 0, alice, "");
         outbox.requestWithdrawal(alice, 500e6, bytes32("w3"), 0, alice, "");
@@ -238,7 +238,7 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_partialBatches_fifoOrder() public {
         // Add 4 withdrawals in order
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 4000e6);
+        zoneToken.approve(address(outbox), 4000e6);
         outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
         outbox.requestWithdrawal(alice, 200e6, bytes32("w2"), 0, alice, "");
         outbox.requestWithdrawal(alice, 300e6, bytes32("w3"), 0, alice, "");
@@ -310,7 +310,7 @@ contract ZoneOutboxTest is Test {
 
     function test_finalizeWithdrawalBatch_emitsEvent() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -339,7 +339,7 @@ contract ZoneOutboxTest is Test {
 
     function test_finalizeWithdrawalBatch_writesLastBatchToState() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -371,7 +371,7 @@ contract ZoneOutboxTest is Test {
 
     function test_finalizeWithdrawalBatch_onlySequencer() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -392,7 +392,7 @@ contract ZoneOutboxTest is Test {
 
     function test_finalizeWithdrawalBatch_withdrawalWithCallback_correctHash() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(
             bob, // to
             500e6, // amount
@@ -429,7 +429,7 @@ contract ZoneOutboxTest is Test {
         assertEq(outbox.nextWithdrawalIndex(), 0);
 
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 3000e6);
+        zoneToken.approve(address(outbox), 3000e6);
 
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
         assertEq(outbox.nextWithdrawalIndex(), 1);
@@ -445,7 +445,7 @@ contract ZoneOutboxTest is Test {
 
     function test_nextWithdrawalIndex_persistsAcrossBatches() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 5000e6);
+        zoneToken.approve(address(outbox), 5000e6);
 
         // First batch
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
@@ -472,7 +472,7 @@ contract ZoneOutboxTest is Test {
         assertEq(outbox.pendingWithdrawalsCount(), 0);
 
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 3000e6);
+        zoneToken.approve(address(outbox), 3000e6);
 
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
         assertEq(outbox.pendingWithdrawalsCount(), 1);
@@ -493,41 +493,41 @@ contract ZoneOutboxTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_requestWithdrawal_transfersFromSender() public {
-        uint256 aliceBalanceBefore = gasToken.balanceOf(alice);
+        uint256 aliceBalanceBefore = zoneToken.balanceOf(alice);
 
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
-        assertEq(gasToken.balanceOf(alice), aliceBalanceBefore - 500e6);
+        assertEq(zoneToken.balanceOf(alice), aliceBalanceBefore - 500e6);
     }
 
     function test_requestWithdrawal_burnsTokens() public {
-        uint256 totalSupplyBefore = gasToken.totalSupply();
+        uint256 totalSupplyBefore = zoneToken.totalSupply();
 
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
-        assertEq(gasToken.totalSupply(), totalSupplyBefore - 500e6);
+        assertEq(zoneToken.totalSupply(), totalSupplyBefore - 500e6);
     }
 
     function test_requestWithdrawal_revertsOnInsufficientBalance() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 200_000e6);
+        zoneToken.approve(address(outbox), 200_000e6);
 
-        vm.expectRevert(MockZoneGasToken.InsufficientBalance.selector);
+        vm.expectRevert(MockZoneToken.InsufficientBalance.selector);
         outbox.requestWithdrawal(bob, 200_000e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
     }
 
     function test_requestWithdrawal_revertsOnInsufficientAllowance() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 100e6);
+        zoneToken.approve(address(outbox), 100e6);
 
-        vm.expectRevert(MockZoneGasToken.InsufficientAllowance.selector);
+        vm.expectRevert(MockZoneToken.InsufficientAllowance.selector);
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
     }
@@ -538,7 +538,7 @@ contract ZoneOutboxTest is Test {
 
     function test_requestWithdrawal_noCallbackNeedsFallback_ok() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
 
         // gasLimit = 0, fallbackRecipient = alice is fine
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
@@ -549,7 +549,7 @@ contract ZoneOutboxTest is Test {
 
     function test_requestWithdrawal_callbackNeedsFallback_reverts() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
 
         // fallbackRecipient = address(0) reverts
         vm.expectRevert(ZoneOutbox.InvalidFallbackRecipient.selector);
@@ -559,7 +559,7 @@ contract ZoneOutboxTest is Test {
 
     function test_requestWithdrawal_callbackWithValidFallback_ok() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
 
         // gasLimit > 0 with valid fallback
         outbox.requestWithdrawal(bob, 500e6, bytes32(0), 100_000, alice, "callback");
@@ -575,17 +575,17 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_hashChainOrder() public {
         // Add three withdrawals
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 3000e6);
+        zoneToken.approve(address(outbox), 3000e6);
         outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(bob);
-        gasToken.approve(address(outbox), 3000e6);
+        zoneToken.approve(address(outbox), 3000e6);
         outbox.requestWithdrawal(bob, 200e6, bytes32("w2"), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(charlie);
-        gasToken.approve(address(outbox), 3000e6);
+        zoneToken.approve(address(outbox), 3000e6);
         outbox.requestWithdrawal(charlie, 300e6, bytes32("w3"), 0, alice, "");
         vm.stopPrank();
 
@@ -634,7 +634,7 @@ contract ZoneOutboxTest is Test {
 
     function test_finalizeWithdrawalBatch_partialBatch_leavesRemainder() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 5000e6);
+        zoneToken.approve(address(outbox), 5000e6);
         outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
         outbox.requestWithdrawal(alice, 200e6, bytes32("w2"), 0, alice, "");
         outbox.requestWithdrawal(alice, 300e6, bytes32("w3"), 0, alice, "");
@@ -654,7 +654,7 @@ contract ZoneOutboxTest is Test {
 
     function test_finalizeWithdrawalBatch_countLargerThanPending() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 1000e6);
+        zoneToken.approve(address(outbox), 1000e6);
         outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
         outbox.requestWithdrawal(alice, 200e6, bytes32("w2"), 0, alice, "");
         vm.stopPrank();
@@ -669,7 +669,7 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_consecutiveBatches() public {
         // First batch
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 10_000e6);
+        zoneToken.approve(address(outbox), 10_000e6);
         outbox.requestWithdrawal(alice, 100e6, bytes32("b1w1"), 0, alice, "");
         outbox.requestWithdrawal(alice, 200e6, bytes32("b1w2"), 0, alice, "");
         vm.stopPrank();
@@ -697,7 +697,7 @@ contract ZoneOutboxTest is Test {
 
     function test_requestWithdrawal_capturesAllFields() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 1000e6);
+        zoneToken.approve(address(outbox), 1000e6);
         outbox.requestWithdrawal(
             bob, // to
             500e6, // amount
@@ -733,7 +733,7 @@ contract ZoneOutboxTest is Test {
 
     function test_requestWithdrawal_zeroAmount() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 0);
+        zoneToken.approve(address(outbox), 0);
         outbox.requestWithdrawal(bob, 0, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -764,7 +764,7 @@ contract ZoneOutboxTest is Test {
 
     function test_requestWithdrawal_emitsEvent() public {
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), 500e6);
+        zoneToken.approve(address(outbox), 500e6);
 
         uint128 expectedFee = outbox.calculateWithdrawalFee(50_000);
         vm.expectEmit(true, true, false, true);
@@ -789,7 +789,7 @@ contract ZoneOutboxTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_immutableGetters() public view {
-        assertEq(address(outbox.gasToken()), address(gasToken));
+        assertEq(address(outbox.zoneToken()), address(zoneToken));
         assertEq(address(outbox.config()), address(config));
         assertEq(config.sequencer(), sequencer);
     }
@@ -802,7 +802,7 @@ contract ZoneOutboxTest is Test {
         uint256 numWithdrawals = 50;
 
         vm.startPrank(alice);
-        gasToken.approve(address(outbox), numWithdrawals * 100e6);
+        zoneToken.approve(address(outbox), numWithdrawals * 100e6);
 
         for (uint256 i = 0; i < numWithdrawals; i++) {
             outbox.requestWithdrawal(bob, 100e6, bytes32(i), 0, alice, "");

--- a/docs/specs/test/zone/mocks/MockZoneToken.sol
+++ b/docs/specs/test/zone/mocks/MockZoneToken.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.13;
 
 import { IZoneToken } from "../../../src/zone/IZone.sol";
 
-/// @title MockZoneGasToken
+/// @title MockZoneToken
 /// @notice Mock TIP-20 for zone testing with mint/burn for system operations
 /// @dev In production, this would be the actual TIP-20 at the same address as L1
-contract MockZoneGasToken is IZoneToken {
+contract MockZoneToken is IZoneToken {
 
     string public name;
     string public symbol;


### PR DESCRIPTION
## Summary

- Rename all `gasToken` / `IZoneGasToken` / `MockZoneGasToken` references to `zoneToken` / `IZoneToken` / `MockZoneToken` for consistent terminology
- Update NatSpec comments from "Gas token units" to "Zone token units"
- Update `overview.md` interface listings to match code (`IZoneGasToken` → `IZoneToken`, `gasToken()` → `zoneToken()`)

Closes #48, closes #49.

## Changes

| File | Change |
|---|---|
| `IZone.sol` | `gasToken()` → `zoneToken()` in `IZoneInbox` and `IZoneOutbox`; NatSpec updates |
| `ZoneInbox.sol` | `gasToken` → `zoneToken` variable and constructor param |
| `ZoneOutbox.sol` | `gasToken` → `zoneToken` variable and constructor param |
| `overview.md` | `IZoneGasToken` → `IZoneToken`; `gasToken` → `zoneToken` in interface listings and code snippets |
| `MockZoneGasToken.sol` → `MockZoneToken.sol` | File and contract rename |
| All test files | Variable and import updates |

## Test plan

- [x] All 207 zone tests pass
- [x] `forge fmt` clean


Made with [Cursor](https://cursor.com)