### PR TITLE
feat(xtask): add create-zone and generate-zone-genesis commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12163,6 +12163,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "tempo-alloy",
  "tempo-chainspec",
  "tempo-commonware-node-config",
  "tempo-contracts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12143,7 +12143,9 @@ name = "tempo-xtask"
 version = "1.0.0-rc.5"
 dependencies = [
  "alloy",
+ "alloy-consensus",
  "alloy-primitives",
+ "alloy-rlp",
  "clap",
  "commonware-codec",
  "commonware-consensus",
@@ -12167,6 +12169,7 @@ dependencies = [
  "tempo-dkg-onchain-artifacts",
  "tempo-evm",
  "tempo-precompiles",
+ "tempo-primitives",
  "tempo-revm",
  "tokio",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+tempo-alloy.workspace = true
 tempo-chainspec.workspace = true
 tempo-contracts.workspace = true
 tempo-commonware-node-config.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,9 +17,11 @@ tempo-commonware-node-config.workspace = true
 tempo-dkg-onchain-artifacts.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true
+tempo-primitives.workspace = true
 tempo-revm.workspace = true
 
 alloy = { workspace = true, features = [
+  "contract",
   "genesis",
   "providers",
   "reqwest",
@@ -31,7 +33,9 @@ alloy = { workspace = true, features = [
   "sol-types",
   "getrandom",
 ] }
+alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+alloy-rlp.workspace = true
 clap = { version = "4.5.45", features = ["derive"] }
 commonware-codec.workspace = true
 commonware-consensus.workspace = true

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -1,16 +1,15 @@
 use alloy::{
-    network::EthereumWallet,
-    primitives::{Address, Bloom, Bytes, B256, B64, U256},
+    network::{EthereumWallet, primitives::{HeaderResponse, ReceiptResponse}},
+    primitives::{Address, B256, keccak256},
     providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
     sol,
 };
-use alloy_consensus::Header;
 use alloy_rlp::Encodable;
-use eyre::{WrapErr as _, eyre};
+use eyre::eyre;
 use std::path::PathBuf;
+use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TEMPO_BASE_FEE;
-use tempo_primitives::TempoHeader;
 
 sol! {
     struct ZoneParams {
@@ -99,7 +98,7 @@ impl CreateZone {
         let key_str = self.private_key.strip_prefix("0x").unwrap_or(&self.private_key);
         let signer: PrivateKeySigner = key_str.parse()?;
         let wallet = EthereumWallet::from(signer);
-        let provider = ProviderBuilder::new()
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
             .connect_http(self.l1_rpc_url.parse()?);
 
@@ -109,41 +108,34 @@ impl CreateZone {
         };
 
         println!("Fetching Tempo block header...");
-        let raw_block: serde_json::Value = retry(|| async {
-            provider
-                .raw_request("eth_getBlockByNumber".into(), (block_number, false))
-                .await
-        })
-        .await?;
+        let block = provider
+            .get_block_by_number(block_number)
+            .await?
+            .ok_or_else(|| eyre!("block not found"))?;
 
-        let header = parse_tempo_header(&raw_block)?;
+        let header = block.header.as_ref();
+        let block_hash = block.header.hash();
+
         let mut header_rlp = Vec::new();
         header.encode(&mut header_rlp);
-        let computed_hash = alloy_primitives::keccak256(&header_rlp);
-        let expected_hash: B256 = raw_block
-            .get("hash")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| eyre!("no hash in block"))?
-            .parse()?;
+        let computed_hash = keccak256(&header_rlp);
 
-        if computed_hash != expected_hash {
+        if computed_hash != block_hash {
             return Err(eyre!(
-                "reconstructed header hash {computed_hash} does not match block hash {expected_hash}"
+                "reconstructed header hash {computed_hash} does not match block hash {block_hash}"
             ));
         }
-        println!("Tempo block {} header validated (hash: {computed_hash})", header.inner.number);
-
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        println!(
+            "Tempo block {} header validated (hash: {computed_hash})",
+            header.inner.number
+        );
 
         let factory = ZoneFactory::new(self.zone_factory, &provider);
         println!("Fetching verifier address from ZoneFactory...");
-        let verifier = Address::from(retry(|| async { factory.verifier().call().await }).await?.0);
+        let verifier = Address::from(factory.verifier().call().await?.0);
         println!("Verifier: {verifier}");
 
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
         let tempo_block_number = header.inner.number;
-        let tempo_block_hash = computed_hash;
 
         let params = CreateZoneParams {
             token: self.zone_token,
@@ -151,20 +143,21 @@ impl CreateZone {
             verifier,
             zoneParams: ZoneParams {
                 genesisBlockHash: B256::ZERO,
-                genesisTempoBlockHash: tempo_block_hash,
+                genesisTempoBlockHash: computed_hash,
                 genesisTempoBlockNumber: tempo_block_number,
             },
         };
 
-        println!("Creating zone on L1 via ZoneFactory at {}...", self.zone_factory);
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        println!(
+            "Creating zone on L1 via ZoneFactory at {}...",
+            self.zone_factory
+        );
         let pending = factory.createZone(params).send().await?;
         println!("Transaction sent, waiting for receipt...");
         let receipt = pending.get_receipt().await?;
         println!("Transaction confirmed in block {:?}", receipt.block_number);
         println!("Status: {}", receipt.status());
         println!("Gas used: {:?}", receipt.gas_used);
-        println!("Logs: {}", receipt.inner.logs().len());
 
         if !receipt.status() {
             return Err(eyre!(
@@ -173,20 +166,17 @@ impl CreateZone {
             ));
         }
 
-        let zone_created_events: Vec<ZoneFactory::ZoneCreated> = receipt
+        let event = receipt
             .inner
             .logs()
             .iter()
-            .filter_map(|log| {
+            .find_map(|log| {
                 log.log_decode::<ZoneFactory::ZoneCreated>()
                     .ok()
                     .map(|decoded| decoded.inner.data)
             })
-            .collect();
-
-        let event = zone_created_events
-            .first()
             .ok_or_else(|| eyre!("no ZoneCreated event in receipt"))?;
+
         let zone_id = event.zoneId;
         let portal = event.portal;
 
@@ -218,126 +208,4 @@ impl CreateZone {
 
         Ok(())
     }
-}
-
-fn parse_tempo_header(block: &serde_json::Value) -> eyre::Result<TempoHeader> {
-    let general_gas_limit = parse_u64_hex(block.get("mainBlockGeneralGasLimit"))?;
-    let shared_gas_limit = parse_u64_hex(block.get("sharedGasLimit"))?;
-    let timestamp_millis_part = parse_u64_hex(block.get("timestampMillisPart"))?;
-
-    let inner = Header {
-        parent_hash: parse_b256(block.get("parentHash"))?,
-        ommers_hash: parse_b256(block.get("sha3Uncles"))?,
-        beneficiary: parse_address(block.get("miner"))?,
-        state_root: parse_b256(block.get("stateRoot"))?,
-        transactions_root: parse_b256(block.get("transactionsRoot"))?,
-        receipts_root: parse_b256(block.get("receiptsRoot"))?,
-        logs_bloom: parse_bloom(block.get("logsBloom"))?,
-        difficulty: parse_u256(block.get("difficulty"))?,
-        number: parse_u64_hex(block.get("number"))?,
-        gas_limit: parse_u64_hex(block.get("gasLimit"))?,
-        gas_used: parse_u64_hex(block.get("gasUsed"))?,
-        timestamp: parse_u64_hex(block.get("timestamp"))?,
-        extra_data: parse_bytes(block.get("extraData"))?,
-        mix_hash: parse_b256(block.get("mixHash"))?,
-        nonce: parse_b64(block.get("nonce"))?,
-        base_fee_per_gas: block
-            .get("baseFeePerGas")
-            .and_then(|v| parse_u64_hex(Some(v)).ok()),
-        withdrawals_root: block
-            .get("withdrawalsRoot")
-            .and_then(|v| parse_b256(Some(v)).ok()),
-        blob_gas_used: block
-            .get("blobGasUsed")
-            .and_then(|v| parse_u64_hex(Some(v)).ok()),
-        excess_blob_gas: block
-            .get("excessBlobGas")
-            .and_then(|v| parse_u64_hex(Some(v)).ok()),
-        parent_beacon_block_root: block
-            .get("parentBeaconBlockRoot")
-            .and_then(|v| parse_b256(Some(v)).ok()),
-        requests_hash: block
-            .get("requestsHash")
-            .and_then(|v| parse_b256(Some(v)).ok()),
-    };
-
-    Ok(TempoHeader {
-        general_gas_limit,
-        shared_gas_limit,
-        timestamp_millis_part,
-        inner,
-    })
-}
-
-fn parse_u64_hex(val: Option<&serde_json::Value>) -> eyre::Result<u64> {
-    let s = val
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| eyre!("missing hex field"))?;
-    let stripped = s.strip_prefix("0x").unwrap_or(s);
-    u64::from_str_radix(stripped, 16).wrap_err("invalid u64 hex")
-}
-
-fn parse_u256(val: Option<&serde_json::Value>) -> eyre::Result<U256> {
-    let s = val
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| eyre!("missing hex field"))?;
-    s.parse::<U256>().wrap_err("invalid U256")
-}
-
-fn parse_b256(val: Option<&serde_json::Value>) -> eyre::Result<B256> {
-    let s = val
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| eyre!("missing bytes32 field"))?;
-    s.parse::<B256>().wrap_err("invalid B256")
-}
-
-fn parse_address(val: Option<&serde_json::Value>) -> eyre::Result<Address> {
-    let s = val
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| eyre!("missing address field"))?;
-    s.parse::<Address>().wrap_err("invalid address")
-}
-
-fn parse_bloom(val: Option<&serde_json::Value>) -> eyre::Result<Bloom> {
-    let s = val
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| eyre!("missing bloom field"))?;
-    s.parse::<Bloom>().wrap_err("invalid bloom")
-}
-
-fn parse_bytes(val: Option<&serde_json::Value>) -> eyre::Result<Bytes> {
-    let s = val
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| eyre!("missing bytes field"))?;
-    let stripped = s.strip_prefix("0x").unwrap_or(s);
-    Ok(Bytes::from(const_hex::decode(stripped)?))
-}
-
-fn parse_b64(val: Option<&serde_json::Value>) -> eyre::Result<B64> {
-    let s = val
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| eyre!("missing B64 field"))?;
-    s.parse::<B64>().wrap_err("invalid B64")
-}
-
-async fn retry<F, Fut, T, E>(mut f: F) -> Result<T, E>
-where
-    F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<T, E>>,
-    E: std::fmt::Debug,
-{
-    for attempt in 0..5 {
-        match f().await {
-            Ok(v) => return Ok(v),
-            Err(e) => {
-                if attempt == 4 {
-                    return Err(e);
-                }
-                let delay = std::time::Duration::from_millis(200 * (attempt + 1));
-                eprintln!("RPC call failed (attempt {}), retrying in {:?}: {e:?}", attempt + 1, delay);
-                tokio::time::sleep(delay).await;
-            }
-        }
-    }
-    unreachable!()
 }

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -1,6 +1,6 @@
 use alloy::{
     network::{EthereumWallet, primitives::{HeaderResponse, ReceiptResponse}},
-    primitives::{Address, B256, keccak256},
+    primitives::{Address, B256},
     providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
     sol,
@@ -107,17 +107,7 @@ impl CreateZone {
 
         let mut header_rlp = Vec::new();
         header.encode(&mut header_rlp);
-        let computed_hash = keccak256(&header_rlp);
-
-        if computed_hash != block_hash {
-            return Err(eyre!(
-                "reconstructed header hash {computed_hash} does not match block hash {block_hash}"
-            ));
-        }
-        println!(
-            "Tempo block {} header validated (hash: {computed_hash})",
-            header.inner.number
-        );
+        println!("Tempo block {} (hash: {block_hash})", header.inner.number);
 
         let factory = ZoneFactory::new(self.zone_factory, &provider);
         println!("Fetching verifier address from ZoneFactory...");
@@ -132,7 +122,7 @@ impl CreateZone {
             verifier,
             zoneParams: ZoneParams {
                 genesisBlockHash: B256::ZERO,
-                genesisTempoBlockHash: computed_hash,
+                genesisTempoBlockHash: block_hash,
                 genesisTempoBlockNumber: tempo_block_number,
             },
         };

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -1,0 +1,343 @@
+use alloy::{
+    network::EthereumWallet,
+    primitives::{Address, Bloom, Bytes, B256, B64, U256},
+    providers::{Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+    sol,
+};
+use alloy_consensus::Header;
+use alloy_rlp::Encodable;
+use eyre::{WrapErr as _, eyre};
+use std::path::PathBuf;
+use tempo_chainspec::spec::TEMPO_BASE_FEE;
+use tempo_primitives::TempoHeader;
+
+sol! {
+    struct ZoneParams {
+        bytes32 genesisBlockHash;
+        bytes32 genesisTempoBlockHash;
+        uint64 genesisTempoBlockNumber;
+    }
+
+    struct CreateZoneParams {
+        address token;
+        address sequencer;
+        address verifier;
+        ZoneParams zoneParams;
+    }
+
+    #[sol(rpc)]
+    contract ZoneFactory {
+        event ZoneCreated(
+            uint64 indexed zoneId,
+            address indexed portal,
+            address indexed messenger,
+            address token,
+            address sequencer,
+            address verifier,
+            bytes32 genesisBlockHash,
+            bytes32 genesisTempoBlockHash,
+            uint64 genesisTempoBlockNumber
+        );
+
+        function verifier() external view returns (address);
+        function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
+    }
+}
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct CreateZone {
+    /// Output directory where genesis.json will be written.
+    #[arg(short, long)]
+    output: PathBuf,
+
+    /// Tempo L1 HTTP RPC URL used to fetch headers and send the createZone transaction.
+    #[arg(long, default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz")]
+    l1_rpc_url: String,
+
+    /// ZoneFactory contract address on Tempo L1.
+    #[arg(long, default_value = "0xb425C093b3f303f63d7af6bd85a45ae15De0d3d9")]
+    zone_factory: Address,
+
+    /// TIP-20 token address for the zone (same address on both Tempo and the zone L2).
+    #[arg(long)]
+    zone_token: Address,
+
+    /// Sequencer address that will operate the zone.
+    #[arg(long)]
+    sequencer: Address,
+
+    /// Private key (hex) for signing the createZone transaction on L1.
+    #[arg(long)]
+    private_key: String,
+
+    /// Tempo block number to anchor the zone genesis to.
+    /// The header at this block is RLP-encoded and stored in TempoState.
+    /// Defaults to the latest block if not specified.
+    #[arg(long)]
+    tempo_block_number: Option<u64>,
+
+    /// Zone L2 chain ID.
+    #[arg(long, default_value_t = 13371)]
+    chain_id: u64,
+
+    /// Base fee per gas for the zone L2.
+    #[arg(long, default_value_t = TEMPO_BASE_FEE.into())]
+    base_fee_per_gas: u128,
+
+    /// Genesis block gas limit for the zone L2.
+    #[arg(long, default_value_t = 30_000_000)]
+    gas_limit: u64,
+
+    /// Path to the Foundry compiled output directory containing zone contract artifacts.
+    #[arg(long, default_value = "docs/specs/out")]
+    specs_out: PathBuf,
+}
+
+impl CreateZone {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let key_str = self.private_key.strip_prefix("0x").unwrap_or(&self.private_key);
+        let signer: PrivateKeySigner = key_str.parse()?;
+        let wallet = EthereumWallet::from(signer);
+        let provider = ProviderBuilder::new()
+            .wallet(wallet)
+            .connect_http(self.l1_rpc_url.parse()?);
+
+        let block_number = match self.tempo_block_number {
+            Some(n) => alloy::eips::BlockNumberOrTag::Number(n),
+            None => alloy::eips::BlockNumberOrTag::Latest,
+        };
+
+        println!("Fetching Tempo block header...");
+        let raw_block: serde_json::Value = retry(|| async {
+            provider
+                .raw_request("eth_getBlockByNumber".into(), (block_number, false))
+                .await
+        })
+        .await?;
+
+        let header = parse_tempo_header(&raw_block)?;
+        let mut header_rlp = Vec::new();
+        header.encode(&mut header_rlp);
+        let computed_hash = alloy_primitives::keccak256(&header_rlp);
+        let expected_hash: B256 = raw_block
+            .get("hash")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| eyre!("no hash in block"))?
+            .parse()?;
+
+        if computed_hash != expected_hash {
+            return Err(eyre!(
+                "reconstructed header hash {computed_hash} does not match block hash {expected_hash}"
+            ));
+        }
+        println!("Tempo block {} header validated (hash: {computed_hash})", header.inner.number);
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let factory = ZoneFactory::new(self.zone_factory, &provider);
+        println!("Fetching verifier address from ZoneFactory...");
+        let verifier = Address::from(retry(|| async { factory.verifier().call().await }).await?.0);
+        println!("Verifier: {verifier}");
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let tempo_block_number = header.inner.number;
+        let tempo_block_hash = computed_hash;
+
+        let params = CreateZoneParams {
+            token: self.zone_token,
+            sequencer: self.sequencer,
+            verifier,
+            zoneParams: ZoneParams {
+                genesisBlockHash: B256::ZERO,
+                genesisTempoBlockHash: tempo_block_hash,
+                genesisTempoBlockNumber: tempo_block_number,
+            },
+        };
+
+        println!("Creating zone on L1 via ZoneFactory at {}...", self.zone_factory);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        let pending = factory.createZone(params).send().await?;
+        println!("Transaction sent, waiting for receipt...");
+        let receipt = pending.get_receipt().await?;
+        println!("Transaction confirmed in block {:?}", receipt.block_number);
+        println!("Status: {}", receipt.status());
+        println!("Gas used: {:?}", receipt.gas_used);
+        println!("Logs: {}", receipt.inner.logs().len());
+
+        if !receipt.status() {
+            return Err(eyre!(
+                "createZone transaction reverted (tx: {:?})",
+                receipt.transaction_hash
+            ));
+        }
+
+        let zone_created_events: Vec<ZoneFactory::ZoneCreated> = receipt
+            .inner
+            .logs()
+            .iter()
+            .filter_map(|log| {
+                log.log_decode::<ZoneFactory::ZoneCreated>()
+                    .ok()
+                    .map(|decoded| decoded.inner.data)
+            })
+            .collect();
+
+        let event = zone_created_events
+            .first()
+            .ok_or_else(|| eyre!("no ZoneCreated event in receipt"))?;
+        let zone_id = event.zoneId;
+        let portal = event.portal;
+
+        let header_rlp_hex = const_hex::encode(&header_rlp);
+
+        let genesis_cmd = crate::generate_zone_genesis::GenerateZoneGenesis {
+            output: self.output.clone(),
+            chain_id: self.chain_id,
+            base_fee_per_gas: self.base_fee_per_gas,
+            gas_limit: self.gas_limit,
+            zone_token: self.zone_token,
+            tempo_portal: portal,
+            tempo_genesis_header_rlp: header_rlp_hex,
+            sequencer: Some(self.sequencer),
+            specs_out: self.specs_out.clone(),
+        };
+        genesis_cmd.run().await?;
+
+        println!("Zone created successfully!");
+        println!("  Zone ID: {zone_id}");
+        println!("  Portal: {portal}");
+        println!("  Token: {}", self.zone_token);
+        println!("  Sequencer: {}", self.sequencer);
+        println!("  Tempo anchor block: {tempo_block_number}");
+        println!(
+            "  Genesis written to: {}",
+            self.output.join("genesis.json").display()
+        );
+
+        Ok(())
+    }
+}
+
+fn parse_tempo_header(block: &serde_json::Value) -> eyre::Result<TempoHeader> {
+    let general_gas_limit = parse_u64_hex(block.get("mainBlockGeneralGasLimit"))?;
+    let shared_gas_limit = parse_u64_hex(block.get("sharedGasLimit"))?;
+    let timestamp_millis_part = parse_u64_hex(block.get("timestampMillisPart"))?;
+
+    let inner = Header {
+        parent_hash: parse_b256(block.get("parentHash"))?,
+        ommers_hash: parse_b256(block.get("sha3Uncles"))?,
+        beneficiary: parse_address(block.get("miner"))?,
+        state_root: parse_b256(block.get("stateRoot"))?,
+        transactions_root: parse_b256(block.get("transactionsRoot"))?,
+        receipts_root: parse_b256(block.get("receiptsRoot"))?,
+        logs_bloom: parse_bloom(block.get("logsBloom"))?,
+        difficulty: parse_u256(block.get("difficulty"))?,
+        number: parse_u64_hex(block.get("number"))?,
+        gas_limit: parse_u64_hex(block.get("gasLimit"))?,
+        gas_used: parse_u64_hex(block.get("gasUsed"))?,
+        timestamp: parse_u64_hex(block.get("timestamp"))?,
+        extra_data: parse_bytes(block.get("extraData"))?,
+        mix_hash: parse_b256(block.get("mixHash"))?,
+        nonce: parse_b64(block.get("nonce"))?,
+        base_fee_per_gas: block
+            .get("baseFeePerGas")
+            .and_then(|v| parse_u64_hex(Some(v)).ok()),
+        withdrawals_root: block
+            .get("withdrawalsRoot")
+            .and_then(|v| parse_b256(Some(v)).ok()),
+        blob_gas_used: block
+            .get("blobGasUsed")
+            .and_then(|v| parse_u64_hex(Some(v)).ok()),
+        excess_blob_gas: block
+            .get("excessBlobGas")
+            .and_then(|v| parse_u64_hex(Some(v)).ok()),
+        parent_beacon_block_root: block
+            .get("parentBeaconBlockRoot")
+            .and_then(|v| parse_b256(Some(v)).ok()),
+        requests_hash: block
+            .get("requestsHash")
+            .and_then(|v| parse_b256(Some(v)).ok()),
+    };
+
+    Ok(TempoHeader {
+        general_gas_limit,
+        shared_gas_limit,
+        timestamp_millis_part,
+        inner,
+    })
+}
+
+fn parse_u64_hex(val: Option<&serde_json::Value>) -> eyre::Result<u64> {
+    let s = val
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre!("missing hex field"))?;
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    u64::from_str_radix(stripped, 16).wrap_err("invalid u64 hex")
+}
+
+fn parse_u256(val: Option<&serde_json::Value>) -> eyre::Result<U256> {
+    let s = val
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre!("missing hex field"))?;
+    s.parse::<U256>().wrap_err("invalid U256")
+}
+
+fn parse_b256(val: Option<&serde_json::Value>) -> eyre::Result<B256> {
+    let s = val
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre!("missing bytes32 field"))?;
+    s.parse::<B256>().wrap_err("invalid B256")
+}
+
+fn parse_address(val: Option<&serde_json::Value>) -> eyre::Result<Address> {
+    let s = val
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre!("missing address field"))?;
+    s.parse::<Address>().wrap_err("invalid address")
+}
+
+fn parse_bloom(val: Option<&serde_json::Value>) -> eyre::Result<Bloom> {
+    let s = val
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre!("missing bloom field"))?;
+    s.parse::<Bloom>().wrap_err("invalid bloom")
+}
+
+fn parse_bytes(val: Option<&serde_json::Value>) -> eyre::Result<Bytes> {
+    let s = val
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre!("missing bytes field"))?;
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    Ok(Bytes::from(const_hex::decode(stripped)?))
+}
+
+fn parse_b64(val: Option<&serde_json::Value>) -> eyre::Result<B64> {
+    let s = val
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| eyre!("missing B64 field"))?;
+    s.parse::<B64>().wrap_err("invalid B64")
+}
+
+async fn retry<F, Fut, T, E>(mut f: F) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    for attempt in 0..5 {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if attempt == 4 {
+                    return Err(e);
+                }
+                let delay = std::time::Duration::from_millis(200 * (attempt + 1));
+                eprintln!("RPC call failed (attempt {}), retrying in {:?}: {e:?}", attempt + 1, delay);
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+    unreachable!()
+}

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -70,12 +70,6 @@ pub(crate) struct CreateZone {
     #[arg(long)]
     private_key: String,
 
-    /// Tempo block number to anchor the zone genesis to.
-    /// The header at this block is RLP-encoded and stored in TempoState.
-    /// Defaults to the latest block if not specified.
-    #[arg(long)]
-    tempo_block_number: Option<u64>,
-
     /// Zone L2 chain ID.
     #[arg(long, default_value_t = 13371)]
     chain_id: u64,
@@ -102,14 +96,9 @@ impl CreateZone {
             .wallet(wallet)
             .connect_http(self.l1_rpc_url.parse()?);
 
-        let block_number = match self.tempo_block_number {
-            Some(n) => alloy::eips::BlockNumberOrTag::Number(n),
-            None => alloy::eips::BlockNumberOrTag::Latest,
-        };
-
         println!("Fetching Tempo block header...");
         let block = provider
-            .get_block_by_number(block_number)
+            .get_block_by_number(alloy::eips::BlockNumberOrTag::Latest)
             .await?
             .ok_or_else(|| eyre!("block not found"))?;
 

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -1,0 +1,324 @@
+use alloy::{
+    genesis::{ChainConfig, Genesis, GenesisAccount},
+    primitives::{Address, Bytes, TxKind, U256, address},
+    sol_types::SolValue,
+};
+use eyre::{WrapErr as _, eyre};
+use reth_evm::{
+    Evm as _, EvmEnv, EvmFactory,
+    revm::{
+        DatabaseCommit,
+        context::TxEnv,
+        context::result::{ExecutionResult, Output},
+        database::{CacheDB, EmptyDB},
+        inspector::JournalExt,
+        state::AccountInfo,
+    },
+};
+use std::{
+    collections::BTreeMap,
+    path::PathBuf,
+};
+use tempo_chainspec::spec::TEMPO_BASE_FEE;
+use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
+use tempo_revm::TempoTxEnv;
+
+const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
+const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
+const ZONE_OUTBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000002");
+const ZONE_CONFIG_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000003");
+
+const DEPLOYER: Address = address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct GenerateZoneGenesis {
+    #[arg(short, long)]
+    pub(crate) output: PathBuf,
+
+    #[arg(long, default_value_t = 13371)]
+    pub(crate) chain_id: u64,
+
+    #[arg(long, default_value_t = TEMPO_BASE_FEE.into())]
+    pub(crate) base_fee_per_gas: u128,
+
+    #[arg(long, default_value_t = 30_000_000)]
+    pub(crate) gas_limit: u64,
+
+    #[arg(long)]
+    pub(crate) zone_token: Address,
+
+    #[arg(long)]
+    pub(crate) tempo_portal: Address,
+
+    #[arg(long)]
+    pub(crate) tempo_genesis_header_rlp: String,
+
+    #[arg(long)]
+    pub(crate) sequencer: Option<Address>,
+
+    #[arg(long, default_value = "docs/specs/out")]
+    pub(crate) specs_out: PathBuf,
+}
+
+#[derive(serde::Deserialize)]
+struct FoundryArtifact {
+    bytecode: BytecodeField,
+}
+
+#[derive(serde::Deserialize)]
+struct BytecodeField {
+    object: String,
+}
+
+impl GenerateZoneGenesis {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let header_rlp = decode_hex(&self.tempo_genesis_header_rlp)?;
+
+        let mut evm = setup_zone_evm(self.chain_id);
+
+        evm.db_mut().insert_account_info(
+            DEPLOYER,
+            AccountInfo {
+                balance: U256::from(1_000_000_000_000_000_000_000u128),
+                ..Default::default()
+            },
+        );
+
+        let tempo_state_bytecode = load_artifact(&self.specs_out, "TempoState")?;
+        let tempo_state_args = (Bytes::from(header_rlp),).abi_encode_params();
+        deploy_contract(
+            &mut evm,
+            &tempo_state_bytecode,
+            &tempo_state_args,
+            TEMPO_STATE_ADDRESS,
+            "TempoState",
+            self.chain_id,
+        )?;
+
+        let zone_config_bytecode = load_artifact(&self.specs_out, "ZoneConfig")?;
+        let zone_config_args =
+            (self.zone_token, self.tempo_portal, TEMPO_STATE_ADDRESS).abi_encode_params();
+        deploy_contract(
+            &mut evm,
+            &zone_config_bytecode,
+            &zone_config_args,
+            ZONE_CONFIG_ADDRESS,
+            "ZoneConfig",
+            self.chain_id,
+        )?;
+
+        let zone_inbox_bytecode = load_artifact(&self.specs_out, "ZoneInbox")?;
+        let zone_inbox_args = (
+            ZONE_CONFIG_ADDRESS,
+            self.tempo_portal,
+            TEMPO_STATE_ADDRESS,
+            self.zone_token,
+        )
+            .abi_encode_params();
+        deploy_contract(
+            &mut evm,
+            &zone_inbox_bytecode,
+            &zone_inbox_args,
+            ZONE_INBOX_ADDRESS,
+            "ZoneInbox",
+            self.chain_id,
+        )?;
+
+        let zone_outbox_bytecode = load_artifact(&self.specs_out, "ZoneOutbox")?;
+        let zone_outbox_args = (ZONE_CONFIG_ADDRESS, self.zone_token).abi_encode_params();
+        deploy_contract(
+            &mut evm,
+            &zone_outbox_bytecode,
+            &zone_outbox_args,
+            ZONE_OUTBOX_ADDRESS,
+            "ZoneOutbox",
+            self.chain_id,
+        )?;
+
+        for (name, addr) in [
+            ("TempoState", TEMPO_STATE_ADDRESS),
+            ("ZoneConfig", ZONE_CONFIG_ADDRESS),
+            ("ZoneInbox", ZONE_INBOX_ADDRESS),
+            ("ZoneOutbox", ZONE_OUTBOX_ADDRESS),
+        ] {
+            let account = evm
+                .ctx_mut()
+                .journaled_state
+                .evm_state()
+                .get(&addr)
+                .ok_or_else(|| eyre!("{name} not found at {addr}"))?;
+            let has_code = account
+                .info
+                .code
+                .as_ref()
+                .is_some_and(|c| !c.is_empty());
+            if !has_code {
+                return Err(eyre!("{name} has no code at {addr}"));
+            }
+        }
+
+        let evm_state = evm.ctx_mut().journaled_state.evm_state();
+        let mut genesis_alloc: BTreeMap<Address, GenesisAccount> = evm_state
+            .iter()
+            .filter(|(addr, _)| **addr != DEPLOYER)
+            .map(|(address, account)| {
+                let storage = if !account.storage.is_empty() {
+                    Some(
+                        account
+                            .storage
+                            .iter()
+                            .map(|(key, val)| ((*key).into(), val.present_value.into()))
+                            .collect(),
+                    )
+                } else {
+                    None
+                };
+                let genesis_account = GenesisAccount {
+                    nonce: Some(account.info.nonce),
+                    code: account.info.code.as_ref().map(|c| c.original_bytes()),
+                    storage,
+                    ..Default::default()
+                };
+                (*address, genesis_account)
+            })
+            .collect();
+
+        if let Some(sequencer) = self.sequencer {
+            genesis_alloc
+                .entry(sequencer)
+                .or_default()
+                .balance = U256::from(1_000_000_000_000_000_000_000u128);
+        }
+
+        let chain_config = ChainConfig {
+            chain_id: self.chain_id,
+            homestead_block: Some(0),
+            eip150_block: Some(0),
+            eip155_block: Some(0),
+            eip158_block: Some(0),
+            byzantium_block: Some(0),
+            constantinople_block: Some(0),
+            petersburg_block: Some(0),
+            istanbul_block: Some(0),
+            berlin_block: Some(0),
+            london_block: Some(0),
+            merge_netsplit_block: Some(0),
+            shanghai_time: Some(0),
+            cancun_time: Some(0),
+            prague_time: Some(0),
+            osaka_time: Some(0),
+            terminal_total_difficulty: Some(U256::from(0)),
+            terminal_total_difficulty_passed: true,
+            deposit_contract_address: Some(Address::ZERO),
+            ..Default::default()
+        };
+
+        let mut genesis = Genesis::default()
+            .with_gas_limit(self.gas_limit)
+            .with_base_fee(Some(self.base_fee_per_gas))
+            .with_nonce(0x42)
+            .with_extra_data(Bytes::from_static(b"tempo-zone-genesis"));
+
+        genesis.alloc = genesis_alloc;
+        genesis.config = chain_config;
+
+        let json =
+            serde_json::to_string_pretty(&genesis).wrap_err("failed encoding genesis as JSON")?;
+
+        std::fs::create_dir_all(&self.output).wrap_err_with(|| {
+            format!(
+                "failed to create directory and parents for `{}`",
+                self.output.display()
+            )
+        })?;
+        let genesis_dst = self.output.join("genesis.json");
+        std::fs::write(&genesis_dst, json).wrap_err_with(|| {
+            format!("failed writing genesis to file `{}`", genesis_dst.display())
+        })?;
+
+        println!("Zone genesis written to {}", genesis_dst.display());
+
+        Ok(())
+    }
+}
+
+fn setup_zone_evm(chain_id: u64) -> TempoEvm<CacheDB<EmptyDB>> {
+    let db = CacheDB::default();
+    let mut env = EvmEnv::default().with_timestamp(U256::ZERO);
+    env.cfg_env.chain_id = chain_id;
+
+    let factory = TempoEvmFactory::default();
+    factory.create_evm(db, env)
+}
+
+fn load_artifact(specs_out: &PathBuf, name: &str) -> eyre::Result<Vec<u8>> {
+    let path = specs_out
+        .join(format!("{name}.sol"))
+        .join(format!("{name}.json"));
+    let content = std::fs::read_to_string(&path)
+        .wrap_err_with(|| format!("failed to read artifact at `{}`", path.display()))?;
+    let artifact: FoundryArtifact = serde_json::from_str(&content)
+        .wrap_err_with(|| format!("failed to parse artifact at `{}`", path.display()))?;
+    decode_hex(&artifact.bytecode.object)
+}
+
+fn decode_hex(input: &str) -> eyre::Result<Vec<u8>> {
+    let stripped = input.strip_prefix("0x").unwrap_or(input);
+    const_hex::decode(stripped).wrap_err("failed to decode hex string")
+}
+
+fn deploy_contract(
+    evm: &mut TempoEvm<CacheDB<EmptyDB>>,
+    creation_bytecode: &[u8],
+    constructor_args: &[u8],
+    predeploy_addr: Address,
+    name: &str,
+    chain_id: u64,
+) -> eyre::Result<()> {
+    let mut initcode = Vec::with_capacity(creation_bytecode.len() + constructor_args.len());
+    initcode.extend_from_slice(creation_bytecode);
+    initcode.extend_from_slice(constructor_args);
+
+    let tx = TempoTxEnv {
+        inner: TxEnv {
+            caller: DEPLOYER,
+            gas_price: 0,
+            gas_limit: 100_000_000,
+            kind: TxKind::Create,
+            data: initcode.into(),
+            chain_id: Some(chain_id),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let result = evm.transact_raw(tx).map_err(|e| eyre!("{name} deployment tx failed: {e:?}"))?;
+
+    let created_addr = match &result.result {
+        ExecutionResult::Success { output, .. } => match output {
+            Output::Create(_, Some(addr)) => *addr,
+            _ => return Err(eyre!("{name} deployment did not return a created address")),
+        },
+        ExecutionResult::Revert { output, .. } => {
+            return Err(eyre!("{name} deployment reverted: {output}"))
+        }
+        ExecutionResult::Halt { reason, .. } => {
+            return Err(eyre!("{name} deployment halted: {reason:?}"))
+        }
+    };
+
+    evm.db_mut().commit(result.state);
+
+    let db = evm.db_mut();
+    if let Some(mut created_account) = db.cache.accounts.remove(&created_addr) {
+        created_account.info.nonce = 1;
+        db.cache.accounts.insert(predeploy_addr, created_account);
+    } else {
+        return Err(eyre!(
+            "{name} deployed to {created_addr} but account not found in CacheDB"
+        ));
+    }
+
+    println!("Deployed {name} at {predeploy_addr} (created at {created_addr})");
+    Ok(())
+}

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -277,8 +277,7 @@ fn load_artifact(specs_out: &PathBuf, name: &str) -> eyre::Result<Vec<u8>> {
 }
 
 fn decode_hex(input: &str) -> eyre::Result<Vec<u8>> {
-    let stripped = input.strip_prefix("0x").unwrap_or(input);
-    const_hex::decode(stripped).wrap_err("failed to decode hex string")
+    const_hex::decode(input).wrap_err("failed to decode hex string")
 }
 
 fn deploy_contract(

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -11,7 +11,7 @@ use reth_evm::{
         context::TxEnv,
         context::result::{ExecutionResult, Output},
         database::{CacheDB, EmptyDB},
-        inspector::JournalExt,
+
         state::AccountInfo,
     },
 };
@@ -21,7 +21,8 @@ use std::{
 };
 use tempo_chainspec::spec::TEMPO_BASE_FEE;
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
-use tempo_revm::TempoTxEnv;
+use tempo_revm::{TempoBlockEnv, TempoTxEnv};
+use tempo_chainspec::hardfork::TempoHardfork;
 
 const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
 const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
@@ -74,7 +75,7 @@ impl GenerateZoneGenesis {
     pub(crate) async fn run(self) -> eyre::Result<()> {
         let header_rlp = decode_hex(&self.tempo_genesis_header_rlp)?;
 
-        let mut evm = setup_zone_evm(self.chain_id);
+        let mut evm = setup_zone_evm(self.chain_id, self.gas_limit);
 
         evm.db_mut().insert_account_info(
             DEPLOYER,
@@ -86,6 +87,8 @@ impl GenerateZoneGenesis {
 
         let tempo_state_bytecode = load_artifact(&self.specs_out, "TempoState")?;
         let tempo_state_args = (Bytes::from(header_rlp),).abi_encode_params();
+        let mut nonce = 0u64;
+
         deploy_contract(
             &mut evm,
             &tempo_state_bytecode,
@@ -93,7 +96,9 @@ impl GenerateZoneGenesis {
             TEMPO_STATE_ADDRESS,
             "TempoState",
             self.chain_id,
+            nonce,
         )?;
+        nonce += 1;
 
         let zone_config_bytecode = load_artifact(&self.specs_out, "ZoneConfig")?;
         let zone_config_args =
@@ -105,7 +110,9 @@ impl GenerateZoneGenesis {
             ZONE_CONFIG_ADDRESS,
             "ZoneConfig",
             self.chain_id,
+            nonce,
         )?;
+        nonce += 1;
 
         let zone_inbox_bytecode = load_artifact(&self.specs_out, "ZoneInbox")?;
         let zone_inbox_args = (
@@ -122,7 +129,9 @@ impl GenerateZoneGenesis {
             ZONE_INBOX_ADDRESS,
             "ZoneInbox",
             self.chain_id,
+            nonce,
         )?;
+        nonce += 1;
 
         let zone_outbox_bytecode = load_artifact(&self.specs_out, "ZoneOutbox")?;
         let zone_outbox_args = (ZONE_CONFIG_ADDRESS, self.zone_token).abi_encode_params();
@@ -133,18 +142,19 @@ impl GenerateZoneGenesis {
             ZONE_OUTBOX_ADDRESS,
             "ZoneOutbox",
             self.chain_id,
+            nonce,
         )?;
 
+        let db = evm.db_mut();
         for (name, addr) in [
             ("TempoState", TEMPO_STATE_ADDRESS),
             ("ZoneConfig", ZONE_CONFIG_ADDRESS),
             ("ZoneInbox", ZONE_INBOX_ADDRESS),
             ("ZoneOutbox", ZONE_OUTBOX_ADDRESS),
         ] {
-            let account = evm
-                .ctx_mut()
-                .journaled_state
-                .evm_state()
+            let account = db
+                .cache
+                .accounts
                 .get(&addr)
                 .ok_or_else(|| eyre!("{name} not found at {addr}"))?;
             let has_code = account
@@ -157,17 +167,18 @@ impl GenerateZoneGenesis {
             }
         }
 
-        let evm_state = evm.ctx_mut().journaled_state.evm_state();
-        let mut genesis_alloc: BTreeMap<Address, GenesisAccount> = evm_state
+        let mut genesis_alloc: BTreeMap<Address, GenesisAccount> = db
+            .cache
+            .accounts
             .iter()
             .filter(|(addr, _)| **addr != DEPLOYER)
             .map(|(address, account)| {
-                let storage = if !account.storage.is_empty() {
+                let storage: Option<BTreeMap<_, _>> = if !account.storage.is_empty() {
                     Some(
                         account
                             .storage
                             .iter()
-                            .map(|(key, val)| ((*key).into(), val.present_value.into()))
+                            .map(|(key, val)| ((*key).into(), (*val).into()))
                             .collect(),
                     )
                 } else {
@@ -242,10 +253,13 @@ impl GenerateZoneGenesis {
     }
 }
 
-fn setup_zone_evm(chain_id: u64) -> TempoEvm<CacheDB<EmptyDB>> {
+fn setup_zone_evm(chain_id: u64, gas_limit: u64) -> TempoEvm<CacheDB<EmptyDB>> {
     let db = CacheDB::default();
-    let mut env = EvmEnv::default().with_timestamp(U256::ZERO);
+    let mut env: EvmEnv<TempoHardfork, TempoBlockEnv> =
+        EvmEnv::default().with_timestamp(U256::ZERO);
     env.cfg_env.chain_id = chain_id;
+    env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+    env.block_env.inner.gas_limit = gas_limit;
 
     let factory = TempoEvmFactory::default();
     factory.create_evm(db, env)
@@ -274,6 +288,7 @@ fn deploy_contract(
     predeploy_addr: Address,
     name: &str,
     chain_id: u64,
+    nonce: u64,
 ) -> eyre::Result<()> {
     let mut initcode = Vec::with_capacity(creation_bytecode.len() + constructor_args.len());
     initcode.extend_from_slice(creation_bytecode);
@@ -283,10 +298,11 @@ fn deploy_contract(
         inner: TxEnv {
             caller: DEPLOYER,
             gas_price: 0,
-            gas_limit: 100_000_000,
+            gas_limit: 30_000_000,
             kind: TxKind::Create,
             data: initcode.into(),
             chain_id: Some(chain_id),
+            nonce: nonce,
             ..Default::default()
         },
         ..Default::default()

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -11,13 +11,12 @@ use reth_evm::{
         context::TxEnv,
         context::result::{ExecutionResult, Output},
         database::{CacheDB, EmptyDB},
-
         state::AccountInfo,
     },
 };
 use std::{
     collections::BTreeMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use tempo_chainspec::spec::TEMPO_BASE_FEE;
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
@@ -73,7 +72,8 @@ struct BytecodeField {
 
 impl GenerateZoneGenesis {
     pub(crate) async fn run(self) -> eyre::Result<()> {
-        let header_rlp = decode_hex(&self.tempo_genesis_header_rlp)?;
+        let header_rlp =
+            const_hex::decode(&self.tempo_genesis_header_rlp).wrap_err("failed to decode hex string")?;
 
         let mut evm = setup_zone_evm(self.chain_id, self.gas_limit);
 
@@ -265,7 +265,7 @@ fn setup_zone_evm(chain_id: u64, gas_limit: u64) -> TempoEvm<CacheDB<EmptyDB>> {
     factory.create_evm(db, env)
 }
 
-fn load_artifact(specs_out: &PathBuf, name: &str) -> eyre::Result<Vec<u8>> {
+fn load_artifact(specs_out: &Path, name: &str) -> eyre::Result<Vec<u8>> {
     let path = specs_out
         .join(format!("{name}.sol"))
         .join(format!("{name}.json"));
@@ -273,11 +273,7 @@ fn load_artifact(specs_out: &PathBuf, name: &str) -> eyre::Result<Vec<u8>> {
         .wrap_err_with(|| format!("failed to read artifact at `{}`", path.display()))?;
     let artifact: FoundryArtifact = serde_json::from_str(&content)
         .wrap_err_with(|| format!("failed to parse artifact at `{}`", path.display()))?;
-    decode_hex(&artifact.bytecode.object)
-}
-
-fn decode_hex(input: &str) -> eyre::Result<Vec<u8>> {
-    const_hex::decode(input).wrap_err("failed to decode hex string")
+    const_hex::decode(&artifact.bytecode.object).wrap_err("failed to decode bytecode hex")
 }
 
 fn deploy_contract(
@@ -301,7 +297,7 @@ fn deploy_contract(
             kind: TxKind::Create,
             data: initcode.into(),
             chain_id: Some(chain_id),
-            nonce: nonce,
+            nonce,
             ..Default::default()
         },
         ..Default::default()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,8 +2,9 @@
 use std::net::SocketAddr;
 
 use crate::{
-    generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
-    generate_localnet::GenerateLocalnet, get_dkg_outcome::GetDkgOutcome,
+    create_zone::CreateZone, generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
+    generate_localnet::GenerateLocalnet, generate_zone_genesis::GenerateZoneGenesis,
+    get_dkg_outcome::GetDkgOutcome,
 };
 
 use alloy::signers::{local::MnemonicBuilder, utils::secret_key_to_address};
@@ -11,9 +12,11 @@ use clap::Parser as _;
 use commonware_codec::DecodeExt;
 use eyre::Context;
 
+mod create_zone;
 mod generate_devnet;
 mod generate_genesis;
 mod generate_localnet;
+mod generate_zone_genesis;
 mod genesis_args;
 mod get_dkg_outcome;
 
@@ -31,6 +34,14 @@ async fn main() -> eyre::Result<()> {
             .run()
             .await
             .wrap_err("failed to generate localnet configs"),
+        Action::CreateZone(args) => args
+            .run()
+            .await
+            .wrap_err("failed to create zone"),
+        Action::GenerateZoneGenesis(args) => args
+            .run()
+            .await
+            .wrap_err("failed to generate zone genesis"),
         Action::GenerateAddPeer(cfg) => generate_config_to_add_peer(cfg),
     }
 }
@@ -47,10 +58,12 @@ struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 enum Action {
+    CreateZone(CreateZone),
     GetDkgOutcome(GetDkgOutcome),
     GenerateGenesis(GenerateGenesis),
     GenerateDevnet(GenerateDevnet),
     GenerateLocalnet(GenerateLocalnet),
+    GenerateZoneGenesis(GenerateZoneGenesis),
     GenerateAddPeer(GenerateAddPeer),
 }
 


### PR DESCRIPTION
Add two new xtask subcommands for zone lifecycle management:

- **`create-zone`**: Calls the `ZoneFactory` contract on L1 to register a new zone, computing genesis block hashes and submitting the `CreateZoneParams` transaction.

- **`generate-zone-genesis`**: Generates a zone genesis file by deploying zone system contracts (`TempoState`, `ZoneInbox`, `ZoneOutbox`, `ZoneConfig`) into a local EVM and producing the resulting genesis JSON.

### Changes
- `xtask/src/create_zone.rs` — new command
- `xtask/src/generate_zone_genesis.rs` — new command
- `xtask/src/main.rs` — wire up both subcommands
- `xtask/Cargo.toml` — add `tempo-primitives`, `alloy-consensus`, `alloy-rlp`, `alloy/contract` deps