### PR TITLE
feat: add stub verifier system contract (always returns true)

### DIFF
--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -7,6 +7,7 @@ pub mod tip20_factory;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
 pub mod validator_config;
+pub mod verifier;
 
 pub use account_keychain::*;
 use alloy_primitives::{Address, address};
@@ -18,6 +19,7 @@ pub use tip20::*;
 pub use tip20_factory::*;
 pub use tip403_registry::*;
 pub use validator_config::*;
+pub use verifier::*;
 
 pub const TIP_FEE_MANAGER_ADDRESS: Address = address!("0xfeec000000000000000000000000000000000000");
 pub const PATH_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000000");
@@ -31,3 +33,5 @@ pub const VALIDATOR_CONFIG_ADDRESS: Address =
     address!("0xCCCCCCCC00000000000000000000000000000000");
 pub const ACCOUNT_KEYCHAIN_ADDRESS: Address =
     address!("0xAAAAAAAA00000000000000000000000000000000");
+pub const VERIFIER_ADDRESS: Address =
+    address!("0x1E81F1E800000000000000000000000000000000");

--- a/crates/contracts/src/precompiles/verifier.rs
+++ b/crates/contracts/src/precompiles/verifier.rs
@@ -1,0 +1,48 @@
+crate::sol! {
+    /// Enshrined verifier interface for zone proof/attestation verification.
+    ///
+    /// This precompile verifies batch proofs submitted to zone portals.
+    /// For prototyping, this stub always returns true.
+    #[derive(Debug, PartialEq, Eq)]
+    #[sol(abi)]
+    #[allow(clippy::too_many_arguments)]
+    interface IVerifier {
+        struct BlockTransition {
+            bytes32 prevBlockHash;
+            bytes32 nextBlockHash;
+        }
+
+        struct DepositQueueTransition {
+            bytes32 prevProcessedHash;
+            bytes32 nextProcessedHash;
+        }
+
+        struct WithdrawalQueueTransition {
+            bytes32 withdrawalQueueHash;
+        }
+
+        /// Verify a batch proof
+        /// @param tempoBlockNumber Block zone committed to (from TempoState)
+        /// @param anchorBlockNumber Block whose hash is verified (tempoBlockNumber or recent block)
+        /// @param anchorBlockHash Hash of anchorBlockNumber (from EIP-2935)
+        /// @param expectedWithdrawalBatchIndex Expected batch index (portal.withdrawalBatchIndex + 1)
+        /// @param sequencer Sequencer address (zone block beneficiary must match)
+        /// @param blockTransition Zone block hash transition
+        /// @param depositQueueTransition Deposit queue processing transition
+        /// @param withdrawalQueueTransition Withdrawal queue hash for this batch
+        /// @param verifierConfig Opaque payload for verifier (TEE attestation envelope, etc.)
+        /// @param proof Validity proof or TEE attestation
+        function verify(
+            uint64 tempoBlockNumber,
+            uint64 anchorBlockNumber,
+            bytes32 anchorBlockHash,
+            uint64 expectedWithdrawalBatchIndex,
+            address sequencer,
+            BlockTransition calldata blockTransition,
+            DepositQueueTransition calldata depositQueueTransition,
+            WithdrawalQueueTransition calldata withdrawalQueueTransition,
+            bytes calldata verifierConfig,
+            bytes calldata proof
+        ) external view returns (bool);
+    }
+}

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -15,6 +15,7 @@ pub mod tip20_factory;
 pub mod tip403_registry;
 pub mod tip_fee_manager;
 pub mod validator_config;
+pub mod verifier;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_util;
@@ -29,6 +30,7 @@ use crate::{
     tip20_factory::TIP20Factory,
     tip403_registry::TIP403Registry,
     validator_config::ValidatorConfig,
+    verifier::Verifier,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 
@@ -48,7 +50,7 @@ use revm::{
 pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
     STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
-    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
+    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS, VERIFIER_ADDRESS,
 };
 
 // Re-export storage layout helpers for read-only contexts (e.g., pool validation)
@@ -88,6 +90,8 @@ pub fn extend_tempo_precompiles(precompiles: &mut PrecompilesMap, cfg: &CfgEnv<T
             Some(ValidatorConfigPrecompile::create(chain_id, spec))
         } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
             Some(AccountKeychainPrecompile::create(chain_id, spec))
+        } else if *address == VERIFIER_ADDRESS {
+            Some(VerifierPrecompile::create(chain_id, spec))
         } else {
             None
         }
@@ -190,6 +194,15 @@ impl ValidatorConfigPrecompile {
     pub fn create(chain_id: u64, spec: TempoHardfork) -> DynPrecompile {
         tempo_precompile!("ValidatorConfig", chain_id, spec, |input| {
             ValidatorConfig::new()
+        })
+    }
+}
+
+pub struct VerifierPrecompile;
+impl VerifierPrecompile {
+    pub fn create(chain_id: u64, spec: TempoHardfork) -> DynPrecompile {
+        tempo_precompile!("Verifier", chain_id, spec, |input| {
+            Verifier::new()
         })
     }
 }

--- a/crates/precompiles/src/verifier/dispatch.rs
+++ b/crates/precompiles/src/verifier/dispatch.rs
@@ -1,0 +1,101 @@
+use super::Verifier;
+use crate::{Precompile, dispatch_call, input_cost, view};
+use alloy::{primitives::Address, sol_types::SolInterface};
+use revm::precompile::{PrecompileError, PrecompileResult};
+use tempo_contracts::precompiles::IVerifier::IVerifierCalls;
+
+impl Precompile for Verifier {
+    fn call(&mut self, calldata: &[u8], _msg_sender: Address) -> PrecompileResult {
+        self.storage
+            .deduct_gas(input_cost(calldata.len()))
+            .map_err(|_| PrecompileError::OutOfGas)?;
+
+        dispatch_call(calldata, IVerifierCalls::abi_decode, |call| match call {
+            IVerifierCalls::verify(call) => view(call, |c| self.verify(c)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        test_util::{assert_full_coverage, check_selector_coverage},
+    };
+    use alloy::{
+        primitives::{Address, FixedBytes},
+        sol_types::{SolCall, SolValue},
+    };
+    use tempo_contracts::precompiles::IVerifier;
+
+    #[test]
+    fn test_verify_dispatch() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut verifier = Verifier::new();
+
+            let verify_call = IVerifier::verifyCall {
+                tempoBlockNumber: 42,
+                anchorBlockNumber: 42,
+                anchorBlockHash: FixedBytes::<32>::ZERO,
+                expectedWithdrawalBatchIndex: 1,
+                sequencer: Address::random(),
+                blockTransition: IVerifier::BlockTransition {
+                    prevBlockHash: FixedBytes::<32>::ZERO,
+                    nextBlockHash: FixedBytes::<32>::ZERO,
+                },
+                depositQueueTransition: IVerifier::DepositQueueTransition {
+                    prevProcessedHash: FixedBytes::<32>::ZERO,
+                    nextProcessedHash: FixedBytes::<32>::ZERO,
+                },
+                withdrawalQueueTransition: IVerifier::WithdrawalQueueTransition {
+                    withdrawalQueueHash: FixedBytes::<32>::ZERO,
+                },
+                verifierConfig: Default::default(),
+                proof: Default::default(),
+            };
+            let calldata = verify_call.abi_encode();
+
+            let result = verifier.call(&calldata, Address::random())?;
+            assert!(!result.reverted);
+
+            let decoded = bool::abi_decode(&result.bytes)?;
+            assert!(decoded);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_invalid_selector() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut verifier = Verifier::new();
+
+            let result = verifier.call(&[0x12, 0x34, 0x56, 0x78], Address::random())?;
+            assert!(result.reverted);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_selector_coverage() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut verifier = Verifier::new();
+
+            let unsupported = check_selector_coverage(
+                &mut verifier,
+                IVerifierCalls::SELECTORS,
+                "IVerifier",
+                IVerifierCalls::name_by_selector,
+            );
+
+            assert_full_coverage([unsupported]);
+
+            Ok(())
+        })
+    }
+}

--- a/crates/precompiles/src/verifier/mod.rs
+++ b/crates/precompiles/src/verifier/mod.rs
@@ -1,0 +1,66 @@
+pub mod dispatch;
+
+use tempo_contracts::precompiles::VERIFIER_ADDRESS;
+pub use tempo_contracts::precompiles::IVerifier;
+use tempo_precompiles_macros::contract;
+
+use crate::error::Result;
+
+/// Enshrined verifier precompile.
+///
+/// Stub implementation that always returns `true` for prototyping.
+#[contract(addr = VERIFIER_ADDRESS)]
+pub struct Verifier {}
+
+impl Verifier {
+    pub fn initialize(&mut self) -> Result<()> {
+        self.__initialize()
+    }
+
+    pub fn verify(
+        &self,
+        _call: IVerifier::verifyCall,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
+    use alloy::primitives::{Address, FixedBytes};
+
+    #[test]
+    fn test_verify_always_returns_true() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let verifier = Verifier::new();
+
+            let result = verifier.verify(IVerifier::verifyCall {
+                tempoBlockNumber: 1,
+                anchorBlockNumber: 1,
+                anchorBlockHash: FixedBytes::<32>::ZERO,
+                expectedWithdrawalBatchIndex: 1,
+                sequencer: Address::ZERO,
+                blockTransition: IVerifier::BlockTransition {
+                    prevBlockHash: FixedBytes::<32>::ZERO,
+                    nextBlockHash: FixedBytes::<32>::ZERO,
+                },
+                depositQueueTransition: IVerifier::DepositQueueTransition {
+                    prevProcessedHash: FixedBytes::<32>::ZERO,
+                    nextProcessedHash: FixedBytes::<32>::ZERO,
+                },
+                withdrawalQueueTransition: IVerifier::WithdrawalQueueTransition {
+                    withdrawalQueueHash: FixedBytes::<32>::ZERO,
+                },
+                verifierConfig: Default::default(),
+                proof: Default::default(),
+            })?;
+
+            assert!(result, "Stub verifier should always return true");
+
+            Ok(())
+        })
+    }
+}

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -57,6 +57,7 @@ use tempo_precompiles::{
     tip20_factory::TIP20Factory,
     tip403_registry::TIP403Registry,
     validator_config::ValidatorConfig,
+    verifier::Verifier,
 };
 
 /// Generate genesis allocation file for testing
@@ -370,6 +371,9 @@ impl GenesisArgs {
 
         println!("Initializing account keychain");
         initialize_account_keychain(&mut evm)?;
+
+        println!("Initializing verifier");
+        initialize_verifier(&mut evm)?;
 
         if !self.no_pairwise_liquidity {
             if let (Some(alpha), Some(beta), Some(theta)) =
@@ -770,6 +774,15 @@ fn initialize_account_keychain(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Re
     let ctx = evm.ctx_mut();
     StorageCtx::enter_evm(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, || {
         AccountKeychain::new().initialize()
+    })?;
+
+    Ok(())
+}
+
+fn initialize_verifier(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Result<()> {
+    let ctx = evm.ctx_mut();
+    StorageCtx::enter_evm(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, || {
+        Verifier::new().initialize()
     })?;
 
     Ok(())


### PR DESCRIPTION
## Summary
Enshrines the verifier as a system contract (precompile) per #54. Stub always returns true for prototyping.

## Motivation
[Issue #54](https://github.com/tempoxyz/zones/issues/54) — enshrine the verifier instead of abstracting behind IVerifier, reducing attack surface from operator-chosen verifiers.

## Changes
- `crates/contracts/src/precompiles/verifier.rs` — IVerifier Solidity interface definition via `sol!` macro
- `crates/contracts/src/precompiles/mod.rs` — register module + `VERIFIER_ADDRESS` at `0x1E81F1E8...`
- `crates/precompiles/src/verifier/mod.rs` — stub implementation (`verify()` always returns true) + `initialize()`
- `crates/precompiles/src/verifier/dispatch.rs` — call dispatch matching IVerifier interface
- `crates/precompiles/src/lib.rs` — register VerifierPrecompile in `extend_tempo_precompiles`
- `xtask/src/genesis_args.rs` — initialize verifier at genesis

## Testing
```
cargo test -p tempo-precompiles -- verifier  # 4 tests pass
cargo clippy -p tempo-contracts -p tempo-precompiles -p tempo-xtask -- -D warnings  # clean
```

Slack thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770586772987439

Closes #54