### PR TITLE
fix(zone): add higher fee for encrypted deposits

### DIFF
--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -425,6 +425,9 @@ interface IZonePortal {
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
 
+    /// @notice Fixed gas value for encrypted deposit fee calculation (200,000 gas)
+    function FIXED_ENCRYPTED_DEPOSIT_GAS() external view returns (uint64);
+
     function zoneId() external view returns (uint64);
     function token() external view returns (address);
     function messenger() external view returns (address);
@@ -496,6 +499,9 @@ interface IZonePortal {
 
     /// @notice Calculate the fee for a deposit
     function calculateDepositFee() external view returns (uint128 fee);
+
+    /// @notice Calculate the fee for an encrypted deposit
+    function calculateEncryptedDepositFee() external view returns (uint128 fee);
 
     /// @notice Check if an encryption key is still valid for new deposits
     /// @dev A key is valid if it's the current key OR if it was superseded less than

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -40,6 +40,11 @@ contract ZonePortal is IZonePortal {
     ///      flexibility to adjust the zoneGasRate based on operational costs.
     uint64 public constant FIXED_DEPOSIT_GAS = 100_000;
 
+    /// @notice Fixed gas value for encrypted deposit fee calculation
+    /// @dev Set to 200,000 gas. Higher than regular deposits to account for
+    ///      zone-side Chaum-Pedersen verification, HKDF-SHA256, and AES-256-GCM decryption.
+    uint64 public constant FIXED_ENCRYPTED_DEPOSIT_GAS = 200_000;
+
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -369,6 +374,13 @@ contract ZonePortal is IZonePortal {
         fee = uint128(FIXED_DEPOSIT_GAS) * zoneGasRate;
     }
 
+    /// @notice Calculate the fee for an encrypted deposit
+    /// @dev Fee = FIXED_ENCRYPTED_DEPOSIT_GAS * zoneGasRate
+    /// @return fee The encrypted deposit fee in zone token units
+    function calculateEncryptedDepositFee() public view returns (uint128 fee) {
+        fee = uint128(FIXED_ENCRYPTED_DEPOSIT_GAS) * zoneGasRate;
+    }
+
     /// @notice Deposit zone token into the zone. Returns the new current deposit queue hash.
     /// @dev Fee is deducted from amount and paid to sequencer. Net amount is credited on zone.
     /// @param to Recipient address on the zone
@@ -451,7 +463,7 @@ contract ZonePortal is IZonePortal {
             revert EncryptionKeyExpired(keyIndex, key.activationBlock, nextKey.activationBlock);
         }
 
-        uint128 fee = calculateDepositFee();
+        uint128 fee = calculateEncryptedDepositFee();
         if (amount <= fee) revert DepositTooSmall();
         uint128 netAmount = amount - fee;
 

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -977,7 +977,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // === STEP 2: Alice makes encrypted deposit on L1 ===
         uint128 depositAmount = 1000e6;
-        uint128 fee = l1Portal.calculateDepositFee();
+        uint128 fee = l1Portal.calculateEncryptedDepositFee();
         uint128 netAmount = depositAmount - fee;
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
 
@@ -1036,7 +1036,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // === STEP 2: Alice makes encrypted deposit on L1 ===
         uint128 depositAmount = 1000e6;
-        uint128 fee = l1Portal.calculateDepositFee();
+        uint128 fee = l1Portal.calculateEncryptedDepositFee();
         uint128 netAmount = depositAmount - fee;
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
 
@@ -1071,8 +1071,8 @@ contract ZoneBridgeTest is BaseTest {
         (bytes32 encKeyX, uint8 encKeyYParity) = _setEncKeyOnL1(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
-        uint128 fee = l1Portal.calculateDepositFee();
-        uint128 netAmount = depositAmount - fee;
+        uint128 encFee = l1Portal.calculateEncryptedDepositFee();
+        uint128 encNetAmount = depositAmount - encFee;
 
         // === STEP 2: Alice makes a regular deposit ===
         vm.startPrank(alice);
@@ -1110,7 +1110,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Encrypted deposit from bob
         EncryptedDeposit memory ed =
-            EncryptedDeposit({ sender: bob, amount: netAmount, keyIndex: 0, encrypted: payload });
+            EncryptedDeposit({ sender: bob, amount: encNetAmount, keyIndex: 0, encrypted: payload });
         bytes32 hash2 = keccak256(abi.encode(DepositType.Encrypted, ed, hash1));
         assertEq(hash2, h2, "hash2 must match L1");
 
@@ -1151,7 +1151,7 @@ contract ZoneBridgeTest is BaseTest {
         // === STEP 7: Verify all balances ===
         assertEq(l2ZoneToken.balanceOf(alice), depositAmount, "Alice gets regular deposit");
         assertEq(
-            l2ZoneToken.balanceOf(decryptedTo), netAmount, "Bob's encrypted recipient gets tokens"
+            l2ZoneToken.balanceOf(decryptedTo), encNetAmount, "Bob's encrypted recipient gets tokens"
         );
         assertEq(l2ZoneToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
         assertEq(l2ZoneToken.balanceOf(carol), depositAmount, "Carol gets regular deposit");
@@ -1160,7 +1160,7 @@ contract ZoneBridgeTest is BaseTest {
         // Total supply = alice_regular + bob_encrypted_net + carol_regular
         assertEq(
             l2ZoneToken.totalSupply(),
-            depositAmount + netAmount + depositAmount,
+            depositAmount + encNetAmount + depositAmount,
             "Total supply should equal all deposits"
         );
 
@@ -1177,7 +1177,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // === STEP 2: Alice deposits with keyIndex=0 ===
         uint128 depositAmount = 1000e6;
-        uint128 fee = l1Portal.calculateDepositFee();
+        uint128 fee = l1Portal.calculateEncryptedDepositFee();
         uint128 netAmount = depositAmount - fee;
         EncryptedDepositPayload memory payload1 = _makeEncryptedPayload();
 

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -1926,7 +1926,7 @@ contract ZonePortalTest is BaseTest {
         _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
-        uint128 fee = portal.calculateDepositFee();
+        uint128 fee = portal.calculateEncryptedDepositFee();
         uint128 netAmount = depositAmount - fee;
 
         EncryptedDepositPayload memory encrypted = _makeEncryptedPayload();
@@ -1969,7 +1969,7 @@ contract ZonePortalTest is BaseTest {
         _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
-        uint128 expectedFee = uint128(100_000) * 1; // FIXED_DEPOSIT_GAS * zoneGasRate
+        uint128 expectedFee = uint128(200_000) * 1; // FIXED_ENCRYPTED_DEPOSIT_GAS * zoneGasRate
         uint256 aliceBefore = pathUSD.balanceOf(alice);
         uint256 seqBefore = pathUSD.balanceOf(admin);
         uint256 portalBefore = pathUSD.balanceOf(address(portal));
@@ -1988,7 +1988,7 @@ contract ZonePortalTest is BaseTest {
         _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 depositAmount = 1000e6;
-        uint128 fee = portal.calculateDepositFee();
+        uint128 fee = portal.calculateEncryptedDepositFee();
         uint128 netAmount = depositAmount - fee;
 
         EncryptedDepositPayload memory encrypted = _makeEncryptedPayload();
@@ -2092,14 +2092,14 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_depositEncrypted_revertsOnDepositTooSmall() public {
-        portal.setZoneGasRate(1); // fee = 100_000
+        portal.setZoneGasRate(1); // fee = 200_000
         _setEncKeyWithPoP(ENC_KEY_1);
 
         vm.startPrank(alice);
-        pathUSD.approve(address(portal), 100_000);
+        pathUSD.approve(address(portal), 200_000);
 
         vm.expectRevert(IZonePortal.DepositTooSmall.selector);
-        portal.depositEncrypted(100_000, 0, _makeEncryptedPayload()); // amount == fee
+        portal.depositEncrypted(200_000, 0, _makeEncryptedPayload()); // amount == fee
         vm.stopPrank();
     }
 


### PR DESCRIPTION
## Summary
Adds FIXED_ENCRYPTED_DEPOSIT_GAS (200,000) separate from FIXED_DEPOSIT_GAS (100,000) to properly price the zone-side computation cost of encrypted deposits (Chaum-Pedersen + HKDF + AES-GCM).

## Changes
- Added `FIXED_ENCRYPTED_DEPOSIT_GAS = 200_000` constant to `ZonePortal.sol`
- Added `calculateEncryptedDepositFee()` function to `ZonePortal.sol`
- Updated `depositEncrypted()` to use `calculateEncryptedDepositFee()` instead of `calculateDepositFee()`
- Added interface declarations to `IZonePortal` in `IZone.sol`
- Updated tests in `ZonePortal.t.sol` and `ZoneBridge.t.sol` to use the new encrypted deposit fee

## Testing
`forge build` passes. Tests updated to reflect the new fee constant.

Closes #71