### PR TITLE
fix(zone): allow chunked deposit processing in advanceTempo

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -129,7 +129,7 @@ struct BlockTransition {
 
 /// @notice Deposit queue transition inputs/outputs for batch proofs
 /// @dev The proof reads currentDepositQueueHash from Tempo state to validate
-///      that nextProcessedHash matches currentDepositQueueHash for now. TODO: allow ancestor checks.
+///      that nextProcessedHash is an ancestor of (or equal to) currentDepositQueueHash.
 struct DepositQueueTransition {
     bytes32 prevProcessedHash;     // where proof starts (verified against zone state)
     bytes32 nextProcessedHash;     // where zone processed up to (proof output)
@@ -214,7 +214,7 @@ Where `deposit` is a `Deposit` struct containing the sender, recipient, amount, 
 
 The portal tracks `currentDepositQueueHash` where new deposits land. The zone tracks its own `processedDepositQueueHash` in EVM state.
 
-**Proof requirements**: The proof validates deposit processing by reading `currentDepositQueueHash` from Tempo state inside the proof. The zone's `advanceTempo()` function processes deposits and updates the zone's `processedDepositQueueHash`. The proof ensures this was done correctly by validating the Tempo state read. For now, the on-chain inbox requires an exact match; TODO: implement a recursive ancestor check in the proof or on-chain as a fallback.
+**Proof requirements**: The proof validates deposit processing by reading `currentDepositQueueHash` from Tempo state inside the proof. The zone's `advanceTempo()` function processes a bounded subset of deposits per block and updates the zone's `processedDepositQueueHash`. The proof ensures the resulting `processedDepositQueueHash` is an ancestor of (or equal to) Tempo's `currentDepositQueueHash`, allowing chunked processing that prevents liveness attacks from deposit queue spam.
 
 **After batch accepted**:
 1. `lastSyncedTempoBlockNumber = tempoBlockNumber` (record how far Tempo state was synced)
@@ -1042,7 +1042,7 @@ Adding d4: currentDepositQueueHash = keccak256(abi.encode(deposit4, currentDepos
 ```
 
 - **On-chain addition is O(1)**: `currentDepositQueueHash = keccak256(abi.encode(deposit, currentDepositQueueHash))` — wrap the outside.
-- **Zone processing**: The zone's `advanceTempo()` processes deposits in FIFO order (oldest first, working outward from its `processedDepositQueueHash`), and validates the result matches `currentDepositQueueHash` (read from Tempo state). TODO: implement a recursive ancestor check in the proof or on-chain as a fallback.
+- **Zone processing**: The zone's `advanceTempo()` processes a bounded subset of deposits in FIFO order (oldest first, working outward from its `processedDepositQueueHash`). The proof validates that the resulting `processedDepositQueueHash` is an ancestor of (or equal to) Tempo's `currentDepositQueueHash`, allowing chunked processing that prevents liveness attacks from deposit queue spam.
 - **After batch**: Tempo updates `lastSyncedTempoBlockNumber` to record how far Tempo state was synced.
 
 ### Withdrawal queue: oldest-outermost per slot
@@ -1106,7 +1106,7 @@ Notes:
 - There is no forced inclusion. If the sequencer withholds deposits, funds are stuck in escrow.
 - The portal only stores `currentDepositQueueHash`, not individual deposits. The sequencer must track deposits off-chain.
 - Tempo state advancement is combined with deposit processing in `ZoneInbox.advanceTempo()`, which calls `TempoState.finalizeTempo()` internally.
-- The proof validates an exact match to `currentDepositQueueHash` from Tempo state, ensuring it cannot claim to process fake deposits. TODO: implement a recursive ancestor check in the proof or on-chain as a fallback.
+- The proof validates that `processedDepositQueueHash` is an ancestor of (or equal to) `currentDepositQueueHash` from Tempo state, ensuring it cannot claim to process fake deposits. This ancestor-or-equal check allows processing a bounded subset of deposits per block, preventing liveness attacks from deposit queue spam.
 
 ### Encrypted deposits
 

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -15,7 +15,6 @@ import {
     IZoneConfig,
     IZoneInbox,
     IZoneToken,
-    PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     PORTAL_ENCRYPTION_KEYS_SLOT,
     QueuedDeposit
 } from "./IZone.sol";
@@ -283,18 +282,13 @@ contract ZoneInbox is IZoneInbox {
         // Verify all decryption data was consumed
         if (decryptionIndex != decryptions.length) revert ExtraDecryptionData();
 
-        // Step 3: Validate against Tempo state
-        // Read currentDepositQueueHash from the portal's storage using the new Tempo state
-        bytes32 tempoCurrentHash =
-            _tempoState.readTempoStorageSlot(tempoPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT);
+        // Deposit processing validated by proof/TEE:
+        // The proof ensures processedDepositQueueHash is a contiguous prefix
+        // of Tempo's currentDepositQueueHash (ancestor-or-equal check).
+        // This allows processing a bounded subset of deposits per block,
+        // preventing liveness issues from deposit queue spam.
 
-        // Our processed hash must match Tempo's current hash for now.
-        // TODO: Implement recursive ancestor check in proof or on-chain as a fallback.
-        if (currentHash != tempoCurrentHash) {
-            revert InvalidDepositQueueHash();
-        }
-
-        // Step 4: Update state
+        // Update state
         processedDepositQueueHash = currentHash;
 
         emit TempoAdvanced(


### PR DESCRIPTION
## Summary
Removes the strict equality requirement between processedDepositQueueHash and Tempo's currentDepositQueueHash in ZoneInbox.advanceTempo(). The proof/TEE validates that the processed hash is a contiguous prefix (ancestor-or-equal) of Tempo's current hash.

This prevents a liveness attack where an adversary spams L1 deposits to make advanceTempo() exceed zone block gas limits.

Closes #63