### PR TITLE
fix(zone): enforce monotonic tempoBlockNumber in submitBatch

### DIFF
--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -582,6 +582,7 @@ contract ZonePortal is IZonePortal {
 
         // Validate tempoBlockNumber is valid (applies to both direct and ancestry modes)
         if (tempoBlockNumber < genesisTempoBlockNumber) revert InvalidTempoBlockNumber();
+        if (tempoBlockNumber < lastSyncedTempoBlockNumber) revert InvalidTempoBlockNumber();
 
         // Determine anchor block: either tempoBlockNumber (direct) or recentTempoBlockNumber (ancestry)
         uint64 anchorBlockNumber;


### PR DESCRIPTION
## Summary
Adds defense-in-depth check that tempoBlockNumber cannot regress in submitBatch(). Without this, a verifier bug could allow syncing to an older Tempo block.

Closes #66