### PR TITLE
docs(zone): document EncryptionKeyEntry storage layout for cross-domain reads

### DIFF
--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -96,8 +96,11 @@ struct EncryptedDeposit {
 }
 
 /// @notice Historical record of an encryption key with its activation block
-/// @dev Used to track key rotations so the prover can determine which key
-///      was valid when a deposit was made
+/// @dev Storage layout per entry (2 slots):
+///      slot 0: x (bytes32) — full slot
+///      slot 1: yParity (uint8, lowest byte) | activationBlock (uint64, next 8 bytes)
+///      WARNING: Do not reorder fields. ZoneInbox._readEncryptionKey() and
+///      ZoneConfig.sequencerEncryptionKey() read these via raw storage slot access.
 struct EncryptionKeyEntry {
     bytes32 x; // X coordinate of the public key
     uint8 yParity; // Y coordinate parity (0x02 or 0x03)

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -91,6 +91,7 @@ contract ZoneConfig is IZoneConfig {
 
         x = tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotX));
         bytes32 metaSlot = tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotMeta));
+        // yParity is packed in the lowest byte of the meta slot (see EncryptionKeyEntry layout)
         yParity = uint8(uint256(metaSlot) & 0xff);
     }
 

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -160,6 +160,7 @@ contract ZoneInbox is IZoneInbox {
         bytes32 xSlot = _tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotX));
         if (xSlot == bytes32(0)) revert InvalidSharedSecretProof();
         bytes32 metaSlot = _tempoState.readTempoStorageSlot(tempoPortal, bytes32(slotMeta));
+        // yParity is packed in the lowest byte of the meta slot (see EncryptionKeyEntry layout)
         return (xSlot, uint8(uint256(metaSlot) & 0xff));
     }
 

--- a/docs/specs/test/zone/EncryptionKeyLayout.t.sol
+++ b/docs/specs/test/zone/EncryptionKeyLayout.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { EncryptionKeyEntry, PORTAL_ENCRYPTION_KEYS_SLOT } from "../../src/zone/IZone.sol";
+import { Test } from "forge-std/Test.sol";
+
+/// @notice Minimal harness that mirrors ZonePortal's _encryptionKeys storage layout.
+/// @dev The array is placed at the same storage slot (6) as in ZonePortal so that
+///      derived slot arithmetic is identical.
+contract EncryptionKeyLayoutHarness {
+    // Slots 0-5: padding to match ZonePortal layout
+    uint256 private _pad0;
+    uint256 private _pad1;
+    uint256 private _pad2;
+    uint256 private _pad3;
+    uint256 private _pad4;
+    uint256 private _pad5;
+
+    // Slot 6: _encryptionKeys — must be at PORTAL_ENCRYPTION_KEYS_SLOT
+    EncryptionKeyEntry[] internal _encryptionKeys;
+
+    function push(bytes32 x, uint8 yParity, uint64 activationBlock) external {
+        _encryptionKeys.push(
+            EncryptionKeyEntry({ x: x, yParity: yParity, activationBlock: activationBlock })
+        );
+    }
+
+    function length() external view returns (uint256) {
+        return _encryptionKeys.length;
+    }
+
+    function get(uint256 i) external view returns (EncryptionKeyEntry memory) {
+        return _encryptionKeys[i];
+    }
+}
+
+/// @title EncryptionKeyLayoutTest
+/// @notice Storage layout regression test for EncryptionKeyEntry.
+///         ZoneInbox._readEncryptionKey() and ZoneConfig.sequencerEncryptionKey()
+///         read raw storage slots and assume yParity is packed in the lowest byte
+///         of the meta slot. If the struct field order ever changes, these tests fail.
+contract EncryptionKeyLayoutTest is Test {
+    EncryptionKeyLayoutHarness harness;
+
+    function setUp() public {
+        harness = new EncryptionKeyLayoutHarness();
+    }
+
+    /// @notice Verify that _encryptionKeys lives at the expected storage slot.
+    function test_arraySlot() public view {
+        bytes32 lengthSlot = bytes32(uint256(PORTAL_ENCRYPTION_KEYS_SLOT));
+        uint256 len = uint256(vm.load(address(harness), lengthSlot));
+        assertEq(len, 0, "empty array length should be 0 at PORTAL_ENCRYPTION_KEYS_SLOT");
+    }
+
+    /// @notice Verify that yParity is stored in the lowest byte of the meta slot,
+    ///         and activationBlock occupies bytes 1-8.
+    function test_structPackingLayout() public {
+        bytes32 keyX = keccak256("regression-key");
+        uint8 yParity = 0x03;
+        uint64 activationBlock = 0xDEADBEEFCAFE;
+
+        harness.push(keyX, yParity, activationBlock);
+
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
+        uint256 slotX = base;
+        uint256 slotMeta = base + 1;
+
+        // Verify x occupies a full slot
+        bytes32 rawX = vm.load(address(harness), bytes32(slotX));
+        assertEq(rawX, keyX, "slot 0 of entry should store x");
+
+        // Verify the meta slot packing
+        bytes32 rawMeta = vm.load(address(harness), bytes32(slotMeta));
+
+        // yParity must be extractable from the lowest byte — this is exactly what
+        // ZoneInbox._readEncryptionKey() and ZoneConfig.sequencerEncryptionKey() do
+        uint8 extractedYParity = uint8(uint256(rawMeta) & 0xff);
+        assertEq(extractedYParity, yParity, "yParity must be in lowest byte of meta slot");
+
+        // activationBlock must be in bytes 1-8 (bits 8..71)
+        uint64 extractedActivation = uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff);
+        assertEq(
+            extractedActivation, activationBlock, "activationBlock must be in bytes 1-8 of meta slot"
+        );
+    }
+
+    /// @notice Same check with multiple entries at different indices.
+    function test_structPackingMultipleEntries() public {
+        bytes32[3] memory xs =
+            [keccak256("key-0"), keccak256("key-1"), keccak256("key-2")];
+        uint8[3] memory yParities = [uint8(0x02), uint8(0x03), uint8(0x02)];
+        uint64[3] memory blocks = [uint64(1), uint64(100_000), uint64(type(uint64).max)];
+
+        for (uint256 i = 0; i < 3; i++) {
+            harness.push(xs[i], yParities[i], blocks[i]);
+        }
+
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
+
+        for (uint256 i = 0; i < 3; i++) {
+            bytes32 rawX = vm.load(address(harness), bytes32(base + i * 2));
+            bytes32 rawMeta = vm.load(address(harness), bytes32(base + i * 2 + 1));
+
+            assertEq(rawX, xs[i], "x mismatch");
+            assertEq(
+                uint8(uint256(rawMeta) & 0xff),
+                yParities[i],
+                "yParity must be in lowest byte"
+            );
+            assertEq(
+                uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff),
+                blocks[i],
+                "activationBlock must be in bytes 1-8"
+            );
+        }
+    }
+
+    /// @notice Verify that each EncryptionKeyEntry occupies exactly 2 storage slots.
+    function test_entrySizeIsTwoSlots() public {
+        harness.push(keccak256("a"), 0x02, 1);
+        harness.push(keccak256("b"), 0x03, 2);
+
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
+
+        // Entry 0 at base+0, base+1
+        bytes32 x0 = vm.load(address(harness), bytes32(base));
+        assertEq(x0, keccak256("a"), "entry 0 x");
+
+        // Entry 1 at base+2, base+3 (stride of 2)
+        bytes32 x1 = vm.load(address(harness), bytes32(base + 2));
+        assertEq(x1, keccak256("b"), "entry 1 x at stride 2");
+    }
+}

--- a/docs/specs/test/zone/EncryptionKeyLayout.t.sol
+++ b/docs/specs/test/zone/EncryptionKeyLayout.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { EncryptionKeyEntry, PORTAL_ENCRYPTION_KEYS_SLOT } from "../../src/zone/IZone.sol";
-import { Test } from "forge-std/Test.sol";
+import {EncryptionKeyEntry, PORTAL_ENCRYPTION_KEYS_SLOT} from "../../src/zone/IZone.sol";
+import {Test} from "forge-std/Test.sol";
 
 /// @notice Minimal harness that mirrors ZonePortal's _encryptionKeys storage layout.
 /// @dev The array is placed at the same storage slot (6) as in ZonePortal so that
@@ -20,9 +20,7 @@ contract EncryptionKeyLayoutHarness {
     EncryptionKeyEntry[] internal _encryptionKeys;
 
     function push(bytes32 x, uint8 yParity, uint64 activationBlock) external {
-        _encryptionKeys.push(
-            EncryptionKeyEntry({ x: x, yParity: yParity, activationBlock: activationBlock })
-        );
+        _encryptionKeys.push(EncryptionKeyEntry({x: x, yParity: yParity, activationBlock: activationBlock}));
     }
 
     function length() external view returns (uint256) {
@@ -80,15 +78,12 @@ contract EncryptionKeyLayoutTest is Test {
 
         // activationBlock must be in bytes 1-8 (bits 8..71)
         uint64 extractedActivation = uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff);
-        assertEq(
-            extractedActivation, activationBlock, "activationBlock must be in bytes 1-8 of meta slot"
-        );
+        assertEq(extractedActivation, activationBlock, "activationBlock must be in bytes 1-8 of meta slot");
     }
 
     /// @notice Same check with multiple entries at different indices.
     function test_structPackingMultipleEntries() public {
-        bytes32[3] memory xs =
-            [keccak256("key-0"), keccak256("key-1"), keccak256("key-2")];
+        bytes32[3] memory xs = [keccak256("key-0"), keccak256("key-1"), keccak256("key-2")];
         uint8[3] memory yParities = [uint8(0x02), uint8(0x03), uint8(0x02)];
         uint64[3] memory blocks = [uint64(1), uint64(100_000), uint64(type(uint64).max)];
 
@@ -103,15 +98,9 @@ contract EncryptionKeyLayoutTest is Test {
             bytes32 rawMeta = vm.load(address(harness), bytes32(base + i * 2 + 1));
 
             assertEq(rawX, xs[i], "x mismatch");
+            assertEq(uint8(uint256(rawMeta) & 0xff), yParities[i], "yParity must be in lowest byte");
             assertEq(
-                uint8(uint256(rawMeta) & 0xff),
-                yParities[i],
-                "yParity must be in lowest byte"
-            );
-            assertEq(
-                uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff),
-                blocks[i],
-                "activationBlock must be in bytes 1-8"
+                uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff), blocks[i], "activationBlock must be in bytes 1-8"
             );
         }
     }

--- a/docs/specs/test/zone/EncryptionKeyLayout.t.sol
+++ b/docs/specs/test/zone/EncryptionKeyLayout.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {EncryptionKeyEntry, PORTAL_ENCRYPTION_KEYS_SLOT} from "../../src/zone/IZone.sol";
-import {Test} from "forge-std/Test.sol";
+import { EncryptionKeyEntry, PORTAL_ENCRYPTION_KEYS_SLOT } from "../../src/zone/IZone.sol";
+import { Test } from "forge-std/Test.sol";
 
 /// @notice Minimal harness that mirrors ZonePortal's _encryptionKeys storage layout.
 /// @dev The array is placed at the same storage slot (6) as in ZonePortal so that
 ///      derived slot arithmetic is identical.
 contract EncryptionKeyLayoutHarness {
+
     // Slots 0-5: padding to match ZonePortal layout
     uint256 private _pad0;
     uint256 private _pad1;
@@ -20,7 +21,9 @@ contract EncryptionKeyLayoutHarness {
     EncryptionKeyEntry[] internal _encryptionKeys;
 
     function push(bytes32 x, uint8 yParity, uint64 activationBlock) external {
-        _encryptionKeys.push(EncryptionKeyEntry({x: x, yParity: yParity, activationBlock: activationBlock}));
+        _encryptionKeys.push(
+            EncryptionKeyEntry({ x: x, yParity: yParity, activationBlock: activationBlock })
+        );
     }
 
     function length() external view returns (uint256) {
@@ -30,6 +33,7 @@ contract EncryptionKeyLayoutHarness {
     function get(uint256 i) external view returns (EncryptionKeyEntry memory) {
         return _encryptionKeys[i];
     }
+
 }
 
 /// @title EncryptionKeyLayoutTest
@@ -38,6 +42,7 @@ contract EncryptionKeyLayoutHarness {
 ///         read raw storage slots and assume yParity is packed in the lowest byte
 ///         of the meta slot. If the struct field order ever changes, these tests fail.
 contract EncryptionKeyLayoutTest is Test {
+
     EncryptionKeyLayoutHarness harness;
 
     function setUp() public {
@@ -78,7 +83,11 @@ contract EncryptionKeyLayoutTest is Test {
 
         // activationBlock must be in bytes 1-8 (bits 8..71)
         uint64 extractedActivation = uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff);
-        assertEq(extractedActivation, activationBlock, "activationBlock must be in bytes 1-8 of meta slot");
+        assertEq(
+            extractedActivation,
+            activationBlock,
+            "activationBlock must be in bytes 1-8 of meta slot"
+        );
     }
 
     /// @notice Same check with multiple entries at different indices.
@@ -100,7 +109,9 @@ contract EncryptionKeyLayoutTest is Test {
             assertEq(rawX, xs[i], "x mismatch");
             assertEq(uint8(uint256(rawMeta) & 0xff), yParities[i], "yParity must be in lowest byte");
             assertEq(
-                uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff), blocks[i], "activationBlock must be in bytes 1-8"
+                uint64((uint256(rawMeta) >> 8) & 0xffffffffffffffff),
+                blocks[i],
+                "activationBlock must be in bytes 1-8"
             );
         }
     }
@@ -120,4 +131,5 @@ contract EncryptionKeyLayoutTest is Test {
         bytes32 x1 = vm.load(address(harness), bytes32(base + 2));
         assertEq(x1, keccak256("b"), "entry 1 x at stride 2");
     }
+
 }


### PR DESCRIPTION
## Summary
Documents the storage layout of EncryptionKeyEntry and adds warnings about field ordering. ZoneInbox._readEncryptionKey() and ZoneConfig.sequencerEncryptionKey() both read raw storage slots and depend on the exact struct packing.

Closes #69