### PR TITLE
fix: pass genesis block number to portal and zone node

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -129,6 +129,7 @@ zone-up name reset="true" args="":
     fi
     PORTAL=$(jq -r '.portal' "$ZONE_JSON")
     TOKEN=$(jq -r '.token' "$ZONE_JSON")
+    ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$ZONE_JSON")
     DATADIR="/tmp/tempo-zone-{{name}}"
     if [[ "{{reset}}" = "true" ]]; then
         rm -rf "$DATADIR" || true
@@ -139,6 +140,7 @@ zone-up name reset="true" args="":
                       --l1.rpc-url "${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}" \
                       --l1.portal-address "$PORTAL" \
                       --l1.token-address "$TOKEN" \
+                      --l1.genesis-block-number "$ANCHOR_BLOCK" \
                       --http \
                       --http.addr 0.0.0.0 \
                       --http.port 8546 \

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -110,8 +110,12 @@ impl CreateZone {
         let verifier = Address::from(factory.verifier().call().await?.0);
         println!("Verifier: {verifier}");
 
-        // Use placeholder values for the zone params — these will be overridden
-        // after the createZone tx confirms, using the confirmation block.
+        // We cannot know the confirmation block number before sending, so we pass
+        // the current block number. The tx typically confirms in the next block, but
+        // zone.json records the actual confirmation block for the zone node to use
+        // via --l1.genesis-block-number.
+        let current_block = provider.get_block_number().await?;
+
         let params = CreateZoneParams {
             token: self.zone_token,
             sequencer: self.sequencer,
@@ -119,7 +123,7 @@ impl CreateZone {
             zoneParams: ZoneParams {
                 genesisBlockHash: B256::ZERO,
                 genesisTempoBlockHash: B256::ZERO,
-                genesisTempoBlockNumber: 0,
+                genesisTempoBlockNumber: current_block,
             },
         };
 


### PR DESCRIPTION
## Problem

`create-zone` passed `genesisTempoBlockNumber: 0` to `ZoneFactory.createZone()`. Since `ZonePortal` stores this as `immutable`, the L1 subscriber read `0` from the portal, skipped backfill entirely, and only fed live L1 blocks (~thousands of blocks ahead). This caused chain continuity errors on every zone startup:

```
L1 block number mismatch — chain continuity broken got=4717468 expected=4714643
```

## Fix

1. **`xtask/src/create_zone.rs`**: Pass the current L1 block number as `genesisTempoBlockNumber` instead of `0`
2. **`Justfile` `zone-up`**: Read `tempoAnchorBlock` from `zone.json` and pass it as `--l1.genesis-block-number` — this is the authoritative confirmation block number that overrides whatever the portal stored

The Justfile fix is the critical one since it uses the exact confirmation block number already recorded in `zone.json`.