### PR TITLE
fix(zone): improve HKDF domain separation for encrypted deposits

### DIFF
--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -236,8 +236,8 @@ contract ZoneInbox is IZoneInbox {
                 // This is done in Solidity using the SHA256 precompile (0x02)
                 bytes32 aesKey = _hkdfSha256(
                     dec.sharedSecret,
-                    "ecies-aes-key", // salt
-                    "" // info (empty)
+                    "ecies-aes-key",
+                    abi.encodePacked(tempoPortal, ed.keyIndex, ed.encrypted.ephemeralPubkeyX)
                 );
 
                 // Step 3: Decrypt using AES-256-GCM precompile


### PR DESCRIPTION
## Summary
Binds the HKDF-SHA256 info parameter to the portal address, key index, and ephemeral public key. This prevents cross-protocol key reuse and unknown-key-share confusion.

Note: off-chain encryptors must match this derivation.

Closes #76