### PR TITLE
chore: flatten WithdrawalQueueTransition struct to plain bytes32

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -135,11 +135,6 @@ struct DepositQueueTransition {
     bytes32 nextProcessedHash;     // where zone processed up to (proof output)
 }
 
-/// @notice Withdrawal queue transition for batch proofs
-struct WithdrawalQueueTransition {
-    bytes32 withdrawalQueueHash;  // hash chain of withdrawals for this batch (0 if none)
-}
-
 interface IVerifier {
     /// @notice Verify a batch proof
     /// @dev The proof validates:
@@ -159,7 +154,7 @@ interface IVerifier {
         address sequencer,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
-        WithdrawalQueueTransition calldata withdrawalQueueTransition,
+        bytes32 withdrawalQueueHash,
         bytes calldata verifierConfig,
         bytes calldata proof
     ) external view returns (bool);
@@ -371,7 +366,7 @@ interface IVerifier {
         address sequencer,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
-        WithdrawalQueueTransition calldata withdrawalQueueTransition,
+        bytes32 withdrawalQueueHash,
         bytes calldata verifierConfig,
         bytes calldata proof
     ) external view returns (bool);
@@ -418,7 +413,7 @@ struct WithdrawalQueue {
 library WithdrawalQueueLib {
     /// @notice Add a batch's withdrawals to the queue (called during batch submission)
     /// @dev Writes to slot at tail, then advances tail. Updates maxSize if needed.
-    function enqueue(WithdrawalQueue storage q, WithdrawalQueueTransition memory transition) internal;
+    function enqueue(WithdrawalQueue storage q, bytes32 withdrawalQueueHash) internal;
 
     /// @notice Pop the next withdrawal from the queue (on-chain operation)
     /// @dev Verifies the withdrawal is at the head of the current slot and advances.
@@ -617,7 +612,7 @@ interface IZonePortal {
         uint64 recentTempoBlockNumber,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
-        WithdrawalQueueTransition calldata withdrawalQueueTransition,
+        bytes32 withdrawalQueueHash,
         bytes calldata verifierConfig,
         bytes calldata proof
     ) external;

--- a/docs/pages/protocol/privacy/prover-design.md
+++ b/docs/pages/protocol/privacy/prover-design.md
@@ -67,8 +67,8 @@ pub struct BatchOutput {
     /// Deposit queue processing
     pub deposit_queue_transition: DepositQueueTransition,
 
-    /// Withdrawal queue updates
-    pub withdrawal_queue_transition: WithdrawalQueueTransition,
+    /// Withdrawal queue hash chain for this batch (0 if no withdrawals)
+    pub withdrawal_queue_hash: B256,
 
     /// Withdrawal batch parameters read from ZoneOutbox.lastBatch
     pub last_batch: LastBatchCommitment,
@@ -80,7 +80,7 @@ pub struct LastBatchCommitment {
 
 /// Mirrors the Solidity `LastBatch` struct from ZoneOutbox.
 /// Used internally when reading from zone state; fields are split across
-/// `WithdrawalQueueTransition` (hash) and `LastBatchCommitment` (index) in output.
+/// `withdrawal_queue_hash` and `LastBatchCommitment` (index) in output.
 pub struct LastBatch {
     pub withdrawal_queue_hash: B256,
     pub withdrawal_batch_index: u64,
@@ -425,9 +425,7 @@ pub fn prove_zone_batch(witness: BatchWitness) -> Result<BatchOutput, Error> {
             prev_processed_hash: deposit_prev,
             next_processed_hash: deposit_next,
         },
-        withdrawal_queue_transition: WithdrawalQueueTransition {
-            withdrawal_queue_hash: last_batch.withdrawal_queue_hash,
-        },
+        withdrawal_queue_hash: last_batch.withdrawal_queue_hash,
         last_batch: LastBatchCommitment {
             withdrawal_batch_index: last_batch.withdrawal_batch_index,
         },

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -49,13 +49,6 @@ struct DepositQueueTransition {
     bytes32 nextProcessedHash; // where zone processed up to (proof output)
 }
 
-/// @notice Withdrawal queue transition for batch proofs
-/// @dev Each batch gets its own slot in an unbounded buffer.
-///      The withdrawalQueueHash is the hash chain of withdrawals for this batch.
-struct WithdrawalQueueTransition {
-    bytes32 withdrawalQueueHash; // hash chain of withdrawals for this batch (0 if none)
-}
-
 /// @notice Deposit type discriminator for the unified deposit queue
 /// @dev Used in hash chain: keccak256(abi.encode(depositType, depositData, prevHash))
 enum DepositType {
@@ -284,7 +277,7 @@ interface IVerifier {
     ///      3. If anchorBlockNumber == tempoBlockNumber: zone's hash matches anchorBlockHash
     ///      4. If anchorBlockNumber > tempoBlockNumber: ancestry chain from tempoBlockNumber to anchorBlockNumber
     ///      5. ZoneOutbox.lastBatch().withdrawalBatchIndex == expectedWithdrawalBatchIndex
-    ///      6. ZoneOutbox.lastBatch().withdrawalQueueHash matches withdrawalQueueTransition
+    ///      6. ZoneOutbox.lastBatch().withdrawalQueueHash matches withdrawalQueueHash
     ///      7. Zone block beneficiary matches sequencer
     ///      8. Deposit processing is correct (validated via Tempo state read inside proof)
     /// @param tempoBlockNumber Block zone committed to (from TempoState)
@@ -294,7 +287,7 @@ interface IVerifier {
     /// @param sequencer Sequencer address (zone block beneficiary must match)
     /// @param blockTransition Zone block hash transition
     /// @param depositQueueTransition Deposit queue processing transition
-    /// @param withdrawalQueueTransition Withdrawal queue hash for this batch
+    /// @param withdrawalQueueHash Withdrawal queue hash chain for this batch (0 if none)
     /// @param verifierConfig Opaque payload for verifier (TEE attestation envelope, etc.)
     /// @param proof Validity proof or TEE attestation
     function verify(
@@ -305,7 +298,7 @@ interface IVerifier {
         address sequencer,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
-        WithdrawalQueueTransition calldata withdrawalQueueTransition,
+        bytes32 withdrawalQueueHash,
         bytes calldata verifierConfig,
         bytes calldata proof
     )
@@ -538,7 +531,7 @@ interface IZonePortal {
         uint64 recentTempoBlockNumber,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
-        WithdrawalQueueTransition calldata withdrawalQueueTransition,
+        bytes32 withdrawalQueueHash,
         bytes calldata verifierConfig,
         bytes calldata proof
     )

--- a/docs/specs/src/zone/WithdrawalQueueLib.sol
+++ b/docs/specs/src/zone/WithdrawalQueueLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Withdrawal, WithdrawalQueueTransition } from "./IZone.sol";
+import { Withdrawal } from "./IZone.sol";
 
 /// @dev Sentinel value for empty slots. Using 0xff...ff instead of 0x00 to avoid
 ///      clearing storage (which would refund gas and create incentive issues).
@@ -43,22 +43,17 @@ library WithdrawalQueueLib {
     /// @dev Called during submitBatch. The batch's withdrawal hash chain goes into
     ///      the slot at tail, then tail advances.
     /// @param queue The withdrawal queue
-    /// @param transition The withdrawal queue transition containing the hash chain
-    function enqueue(
-        WithdrawalQueue storage queue,
-        WithdrawalQueueTransition memory transition
-    )
-        internal
-    {
+    /// @param withdrawalQueueHash The hash chain of withdrawals for this batch (0 if none)
+    function enqueue(WithdrawalQueue storage queue, bytes32 withdrawalQueueHash) internal {
         // If no withdrawals in this batch, nothing to do
-        if (transition.withdrawalQueueHash == bytes32(0)) {
+        if (withdrawalQueueHash == bytes32(0)) {
             return;
         }
 
         uint256 tail = queue.tail;
 
         // Write the withdrawal hash chain to this slot
-        queue.slots[tail] = transition.withdrawalQueueHash;
+        queue.slots[tail] = withdrawalQueueHash;
 
         // Advance tail
         queue.tail = tail + 1;

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -19,8 +19,7 @@ import {
     IZoneMessenger,
     IZonePortal,
     QueuedDeposit,
-    Withdrawal,
-    WithdrawalQueueTransition
+    Withdrawal
 } from "./IZone.sol";
 import { WithdrawalQueue, WithdrawalQueueLib } from "./WithdrawalQueueLib.sol";
 
@@ -573,7 +572,7 @@ contract ZonePortal is IZonePortal {
         uint64 recentTempoBlockNumber,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
-        WithdrawalQueueTransition calldata withdrawalQueueTransition,
+        bytes32 withdrawalQueueHash,
         bytes calldata verifierConfig,
         bytes calldata proof
     )
@@ -619,7 +618,7 @@ contract ZonePortal is IZonePortal {
                 sequencer,
                 blockTransition,
                 depositQueueTransition,
-                withdrawalQueueTransition,
+                withdrawalQueueHash,
                 verifierConfig,
                 proof
             );
@@ -632,14 +631,14 @@ contract ZonePortal is IZonePortal {
 
         // Update withdrawal queue - each batch gets its own slot
         // Gas note: charge new storage only when (tail - head) exceeds maxSize.
-        _withdrawalQueue.enqueue(withdrawalQueueTransition);
+        _withdrawalQueue.enqueue(withdrawalQueueHash);
 
         // Emit event after state updates
         emit BatchSubmitted(
             withdrawalBatchIndex,
             depositQueueTransition.nextProcessedHash,
             blockHash,
-            withdrawalQueueTransition.withdrawalQueueHash
+            withdrawalQueueHash
         );
     }
 

--- a/docs/specs/test/zone/WithdrawalQueueLib.t.sol
+++ b/docs/specs/test/zone/WithdrawalQueueLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { Withdrawal, WithdrawalQueueTransition } from "../../src/zone/IZone.sol";
+import { Withdrawal } from "../../src/zone/IZone.sol";
 import {
     EMPTY_SENTINEL,
     WithdrawalQueue,
@@ -17,8 +17,8 @@ contract WithdrawalQueueHarness {
 
     WithdrawalQueue internal queue;
 
-    function enqueue(WithdrawalQueueTransition memory transition) external {
-        queue.enqueue(transition);
+    function enqueue(bytes32 withdrawalQueueHash) external {
+        queue.enqueue(withdrawalQueueHash);
     }
 
     function dequeue(Withdrawal calldata withdrawal, bytes32 remainingQueue) external {
@@ -85,7 +85,7 @@ contract WithdrawalQueueLibTest is Test {
         Withdrawal memory w = _makeWithdrawal(alice, bob, 100e6);
         bytes32 wHash = keccak256(abi.encode(w, EMPTY_SENTINEL));
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: wHash }));
+        harness.enqueue(wHash);
 
         assertEq(harness.head(), 0);
         assertEq(harness.tail(), 1);
@@ -100,15 +100,15 @@ contract WithdrawalQueueLibTest is Test {
         bytes32 h2 = keccak256("batch2");
         bytes32 h3 = keccak256("batch3");
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h1 }));
+        harness.enqueue(h1);
         assertEq(harness.tail(), 1);
         assertEq(harness.maxSize(), 1);
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h2 }));
+        harness.enqueue(h2);
         assertEq(harness.tail(), 2);
         assertEq(harness.maxSize(), 2);
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h3 }));
+        harness.enqueue(h3);
         assertEq(harness.tail(), 3);
         assertEq(harness.maxSize(), 3);
 
@@ -119,7 +119,7 @@ contract WithdrawalQueueLibTest is Test {
     }
 
     function test_enqueue_emptyTransition_noOp() public {
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }));
+        harness.enqueue(bytes32(0));
 
         assertEq(harness.head(), 0);
         assertEq(harness.tail(), 0);
@@ -131,14 +131,14 @@ contract WithdrawalQueueLibTest is Test {
         bytes32 h1 = keccak256("batch1");
         bytes32 h2 = keccak256("batch2");
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h1 }));
+        harness.enqueue(h1);
         assertEq(harness.tail(), 1);
 
         // Empty batch - no change
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }));
+        harness.enqueue(bytes32(0));
         assertEq(harness.tail(), 1);
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h2 }));
+        harness.enqueue(h2);
         assertEq(harness.tail(), 2);
 
         // Slots should be contiguous
@@ -154,7 +154,7 @@ contract WithdrawalQueueLibTest is Test {
         Withdrawal memory w = _makeWithdrawal(alice, bob, 100e6);
         bytes32 wHash = keccak256(abi.encode(w, EMPTY_SENTINEL));
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: wHash }));
+        harness.enqueue(wHash);
 
         harness.dequeue(w, bytes32(0));
 
@@ -172,7 +172,7 @@ contract WithdrawalQueueLibTest is Test {
         bytes32 innerHash = keccak256(abi.encode(w2, EMPTY_SENTINEL));
         bytes32 batchHash = keccak256(abi.encode(w1, innerHash));
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: batchHash }));
+        harness.enqueue(batchHash);
 
         // Dequeue w1
         harness.dequeue(w1, innerHash);
@@ -192,8 +192,8 @@ contract WithdrawalQueueLibTest is Test {
         bytes32 h1 = keccak256(abi.encode(w1, EMPTY_SENTINEL));
         bytes32 h2 = keccak256(abi.encode(w2, EMPTY_SENTINEL));
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h1 }));
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h2 }));
+        harness.enqueue(h1);
+        harness.enqueue(h2);
 
         // Dequeue from slot 0
         harness.dequeue(w1, bytes32(0));
@@ -218,7 +218,7 @@ contract WithdrawalQueueLibTest is Test {
         Withdrawal memory w2 = _makeWithdrawal(bob, charlie, 200e6);
 
         bytes32 h1 = keccak256(abi.encode(w1, EMPTY_SENTINEL));
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h1 }));
+        harness.enqueue(h1);
 
         // Try to dequeue w2 (wrong withdrawal)
         vm.expectRevert(WithdrawalQueueLib.InvalidWithdrawalHash.selector);
@@ -232,7 +232,7 @@ contract WithdrawalQueueLibTest is Test {
         bytes32 innerHash = keccak256(abi.encode(w2, EMPTY_SENTINEL));
         bytes32 batchHash = keccak256(abi.encode(w1, innerHash));
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: batchHash }));
+        harness.enqueue(batchHash);
 
         // Try to dequeue with wrong remaining queue
         vm.expectRevert(WithdrawalQueueLib.InvalidWithdrawalHash.selector);
@@ -248,10 +248,10 @@ contract WithdrawalQueueLibTest is Test {
         bytes32 h2 = keccak256("b2");
         bytes32 h3 = keccak256("b3");
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h1 }));
+        harness.enqueue(h1);
         assertEq(harness.maxSize(), 1);
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h2 }));
+        harness.enqueue(h2);
         assertEq(harness.maxSize(), 2);
 
         // Dequeue one
@@ -260,7 +260,7 @@ contract WithdrawalQueueLibTest is Test {
         // Skip this part and verify maxSize doesn't decrease
 
         // Add more
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: h3 }));
+        harness.enqueue(h3);
         assertEq(harness.maxSize(), 3);
     }
 
@@ -271,17 +271,17 @@ contract WithdrawalQueueLibTest is Test {
     function test_length_accurate() public {
         assertEq(harness.length(), 0);
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: keccak256("b1") }));
+        harness.enqueue(keccak256("b1"));
         assertEq(harness.length(), 1);
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: keccak256("b2") }));
+        harness.enqueue(keccak256("b2"));
         assertEq(harness.length(), 2);
     }
 
     function test_hasWithdrawals_accurate() public {
         assertFalse(harness.hasWithdrawals());
 
-        harness.enqueue(WithdrawalQueueTransition({ withdrawalQueueHash: keccak256("b1") }));
+        harness.enqueue(keccak256("b1"));
         assertTrue(harness.hasWithdrawals());
     }
 

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -24,7 +24,6 @@ import {
     PORTAL_ENCRYPTION_KEYS_SLOT,
     QueuedDeposit,
     Withdrawal,
-    WithdrawalQueueTransition,
     ZoneParams
 } from "../../src/zone/IZone.sol";
 import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
@@ -315,7 +314,7 @@ contract ZoneBridgeTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: newProcessedDepositQueueHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalQueueHash }),
+            withdrawalQueueHash,
             "",
             ""
         );

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -14,7 +14,6 @@ import {
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     QueuedDeposit,
     Withdrawal,
-    WithdrawalQueueTransition,
     ZoneParams
 } from "../../src/zone/IZone.sol";
 import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
@@ -219,7 +218,7 @@ contract ZoneIntegrationTest is BaseTest {
                 prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
             }),
             DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: d1 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -289,7 +288,7 @@ contract ZoneIntegrationTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalHash }),
+            withdrawalHash,
             "",
             ""
         );
@@ -353,7 +352,7 @@ contract ZoneIntegrationTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash1 }),
+            wHash1,
             "",
             ""
         );
@@ -376,7 +375,7 @@ contract ZoneIntegrationTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash2 }),
+            wHash2,
             "",
             ""
         );
@@ -399,7 +398,7 @@ contract ZoneIntegrationTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash3 }),
+            wHash3,
             "",
             ""
         );
@@ -514,7 +513,7 @@ contract ZoneIntegrationTest is BaseTest {
                 prevBlockHash: l1Portal.blockHash(), nextBlockHash: keccak256("s1")
             }),
             DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: d2 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -23,7 +23,6 @@ import {
     PORTAL_PENDING_SEQUENCER_SLOT,
     PORTAL_SEQUENCER_SLOT,
     Withdrawal,
-    WithdrawalQueueTransition,
     ZoneInfo,
     ZoneParams
 } from "../../src/zone/IZone.sol";
@@ -294,7 +293,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -319,7 +318,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -340,7 +339,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -362,7 +361,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -408,7 +407,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: withdrawalHash }),
+            withdrawalHash,
             "",
             ""
         );
@@ -477,7 +476,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: bytes32(0),
                     nextProcessedHash: portal.currentDepositQueueHash()
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: batchQueueHash }),
+            batchQueueHash,
             "",
             ""
         );
@@ -535,7 +534,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: bytes32(0),
                     nextProcessedHash: portal.currentDepositQueueHash()
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
+            w1Hash,
             "",
             ""
         );
@@ -564,7 +563,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: bytes32(0),
                     nextProcessedHash: portal.currentDepositQueueHash()
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
+            w2Hash,
             "",
             ""
         );
@@ -605,7 +604,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: bytes32(0),
                     nextProcessedHash: portal.currentDepositQueueHash()
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }), // No withdrawals
+            bytes32(0), // No withdrawals
             "",
             ""
         );
@@ -653,7 +652,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: bytes32(0),
                     nextProcessedHash: portal.currentDepositQueueHash()
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -707,7 +706,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -759,7 +758,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -814,7 +813,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -881,7 +880,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: bytes32(0),
                     nextProcessedHash: portal.currentDepositQueueHash()
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -934,7 +933,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: bytes32(0),
                     nextProcessedHash: portal.currentDepositQueueHash()
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -978,7 +977,7 @@ contract ZonePortalTest is BaseTest {
                 prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
             }),
             DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: h1 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1010,7 +1009,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1028,7 +1027,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1047,7 +1046,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1069,7 +1068,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1090,7 +1089,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1111,7 +1110,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1131,7 +1130,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                     prevProcessedHash: bytes32(0), nextProcessedHash: bytes32(0)
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1170,7 +1169,7 @@ contract ZonePortalTest is BaseTest {
                     prevProcessedHash: keccak256("wrongHash"), // This is ignored by implementation
                     nextProcessedHash: depositHash
                 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1198,7 +1197,7 @@ contract ZonePortalTest is BaseTest {
                 prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state1")
             }),
             DepositQueueTransition({ prevProcessedHash: bytes32(0), nextProcessedHash: h1 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1215,7 +1214,7 @@ contract ZonePortalTest is BaseTest {
                 prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state2")
             }),
             DepositQueueTransition({ prevProcessedHash: h1, nextProcessedHash: h2 }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1260,7 +1259,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
+            w1Hash,
             "",
             ""
         );
@@ -1291,7 +1290,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
+            w2Hash,
             "",
             ""
         );
@@ -1324,7 +1323,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }), // No withdrawals
+            bytes32(0), // No withdrawals
             "",
             ""
         );
@@ -1367,7 +1366,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w1Hash }),
+            w1Hash,
             "",
             ""
         );
@@ -1392,7 +1391,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: w2Hash }),
+            w2Hash,
             "",
             ""
         );
@@ -1442,7 +1441,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -1487,7 +1486,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -1533,7 +1532,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -1579,7 +1578,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHashBefore
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -1621,7 +1620,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1635,7 +1634,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1649,7 +1648,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: depositHash
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: bytes32(0) }),
+            bytes32(0),
             "",
             ""
         );
@@ -1707,7 +1706,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );
@@ -1745,7 +1744,7 @@ contract ZonePortalTest is BaseTest {
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0), nextProcessedHash: portal.currentDepositQueueHash()
             }),
-            WithdrawalQueueTransition({ withdrawalQueueHash: wHash }),
+            wHash,
             "",
             ""
         );

--- a/docs/specs/test/zone/mocks/MockVerifier.sol
+++ b/docs/specs/test/zone/mocks/MockVerifier.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {
-    BlockTransition,
-    DepositQueueTransition,
-    IVerifier,
-    WithdrawalQueueTransition
-} from "../../../src/zone/IZone.sol";
+import { BlockTransition, DepositQueueTransition, IVerifier } from "../../../src/zone/IZone.sol";
 
 /// @title MockVerifier
 /// @notice Mock verifier for testing that always accepts proofs (configurable)
@@ -26,7 +21,7 @@ contract MockVerifier is IVerifier {
         address, // sequencer
         BlockTransition calldata,
         DepositQueueTransition calldata,
-        WithdrawalQueueTransition calldata,
+        bytes32, // withdrawalQueueHash
         bytes calldata, // verifierConfig
         bytes calldata // proof
     )


### PR DESCRIPTION
## Summary

- Removes the `WithdrawalQueueTransition` struct which wrapped a single `bytes32` field, replacing it with a plain `bytes32 withdrawalQueueHash` parameter throughout the codebase
- Simplifies calldata encoding and reduces gas overhead for `submitBatch` calls
- Updates all contracts (`IZone.sol`, `ZonePortal.sol`, `WithdrawalQueueLib.sol`), tests, mocks, and documentation (`overview.md`, `prover-design.md`)

Closes #52

## Test plan

- [x] All 207 zone tests pass
- [x] `forge fmt` clean
- [x] No remaining references to `WithdrawalQueueTransition` in specs or docs

Made with [Cursor](https://cursor.com)