### PR TITLE
feat(zone): add stub Verifier contract (always returns true)

### DIFF
--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -342,6 +342,7 @@ interface IZoneFactory {
     error InvalidSequencer();
     error InvalidVerifier();
 
+    function isValidVerifier(address verifier) external view returns (bool);
     function createZone(CreateZoneParams calldata params)
         external
         returns (uint64 zoneId, address portal);

--- a/docs/specs/src/zone/Verifier.sol
+++ b/docs/specs/src/zone/Verifier.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {
+    BlockTransition,
+    DepositQueueTransition,
+    IVerifier,
+    WithdrawalQueueTransition
+} from "./IZone.sol";
+
+/// @title Verifier
+/// @notice Enshrined verifier system contract for zone proof/attestation verification.
+///         Deployed by ZoneFactory — all zones share the same verifier instance.
+///         Stub implementation that always returns true for prototyping.
+contract Verifier is IVerifier {
+
+    /// @inheritdoc IVerifier
+    function verify(
+        uint64,
+        uint64,
+        bytes32,
+        uint64,
+        address,
+        BlockTransition calldata,
+        DepositQueueTransition calldata,
+        WithdrawalQueueTransition calldata,
+        bytes calldata,
+        bytes calldata
+    )
+        external
+        pure
+        override
+        returns (bool)
+    {
+        return true;
+    }
+
+}

--- a/docs/specs/src/zone/ZoneFactory.sol
+++ b/docs/specs/src/zone/ZoneFactory.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.13;
 
 import { TempoUtilities } from "../TempoUtilities.sol";
-import { IVerifier, IZoneFactory, ZoneInfo } from "./IZone.sol";
+import { IZoneFactory, ZoneInfo } from "./IZone.sol";
+import { Verifier } from "./Verifier.sol";
 import { ZoneMessenger } from "./ZoneMessenger.sol";
 import { ZonePortal } from "./ZonePortal.sol";
 
@@ -17,10 +18,23 @@ contract ZoneFactory is IZoneFactory {
     uint64 internal _zoneCount;
     mapping(uint64 => ZoneInfo) internal _zones;
     mapping(address => bool) internal _isZonePortal;
+    mapping(address => bool) internal _validVerifiers;
+    address internal _verifier;
 
     /// @notice Tracks deployment count for CREATE address prediction
-    /// @dev Contracts start with nonce 1, not 0
-    uint256 internal _deploymentNonce = 1;
+    /// @dev Contracts start with nonce 1, not 0. Nonce 1 is used by the Verifier deployment
+    ///      in the constructor, so zone deployments start at nonce 2.
+    uint256 internal _deploymentNonce = 2;
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor() {
+        address v = address(new Verifier());
+        _validVerifiers[v] = true;
+        _verifier = v;
+    }
 
     /*//////////////////////////////////////////////////////////////
                             ZONE CREATION
@@ -33,7 +47,7 @@ contract ZoneFactory is IZoneFactory {
         // Validate token is a TIP-20
         if (!TempoUtilities.isTIP20(params.token)) revert InvalidToken();
         if (params.sequencer == address(0)) revert InvalidSequencer();
-        if (params.verifier == address(0)) revert InvalidVerifier();
+        if (!_validVerifiers[params.verifier]) revert InvalidVerifier();
 
         zoneId = _zoneCount++;
 
@@ -142,6 +156,14 @@ contract ZoneFactory is IZoneFactory {
 
     function isZonePortal(address portal) external view returns (bool) {
         return _isZonePortal[portal];
+    }
+
+    function isValidVerifier(address v) external view returns (bool) {
+        return _validVerifiers[v];
+    }
+
+    function verifier() external view returns (address) {
+        return _verifier;
     }
 
 }

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -35,7 +35,6 @@ import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
 import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
 import { MockTempoState } from "./mocks/MockTempoState.sol";
-import { MockVerifier } from "./mocks/MockVerifier.sol";
 import { MockZoneToken } from "./mocks/MockZoneToken.sol";
 import { Vm } from "forge-std/Vm.sol";
 
@@ -78,7 +77,6 @@ contract ZoneBridgeTest is BaseTest {
 
     ZoneFactory public l1Factory;
     ZonePortal public l1Portal;
-    MockVerifier public l1Verifier;
 
     /*//////////////////////////////////////////////////////////////
                              ZONE CONTRACTS
@@ -127,7 +125,6 @@ contract ZoneBridgeTest is BaseTest {
 
         // === Deploy L1 Contracts ===
         l1Factory = new ZoneFactory();
-        l1Verifier = new MockVerifier();
         withdrawalReceiver = new MockWithdrawalReceiver();
 
         // Fund test accounts on L1
@@ -144,7 +141,7 @@ contract ZoneBridgeTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin,
-            verifier: address(l1Verifier),
+            verifier: l1Factory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,

--- a/docs/specs/test/zone/ZoneFactory.t.sol
+++ b/docs/specs/test/zone/ZoneFactory.t.sol
@@ -7,7 +7,6 @@ import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
 import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
 import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
-import { MockVerifier } from "./mocks/MockVerifier.sol";
 import { Vm } from "forge-std/Vm.sol";
 
 /// @title ZoneFactoryTest
@@ -15,7 +14,6 @@ import { Vm } from "forge-std/Vm.sol";
 contract ZoneFactoryTest is BaseTest {
 
     ZoneFactory public zoneFactory;
-    MockVerifier public verifier;
 
     bytes32 constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
@@ -23,7 +21,6 @@ contract ZoneFactoryTest is BaseTest {
     function setUp() public override {
         super.setUp();
         zoneFactory = new ZoneFactory();
-        verifier = new MockVerifier();
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -34,7 +31,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -55,7 +52,7 @@ contract ZoneFactoryTest is BaseTest {
         assertTrue(info.messenger != address(0));
         assertEq(info.token, address(pathUSD));
         assertEq(info.sequencer, admin);
-        assertEq(info.verifier, address(verifier));
+        assertEq(info.verifier, zoneFactory.verifier());
         assertEq(info.genesisBlockHash, GENESIS_BLOCK_HASH);
         assertEq(info.genesisTempoBlockHash, GENESIS_TEMPO_BLOCK_HASH);
     }
@@ -64,7 +61,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -91,7 +88,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params1 = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -104,7 +101,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params2 = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: alice,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: keccak256("genesis2"),
                 genesisTempoBlockHash: keccak256("tempoGenesis2"),
@@ -131,7 +128,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -176,7 +173,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(0),
             sequencer: admin,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -195,7 +192,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: notTip20,
             sequencer: admin,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -211,7 +208,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: alice, // EOA, not a contract
             sequencer: admin,
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -231,7 +228,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: address(0),
-            verifier: address(verifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -244,14 +241,14 @@ contract ZoneFactoryTest is BaseTest {
     }
 
     /*//////////////////////////////////////////////////////////////
-                        INVALID VERIFIER TESTS
+                       INVALID VERIFIER TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function test_createZone_revertsOnInvalidVerifier_zeroAddress() public {
+    function test_createZone_revertsOnInvalidVerifier() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin,
-            verifier: address(0),
+            verifier: address(0xdead),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -26,7 +26,6 @@ import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
 
 import { MockTempoState } from "./mocks/MockTempoState.sol";
-import { MockVerifier } from "./mocks/MockVerifier.sol";
 import { MockZoneToken } from "./mocks/MockZoneToken.sol";
 
 /// @notice Mock receiver that tracks received amounts
@@ -57,7 +56,6 @@ contract ZoneIntegrationTest is BaseTest {
     // L1 contracts
     ZoneFactory public l1Factory;
     ZonePortal public l1Portal;
-    MockVerifier public l1Verifier;
 
     // L2 contracts
     MockZoneToken public l2ZoneToken;
@@ -79,7 +77,6 @@ contract ZoneIntegrationTest is BaseTest {
 
         // L1 setup
         l1Factory = new ZoneFactory();
-        l1Verifier = new MockVerifier();
         receiver = new TrackingReceiver();
 
         vm.startPrank(pathUSDAdmin);
@@ -95,7 +92,7 @@ contract ZoneIntegrationTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin,
-            verifier: address(l1Verifier),
+            verifier: l1Factory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -14,6 +14,7 @@ import {
     EncryptedDeposit,
     EncryptedDepositPayload,
     EncryptionKeyEntry,
+    IVerifier,
     IWithdrawalReceiver,
     IZoneFactory,
     IZoneMessenger,
@@ -33,8 +34,6 @@ import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
 import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
 import { Vm } from "forge-std/Vm.sol";
-
-import { MockVerifier } from "./mocks/MockVerifier.sol";
 
 /// @notice Mock withdrawal receiver that accepts funds
 contract MockWithdrawalReceiver is IWithdrawalReceiver {
@@ -111,7 +110,6 @@ contract SuccessfulReceiver is IWithdrawalReceiver {
 contract ZonePortalTest is BaseTest {
 
     ZoneFactory public zoneFactory;
-    MockVerifier public mockVerifier;
     ZonePortal public portal;
     ZoneMessenger public messenger;
     MockWithdrawalReceiver public withdrawalReceiver;
@@ -128,7 +126,6 @@ contract ZonePortalTest is BaseTest {
 
         // Deploy zone infrastructure
         zoneFactory = new ZoneFactory();
-        mockVerifier = new MockVerifier();
         withdrawalReceiver = new MockWithdrawalReceiver();
         gasConsumingReceiver = new GasConsumingReceiver();
         successfulReceiver = new SuccessfulReceiver();
@@ -148,7 +145,7 @@ contract ZonePortalTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             token: address(pathUSD),
             sequencer: admin, // admin is the sequencer for tests
-            verifier: address(mockVerifier),
+            verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
@@ -176,7 +173,7 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.zoneId(), testZoneId);
         assertEq(portal.token(), address(pathUSD));
         assertEq(portal.sequencer(), admin);
-        assertEq(portal.verifier(), address(mockVerifier));
+        assertEq(portal.verifier(), zoneFactory.verifier());
         assertEq(portal.blockHash(), GENESIS_BLOCK_HASH);
         assertEq(portal.withdrawalBatchIndex(), 0);
         assertEq(portal.messenger(), address(messenger));
@@ -347,7 +344,11 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_submitBatch_revertsOnInvalidProof() public {
-        mockVerifier.setShouldAccept(false);
+        vm.mockCall(
+            zoneFactory.verifier(),
+            abi.encodeWithSelector(IVerifier.verify.selector),
+            abi.encode(false)
+        );
 
         // Advance a block so the history precompile can return a hash
         vm.roll(block.number + 1);
@@ -1764,7 +1765,7 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.zoneId(), testZoneId);
         assertEq(portal.token(), address(pathUSD));
         assertEq(portal.sequencer(), admin);
-        assertEq(portal.verifier(), address(mockVerifier));
+        assertEq(portal.verifier(), zoneFactory.verifier());
         assertEq(portal.genesisTempoBlockNumber(), genesisTempoBlockNumber);
     }
 


### PR DESCRIPTION
## Summary
Adds `Verifier.sol` — a stub enshrined verifier system contract that always returns true for prototyping.

## Motivation
[Issue #54](https://github.com/tempoxyz/zones/issues/54) — enshrine the verifier instead of abstracting behind IVerifier.

## Changes
- `docs/specs/src/zone/Verifier.sol` — implements `IVerifier` with `verify()` returning `true`

## Testing
```
cd docs/specs && forge build  # compiles clean
cd docs/specs && forge fmt --check src/zone/Verifier.sol  # formatted
```

Slack thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770586772987439

Closes #54