### PR TITLE
Remove xDomainMessageSender() flow from ZoneMessenger

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -633,10 +633,6 @@ interface IZoneMessenger {
     /// @notice Returns the zone token address
     function token() external view returns (address);
 
-    /// @notice Returns the L2 sender during callback execution
-    /// @dev Reverts if not in a callback context
-    function xDomainMessageSender() external view returns (address);
-
     /// @notice Relay a withdrawal message. Only callable by the portal.
     /// @dev Transfers tokens from portal to target via transferFrom, then executes callback.
     ///      If callback reverts, the entire call reverts (including the transfer).
@@ -655,7 +651,7 @@ interface IZoneMessenger {
 }
 ```
 
-The messenger does `token.transferFrom(portal, target, amount)` then calls the target with `data`. Both are atomic: if the callback reverts, the transfer is also reverted. Receivers check `msg.sender == zoneMessenger` and call `zoneMessenger.xDomainMessageSender()` to authenticate the L2 origin.
+The messenger does `token.transferFrom(portal, target, amount)` then calls the target with `data`. Both are atomic: if the callback reverts, the transfer is also reverted. Receivers check `msg.sender == zoneMessenger` to authenticate the call, and receive the L2 origin as the `sender` parameter in `onWithdrawalReceived`.
 
 #### Withdrawal receiver
 
@@ -1512,7 +1508,7 @@ function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) extern
 }
 ```
 
-The messenger does `token.transferFrom(portal, target, amount)` then executes the callback. Both are atomic: if the callback reverts, the transferFrom reverts too, and funds remain in the portal for bounce-back. Receivers check `msg.sender == messenger` and call `messenger.xDomainMessageSender()` to authenticate the L2 origin. This enables composable withdrawals where funds can flow directly into Tempo contracts (e.g., DEX swaps, staking, cross-zone deposits).
+The messenger does `token.transferFrom(portal, target, amount)` then executes the callback. Both are atomic: if the callback reverts, the transferFrom reverts too, and funds remain in the portal for bounce-back. Receivers check `msg.sender == messenger` to authenticate the call, and receive the L2 origin as the `sender` parameter in `onWithdrawalReceived`. This enables composable withdrawals where funds can flow directly into Tempo contracts (e.g., DEX swaps, staking, cross-zone deposits).
 
 ## Withdrawal failure and bounce-back
 

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -562,10 +562,6 @@ interface IZoneMessenger {
     /// @notice Returns the zone token address
     function token() external view returns (address);
 
-    /// @notice Returns the L2 sender during callback execution
-    /// @dev Reverts if not in a callback context
-    function xDomainMessageSender() external view returns (address);
-
     /// @notice Relay a withdrawal message. Only callable by the portal.
     /// @dev Transfers tokens from portal to target via transferFrom, then executes callback.
     ///      If callback reverts, the entire call reverts (including the transfer).

--- a/docs/specs/src/zone/SwapAndDepositRouter.sol
+++ b/docs/specs/src/zone/SwapAndDepositRouter.sol
@@ -32,7 +32,6 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     //////////////////////////////////////////////////////////////*/
 
     error UnauthorizedMessenger();
-    error SenderMismatch();
     error InvalidTargetPortal();
     error InvalidToken();
 
@@ -53,7 +52,6 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     /// @dev Implements IWithdrawalReceiver. Only callable by registered zone messengers.
     ///      The messenger has already transferred tokens to this router.
     ///      On failure, the entire callback reverts, triggering bounce-back to source zone.
-    /// @param sender The original sender on the source zone
     /// @param amount The amount of tokens transferred
     /// @param data ABI-encoded callbackData (see format below)
     /// @return selector The function selector to confirm successful handling
@@ -63,7 +61,7 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     ///
     /// Note: minAmountOut is ignored for same-token transfers (no swap)
     function onWithdrawalReceived(
-        address sender,
+        address, /* sender */
         uint128 amount,
         bytes calldata data
     )
@@ -72,10 +70,6 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     {
         if (!zoneFactory.isZoneMessenger(msg.sender)) {
             revert UnauthorizedMessenger();
-        }
-
-        if (sender != IZoneMessenger(msg.sender).xDomainMessageSender()) {
-            revert SenderMismatch();
         }
 
         address tokenIn = IZoneMessenger(msg.sender).token();

--- a/docs/specs/src/zone/ZoneMessenger.sol
+++ b/docs/specs/src/zone/ZoneMessenger.sol
@@ -20,15 +20,11 @@ contract ZoneMessenger is IZoneMessenger {
     /// @notice The zone token address
     address public immutable token;
 
-    /// @notice The L2 sender during callback execution (only valid within a callback)
-    address internal _xDomainMessageSender;
-
     /*//////////////////////////////////////////////////////////////
                                 ERRORS
     //////////////////////////////////////////////////////////////*/
 
     error OnlyPortal();
-    error NotInCallback();
     error CallbackRejected();
     error TransferFailed();
 
@@ -53,13 +49,6 @@ contract ZoneMessenger is IZoneMessenger {
     /*//////////////////////////////////////////////////////////////
                            MESSAGE RELAY
     //////////////////////////////////////////////////////////////*/
-
-    /// @notice Returns the L2 sender during callback execution
-    /// @dev Reverts if not in a callback context
-    function xDomainMessageSender() external view returns (address) {
-        if (_xDomainMessageSender == address(0)) revert NotInCallback();
-        return _xDomainMessageSender;
-    }
 
     /// @notice Relay a withdrawal message. Only callable by the portal.
     /// @dev Transfers tokens from portal to target via transferFrom, then executes callback.
@@ -103,15 +92,9 @@ contract ZoneMessenger is IZoneMessenger {
             revert TransferFailed();
         }
 
-        // Set the L2 sender for the callback
-        _xDomainMessageSender = sender;
-
         // Call the receiver
         bytes4 selector =
             IWithdrawalReceiver(target).onWithdrawalReceived{ gas: gasLimit }(sender, amount, data);
-
-        // Clear the L2 sender
-        _xDomainMessageSender = address(0);
 
         // Verify the callback returned the correct selector
         if (selector != IWithdrawalReceiver.onWithdrawalReceived.selector) {

--- a/docs/specs/test/zone/SwapAndDepositRouter.t.sol
+++ b/docs/specs/test/zone/SwapAndDepositRouter.t.sol
@@ -72,22 +72,13 @@ contract MockZoneFactoryForRouter {
 contract MockZoneMessengerForRouter {
 
     address public tokenAddr;
-    address public xDomainSender;
 
     function setToken(address _token) external {
         tokenAddr = _token;
     }
 
-    function setXDomainMessageSender(address _sender) external {
-        xDomainSender = _sender;
-    }
-
     function token() external view returns (address) {
         return tokenAddr;
-    }
-
-    function xDomainMessageSender() external view returns (address) {
-        return xDomainSender;
     }
 
 }
@@ -170,7 +161,6 @@ contract SwapAndDepositRouterTest is BaseTest {
         mockPortal2.setToken(address(token1));
 
         mockMessenger.setToken(address(pathUSD));
-        mockMessenger.setXDomainMessageSender(sender);
 
         vm.startPrank(pathUSDAdmin);
         pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
@@ -230,17 +220,6 @@ contract SwapAndDepositRouterTest is BaseTest {
 
         vm.prank(alice);
         vm.expectRevert(SwapAndDepositRouter.UnauthorizedMessenger.selector);
-        router.onWithdrawalReceived(sender, AMOUNT, data);
-    }
-
-    function test_revertSenderMismatch() public {
-        bytes memory data =
-            _buildPlaintextData(address(pathUSD), address(mockPortal), alice, bytes32("memo"), 0);
-
-        mockMessenger.setXDomainMessageSender(address(0xBAD));
-
-        vm.prank(address(mockMessenger));
-        vm.expectRevert(SwapAndDepositRouter.SenderMismatch.selector);
         router.onWithdrawalReceived(sender, AMOUNT, data);
     }
 


### PR DESCRIPTION
## Summary

- Removes the `xDomainMessageSender()` transient-sender pattern from `ZoneMessenger`, its interface, and all consumers
- The `sender` parameter is already passed directly to `onWithdrawalReceived(sender, amount, data)` by the trusted messenger, so checking `msg.sender == messenger` is sufficient — the extra callback to `xDomainMessageSender()` was redundant
- Updates documentation to reflect the simpler authentication model

## Changes

| File | What changed |
|---|---|
| `ZoneMessenger.sol` | Removed `_xDomainMessageSender` storage, `NotInCallback` error, `xDomainMessageSender()` getter, and the set/clear around callbacks |
| `IZone.sol` | Removed `xDomainMessageSender()` from `IZoneMessenger` interface |
| `SwapAndDepositRouter.sol` | Removed `SenderMismatch` error and the `xDomainMessageSender()` check |
| `SwapAndDepositRouter.t.sol` | Removed mock `xDomainMessageSender`, `test_revertSenderMismatch`, and related setup |
| `overview.md` | Updated two documentation passages |

## Test plan

- [x] `SwapAndDepositRouter` tests pass (8/8)
- [x] `ZonePortal` tests pass (74/74)
- [x] `ZoneBridge` integration tests pass (15/15)
- [x] `ZoneIntegration` tests pass (7/7)
- [x] `ZoneFactory` tests pass (12/12)

Closes #61

Made with [Cursor](https://cursor.com)