### PR TITLE
feat(batch): auto-select EIP-2935 direct vs ancestry mode

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -14,12 +14,20 @@
 //! accept empty proofs for this to work.
 
 use alloy_primitives::{Address, B256, Bytes};
-use alloy_provider::DynProvider;
+use alloy_provider::{DynProvider, Provider};
 use eyre::Result;
 use tempo_alloy::TempoNetwork;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::abi::{BlockTransition, DepositQueueTransition, ZonePortal};
+
+/// EIP-2935 stores the last 8192 block hashes. Blocks older than this require
+/// ancestry mode.
+const EIP2935_HISTORY_WINDOW: u64 = 8192;
+
+/// Safety margin (~3 min at 500ms block time) to avoid race conditions where
+/// the block falls out of the window between our check and on-chain execution.
+const EIP2935_SAFETY_MARGIN: u64 = 360;
 
 /// Data required to submit a single batch to the ZonePortal on L1.
 ///
@@ -45,7 +53,13 @@ pub struct BatchData {
 /// Holds a contract instance pointing at the portal, backed by a shared
 /// [`DynProvider`] with the sequencer's signing wallet.
 pub struct BatchSubmitter {
+    /// ZonePortal contract address on Tempo L1 (used in tracing spans).
     portal_address: Address,
+    /// Shared L1 provider for querying the current block number (EIP-2935
+    /// window check). The same provider backs the `portal` contract instance.
+    l1_provider: DynProvider<TempoNetwork>,
+    /// ZonePortal contract instance for calling `submitBatch` and reading
+    /// on-chain state such as `blockHash()`.
     portal: ZonePortal::ZonePortalInstance<DynProvider<TempoNetwork>, TempoNetwork>,
 }
 
@@ -54,17 +68,27 @@ impl BatchSubmitter {
     ///
     /// The provider must already include the sequencer wallet for signing.
     pub fn new(portal_address: Address, provider: DynProvider<TempoNetwork>) -> Self {
-        let portal = ZonePortal::new(portal_address, provider);
+        let portal = ZonePortal::new(portal_address, provider.clone());
         Self {
             portal_address,
+            l1_provider: provider,
             portal,
         }
     }
 
     /// Submit a batch to the ZonePortal on Tempo L1.
     ///
-    /// Constructs the on-chain structs from [`BatchData`], sends the
-    /// `submitBatch` transaction, and waits for the receipt.
+    /// Automatically selects **direct mode** or **ancestry mode** based on how
+    /// old `tempoBlockNumber` is relative to the current L1 tip:
+    ///
+    /// - **Direct** (`recentTempoBlockNumber = 0`): used when `tempoBlockNumber`
+    ///   is within the EIP-2935 history window (8192 blocks). The portal reads
+    ///   its hash directly from EIP-2935.
+    /// - **Ancestry** (`recentTempoBlockNumber > 0`): used when `tempoBlockNumber`
+    ///   has fallen out of the EIP-2935 window (e.g. sequencer was offline for
+    ///   >2 hours). A recent L1 block within the window is chosen as anchor and
+    ///   the proof must include a block header chain from `recentTempoBlockNumber`
+    ///   back to `tempoBlockNumber`.
     ///
     /// # POC note
     ///
@@ -89,13 +113,20 @@ impl BatchSubmitter {
             nextProcessedHash: batch.next_processed_deposit_hash,
         };
 
-        info!("Submitting batch to ZonePortal on L1");
+        let anchor_mode = self.resolve_anchor_mode(batch.tempo_block_number).await?;
+
+        let recent_tempo_block_number = anchor_mode.recent_block_number();
+
+        info!(
+            ?anchor_mode,
+            "Submitting batch to ZonePortal on L1"
+        );
 
         let tx_hash = self
             .portal
             .submitBatch(
                 batch.tempo_block_number,
-                0u64, // recentTempoBlockNumber: 0 = direct mode (use EIP-2935 lookup)
+                recent_tempo_block_number,
                 block_transition,
                 deposit_transition,
                 batch.withdrawal_queue_hash,
@@ -114,6 +145,50 @@ impl BatchSubmitter {
         Ok(tx_hash)
     }
 
+    /// Determine whether to use direct or ancestry mode for the given
+    /// `tempo_block_number`.
+    ///
+    /// The ZonePortal's `submitBatch` verifies that the zone committed to a
+    /// real Tempo block by reading its hash from the EIP-2935 system contract,
+    /// which only stores the most recent [`EIP2935_HISTORY_WINDOW`] (8192)
+    /// block hashes. If `tempo_block_number` has already fallen out of that
+    /// window (e.g. the sequencer was offline for >2 hours), a direct lookup
+    /// would return `bytes32(0)` and the transaction would revert.
+    ///
+    /// **Ancestry mode** solves this by supplying a *recent* L1 block number
+    /// that IS within the EIP-2935 window as the anchor. The portal reads
+    /// that anchor's hash from EIP-2935 instead, and the proof is expected to
+    /// include a chain of block headers linking the anchor back to
+    /// `tempo_block_number`, proving ancestry on-chain.
+    ///
+    /// A safety margin of [`EIP2935_SAFETY_MARGIN`] (360 blocks, ~3 min) is
+    /// applied to guard against the block aging out of the window between our
+    /// check here and the transaction's on-chain execution.
+    ///
+    async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
+        let current_l1_block = self.l1_provider.get_block_number().await?;
+
+        let effective_window = EIP2935_HISTORY_WINDOW.saturating_sub(EIP2935_SAFETY_MARGIN);
+
+        if current_l1_block.saturating_sub(tempo_block_number) < effective_window {
+            return Ok(AnchorMode::Direct);
+        }
+
+        // tempo_block_number is outside the EIP-2935 window — use ancestry mode.
+        // Pick a recent block well within the window as anchor.
+        let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
+
+        warn!(
+            tempo_block_number,
+            current_l1_block,
+            anchor_block,
+            gap = current_l1_block.saturating_sub(tempo_block_number),
+            "tempo_block_number outside EIP-2935 window, using ancestry mode"
+        );
+
+        Ok(AnchorMode::Ancestry { anchor_block })
+    }
+
     /// Read the current `blockHash` from the ZonePortal on L1.
     ///
     /// Used to resync the monitor's `prev_block_hash` after repeated submission
@@ -121,5 +196,36 @@ impl BatchSubmitter {
     pub async fn read_portal_block_hash(&self) -> Result<B256> {
         let hash = self.portal.blockHash().call().await?;
         Ok(hash)
+    }
+}
+
+/// How the batch submitter should anchor `tempoBlockNumber` for EIP-2935
+/// verification on the ZonePortal.
+#[derive(Debug)]
+enum AnchorMode {
+    /// `tempoBlockNumber` is within the EIP-2935 window — the portal reads its
+    /// hash directly. No extra proof data required.
+    Direct,
+    /// `tempoBlockNumber` has expired from EIP-2935. A recent L1 block is used
+    /// as anchor, and the proof must include block headers linking the anchor
+    /// back to `tempoBlockNumber`.
+    // TODO: once the verifier is implemented, ancestry mode must also collect
+    // the intermediate block headers (from `anchor_block` down to
+    // `tempoBlockNumber`) and include them in the proof bytes.
+    Ancestry {
+        /// Recent L1 block number within the EIP-2935 window, used as the
+        /// on-chain anchor for hash verification.
+        anchor_block: u64,
+    },
+}
+
+impl AnchorMode {
+    /// Returns the `recentTempoBlockNumber` argument for `submitBatch`:
+    /// `0` for direct mode, or the anchor block number for ancestry mode.
+    const fn recent_block_number(&self) -> u64 {
+        match self {
+            Self::Direct => 0,
+            Self::Ancestry { anchor_block } => *anchor_block,
+        }
     }
 }

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -14,13 +14,15 @@
 //! Withdrawals from all blocks in the range are combined into a single hash chain
 //! and stored under one portal queue slot.
 //!
-//! ## EIP-2935 constraint
+//! ## EIP-2935 and ancestry mode
 //!
 //! The portal verifies `tempoBlockNumber` via EIP-2935, which stores the last 8192
-//! block hashes. The batch's `tempoBlockNumber` must be within this window of the
-//! current L1 block. In practice this is not a concern because the zone produces
-//! blocks at L1 speed — the monitor would need to fall ~2.3 hours behind to hit
-//! this limit.
+//! block hashes. When `tempoBlockNumber` is within this window the batch submitter
+//! uses **direct mode** (reading the hash straight from EIP-2935). If the zone
+//! falls behind (e.g. sequencer downtime >2 hours), the submitter automatically
+//! switches to **ancestry mode**: it supplies a recent L1 block number that IS
+//! within the EIP-2935 window, and the proof must include a block header chain
+//! linking that anchor back to `tempoBlockNumber`.
 
 use std::{sync::Arc, time::Duration};
 


### PR DESCRIPTION
## Summary

BatchSubmitter now queries the current L1 block number and automatically selects the appropriate anchor mode for `submitBatch`:

- **Direct mode** (`recentTempoBlockNumber=0`): used when `tempoBlockNumber` is within the EIP-2935 history window (8192 blocks). The portal reads the hash directly from EIP-2935. No extra proof data required.

- **Ancestry mode** (`recentTempoBlockNumber>0`): used when `tempoBlockNumber` has fallen out of the EIP-2935 window (e.g. sequencer offline >~68 min at 500ms blocks). A recent L1 block within the window is chosen as anchor and the proof must include block headers linking the anchor back to `tempoBlockNumber`.

## Changes

- Store L1 provider on `BatchSubmitter` so we can query the current block number
- Add `resolve_anchor_mode()` that compares `tempoBlockNumber` against the EIP-2935 window with a 360-block (~3 min) safety margin
- Introduce `AnchorMode` enum (`Direct` / `Ancestry`) to make the two modes explicit
- Add TODO on `Ancestry` variant for collecting intermediate block headers once the verifier is implemented
- Update zonemonitor docs to describe both modes

## Notes

Direct mode is preferred (cheaper, no extra proof data). Ancestry mode is the fallback for recovery/catch-up scenarios where the sequencer was offline long enough for `tempoBlockNumber` to expire from EIP-2935.