### PR TITLE
fix(zone): validate token in ZoneOutbox and fix enableToken error

### DIFF
--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -6,24 +6,25 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 - Create a Tempo-native validium called a zone.
 - Each zone has exactly one permissioned sequencer.
-- Each zone bridges exactly one TIP-20 token, which is called its *zone token*. The zone token is used to pay transaction fees on the zone.
+- Each zone supports multiple TIP-20 tokens for bridging. The sequencer can enable additional TIP-20 tokens at any time. All enabled tokens are usable as gas tokens on the zone (no feeAMMs).
 - Settlement uses fast validity proofs or TEE attestations (ZK or TEE). Data availability is fully trusted to the sequencer.
 - Cross-chain operations are Tempo-centric: bridge in (simple deposit), bridge out (with optional callback to receiver contracts for Tempo composability).
 - Verifier is abstracted behind a minimal `IVerifier` interface.
 - Liveness (including exits) is wholly dependent on the permissioned sequencer; there is no permissionless fallback.
+- Non-custodial withdrawal guarantee: once a token is enabled, withdrawals for that token can never be disabled.
 
 ## Non-goals
 
 - No attempt to solve data availability, forced inclusion, or censorship resistance.
 - No upgradeability or governance model.
-- No general messaging or multi-asset bridging. Only one TIP-20 per zone.
+- No general messaging. Multi-asset bridging is supported for all TIP-20 tokens enabled by the sequencer.
 
 ## Terminology
 
 - Tempo: the base chain.
 - Zone: the validium chain anchored to Tempo.
-- Zone token: the zone's only TIP-20, bridged from Tempo.
-- Portal: the Tempo-side contract that escrows the zone token and finalizes exits.
+- Enabled tokens: TIP-20 tokens that the sequencer has enabled for bridging in/out. Each zone starts with an initial token and the sequencer can enable more. Token enablement is permanent (append-only).
+- Portal: the Tempo-side contract that escrows enabled tokens and finalizes exits.
 - Batch: a sequencer-produced commitment covering one or more zone blocks. The batch **must** end with a single `finalizeWithdrawalBatch()` call in the final block, and intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The sequencer controls batch frequency.
 
 ## System overview
@@ -37,7 +38,7 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 ### Tempo contracts
 
 - `ZoneFactory`: creates zones and registers parameters.
-- `ZonePortal`: per-zone portal that escrows the zone token on Tempo and finalizes exits.
+- `ZonePortal`: per-zone portal that escrows enabled tokens on Tempo and finalizes exits. Manages the token registry.
 
 ### Zone components (off-chain or zone-side)
 
@@ -49,12 +50,22 @@ This document proposes a new validium protocol designed for Tempo. It is a desig
 
 A zone is created via `ZoneFactory.createZone(...)` with:
 
-- `token`: the Tempo TIP-20 address to bridge. This is the only bridged token and the zone token.
+- `initialToken`: the first Tempo TIP-20 address to enable. The sequencer can enable additional tokens later via `ZonePortal.enableToken()`.
 - `sequencer`: permissioned sequencer address.
 - `verifier`: `IVerifier` implementation for proof or attestation.
 - `zoneParams`: initial configuration (genesis block hash, genesis Tempo block hash/number).
 
-The factory deploys a `ZonePortal` that escrows the zone token on Tempo. The zone genesis includes the portal address and the zone token configuration.
+The factory deploys a `ZonePortal` that escrows enabled tokens on Tempo and a `ZoneMessenger` for withdrawal callbacks. The initial token is automatically enabled at deployment.
+
+### Token management
+
+The sequencer manages which tokens are available for bridging:
+
+- `enableToken(address token)`: Enable a new TIP-20 for bridging. **Irreversible** — once enabled, a token can never be disabled.
+- `pauseDeposits(address token)`: Pause new deposits for a token (sequencer-only). Does not affect withdrawals.
+- `resumeDeposits(address token)`: Resume deposits for a previously paused token.
+
+The portal maintains a `TokenConfig` per token with `enabled` (permanent) and `depositsActive` (toggleable) flags, and an append-only `enabledTokens` list for enumeration. This design enforces the **non-custodial withdrawal guarantee**: the sequencer can halt deposits but can never prevent users from withdrawing an enabled token.
 
 ### Sequencer transfer
 
@@ -68,18 +79,18 @@ The sequencer can transfer control to a new address via a two-step process on **
 ## Execution and fees
 
 - The zone reuses Tempo's fee units and accounting model.
-- The fee token is always the zone token. There is no fee token selection.
-- Transactions use Tempo transaction semantics for fee payer, max fee per gas, and gas limit. The fee token field is fixed to the zone token.
+- Zone transactions specify which enabled TIP-20 token to use for gas fees via a `feeToken` field. The sequencer is required to accept all enabled tokens as gas (no feeAMMs on the zone).
+- Transactions use Tempo transaction semantics for fee payer, max fee per gas, and gas limit.
 
 ### Deposit fees
 
 Deposits incur a processing fee to compensate the sequencer for zone-side processing costs:
 
-- **Zone gas rate**: Sequencer publishes `zoneGasRate` (zone token units per gas unit)
+- **Zone gas rate**: Sequencer publishes `zoneGasRate` (token units per gas unit)
 - **Fixed gas value**: `FIXED_DEPOSIT_GAS` is fixed at 100,000 gas
 - **Total fee**: `FIXED_DEPOSIT_GAS * zoneGasRate` = `100,000 * zoneGasRate`
 
-The sequencer configures `zoneGasRate` via `ZonePortal.setZoneGasRate()`. The fixed gas value of 100,000 provides a stable pricing basis for deposits while allowing the sequencer flexibility to adjust the rate based on operational costs and future deposit mechanism variations.
+The fee is paid in the **same token being deposited**. The sequencer configures `zoneGasRate` via `ZonePortal.setZoneGasRate()`. The fixed gas value of 100,000 provides a stable pricing basis for deposits while allowing the sequencer flexibility to adjust the rate based on operational costs and future deposit mechanism variations. A single uniform `zoneGasRate` applies to all tokens (stablecoins of similar value).
 
 The fee is deducted from the deposit amount and paid to the sequencer immediately on Tempo. The deposit queue stores the net amount (`amount - fee`) which is minted on the zone.
 
@@ -87,13 +98,13 @@ The fee is deducted from the deposit amount and paid to the sequencer immediatel
 
 Withdrawals incur a processing fee to compensate the sequencer for Tempo-side gas costs:
 
-- **Tempo gas rate**: Sequencer publishes `tempoGasRate` (zone token units per gas unit)
+- **Tempo gas rate**: Sequencer publishes `tempoGasRate` (token units per gas unit)
 - **Gas limit**: User specifies `gasLimit` covering all execution costs (processing + callback)
 - **Total fee**: `gasLimit * tempoGasRate`
 
-The user must estimate total gas needed for their withdrawal, including `processWithdrawal` overhead and any callback. The sequencer configures `tempoGasRate` via `ZoneOutbox.setTempoGasRate()` and takes the risk on Tempo gas price fluctuations. If actual Tempo gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
+The fee is paid in the **same token being withdrawn**. The user must estimate total gas needed for their withdrawal, including `processWithdrawal` overhead and any callback. The sequencer configures `tempoGasRate` via `ZoneOutbox.setTempoGasRate()` and takes the risk on Tempo gas price fluctuations. If actual Tempo gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
 
-Users burn `amount + fee` when requesting a withdrawal. On success, `amount` goes to the recipient and `fee` goes to the sequencer. On failure (bounce-back), only `amount` is re-deposited to `fallbackRecipient`; the sequencer keeps the fee.
+Users burn `amount + fee` of the specified token when requesting a withdrawal. On success, `amount` goes to the recipient and `fee` goes to the sequencer. On failure (bounce-back), only `amount` is re-deposited to `fallbackRecipient`; the sequencer keeps the fee.
 
 ## Batch submission
 
@@ -320,7 +331,7 @@ struct ZoneInfo {
     uint64 zoneId;
     address portal;
     address messenger;
-    address token;
+    address initialToken;       // first TIP-20 enabled at creation
     address sequencer;
     address verifier;
     bytes32 genesisBlockHash;
@@ -334,7 +345,14 @@ struct ZoneParams {
     uint64 genesisTempoBlockNumber;
 }
 
+/// @notice Per-token configuration in the portal's token registry
+struct TokenConfig {
+    bool enabled;          // true once sequencer enables this token (permanent)
+    bool depositsActive;   // sequencer can pause/unpause deposits
+}
+
 struct Deposit {
+    address token;          // TIP-20 token being deposited
     address sender;
     address to;
     uint128 amount;
@@ -342,6 +360,7 @@ struct Deposit {
 }
 
 struct Withdrawal {
+    address token;              // TIP-20 token being withdrawn
     address sender;             // who initiated the withdrawal on the zone
     address to;                 // Tempo recipient
     uint128 amount;             // amount to send to recipient (excludes fee)
@@ -445,7 +464,7 @@ library WithdrawalQueueLib {
 ```solidity
 interface IZoneFactory {
     struct CreateZoneParams {
-        address token;
+        address initialToken;   // first TIP-20 to enable (sequencer can enable more later)
         address sequencer;
         address verifier;
         ZoneParams zoneParams;
@@ -455,7 +474,7 @@ interface IZoneFactory {
         uint64 indexed zoneId,
         address indexed portal,
         address indexed messenger,
-        address token,
+        address initialToken,
         address sequencer,
         address verifier,
         bytes32 genesisBlockHash,
@@ -477,6 +496,7 @@ interface IZonePortal {
     event DepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
+        address token,
         address to,
         uint128 netAmount,
         uint128 fee,
@@ -509,6 +529,7 @@ interface IZonePortal {
     event EncryptedDepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
+        address token,
         uint128 netAmount,
         uint128 fee,
         uint256 keyIndex,
@@ -543,13 +564,21 @@ interface IZonePortal {
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
 
     function zoneId() external view returns (uint64);
-    function token() external view returns (address);
     function messenger() external view returns (address);
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);
     function zoneGasRate() external view returns (uint128);
     function verifier() external view returns (address);
     function genesisTempoBlockNumber() external view returns (uint64);
+
+    /// @notice Token registry (multi-asset support)
+    function isTokenEnabled(address token) external view returns (bool);
+    function areDepositsActive(address token) external view returns (bool);
+    function enabledTokenCount() external view returns (uint256);
+    function enabledTokenAt(uint256 index) external view returns (address);
+    function enableToken(address token) external;
+    function pauseDeposits(address token) external;
+    function resumeDeposits(address token) external;
     function withdrawalBatchIndex() external view returns (uint64);
     function blockHash() external view returns (bytes32);
     function currentDepositQueueHash() external view returns (bytes32);
@@ -570,11 +599,12 @@ interface IZonePortal {
     /// @notice Calculate the fee for a deposit.
     function calculateDepositFee() external view returns (uint128 fee);
 
-    /// @notice Deposit zone token into the zone. Fee is deducted from amount.
-    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
+    /// @notice Deposit a TIP-20 token into the zone. Fee is deducted from amount.
+    function deposit(address token, address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
 
     /// @notice Deposit with encrypted recipient and memo. Fee is deducted from amount.
     function depositEncrypted(
+        address token,
         uint128 amount,
         uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
@@ -623,25 +653,24 @@ interface IZonePortal {
 
 #### Zone messenger (Tempo)
 
-Each zone has a dedicated messenger contract on Tempo. The portal gives the messenger max approval for the zone token. Withdrawal callbacks originate from this contract, not the portal.
+Each zone has a dedicated messenger contract on Tempo. The portal gives the messenger max approval for each enabled token (granted when `enableToken()` is called). Withdrawal callbacks originate from this contract, not the portal.
 
 ```solidity
 interface IZoneMessenger {
     /// @notice Returns the zone's portal address
     function portal() external view returns (address);
 
-    /// @notice Returns the zone token address
-    function token() external view returns (address);
-
     /// @notice Relay a withdrawal message. Only callable by the portal.
     /// @dev Transfers tokens from portal to target via transferFrom, then executes callback.
     ///      If callback reverts, the entire call reverts (including the transfer).
+    /// @param token The TIP-20 token to transfer
     /// @param sender The L2 origin address
     /// @param target The Tempo recipient
     /// @param amount Tokens to transfer from portal to target
     /// @param gasLimit Max gas for the callback
     /// @param data Calldata for the target
     function relayMessage(
+        address token,
         address sender,
         address target,
         uint128 amount,
@@ -651,7 +680,7 @@ interface IZoneMessenger {
 }
 ```
 
-The messenger does `token.transferFrom(portal, target, amount)` then calls the target with `data`. Both are atomic: if the callback reverts, the transfer is also reverted. Receivers check `msg.sender == zoneMessenger` to authenticate the call, and receive the L2 origin as the `sender` parameter in `onWithdrawalReceived`.
+The messenger does `ITIP20(token).transferFrom(portal, target, amount)` then calls the target with `data`. Both are atomic: if the callback reverts, the transfer is also reverted. Receivers check `msg.sender == zoneMessenger` to authenticate the call, and receive the L2 origin as the `sender` parameter in `onWithdrawalReceived`. This enables composable withdrawals where funds can flow directly into Tempo contracts (e.g., DEX swaps, staking, cross-zone deposits).
 
 #### Withdrawal receiver
 
@@ -661,11 +690,13 @@ Contracts that receive withdrawals with callbacks must implement this interface:
 interface IWithdrawalReceiver {
     /// @notice Called when a withdrawal with callback is received
     /// @param sender The L2 origin address
+    /// @param token The TIP-20 token transferred
     /// @param amount The amount of tokens transferred
     /// @param callbackData The callback data from the withdrawal request
     /// @return The function selector to confirm successful handling
     function onWithdrawalReceived(
         address sender,
+        address token,
         uint128 amount,
         bytes calldata callbackData
     ) external returns (bytes4);
@@ -683,9 +714,9 @@ Zones have four system contract predeploys at fixed addresses:
 - **ZoneOutbox** (0x1c00000000000000000000000000000000000002) - Handles withdrawal requests back to Tempo
 - **ZoneConfig** (0x1c00000000000000000000000000000000000003) - Central configuration that reads sequencer from L1
 
-#### Zone token
+#### Zone tokens
 
-The zone token is the only bridged TIP-20 from Tempo allowed on the zone. It is deployed at the **same address** on the zone as on Tempo. Users interact with it via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints tokens when processing deposits and burns them when withdrawals are requested.
+Each enabled TIP-20 token is bridged from Tempo to the zone. Each is deployed at the **same address** on the zone as on Tempo. Users interact with them via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints the correct token when processing deposits and burns the correct token when withdrawals are requested. The zone node must deploy/configure zone-side representations for each enabled token.
 
 #### ZoneConfig predeploy
 
@@ -695,9 +726,6 @@ ZoneConfig is the central zone configuration contract that provides access to zo
 interface IZoneConfig {
     error NotSequencer();
     error NoEncryptionKeySet();
-
-    /// @notice Zone token address (TIP-20 at same address as Tempo)
-    function zoneToken() external view returns (address);
 
     /// @notice L1 ZonePortal address
     function tempoPortal() external view returns (address);
@@ -718,12 +746,12 @@ interface IZoneConfig {
     /// @notice Check if an address is the current sequencer
     function isSequencer(address account) external view returns (bool);
 
-    /// @notice Get zone token as IZoneToken interface
-    function getZoneToken() external view returns (IZoneToken);
+    /// @notice Check if a token is enabled by reading from L1 ZonePortal
+    function isEnabledToken(address token) external view returns (bool);
 }
 ```
 
-ZoneConfig reads the sequencer address from the finalized L1 `ZonePortal` storage via `TempoState.readTempoStorageSlot()`. This makes L1 the **single source of truth** for sequencer management, eliminating duplicate sequencer logic on zone-side contracts. Zone system contracts (`ZoneInbox`, `ZoneOutbox`) reference `ZoneConfig` for sequencer checks.
+ZoneConfig reads the sequencer address and token registry from the finalized L1 `ZonePortal` storage via `TempoState.readTempoStorageSlot()`. This makes L1 the **single source of truth** for sequencer management and token enablement, eliminating duplicate logic on zone-side contracts. Zone system contracts (`ZoneInbox`, `ZoneOutbox`) reference `ZoneConfig` for sequencer checks.
 
 #### TempoState predeploy
 
@@ -804,6 +832,7 @@ interface IZoneInbox {
         bytes32 indexed depositHash,
         address indexed sender,
         address indexed to,
+        address token,
         uint128 amount,
         bytes32 memo
     );
@@ -813,13 +842,14 @@ interface IZoneInbox {
         bytes32 indexed depositHash,
         address indexed sender,
         address indexed to,
+        address token,
         uint128 amount,
         bytes32 memo
     );
 
     /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
     event EncryptedDepositFailed(
-        bytes32 indexed depositHash, address indexed sender, uint128 amount
+        bytes32 indexed depositHash, address indexed sender, address token, uint128 amount
     );
 
     error OnlySequencer();
@@ -836,9 +866,6 @@ interface IZoneInbox {
 
     /// @notice The TempoState predeploy address.
     function tempoState() external view returns (ITempoState);
-
-    /// @notice The zone token (TIP-20 at same address as Tempo).
-    function zoneToken() external view returns (IZoneToken);
 
     /// @notice The zone's last processed deposit queue hash.
     function processedDepositQueueHash() external view returns (bytes32);
@@ -862,7 +889,7 @@ interface IZoneInbox {
 The sequencer observes `DepositMade` events on the Tempo portal and relays them to the zone via `advanceTempo`. This function:
 
 1. Calls `TempoState.finalizeTempo(header)` to advance the zone's view of Tempo
-2. Processes deposits in order, building the hash chain and minting zone tokens
+2. Processes deposits in order, building the hash chain and minting the correct zone-side TIP-20 tokens
 3. Reads `currentDepositQueueHash` from the Tempo portal's storage via `TempoState.readTempoStorageSlot()`
 4. Validates the resulting hash matches Tempo's current state
 
@@ -870,7 +897,7 @@ This combined approach ensures Tempo state advancement and deposit processing ar
 
 #### Zone outbox
 
-The zone outbox handles withdrawal requests. Users approve the outbox to spend their zone tokens, then call `requestWithdrawal`. The outbox stores pending withdrawals in an array. When the sequencer is ready to finalize a **batch**, it calls `finalizeWithdrawalBatch(count)` at the end of the **final block** in that batch. This constructs the withdrawal queue hash on-chain and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to storage. Intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The call is required even if there are zero withdrawals (use `count = 0`) so the withdrawal batch index advances. The event is emitted for observability, but the proof reads from state (via the `lastBatch` storage) rather than parsing event logs.
+The zone outbox handles withdrawal requests. Users approve the outbox to spend their tokens, then call `requestWithdrawal(token, ...)` specifying which TIP-20 to withdraw. The outbox stores pending withdrawals in an array. When the sequencer is ready to finalize a **batch**, it calls `finalizeWithdrawalBatch(count)` at the end of the **final block** in that batch. This constructs the withdrawal queue hash on-chain and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to storage. Intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The call is required even if there are zero withdrawals (use `count = 0`) so the withdrawal batch index advances. The event is emitted for observability, but the proof reads from state (via the `lastBatch` storage) rather than parsing event logs.
 
 ```solidity
 /// @notice Withdrawal batch parameters stored in state for proof access
@@ -886,6 +913,7 @@ interface IZoneOutbox {
     event WithdrawalRequested(
         uint64 indexed withdrawalIndex,
         address indexed sender,
+        address token,
         address to,
         uint128 amount,
         uint128 fee,
@@ -907,16 +935,7 @@ interface IZoneOutbox {
     event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
 
-    /// @notice The zone token (same as Tempo portal's token).
-    function zoneToken() external view returns (IZoneToken);
-
-    /// @notice Current sequencer address.
-    function sequencer() external view returns (address);
-
-    /// @notice Pending sequencer for two-step transfer.
-    function pendingSequencer() external view returns (address);
-
-    /// @notice Tempo gas rate (zone token units per gas unit on Tempo).
+    /// @notice Tempo gas rate (token units per gas unit on Tempo).
     /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
     function tempoGasRate() external view returns (uint128);
 
@@ -953,9 +972,12 @@ interface IZoneOutbox {
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo.
-    /// @dev Caller must have approved the outbox to spend `amount + fee` of zone tokens.
+    /// @dev Caller must have approved the outbox to spend `amount + fee` of the specified token.
+    ///      The token must be enabled on the portal. Withdrawals can never be disabled
+    ///      for an enabled token (non-custodial guarantee).
     ///      Subject to maxWithdrawalsPerBlock cap if set by the sequencer.
     ///      Tokens are burned immediately and withdrawal is stored in pending array.
+    /// @param token The TIP-20 token to withdraw.
     /// @param to The Tempo recipient address.
     /// @param amount Amount to send to recipient (fee is additional).
     /// @param memo User-provided context (e.g., payment reference).
@@ -963,6 +985,7 @@ interface IZoneOutbox {
     /// @param fallbackRecipient Zone address for bounce-back if callback fails.
     /// @param data Calldata for the target (max 1KB).
     function requestWithdrawal(
+        address token,
         address to,
         uint128 amount,
         bytes32 memo,
@@ -1093,9 +1116,9 @@ The key insight: structure the hash chain so the **on-chain operation touches th
 
 ## Bridging in (Tempo to zone)
 
-1. User calls `ZonePortal.deposit(to, amount, memo)` on Tempo.
-2. `ZonePortal` transfers `amount` of the zone token into escrow and appends a deposit to the queue: `currentDepositQueueHash = keccak256(abi.encode(deposit, currentDepositQueueHash))`.
-3. The sequencer observes `DepositMade` events and processes deposits in order via `ZoneInbox.advanceTempo()`, crediting `to` with `amount` of the zone token (TIP-20 balance). Deposits always succeed—there is no callback or bounce mechanism.
+1. User calls `ZonePortal.deposit(token, to, amount, memo)` on Tempo, specifying which enabled TIP-20 to deposit.
+2. `ZonePortal` validates the token is enabled and deposits are active, transfers `amount` of the specified token into escrow, and appends a deposit to the queue: `currentDepositQueueHash = keccak256(abi.encode(DepositType.Regular, deposit, currentDepositQueueHash))`. The `Deposit` struct includes the `token` field.
+3. The sequencer observes `DepositMade` events and processes deposits in order via `ZoneInbox.advanceTempo()`, minting the correct zone-side TIP-20 to the recipient: `IZoneToken(d.token).mint(d.to, d.amount)`. Deposits always succeed—there is no callback or bounce mechanism.
 4. A batch proof/attestation must prove the zone correctly processed deposits by validating the Tempo state read inside the proof.
 5. After the batch is accepted, `lastSyncedTempoBlockNumber` is updated to record how far Tempo state was synced.
 
@@ -1107,6 +1130,7 @@ Notes:
 - The portal only stores `currentDepositQueueHash`, not individual deposits. The sequencer must track deposits off-chain.
 - Tempo state advancement is combined with deposit processing in `ZoneInbox.advanceTempo()`, which calls `TempoState.finalizeTempo()` internally.
 - The proof validates an exact match to `currentDepositQueueHash` from Tempo state, ensuring it cannot claim to process fake deposits.
+- Each enabled TIP-20 is deployed at the **same address** on the zone as on Tempo. The zone node must deploy/configure zone-side representations for each enabled token.
 
 ### Encrypted deposits
 
@@ -1131,8 +1155,10 @@ struct EncryptedDepositPayload {
 
 /// @notice Encrypted deposit stored in the queue
 struct EncryptedDeposit {
+    address token;               // TIP-20 token (public, for escrow accounting)
     address sender;              // Depositor (public, for refunds)
     uint128 amount;              // Amount (public, for accounting)
+    uint256 keyIndex;            // Index of encryption key used (specified by depositor)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
 }
 ```
@@ -1141,6 +1167,7 @@ struct EncryptedDeposit {
 
 | Field | Visibility | Reason |
 |-------|------------|--------|
+| `token` | Public | Needed for on-chain escrow accounting and zone-side minting |
 | `sender` | Public | Needed for potential refunds if decryption fails |
 | `amount` | Public | Needed for on-chain accounting/escrow |
 | `to` | Encrypted | Privacy - only sequencer knows recipient |
@@ -1148,7 +1175,7 @@ struct EncryptedDeposit {
 
 **Processing flow:**
 
-1. User calls `depositEncrypted(amount, keyIndex, encrypted)` on Tempo portal
+1. User calls `depositEncrypted(token, amount, keyIndex, encrypted)` on Tempo portal
 2. Portal escrows funds, adds to the **unified deposit queue**, and emits `EncryptedDepositMade`
 3. Sequencer decrypts the payload off-chain using their private key
 4. When processing the zone block, sequencer calls `advanceTempo()` with deposits from the unified queue
@@ -1233,7 +1260,7 @@ bytes32 aesKey = _hkdfSha256(dec.sharedSecret, "ecies-aes-key", "");
 
 // Step 5: If decryption fails, return funds to sender (don't block chain)
 if (!valid) {
-    zoneToken.mint(ed.sender, ed.amount);
+    IZoneToken(ed.token).mint(ed.sender, ed.amount);
     emit EncryptedDepositFailed(...);
 }
 ```
@@ -1341,12 +1368,12 @@ if (valid && decryptedPlaintext.length == ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
 // Step 6: Handle success or failure
 if (!valid) {
     // Decryption failed - return funds to sender
-    zoneToken.mint(ed.sender, ed.amount);
-    emit EncryptedDepositFailed(currentHash, ed.sender, ed.amount);
+    IZoneToken(ed.token).mint(ed.sender, ed.amount);
+    emit EncryptedDepositFailed(currentHash, ed.sender, ed.token, ed.amount);
 } else {
-    // Decryption succeeded - mint to decrypted recipient
-    zoneToken.mint(dec.to, ed.amount);
-    emit DepositProcessed(currentHash, ed.sender, dec.to, ed.amount, dec.memo);
+    // Decryption succeeded - mint correct zone-side TIP-20 to decrypted recipient
+    IZoneToken(ed.token).mint(dec.to, ed.amount);
+    emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.token, ed.amount, dec.memo);
 }
 ```
 
@@ -1395,16 +1422,18 @@ struct EncryptionKeyEntry {
     uint64 activationBlock; // Tempo block number when this key became active
 }
 
-/// @notice Encrypted deposit includes the key index used for encryption
+/// @notice Encrypted deposit includes the key index and token used for encryption
 struct EncryptedDeposit {
+    address token;               // TIP-20 token (public, for escrow accounting)
     address sender;              // Depositor (public, for refunds)
     uint128 amount;              // Amount (public, for accounting)
     uint256 keyIndex;            // Index of encryption key used (specified by depositor)
     EncryptedDepositPayload encrypted; // Encrypted (to, memo)
 }
 
-/// @notice Deposit function requires explicit key index
+/// @notice Deposit function requires explicit key index and token
 function depositEncrypted(
+    address token,                          // Token is public (needed for escrow)
     uint128 amount,
     uint256 keyIndex,                      // User specifies which key they encrypted to
     EncryptedDepositPayload calldata encrypted
@@ -1494,35 +1523,36 @@ function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) extern
     }
 
     if (w.gasLimit == 0) {
-        ITIP20(token).transfer(w.to, w.amount);
+        ITIP20(w.token).transfer(w.to, w.amount);
         return;
     }
 
-    // Try callback via self-call for atomicity
-    try this._executeWithdrawal(w) {
+    // Try callback via messenger for atomicity
+    try IZoneMessenger(messenger).relayMessage(w.token, w.sender, w.to, w.amount, w.gasLimit, w.callbackData) {
         // Success: tokens transferred and callback executed
     } catch {
         // Callback failed: bounce back to zone
-        _enqueueBounceBack(w.amount, w.fallbackRecipient);
+        _enqueueBounceBack(w.token, w.amount, w.fallbackRecipient);
     }
 }
 ```
 
-The messenger does `token.transferFrom(portal, target, amount)` then executes the callback. Both are atomic: if the callback reverts, the transferFrom reverts too, and funds remain in the portal for bounce-back. Receivers check `msg.sender == messenger` to authenticate the call, and receive the L2 origin as the `sender` parameter in `onWithdrawalReceived`. This enables composable withdrawals where funds can flow directly into Tempo contracts (e.g., DEX swaps, staking, cross-zone deposits).
+The messenger does `ITIP20(token).transferFrom(portal, target, amount)` then executes the callback. Both are atomic: if the callback reverts, the transferFrom reverts too, and funds remain in the portal for bounce-back. Receivers check `msg.sender == messenger` to authenticate the call, and receive the L2 origin as the `sender` parameter in `onWithdrawalReceived`. This enables composable withdrawals where funds can flow directly into Tempo contracts (e.g., DEX swaps, staking, cross-zone deposits).
 
 ## Withdrawal failure and bounce-back
 
 Withdrawals can fail if the token transfer or messenger callback reverts (out of gas, logic error, TIP-403 policy, token pause, etc.). When this happens, the portal "bounces back" the funds by re-depositing into the same zone to the withdrawal's `fallbackRecipient`.
 
 ```solidity
-function _enqueueBounceBack(uint128 amount, address fallbackRecipient) internal {
+function _enqueueBounceBack(address token, uint128 amount, address fallbackRecipient) internal {
     Deposit memory d = Deposit({
+        token: token,           // same token from the failed withdrawal
         sender: address(this),
         to: fallbackRecipient,
         amount: amount,
         memo: bytes32(0)
     });
-    currentDepositQueueHash = keccak256(abi.encode(d, currentDepositQueueHash));
+    currentDepositQueueHash = keccak256(abi.encode(DepositType.Regular, d, currentDepositQueueHash));
     emit BounceBack(...);
 }
 ```
@@ -1544,7 +1574,7 @@ Withdrawals can fail for various reasons. The system handles failures gracefully
 Withdrawals can fail due to:
 - **Transfer failure**: `transfer` or `transferFrom` reverts (includes gasLimit = 0 cases)
 - **TIP-403 policy**: Recipient not authorized under the token's transfer policy
-- **Token paused**: The zone token is globally paused
+- **Token paused**: The token is globally paused
 - **Callback revert**: The receiver contract reverts (out of gas, logic error, etc.)
 - **Callback rejection**: Receiver returns wrong selector
 
@@ -1562,7 +1592,7 @@ Tempo TIP-20 tokens use TIP-403 for transfer authorization:
 - Policy types: WHITELIST (must be in set) or BLACKLIST (must not be in set)
 - Policy ID 1 is "always-allow" (default for most tokens)
 
-Zone creators SHOULD choose zone tokens with `transferPolicyId == 1` to avoid complexity. If using restricted policies:
+Zone creators SHOULD choose tokens with `transferPolicyId == 1` to avoid complexity. If using restricted policies:
 - The portal address MUST be whitelisted
 - Users should set `fallbackRecipient` to an address they control
 
@@ -1573,8 +1603,8 @@ Zone creators SHOULD choose zone tokens with `transferPolicyId == 1` to avoid co
 - Withdrawals with callbacks go through the zone messenger with a user-specified gas limit. The messenger does `transferFrom` + callback atomically; any transfer or callback failure triggers a bounce-back to `fallbackRecipient`.
 - Deposits are locked on Tempo until a verified batch consumes them.
 - **Bounce-back guarantees**: Failed withdrawals bounce back to zone `fallbackRecipient`. Users always retain their funds.
-- **TIP-403 policy changes**: If the zone token's policy restricts the portal, withdrawals will fail and bounce back.
-- **Token pause**: If the zone token is paused, withdrawals bounce back to zone.
+- **TIP-403 policy changes**: If a token's policy restricts the portal, withdrawals for that token will fail and bounce back.
+- **Token pause**: If a token is paused, withdrawals for that token bounce back to zone.
 
 ## Implementation architecture
 
@@ -1657,14 +1687,14 @@ zone_getReceipt(txHash) -> receipt
 
 ```
 Tempo Node
-├── ExEx: USDC Zone
-│   ├── TIP-20 Precompile (USDC)
+├── ExEx: Zone A (multi-asset: USDC, USDT, DAI, ...)
+│   ├── TIP-20 Precompiles (per enabled token)
 │   ├── Payments Precompile
 │   ├── In-memory State Store
 │   └── SP1 Prover (mock for dev)
 │
-└── ExEx: USDT Zone
-    ├── TIP-20 Precompile (USDT)
+└── ExEx: Zone B (multi-asset: USDC, EURC, ...)
+    ├── TIP-20 Precompiles (per enabled token)
     ├── Payments Precompile
     ├── In-memory State Store
     └── SP1 Prover (mock for dev)

--- a/docs/specs/src/AccountKeychain.sol
+++ b/docs/specs/src/AccountKeychain.sol
@@ -99,7 +99,10 @@ contract AccountKeychain is IAccountKeychain {
 
         // Store the new key
         keys[msg.sender][keyId] = AuthorizedKey({
-            signatureType: sigType, expiry: expiry, enforceLimits: enforceLimits, isRevoked: false
+            signatureType: sigType,
+            expiry: expiry,
+            enforceLimits: enforceLimits,
+            isRevoked: false
         });
 
         // Set initial spending limits (only if enforce_limits is true)

--- a/docs/specs/src/FeeAMM.sol
+++ b/docs/specs/src/FeeAMM.sol
@@ -40,7 +40,10 @@ contract FeeAMM is IFeeAMM {
         return keccak256(abi.encode(userToken, validatorToken));
     }
 
-    function getPool(address userToken, address validatorToken)
+    function getPool(
+        address userToken,
+        address validatorToken
+    )
         external
         view
         returns (Pool memory)

--- a/docs/specs/src/Nonce.sol
+++ b/docs/specs/src/Nonce.sol
@@ -43,7 +43,13 @@ contract Nonce is INonce {
     /// @param account The account whose nonce to increment
     /// @param nonceKey The nonce key to increment (must be > 0)
     /// @return newNonce The new nonce value after incrementing
-    function _incrementNonce(address account, uint256 nonceKey) internal returns (uint64 newNonce) {
+    function _incrementNonce(
+        address account,
+        uint256 nonceKey
+    )
+        internal
+        returns (uint64 newNonce)
+    {
         if (nonceKey == 0) {
             revert InvalidNonceKey();
         }

--- a/docs/specs/src/StablecoinDEX.sol
+++ b/docs/specs/src/StablecoinDEX.sol
@@ -635,7 +635,13 @@ contract StablecoinDEX is IStablecoinDEX {
     /// @param user The user to transfer from
     /// @param token The token to transfer
     /// @param amount The amount to transfer
-    function _decrementBalanceOrTransferFrom(address user, address token, uint128 amount) internal {
+    function _decrementBalanceOrTransferFrom(
+        address user,
+        address token,
+        uint128 amount
+    )
+        internal
+    {
         // Check if user is authorized by the token's transfer policy before using internal balance
         uint64 policyId = ITIP20(token).transferPolicyId();
         if (

--- a/docs/specs/src/TIP20.sol
+++ b/docs/specs/src/TIP20.sol
@@ -187,7 +187,14 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
         emit BurnBlocked(from, amount);
     }
 
-    function mintWithMemo(address to, uint256 amount, bytes32 memo) external onlyRole(ISSUER_ROLE) {
+    function mintWithMemo(
+        address to,
+        uint256 amount,
+        bytes32 memo
+    )
+        external
+        onlyRole(ISSUER_ROLE)
+    {
         _mint(to, amount);
         emit TransferWithMemo(address(0), to, amount, memo);
         emit Mint(to, amount);
@@ -556,4 +563,4 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
         }
     }
 
-    }
+}

--- a/docs/specs/src/TIP403Registry.sol
+++ b/docs/specs/src/TIP403Registry.sol
@@ -19,7 +19,10 @@ contract TIP403Registry is ITIP403Registry {
                       GENERAL POLICY ADMINISTRATION
     //////////////////////////////////////////////////////////////*/
 
-    function createPolicy(address admin, PolicyType policyType)
+    function createPolicy(
+        address admin,
+        PolicyType policyType
+    )
         public
         returns (uint64 newPolicyId)
     {

--- a/docs/specs/src/interfaces/IFeeAMM.sol
+++ b/docs/specs/src/interfaces/IFeeAMM.sol
@@ -63,7 +63,13 @@ interface IFeeAMM {
         external
         returns (uint256 amountUserToken, uint256 amountValidatorToken);
 
-    function getPool(address userToken, address validatorToken) external view returns (Pool memory);
+    function getPool(
+        address userToken,
+        address validatorToken
+    )
+        external
+        view
+        returns (Pool memory);
 
     function getPoolId(address userToken, address validatorToken) external pure returns (bytes32);
 

--- a/docs/specs/src/zone/EncryptedDeposit.sol
+++ b/docs/specs/src/zone/EncryptedDeposit.sol
@@ -43,6 +43,7 @@ uint256 constant MIN_CIPHERTEXT_SIZE = 64;
 /// @notice Decrypted deposit (after sequencer decryption)
 /// @dev This is what the sequencer works with internally on the zone
 struct DecryptedDeposit {
+    address token;
     address sender;
     address to;
     uint128 amount;

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -18,7 +18,7 @@ struct ZoneInfo {
     uint64 zoneId;
     address portal;
     address messenger;
-    address token;
+    address initialToken; // first TIP-20 enabled at zone creation (additional tokens enabled via enableToken)
     address sequencer;
     address verifier;
     bytes32 genesisBlockHash;
@@ -58,6 +58,7 @@ enum DepositType {
 }
 
 struct Deposit {
+    address token; // TIP-20 token being deposited
     address sender;
     address to;
     uint128 amount;
@@ -79,10 +80,12 @@ struct EncryptedDepositPayload {
 }
 
 /// @notice Encrypted deposit stored in the queue
-/// @dev Sender, amount, and key index are public; recipient and memo are encrypted.
+/// @dev Sender, token, amount, and key index are public; recipient and memo are encrypted.
+///      The token identity is public because the portal must escrow the correct token.
 ///      The keyIndex specifies which encryption key the user used, allowing the prover
 ///      to look up the correct key for decryption even after key rotations.
 struct EncryptedDeposit {
+    address token; // TIP-20 token being deposited (public, for escrow accounting)
     address sender; // Depositor (public, for refunds)
     uint128 amount; // Amount (public, for accounting)
     uint256 keyIndex; // Index of encryption key used (specified by depositor)
@@ -225,6 +228,7 @@ interface IAesGcmDecrypt {
 }
 
 struct Withdrawal {
+    address token; // TIP-20 token being withdrawn
     address sender; // who initiated the withdrawal on the zone
     address to; // Tempo recipient
     uint128 amount; // amount to send to recipient (excludes fee)
@@ -263,6 +267,8 @@ address constant ZONE_CONFIG = 0x1c00000000000000000000000000000000000003;
 //   slot 4: currentDepositQueueHash (bytes32)
 //   slot 5: lastSyncedTempoBlockNumber (uint64)
 //   slot 6: _encryptionKeys (EncryptionKeyEntry[])
+//   slot 7: _tokenConfigs (mapping(address => TokenConfig))
+//   slot 8: _enabledTokens (address[])
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via
@@ -272,6 +278,8 @@ bytes32 constant PORTAL_SEQUENCER_SLOT = bytes32(uint256(0));
 bytes32 constant PORTAL_PENDING_SEQUENCER_SLOT = bytes32(uint256(1));
 bytes32 constant PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(4));
 bytes32 constant PORTAL_ENCRYPTION_KEYS_SLOT = bytes32(uint256(6));
+bytes32 constant PORTAL_TOKEN_CONFIGS_SLOT = bytes32(uint256(7));
+bytes32 constant PORTAL_ENABLED_TOKENS_SLOT = bytes32(uint256(8));
 
 /// @title IVerifier
 /// @notice Interface for zone proof/attestation verification
@@ -320,7 +328,7 @@ interface IVerifier {
 interface IZoneFactory {
 
     struct CreateZoneParams {
-        address token;
+        address initialToken; // first TIP-20 to enable (sequencer can enable more later)
         address sequencer;
         address verifier;
         ZoneParams zoneParams;
@@ -330,7 +338,7 @@ interface IZoneFactory {
         uint64 indexed zoneId,
         address indexed portal,
         address indexed messenger,
-        address token,
+        address initialToken,
         address sequencer,
         address verifier,
         bytes32 genesisBlockHash,
@@ -353,6 +361,14 @@ interface IZoneFactory {
 
 }
 
+/// @notice Per-token configuration in the portal's token registry
+/// @dev enabled is permanent (write-once true); depositsActive can be toggled by sequencer.
+///      Once enabled, withdrawals can never be disabled (non-custodial guarantee).
+struct TokenConfig {
+    bool enabled; // true once sequencer enables this token (permanent, irreversible)
+    bool depositsActive; // sequencer can pause/unpause deposits; does not affect withdrawals
+}
+
 /// @title IZonePortal
 /// @notice Interface for zone portal on Tempo
 interface IZonePortal {
@@ -360,6 +376,7 @@ interface IZonePortal {
     event DepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
+        address token,
         address to,
         uint128 netAmount,
         uint128 fee,
@@ -373,11 +390,14 @@ interface IZonePortal {
         bytes32 withdrawalQueueHash
     );
 
-    event WithdrawalProcessed(address indexed to, uint128 amount, bool callbackSuccess);
+    event WithdrawalProcessed(
+        address indexed to, address token, uint128 amount, bool callbackSuccess
+    );
 
     event BounceBack(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed fallbackRecipient,
+        address token,
         uint128 amount
     );
 
@@ -390,6 +410,7 @@ interface IZonePortal {
     event EncryptedDepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
+        address token,
         uint128 netAmount,
         uint128 fee,
         uint256 keyIndex,
@@ -410,6 +431,15 @@ interface IZonePortal {
     );
     event ZoneGasRateUpdated(uint128 zoneGasRate);
 
+    /// @notice Emitted when sequencer enables a new TIP-20 token for bridging
+    event TokenEnabled(address indexed token);
+
+    /// @notice Emitted when sequencer pauses deposits for a token
+    event DepositsPaused(address indexed token);
+
+    /// @notice Emitted when sequencer resumes deposits for a token
+    event DepositsResumed(address indexed token);
+
     error NotSequencer();
     error NotPendingSequencer();
     error InvalidProof();
@@ -424,6 +454,9 @@ interface IZonePortal {
     error InvalidProofOfPossession();
     error DepositTooSmall();
     error GasFeeRateTooHigh();
+    error TokenNotEnabled();
+    error DepositsNotActive();
+    error TokenAlreadyEnabled();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
@@ -432,7 +465,6 @@ interface IZonePortal {
     function MAX_GAS_FEE_RATE() external view returns (uint128);
 
     function zoneId() external view returns (uint64);
-    function token() external view returns (address);
     function messenger() external view returns (address);
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);
@@ -447,6 +479,37 @@ interface IZonePortal {
     function withdrawalQueueSlot(uint256 slot) external view returns (bytes32);
 
     function genesisTempoBlockNumber() external view returns (uint64);
+
+    /*//////////////////////////////////////////////////////////////
+                          TOKEN REGISTRY
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Check if a token is enabled for bridging (permanent once enabled)
+    function isTokenEnabled(address token) external view returns (bool);
+
+    /// @notice Check if deposits are currently active for a token
+    function areDepositsActive(address token) external view returns (bool);
+
+    /// @notice Get the token configuration for a specific token
+    function tokenConfig(address token) external view returns (TokenConfig memory);
+
+    /// @notice Get the number of enabled tokens
+    function enabledTokenCount() external view returns (uint256);
+
+    /// @notice Get an enabled token by index
+    function enabledTokenAt(uint256 index) external view returns (address);
+
+    /// @notice Enable a new TIP-20 token for bridging. Only callable by sequencer.
+    /// @dev Irreversible: once enabled, a token cannot be disabled.
+    ///      Validates the token is a TIP-20 and grants messenger max approval.
+    function enableToken(address token) external;
+
+    /// @notice Pause deposits for a token. Only callable by sequencer.
+    /// @dev Does not affect withdrawal processing (non-custodial guarantee).
+    function pauseDeposits(address token) external;
+
+    /// @notice Resume deposits for a token. Only callable by sequencer.
+    function resumeDeposits(address token) external;
 
     /// @notice Start a sequencer transfer. Only callable by current sequencer.
     /// @param newSequencer The address that will become sequencer after accepting.
@@ -515,6 +578,7 @@ interface IZonePortal {
         returns (bool valid, uint64 expiresAtBlock);
 
     function deposit(
+        address token,
         address to,
         uint128 amount,
         bytes32 memo
@@ -526,11 +590,14 @@ interface IZonePortal {
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key
     ///      at the specified keyIndex. The user must specify which key they encrypted to,
     ///      ensuring correct decryption even if the key rotates before inclusion.
+    ///      The token identity is public (not encrypted) since the portal must escrow it.
+    /// @param token The TIP-20 token to deposit
     /// @param amount Amount to deposit
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
     function depositEncrypted(
+        address token,
         uint128 amount,
         uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
@@ -559,18 +626,17 @@ interface IZoneMessenger {
     /// @notice Returns the zone's portal address
     function portal() external view returns (address);
 
-    /// @notice Returns the zone token address
-    function token() external view returns (address);
-
     /// @notice Relay a withdrawal message. Only callable by the portal.
     /// @dev Transfers tokens from portal to target via transferFrom, then executes callback.
     ///      If callback reverts, the entire call reverts (including the transfer).
+    /// @param token The TIP-20 token to transfer
     /// @param sender The L2 origin address
     /// @param target The Tempo recipient
     /// @param amount Tokens to transfer from portal to target
     /// @param gasLimit Max gas for the callback
     /// @param data Calldata for the target
     function relayMessage(
+        address token,
         address sender,
         address target,
         uint128 amount,
@@ -587,6 +653,7 @@ interface IWithdrawalReceiver {
 
     function onWithdrawalReceived(
         address sender,
+        address token,
         uint128 amount,
         bytes calldata callbackData
     )
@@ -674,22 +741,25 @@ interface IZoneInbox {
         bytes32 indexed depositHash,
         address indexed sender,
         address indexed to,
+        address token,
         uint128 amount,
         bytes32 memo
     );
 
     /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
+    // Revealed after decryption
     event EncryptedDepositProcessed(
         bytes32 indexed depositHash,
         address indexed sender,
-        address indexed to, // Revealed after decryption
+        address indexed to,
+        address token,
         uint128 amount,
-        bytes32 memo // Revealed after decryption
+        bytes32 memo
     );
 
     /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
     event EncryptedDepositFailed(
-        bytes32 indexed depositHash, address indexed sender, uint128 amount
+        bytes32 indexed depositHash, address indexed sender, address token, uint128 amount
     );
     event MaxDepositsPerTempoBlockUpdated(uint256 maxDepositsPerTempoBlock);
 
@@ -708,9 +778,6 @@ interface IZoneInbox {
 
     /// @notice The TempoState predeploy address
     function tempoState() external view returns (ITempoState);
-
-    /// @notice The zone token (TIP-20 at same address as Tempo)
-    function zoneToken() external view returns (IZoneToken);
 
     /// @notice The zone's last processed deposit queue hash
     function processedDepositQueueHash() external view returns (bytes32);
@@ -761,6 +828,7 @@ interface IZoneOutbox {
     event WithdrawalRequested(
         uint64 indexed withdrawalIndex,
         address indexed sender,
+        address token,
         address to,
         uint128 amount,
         uint128 fee,
@@ -780,9 +848,6 @@ interface IZoneOutbox {
 
     /// @notice Zone configuration (reads sequencer from L1)
     function config() external view returns (IZoneConfig);
-
-    /// @notice The zone token (same as Tempo portal's token)
-    function zoneToken() external view returns (IZoneToken);
 
     /// @notice Tempo gas rate (zone token units per gas unit on Tempo)
     /// @dev Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
@@ -817,8 +882,12 @@ interface IZoneOutbox {
     function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
 
     /// @notice Request a withdrawal from the zone back to Tempo
-    /// @dev Caller must approve outbox to spend amount + fee
+    /// @dev Caller must approve outbox to spend amount + fee of the specified token.
+    ///      The token must be enabled on the portal. Withdrawals can never be disabled
+    ///      for an enabled token (non-custodial guarantee).
+    /// @param token The TIP-20 token to withdraw
     function requestWithdrawal(
+        address token,
         address to,
         uint128 amount,
         bytes32 memo,
@@ -846,9 +915,6 @@ interface IZoneConfig {
     error NotSequencer();
     error NoEncryptionKeySet();
 
-    /// @notice Zone token address (TIP-20 at same address as Tempo)
-    function zoneToken() external view returns (address);
-
     /// @notice L1 ZonePortal address
     function tempoPortal() external view returns (address);
 
@@ -869,7 +935,7 @@ interface IZoneConfig {
     /// @notice Check if an address is the current sequencer
     function isSequencer(address account) external view returns (bool);
 
-    /// @notice Get zone token as IZoneToken interface
-    function getZoneToken() external view returns (IZoneToken);
+    /// @notice Check if a token is enabled by reading from L1 ZonePortal
+    function isEnabledToken(address token) external view returns (bool);
 
 }

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -454,6 +454,7 @@ interface IZonePortal {
     error InvalidProofOfPossession();
     error DepositTooSmall();
     error GasFeeRateTooHigh();
+    error InvalidToken();
     error TokenNotEnabled();
     error DepositsNotActive();
     error TokenAlreadyEnabled();

--- a/docs/specs/src/zone/SwapAndDepositRouter.sol
+++ b/docs/specs/src/zone/SwapAndDepositRouter.sol
@@ -7,7 +7,6 @@ import {
     EncryptedDepositPayload,
     IWithdrawalReceiver,
     IZoneFactory,
-    IZoneMessenger,
     IZonePortal
 } from "./IZone.sol";
 
@@ -52,6 +51,7 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     /// @dev Implements IWithdrawalReceiver. Only callable by registered zone messengers.
     ///      The messenger has already transferred tokens to this router.
     ///      On failure, the entire callback reverts, triggering bounce-back to source zone.
+    /// @param tokenIn The TIP-20 token received from the source zone withdrawal
     /// @param amount The amount of tokens transferred
     /// @param data ABI-encoded callbackData (see format below)
     /// @return selector The function selector to confirm successful handling
@@ -62,6 +62,7 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     /// Note: minAmountOut is ignored for same-token transfers (no swap)
     function onWithdrawalReceived(
         address, /* sender */
+        address tokenIn,
         uint128 amount,
         bytes calldata data
     )
@@ -71,8 +72,6 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
         if (!zoneFactory.isZoneMessenger(msg.sender)) {
             revert UnauthorizedMessenger();
         }
-
-        address tokenIn = IZoneMessenger(msg.sender).token();
 
         bool isEncrypted = abi.decode(data, (bool));
 
@@ -92,7 +91,7 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
             uint128 amountOut = _swapIfNeeded(tokenIn, tokenOut, amount, minAmountOut);
 
             IERC20(tokenOut).approve(targetPortal, amountOut);
-            IZonePortal(targetPortal).depositEncrypted(amountOut, keyIndex, encrypted);
+            IZonePortal(targetPortal).depositEncrypted(tokenOut, amountOut, keyIndex, encrypted);
         } else {
             (, // skip isEncrypted
                 address tokenOut,
@@ -107,7 +106,7 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
             uint128 amountOut = _swapIfNeeded(tokenIn, tokenOut, amount, minAmountOut);
 
             IERC20(tokenOut).approve(targetPortal, amountOut);
-            IZonePortal(targetPortal).deposit(recipient, amountOut, memo);
+            IZonePortal(targetPortal).deposit(tokenOut, recipient, amountOut, memo);
         }
 
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
@@ -117,11 +116,12 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
                            INTERNAL HELPERS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Validate the target portal is registered and the token is enabled on it
     function _validateTarget(address targetPortal, address tokenOut) internal view {
         if (!zoneFactory.isZonePortal(targetPortal)) {
             revert InvalidTargetPortal();
         }
-        if (IZonePortal(targetPortal).token() != tokenOut) {
+        if (!IZonePortal(targetPortal).isTokenEnabled(tokenOut)) {
             revert InvalidToken();
         }
     }

--- a/docs/specs/src/zone/ZoneConfig.sol
+++ b/docs/specs/src/zone/ZoneConfig.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.13;
 import {
     ITempoState,
     IZoneConfig,
-    IZoneToken,
     PORTAL_ENCRYPTION_KEYS_SLOT,
     PORTAL_PENDING_SEQUENCER_SLOT,
-    PORTAL_SEQUENCER_SLOT
+    PORTAL_SEQUENCER_SLOT,
+    PORTAL_TOKEN_CONFIGS_SLOT
 } from "./IZone.sol";
 
 /// @title ZoneConfig
@@ -20,9 +20,6 @@ contract ZoneConfig is IZoneConfig {
     /*//////////////////////////////////////////////////////////////
                                IMMUTABLES
     //////////////////////////////////////////////////////////////*/
-
-    /// @notice Zone token address (TIP-20 at same address as Tempo)
-    address public immutable zoneToken;
 
     /// @notice L1 ZonePortal address
     address public immutable tempoPortal;
@@ -38,8 +35,7 @@ contract ZoneConfig is IZoneConfig {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address _zoneToken, address _tempoPortal, address _tempoState) {
-        zoneToken = _zoneToken;
+    constructor(address _tempoPortal, address _tempoState) {
         tempoPortal = _tempoPortal;
         tempoState = ITempoState(_tempoState);
     }
@@ -118,10 +114,19 @@ contract ZoneConfig is IZoneConfig {
         return account == this.sequencer();
     }
 
-    /// @notice Get zone token as IZoneToken interface
-    /// @return Zone token interface
-    function getZoneToken() external view returns (IZoneToken) {
-        return IZoneToken(zoneToken);
+    /*//////////////////////////////////////////////////////////////
+                         TOKEN REGISTRY ACCESS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Check if a token is enabled by reading from L1 ZonePortal
+    /// @dev Reads the TokenConfig.enabled field from the portal's _tokenConfigs mapping.
+    ///      Mapping storage slot: keccak256(abi.encode(token, PORTAL_TOKEN_CONFIGS_SLOT))
+    ///      TokenConfig is packed: enabled (bool, byte 0) and depositsActive (bool, byte 1)
+    function isEnabledToken(address token) external view returns (bool) {
+        bytes32 configSlot = keccak256(abi.encode(token, PORTAL_TOKEN_CONFIGS_SLOT));
+        bytes32 value = tempoState.readTempoStorageSlot(tempoPortal, configSlot);
+        // TokenConfig.enabled is the first bool in the struct (lowest byte)
+        return uint8(uint256(value) & 0xff) != 0;
     }
 
 }

--- a/docs/specs/src/zone/ZoneFactory.sol
+++ b/docs/specs/src/zone/ZoneFactory.sol
@@ -48,8 +48,8 @@ contract ZoneFactory is IZoneFactory {
         external
         returns (uint64 zoneId, address portal)
     {
-        // Validate token is a TIP-20
-        if (!TempoUtilities.isTIP20(params.token)) revert InvalidToken();
+        // Validate initial token is a TIP-20
+        if (!TempoUtilities.isTIP20(params.initialToken)) revert InvalidToken();
         if (params.sequencer == address(0)) revert InvalidSequencer();
         if (!_validVerifiers[params.verifier]) revert InvalidVerifier();
 
@@ -71,14 +71,15 @@ contract ZoneFactory is IZoneFactory {
         // Compute portal's address (will be deployed at nonce+1)
         address predictedPortal = _computeCreateAddress(address(this), currentNonce + 1);
 
-        // Deploy messenger with predicted portal address
-        ZoneMessenger messengerContract = new ZoneMessenger(predictedPortal, params.token);
+        // Deploy messenger with predicted portal address (no token needed -- portal grants approval per-token)
+        ZoneMessenger messengerContract = new ZoneMessenger(predictedPortal);
         address messengerAddress = address(messengerContract);
 
-        // Deploy portal with messenger address
+        // Deploy portal with messenger address and initial token
+        // The portal constructor enables the initial token automatically
         ZonePortal portalContract = new ZonePortal(
             zoneId,
-            params.token,
+            params.initialToken,
             messengerAddress,
             params.sequencer,
             params.verifier,
@@ -95,7 +96,7 @@ contract ZoneFactory is IZoneFactory {
             zoneId: zoneId,
             portal: portal,
             messenger: messengerAddress,
-            token: params.token,
+            initialToken: params.initialToken,
             sequencer: params.sequencer,
             verifier: params.verifier,
             genesisBlockHash: params.zoneParams.genesisBlockHash,
@@ -110,7 +111,7 @@ contract ZoneFactory is IZoneFactory {
             zoneId,
             portal,
             messengerAddress,
-            params.token,
+            params.initialToken,
             params.sequencer,
             params.verifier,
             params.zoneParams.genesisBlockHash,

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -40,9 +40,6 @@ contract ZoneInbox is IZoneInbox {
     /// @notice The TempoState predeploy address (stored as concrete type for internal use)
     TempoState internal immutable _tempoState;
 
-    /// @notice The zone token (TIP-20 at same address as Tempo)
-    IZoneToken public immutable zoneToken;
-
     /// @notice Last processed deposit queue hash (validated against Tempo state)
     bytes32 public processedDepositQueueHash;
 
@@ -54,16 +51,10 @@ contract ZoneInbox is IZoneInbox {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(
-        address _config,
-        address _tempoPortalAddr,
-        address _tempoStateAddr,
-        address _zoneToken
-    ) {
+    constructor(address _config, address _tempoPortalAddr, address _tempoStateAddr) {
         config = IZoneConfig(_config);
         tempoPortal = _tempoPortalAddr;
         _tempoState = TempoState(_tempoStateAddr);
-        zoneToken = IZoneToken(_zoneToken);
     }
 
     /// @notice The TempoState predeploy address
@@ -228,10 +219,10 @@ contract ZoneInbox is IZoneInbox {
                 // Advance the hash chain with type discriminator
                 currentHash = keccak256(abi.encode(DepositType.Regular, d, currentHash));
 
-                // Mint zone tokens to the recipient
-                zoneToken.mint(d.to, d.amount);
+                // Mint the correct zone-side TIP-20 token to the recipient
+                IZoneToken(d.token).mint(d.to, d.amount);
 
-                emit DepositProcessed(currentHash, d.sender, d.to, d.amount, d.memo);
+                emit DepositProcessed(currentHash, d.sender, d.to, d.token, d.amount, d.memo);
             } else {
                 // Decode encrypted deposit
                 EncryptedDeposit memory ed = abi.decode(qd.depositData, (EncryptedDeposit));
@@ -295,13 +286,13 @@ contract ZoneInbox is IZoneInbox {
                 if (!valid) {
                     // Decryption failed (user encrypted garbage or corrupted data)
                     // Return funds to sender instead of blocking chain progress
-                    zoneToken.mint(ed.sender, ed.amount);
-                    emit EncryptedDepositFailed(currentHash, ed.sender, ed.amount);
+                    IZoneToken(ed.token).mint(ed.sender, ed.amount);
+                    emit EncryptedDepositFailed(currentHash, ed.sender, ed.token, ed.amount);
                 } else {
-                    // Decryption succeeded - mint to the decrypted recipient
-                    zoneToken.mint(dec.to, ed.amount);
+                    // Decryption succeeded - mint the correct zone-side TIP-20 to the decrypted recipient
+                    IZoneToken(ed.token).mint(dec.to, ed.amount);
                     emit EncryptedDepositProcessed(
-                        currentHash, ed.sender, dec.to, ed.amount, dec.memo
+                        currentHash, ed.sender, dec.to, ed.token, ed.amount, dec.memo
                     );
                 }
             }

--- a/docs/specs/src/zone/ZoneMessenger.sol
+++ b/docs/specs/src/zone/ZoneMessenger.sol
@@ -7,7 +7,7 @@ import { IWithdrawalReceiver, IZoneMessenger } from "./IZone.sol";
 /// @title ZoneMessenger
 /// @notice Per-zone messenger that handles withdrawal callbacks
 /// @dev Deployed by ZoneFactory for each zone. The portal gives the messenger max approval
-///      for the zone token. Withdrawal callbacks originate from this contract, not the portal.
+///      for each enabled token. Withdrawal callbacks originate from this contract, not the portal.
 contract ZoneMessenger is IZoneMessenger {
 
     /*//////////////////////////////////////////////////////////////
@@ -16,9 +16,6 @@ contract ZoneMessenger is IZoneMessenger {
 
     /// @notice The zone's portal address
     address public immutable portal;
-
-    /// @notice The zone token address
-    address public immutable token;
 
     /*//////////////////////////////////////////////////////////////
                                 ERRORS
@@ -32,9 +29,8 @@ contract ZoneMessenger is IZoneMessenger {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address _portal, address _token) {
+    constructor(address _portal) {
         portal = _portal;
-        token = _token;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -54,12 +50,14 @@ contract ZoneMessenger is IZoneMessenger {
     /// @dev Transfers tokens from portal to target via transferFrom, then executes callback.
     ///      If callback reverts, returns false (does not revert). The transfer is atomic
     ///      with the callback via a self-call pattern.
+    /// @param _token The TIP-20 token to transfer
     /// @param sender The L2 origin address
     /// @param target The Tempo recipient
     /// @param amount Tokens to transfer from portal to target
     /// @param gasLimit Max gas for the callback
     /// @param data Calldata for the target
     function relayMessage(
+        address _token,
         address sender,
         address target,
         uint128 amount,
@@ -70,12 +68,13 @@ contract ZoneMessenger is IZoneMessenger {
         onlyPortal
     {
         // Atomic transfer + callback via self-call
-        this._executeRelay(sender, target, amount, gasLimit, data);
+        this._executeRelay(_token, sender, target, amount, gasLimit, data);
     }
 
     /// @notice Internal function for atomic transfer + callback (called via self-call)
     /// @dev This function reverts if either the transfer or callback fails
     function _executeRelay(
+        address _token,
         address sender,
         address target,
         uint128 amount,
@@ -88,13 +87,14 @@ contract ZoneMessenger is IZoneMessenger {
         if (msg.sender != address(this)) revert OnlyPortal();
 
         // Transfer tokens from portal to target
-        if (!ITIP20(token).transferFrom(portal, target, amount)) {
+        if (!ITIP20(_token).transferFrom(portal, target, amount)) {
             revert TransferFailed();
         }
 
-        // Call the receiver
-        bytes4 selector =
-            IWithdrawalReceiver(target).onWithdrawalReceived{ gas: gasLimit }(sender, amount, data);
+        // Call the receiver (includes token address for multi-asset awareness)
+        bytes4 selector = IWithdrawalReceiver(target).onWithdrawalReceived{ gas: gasLimit }(
+            sender, _token, amount, data
+        );
 
         // Verify the callback returned the correct selector
         if (selector != IWithdrawalReceiver.onWithdrawalReceived.selector) {

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { IZoneConfig, IZoneOutbox, IZoneToken, LastBatch, Withdrawal } from "./IZone.sol";
+
 import { EMPTY_SENTINEL } from "./WithdrawalQueueLib.sol";
 
 /// @title ZoneOutbox
@@ -33,9 +34,6 @@ contract ZoneOutbox is IZoneOutbox {
 
     /// @notice Zone configuration (reads sequencer from L1)
     IZoneConfig public immutable config;
-
-    /// @notice The zone token (TIP-20 at same address as Tempo)
-    IZoneToken public immutable zoneToken;
 
     /// @notice Tempo gas rate (zone token units per gas unit on Tempo)
     /// @dev Sequencer publishes this rate and takes the risk on Tempo gas price changes.
@@ -84,9 +82,8 @@ contract ZoneOutbox is IZoneOutbox {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address _config, address _zoneToken) {
+    constructor(address _config) {
         config = IZoneConfig(_config);
-        zoneToken = IZoneToken(_zoneToken);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -127,9 +124,12 @@ contract ZoneOutbox is IZoneOutbox {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Request a withdrawal from the zone back to Tempo
-    /// @dev Caller must have approved the outbox to spend `amount + fee` of zone tokens.
+    /// @dev Caller must have approved the outbox to spend `amount + fee` of the specified token.
     ///      The outbox burns the tokens and stores the withdrawal. The sequencer
     ///      calls finalizeWithdrawalBatch() to construct the withdrawal queue hash.
+    ///      The token must be enabled on the portal. Withdrawals can never be disabled
+    ///      for an enabled token (non-custodial guarantee).
+    /// @param token The TIP-20 token to withdraw
     /// @param to The Tempo recipient address
     /// @param amount Amount to send to recipient (fee is additional)
     /// @param memo User-provided context (e.g., payment reference)
@@ -137,6 +137,7 @@ contract ZoneOutbox is IZoneOutbox {
     /// @param fallbackRecipient Zone address for bounce-back if callback fails
     /// @param data Calldata for IWithdrawalReceiver callback
     function requestWithdrawal(
+        address token,
         address to,
         uint128 amount,
         bytes32 memo,
@@ -169,11 +170,13 @@ contract ZoneOutbox is IZoneOutbox {
         }
 
         // Calculate processing fee (locked in at request time)
+        // Fee is paid in the same token being withdrawn
         uint128 fee = calculateWithdrawalFee(gasLimit);
         uint128 totalBurn = amount + fee;
 
         // Transfer tokens from sender to this contract, then burn
         // (Using transferFrom so user must approve first)
+        IZoneToken zoneToken = IZoneToken(token);
         if (!zoneToken.transferFrom(msg.sender, address(this), totalBurn)) {
             revert TransferFailed();
         }
@@ -185,6 +188,7 @@ contract ZoneOutbox is IZoneOutbox {
         // Store withdrawal in pending array
         _pendingWithdrawals.push(
             Withdrawal({
+                token: token,
                 sender: msg.sender,
                 to: to,
                 amount: amount,
@@ -200,7 +204,7 @@ contract ZoneOutbox is IZoneOutbox {
         uint64 index = nextWithdrawalIndex++;
 
         emit WithdrawalRequested(
-            index, msg.sender, to, amount, fee, memo, gasLimit, fallbackRecipient, data
+            index, msg.sender, token, to, amount, fee, memo, gasLimit, fallbackRecipient, data
         );
     }
 

--- a/docs/specs/src/zone/ZoneOutbox.sol
+++ b/docs/specs/src/zone/ZoneOutbox.sol
@@ -77,6 +77,7 @@ contract ZoneOutbox is IZoneOutbox {
     error TransferFailed();
     error OnlySequencer();
     error TooManyWithdrawalsThisBlock();
+    error TokenNotEnabled();
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
@@ -147,6 +148,9 @@ contract ZoneOutbox is IZoneOutbox {
     )
         external
     {
+        // Validate token is enabled (withdrawals can never be disabled for enabled tokens)
+        if (!config.isEnabledToken(token)) revert TokenNotEnabled();
+
         // Always require a valid fallback recipient
         if (fallbackRecipient == address(0)) {
             revert InvalidFallbackRecipient();

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import { ITIP20 } from "../interfaces/ITIP20.sol";
 
+import { TempoUtilities } from "../TempoUtilities.sol";
 import { BLOCKHASH_HISTORY, IBlockHashHistory } from "./BlockHashHistory.sol";
 import { DepositQueueLib } from "./DepositQueueLib.sol";
 import { ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE } from "./EncryptedDeposit.sol";
@@ -19,6 +20,7 @@ import {
     IZoneMessenger,
     IZonePortal,
     QueuedDeposit,
+    TokenConfig,
     Withdrawal
 } from "./IZone.sol";
 import { WithdrawalQueue, WithdrawalQueueLib } from "./WithdrawalQueueLib.sol";
@@ -47,7 +49,6 @@ contract ZonePortal is IZonePortal {
     //////////////////////////////////////////////////////////////*/
 
     uint64 public immutable zoneId;
-    address public immutable token;
     address public immutable messenger;
     address public immutable verifier;
     uint64 public immutable genesisTempoBlockNumber;
@@ -76,6 +77,14 @@ contract ZonePortal is IZonePortal {
     ///      Stored at slot 6 in the ZonePortal storage layout.
     EncryptionKeyEntry[] internal _encryptionKeys;
 
+    /// @notice Per-token configuration (stored at slot 7)
+    /// @dev TokenConfig.enabled is permanent (write-once true); depositsActive can be toggled.
+    mapping(address => TokenConfig) internal _tokenConfigs;
+
+    /// @notice Append-only list of enabled tokens (stored at slot 8)
+    /// @dev Tokens can never be removed from this list (non-custodial guarantee).
+    address[] internal _enabledTokens;
+
     /// @notice Withdrawal queue (zone→Tempo): fixed-size ring buffer
     WithdrawalQueue internal _withdrawalQueue;
 
@@ -85,7 +94,7 @@ contract ZonePortal is IZonePortal {
 
     constructor(
         uint64 _zoneId,
-        address _token,
+        address _initialToken,
         address _messenger,
         address _sequencer,
         address _verifier,
@@ -93,15 +102,14 @@ contract ZonePortal is IZonePortal {
         uint64 _genesisTempoBlockNumber
     ) {
         zoneId = _zoneId;
-        token = _token;
         messenger = _messenger;
         sequencer = _sequencer;
         verifier = _verifier;
         blockHash = _genesisBlockHash;
         genesisTempoBlockNumber = _genesisTempoBlockNumber;
 
-        // Give messenger max approval for the zone token
-        ITIP20(_token).approve(_messenger, type(uint256).max);
+        // Enable the initial token
+        _enableTokenInternal(_initialToken);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -158,6 +166,71 @@ contract ZonePortal is IZonePortal {
 
     function withdrawalQueueSlot(uint256 slot) external view returns (bytes32) {
         return _withdrawalQueue.slots[slot];
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          TOKEN REGISTRY
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Check if a token is enabled for bridging
+    function isTokenEnabled(address _token) external view returns (bool) {
+        return _tokenConfigs[_token].enabled;
+    }
+
+    /// @notice Check if deposits are currently active for a token
+    function areDepositsActive(address _token) external view returns (bool) {
+        TokenConfig storage cfg = _tokenConfigs[_token];
+        return cfg.enabled && cfg.depositsActive;
+    }
+
+    /// @notice Get the token configuration for a specific token
+    function tokenConfig(address _token) external view returns (TokenConfig memory) {
+        return _tokenConfigs[_token];
+    }
+
+    /// @notice Get the number of enabled tokens
+    function enabledTokenCount() external view returns (uint256) {
+        return _enabledTokens.length;
+    }
+
+    /// @notice Get an enabled token by index
+    function enabledTokenAt(uint256 index) external view returns (address) {
+        return _enabledTokens[index];
+    }
+
+    /// @notice Enable a new TIP-20 token for bridging. Only callable by sequencer.
+    /// @dev Irreversible: once enabled, a token cannot be disabled (non-custodial guarantee).
+    ///      Validates the token is a TIP-20 and grants messenger max approval.
+    function enableToken(address _token) external onlySequencer {
+        if (_tokenConfigs[_token].enabled) revert TokenAlreadyEnabled();
+        if (!TempoUtilities.isTIP20(_token)) revert TokenNotEnabled();
+        _enableTokenInternal(_token);
+    }
+
+    /// @notice Pause deposits for a token. Only callable by sequencer.
+    /// @dev Does not affect withdrawal processing (non-custodial guarantee).
+    function pauseDeposits(address _token) external onlySequencer {
+        if (!_tokenConfigs[_token].enabled) revert TokenNotEnabled();
+        _tokenConfigs[_token].depositsActive = false;
+        emit DepositsPaused(_token);
+    }
+
+    /// @notice Resume deposits for a token. Only callable by sequencer.
+    function resumeDeposits(address _token) external onlySequencer {
+        if (!_tokenConfigs[_token].enabled) revert TokenNotEnabled();
+        _tokenConfigs[_token].depositsActive = true;
+        emit DepositsResumed(_token);
+    }
+
+    /// @notice Internal function to enable a token (used by constructor and enableToken)
+    function _enableTokenInternal(address _token) internal {
+        _tokenConfigs[_token] = TokenConfig({ enabled: true, depositsActive: true });
+        _enabledTokens.push(_token);
+
+        // Give messenger max approval for this token
+        ITIP20(_token).approve(messenger, type(uint256).max);
+
+        emit TokenEnabled(_token);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -372,13 +445,16 @@ contract ZonePortal is IZonePortal {
         fee = uint128(FIXED_DEPOSIT_GAS) * zoneGasRate;
     }
 
-    /// @notice Deposit zone token into the zone. Returns the new current deposit queue hash.
-    /// @dev Fee is deducted from amount and paid to sequencer. Net amount is credited on zone.
+    /// @notice Deposit a TIP-20 token into the zone. Returns the new current deposit queue hash.
+    /// @dev Fee is deducted from amount and paid to sequencer in the same token.
+    ///      The token must be enabled and deposits must be active.
+    /// @param _token The TIP-20 token to deposit
     /// @param to Recipient address on the zone
     /// @param amount Total amount to deposit (fee will be deducted)
     /// @param memo User-provided context
     /// @return newCurrentDepositQueueHash The new deposit queue hash after this deposit
     function deposit(
+        address _token,
         address to,
         uint128 amount,
         bytes32 memo
@@ -386,6 +462,11 @@ contract ZonePortal is IZonePortal {
         external
         returns (bytes32 newCurrentDepositQueueHash)
     {
+        // Validate token is enabled and deposits are active
+        TokenConfig storage cfg = _tokenConfigs[_token];
+        if (!cfg.enabled) revert TokenNotEnabled();
+        if (!cfg.depositsActive) revert DepositsNotActive();
+
         // Calculate deposit fee
         uint128 fee = calculateDepositFee();
         if (amount <= fee) revert DepositTooSmall();
@@ -393,33 +474,36 @@ contract ZonePortal is IZonePortal {
 
         // Transfer full amount from sender to this contract
         // TIP-20 transfers revert on failure, so no boolean check is needed here.
-        ITIP20(token).transferFrom(msg.sender, address(this), amount);
+        ITIP20(_token).transferFrom(msg.sender, address(this), amount);
 
         // Transfer fee to sequencer
         if (fee > 0) {
-            ITIP20(token).transfer(sequencer, fee);
+            ITIP20(_token).transfer(sequencer, fee);
         }
 
         // Build deposit struct with net amount (fee already paid to sequencer on Tempo)
         Deposit memory depositData =
-            Deposit({ sender: msg.sender, to: to, amount: netAmount, memo: memo });
+            Deposit({ token: _token, sender: msg.sender, to: to, amount: netAmount, memo: memo });
 
         // Insert deposit into queue
         newCurrentDepositQueueHash = DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
-        emit DepositMade(newCurrentDepositQueueHash, msg.sender, to, netAmount, fee, memo);
+        emit DepositMade(newCurrentDepositQueueHash, msg.sender, _token, to, netAmount, fee, memo);
     }
 
     /// @notice Deposit with encrypted recipient and memo
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key.
+    ///      The token identity is public (not encrypted) since the portal must escrow it.
     ///      Validates that keyIndex is valid (exists and not expired).
     ///      Charges the same deposit fee as regular deposits.
+    /// @param _token The TIP-20 token to deposit
     /// @param amount Amount to deposit (fee deducted from this amount)
     /// @param keyIndex Index of the encryption key used (from encryptionKeyAt)
     /// @param encrypted The encrypted payload (recipient and memo)
     /// @return newCurrentDepositQueueHash The new deposit queue hash
     function depositEncrypted(
+        address _token,
         uint128 amount,
         uint256 keyIndex,
         EncryptedDepositPayload calldata encrypted
@@ -427,6 +511,11 @@ contract ZonePortal is IZonePortal {
         external
         returns (bytes32 newCurrentDepositQueueHash)
     {
+        // Validate token is enabled and deposits are active
+        TokenConfig storage cfg = _tokenConfigs[_token];
+        if (!cfg.enabled) revert TokenNotEnabled();
+        if (!cfg.depositsActive) revert DepositsNotActive();
+
         // Validate ephemeral public key is a valid secp256k1 point
         // Prevents griefing: invalid points make Chaum-Pedersen proofs impossible,
         // which would block chain progress on the zone side.
@@ -459,14 +548,18 @@ contract ZonePortal is IZonePortal {
         uint128 netAmount = amount - fee;
 
         // Transfer full amount from sender to this contract
-        ITIP20(token).transferFrom(msg.sender, address(this), amount);
+        ITIP20(_token).transferFrom(msg.sender, address(this), amount);
         if (fee > 0) {
-            ITIP20(token).transfer(sequencer, fee);
+            ITIP20(_token).transfer(sequencer, fee);
         }
 
         // Build encrypted deposit struct
         EncryptedDeposit memory depositData = EncryptedDeposit({
-            sender: msg.sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted
+            token: _token,
+            sender: msg.sender,
+            amount: netAmount,
+            keyIndex: keyIndex,
+            encrypted: encrypted
         });
 
         // Insert encrypted deposit into queue
@@ -477,6 +570,7 @@ contract ZonePortal is IZonePortal {
         emit EncryptedDepositMade(
             newCurrentDepositQueueHash,
             msg.sender,
+            _token,
             netAmount,
             fee,
             keyIndex,
@@ -495,6 +589,7 @@ contract ZonePortal is IZonePortal {
     /// @notice Process the next withdrawal from the queue. Only callable by the sequencer.
     /// @dev Fee is always paid to sequencer regardless of success/failure.
     ///      On failure, only the amount (not fee) is bounced back.
+    ///      The token to transfer is read from the withdrawal struct.
     function processWithdrawal(
         Withdrawal calldata withdrawal,
         bytes32 remainingQueue
@@ -505,59 +600,75 @@ contract ZonePortal is IZonePortal {
         // Pop from withdrawal queue (library handles swap and hash verification)
         _withdrawalQueue.dequeue(withdrawal, remainingQueue);
 
+        address _token = withdrawal.token;
+
         // Transfer fee to sequencer (always, regardless of withdrawal success)
         if (withdrawal.fee > 0) {
-            ITIP20(token).transfer(sequencer, withdrawal.fee);
+            ITIP20(_token).transfer(sequencer, withdrawal.fee);
         }
 
         // Execute the withdrawal
         if (withdrawal.gasLimit == 0) {
             // Simple transfer, no callback
             bool success;
-            try ITIP20(token).transfer(withdrawal.to, withdrawal.amount) returns (bool ok) {
+            try ITIP20(_token).transfer(withdrawal.to, withdrawal.amount) returns (bool ok) {
                 success = ok;
             } catch {
                 success = false;
             }
 
             if (!success) {
-                _enqueueBounceBack(withdrawal.amount, withdrawal.fallbackRecipient);
-                emit WithdrawalProcessed(withdrawal.to, withdrawal.amount, false);
+                _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
+                emit WithdrawalProcessed(withdrawal.to, _token, withdrawal.amount, false);
                 return;
             }
 
-            emit WithdrawalProcessed(withdrawal.to, withdrawal.amount, true);
+            emit WithdrawalProcessed(withdrawal.to, _token, withdrawal.amount, true);
             return;
         }
 
         // Try callback via messenger; revert is treated as failure
         try IZoneMessenger(messenger)
             .relayMessage(
+                _token,
                 withdrawal.sender,
                 withdrawal.to,
                 withdrawal.amount,
                 withdrawal.gasLimit,
                 withdrawal.callbackData
             ) {
-            emit WithdrawalProcessed(withdrawal.to, withdrawal.amount, true);
+            emit WithdrawalProcessed(withdrawal.to, _token, withdrawal.amount, true);
         } catch {
             // Callback failed: bounce back to zone (only amount, not fee)
-            _enqueueBounceBack(withdrawal.amount, withdrawal.fallbackRecipient);
-            emit WithdrawalProcessed(withdrawal.to, withdrawal.amount, false);
+            _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
+            emit WithdrawalProcessed(withdrawal.to, _token, withdrawal.amount, false);
         }
     }
 
     /// @notice Enqueue a bounce-back deposit for failed callback
-    function _enqueueBounceBack(uint128 amount, address fallbackRecipient) internal {
+    /// @param _token The token from the failed withdrawal
+    /// @param amount The amount to bounce back
+    /// @param fallbackRecipient The zone address to receive the bounce-back
+    function _enqueueBounceBack(
+        address _token,
+        uint128 amount,
+        address fallbackRecipient
+    )
+        internal
+    {
         Deposit memory depositData = Deposit({
-            sender: address(this), to: fallbackRecipient, amount: amount, memo: bytes32(0)
+            token: _token,
+            sender: address(this),
+            to: fallbackRecipient,
+            amount: amount,
+            memo: bytes32(0)
         });
 
         bytes32 newCurrentDepositQueueHash =
             DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
         currentDepositQueueHash = newCurrentDepositQueueHash;
 
-        emit BounceBack(newCurrentDepositQueueHash, fallbackRecipient, amount);
+        emit BounceBack(newCurrentDepositQueueHash, fallbackRecipient, _token, amount);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -203,7 +203,7 @@ contract ZonePortal is IZonePortal {
     ///      Validates the token is a TIP-20 and grants messenger max approval.
     function enableToken(address _token) external onlySequencer {
         if (_tokenConfigs[_token].enabled) revert TokenAlreadyEnabled();
-        if (!TempoUtilities.isTIP20(_token)) revert TokenNotEnabled();
+        if (!TempoUtilities.isTIP20(_token)) revert InvalidToken();
         _enableTokenInternal(_token);
     }
 

--- a/docs/specs/test/AccountKeychain.t.sol
+++ b/docs/specs/test/AccountKeychain.t.sol
@@ -36,7 +36,7 @@ contract AccountKeychainTest is BaseTest {
         limits[0] = IAccountKeychain.TokenLimit({
             token: USDC,
             amount: 1000e6 // 1000 USDC
-        });
+         });
 
         keychain.authorizeKey(
             aliceAccessKey,
@@ -66,11 +66,11 @@ contract AccountKeychainTest is BaseTest {
         limits[0] = IAccountKeychain.TokenLimit({
             token: USDC,
             amount: 1000e6 // 1000 USDC
-        });
+         });
         limits[1] = IAccountKeychain.TokenLimit({
             token: USDT,
             amount: 500e6 // 500 USDT
-        });
+         });
 
         keychain.authorizeKey(
             aliceAccessKey,

--- a/docs/specs/test/BaseTest.t.sol
+++ b/docs/specs/test/BaseTest.t.sol
@@ -63,8 +63,7 @@ contract BaseTest is Test {
     function setUp() public virtual {
         // Is this tempo chain?
         isTempo = _TIP403REGISTRY.code.length + _TIP20FACTORY.code.length + _PATH_USD.code.length
-                + _STABLECOIN_DEX.code.length + _NONCE.code.length + _ACCOUNT_KEYCHAIN.code.length
-            > 0;
+            + _STABLECOIN_DEX.code.length + _NONCE.code.length + _ACCOUNT_KEYCHAIN.code.length > 0;
 
         console.log("Tests running with isTempo =", isTempo);
 

--- a/docs/specs/test/Nonce.t.sol
+++ b/docs/specs/test/Nonce.t.sol
@@ -117,9 +117,8 @@ contract NonceTest is BaseTest {
         // We use a direct require in the helper, so we test with try-catch
         bool reverted = false;
         try this.externalIncrementNonceViaStorage(testAlice, 0) {
-        // Should not reach here
-        }
-        catch {
+            // Should not reach here
+        } catch {
             reverted = true;
         }
         assertTrue(reverted, "Should revert when trying to increment protocol key 0");

--- a/docs/specs/test/StablecoinDEX.t.sol
+++ b/docs/specs/test/StablecoinDEX.t.sol
@@ -675,9 +675,8 @@ contract StablecoinDEXTest is BaseTest {
         } else {
             // May fail due to insufficient balance/allowance - that's OK
             try exchange.place(address(token1), amount, true, tick) {
-            // Success is fine
-            }
-                catch {
+                // Success is fine
+            } catch {
                 // Failure due to balance/allowance is also OK for fuzz test
             }
         }
@@ -732,9 +731,8 @@ contract StablecoinDEXTest is BaseTest {
         } else {
             // May fail due to insufficient balance/allowance - that's OK
             try exchange.placeFlip(address(token1), amount, isBid, tick, flipTick) {
-            // Success is fine
-            }
-                catch {
+                // Success is fine
+            } catch {
                 // Failure due to balance/allowance is also OK for fuzz test
             }
         }
@@ -1920,9 +1918,8 @@ contract StablecoinDEXTest is BaseTest {
                 thisAmount += remainder; // last split gets the remainder
             }
             if (thisAmount > 0) {
-                totalSplitQuote += exchange.quoteSwapExactAmountOut(
-                    address(pathUSD), address(token1), thisAmount
-                );
+                totalSplitQuote +=
+                    exchange.quoteSwapExactAmountOut(address(pathUSD), address(token1), thisAmount);
             }
         }
 

--- a/docs/specs/test/TIP20.t.sol
+++ b/docs/specs/test/TIP20.t.sol
@@ -483,9 +483,8 @@ contract TIP20Test is BaseTest {
         // Create a policy that blocks alice
         address[] memory accounts = new address[](1);
         accounts[0] = alice;
-        uint64 blockingPolicy = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.BLACKLIST, accounts
-        );
+        uint64 blockingPolicy =
+            registry.createPolicyWithAccounts(admin, ITIP403Registry.PolicyType.BLACKLIST, accounts);
 
         vm.prank(admin);
         token.changeTransferPolicyId(blockingPolicy);
@@ -854,9 +853,8 @@ contract TIP20Test is BaseTest {
         // Create a policy that blocks alice
         address[] memory accounts = new address[](1);
         accounts[0] = alice;
-        uint64 blockingPolicy = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.BLACKLIST, accounts
-        );
+        uint64 blockingPolicy =
+            registry.createPolicyWithAccounts(admin, ITIP403Registry.PolicyType.BLACKLIST, accounts);
 
         // Change to a policy where alice is blocked
         vm.startPrank(admin);
@@ -880,9 +878,8 @@ contract TIP20Test is BaseTest {
         // Create a policy that blocks alice
         address[] memory accounts = new address[](1);
         accounts[0] = alice;
-        uint64 blockingPolicy = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.BLACKLIST, accounts
-        );
+        uint64 blockingPolicy =
+            registry.createPolicyWithAccounts(admin, ITIP403Registry.PolicyType.BLACKLIST, accounts);
 
         vm.prank(admin);
         token.changeTransferPolicyId(blockingPolicy);
@@ -1054,9 +1051,8 @@ contract TIP20Test is BaseTest {
     }
 
     function testCompleteQuoteTokenUpdateCannotCreateIndirectLoop() public {
-        TIP20 newToken = TIP20(
-            factory.createToken("New Token", "NEW", "USD", token, admin, bytes32("newtoken"))
-        );
+        TIP20 newToken =
+            TIP20(factory.createToken("New Token", "NEW", "USD", token, admin, bytes32("newtoken")));
 
         // Try to set token's quote token to newToken (which would create a loop)
         vm.startPrank(admin);
@@ -2270,9 +2266,8 @@ contract TIP20Test is BaseTest {
     function test_ClaimRewards_RevertsIf_UserUnauthorized() public {
         address[] memory accounts = new address[](1);
         accounts[0] = alice;
-        uint64 blacklistPolicy = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.BLACKLIST, accounts
-        );
+        uint64 blacklistPolicy =
+            registry.createPolicyWithAccounts(admin, ITIP403Registry.PolicyType.BLACKLIST, accounts);
 
         vm.prank(admin);
         token.changeTransferPolicyId(blacklistPolicy);

--- a/docs/specs/test/TIP20Factory.t.sol
+++ b/docs/specs/test/TIP20Factory.t.sol
@@ -180,11 +180,8 @@ contract TIP20FactoryTest is BaseTest {
         vm.assume(!factory.isTIP20(invalidQuote));
 
         // Try-catch is better for precompiles than expectRevert
-        try factory.createToken(
-            "Token", "TK", "USD", ITIP20(invalidQuote), admin, bytes32("fuzz")
-        ) returns (
-            address
-        ) {
+        try factory.createToken("Token", "TK", "USD", ITIP20(invalidQuote), admin, bytes32("fuzz"))
+        returns (address) {
             revert CallShouldHaveReverted();
         } catch (bytes memory reason) {
             // Verify it's the correct error

--- a/docs/specs/test/TIP403Registry.t.sol
+++ b/docs/specs/test/TIP403Registry.t.sol
@@ -49,7 +49,7 @@ contract TIP403RegistryTest is BaseTest {
         assertTrue(registry.isAuthorized(newPolicyId, alice));
         assertTrue(registry.isAuthorized(newPolicyId, bob));
         assertFalse(registry.isAuthorized(newPolicyId, charlie)); // Not in
-        // initial set
+            // initial set
     }
 
     function test_CreatePolicy_WithInitialAccounts_Blacklist() public {
@@ -68,7 +68,7 @@ contract TIP403RegistryTest is BaseTest {
         assertFalse(registry.isAuthorized(newPolicyId, alice));
         assertFalse(registry.isAuthorized(newPolicyId, bob));
         assertTrue(registry.isAuthorized(newPolicyId, charlie)); // Not in
-        // initial set
+            // initial set
     }
 
     function test_CreatePolicy_WithAdmin() public {
@@ -698,9 +698,8 @@ contract TIP403RegistryTest is BaseTest {
         address[] memory accounts = new address[](1);
         accounts[0] = alice;
 
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.WHITELIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.WHITELIST, accounts);
 
         // Alice is the admin, so she should be able to modify it
         vm.prank(alice);
@@ -746,9 +745,8 @@ contract TIP403RegistryTest is BaseTest {
         // Create a whitelist policy with alice as admin
         address[] memory accounts = new address[](1);
         accounts[0] = bob;
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.WHITELIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.WHITELIST, accounts);
 
         // Alice should be able to modify the policy (she is the admin)
         vm.prank(alice);
@@ -762,9 +760,8 @@ contract TIP403RegistryTest is BaseTest {
         // Create a blacklist policy with alice as admin
         address[] memory accounts = new address[](1);
         accounts[0] = bob;
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.BLACKLIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.BLACKLIST, accounts);
 
         // Alice should be able to modify the policy (she is the admin)
         vm.prank(alice);
@@ -851,9 +848,8 @@ contract TIP403RegistryTest is BaseTest {
         // Create a policy with alice as admin
         address[] memory accounts = new address[](1);
         accounts[0] = david;
-        uint64 policyId = registry.createPolicyWithAccounts(
-            alice, ITIP403Registry.PolicyType.WHITELIST, accounts
-        );
+        uint64 policyId =
+            registry.createPolicyWithAccounts(alice, ITIP403Registry.PolicyType.WHITELIST, accounts);
 
         // Alice transfers admin to bob
         vm.prank(alice);

--- a/docs/specs/test/ValidatorConfig.t.sol
+++ b/docs/specs/test/ValidatorConfig.t.sol
@@ -106,9 +106,8 @@ contract ValidatorConfigTest is BaseTest {
 
     function test_AddValidator_Unauthorized() public {
         vm.prank(nonOwner);
-        try validatorConfig.addValidator(
-            validator1, publicKey1, true, inboundAddr1, outboundAddr1
-        ) {
+        try validatorConfig.addValidator(validator1, publicKey1, true, inboundAddr1, outboundAddr1)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.Unauthorized.selector));
@@ -118,9 +117,8 @@ contract ValidatorConfigTest is BaseTest {
     function test_AddValidator_DuplicateValidator() public {
         validatorConfig.addValidator(validator1, publicKey1, true, inboundAddr1, outboundAddr1);
 
-        try validatorConfig.addValidator(
-            validator1, publicKey2, true, inboundAddr2, outboundAddr2
-        ) {
+        try validatorConfig.addValidator(validator1, publicKey2, true, inboundAddr2, outboundAddr2)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.ValidatorAlreadyExists.selector));
@@ -241,9 +239,8 @@ contract ValidatorConfigTest is BaseTest {
         // Validator tries to update with zero public key
         bytes32 zeroPublicKey = bytes32(0);
         vm.prank(validator1);
-        try validatorConfig.updateValidator(
-            validator1, zeroPublicKey, inboundAddr2, outboundAddr2
-        ) {
+        try validatorConfig.updateValidator(validator1, zeroPublicKey, inboundAddr2, outboundAddr2)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.InvalidPublicKey.selector));
@@ -356,9 +353,8 @@ contract ValidatorConfigTest is BaseTest {
         vm.assume(caller != admin);
 
         vm.prank(caller);
-        try validatorConfig.addValidator(
-            validator1, publicKey1, true, inboundAddr1, outboundAddr1
-        ) {
+        try validatorConfig.addValidator(validator1, publicKey1, true, inboundAddr1, outboundAddr1)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.Unauthorized.selector));
@@ -482,9 +478,8 @@ contract ValidatorConfigTest is BaseTest {
         validatorConfig.addValidator(validator2, publicKey2, true, inboundAddr2, outboundAddr2);
 
         // Original owner cannot add validators
-        try validatorConfig.addValidator(
-            validator3, publicKey3, true, inboundAddr3, outboundAddr3
-        ) {
+        try validatorConfig.addValidator(validator3, publicKey3, true, inboundAddr3, outboundAddr3)
+        {
             revert CallShouldHaveReverted();
         } catch (bytes memory err) {
             assertEq(err, abi.encodeWithSelector(IValidatorConfig.Unauthorized.selector));

--- a/docs/specs/test/invariants/FeeAMM.t.sol
+++ b/docs/specs/test/invariants/FeeAMM.t.sol
@@ -597,9 +597,8 @@ contract FeeAMMInvariantTest is BaseTest {
         vm.startPrank(actor);
         try amm.mint(userToken, validatorToken, amount, actor) returns (uint256 liquidity) {
             if (liquidity > 0) {
-                try amm.burn(userToken, validatorToken, liquidity, actor) returns (
-                    uint256, uint256
-                ) {
+                try amm.burn(userToken, validatorToken, liquidity, actor) returns (uint256, uint256)
+                {
                     _totalMintBurnCycles++;
 
                     uint256 actorBalAfter = TIP20(validatorToken).balanceOf(actor);
@@ -1948,8 +1947,7 @@ contract FeeAMMInvariantTest is BaseTest {
             || selector == IFeeAMM.InvalidToken.selector
             || selector == IFeeAMM.InsufficientLiquidity.selector
             || selector == IFeeAMM.InsufficientReserves.selector
-            || selector == IFeeAMM.InvalidAmount.selector
-            || selector == IFeeAMM.DivisionByZero.selector
+            || selector == IFeeAMM.InvalidAmount.selector || selector == IFeeAMM.DivisionByZero.selector
             || selector == IFeeAMM.InvalidSwapCalculation.selector
             || selector == IFeeAMM.InvalidCurrency.selector
             || selector == ITIP20.InsufficientBalance.selector
@@ -1967,9 +1965,9 @@ contract FeeAMMInvariantTest is BaseTest {
             || selector == IFeeAMM.InvalidCurrency.selector
             || selector == ITIP20.InsufficientBalance.selector
             || selector == ITIP20.PolicyForbids.selector
-            // FeeManager specific (string reverts)
-            || keccak256(reason)
-                == keccak256(abi.encodeWithSignature("Error(string)", "ONLY_DIRECT_CALL"))
+        // FeeManager specific (string reverts)
+        || keccak256(reason)
+            == keccak256(abi.encodeWithSignature("Error(string)", "ONLY_DIRECT_CALL"))
             || keccak256(reason)
                 == keccak256(abi.encodeWithSignature("Error(string)", "CANNOT_CHANGE_WITHIN_BLOCK"));
         assertTrue(isKnownError, "Failed with unknown FeeManager error");

--- a/docs/specs/test/invariants/StablecoinDEX.t.sol
+++ b/docs/specs/test/invariants/StablecoinDEX.t.sol
@@ -850,9 +850,9 @@ contract StablecoinDEXInvariantTest is BaseTest {
                 orderCount++;
                 if (order.isBid) {
                     uint32 price = exchange.tickToPrice(order.tick);
-                    uint256 escrow =
-                        (uint256(order.remaining) * uint256(price) + exchange.PRICE_SCALE() - 1)
-                            / exchange.PRICE_SCALE();
+                    uint256 escrow = (
+                        uint256(order.remaining) * uint256(price) + exchange.PRICE_SCALE() - 1
+                    ) / exchange.PRICE_SCALE();
                     pathUsdEscrowed += escrow;
                 } else {
                     // Find which token this order is for
@@ -894,11 +894,8 @@ contract StablecoinDEXInvariantTest is BaseTest {
         }
 
         vm.recordLogs();
-        try exchange.swapExactAmountIn(
-            before.tokenIn, before.tokenOut, amount, amount - 100
-        ) returns (
-            uint128 amountOut
-        ) {
+        try exchange.swapExactAmountIn(before.tokenIn, before.tokenOut, amount, amount - 100)
+        returns (uint128 amountOut) {
             _maxDust += _countOrderFilledEvents();
             // TEMPO-DEX4: amountOut >= minAmountOut
             assertTrue(
@@ -955,11 +952,8 @@ contract StablecoinDEXInvariantTest is BaseTest {
         }
 
         vm.recordLogs();
-        try exchange.swapExactAmountOut(
-            before.tokenIn, before.tokenOut, amount, amount + 100
-        ) returns (
-            uint128 amountIn
-        ) {
+        try exchange.swapExactAmountOut(before.tokenIn, before.tokenOut, amount, amount + 100)
+        returns (uint128 amountIn) {
             _maxDust += _countOrderFilledEvents();
             // TEMPO-DEX5: amountIn <= maxAmountIn
             assertTrue(
@@ -1017,8 +1011,8 @@ contract StablecoinDEXInvariantTest is BaseTest {
 
         uint256 tokenInTotalAfter =
             TIP20(before.tokenIn).balanceOf(swapper) + exchange.balanceOf(swapper, before.tokenIn);
-        uint256 tokenOutTotalAfter = TIP20(before.tokenOut).balanceOf(swapper)
-            + exchange.balanceOf(swapper, before.tokenOut);
+        uint256 tokenOutTotalAfter =
+            TIP20(before.tokenOut).balanceOf(swapper) + exchange.balanceOf(swapper, before.tokenOut);
 
         // Swapper's total tokenIn should decrease by tokenInSpent
         assertEq(

--- a/docs/specs/test/zone/DepositQueueLib.t.sol
+++ b/docs/specs/test/zone/DepositQueueLib.t.sol
@@ -36,7 +36,11 @@ contract DepositQueueLibTest is Test {
 
     function test_enqueue_singleDeposit() public pure {
         Deposit memory d = Deposit({
-            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("memo")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x300),
+            amount: 100e6,
+            memo: bytes32("memo")
         });
 
         bytes32 newHash = DepositQueueLib.enqueue(bytes32(0), d);
@@ -47,13 +51,25 @@ contract DepositQueueLibTest is Test {
 
     function test_enqueue_multipleDeposits() public pure {
         Deposit memory d1 = Deposit({
-            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("d1")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x300),
+            amount: 100e6,
+            memo: bytes32("d1")
         });
         Deposit memory d2 = Deposit({
-            sender: address(0x300), to: address(0x200), amount: 200e6, memo: bytes32("d2")
+            token: address(0x1000),
+            sender: address(0x300),
+            to: address(0x200),
+            amount: 200e6,
+            memo: bytes32("d2")
         });
         Deposit memory d3 = Deposit({
-            sender: address(0x200), to: address(0x200), amount: 300e6, memo: bytes32("d3")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x200),
+            amount: 300e6,
+            memo: bytes32("d3")
         });
 
         bytes32 h1 = DepositQueueLib.enqueue(bytes32(0), d1);
@@ -73,10 +89,18 @@ contract DepositQueueLibTest is Test {
     function test_enqueue_hashChainStructure() public pure {
         // Verify that newer deposits wrap older ones
         Deposit memory d1 = Deposit({
-            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("first")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x300),
+            amount: 100e6,
+            memo: bytes32("first")
         });
         Deposit memory d2 = Deposit({
-            sender: address(0x300), to: address(0x200), amount: 200e6, memo: bytes32("second")
+            token: address(0x1000),
+            sender: address(0x300),
+            to: address(0x200),
+            amount: 200e6,
+            memo: bytes32("second")
         });
 
         bytes32 h1 = DepositQueueLib.enqueue(bytes32(0), d1);
@@ -88,8 +112,9 @@ contract DepositQueueLibTest is Test {
 
     function test_enqueue_emptyToEmpty() public pure {
         // An empty deposit struct should still produce a valid hash
-        Deposit memory d =
-            Deposit({ sender: address(0), to: address(0), amount: 0, memo: bytes32(0) });
+        Deposit memory d = Deposit({
+            token: address(0x1000), sender: address(0), to: address(0), amount: 0, memo: bytes32(0)
+        });
 
         bytes32 h = DepositQueueLib.enqueue(bytes32(0), d);
         bytes32 expected = keccak256(abi.encode(DepositType.Regular, d, bytes32(0)));
@@ -99,9 +124,14 @@ contract DepositQueueLibTest is Test {
 
     function test_enqueue_differentInputsProduceDifferentHashes() public pure {
         Deposit memory d1 = Deposit({
-            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("memo1")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x300),
+            amount: 100e6,
+            memo: bytes32("memo1")
         });
         Deposit memory d2 = Deposit({
+            token: address(0x1000),
             sender: address(0x200),
             to: address(0x300),
             amount: 100e6,
@@ -116,7 +146,11 @@ contract DepositQueueLibTest is Test {
 
     function test_enqueue_sameDepositDifferentPrevHashProducesDifferentResult() public pure {
         Deposit memory d = Deposit({
-            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("memo")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x300),
+            amount: 100e6,
+            memo: bytes32("memo")
         });
 
         bytes32 h1 = DepositQueueLib.enqueue(bytes32(0), d);
@@ -131,6 +165,7 @@ contract DepositQueueLibTest is Test {
 
     function test_enqueueEncrypted_singleDeposit() public pure {
         EncryptedDeposit memory ed = EncryptedDeposit({
+            token: address(0x1000),
             sender: address(0x200),
             amount: 100e6,
             keyIndex: 0,
@@ -150,10 +185,15 @@ contract DepositQueueLibTest is Test {
 
     function test_enqueueEncrypted_mixedQueue() public pure {
         Deposit memory d1 = Deposit({
-            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("d1")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x300),
+            amount: 100e6,
+            memo: bytes32("d1")
         });
 
         EncryptedDeposit memory ed = EncryptedDeposit({
+            token: address(0x1000),
             sender: address(0x300),
             amount: 200e6,
             keyIndex: 0,
@@ -167,7 +207,11 @@ contract DepositQueueLibTest is Test {
         });
 
         Deposit memory d2 = Deposit({
-            sender: address(0x200), to: address(0x200), amount: 300e6, memo: bytes32("d3")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x200),
+            amount: 300e6,
+            memo: bytes32("d3")
         });
 
         bytes32 h1 = DepositQueueLib.enqueue(bytes32(0), d1);
@@ -186,10 +230,15 @@ contract DepositQueueLibTest is Test {
     function test_enqueue_typeDiscriminatorPreventsCollision() public pure {
         // Same sender/amount but different type discriminators produce different hashes
         Deposit memory d = Deposit({
-            sender: address(0x200), to: address(0x300), amount: 100e6, memo: bytes32("memo")
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(0x300),
+            amount: 100e6,
+            memo: bytes32("memo")
         });
 
         EncryptedDeposit memory ed = EncryptedDeposit({
+            token: address(0x1000),
             sender: address(0x200),
             amount: 100e6,
             keyIndex: 0,

--- a/docs/specs/test/zone/SwapAndDepositRouter.t.sol
+++ b/docs/specs/test/zone/SwapAndDepositRouter.t.sol
@@ -69,23 +69,11 @@ contract MockZoneFactoryForRouter {
 
 }
 
-contract MockZoneMessengerForRouter {
-
-    address public tokenAddr;
-
-    function setToken(address _token) external {
-        tokenAddr = _token;
-    }
-
-    function token() external view returns (address) {
-        return tokenAddr;
-    }
-
-}
+contract MockZoneMessengerForRouter { }
 
 contract MockZonePortalForRouter {
 
-    address public tokenAddr;
+    mapping(address => bool) public enabledTokens;
 
     address public lastDepositRecipient;
     uint128 public lastDepositAmount;
@@ -96,16 +84,24 @@ contract MockZonePortalForRouter {
     uint256 public lastEncryptedKeyIndex;
     bool public encryptedDepositCalled;
 
-    function setToken(address _token) external {
-        tokenAddr = _token;
+    function enableToken(address _token) external {
+        enabledTokens[_token] = true;
     }
 
-    function token() external view returns (address) {
-        return tokenAddr;
+    function isTokenEnabled(address _token) external view returns (bool) {
+        return enabledTokens[_token];
     }
 
-    function deposit(address to, uint128 amount, bytes32 memo) external returns (bytes32) {
-        IERC20(tokenAddr).transferFrom(msg.sender, address(this), amount);
+    function deposit(
+        address _token,
+        address to,
+        uint128 amount,
+        bytes32 memo
+    )
+        external
+        returns (bytes32)
+    {
+        IERC20(_token).transferFrom(msg.sender, address(this), amount);
         lastDepositRecipient = to;
         lastDepositAmount = amount;
         lastDepositMemo = memo;
@@ -114,6 +110,7 @@ contract MockZonePortalForRouter {
     }
 
     function depositEncrypted(
+        address _token,
         uint128 amount,
         uint256 keyIndex,
         EncryptedDepositPayload calldata
@@ -121,7 +118,7 @@ contract MockZonePortalForRouter {
         external
         returns (bytes32)
     {
-        IERC20(tokenAddr).transferFrom(msg.sender, address(this), amount);
+        IERC20(_token).transferFrom(msg.sender, address(this), amount);
         lastEncryptedAmount = amount;
         lastEncryptedKeyIndex = keyIndex;
         encryptedDepositCalled = true;
@@ -157,10 +154,8 @@ contract SwapAndDepositRouterTest is BaseTest {
         mockFactory.setPortal(address(mockPortal), true);
         mockFactory.setPortal(address(mockPortal2), true);
 
-        mockPortal.setToken(address(pathUSD));
-        mockPortal2.setToken(address(token1));
-
-        mockMessenger.setToken(address(pathUSD));
+        mockPortal.enableToken(address(pathUSD));
+        mockPortal2.enableToken(address(token1));
 
         vm.startPrank(pathUSDAdmin);
         pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
@@ -220,7 +215,7 @@ contract SwapAndDepositRouterTest is BaseTest {
 
         vm.prank(alice);
         vm.expectRevert(SwapAndDepositRouter.UnauthorizedMessenger.selector);
-        router.onWithdrawalReceived(sender, AMOUNT, data);
+        router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
     }
 
     function test_revertInvalidTargetPortal() public {
@@ -230,7 +225,7 @@ contract SwapAndDepositRouterTest is BaseTest {
 
         vm.prank(address(mockMessenger));
         vm.expectRevert(SwapAndDepositRouter.InvalidTargetPortal.selector);
-        router.onWithdrawalReceived(sender, AMOUNT, data);
+        router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
     }
 
     function test_revertInvalidToken() public {
@@ -239,16 +234,15 @@ contract SwapAndDepositRouterTest is BaseTest {
 
         vm.prank(address(mockMessenger));
         vm.expectRevert(SwapAndDepositRouter.InvalidToken.selector);
-        router.onWithdrawalReceived(sender, AMOUNT, data);
+        router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
     }
 
     function test_plaintextDeposit_sameToken() public {
-        bytes memory data = _buildPlaintextData(
-            address(pathUSD), address(mockPortal), alice, bytes32("hello"), 0
-        );
+        bytes memory data =
+            _buildPlaintextData(address(pathUSD), address(mockPortal), alice, bytes32("hello"), 0);
 
         vm.prank(address(mockMessenger));
-        bytes4 ret = router.onWithdrawalReceived(sender, AMOUNT, data);
+        bytes4 ret = router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
 
         assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
         assertTrue(mockPortal.depositCalled());
@@ -258,7 +252,6 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_plaintextDeposit_withSwap() public {
-        mockMessenger.setToken(address(pathUSD));
         uint128 swapOut = 990e6;
         mockDEX.setNextAmountOut(swapOut);
 
@@ -267,7 +260,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         );
 
         vm.prank(address(mockMessenger));
-        bytes4 ret = router.onWithdrawalReceived(sender, AMOUNT, data);
+        bytes4 ret = router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
 
         assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
         assertTrue(mockPortal2.depositCalled());
@@ -282,7 +275,7 @@ contract SwapAndDepositRouterTest is BaseTest {
             _buildEncryptedData(address(pathUSD), address(mockPortal), 0, payload, 0);
 
         vm.prank(address(mockMessenger));
-        bytes4 ret = router.onWithdrawalReceived(sender, AMOUNT, data);
+        bytes4 ret = router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
 
         assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
         assertTrue(mockPortal.encryptedDepositCalled());
@@ -291,7 +284,6 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_encryptedDeposit_withSwap() public {
-        mockMessenger.setToken(address(pathUSD));
         uint128 swapOut = 950e6;
         mockDEX.setNextAmountOut(swapOut);
 
@@ -300,7 +292,7 @@ contract SwapAndDepositRouterTest is BaseTest {
             _buildEncryptedData(address(token1), address(mockPortal2), 1, payload, 900e6);
 
         vm.prank(address(mockMessenger));
-        bytes4 ret = router.onWithdrawalReceived(sender, AMOUNT, data);
+        bytes4 ret = router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
 
         assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
         assertTrue(mockPortal2.encryptedDepositCalled());
@@ -309,7 +301,6 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_swapSlippageReverts() public {
-        mockMessenger.setToken(address(pathUSD));
         mockDEX.setNextAmountOut(800e6);
 
         bytes memory data = _buildPlaintextData(
@@ -318,7 +309,7 @@ contract SwapAndDepositRouterTest is BaseTest {
 
         vm.prank(address(mockMessenger));
         vm.expectRevert(IStablecoinDEX.InsufficientOutput.selector);
-        router.onWithdrawalReceived(sender, AMOUNT, data);
+        router.onWithdrawalReceived(sender, address(pathUSD), AMOUNT, data);
     }
 
 }

--- a/docs/specs/test/zone/WithdrawalQueueLib.t.sol
+++ b/docs/specs/test/zone/WithdrawalQueueLib.t.sol
@@ -353,6 +353,7 @@ contract WithdrawalQueueLibTest is Test {
         returns (Withdrawal memory)
     {
         return Withdrawal({
+            token: address(0x100),
             sender: sender,
             to: to,
             amount: amount,

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -22,6 +22,7 @@ import {
     IZonePortal,
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     PORTAL_ENCRYPTION_KEYS_SLOT,
+    PORTAL_TOKEN_CONFIGS_SLOT,
     QueuedDeposit,
     Withdrawal,
     ZoneParams
@@ -169,6 +170,10 @@ contract ZoneBridgeTest is BaseTest {
         l2TempoState.setMockStorageValue(
             address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
         );
+
+        // Enable l2ZoneToken in the mock portal's token registry for zone-side validation
+        bytes32 tokenConfigSlot = keccak256(abi.encode(address(l2ZoneToken), PORTAL_TOKEN_CONFIGS_SLOT));
+        l2TempoState.setMockStorageValue(address(l1Portal), tokenConfigSlot, bytes32(uint256(0x0101)));
 
         // Zone inbox (advances Tempo state and processes deposits)
         l2Inbox = new ZoneInbox(address(l2Config), address(l1Portal), address(l2TempoState));

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -30,6 +30,7 @@ import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
 import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
+import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
 import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
 import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
@@ -42,6 +43,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
 
     bool public shouldAccept = true;
     address public lastSender;
+    address public lastToken;
     uint128 public lastAmount;
     bytes public lastCallbackData;
 
@@ -51,6 +53,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
 
     function onWithdrawalReceived(
         address sender,
+        address token,
         uint128 amount,
         bytes calldata callbackData
     )
@@ -58,6 +61,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         returns (bytes4)
     {
         lastSender = sender;
+        lastToken = token;
         lastAmount = amount;
         lastCallbackData = callbackData;
         return shouldAccept ? IWithdrawalReceiver.onWithdrawalReceived.selector : bytes4(0);
@@ -123,55 +127,55 @@ contract ZoneBridgeTest is BaseTest {
         super.setUp();
 
         // === Deploy L1 Contracts ===
-        l1Factory = new ZoneFactory();
+        l1Factory = new ZoneFactory(); // Keep factory for verifier only
         withdrawalReceiver = new MockWithdrawalReceiver();
 
-        // Fund test accounts on L1
-        vm.startPrank(pathUSDAdmin);
-        pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
-        pathUSD.mint(alice, 100_000e6);
-        pathUSD.mint(bob, 100_000e6);
-        vm.stopPrank();
+        // Deploy zone token FIRST (used for both L1 escrow and zone-side operations).
+        // In production, L1 and zone-side tokens are at the same address, so we use
+        // a single MockZoneToken for both roles to avoid ISSUER_ROLE issues with pathUSD.
+        l2ZoneToken = new MockZoneToken("Zone USD", "zUSD");
+
+        // Fund test accounts with zone token (for L1 deposits)
+        l2ZoneToken.setMinter(address(this), true);
+        l2ZoneToken.mint(alice, 100_000e6);
+        l2ZoneToken.mint(bob, 100_000e6);
+        l2ZoneToken.setMinter(address(this), false);
 
         // Record genesis block number for Tempo
         genesisTempoBlockNumber = uint64(block.number);
 
-        // Create zone on L1
-        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
-            sequencer: admin,
-            verifier: l1Factory.verifier(),
-            zoneParams: ZoneParams({
-                genesisBlockHash: GENESIS_BLOCK_HASH,
-                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
-                genesisTempoBlockNumber: genesisTempoBlockNumber
-            })
-        });
-        address portalAddr;
-        (zoneId, portalAddr) = l1Factory.createZone(params);
-        l1Portal = ZonePortal(portalAddr);
+        // Deploy messenger and portal directly (bypass factory to avoid TIP20 prefix check).
+        // Predict portal address so messenger can reference it in its constructor.
+        uint256 currentNonce = vm.getNonce(address(this));
+        address predictedPortal = vm.computeCreateAddress(address(this), currentNonce + 1);
+        ZoneMessenger messengerContract = new ZoneMessenger(predictedPortal);
+        l1Portal = new ZonePortal(
+            1, // zoneId
+            address(l2ZoneToken), // initialToken = MockZoneToken (NOT pathUSD)
+            address(messengerContract),
+            admin, // sequencer
+            l1Factory.verifier(),
+            GENESIS_BLOCK_HASH,
+            genesisTempoBlockNumber
+        );
+        zoneId = 1;
 
         // === Deploy zone contracts ===
-        // Zone token (same concept as pathUSD, deployed at "same address" conceptually)
-        l2ZoneToken = new MockZoneToken("Zone USD", "zUSD");
-
         // TempoState mock for testing
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
 
         // Zone config (reads sequencer from L1 portal via Tempo state)
-        l2Config = new ZoneConfig(address(l2ZoneToken), portalAddr, address(l2TempoState));
+        l2Config = new ZoneConfig(address(l1Portal), address(l2TempoState));
         l2TempoState.setMockStorageValue(
-            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+            address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
         );
 
         // Zone inbox (advances Tempo state and processes deposits)
-        l2Inbox = new ZoneInbox(
-            address(l2Config), portalAddr, address(l2TempoState), address(l2ZoneToken)
-        );
+        l2Inbox = new ZoneInbox(address(l2Config), address(l1Portal), address(l2TempoState));
         l2ZoneToken.setMinter(address(l2Inbox), true);
 
         // Zone outbox (handles withdrawals)
-        l2Outbox = new ZoneOutbox(address(l2Config), address(l2ZoneToken));
+        l2Outbox = new ZoneOutbox(address(l2Config));
         l2ZoneToken.setBurner(address(l2Outbox), true);
 
         // Initialize zone block hash
@@ -193,7 +197,9 @@ contract ZoneBridgeTest is BaseTest {
         returns (bytes32 newHash)
     {
         // Record the deposit
-        Deposit memory d = Deposit({ sender: sender, to: to, amount: amount, memo: memo });
+        Deposit memory d = Deposit({
+            token: address(l2ZoneToken), sender: sender, to: to, amount: amount, memo: memo
+        });
 
         // Calculate the new hash (matches what Tempo portal computes)
         bytes32 prevHash = pendingDeposits.length > 0
@@ -265,6 +271,7 @@ contract ZoneBridgeTest is BaseTest {
             ObservedWithdrawal({
                 index: index,
                 withdrawal: Withdrawal({
+                    token: address(l2ZoneToken),
                     sender: sender,
                     to: to,
                     amount: amount,
@@ -338,13 +345,14 @@ contract ZoneBridgeTest is BaseTest {
         // === STEP 1: Alice deposits on L1 ===
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), depositAmount);
-        bytes32 l1DepositHash = l1Portal.deposit(alice, depositAmount, bytes32("hello zone"));
+        l2ZoneToken.approve(address(l1Portal), depositAmount);
+        bytes32 l1DepositHash =
+            l1Portal.deposit(address(l2ZoneToken), alice, depositAmount, bytes32("hello zone"));
         vm.stopPrank();
 
         // Verify L1 state
         assertEq(l1Portal.currentDepositQueueHash(), l1DepositHash);
-        assertEq(pathUSD.balanceOf(address(l1Portal)), depositAmount);
+        assertEq(l2ZoneToken.balanceOf(address(l1Portal)), depositAmount);
 
         // === STEP 2: Sequencer observes deposit (simulated event watching) ===
         _sequencerObserveDeposit(alice, alice, depositAmount, bytes32("hello zone"));
@@ -352,10 +360,10 @@ contract ZoneBridgeTest is BaseTest {
         // === STEP 3: Sequencer relays deposit to zone (sequencer-only call) ===
         bytes32 newProcessedHash = _sequencerRelayDepositsToL2();
 
-        // Verify zone state
-        assertEq(l2ZoneToken.balanceOf(alice), depositAmount);
+        // Verify zone state (alice's net balance is unchanged: -deposit on L1, +mint on zone)
+        assertEq(l2ZoneToken.balanceOf(alice), 100_000e6);
         assertEq(l2Inbox.processedDepositQueueHash(), newProcessedHash);
-        assertEq(l2ZoneToken.totalSupply(), depositAmount);
+        assertEq(l2ZoneToken.totalSupply(), 200_000e6 + depositAmount);
 
         // === STEP 4: Submit batch to L1 (no withdrawals yet) ===
         _sequencerSubmitBatch(newProcessedHash);
@@ -369,6 +377,7 @@ contract ZoneBridgeTest is BaseTest {
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), withdrawAmount);
         l2Outbox.requestWithdrawal(
+            address(l2ZoneToken),
             alice, // to (back to self on L1)
             withdrawAmount,
             bytes32(0), // memo
@@ -378,8 +387,8 @@ contract ZoneBridgeTest is BaseTest {
         );
         vm.stopPrank();
 
-        // Verify zone state - tokens burned
-        assertEq(l2ZoneToken.balanceOf(alice), depositAmount - withdrawAmount);
+        // Verify zone state - tokens burned (from alice's net balance of 100_000e6)
+        assertEq(l2ZoneToken.balanceOf(alice), 100_000e6 - withdrawAmount);
 
         // === STEP 6: Sequencer observes withdrawal event ===
         _sequencerObserveWithdrawal(0, alice, alice, withdrawAmount, bytes32(0), 0, alice, "");
@@ -393,6 +402,7 @@ contract ZoneBridgeTest is BaseTest {
         // Verify L1 queue updated
         assertEq(l1Portal.withdrawalBatchIndex(), 2);
         Withdrawal memory w = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: alice,
             amount: withdrawAmount,
@@ -408,11 +418,11 @@ contract ZoneBridgeTest is BaseTest {
         assertEq(l1Portal.withdrawalQueueTail(), 1);
 
         // === STEP 8: Sequencer processes withdrawal on L1 ===
-        uint256 aliceL1BalanceBefore = pathUSD.balanceOf(alice);
+        uint256 aliceL1BalanceBefore = l2ZoneToken.balanceOf(alice);
         l1Portal.processWithdrawal(w, bytes32(0)); // 0 = last item in slot
 
         // Verify Alice received funds on L1
-        assertEq(pathUSD.balanceOf(alice), aliceL1BalanceBefore + withdrawAmount);
+        assertEq(l2ZoneToken.balanceOf(alice), aliceL1BalanceBefore + withdrawAmount);
 
         // Verify slot cleared and head advanced
         assertEq(l1Portal.withdrawalQueueSlot(0), EMPTY_SENTINEL);
@@ -422,13 +432,13 @@ contract ZoneBridgeTest is BaseTest {
     function test_fullFlow_multipleDepositsAndWithdrawals() public {
         // === Alice and Bob both deposit ===
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 5000e6);
-        l1Portal.deposit(alice, 2000e6, bytes32("alice1"));
+        l2ZoneToken.approve(address(l1Portal), 5000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 2000e6, bytes32("alice1"));
         vm.stopPrank();
 
         vm.startPrank(bob);
-        pathUSD.approve(address(l1Portal), 5000e6);
-        l1Portal.deposit(bob, 3000e6, bytes32("bob1"));
+        l2ZoneToken.approve(address(l1Portal), 5000e6);
+        l1Portal.deposit(address(l2ZoneToken), bob, 3000e6, bytes32("bob1"));
         vm.stopPrank();
 
         // Sequencer observes and relays
@@ -436,9 +446,9 @@ contract ZoneBridgeTest is BaseTest {
         _sequencerObserveDeposit(bob, bob, 3000e6, bytes32("bob1"));
         bytes32 processedHash = _sequencerRelayDepositsToL2();
 
-        // Verify zone balances
-        assertEq(l2ZoneToken.balanceOf(alice), 2000e6);
-        assertEq(l2ZoneToken.balanceOf(bob), 3000e6);
+        // Verify zone balances (net: -deposit on L1, +mint on zone = initial funding)
+        assertEq(l2ZoneToken.balanceOf(alice), 100_000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), 100_000e6);
 
         // Submit batch
         _sequencerSubmitBatch(processedHash);
@@ -446,12 +456,12 @@ contract ZoneBridgeTest is BaseTest {
         // === Both request withdrawals ===
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), 500e6);
-        l2Outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
+        l2Outbox.requestWithdrawal(address(l2ZoneToken), alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(bob);
         l2ZoneToken.approve(address(l2Outbox), 1000e6);
-        l2Outbox.requestWithdrawal(bob, 1000e6, bytes32(0), 0, bob, "");
+        l2Outbox.requestWithdrawal(address(l2ZoneToken), bob, 1000e6, bytes32(0), 0, bob, "");
         vm.stopPrank();
 
         // Sequencer observes withdrawals
@@ -464,6 +474,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Build expected queue hash (oldest = outermost, innermost wraps EMPTY_SENTINEL)
         Withdrawal memory w0 = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: alice,
             amount: 500e6,
@@ -474,6 +485,7 @@ contract ZoneBridgeTest is BaseTest {
             callbackData: ""
         });
         Withdrawal memory w1 = Withdrawal({
+            token: address(l2ZoneToken),
             sender: bob,
             to: bob,
             amount: 1000e6,
@@ -489,21 +501,21 @@ contract ZoneBridgeTest is BaseTest {
         assertEq(l1Portal.withdrawalQueueSlot(0), queueHash);
 
         // Process withdrawals in order
-        uint256 aliceBefore = pathUSD.balanceOf(alice);
-        uint256 bobBefore = pathUSD.balanceOf(bob);
+        uint256 aliceBefore = l2ZoneToken.balanceOf(alice);
+        uint256 bobBefore = l2ZoneToken.balanceOf(bob);
 
         l1Portal.processWithdrawal(w0, innerHash);
-        assertEq(pathUSD.balanceOf(alice), aliceBefore + 500e6);
+        assertEq(l2ZoneToken.balanceOf(alice), aliceBefore + 500e6);
 
         l1Portal.processWithdrawal(w1, bytes32(0)); // 0 = last item in slot
-        assertEq(pathUSD.balanceOf(bob), bobBefore + 1000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), bobBefore + 1000e6);
     }
 
     function test_fullFlow_withdrawalWithCallback() public {
         // Setup: deposit to zone
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
@@ -514,6 +526,7 @@ contract ZoneBridgeTest is BaseTest {
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), 500e6);
         l2Outbox.requestWithdrawal(
+            address(l2ZoneToken),
             address(withdrawalReceiver), // to: receiver contract
             500e6,
             bytes32(0), // memo
@@ -539,6 +552,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Process withdrawal
         Withdrawal memory w = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: address(withdrawalReceiver),
             amount: 500e6,
@@ -551,7 +565,7 @@ contract ZoneBridgeTest is BaseTest {
         l1Portal.processWithdrawal(w, bytes32(0));
 
         // Verify callback was executed
-        assertEq(pathUSD.balanceOf(address(withdrawalReceiver)), 500e6);
+        assertEq(l2ZoneToken.balanceOf(address(withdrawalReceiver)), 500e6);
         assertEq(withdrawalReceiver.lastSender(), alice);
         assertEq(withdrawalReceiver.lastAmount(), 500e6);
         assertEq(withdrawalReceiver.lastCallbackData(), "callback_data");
@@ -560,8 +574,8 @@ contract ZoneBridgeTest is BaseTest {
     function test_fullFlow_bounceBackOnCallbackFailure() public {
         // Setup: deposit to zone
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
@@ -573,6 +587,7 @@ contract ZoneBridgeTest is BaseTest {
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), 500e6);
         l2Outbox.requestWithdrawal(
+            address(l2ZoneToken),
             address(withdrawalReceiver),
             500e6,
             bytes32(0), // memo
@@ -593,6 +608,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Process withdrawal - callback will fail, triggering bounce-back
         Withdrawal memory w = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: address(withdrawalReceiver),
             amount: 500e6,
@@ -605,7 +621,7 @@ contract ZoneBridgeTest is BaseTest {
         l1Portal.processWithdrawal(w, bytes32(0));
 
         // Verify receiver did NOT get funds (transfer reverted)
-        assertEq(pathUSD.balanceOf(address(withdrawalReceiver)), 0);
+        assertEq(l2ZoneToken.balanceOf(address(withdrawalReceiver)), 0);
 
         // Verify bounce-back deposit was created
         assertTrue(l1Portal.currentDepositQueueHash() != depositHashBefore);
@@ -614,8 +630,8 @@ contract ZoneBridgeTest is BaseTest {
     function test_fullFlow_transferOnL2() public {
         // Deposit to Alice
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
@@ -625,60 +641,62 @@ contract ZoneBridgeTest is BaseTest {
         vm.prank(alice);
         l2ZoneToken.transfer(bob, 300e6);
 
-        // Verify zone balances
-        assertEq(l2ZoneToken.balanceOf(alice), 700e6);
-        assertEq(l2ZoneToken.balanceOf(bob), 300e6);
+        // Verify zone balances (alice net = 100K, then -300e6 transfer; bob = 100K + 300e6)
+        assertEq(l2ZoneToken.balanceOf(alice), 100_000e6 - 300e6);
+        assertEq(l2ZoneToken.balanceOf(bob), 100_000e6 + 300e6);
 
         // Bob withdraws on zone
         vm.startPrank(bob);
         l2ZoneToken.approve(address(l2Outbox), 300e6);
-        l2Outbox.requestWithdrawal(bob, 300e6, bytes32(0), 0, bob, "");
+        l2Outbox.requestWithdrawal(address(l2ZoneToken), bob, 300e6, bytes32(0), 0, bob, "");
         vm.stopPrank();
 
-        // Verify Bob's zone balance debited
-        assertEq(l2ZoneToken.balanceOf(bob), 0);
+        // Verify Bob's zone balance debited (100K + 300e6 received - 300e6 withdrawn)
+        assertEq(l2ZoneToken.balanceOf(bob), 100_000e6);
         assertEq(l2Outbox.nextWithdrawalIndex(), 1);
     }
 
     function test_l2_insufficientBalanceReverts() public {
         // Deposit to Alice
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
         _sequencerRelayDepositsToL2();
 
-        // Alice tries to withdraw more than balance
+        // Alice tries to withdraw more than balance (net balance is 100_000e6 after deposit+mint)
         vm.startPrank(alice);
-        l2ZoneToken.approve(address(l2Outbox), 2000e6);
+        l2ZoneToken.approve(address(l2Outbox), type(uint256).max);
         vm.expectRevert(MockZoneToken.InsufficientBalance.selector);
-        l2Outbox.requestWithdrawal(alice, 2000e6, bytes32(0), 0, alice, "");
+        l2Outbox.requestWithdrawal(
+            address(l2ZoneToken), alice, uint128(100_001e6), bytes32(0), 0, alice, ""
+        );
         vm.stopPrank();
     }
 
     function test_l2_transferInsufficientBalance() public {
         // Deposit to Alice
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
         _sequencerRelayDepositsToL2();
 
-        // Alice tries to transfer more than balance
+        // Alice tries to transfer more than balance (net balance is 100_000e6 after deposit+mint)
         vm.prank(alice);
         vm.expectRevert(MockZoneToken.InsufficientBalance.selector);
-        l2ZoneToken.transfer(bob, 2000e6);
+        l2ZoneToken.transfer(bob, 100_001e6);
     }
 
     function test_l2_depositHashMismatchAllowed() public {
         // Deposit on L1
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
@@ -699,8 +717,8 @@ contract ZoneBridgeTest is BaseTest {
     function test_l2_callbackRequiresFallbackRecipient() public {
         // Deposit to Alice
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
@@ -711,6 +729,7 @@ contract ZoneBridgeTest is BaseTest {
         l2ZoneToken.approve(address(l2Outbox), 500e6);
         vm.expectRevert(ZoneOutbox.InvalidFallbackRecipient.selector);
         l2Outbox.requestWithdrawal(
+            address(l2ZoneToken),
             address(withdrawalReceiver),
             500e6,
             bytes32(0), // memo
@@ -723,8 +742,8 @@ contract ZoneBridgeTest is BaseTest {
 
     function test_l2_onlySequencerCanAdvanceTempo() public {
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32(""));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         _sequencerObserveDeposit(alice, alice, 1000e6, bytes32(""));
@@ -753,8 +772,8 @@ contract ZoneBridgeTest is BaseTest {
     function test_storageLayout_currentDepositQueueHashSlot() public {
         // Make a deposit to get a non-zero currentDepositQueueHash
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32("layout-test"));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32("layout-test"));
         vm.stopPrank();
 
         // Read via vm.load using our constant
@@ -824,7 +843,11 @@ contract ZoneBridgeTest is BaseTest {
         returns (bytes32 newHash)
     {
         EncryptedDeposit memory ed = EncryptedDeposit({
-            sender: sender, amount: netAmount, keyIndex: keyIndex, encrypted: encrypted
+            token: address(l2ZoneToken),
+            sender: sender,
+            amount: netAmount,
+            keyIndex: keyIndex,
+            encrypted: encrypted
         });
 
         // Calculate the new hash (matches what portal computes via DepositQueueLib)
@@ -978,14 +1001,15 @@ contract ZoneBridgeTest is BaseTest {
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
 
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), depositAmount);
-        bytes32 l1DepositHash = l1Portal.depositEncrypted(depositAmount, 0, payload);
+        l2ZoneToken.approve(address(l1Portal), depositAmount);
+        bytes32 l1DepositHash =
+            l1Portal.depositEncrypted(address(l2ZoneToken), depositAmount, 0, payload);
         vm.stopPrank();
 
         // Verify L1 state
         assertEq(l1Portal.currentDepositQueueHash(), l1DepositHash, "L1 queue hash mismatch");
         assertEq(
-            pathUSD.balanceOf(address(l1Portal)),
+            l2ZoneToken.balanceOf(address(l1Portal)),
             depositAmount - fee,
             "Portal should hold net amount"
         );
@@ -1008,11 +1032,17 @@ contract ZoneBridgeTest is BaseTest {
         bytes32 newProcessedHash =
             _sequencerRelayEncryptedDepositsToL2(decryptedRecipient, decryptedMemo, true);
 
-        // Verify zone state — tokens minted to decrypted recipient
+        // Verify zone state — tokens minted to decrypted recipient (bob starts with 100K)
         assertEq(
-            l2ZoneToken.balanceOf(decryptedRecipient), netAmount, "Recipient should receive tokens"
+            l2ZoneToken.balanceOf(decryptedRecipient),
+            100_000e6 + netAmount,
+            "Recipient should receive tokens"
         );
-        assertEq(l2ZoneToken.balanceOf(alice), 0, "Sender should not receive tokens");
+        assertEq(
+            l2ZoneToken.balanceOf(alice),
+            100_000e6 - depositAmount,
+            "Sender keeps remaining balance"
+        );
         assertEq(
             l2Inbox.processedDepositQueueHash(), newProcessedHash, "Zone processed hash mismatch"
         );
@@ -1037,8 +1067,8 @@ contract ZoneBridgeTest is BaseTest {
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
 
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), depositAmount);
-        l1Portal.depositEncrypted(depositAmount, 0, payload);
+        l2ZoneToken.approve(address(l1Portal), depositAmount);
+        l1Portal.depositEncrypted(address(l2ZoneToken), depositAmount, 0, payload);
         vm.stopPrank();
 
         // === STEP 3: Sequencer observes and relays with FAILED decryption ===
@@ -1049,8 +1079,12 @@ contract ZoneBridgeTest is BaseTest {
         bytes32 newProcessedHash =
             _sequencerRelayEncryptedDepositsToL2(address(0xBEEF), bytes32("wrong"), false);
 
-        // Verify zone state — tokens bounced back to sender (alice), not to any recipient
-        assertEq(l2ZoneToken.balanceOf(alice), netAmount, "Sender should get bounced tokens");
+        // Verify zone state — tokens bounced back to sender (alice = 100K - deposit + bounce)
+        assertEq(
+            l2ZoneToken.balanceOf(alice),
+            100_000e6 - depositAmount + netAmount,
+            "Sender should get bounced tokens"
+        );
         assertEq(l2ZoneToken.balanceOf(address(0xBEEF)), 0, "Failed recipient should get nothing");
         assertEq(
             l2Inbox.processedDepositQueueHash(), newProcessedHash, "Zone processed hash mismatch"
@@ -1072,24 +1106,26 @@ contract ZoneBridgeTest is BaseTest {
 
         // === STEP 2: Alice makes a regular deposit ===
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), depositAmount * 2);
-        bytes32 h1 = l1Portal.deposit(alice, depositAmount, bytes32("regular"));
+        l2ZoneToken.approve(address(l1Portal), depositAmount * 2);
+        bytes32 h1 =
+            l1Portal.deposit(address(l2ZoneToken), alice, depositAmount, bytes32("regular"));
         vm.stopPrank();
 
         // === STEP 3: Bob makes an encrypted deposit ===
         EncryptedDepositPayload memory payload = _makeEncryptedPayload();
         vm.startPrank(bob);
-        pathUSD.approve(address(l1Portal), depositAmount);
-        bytes32 h2 = l1Portal.depositEncrypted(depositAmount, 0, payload);
+        l2ZoneToken.approve(address(l1Portal), depositAmount);
+        bytes32 h2 = l1Portal.depositEncrypted(address(l2ZoneToken), depositAmount, 0, payload);
         vm.stopPrank();
 
         // === STEP 4: Carol makes another regular deposit ===
         address carol = address(0x600);
-        vm.prank(pathUSDAdmin);
-        pathUSD.mint(carol, 100_000e6);
+        l2ZoneToken.setMinter(address(this), true);
+        l2ZoneToken.mint(carol, 100_000e6);
+        l2ZoneToken.setMinter(address(this), false);
         vm.startPrank(carol);
-        pathUSD.approve(address(l1Portal), depositAmount);
-        bytes32 h3 = l1Portal.deposit(carol, depositAmount, bytes32("carol"));
+        l2ZoneToken.approve(address(l1Portal), depositAmount);
+        bytes32 h3 = l1Portal.deposit(address(l2ZoneToken), carol, depositAmount, bytes32("carol"));
         vm.stopPrank();
 
         assertEq(l1Portal.currentDepositQueueHash(), h3, "L1 hash should be after 3rd deposit");
@@ -1098,21 +1134,36 @@ contract ZoneBridgeTest is BaseTest {
         // We need to compute hashes in the same order the portal did
 
         // Regular deposit from alice
-        Deposit memory d1 =
-            Deposit({ sender: alice, to: alice, amount: depositAmount, memo: bytes32("regular") });
+        Deposit memory d1 = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: depositAmount,
+            memo: bytes32("regular")
+        });
         bytes32 prevHash = l2Inbox.processedDepositQueueHash();
         bytes32 hash1 = keccak256(abi.encode(DepositType.Regular, d1, prevHash));
         assertEq(hash1, h1, "hash1 must match L1");
 
         // Encrypted deposit from bob
-        EncryptedDeposit memory ed =
-            EncryptedDeposit({ sender: bob, amount: netAmount, keyIndex: 0, encrypted: payload });
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            token: address(l2ZoneToken),
+            sender: bob,
+            amount: netAmount,
+            keyIndex: 0,
+            encrypted: payload
+        });
         bytes32 hash2 = keccak256(abi.encode(DepositType.Encrypted, ed, hash1));
         assertEq(hash2, h2, "hash2 must match L1");
 
         // Regular deposit from carol
-        Deposit memory d3 =
-            Deposit({ sender: carol, to: carol, amount: depositAmount, memo: bytes32("carol") });
+        Deposit memory d3 = Deposit({
+            token: address(l2ZoneToken),
+            sender: carol,
+            to: carol,
+            amount: depositAmount,
+            memo: bytes32("carol")
+        });
         bytes32 hash3 = keccak256(abi.encode(DepositType.Regular, d3, hash2));
         assertEq(hash3, h3, "hash3 must match L1");
 
@@ -1146,19 +1197,27 @@ contract ZoneBridgeTest is BaseTest {
         l2Inbox.advanceTempo("", queued, decs);
 
         // === STEP 7: Verify all balances ===
-        assertEq(l2ZoneToken.balanceOf(alice), depositAmount, "Alice gets regular deposit");
+        // alice: 100K - deposit + zone mint = 100K
+        assertEq(l2ZoneToken.balanceOf(alice), 100_000e6, "Alice gets regular deposit");
+        // decryptedTo (0x700) has no initial balance, receives only zone mint
         assertEq(
             l2ZoneToken.balanceOf(decryptedTo), netAmount, "Bob's encrypted recipient gets tokens"
         );
-        assertEq(l2ZoneToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
-        assertEq(l2ZoneToken.balanceOf(carol), depositAmount, "Carol gets regular deposit");
+        // bob: 100K - deposit, no zone mint to bob (encrypted goes to decryptedTo)
+        assertEq(
+            l2ZoneToken.balanceOf(bob),
+            100_000e6 - depositAmount,
+            "Bob (sender) keeps remaining balance"
+        );
+        // carol: 100K - deposit + zone mint = 100K
+        assertEq(l2ZoneToken.balanceOf(carol), 100_000e6, "Carol gets regular deposit");
         assertEq(l2Inbox.processedDepositQueueHash(), hash3, "Zone processed hash matches L1");
 
-        // Total supply = alice_regular + bob_encrypted_net + carol_regular
+        // Total supply = initial (alice 100K + bob 100K + carol 100K) + zone mints
         assertEq(
             l2ZoneToken.totalSupply(),
-            depositAmount + netAmount + depositAmount,
-            "Total supply should equal all deposits"
+            300_000e6 + depositAmount + netAmount + depositAmount,
+            "Total supply should equal initial funding plus all zone mints"
         );
 
         // === STEP 8: Submit batch to L1 ===
@@ -1179,8 +1238,8 @@ contract ZoneBridgeTest is BaseTest {
         EncryptedDepositPayload memory payload1 = _makeEncryptedPayload();
 
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), depositAmount);
-        bytes32 h1 = l1Portal.depositEncrypted(depositAmount, 0, payload1);
+        l2ZoneToken.approve(address(l1Portal), depositAmount);
+        bytes32 h1 = l1Portal.depositEncrypted(address(l2ZoneToken), depositAmount, 0, payload1);
         vm.stopPrank();
 
         // === STEP 3: Sequencer rotates to second encryption key ===
@@ -1191,8 +1250,8 @@ contract ZoneBridgeTest is BaseTest {
         EncryptedDepositPayload memory payload2 = _makeEncryptedPayload();
 
         vm.startPrank(bob);
-        pathUSD.approve(address(l1Portal), depositAmount);
-        bytes32 h2 = l1Portal.depositEncrypted(depositAmount, 1, payload2);
+        l2ZoneToken.approve(address(l1Portal), depositAmount);
+        bytes32 h2 = l1Portal.depositEncrypted(address(l2ZoneToken), depositAmount, 1, payload2);
         vm.stopPrank();
 
         assertEq(l1Portal.currentDepositQueueHash(), h2, "L1 hash after both deposits");
@@ -1200,13 +1259,22 @@ contract ZoneBridgeTest is BaseTest {
         // === STEP 5: Compute expected hashes ===
         bytes32 prevHash = l2Inbox.processedDepositQueueHash();
         EncryptedDeposit memory ed1 = EncryptedDeposit({
-            sender: alice, amount: netAmount, keyIndex: 0, encrypted: payload1
+            token: address(l2ZoneToken),
+            sender: alice,
+            amount: netAmount,
+            keyIndex: 0,
+            encrypted: payload1
         });
         bytes32 hash1 = keccak256(abi.encode(DepositType.Encrypted, ed1, prevHash));
         assertEq(hash1, h1, "hash1 must match L1");
 
-        EncryptedDeposit memory ed2 =
-            EncryptedDeposit({ sender: bob, amount: netAmount, keyIndex: 1, encrypted: payload2 });
+        EncryptedDeposit memory ed2 = EncryptedDeposit({
+            token: address(l2ZoneToken),
+            sender: bob,
+            amount: netAmount,
+            keyIndex: 1,
+            encrypted: payload2
+        });
         bytes32 hash2 = keccak256(abi.encode(DepositType.Encrypted, ed2, hash1));
         assertEq(hash2, h2, "hash2 must match L1");
 
@@ -1289,14 +1357,19 @@ contract ZoneBridgeTest is BaseTest {
         l2Inbox.advanceTempo("", queued, decs);
 
         // === STEP 7: Verify ===
-        // Both deposits go to sharedRecipient
+        // Both deposits go to sharedRecipient (no prior balance)
         assertEq(
             l2ZoneToken.balanceOf(sharedRecipient),
             netAmount * 2,
             "Recipient should receive both deposits"
         );
-        assertEq(l2ZoneToken.balanceOf(alice), 0, "Alice (sender) should not receive tokens");
-        assertEq(l2ZoneToken.balanceOf(bob), 0, "Bob (sender) should not receive tokens");
+        // alice/bob: 100K - deposit, no zone mint to them (encrypted goes to sharedRecipient)
+        assertEq(
+            l2ZoneToken.balanceOf(alice), 100_000e6 - depositAmount, "Alice keeps remaining balance"
+        );
+        assertEq(
+            l2ZoneToken.balanceOf(bob), 100_000e6 - depositAmount, "Bob keeps remaining balance"
+        );
         assertEq(l2Inbox.processedDepositQueueHash(), hash2, "Zone processed hash matches L1");
 
         // === STEP 8: Submit batch ===

--- a/docs/specs/test/zone/ZoneFactory.t.sol
+++ b/docs/specs/test/zone/ZoneFactory.t.sol
@@ -29,7 +29,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_success() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: admin,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -50,7 +50,7 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(info.zoneId, 1);
         assertEq(info.portal, portal);
         assertTrue(info.messenger != address(0));
-        assertEq(info.token, address(pathUSD));
+        assertEq(info.initialToken, address(pathUSD));
         assertEq(info.sequencer, admin);
         assertEq(info.verifier, zoneFactory.verifier());
         assertEq(info.genesisBlockHash, GENESIS_BLOCK_HASH);
@@ -59,7 +59,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_deploysMessenger() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: admin,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -77,7 +77,6 @@ contract ZoneFactoryTest is BaseTest {
         // Verify messenger is deployed and configured correctly
         ZoneMessenger messenger = ZoneMessenger(messengerAddr);
         assertEq(messenger.portal(), portal);
-        assertEq(messenger.token(), address(pathUSD));
 
         // Verify portal references the messenger
         ZonePortal portalContract = ZonePortal(portal);
@@ -86,7 +85,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_multipleZones() public {
         IZoneFactory.CreateZoneParams memory params1 = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: admin,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -99,7 +98,7 @@ contract ZoneFactoryTest is BaseTest {
         (uint64 zoneId1, address portal1) = zoneFactory.createZone(params1);
 
         IZoneFactory.CreateZoneParams memory params2 = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: alice,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -126,7 +125,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_emitsEvent() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: admin,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -171,7 +170,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidToken_zeroAddress() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(0),
+            initialToken: address(0),
             sequencer: admin,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -190,7 +189,7 @@ contract ZoneFactoryTest is BaseTest {
         address notTip20 = address(new NotATIP20());
 
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: notTip20,
+            initialToken: notTip20,
             sequencer: admin,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -206,7 +205,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidToken_eoa() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: alice, // EOA, not a contract
+            initialToken: alice, // EOA, not a contract
             sequencer: admin,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -226,7 +225,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidSequencer_zeroAddress() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: address(0),
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -246,7 +245,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidVerifier() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: admin,
             verifier: address(0xdead),
             zoneParams: ZoneParams({
@@ -279,7 +278,7 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(info.zoneId, 0);
         assertEq(info.portal, address(0));
         assertEq(info.messenger, address(0));
-        assertEq(info.token, address(0));
+        assertEq(info.initialToken, address(0));
     }
 
 }

--- a/docs/specs/test/zone/ZoneInbox.t.sol
+++ b/docs/specs/test/zone/ZoneInbox.t.sol
@@ -46,11 +46,11 @@ contract ZoneInboxTest is Test {
         zoneToken = new MockZoneToken("Zone USD", "zUSD");
         tempoState =
             new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
-        config = new ZoneConfig(address(zoneToken), mockPortal, address(tempoState));
+        config = new ZoneConfig(mockPortal, address(tempoState));
         tempoState.setMockStorageValue(
             mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
         );
-        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(zoneToken));
+        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState));
 
         zoneToken.setMinter(address(inbox), true);
     }
@@ -93,7 +93,13 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_singleDeposit() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({
+            token: address(zoneToken),
+            sender: alice,
+            to: bob,
+            amount: 1000e6,
+            memo: bytes32("payment")
+        });
 
         // Calculate expected hash
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
@@ -111,9 +117,15 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_multipleDeposits() public {
         Deposit[] memory deposits = new Deposit[](3);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        deposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
-        deposits[2] = Deposit({ sender: alice, to: bob, amount: 300e6, memo: bytes32("d3") });
+        deposits[0] = Deposit({
+            token: address(zoneToken), sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")
+        });
+        deposits[1] = Deposit({
+            token: address(zoneToken), sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")
+        });
+        deposits[2] = Deposit({
+            token: address(zoneToken), sender: alice, to: bob, amount: 300e6, memo: bytes32("d3")
+        });
 
         // Calculate expected hash chain
         bytes32 h0 = bytes32(0);
@@ -138,7 +150,13 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_allowsHashMismatch() public {
         // Hash mismatch is now allowed on-chain — the proof validates ancestor contiguity
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({
+            token: address(zoneToken),
+            sender: alice,
+            to: bob,
+            amount: 1000e6,
+            memo: bytes32("payment")
+        });
 
         // Set a different hash (simulating more deposits pending on Tempo)
         tempoState.setMockStorageValue(
@@ -158,8 +176,12 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_partialProcessingAllowed() public {
         // Partial processing is now allowed — the proof validates ancestor contiguity
         Deposit[] memory allDeposits = new Deposit[](2);
-        allDeposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        allDeposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        allDeposits[0] = Deposit({
+            token: address(zoneToken), sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")
+        });
+        allDeposits[1] = Deposit({
+            token: address(zoneToken), sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")
+        });
 
         // Set hash to be for both deposits
         bytes32 h0 = bytes32(0);
@@ -247,8 +269,12 @@ contract ZoneInboxTest is Test {
         inbox.setMaxDepositsPerTempoBlock(1);
 
         Deposit[] memory deposits = new Deposit[](2);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        deposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        deposits[0] = Deposit({
+            token: address(zoneToken), sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")
+        });
+        deposits[1] = Deposit({
+            token: address(zoneToken), sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")
+        });
 
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, deposits[0], h0));
@@ -274,9 +300,15 @@ contract ZoneInboxTest is Test {
         assertEq(inbox.maxDepositsPerTempoBlock(), 0);
 
         Deposit[] memory deposits = new Deposit[](3);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        deposits[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
-        deposits[2] = Deposit({ sender: alice, to: bob, amount: 300e6, memo: bytes32("d3") });
+        deposits[0] = Deposit({
+            token: address(zoneToken), sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")
+        });
+        deposits[1] = Deposit({
+            token: address(zoneToken), sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")
+        });
+        deposits[2] = Deposit({
+            token: address(zoneToken), sender: alice, to: bob, amount: 300e6, memo: bytes32("d3")
+        });
 
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, deposits[0], h0));
@@ -298,8 +330,12 @@ contract ZoneInboxTest is Test {
     function test_advanceTempo_incrementalProcessing() public {
         // First batch of deposits
         Deposit[] memory batch1 = new Deposit[](2);
-        batch1[0] = Deposit({ sender: alice, to: alice, amount: 100e6, memo: bytes32("d1") });
-        batch1[1] = Deposit({ sender: bob, to: bob, amount: 200e6, memo: bytes32("d2") });
+        batch1[0] = Deposit({
+            token: address(zoneToken), sender: alice, to: alice, amount: 100e6, memo: bytes32("d1")
+        });
+        batch1[1] = Deposit({
+            token: address(zoneToken), sender: bob, to: bob, amount: 200e6, memo: bytes32("d2")
+        });
 
         bytes32 h0 = bytes32(0);
         bytes32 h1 = keccak256(abi.encode(DepositType.Regular, batch1[0], h0));
@@ -314,7 +350,9 @@ contract ZoneInboxTest is Test {
 
         // Second batch of deposits
         Deposit[] memory batch2 = new Deposit[](1);
-        batch2[0] = Deposit({ sender: alice, to: bob, amount: 500e6, memo: bytes32("d3") });
+        batch2[0] = Deposit({
+            token: address(zoneToken), sender: alice, to: bob, amount: 500e6, memo: bytes32("d3")
+        });
 
         bytes32 h3 = keccak256(abi.encode(DepositType.Regular, batch2[0], h2));
 
@@ -334,7 +372,13 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_emitsTempoAdvancedEvent() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({
+            token: address(zoneToken),
+            sender: alice,
+            to: bob,
+            amount: 1000e6,
+            memo: bytes32("payment")
+        });
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
@@ -356,7 +400,13 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_emitsDepositProcessedEvent() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 1000e6, memo: bytes32("payment") });
+        deposits[0] = Deposit({
+            token: address(zoneToken),
+            sender: alice,
+            to: bob,
+            amount: 1000e6,
+            memo: bytes32("payment")
+        });
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
@@ -366,7 +416,9 @@ contract ZoneInboxTest is Test {
 
         vm.prank(sequencer);
         vm.expectEmit(true, true, true, true);
-        emit IZoneInbox.DepositProcessed(expectedHash, alice, bob, 1000e6, bytes32("payment"));
+        emit IZoneInbox.DepositProcessed(
+            expectedHash, alice, bob, address(zoneToken), 1000e6, bytes32("payment")
+        );
         _advanceTempo(deposits);
     }
 
@@ -376,7 +428,9 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_zeroAmountDeposit() public {
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: bob, amount: 0, memo: bytes32("empty") });
+        deposits[0] = Deposit({
+            token: address(zoneToken), sender: alice, to: bob, amount: 0, memo: bytes32("empty")
+        });
 
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)));
 
@@ -399,7 +453,6 @@ contract ZoneInboxTest is Test {
         assertEq(address(inbox.config()), address(config));
         assertEq(inbox.tempoPortal(), mockPortal);
         assertEq(address(inbox.tempoState()), address(tempoState));
-        assertEq(address(inbox.zoneToken()), address(zoneToken));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -412,8 +465,13 @@ contract ZoneInboxTest is Test {
 
         bytes32 currentHash = bytes32(0);
         for (uint256 i = 0; i < numDeposits; i++) {
-            deposits[i] =
-                Deposit({ sender: alice, to: bob, amount: uint128(i + 1) * 1e6, memo: bytes32(i) });
+            deposits[i] = Deposit({
+                token: address(zoneToken),
+                sender: alice,
+                to: bob,
+                amount: uint128(i + 1) * 1e6,
+                memo: bytes32(i)
+            });
             currentHash = keccak256(abi.encode(DepositType.Regular, deposits[i], currentHash));
         }
 
@@ -451,10 +509,11 @@ contract ZoneInboxTest is Test {
         uint256 keyIndex
     )
         internal
-        pure
+        view
         returns (QueuedDeposit memory qd, EncryptedDeposit memory ed)
     {
         ed = EncryptedDeposit({
+            token: address(zoneToken),
             sender: sender,
             amount: amount,
             keyIndex: keyIndex,
@@ -598,7 +657,9 @@ contract ZoneInboxTest is Test {
         _setupPrecompileMocks(recipient, encMemo);
 
         // Build regular deposit
-        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
+        Deposit memory d = Deposit({
+            token: address(zoneToken), sender: alice, to: bob, amount: 100e6, memo: bytes32("d1")
+        });
         QueuedDeposit memory qdRegular =
             QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
 
@@ -659,7 +720,9 @@ contract ZoneInboxTest is Test {
 
     function test_advanceTempo_extraDecryptionData() public {
         // Build a regular deposit only (no encrypted deposits)
-        Deposit memory d = Deposit({ sender: alice, to: bob, amount: 100e6, memo: bytes32("d1") });
+        Deposit memory d = Deposit({
+            token: address(zoneToken), sender: alice, to: bob, amount: 100e6, memo: bytes32("d1")
+        });
         QueuedDeposit memory qd =
             QueuedDeposit({ depositType: DepositType.Regular, depositData: abi.encode(d) });
 

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -20,6 +20,7 @@ import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
 import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
+import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
 import { ZoneOutbox } from "../../src/zone/ZoneOutbox.sol";
 import { ZonePortal } from "../../src/zone/ZonePortal.sol";
 import { BaseTest } from "../BaseTest.t.sol";
@@ -34,6 +35,7 @@ contract TrackingReceiver is IWithdrawalReceiver {
     uint256 public callCount;
 
     function onWithdrawalReceived(
+        address,
         address,
         uint128 amount,
         bytes calldata
@@ -74,45 +76,44 @@ contract ZoneIntegrationTest is BaseTest {
     function setUp() public override {
         super.setUp();
 
-        // L1 setup
-        l1Factory = new ZoneFactory();
+        l1Factory = new ZoneFactory(); // Keep for verifier only
         receiver = new TrackingReceiver();
 
-        vm.startPrank(pathUSDAdmin);
-        pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
-        pathUSD.mint(alice, 1_000_000e6);
-        pathUSD.mint(bob, 1_000_000e6);
-        pathUSD.mint(charlie, 1_000_000e6);
-        vm.stopPrank();
+        // Deploy zone token FIRST
+        l2ZoneToken = new MockZoneToken("Zone USD", "zUSD");
+
+        // Fund test accounts with zone token (for L1 deposits)
+        l2ZoneToken.setMinter(address(this), true);
+        l2ZoneToken.mint(alice, 1_000_000e6);
+        l2ZoneToken.mint(bob, 1_000_000e6);
+        l2ZoneToken.mint(charlie, 1_000_000e6);
+        l2ZoneToken.setMinter(address(this), false);
 
         genesisTempoBlockNumber = uint64(block.number);
 
-        // Create zone
-        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
-            sequencer: admin,
-            verifier: l1Factory.verifier(),
-            zoneParams: ZoneParams({
-                genesisBlockHash: GENESIS_BLOCK_HASH,
-                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
-                genesisTempoBlockNumber: genesisTempoBlockNumber
-            })
-        });
-        address portalAddr;
-        (zoneId, portalAddr) = l1Factory.createZone(params);
-        l1Portal = ZonePortal(portalAddr);
+        // Deploy messenger and portal directly (bypass factory TIP20 prefix check)
+        uint256 currentNonce = vm.getNonce(address(this));
+        address predictedPortal = vm.computeCreateAddress(address(this), currentNonce + 1);
+        ZoneMessenger messengerContract = new ZoneMessenger(predictedPortal);
+        l1Portal = new ZonePortal(
+            1,
+            address(l2ZoneToken),
+            address(messengerContract),
+            admin,
+            l1Factory.verifier(),
+            GENESIS_BLOCK_HASH,
+            genesisTempoBlockNumber
+        );
+        zoneId = 1;
 
         // L2 setup
-        l2ZoneToken = new MockZoneToken("Zone USD", "zUSD");
         l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
-        l2Config = new ZoneConfig(address(l2ZoneToken), portalAddr, address(l2TempoState));
+        l2Config = new ZoneConfig(address(l1Portal), address(l2TempoState));
         l2TempoState.setMockStorageValue(
-            portalAddr, bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+            address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
         );
-        l2Inbox = new ZoneInbox(
-            address(l2Config), portalAddr, address(l2TempoState), address(l2ZoneToken)
-        );
-        l2Outbox = new ZoneOutbox(address(l2Config), address(l2ZoneToken));
+        l2Inbox = new ZoneInbox(address(l2Config), address(l1Portal), address(l2TempoState));
+        l2Outbox = new ZoneOutbox(address(l2Config));
 
         l2ZoneToken.setMinter(address(l2Inbox), true);
         l2ZoneToken.setBurner(address(l2Outbox), true);
@@ -142,43 +143,73 @@ contract ZoneIntegrationTest is BaseTest {
     function test_multiUserDeposit_processedCorrectly() public {
         // Alice, Bob, Charlie all deposit
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 10_000e6);
-        bytes32 h1 = l1Portal.deposit(alice, 1000e6, bytes32("alice1"));
-        bytes32 h2 = l1Portal.deposit(alice, 2000e6, bytes32("alice2"));
+        l2ZoneToken.approve(address(l1Portal), 10_000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32("alice1"));
+        l1Portal.deposit(address(l2ZoneToken), alice, 2000e6, bytes32("alice2"));
         vm.stopPrank();
 
         vm.startPrank(bob);
-        pathUSD.approve(address(l1Portal), 5000e6);
-        bytes32 h3 = l1Portal.deposit(bob, 3000e6, bytes32("bob1"));
+        l2ZoneToken.approve(address(l1Portal), 5000e6);
+        l1Portal.deposit(address(l2ZoneToken), bob, 3000e6, bytes32("bob1"));
         vm.stopPrank();
 
         vm.startPrank(charlie);
-        pathUSD.approve(address(l1Portal), 2000e6);
-        bytes32 h4 = l1Portal.deposit(charlie, 500e6, bytes32("charlie1"));
+        l2ZoneToken.approve(address(l1Portal), 2000e6);
+        l1Portal.deposit(address(l2ZoneToken), charlie, 500e6, bytes32("charlie1"));
         vm.stopPrank();
 
         // Build deposit array
         Deposit[] memory deposits = new Deposit[](4);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 1000e6, memo: bytes32("alice1") });
-        deposits[1] = Deposit({ sender: alice, to: alice, amount: 2000e6, memo: bytes32("alice2") });
-        deposits[2] = Deposit({ sender: bob, to: bob, amount: 3000e6, memo: bytes32("bob1") });
-        deposits[3] =
-            Deposit({ sender: charlie, to: charlie, amount: 500e6, memo: bytes32("charlie1") });
+        deposits[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 1000e6,
+            memo: bytes32("alice1")
+        });
+        deposits[1] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 2000e6,
+            memo: bytes32("alice2")
+        });
+        deposits[2] = Deposit({
+            token: address(l2ZoneToken), sender: bob, to: bob, amount: 3000e6, memo: bytes32("bob1")
+        });
+        deposits[3] = Deposit({
+            token: address(l2ZoneToken),
+            sender: charlie,
+            to: charlie,
+            amount: 500e6,
+            memo: bytes32("charlie1")
+        });
 
-        // Set up L2 mock
+        // Set up L2 mock — hash chain uses l2ZoneToken consistently
+        bytes32 l2h0 = bytes32(0);
+        bytes32 l2h1 = keccak256(abi.encode(DepositType.Regular, deposits[0], l2h0));
+        bytes32 l2h2 = keccak256(abi.encode(DepositType.Regular, deposits[1], l2h1));
+        bytes32 l2h3 = keccak256(abi.encode(DepositType.Regular, deposits[2], l2h2));
+        bytes32 l2h4 = keccak256(abi.encode(DepositType.Regular, deposits[3], l2h3));
         l2TempoState.setMockStorageValue(
-            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, h4
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, l2h4
         );
+
+        // Capture balances after L1 deposits but before L2 minting
+        uint256 alicePre = l2ZoneToken.balanceOf(alice);
+        uint256 bobPre = l2ZoneToken.balanceOf(bob);
+        uint256 charliePre = l2ZoneToken.balanceOf(charlie);
+        uint256 supplyPre = l2ZoneToken.totalSupply();
 
         // Process on L2
         vm.prank(admin);
         _advanceTempo(deposits);
 
-        // Verify L2 balances
-        assertEq(l2ZoneToken.balanceOf(alice), 3000e6);
-        assertEq(l2ZoneToken.balanceOf(bob), 3000e6);
-        assertEq(l2ZoneToken.balanceOf(charlie), 500e6);
-        assertEq(l2ZoneToken.totalSupply(), 6500e6);
+        // Verify L2 minting: each user receives their deposited amounts
+        assertEq(l2ZoneToken.balanceOf(alice), alicePre + 3000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), bobPre + 3000e6);
+        assertEq(l2ZoneToken.balanceOf(charlie), charliePre + 500e6);
+        assertEq(l2ZoneToken.totalSupply(), supplyPre + 6500e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -188,23 +219,32 @@ contract ZoneIntegrationTest is BaseTest {
     function test_incrementalBatchProcessing() public {
         // Batch 1: Two deposits
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 10_000e6);
-        bytes32 d1 = l1Portal.deposit(alice, 1000e6, bytes32("d1"));
-        bytes32 d2 = l1Portal.deposit(alice, 2000e6, bytes32("d2"));
+        l2ZoneToken.approve(address(l1Portal), 10_000e6);
+        bytes32 d1 = l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32("d1"));
+        bytes32 d2 = l1Portal.deposit(address(l2ZoneToken), alice, 2000e6, bytes32("d2"));
         vm.stopPrank();
 
         // Process only first deposit
         Deposit[] memory batch1 = new Deposit[](1);
-        batch1[0] = Deposit({ sender: alice, to: alice, amount: 1000e6, memo: bytes32("d1") });
+        batch1[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 1000e6,
+            memo: bytes32("d1")
+        });
 
+        // Deposit hash uses l2ZoneToken consistently
+        bytes32 l2Hash1 = keccak256(abi.encode(DepositType.Regular, batch1[0], bytes32(0)));
         l2TempoState.setMockStorageValue(
-            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, l2Hash1
         );
+        uint256 alicePreBatch1 = l2ZoneToken.balanceOf(alice);
         vm.prank(admin);
         _advanceTempo(batch1);
 
-        assertEq(l2ZoneToken.balanceOf(alice), 1000e6);
-        assertEq(l2Inbox.processedDepositQueueHash(), d1);
+        assertEq(l2ZoneToken.balanceOf(alice), alicePreBatch1 + 1000e6);
+        assertEq(l2Inbox.processedDepositQueueHash(), l2Hash1);
 
         // Submit L1 batch for first deposit
         vm.roll(block.number + 1);
@@ -225,20 +265,36 @@ contract ZoneIntegrationTest is BaseTest {
 
         // More deposits arrive
         vm.prank(alice);
-        bytes32 d3 = l1Portal.deposit(alice, 3000e6, bytes32("d3"));
+        l1Portal.deposit(address(l2ZoneToken), alice, 3000e6, bytes32("d3"));
 
         // Process remaining deposits
         Deposit[] memory batch2 = new Deposit[](2);
-        batch2[0] = Deposit({ sender: alice, to: alice, amount: 2000e6, memo: bytes32("d2") });
-        batch2[1] = Deposit({ sender: alice, to: alice, amount: 3000e6, memo: bytes32("d3") });
+        batch2[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 2000e6,
+            memo: bytes32("d2")
+        });
+        batch2[1] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 3000e6,
+            memo: bytes32("d3")
+        });
 
+        // Compute L2 hash chain continuing from l2Hash1
+        bytes32 l2Hash2 = keccak256(abi.encode(DepositType.Regular, batch2[0], l2Hash1));
+        bytes32 l2Hash3 = keccak256(abi.encode(DepositType.Regular, batch2[1], l2Hash2));
         l2TempoState.setMockStorageValue(
-            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3
+            address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, l2Hash3
         );
+        uint256 alicePreBatch2 = l2ZoneToken.balanceOf(alice);
         vm.prank(admin);
         _advanceTempo(batch2);
 
-        assertEq(l2ZoneToken.balanceOf(alice), 6000e6);
+        assertEq(l2ZoneToken.balanceOf(alice), alicePreBatch2 + 5000e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -248,14 +304,20 @@ contract ZoneIntegrationTest is BaseTest {
     function test_withdrawalWithCallback_fullFlow() public {
         // Setup: Alice deposits
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 10_000e6);
-        bytes32 depositHash = l1Portal.deposit(alice, 5000e6, bytes32("deposit"));
+        l2ZoneToken.approve(address(l1Portal), 10_000e6);
+        bytes32 depositHash =
+            l1Portal.deposit(address(l2ZoneToken), alice, 5000e6, bytes32("deposit"));
         vm.stopPrank();
 
         // Process deposit on L2
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] =
-            Deposit({ sender: alice, to: alice, amount: 5000e6, memo: bytes32("deposit") });
+        deposits[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 5000e6,
+            memo: bytes32("deposit")
+        });
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
         );
@@ -266,7 +328,13 @@ contract ZoneIntegrationTest is BaseTest {
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), 2000e6);
         l2Outbox.requestWithdrawal(
-            address(receiver), 2000e6, bytes32("payment"), 100_000, alice, "callback"
+            address(l2ZoneToken),
+            address(receiver),
+            2000e6,
+            bytes32("payment"),
+            100_000,
+            alice,
+            "callback"
         );
         vm.stopPrank();
 
@@ -292,6 +360,7 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process withdrawal
         Withdrawal memory w = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: address(receiver),
             amount: 2000e6,
@@ -306,7 +375,7 @@ contract ZoneIntegrationTest is BaseTest {
         // Verify callback was executed
         assertEq(receiver.callCount(), 1);
         assertEq(receiver.totalReceived(), 2000e6);
-        assertEq(pathUSD.balanceOf(address(receiver)), 2000e6);
+        assertEq(l2ZoneToken.balanceOf(address(receiver)), 2000e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -316,14 +385,20 @@ contract ZoneIntegrationTest is BaseTest {
     function test_multipleBatches_withdrawalsInDifferentSlots() public {
         // Initial deposit
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 100_000e6);
-        bytes32 depositHash = l1Portal.deposit(alice, 50_000e6, bytes32("big deposit"));
+        l2ZoneToken.approve(address(l1Portal), 100_000e6);
+        bytes32 depositHash =
+            l1Portal.deposit(address(l2ZoneToken), alice, 50_000e6, bytes32("big deposit"));
         vm.stopPrank();
 
         // Process on L2
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] =
-            Deposit({ sender: alice, to: alice, amount: 50_000e6, memo: bytes32("big deposit") });
+        deposits[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 50_000e6,
+            memo: bytes32("big deposit")
+        });
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
         );
@@ -333,7 +408,9 @@ contract ZoneIntegrationTest is BaseTest {
         // First batch: Alice withdraws to Bob
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), 50_000e6);
-        l2Outbox.requestWithdrawal(bob, 1000e6, bytes32("to bob"), 0, alice, "");
+        l2Outbox.requestWithdrawal(
+            address(l2ZoneToken), bob, 1000e6, bytes32("to bob"), 0, alice, ""
+        );
         vm.stopPrank();
 
         vm.prank(admin);
@@ -356,7 +433,9 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Second batch: Alice withdraws to Charlie
         vm.startPrank(alice);
-        l2Outbox.requestWithdrawal(charlie, 2000e6, bytes32("to charlie"), 0, alice, "");
+        l2Outbox.requestWithdrawal(
+            address(l2ZoneToken), charlie, 2000e6, bytes32("to charlie"), 0, alice, ""
+        );
         vm.stopPrank();
 
         vm.prank(admin);
@@ -379,7 +458,9 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Third batch: Alice withdraws to herself
         vm.startPrank(alice);
-        l2Outbox.requestWithdrawal(alice, 3000e6, bytes32("to self"), 0, alice, "");
+        l2Outbox.requestWithdrawal(
+            address(l2ZoneToken), alice, 3000e6, bytes32("to self"), 0, alice, ""
+        );
         vm.stopPrank();
 
         vm.prank(admin);
@@ -403,12 +484,13 @@ contract ZoneIntegrationTest is BaseTest {
         // Verify queue state
         assertEq(l1Portal.withdrawalQueueHead(), 0);
         assertEq(l1Portal.withdrawalQueueTail(), 3);
-        // Process in order
-        uint256 bobBefore = pathUSD.balanceOf(bob);
-        uint256 charlieBefore = pathUSD.balanceOf(charlie);
-        uint256 aliceBefore = pathUSD.balanceOf(alice);
+        // Process in order (portal transfers l2ZoneToken from its balance)
+        uint256 bobBefore = l2ZoneToken.balanceOf(bob);
+        uint256 charlieBefore = l2ZoneToken.balanceOf(charlie);
+        uint256 aliceBefore = l2ZoneToken.balanceOf(alice);
 
         Withdrawal memory w1 = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: bob,
             amount: 1000e6,
@@ -419,9 +501,10 @@ contract ZoneIntegrationTest is BaseTest {
             callbackData: ""
         });
         l1Portal.processWithdrawal(w1, bytes32(0));
-        assertEq(pathUSD.balanceOf(bob), bobBefore + 1000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), bobBefore + 1000e6);
 
         Withdrawal memory w2 = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: charlie,
             amount: 2000e6,
@@ -432,9 +515,10 @@ contract ZoneIntegrationTest is BaseTest {
             callbackData: ""
         });
         l1Portal.processWithdrawal(w2, bytes32(0));
-        assertEq(pathUSD.balanceOf(charlie), charlieBefore + 2000e6);
+        assertEq(l2ZoneToken.balanceOf(charlie), charlieBefore + 2000e6);
 
         Withdrawal memory w3 = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: alice,
             amount: 3000e6,
@@ -445,7 +529,7 @@ contract ZoneIntegrationTest is BaseTest {
             callbackData: ""
         });
         l1Portal.processWithdrawal(w3, bytes32(0));
-        assertEq(pathUSD.balanceOf(alice), aliceBefore + 3000e6);
+        assertEq(l2ZoneToken.balanceOf(alice), aliceBefore + 3000e6);
 
         // All processed
         assertEq(l1Portal.withdrawalQueueHead(), 3);
@@ -459,19 +543,27 @@ contract ZoneIntegrationTest is BaseTest {
     function test_mixedFlow_depositsAndWithdrawalsInterleaved() public {
         // Phase 1: Initial deposits
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 100_000e6);
-        l1Portal.deposit(alice, 10_000e6, bytes32("d1"));
+        l2ZoneToken.approve(address(l1Portal), 100_000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 10_000e6, bytes32("d1"));
         vm.stopPrank();
 
         vm.startPrank(bob);
-        pathUSD.approve(address(l1Portal), 100_000e6);
-        bytes32 d2 = l1Portal.deposit(bob, 5000e6, bytes32("d2"));
+        l2ZoneToken.approve(address(l1Portal), 100_000e6);
+        bytes32 d2 = l1Portal.deposit(address(l2ZoneToken), bob, 5000e6, bytes32("d2"));
         vm.stopPrank();
 
         // Process both deposits
         Deposit[] memory deposits1 = new Deposit[](2);
-        deposits1[0] = Deposit({ sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1") });
-        deposits1[1] = Deposit({ sender: bob, to: bob, amount: 5000e6, memo: bytes32("d2") });
+        deposits1[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 10_000e6,
+            memo: bytes32("d1")
+        });
+        deposits1[1] = Deposit({
+            token: address(l2ZoneToken), sender: bob, to: bob, amount: 5000e6, memo: bytes32("d2")
+        });
 
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d2
@@ -482,12 +574,12 @@ contract ZoneIntegrationTest is BaseTest {
         // Phase 2: Withdrawals
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), 5000e6);
-        l2Outbox.requestWithdrawal(charlie, 2000e6, bytes32(0), 0, alice, "");
+        l2Outbox.requestWithdrawal(address(l2ZoneToken), charlie, 2000e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(bob);
         l2ZoneToken.approve(address(l2Outbox), 3000e6);
-        l2Outbox.requestWithdrawal(charlie, 1500e6, bytes32(0), 0, alice, "");
+        l2Outbox.requestWithdrawal(address(l2ZoneToken), charlie, 1500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         vm.prank(admin);
@@ -495,8 +587,8 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Phase 3: More deposits arrive while withdrawals are pending
         vm.startPrank(charlie);
-        pathUSD.approve(address(l1Portal), 20_000e6);
-        bytes32 d3 = l1Portal.deposit(charlie, 7500e6, bytes32("d3"));
+        l2ZoneToken.approve(address(l1Portal), 20_000e6);
+        bytes32 d3 = l1Portal.deposit(address(l2ZoneToken), charlie, 7500e6, bytes32("d3"));
         vm.stopPrank();
 
         // Submit batch with withdrawals
@@ -515,8 +607,13 @@ contract ZoneIntegrationTest is BaseTest {
 
         // Process new deposit
         Deposit[] memory deposits2 = new Deposit[](1);
-        deposits2[0] =
-            Deposit({ sender: charlie, to: charlie, amount: 7500e6, memo: bytes32("d3") });
+        deposits2[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: charlie,
+            to: charlie,
+            amount: 7500e6,
+            memo: bytes32("d3")
+        });
 
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3
@@ -524,13 +621,16 @@ contract ZoneIntegrationTest is BaseTest {
         vm.prank(admin);
         _advanceTempo(deposits2);
 
-        // Verify all L2 balances
-        assertEq(l2ZoneToken.balanceOf(alice), 10_000e6 - 2000e6);
-        assertEq(l2ZoneToken.balanceOf(bob), 5000e6 - 1500e6);
-        assertEq(l2ZoneToken.balanceOf(charlie), 7500e6);
+        // Verify all L2 balances (initial 1M - deposited + minted - burned)
+        // alice: 1M - 10k + 10k - 2k = 998k; bob: 1M - 5k + 5k - 1.5k = 998.5k
+        // charlie: 1M - 7.5k + 7.5k = 1M
+        assertEq(l2ZoneToken.balanceOf(alice), 1_000_000e6 - 2000e6);
+        assertEq(l2ZoneToken.balanceOf(bob), 1_000_000e6 - 1500e6);
+        assertEq(l2ZoneToken.balanceOf(charlie), 1_000_000e6);
 
         // Process withdrawals
         Withdrawal memory w1 = Withdrawal({
+            token: address(l2ZoneToken),
             sender: alice,
             to: charlie,
             amount: 2000e6,
@@ -541,6 +641,7 @@ contract ZoneIntegrationTest is BaseTest {
             callbackData: ""
         });
         Withdrawal memory w2 = Withdrawal({
+            token: address(l2ZoneToken),
             sender: bob,
             to: charlie,
             amount: 1500e6,
@@ -552,12 +653,12 @@ contract ZoneIntegrationTest is BaseTest {
         });
 
         bytes32 innerHash = keccak256(abi.encode(w2, EMPTY_SENTINEL));
-        uint256 charlieBefore = pathUSD.balanceOf(charlie);
+        uint256 charlieBefore = l2ZoneToken.balanceOf(charlie);
 
         l1Portal.processWithdrawal(w1, innerHash);
         l1Portal.processWithdrawal(w2, bytes32(0));
 
-        assertEq(pathUSD.balanceOf(charlie), charlieBefore + 3500e6);
+        assertEq(l2ZoneToken.balanceOf(charlie), charlieBefore + 3500e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -565,35 +666,44 @@ contract ZoneIntegrationTest is BaseTest {
     //////////////////////////////////////////////////////////////*/
 
     function test_invariant_totalSupplyMatchesNetDeposits() public {
+        // Initial supply: 3 users × 1M = 3M (from setUp)
+        uint256 initialSupply = l2ZoneToken.totalSupply();
+
         // Deposit 10000
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 10_000e6);
-        bytes32 d1 = l1Portal.deposit(alice, 10_000e6, bytes32("d1"));
+        l2ZoneToken.approve(address(l1Portal), 10_000e6);
+        bytes32 d1 = l1Portal.deposit(address(l2ZoneToken), alice, 10_000e6, bytes32("d1"));
         vm.stopPrank();
 
         Deposit[] memory deposits = new Deposit[](1);
-        deposits[0] = Deposit({ sender: alice, to: alice, amount: 10_000e6, memo: bytes32("d1") });
+        deposits[0] = Deposit({
+            token: address(l2ZoneToken),
+            sender: alice,
+            to: alice,
+            amount: 10_000e6,
+            memo: bytes32("d1")
+        });
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1
         );
         vm.prank(admin);
         _advanceTempo(deposits);
 
-        assertEq(l2ZoneToken.totalSupply(), 10_000e6);
+        assertEq(l2ZoneToken.totalSupply(), initialSupply + 10_000e6);
 
         // Withdraw 3000
         vm.startPrank(alice);
         l2ZoneToken.approve(address(l2Outbox), 3000e6);
-        l2Outbox.requestWithdrawal(bob, 3000e6, bytes32(0), 0, alice, "");
+        l2Outbox.requestWithdrawal(address(l2ZoneToken), bob, 3000e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
-        assertEq(l2ZoneToken.totalSupply(), 7000e6); // Tokens burned on withdrawal request
+        assertEq(l2ZoneToken.totalSupply(), initialSupply + 10_000e6 - 3000e6); // Tokens burned on withdrawal request
 
         // Transfer on L2 shouldn't change supply
         vm.prank(alice);
         l2ZoneToken.transfer(bob, 2000e6);
 
-        assertEq(l2ZoneToken.totalSupply(), 7000e6);
+        assertEq(l2ZoneToken.totalSupply(), initialSupply + 10_000e6 - 3000e6);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -605,8 +715,8 @@ contract ZoneIntegrationTest is BaseTest {
     function test_storageLayout_currentDepositQueueHashSlot() public {
         // Make a deposit to get a non-zero currentDepositQueueHash
         vm.startPrank(alice);
-        pathUSD.approve(address(l1Portal), 1000e6);
-        l1Portal.deposit(alice, 1000e6, bytes32("layout-test"));
+        l2ZoneToken.approve(address(l1Portal), 1000e6);
+        l1Portal.deposit(address(l2ZoneToken), alice, 1000e6, bytes32("layout-test"));
         vm.stopPrank();
 
         // Read via vm.load using our constant

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -12,6 +12,7 @@ import {
     IZoneFactory,
     IZonePortal,
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
+    PORTAL_TOKEN_CONFIGS_SLOT,
     QueuedDeposit,
     Withdrawal,
     ZoneParams
@@ -112,6 +113,9 @@ contract ZoneIntegrationTest is BaseTest {
         l2TempoState.setMockStorageValue(
             address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
         );
+        // Enable l2ZoneToken in the mock portal's token registry for zone-side validation
+        bytes32 tokenConfigSlot = keccak256(abi.encode(address(l2ZoneToken), PORTAL_TOKEN_CONFIGS_SLOT));
+        l2TempoState.setMockStorageValue(address(l1Portal), tokenConfigSlot, bytes32(uint256(0x0101)));
         l2Inbox = new ZoneInbox(address(l2Config), address(l1Portal), address(l2TempoState));
         l2Outbox = new ZoneOutbox(address(l2Config));
 

--- a/docs/specs/test/zone/ZoneOutbox.t.sol
+++ b/docs/specs/test/zone/ZoneOutbox.t.sol
@@ -33,12 +33,12 @@ contract ZoneOutboxTest is Test {
         zoneToken = new MockZoneToken("Zone USD", "zUSD");
         tempoState =
             new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, GENESIS_TEMPO_BLOCK_NUMBER);
-        config = new ZoneConfig(address(zoneToken), mockPortal, address(tempoState));
+        config = new ZoneConfig(mockPortal, address(tempoState));
         tempoState.setMockStorageValue(
             mockPortal, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
         );
-        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState), address(zoneToken));
-        outbox = new ZoneOutbox(address(config), address(zoneToken));
+        inbox = new ZoneInbox(address(config), mockPortal, address(tempoState));
+        outbox = new ZoneOutbox(address(config));
 
         // Grant minter role to inbox and burner role to outbox
         zoneToken.setMinter(address(inbox), true);
@@ -58,14 +58,14 @@ contract ZoneOutboxTest is Test {
     function test_requestWithdrawal_storesInArray() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32("memo"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32("memo"), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 1);
 
         vm.startPrank(bob);
         zoneToken.approve(address(outbox), 300e6);
-        outbox.requestWithdrawal(bob, 300e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 300e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 2);
@@ -87,7 +87,7 @@ contract ZoneOutboxTest is Test {
         // Add a withdrawal
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 1);
@@ -103,11 +103,12 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_singleWithdrawal_correctHash() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32("memo"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32("memo"), 0, alice, "");
         vm.stopPrank();
 
         // Expected hash
         Withdrawal memory w = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 500e6,
@@ -129,13 +130,13 @@ contract ZoneOutboxTest is Test {
         // Alice withdraws
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         // Bob withdraws
         vm.startPrank(bob);
         zoneToken.approve(address(outbox), 300e6);
-        outbox.requestWithdrawal(bob, 300e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 300e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         // Build expected hash (oldest = outermost)
@@ -143,6 +144,7 @@ contract ZoneOutboxTest is Test {
         // w1 = bob's withdrawal (second, newest)
         // Hash chain: hash(w0, hash(w1, EMPTY_SENTINEL))
         Withdrawal memory w0 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 500e6,
@@ -153,6 +155,7 @@ contract ZoneOutboxTest is Test {
             callbackData: ""
         });
         Withdrawal memory w1 = Withdrawal({
+            token: address(zoneToken),
             sender: bob,
             to: bob,
             amount: 300e6,
@@ -176,8 +179,8 @@ contract ZoneOutboxTest is Test {
         // Add withdrawals
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 1000e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
-        outbox.requestWithdrawal(alice, 300e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 300e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 2);
@@ -193,9 +196,9 @@ contract ZoneOutboxTest is Test {
         // Add 3 withdrawals
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 1500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32("w1"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 500e6, bytes32("w2"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 500e6, bytes32("w3"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32("w1"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32("w2"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32("w3"), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 3);
@@ -209,6 +212,7 @@ contract ZoneOutboxTest is Test {
 
         // Expected hash for w1 and w2 (w1 is oldest of the two)
         Withdrawal memory w1 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 500e6,
@@ -219,6 +223,7 @@ contract ZoneOutboxTest is Test {
             callbackData: ""
         });
         Withdrawal memory w2 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 500e6,
@@ -239,10 +244,10 @@ contract ZoneOutboxTest is Test {
         // Add 4 withdrawals in order
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 4000e6);
-        outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 200e6, bytes32("w2"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 300e6, bytes32("w3"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 400e6, bytes32("w4"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 100e6, bytes32("w1"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 200e6, bytes32("w2"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 300e6, bytes32("w3"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 400e6, bytes32("w4"), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 4);
@@ -252,6 +257,7 @@ contract ZoneOutboxTest is Test {
         bytes32 hash1 = outbox.finalizeWithdrawalBatch(2);
 
         Withdrawal memory w1 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 100e6,
@@ -262,6 +268,7 @@ contract ZoneOutboxTest is Test {
             callbackData: ""
         });
         Withdrawal memory w2 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 200e6,
@@ -282,6 +289,7 @@ contract ZoneOutboxTest is Test {
         bytes32 hash2 = outbox.finalizeWithdrawalBatch(2);
 
         Withdrawal memory w3 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 300e6,
@@ -292,6 +300,7 @@ contract ZoneOutboxTest is Test {
             callbackData: ""
         });
         Withdrawal memory w4 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 400e6,
@@ -311,10 +320,11 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_emitsEvent() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 500e6,
@@ -340,10 +350,11 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_writesLastBatchToState() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 500e6,
@@ -372,7 +383,7 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_onlySequencer() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(alice, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         // Non-sequencer should revert
@@ -394,6 +405,7 @@ contract ZoneOutboxTest is Test {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(
+            address(zoneToken), // token
             bob, // to
             500e6, // amount
             bytes32("pay"), // memo
@@ -404,6 +416,7 @@ contract ZoneOutboxTest is Test {
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -431,13 +444,13 @@ contract ZoneOutboxTest is Test {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 3000e6);
 
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         assertEq(outbox.nextWithdrawalIndex(), 1);
 
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         assertEq(outbox.nextWithdrawalIndex(), 2);
 
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         assertEq(outbox.nextWithdrawalIndex(), 3);
 
         vm.stopPrank();
@@ -448,8 +461,8 @@ contract ZoneOutboxTest is Test {
         zoneToken.approve(address(outbox), 5000e6);
 
         // First batch
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
 
         vm.stopPrank();
 
@@ -458,7 +471,7 @@ contract ZoneOutboxTest is Test {
 
         // Second batch
         vm.startPrank(alice);
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
 
         assertEq(outbox.nextWithdrawalIndex(), 3);
         vm.stopPrank();
@@ -474,10 +487,10 @@ contract ZoneOutboxTest is Test {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 3000e6);
 
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         assertEq(outbox.pendingWithdrawalsCount(), 1);
 
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         assertEq(outbox.pendingWithdrawalsCount(), 2);
 
         vm.stopPrank();
@@ -497,7 +510,7 @@ contract ZoneOutboxTest is Test {
 
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(zoneToken.balanceOf(alice), aliceBalanceBefore - 500e6);
@@ -508,7 +521,7 @@ contract ZoneOutboxTest is Test {
 
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(zoneToken.totalSupply(), totalSupplyBefore - 500e6);
@@ -519,7 +532,7 @@ contract ZoneOutboxTest is Test {
         zoneToken.approve(address(outbox), 200_000e6);
 
         vm.expectRevert(MockZoneToken.InsufficientBalance.selector);
-        outbox.requestWithdrawal(bob, 200_000e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 200_000e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
     }
 
@@ -528,7 +541,7 @@ contract ZoneOutboxTest is Test {
         zoneToken.approve(address(outbox), 100e6);
 
         vm.expectRevert(MockZoneToken.InsufficientAllowance.selector);
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
     }
 
@@ -541,7 +554,7 @@ contract ZoneOutboxTest is Test {
         zoneToken.approve(address(outbox), 500e6);
 
         // gasLimit = 0, fallbackRecipient = alice is fine
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 1);
@@ -553,7 +566,7 @@ contract ZoneOutboxTest is Test {
 
         // fallbackRecipient = address(0) reverts
         vm.expectRevert(ZoneOutbox.InvalidFallbackRecipient.selector);
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 0, address(0), "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, address(0), "");
         vm.stopPrank();
     }
 
@@ -562,7 +575,9 @@ contract ZoneOutboxTest is Test {
         zoneToken.approve(address(outbox), 500e6);
 
         // gasLimit > 0 with valid fallback
-        outbox.requestWithdrawal(bob, 500e6, bytes32(0), 100_000, alice, "callback");
+        outbox.requestWithdrawal(
+            address(zoneToken), bob, 500e6, bytes32(0), 100_000, alice, "callback"
+        );
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 1);
@@ -576,21 +591,22 @@ contract ZoneOutboxTest is Test {
         // Add three withdrawals
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 3000e6);
-        outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 100e6, bytes32("w1"), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(bob);
         zoneToken.approve(address(outbox), 3000e6);
-        outbox.requestWithdrawal(bob, 200e6, bytes32("w2"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 200e6, bytes32("w2"), 0, alice, "");
         vm.stopPrank();
 
         vm.startPrank(charlie);
         zoneToken.approve(address(outbox), 3000e6);
-        outbox.requestWithdrawal(charlie, 300e6, bytes32("w3"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), charlie, 300e6, bytes32("w3"), 0, alice, "");
         vm.stopPrank();
 
         // Build expected hash (oldest = outermost)
         Withdrawal memory w1 = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: alice,
             amount: 100e6,
@@ -601,6 +617,7 @@ contract ZoneOutboxTest is Test {
             callbackData: ""
         });
         Withdrawal memory w2 = Withdrawal({
+            token: address(zoneToken),
             sender: bob,
             to: bob,
             amount: 200e6,
@@ -611,6 +628,7 @@ contract ZoneOutboxTest is Test {
             callbackData: ""
         });
         Withdrawal memory w3 = Withdrawal({
+            token: address(zoneToken),
             sender: charlie,
             to: charlie,
             amount: 300e6,
@@ -635,11 +653,11 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_partialBatch_leavesRemainder() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 5000e6);
-        outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 200e6, bytes32("w2"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 300e6, bytes32("w3"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 400e6, bytes32("w4"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 500e6, bytes32("w5"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 100e6, bytes32("w1"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 200e6, bytes32("w2"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 300e6, bytes32("w3"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 400e6, bytes32("w4"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32("w5"), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 5);
@@ -655,8 +673,8 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_countLargerThanPending() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 1000e6);
-        outbox.requestWithdrawal(alice, 100e6, bytes32("w1"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 200e6, bytes32("w2"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 100e6, bytes32("w1"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 200e6, bytes32("w2"), 0, alice, "");
         vm.stopPrank();
 
         // Process with large count
@@ -670,8 +688,8 @@ contract ZoneOutboxTest is Test {
         // First batch
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 10_000e6);
-        outbox.requestWithdrawal(alice, 100e6, bytes32("b1w1"), 0, alice, "");
-        outbox.requestWithdrawal(alice, 200e6, bytes32("b1w2"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 100e6, bytes32("b1w1"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 200e6, bytes32("b1w2"), 0, alice, "");
         vm.stopPrank();
 
         vm.prank(sequencer);
@@ -680,7 +698,7 @@ contract ZoneOutboxTest is Test {
 
         // Second batch
         vm.startPrank(alice);
-        outbox.requestWithdrawal(alice, 300e6, bytes32("b2w1"), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 300e6, bytes32("b2w1"), 0, alice, "");
         vm.stopPrank();
 
         vm.prank(sequencer);
@@ -699,6 +717,7 @@ contract ZoneOutboxTest is Test {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 1000e6);
         outbox.requestWithdrawal(
+            address(zoneToken), // token
             bob, // to
             500e6, // amount
             bytes32("payment123"), // memo
@@ -710,6 +729,7 @@ contract ZoneOutboxTest is Test {
 
         // Finalize and verify hash includes all fields
         Withdrawal memory expected = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -734,13 +754,14 @@ contract ZoneOutboxTest is Test {
     function test_requestWithdrawal_zeroAmount() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 0);
-        outbox.requestWithdrawal(bob, 0, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), bob, 0, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 1);
 
         // Should still produce valid hash
         Withdrawal memory w = Withdrawal({
+            token: address(zoneToken),
             sender: alice,
             to: bob,
             amount: 0,
@@ -771,6 +792,7 @@ contract ZoneOutboxTest is Test {
         emit IZoneOutbox.WithdrawalRequested(
             0, // index
             alice, // sender
+            address(zoneToken), // token
             bob, // to
             500e6, // amount
             expectedFee, // fee
@@ -780,7 +802,9 @@ contract ZoneOutboxTest is Test {
             "data"
         );
 
-        outbox.requestWithdrawal(bob, 500e6, bytes32("memo"), 50_000, charlie, "data");
+        outbox.requestWithdrawal(
+            address(zoneToken), bob, 500e6, bytes32("memo"), 50_000, charlie, "data"
+        );
         vm.stopPrank();
     }
 
@@ -789,7 +813,6 @@ contract ZoneOutboxTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_immutableGetters() public view {
-        assertEq(address(outbox.zoneToken()), address(zoneToken));
         assertEq(address(outbox.config()), address(config));
         assertEq(config.sequencer(), sequencer);
     }
@@ -805,7 +828,7 @@ contract ZoneOutboxTest is Test {
         zoneToken.approve(address(outbox), numWithdrawals * 100e6);
 
         for (uint256 i = 0; i < numWithdrawals; i++) {
-            outbox.requestWithdrawal(bob, 100e6, bytes32(i), 0, alice, "");
+            outbox.requestWithdrawal(address(zoneToken), bob, 100e6, bytes32(i), 0, alice, "");
         }
         vm.stopPrank();
 
@@ -842,7 +865,7 @@ contract ZoneOutboxTest is Test {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 1000e6);
         for (uint256 i = 0; i < 10; i++) {
-            outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+            outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
         }
         vm.stopPrank();
         assertEq(outbox.pendingWithdrawalsCount(), 10);
@@ -855,12 +878,12 @@ contract ZoneOutboxTest is Test {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 1000e6);
 
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
 
         vm.expectRevert(ZoneOutbox.TooManyWithdrawalsThisBlock.selector);
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
     }
 
@@ -871,19 +894,19 @@ contract ZoneOutboxTest is Test {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 1000e6);
 
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
 
         vm.expectRevert(ZoneOutbox.TooManyWithdrawalsThisBlock.selector);
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
 
         vm.roll(block.number + 1);
 
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
 
         vm.expectRevert(ZoneOutbox.TooManyWithdrawalsThisBlock.selector);
-        outbox.requestWithdrawal(alice, 10e6, bytes32(0), 0, alice, "");
+        outbox.requestWithdrawal(address(zoneToken), alice, 10e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
         assertEq(outbox.pendingWithdrawalsCount(), 4);

--- a/docs/specs/test/zone/ZoneOutbox.t.sol
+++ b/docs/specs/test/zone/ZoneOutbox.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { IZoneOutbox, LastBatch, Withdrawal } from "../../src/zone/IZone.sol";
+import { IZoneOutbox, LastBatch, PORTAL_TOKEN_CONFIGS_SLOT, Withdrawal } from "../../src/zone/IZone.sol";
 import { EMPTY_SENTINEL } from "../../src/zone/WithdrawalQueueLib.sol";
 import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
 import { ZoneInbox } from "../../src/zone/ZoneInbox.sol";
@@ -43,6 +43,12 @@ contract ZoneOutboxTest is Test {
         // Grant minter role to inbox and burner role to outbox
         zoneToken.setMinter(address(inbox), true);
         zoneToken.setBurner(address(outbox), true);
+
+        // Enable zoneToken in the mock portal's token registry
+        // TokenConfig is packed: enabled (bool, byte 0) and depositsActive (bool, byte 1)
+        bytes32 tokenConfigSlot = keccak256(abi.encode(address(zoneToken), PORTAL_TOKEN_CONFIGS_SLOT));
+        // enabled=true (0x01) | depositsActive=true (0x01 << 8) = 0x0101
+        tempoState.setMockStorageValue(mockPortal, tokenConfigSlot, bytes32(uint256(0x0101)));
 
         // Give alice and bob tokens
         zoneToken.setMinter(address(this), true);

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -41,6 +41,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
     bool public shouldRevert = false;
 
     address public lastSender;
+    address public lastToken;
     uint128 public lastAmount;
     bytes public lastCallbackData;
     address public expectedMessenger;
@@ -59,6 +60,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
 
     function onWithdrawalReceived(
         address sender,
+        address token,
         uint128 amount,
         bytes calldata callbackData
     )
@@ -66,6 +68,7 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
         returns (bytes4)
     {
         lastSender = sender;
+        lastToken = token;
         lastAmount = amount;
         lastCallbackData = callbackData;
 
@@ -85,7 +88,15 @@ contract MockWithdrawalReceiver is IWithdrawalReceiver {
 /// @notice Mock receiver that consumes all gas
 contract GasConsumingReceiver is IWithdrawalReceiver {
 
-    function onWithdrawalReceived(address, uint128, bytes calldata) external returns (bytes4) {
+    function onWithdrawalReceived(
+        address,
+        address,
+        uint128,
+        bytes calldata
+    )
+        external
+        returns (bytes4)
+    {
         // Infinite loop to consume all gas
         while (true) { }
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
@@ -98,7 +109,15 @@ contract SuccessfulReceiver is IWithdrawalReceiver {
 
     uint256 public callCount;
 
-    function onWithdrawalReceived(address, uint128, bytes calldata) external returns (bytes4) {
+    function onWithdrawalReceived(
+        address,
+        address,
+        uint128,
+        bytes calldata
+    )
+        external
+        returns (bytes4)
+    {
         callCount++;
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }
@@ -142,7 +161,7 @@ contract ZonePortalTest is BaseTest {
 
         // Create a zone
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
-            token: address(pathUSD),
+            initialToken: address(pathUSD),
             sequencer: admin, // admin is the sequencer for tests
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
@@ -170,7 +189,7 @@ contract ZonePortalTest is BaseTest {
 
     function test_zoneCreation() public view {
         assertEq(portal.zoneId(), testZoneId);
-        assertEq(portal.token(), address(pathUSD));
+        assertTrue(portal.isTokenEnabled(address(pathUSD)));
         assertEq(portal.sequencer(), admin);
         assertEq(portal.verifier(), zoneFactory.verifier());
         assertEq(portal.blockHash(), GENESIS_BLOCK_HASH);
@@ -186,7 +205,7 @@ contract ZonePortalTest is BaseTest {
         assertEq(info.zoneId, testZoneId);
         assertEq(info.portal, address(portal));
         assertEq(info.messenger, address(messenger));
-        assertEq(info.token, address(pathUSD));
+        assertEq(info.initialToken, address(pathUSD));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -199,7 +218,7 @@ contract ZonePortalTest is BaseTest {
         // Approve and deposit
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        bytes32 hash1 = portal.deposit(alice, depositAmount, bytes32("memo1"));
+        bytes32 hash1 = portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo1"));
         vm.stopPrank();
 
         // Verify hash chain updated
@@ -217,13 +236,13 @@ contract ZonePortalTest is BaseTest {
         // First deposit from alice
         vm.startPrank(alice);
         pathUSD.approve(address(portal), amount1);
-        bytes32 hash1 = portal.deposit(alice, amount1, bytes32("memo1"));
+        bytes32 hash1 = portal.deposit(address(pathUSD), alice, amount1, bytes32("memo1"));
         vm.stopPrank();
 
         // Second deposit from bob
         vm.startPrank(bob);
         pathUSD.approve(address(portal), amount2);
-        bytes32 hash2 = portal.deposit(bob, amount2, bytes32("memo2"));
+        bytes32 hash2 = portal.deposit(address(pathUSD), bob, amount2, bytes32("memo2"));
         vm.stopPrank();
 
         // Hash chain should have updated
@@ -246,15 +265,15 @@ contract ZonePortalTest is BaseTest {
         assertEq(initialHash, bytes32(0));
 
         // After deposit 1
-        portal.deposit(alice, amount, bytes32("d1"));
+        portal.deposit(address(pathUSD), alice, amount, bytes32("d1"));
         bytes32 hash1 = portal.currentDepositQueueHash();
 
         // After deposit 2: hash2 = keccak256(abi.encode(message2, hash1))
-        portal.deposit(alice, amount, bytes32("d2"));
+        portal.deposit(address(pathUSD), alice, amount, bytes32("d2"));
         bytes32 hash2 = portal.currentDepositQueueHash();
 
         // After deposit 3: hash3 = keccak256(abi.encode(message3, hash2))
-        portal.deposit(alice, amount, bytes32("d3"));
+        portal.deposit(address(pathUSD), alice, amount, bytes32("d3"));
         bytes32 hash3 = portal.currentDepositQueueHash();
 
         vm.stopPrank();
@@ -274,7 +293,8 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        bytes32 depositHash = portal.deposit(alice, depositAmount, bytes32("memo"));
+        bytes32 depositHash =
+            portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         // Submit a batch (as sequencer)
@@ -377,11 +397,12 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         // Create a withdrawal and add to queue via batch
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -434,11 +455,12 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 2000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         // Create two withdrawals in the same batch
         Withdrawal memory w1 = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 300e6,
@@ -449,6 +471,7 @@ contract ZonePortalTest is BaseTest {
             callbackData: ""
         });
         Withdrawal memory w2 = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: charlie,
             amount: 400e6,
@@ -508,11 +531,12 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 3000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         // Batch 1: withdrawal to bob
         Withdrawal memory w1 = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -542,6 +566,7 @@ contract ZonePortalTest is BaseTest {
 
         // Batch 2: withdrawal to charlie
         Withdrawal memory w2 = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: charlie,
             amount: 600e6,
@@ -589,7 +614,7 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         uint256 tailBefore = portal.withdrawalQueueTail();
@@ -623,11 +648,12 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         // Create withdrawal with callback
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(withdrawalReceiver),
             amount: 500e6,
@@ -673,7 +699,7 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         bytes32 depositHashBefore = portal.currentDepositQueueHash();
@@ -683,6 +709,7 @@ contract ZonePortalTest is BaseTest {
 
         // Create withdrawal with callback
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(withdrawalReceiver),
             amount: 500e6,
@@ -727,7 +754,7 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         bytes32 depositHashBefore = portal.currentDepositQueueHash();
@@ -736,6 +763,7 @@ contract ZonePortalTest is BaseTest {
         withdrawalReceiver.setShouldAccept(false);
 
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(withdrawalReceiver),
             amount: 500e6,
@@ -777,7 +805,7 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         bytes32 depositHashBefore = portal.currentDepositQueueHash();
@@ -791,6 +819,7 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -834,6 +863,7 @@ contract ZonePortalTest is BaseTest {
 
     function test_processWithdrawal_revertsIfEmpty() public {
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 100e6,
@@ -853,10 +883,11 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -888,6 +919,7 @@ contract ZonePortalTest is BaseTest {
 
         // Try to process with wrong withdrawal data
         Withdrawal memory wrongW = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: charlie,
             amount: 500e6,
@@ -906,10 +938,11 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.deposit(alice, depositAmount, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"));
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -960,8 +993,8 @@ contract ZonePortalTest is BaseTest {
         // Make deposits
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 3000e6);
-        bytes32 h1 = portal.deposit(alice, 1000e6, bytes32("d1"));
-        bytes32 h2 = portal.deposit(alice, 1000e6, bytes32("d2"));
+        bytes32 h1 = portal.deposit(address(pathUSD), alice, 1000e6, bytes32("d1"));
+        bytes32 h2 = portal.deposit(address(pathUSD), alice, 1000e6, bytes32("d2"));
         vm.stopPrank();
 
         // currentDepositQueueHash should be h2 (latest)
@@ -989,7 +1022,7 @@ contract ZonePortalTest is BaseTest {
 
         // New deposit arrives
         vm.startPrank(alice);
-        bytes32 h3 = portal.deposit(alice, 1000e6, bytes32("d3"));
+        bytes32 h3 = portal.deposit(address(pathUSD), alice, 1000e6, bytes32("d3"));
         vm.stopPrank();
 
         // currentDepositQueueHash updated
@@ -1151,7 +1184,7 @@ contract ZonePortalTest is BaseTest {
         // Make a deposit first
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32("memo"));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32("memo"));
         vm.stopPrank();
 
         bytes32 depositHash = portal.currentDepositQueueHash();
@@ -1184,8 +1217,8 @@ contract ZonePortalTest is BaseTest {
         // Make deposits
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 3000e6);
-        bytes32 h1 = portal.deposit(alice, 1000e6, bytes32("d1"));
-        bytes32 h2 = portal.deposit(alice, 1000e6, bytes32("d2"));
+        bytes32 h1 = portal.deposit(address(pathUSD), alice, 1000e6, bytes32("d1"));
+        bytes32 h2 = portal.deposit(address(pathUSD), alice, 1000e6, bytes32("d2"));
         vm.stopPrank();
 
         vm.roll(block.number + 1);
@@ -1230,7 +1263,7 @@ contract ZonePortalTest is BaseTest {
     function test_withdrawalQueue_emptyBatchDoesNotIncreaseTail() public {
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         bytes32 depositHash = portal.currentDepositQueueHash();
@@ -1261,13 +1294,14 @@ contract ZonePortalTest is BaseTest {
         // Fund portal
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 10_000e6);
-        portal.deposit(alice, 10_000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 10_000e6, bytes32(""));
         vm.stopPrank();
 
         bytes32 depositHash = portal.currentDepositQueueHash();
 
         // Create two batches with different withdrawals
         Withdrawal memory w1 = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 100e6,
@@ -1293,6 +1327,7 @@ contract ZonePortalTest is BaseTest {
         );
 
         Withdrawal memory w2 = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: charlie,
             amount: 200e6,
@@ -1336,13 +1371,14 @@ contract ZonePortalTest is BaseTest {
         // Fund portal
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         bytes32 depositHashBefore = portal.currentDepositQueueHash();
 
         // Create withdrawal with callback to gas-consuming receiver
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(gasConsumingReceiver),
             amount: 500e6,
@@ -1381,13 +1417,14 @@ contract ZonePortalTest is BaseTest {
         // Fund portal
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         bytes32 depositHash = portal.currentDepositQueueHash();
 
         // Create withdrawal with gasLimit = 0
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(successfulReceiver),
             amount: 500e6,
@@ -1427,13 +1464,14 @@ contract ZonePortalTest is BaseTest {
         // Fund portal
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         bytes32 depositHash = portal.currentDepositQueueHash();
 
         // Create withdrawal with callback
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(successfulReceiver),
             amount: 500e6,
@@ -1473,13 +1511,14 @@ contract ZonePortalTest is BaseTest {
         // Fund portal
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         bytes32 depositHashBefore = portal.currentDepositQueueHash();
 
         // Create withdrawal with callback that will fail
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(gasConsumingReceiver),
             amount: 500e6,
@@ -1512,8 +1551,13 @@ contract ZonePortalTest is BaseTest {
 
         // The bounce-back deposit should be:
         // Deposit { sender: portal, to: bob, amount: 500e6, fee: 0, memo: 0 }
-        Deposit memory expectedBounceBack =
-            Deposit({ sender: address(portal), to: bob, amount: 500e6, memo: bytes32(0) });
+        Deposit memory expectedBounceBack = Deposit({
+            token: address(pathUSD),
+            sender: address(portal),
+            to: bob,
+            amount: 500e6,
+            memo: bytes32(0)
+        });
         bytes32 expectedHash =
             keccak256(abi.encode(DepositType.Regular, expectedBounceBack, depositHashBefore));
         assertEq(newDepositHash, expectedHash);
@@ -1526,7 +1570,7 @@ contract ZonePortalTest is BaseTest {
     function test_withdrawalBatchIndex_incrementsOnEachBatch() public {
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 3000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         bytes32 depositHash = portal.currentDepositQueueHash();
@@ -1590,13 +1634,21 @@ contract ZonePortalTest is BaseTest {
         bytes32 expectedHash = keccak256(
             abi.encode(
                 DepositType.Regular,
-                Deposit({ sender: alice, to: bob, amount: netAmount, memo: bytes32("test") }),
+                Deposit({
+                    token: address(pathUSD),
+                    sender: alice,
+                    to: bob,
+                    amount: netAmount,
+                    memo: bytes32("test")
+                }),
                 bytes32(0)
             )
         );
-        emit IZonePortal.DepositMade(expectedHash, alice, bob, netAmount, fee, bytes32("test"));
+        emit IZonePortal.DepositMade(
+            expectedHash, alice, address(pathUSD), bob, netAmount, fee, bytes32("test")
+        );
 
-        portal.deposit(bob, 500e6, bytes32("test"));
+        portal.deposit(address(pathUSD), bob, 500e6, bytes32("test"));
         vm.stopPrank();
     }
 
@@ -1604,10 +1656,11 @@ contract ZonePortalTest is BaseTest {
         // Setup withdrawal
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: bob,
             amount: 500e6,
@@ -1633,7 +1686,7 @@ contract ZonePortalTest is BaseTest {
         );
 
         vm.expectEmit(true, false, false, true);
-        emit IZonePortal.WithdrawalProcessed(bob, 500e6, true);
+        emit IZonePortal.WithdrawalProcessed(bob, address(pathUSD), 500e6, true);
 
         portal.processWithdrawal(w, bytes32(0));
     }
@@ -1642,10 +1695,11 @@ contract ZonePortalTest is BaseTest {
         // Setup withdrawal with failing callback
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
-        portal.deposit(alice, 1000e6, bytes32(""));
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""));
         vm.stopPrank();
 
         Withdrawal memory w = Withdrawal({
+            token: address(pathUSD),
             sender: alice,
             to: address(gasConsumingReceiver),
             amount: 500e6,
@@ -1671,7 +1725,9 @@ contract ZonePortalTest is BaseTest {
         );
 
         vm.expectEmit(true, false, false, true);
-        emit IZonePortal.WithdrawalProcessed(address(gasConsumingReceiver), 500e6, false);
+        emit IZonePortal.WithdrawalProcessed(
+            address(gasConsumingReceiver), address(pathUSD), 500e6, false
+        );
 
         portal.processWithdrawal(w, bytes32(0));
     }
@@ -1682,7 +1738,6 @@ contract ZonePortalTest is BaseTest {
 
     function test_immutableGetters() public view {
         assertEq(portal.zoneId(), testZoneId);
-        assertEq(portal.token(), address(pathUSD));
         assertEq(portal.sequencer(), admin);
         assertEq(portal.verifier(), zoneFactory.verifier());
         assertEq(portal.genesisTempoBlockNumber(), genesisTempoBlockNumber);
@@ -1915,7 +1970,8 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        bytes32 hash = portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        bytes32 hash =
+            portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload());
         vm.stopPrank();
 
         assertEq(portal.currentDepositQueueHash(), hash);
@@ -1933,12 +1989,16 @@ contract ZonePortalTest is BaseTest {
 
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        bytes32 hash = portal.depositEncrypted(depositAmount, 0, encrypted);
+        bytes32 hash = portal.depositEncrypted(address(pathUSD), depositAmount, 0, encrypted);
         vm.stopPrank();
 
         // Reconstruct expected hash using the same encoding as DepositQueueLib
         EncryptedDeposit memory ed = EncryptedDeposit({
-            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
+            token: address(pathUSD),
+            sender: alice,
+            amount: netAmount,
+            keyIndex: 0,
+            encrypted: encrypted
         });
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
         assertEq(hash, expectedHash);
@@ -1952,10 +2012,10 @@ contract ZonePortalTest is BaseTest {
         // Regular deposit from alice
         vm.startPrank(alice);
         pathUSD.approve(address(portal), amount * 3);
-        bytes32 h1 = portal.deposit(alice, amount, bytes32("memo"));
+        bytes32 h1 = portal.deposit(address(pathUSD), alice, amount, bytes32("memo"));
 
         // Encrypted deposit from alice
-        bytes32 h2 = portal.depositEncrypted(amount, 0, _makeEncryptedPayload());
+        bytes32 h2 = portal.depositEncrypted(address(pathUSD), amount, 0, _makeEncryptedPayload());
         vm.stopPrank();
 
         // Both should update the same queue
@@ -1976,7 +2036,7 @@ contract ZonePortalTest is BaseTest {
 
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload());
         vm.stopPrank();
 
         assertEq(pathUSD.balanceOf(alice), aliceBefore - depositAmount);
@@ -1998,7 +2058,11 @@ contract ZonePortalTest is BaseTest {
 
         // Build expected hash
         EncryptedDeposit memory ed = EncryptedDeposit({
-            sender: alice, amount: netAmount, keyIndex: 0, encrypted: encrypted
+            token: address(pathUSD),
+            sender: alice,
+            amount: netAmount,
+            keyIndex: 0,
+            encrypted: encrypted
         });
         bytes32 expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, bytes32(0)));
 
@@ -2006,6 +2070,7 @@ contract ZonePortalTest is BaseTest {
         emit IZonePortal.EncryptedDepositMade(
             expectedHash,
             alice,
+            address(pathUSD),
             netAmount,
             fee,
             0,
@@ -2015,7 +2080,7 @@ contract ZonePortalTest is BaseTest {
             encrypted.nonce,
             encrypted.tag
         );
-        portal.depositEncrypted(depositAmount, 0, encrypted);
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, encrypted);
         vm.stopPrank();
     }
 
@@ -2036,7 +2101,7 @@ contract ZonePortalTest is BaseTest {
 
         // Should revert with EncryptionKeyExpired for key index 0
         vm.expectRevert();
-        portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload());
         vm.stopPrank();
     }
 
@@ -2047,7 +2112,7 @@ contract ZonePortalTest is BaseTest {
 
         // No keys set, index 0 is invalid
         vm.expectRevert(abi.encodeWithSelector(IZonePortal.InvalidEncryptionKeyIndex.selector, 0));
-        portal.depositEncrypted(depositAmount, 0, _makeEncryptedPayload());
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload());
         vm.stopPrank();
     }
 
@@ -2067,7 +2132,7 @@ contract ZonePortalTest is BaseTest {
         });
 
         vm.expectRevert(IZonePortal.InvalidEphemeralPubkey.selector);
-        portal.depositEncrypted(depositAmount, 0, encrypted);
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, encrypted);
         vm.stopPrank();
     }
 
@@ -2087,7 +2152,7 @@ contract ZonePortalTest is BaseTest {
         });
 
         vm.expectRevert(IZonePortal.InvalidEphemeralPubkey.selector);
-        portal.depositEncrypted(depositAmount, 0, encrypted);
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, encrypted);
         vm.stopPrank();
     }
 
@@ -2099,7 +2164,7 @@ contract ZonePortalTest is BaseTest {
         pathUSD.approve(address(portal), 100_000);
 
         vm.expectRevert(IZonePortal.DepositTooSmall.selector);
-        portal.depositEncrypted(100_000, 0, _makeEncryptedPayload()); // amount == fee
+        portal.depositEncrypted(address(pathUSD), 100_000, 0, _makeEncryptedPayload()); // amount == fee
         vm.stopPrank();
     }
 
@@ -2115,7 +2180,7 @@ contract ZonePortalTest is BaseTest {
         vm.expectRevert(
             abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 63, 64)
         );
-        portal.depositEncrypted(1000e6, 0, payload);
+        portal.depositEncrypted(address(pathUSD), 1000e6, 0, payload);
         vm.stopPrank();
     }
 
@@ -2131,7 +2196,7 @@ contract ZonePortalTest is BaseTest {
         vm.expectRevert(
             abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 65, 64)
         );
-        portal.depositEncrypted(1000e6, 0, payload);
+        portal.depositEncrypted(address(pathUSD), 1000e6, 0, payload);
         vm.stopPrank();
     }
 
@@ -2145,7 +2210,7 @@ contract ZonePortalTest is BaseTest {
         pathUSD.approve(address(portal), 1000e6);
 
         vm.expectRevert(abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 0, 64));
-        portal.depositEncrypted(1000e6, 0, payload);
+        portal.depositEncrypted(address(pathUSD), 1000e6, 0, payload);
         vm.stopPrank();
     }
 
@@ -2161,7 +2226,7 @@ contract ZonePortalTest is BaseTest {
         vm.expectRevert(
             abi.encodeWithSelector(IZonePortal.InvalidCiphertextLength.selector, 1024, 64)
         );
-        portal.depositEncrypted(1000e6, 0, payload);
+        portal.depositEncrypted(address(pathUSD), 1000e6, 0, payload);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
## Summary
Two fixes for the multi-asset-zones branch:

## Changes
- **ZoneOutbox.requestWithdrawal**: Add `config.isEnabledToken(token)` check before burning. Previously accepted any address as token, enabling arbitrary external calls via `transferFrom`/`burn` on unvalidated contracts.
- **ZonePortal.enableToken**: Change TIP-20 validation from `revert TokenNotEnabled()` to `revert InvalidToken()`. `TokenNotEnabled` is semantically wrong here — the token hasn't been enabled *yet*, the issue is it's not a valid TIP-20.
- Test setups updated to mock the token registry in `TempoState` so zone-side `isEnabledToken` reads succeed.

## Testing
- All 231 zone tests pass (`forge test --match-path 'test/zone/*'`)

Prompted by: dan