### PR TITLE
fix(zone): add maxWithdrawalsPerBlock cap and fix docs to reflect fixed-size ring buffer

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -101,7 +101,7 @@ The sequencer posts batches to Tempo via a single `submitBatch` call (sequencer-
 
 1. Verifies the proof/attestation for the state transition (including chain integrity via `prevBlockHash`).
 2. Updates the portal's `withdrawalBatchIndex`, `blockHash`, and `lastSyncedTempoBlockNumber`.
-3. Updates the withdrawal queue (adds new withdrawals to the next slot in the unbounded buffer).
+3. Updates the withdrawal queue (adds new withdrawals to the next slot in the fixed-size ring buffer).
 
 Each batch submission includes:
 
@@ -113,7 +113,7 @@ Each batch submission includes:
 - `verifierConfig` - Opaque payload for verifier (domain separation/attestation)
 - `proof` - Validity proof or TEE attestation
 
-The portal tracks `withdrawalBatchIndex`, `blockHash` (last proven batch block), `lastSyncedTempoBlockNumber` (Tempo block zone synced to), `currentDepositQueueHash` (deposit queue head), and an unbounded buffer for withdrawals.
+The portal tracks `withdrawalBatchIndex`, `blockHash` (last proven batch block), `lastSyncedTempoBlockNumber` (Tempo block zone synced to), `currentDepositQueueHash` (deposit queue head), and a fixed-size ring buffer for withdrawals.
 
 **Ancestry proofs for historical blocks**: If `tempoBlockNumber` is outside the EIP-2935 window (~8192 blocks), use `recentTempoBlockNumber` to specify a recent block still in EIP-2935. The proof verifies the ancestry chain (via parent hashes) from `tempoBlockNumber` to `recentTempoBlockNumber` inside the ZK proof, avoiding expensive on-chain header verification. This prevents zone bricking after extended downtime.
 
@@ -220,15 +220,14 @@ Proofs or attestations are assumed to be fast. No data availability is required 
 
 ## Withdrawal queue
 
-Withdrawals use an unbounded buffer that allows the sequencer to process withdrawals independently of proof generation. Each batch gets its own slot, and the sequencer processes withdrawals from the oldest slot while new batches add to the next available slot.
+Withdrawals use a fixed-size ring buffer (`WITHDRAWAL_QUEUE_CAPACITY = 100`) that allows the sequencer to process withdrawals independently of proof generation. Each batch gets its own slot, and the sequencer processes withdrawals from the oldest slot while new batches add to the next available slot. If the sequencer does not process withdrawals quickly enough and the buffer fills, batch submission reverts — this is intentional, as it forces the sequencer to keep up with withdrawal processing in order to make batch progress.
 
 The portal tracks:
 - `head` - slot index of the oldest unprocessed batch (where sequencer removes)
 - `tail` - slot index where the next batch will write (where proofs add)
-- `maxSize` - maximum queue length ever reached (for gas accounting)
 - `slots` - mapping of slot index to hash chain (`EMPTY_SENTINEL` = empty)
 
-**Gas note**: Since this is implemented as a precompile on Tempo, storage gas should only be charged when `(tail - head) > maxSize`, i.e., when the queue length exceeds its previous maximum. This allows the queue to shrink and regrow without repeated storage charges.
+The ring buffer uses modular arithmetic for slot indexing (`tail % WITHDRAWAL_QUEUE_CAPACITY`) so head and tail never wrap, keeping the implementation simple. The queue reverts with `WithdrawalQueueFull` if `tail - head >= WITHDRAWAL_QUEUE_CAPACITY`.
 
 ### Hash chain structure
 
@@ -250,7 +249,8 @@ function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) extern
         revert NoWithdrawalsInQueue();
     }
 
-    bytes32 currentSlot = _withdrawalQueue.slots[head];
+    uint256 slotIndex = head % WITHDRAWAL_QUEUE_CAPACITY;
+    bytes32 currentSlot = _withdrawalQueue.slots[slotIndex];
 
     // Verify this is the head of the current slot
     // The remainingQueue for the last item should be 0 (we convert to EMPTY_SENTINEL internally)
@@ -261,11 +261,11 @@ function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) extern
 
     if (remainingQueue == bytes32(0)) {
         // Slot exhausted, mark as empty and advance head
-        _withdrawalQueue.slots[head] = EMPTY_SENTINEL;
+        _withdrawalQueue.slots[slotIndex] = EMPTY_SENTINEL;
         _withdrawalQueue.head = head + 1;
     } else {
         // More withdrawals in this slot
-        _withdrawalQueue.slots[head] = remainingQueue;
+        _withdrawalQueue.slots[slotIndex] = remainingQueue;
     }
 }
 ```
@@ -285,21 +285,20 @@ function submitBatch(...) external onlySequencer {
 
     uint256 tail = _withdrawalQueue.tail;
 
-    // Write the withdrawal hash chain to this slot
-    _withdrawalQueue.slots[tail] = withdrawalQueueTransition.withdrawalQueueHash;
+    // Revert if ring buffer is full — sequencer must process withdrawals to make room
+    if (tail - _withdrawalQueue.head >= WITHDRAWAL_QUEUE_CAPACITY) {
+        revert WithdrawalQueueFull();
+    }
+
+    // Write the withdrawal hash chain to this slot (using modular indexing)
+    _withdrawalQueue.slots[tail % WITHDRAWAL_QUEUE_CAPACITY] = withdrawalQueueTransition.withdrawalQueueHash;
 
     // Advance tail
     _withdrawalQueue.tail = tail + 1;
-
-    // Update maxSize if current queue length exceeds previous maximum
-    uint256 currentSize = _withdrawalQueue.tail - _withdrawalQueue.head;
-    if (currentSize > _withdrawalQueue.maxSize) {
-        _withdrawalQueue.maxSize = currentSize;
-    }
 }
 ```
 
-This design eliminates race conditions entirely - each batch has its own independent slot, and the sequencer processes slots in order. The unbounded buffer means the queue can never be "full".
+This design eliminates race conditions entirely — each batch has its own independent slot, and the sequencer processes slots in order. The fixed-size ring buffer ensures the sequencer must keep up with withdrawal processing to continue submitting batches.
 
 ## Interfaces and functions
 
@@ -394,25 +393,28 @@ library DepositQueueLib {
 }
 ```
 
-#### WithdrawalQueueLib (unbounded buffer)
+#### WithdrawalQueueLib (fixed-size ring buffer)
 
-Handles L2→Tempo withdrawals where the producer (proof) is slow and the consumer (on-chain) is fast. Each batch gets its own slot in an unbounded buffer.
+Handles L2→Tempo withdrawals where the producer (proof) is slow and the consumer (on-chain) is fast. Each batch gets its own slot in a fixed-size ring buffer of `WITHDRAWAL_QUEUE_CAPACITY` slots. If the buffer is full when a new batch is submitted, the transaction reverts — this forces the sequencer to keep up with withdrawal processing.
 
 ```solidity
 /// @dev Sentinel value for empty slots. Using 0xff...ff instead of 0x00 to avoid
 ///      clearing storage (which would refund gas and create incentive issues).
 bytes32 constant EMPTY_SENTINEL = bytes32(type(uint256).max);
 
+/// @dev Fixed capacity for the withdrawal ring buffer (number of batch slots).
+uint256 constant WITHDRAWAL_QUEUE_CAPACITY = 100;
+
 struct WithdrawalQueue {
-    uint256 head;     // slot index of oldest unprocessed batch
-    uint256 tail;     // slot index where next batch will write
-    uint256 maxSize;  // maximum queue length ever reached (for gas accounting)
+    uint256 head;     // logical index of oldest unprocessed batch
+    uint256 tail;     // logical index where next batch will write
     mapping(uint256 => bytes32) slots;  // hash chains per batch (EMPTY_SENTINEL = empty)
 }
 
 library WithdrawalQueueLib {
     /// @notice Add a batch's withdrawals to the queue (called during batch submission)
-    /// @dev Writes to slot at tail, then advances tail. Updates maxSize if needed.
+    /// @dev Writes to slot at tail % WITHDRAWAL_QUEUE_CAPACITY, then advances tail.
+    ///      Reverts with WithdrawalQueueFull if tail - head >= WITHDRAWAL_QUEUE_CAPACITY.
     function enqueue(WithdrawalQueue storage q, bytes32 withdrawalQueueHash) internal;
 
     /// @notice Pop the next withdrawal from the queue (on-chain operation)
@@ -427,8 +429,6 @@ library WithdrawalQueueLib {
     function length(WithdrawalQueue storage q) internal view returns (uint256);
 }
 ```
-
-**Gas note**: Storage gas should only be charged when `(tail - head) > maxSize`. This is enforced by the precompile implementation.
 
 | Queue | Tempo operation | Zone/Proof operation |
 |-------|--------------|---------------------|
@@ -943,12 +943,20 @@ interface IZoneOutbox {
     /// @notice Set Tempo gas rate. Only callable by sequencer.
     function setTempoGasRate(uint128 _tempoGasRate) external;
 
+    /// @notice Maximum number of withdrawal requests per zone block (0 = unlimited).
+    function maxWithdrawalsPerBlock() external view returns (uint256);
+
+    /// @notice Set maximum withdrawal requests per zone block. Only callable by sequencer.
+    /// @dev Set to 0 for unlimited. Provides rate-limiting in addition to the gas fee.
+    function setMaxWithdrawalsPerBlock(uint256 _maxWithdrawalsPerBlock) external;
+
     /// @notice Calculate the fee for a withdrawal with the given gasLimit.
     /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo.
     /// @dev Caller must have approved the outbox to spend `amount + fee` of zone tokens.
+    ///      Subject to maxWithdrawalsPerBlock cap if set by the sequencer.
     ///      Tokens are burned immediately and withdrawal is stored in pending array.
     /// @param to The Tempo recipient address.
     /// @param amount Amount to send to recipient (fee is additional).
@@ -969,7 +977,7 @@ interface IZoneOutbox {
     /// @dev Only callable by sequencer in the final block of a batch.
     ///      Must be called exactly once per batch (count may be 0). Writes `withdrawalQueueHash`
     ///      and `withdrawalBatchIndex` to lastBatch storage for proof access.
-    /// @param count Max number of withdrawals to process (avoids unbounded loops).
+    /// @param count Max number of withdrawals to process (limits per-call gas cost).
     /// @return withdrawalQueueHash The hash chain for Tempo batch submission.
     function finalizeWithdrawalBatch(uint256 count) external returns (bytes32 withdrawalQueueHash);
 }
@@ -1012,7 +1020,7 @@ Both the deposit queue and withdrawal queue are FIFO queues that require constan
 Both use hash chains, but with different models:
 
 - **Deposit queue**: Tempo tracks only `currentDepositQueueHash` (where new deposits land). The zone tracks its own `processedDepositQueueHash` in EVM state. The proof validates deposit processing by reading `currentDepositQueueHash` from Tempo state inside the proof.
-- **Withdrawal queue**: unbounded buffer (each batch gets its own slot, `head` points to oldest unprocessed batch, `tail` points to where next batch writes, `maxSize` tracks peak queue length for gas accounting)
+- **Withdrawal queue**: fixed-size ring buffer of `WITHDRAWAL_QUEUE_CAPACITY` slots (each batch gets its own slot, `head` points to oldest unprocessed batch, `tail` points to where next batch writes; reverts if full)
 
 The hash chains are structured differently to optimize for their on-chain operation:
 
@@ -1063,25 +1071,24 @@ When slot exhausted: slots[head] = EMPTY_SENTINEL, head++
 
 - **On-chain removal is O(1)**: Sequencer provides withdrawal + remaining hash, portal verifies and unwraps one layer.
 - **Proving additions**: Proof builds queue with new withdrawals at innermost (O(N) inside ZKP), writes to slot at tail.
-- **Unbounded buffer**: Each batch gets its own slot. Sequencer processes from `head`, proofs add at `tail`. The `maxSize` field tracks peak queue length for gas accounting.
+- **Fixed-size ring buffer**: Each batch gets its own slot. Sequencer processes from `head`, proofs add at `tail`. Reverts with `WithdrawalQueueFull` if the buffer is full (`tail - head >= WITHDRAWAL_QUEUE_CAPACITY`). This forces the sequencer to keep up with withdrawal processing.
 
 ```
-Unbounded buffer:
+Fixed-size ring buffer (WITHDRAWAL_QUEUE_CAPACITY slots):
 
      head                              tail
       │                                 │
       ▼                                 ▼
-  ┌─────┬─────┬─────┬─────┬─────┬─────┬─────┬─────┐
-  │ w1  │ w4  │ w6  │EMPTY│EMPTY│EMPTY│     │     │  ...unbounded
-  │ w2  │ w5  │     │     │     │     │     │     │
-  │ w3  │     │     │     │     │     │     │     │
-  └─────┴─────┴─────┴─────┴─────┴─────┴─────┴─────┘
-  slot 0 slot 1 slot 2 ...
+  ┌─────┬─────┬─────┬─────┬─────┬─────┐
+  │ w1  │ w4  │ w6  │EMPTY│EMPTY│EMPTY│  (capacity = WITHDRAWAL_QUEUE_CAPACITY)
+  │ w2  │ w5  │     │     │     │     │
+  │ w3  │     │     │     │     │     │
+  └─────┴─────┴─────┴─────┴─────┴─────┘
+  slot 0 slot 1 slot 2 ...  (indexed by tail % capacity)
 
-- Batches write to slots[tail], then tail++
-- Sequencer processes from slots[head], then head++ when slot exhausted
-- maxSize updated when (tail - head) exceeds previous maximum
-- Gas only charged for new storage when queue length exceeds maxSize
+- Batches write to slots[tail % capacity], then tail++
+- Sequencer processes from slots[head % capacity], then head++ when slot exhausted
+- Reverts if tail - head >= WITHDRAWAL_QUEUE_CAPACITY (queue full)
 ```
 
 The key insight: structure the hash chain so the **on-chain operation touches the outermost layer**. Additions wrap the outside; removals unwrap from the outside. The expensive operation (processing the full queue) happens inside the ZKP where O(N) is acceptable. Using `EMPTY_SENTINEL` (0xffffffff...fff) instead of 0x00 avoids storage clearing and gas refund incentive issues.
@@ -1471,7 +1478,8 @@ function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) extern
         revert NoWithdrawalsInQueue();
     }
 
-    bytes32 currentSlot = _withdrawalQueue.slots[head];
+    uint256 slotIndex = head % WITHDRAWAL_QUEUE_CAPACITY;
+    bytes32 currentSlot = _withdrawalQueue.slots[slotIndex];
 
     // Verify head (remainingQueue of 0 means last item, we check against EMPTY_SENTINEL)
     bytes32 expectedRemainingQueue = remainingQueue == bytes32(0) ? EMPTY_SENTINEL : remainingQueue;
@@ -1480,11 +1488,11 @@ function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) extern
     // Pop the withdrawal regardless of success/failure
     if (remainingQueue == bytes32(0)) {
         // Slot exhausted, mark as empty and advance head
-        _withdrawalQueue.slots[head] = EMPTY_SENTINEL;
+        _withdrawalQueue.slots[slotIndex] = EMPTY_SENTINEL;
         _withdrawalQueue.head = head + 1;
     } else {
         // More withdrawals in this slot
-        _withdrawalQueue.slots[head] = remainingQueue;
+        _withdrawalQueue.slots[slotIndex] = remainingQueue;
     }
 
     if (w.gasLimit == 0) {

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -754,6 +754,8 @@ interface IZoneOutbox {
 
     event TempoGasRateUpdated(uint128 tempoGasRate);
 
+    event MaxWithdrawalsPerBlockUpdated(uint256 maxWithdrawalsPerBlock);
+
     /// @notice Emitted when sequencer finalizes a batch at end of block
     /// @dev Kept for observability. Proof reads from lastBatch storage instead.
     event BatchFinalized(bytes32 indexed withdrawalQueueHash, uint64 withdrawalBatchIndex);
@@ -780,10 +782,17 @@ interface IZoneOutbox {
     /// @notice Number of pending withdrawals
     function pendingWithdrawalsCount() external view returns (uint256);
 
+    /// @notice Maximum number of withdrawal requests per zone block (0 = unlimited)
+    function maxWithdrawalsPerBlock() external view returns (uint256);
+
     /// @notice Set Tempo gas rate. Only callable by sequencer.
     /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price fluctuations.
     /// @param _tempoGasRate Zone token units per gas unit on Tempo
     function setTempoGasRate(uint128 _tempoGasRate) external;
+
+    /// @notice Set maximum withdrawal requests per zone block. Only callable by sequencer.
+    /// @dev Set to 0 for unlimited. Provides rate-limiting in addition to the gas fee mechanism.
+    function setMaxWithdrawalsPerBlock(uint256 _maxWithdrawalsPerBlock) external;
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit
     /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -57,6 +57,18 @@ contract ZoneOutbox is IZoneOutbox {
     Withdrawal[] internal _pendingWithdrawals;
     uint256 internal _pendingWithdrawalsHead;
 
+    /// @notice Maximum number of withdrawal requests allowed per zone block (0 = unlimited)
+    /// @dev Sequencer-configurable cap to prevent DoS via mass withdrawal requests.
+    ///      This limits the number of requestWithdrawal() calls per block, complementing
+    ///      the gas fee mechanism which already provides economic rate-limiting.
+    uint256 public maxWithdrawalsPerBlock;
+
+    /// @notice Number of withdrawal requests in the current block
+    uint256 internal _withdrawalsThisBlock;
+
+    /// @notice Block number for tracking per-block withdrawal count
+    uint256 internal _currentBlockNumber;
+
     /*//////////////////////////////////////////////////////////////
                                 ERRORS
     //////////////////////////////////////////////////////////////*/
@@ -66,6 +78,7 @@ contract ZoneOutbox is IZoneOutbox {
     error GasFeeRateTooHigh();
     error TransferFailed();
     error OnlySequencer();
+    error TooManyWithdrawalsThisBlock();
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
@@ -90,6 +103,15 @@ contract ZoneOutbox is IZoneOutbox {
         if (_tempoGasRate > MAX_GAS_FEE_RATE) revert GasFeeRateTooHigh();
         tempoGasRate = _tempoGasRate;
         emit TempoGasRateUpdated(_tempoGasRate);
+    }
+
+    /// @notice Set maximum withdrawal requests per zone block. Only callable by sequencer.
+    /// @dev Set to 0 for unlimited. Provides rate-limiting in addition to the gas fee mechanism.
+    /// @param _maxWithdrawalsPerBlock The maximum number of requestWithdrawal() calls per block
+    function setMaxWithdrawalsPerBlock(uint256 _maxWithdrawalsPerBlock) external {
+        if (msg.sender != config.sequencer()) revert OnlySequencer();
+        maxWithdrawalsPerBlock = _maxWithdrawalsPerBlock;
+        emit MaxWithdrawalsPerBlockUpdated(_maxWithdrawalsPerBlock);
     }
 
     /// @notice Calculate the fee for a withdrawal with the given gasLimit
@@ -132,6 +154,18 @@ contract ZoneOutbox is IZoneOutbox {
         // Limit callback data size to prevent storage bloat and hash computation abuse
         if (data.length > MAX_CALLBACK_DATA_SIZE) {
             revert CallbackDataTooLarge();
+        }
+
+        // Enforce per-block withdrawal cap (0 = unlimited)
+        if (maxWithdrawalsPerBlock > 0) {
+            if (block.number != _currentBlockNumber) {
+                _currentBlockNumber = block.number;
+                _withdrawalsThisBlock = 0;
+            }
+            if (_withdrawalsThisBlock >= maxWithdrawalsPerBlock) {
+                revert TooManyWithdrawalsThisBlock();
+            }
+            _withdrawalsThisBlock++;
         }
 
         // Calculate processing fee (locked in at request time)

--- a/docs/specs/test/zone/ZoneOutbox.t.sol
+++ b/docs/specs/test/zone/ZoneOutbox.t.sol
@@ -818,4 +818,88 @@ contract ZoneOutboxTest is Test {
         assertEq(outbox.pendingWithdrawalsCount(), 0);
     }
 
+    /*//////////////////////////////////////////////////////////////
+                     MAX WITHDRAWALS PER BLOCK TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_setMaxWithdrawalsPerBlock_onlySequencer() public {
+        vm.prank(alice);
+        vm.expectRevert(ZoneOutbox.OnlySequencer.selector);
+        outbox.setMaxWithdrawalsPerBlock(10);
+    }
+
+    function test_setMaxWithdrawalsPerBlock_sequencerCanSet() public {
+        vm.prank(sequencer);
+        outbox.setMaxWithdrawalsPerBlock(5);
+        assertEq(outbox.maxWithdrawalsPerBlock(), 5);
+    }
+
+    function test_setMaxWithdrawalsPerBlock_zeroMeansUnlimited() public {
+        vm.prank(sequencer);
+        outbox.setMaxWithdrawalsPerBlock(0);
+        assertEq(outbox.maxWithdrawalsPerBlock(), 0);
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 1000e6);
+        for (uint256 i = 0; i < 10; i++) {
+            outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        }
+        vm.stopPrank();
+        assertEq(outbox.pendingWithdrawalsCount(), 10);
+    }
+
+    function test_maxWithdrawalsPerBlock_enforcesLimit() public {
+        vm.prank(sequencer);
+        outbox.setMaxWithdrawalsPerBlock(3);
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 1000e6);
+
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+
+        vm.expectRevert(ZoneOutbox.TooManyWithdrawalsThisBlock.selector);
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        vm.stopPrank();
+    }
+
+    function test_maxWithdrawalsPerBlock_resetsOnNewBlock() public {
+        vm.prank(sequencer);
+        outbox.setMaxWithdrawalsPerBlock(2);
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 1000e6);
+
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+
+        vm.expectRevert(ZoneOutbox.TooManyWithdrawalsThisBlock.selector);
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+
+        vm.roll(block.number + 1);
+
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+
+        vm.expectRevert(ZoneOutbox.TooManyWithdrawalsThisBlock.selector);
+        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        vm.stopPrank();
+
+        assertEq(outbox.pendingWithdrawalsCount(), 4);
+    }
+
+    function test_maxWithdrawalsPerBlock_canBeUpdated() public {
+        vm.startPrank(sequencer);
+        outbox.setMaxWithdrawalsPerBlock(1);
+        assertEq(outbox.maxWithdrawalsPerBlock(), 1);
+
+        outbox.setMaxWithdrawalsPerBlock(100);
+        assertEq(outbox.maxWithdrawalsPerBlock(), 100);
+
+        outbox.setMaxWithdrawalsPerBlock(0);
+        assertEq(outbox.maxWithdrawalsPerBlock(), 0);
+        vm.stopPrank();
+    }
+
 }


### PR DESCRIPTION
## Summary

Reworks the approach for #67. The fixed-size ring buffer (capacity 100) is **intentional** — it forces the sequencer to process withdrawals to keep making batch progress.

## Changes

1. **Docs updated**: All references to "unbounded buffer" replaced with "fixed-size ring buffer", removed `maxSize` field references, updated ASCII art and code examples to use modular indexing
2. **Per-block withdrawal cap**: Added `maxWithdrawalsPerBlock` (sequencer-configurable, 0 = unlimited) to `ZoneOutbox` as an additional DoS protection layer alongside the existing gas fee mechanism
3. **Tests**: Added tests for the per-block cap (enforces limit, resets on new block, 0 = unlimited, sequencer-only)

## Rationale

Per the issue discussion: the fixed capacity is intentional to force sequencer liveness. The per-block cap adds a second layer of protection (similar to #63's approach for deposits) where the sequencer can limit how many withdrawal requests are accepted per zone block.

Closes #67