### PR TITLE
fix(zone): add sharedSecretYParity to Chaum-Pedersen interface

### DIFF
--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -139,6 +139,7 @@ struct ChaumPedersenProof {
 ///      so it does not need to be included here.
 struct DecryptionData {
     bytes32 sharedSecret; // ECDH shared secret (x-coordinate of privSeq * ephemeralPub)
+    uint8 sharedSecretYParity; // Y coordinate parity of the shared secret point (0x02 or 0x03)
     address to; // Decrypted recipient
     bytes32 memo; // Decrypted memo
     ChaumPedersenProof cpProof; // Proof of correct shared secret derivation
@@ -177,6 +178,7 @@ interface IChaumPedersenVerify {
     /// @param ephemeralPubX The X coordinate of the ephemeral public key
     /// @param ephemeralPubYParity The Y coordinate parity (0x02 or 0x03)
     /// @param sharedSecret The claimed shared secret (x-coordinate)
+    /// @param sharedSecretYParity The Y coordinate parity of the shared secret point (0x02 or 0x03)
     /// @param sequencerPubX The sequencer's public key X coordinate
     /// @param sequencerPubYParity The sequencer's public key Y parity
     /// @param proof The Chaum-Pedersen proof (s, c)
@@ -185,6 +187,7 @@ interface IChaumPedersenVerify {
         bytes32 ephemeralPubX,
         uint8 ephemeralPubYParity,
         bytes32 sharedSecret,
+        uint8 sharedSecretYParity,
         bytes32 sequencerPubX,
         uint8 sequencerPubYParity,
         ChaumPedersenProof calldata proof

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -226,6 +226,7 @@ contract ZoneInbox is IZoneInbox {
                         ed.encrypted.ephemeralPubkeyX,
                         ed.encrypted.ephemeralPubkeyYParity,
                         dec.sharedSecret,
+                        dec.sharedSecretYParity,
                         seqPubX,
                         seqPubYParity,
                         dec.cpProof

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -933,6 +933,7 @@ contract ZoneBridgeTest is BaseTest {
             });
             decs[i] = DecryptionData({
                 sharedSecret: bytes32(uint256(0xDEAD)),
+                sharedSecretYParity: 0x02,
                 to: decryptedTo,
                 memo: decryptedMemo,
                 cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
@@ -1133,6 +1134,7 @@ contract ZoneBridgeTest is BaseTest {
         DecryptionData[] memory decs = new DecryptionData[](1);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(0xDEAD)),
+            sharedSecretYParity: 0x02,
             to: decryptedTo,
             memo: decryptedMemo,
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
@@ -1228,12 +1230,14 @@ contract ZoneBridgeTest is BaseTest {
         DecryptionData[] memory decs = new DecryptionData[](2);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(0xDEAD)),
+            sharedSecretYParity: 0x02,
             to: aliceRecipient,
             memo: aliceMemo,
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
         });
         decs[1] = DecryptionData({
             sharedSecret: bytes32(uint256(0xBEEF)),
+            sharedSecretYParity: 0x02,
             to: bobRecipient,
             memo: bobMemo,
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(3)), c: bytes32(uint256(4)) })

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -445,6 +445,7 @@ contract ZoneInboxTest is Test {
         DecryptionData[] memory decs = new DecryptionData[](1);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(0xdeadbeef)),
+            sharedSecretYParity: 0x02,
             to: recipient,
             memo: memo,
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
@@ -497,6 +498,7 @@ contract ZoneInboxTest is Test {
         DecryptionData[] memory decs = new DecryptionData[](1);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(0xdeadbeef)),
+            sharedSecretYParity: 0x02,
             to: address(0x500),
             memo: bytes32("memo"),
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
@@ -541,6 +543,7 @@ contract ZoneInboxTest is Test {
         DecryptionData[] memory decs = new DecryptionData[](1);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(0xabcd)),
+            sharedSecretYParity: 0x02,
             to: recipient,
             memo: encMemo,
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
@@ -596,6 +599,7 @@ contract ZoneInboxTest is Test {
         DecryptionData[] memory decs = new DecryptionData[](1);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(1)),
+            sharedSecretYParity: 0x02,
             to: address(0x500),
             memo: bytes32("memo"),
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
@@ -723,6 +727,7 @@ contract ZoneInboxTest is Test {
         DecryptionData[] memory decs = new DecryptionData[](1);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(0xbad)),
+            sharedSecretYParity: 0x02,
             to: address(0x500),
             memo: bytes32("memo"),
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
@@ -785,6 +790,7 @@ contract ZoneInboxTest is Test {
         decs = new DecryptionData[](1);
         decs[0] = DecryptionData({
             sharedSecret: bytes32(uint256(0xdeadbeef)),
+            sharedSecretYParity: 0x02,
             to: recipient,
             memo: memo,
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })


### PR DESCRIPTION
## Summary
Adds explicit sharedSecretYParity parameter to the Chaum-Pedersen verification precompile interface and DecryptionData struct. Without this, the precompile must guess which y-parity to use when reconstructing the shared secret point, which can cause liveness or integrity failures.

Closes #70