### PR TITLE
fix(monitor): initialize withdrawal queue tail from portal at startup

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -117,10 +117,7 @@ impl BatchSubmitter {
 
         let recent_tempo_block_number = anchor_mode.recent_block_number();
 
-        info!(
-            ?anchor_mode,
-            "Submitting batch to ZonePortal on L1"
-        );
+        info!(?anchor_mode, "Submitting batch to ZonePortal on L1");
 
         let tx_hash = self
             .portal
@@ -164,7 +161,6 @@ impl BatchSubmitter {
     /// A safety margin of [`EIP2935_SAFETY_MARGIN`] (360 blocks, ~3 min) is
     /// applied to guard against the block aging out of the window between our
     /// check here and the transaction's on-chain execution.
-    ///
     async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
         let current_l1_block = self.l1_provider.get_block_number().await?;
 
@@ -196,6 +192,19 @@ impl BatchSubmitter {
     pub async fn read_portal_block_hash(&self) -> Result<B256> {
         let hash = self.portal.blockHash().call().await?;
         Ok(hash)
+    }
+
+    /// Read the current withdrawal queue tail from the ZonePortal on L1.
+    ///
+    /// Used at startup and during resync to initialize
+    /// `portal_withdrawal_queue_tail` so withdrawal data is stored under the
+    /// correct portal queue slot.
+    pub async fn read_portal_withdrawal_queue_tail(&self) -> Result<u64> {
+        let tail = self.portal.withdrawalQueueTail().call().await?;
+        let tail: u64 = tail
+            .try_into()
+            .map_err(|_| eyre::eyre!("withdrawal queue tail overflow"))?;
+        Ok(tail)
     }
 }
 

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -427,4 +427,27 @@ mod tests {
         assert!(!store.has_batch(0));
         assert_eq!(store.batch_count(), 0);
     }
+
+    #[test]
+    fn store_slot_index_must_match_portal_tail() {
+        // Demonstrates that withdrawals must be stored under the portal's actual
+        // queue tail index. If the monitor starts with tail=0 but the portal is
+        // at tail=5, withdrawals end up in slot 0 while the withdrawal processor
+        // looks for them in slot 5.
+        let mut store = WithdrawalStore::new();
+        let w = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 100);
+
+        // Simulate storing under the wrong slot (tail=0 when portal is at 5).
+        store.add_withdrawal(0, w.clone());
+        assert!(store.has_batch(0));
+        assert!(
+            !store.has_batch(5),
+            "withdrawal processor would look at slot 5 and find nothing"
+        );
+
+        // Correct: store under the portal's actual tail.
+        let portal_tail = 5u64;
+        store.add_withdrawal(portal_tail, w);
+        assert!(store.has_batch(portal_tail));
+    }
 }

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -99,8 +99,9 @@ pub struct ZoneMonitor {
     prev_block_hash: B256,
     /// Tracks the portal's withdrawal queue tail position.
     /// The withdrawal store keys must match the portal's queue slot indices
-    /// (not the L2 outbox's internal `withdrawalBatchIndex`). This counter
-    /// starts at 0 and increments each time a batch with a non-zero
+    /// (not the L2 outbox's internal `withdrawalBatchIndex`). This counter is
+    /// initialized from the portal’s on-chain `withdrawalQueueTail()` at startup,
+    /// and incremented each time a batch with a non-zero
     /// `withdrawal_queue_hash` is successfully submitted to L1.
     portal_withdrawal_queue_tail: u64,
 }
@@ -129,10 +130,17 @@ impl ZoneMonitor {
 
         let batch_submitter = BatchSubmitter::new(config.portal_address, l1_provider);
 
-        let prev_block_hash = batch_submitter
-            .read_portal_block_hash()
-            .await
-            .expect("failed to read portal blockHash at startup");
+        let (prev_block_hash, portal_withdrawal_queue_tail) = tokio::try_join!(
+            batch_submitter.read_portal_block_hash(),
+            batch_submitter.read_portal_withdrawal_queue_tail(),
+        )
+        .expect("failed to read portal state at startup");
+
+        info!(
+            %prev_block_hash,
+            portal_withdrawal_queue_tail,
+            "Initialized from portal state"
+        );
 
         Self {
             config,
@@ -146,7 +154,7 @@ impl ZoneMonitor {
             last_processed_block: 0,
             prev_processed_deposit_hash: B256::ZERO,
             prev_block_hash,
-            portal_withdrawal_queue_tail: 0,
+            portal_withdrawal_queue_tail,
         }
     }
 
@@ -311,20 +319,24 @@ impl ZoneMonitor {
         let tempo_call = self.tempo_state.tempoBlockNumber().block(to.into());
         let deposit_call = self.inbox.processedDepositQueueHash().block(to.into());
         let block_fut = async {
-            self.provider.get_block_by_number(to.into()).await.map_err(Into::into)
+            self.provider
+                .get_block_by_number(to.into())
+                .await
+                .map_err(Into::into)
         };
-        let (tempo_block_number, processed_deposit_hash, block) = tokio::try_join!(
-            tempo_call.call(),
-            deposit_call.call(),
-            block_fut,
-        )?;
+        let (tempo_block_number, processed_deposit_hash, block) =
+            tokio::try_join!(tempo_call.call(), deposit_call.call(), block_fut,)?;
 
         let block_hash = block
             .ok_or_else(|| eyre::eyre!("zone block {to} not found"))?
             .header
             .hash;
 
-        Ok(ZoneBlockSnapshot { tempo_block_number, processed_deposit_hash, block_hash })
+        Ok(ZoneBlockSnapshot {
+            tempo_block_number,
+            processed_deposit_hash,
+            block_hash,
+        })
     }
 
     /// Submit a `submitBatch` transaction to the ZonePortal on L1 with exponential
@@ -338,8 +350,9 @@ impl ZoneMonitor {
     ///   so it can finalize newly enqueued withdrawal slots.
     ///
     /// On failure (after [`MAX_RETRIES`] attempts with [`INITIAL_RETRY_DELAY`]
-    /// doubling each time): resyncs `prev_block_hash` from the portal's on-chain
-    /// `blockHash()` and skips this block range so the monitor can continue.
+    /// doubling each time): resyncs `prev_block_hash` and
+    /// `portal_withdrawal_queue_tail` from the portal and skips this block range
+    /// so the monitor can continue.
     async fn submit_batch_with_retry(
         &mut self,
         batch_data: &BatchData,
@@ -406,28 +419,36 @@ impl ZoneMonitor {
         Ok(())
     }
 
-    /// Resync `prev_block_hash` from the portal's on-chain `blockHash()`.
+    /// Resync `prev_block_hash` and `portal_withdrawal_queue_tail` from the
+    /// portal's on-chain `blockHash()` and `withdrawalQueueTail()`.
     ///
     /// Called after exhausting retries so subsequent batches start from the
-    /// portal's actual state rather than the stale local value.
+    /// portal's actual state rather than stale local values.
     async fn resync_from_portal(&mut self, block_number: u64) {
         let old_hash = self.prev_block_hash;
-        match self.batch_submitter.read_portal_block_hash().await {
-            Ok(portal_hash) => {
+        let old_tail = self.portal_withdrawal_queue_tail;
+        match tokio::try_join!(
+            self.batch_submitter.read_portal_block_hash(),
+            self.batch_submitter.read_portal_withdrawal_queue_tail(),
+        ) {
+            Ok((portal_hash, portal_tail)) => {
                 warn!(
                     old_prev_block_hash = %old_hash,
                     new_block_hash = %portal_hash,
+                    old_portal_tail = old_tail,
+                    new_portal_tail = portal_tail,
                     block_number,
-                    "Resynced prev_block_hash from portal after max retries"
+                    "Resynced prev_block_hash and portal_withdrawal_queue_tail from portal after max retries"
                 );
                 self.prev_block_hash = portal_hash;
+                self.portal_withdrawal_queue_tail = portal_tail;
                 // Skip this block — the monitor will pick up from the next one.
                 self.last_processed_block = block_number;
             }
             Err(e) => {
                 error!(
                     error = %e,
-                    "Failed to read blockHash from portal during resync"
+                    "Failed to read portal state during resync"
                 );
                 // Don't advance last_processed_block so we retry this block.
             }


### PR DESCRIPTION
## Summary

Stacked on #122.

Previously `portal_withdrawal_queue_tail` was hardcoded to `0` at startup. After a monitor restart, this caused withdrawals to be stored under incorrect slot indices — the withdrawal processor looks them up by the portal's actual queue tail, so they'd be invisible.

## Bug

1. Monitor starts, sets `portal_withdrawal_queue_tail = 0`
2. Portal's actual tail is `5` (from previous batches before restart)
3. Monitor stores withdrawals under slot `0`
4. Withdrawal processor reads portal head/tail, looks for data at slot `5` → finds nothing
5. Withdrawals are never processed

## Fix

- Read `withdrawalQueueTail()` from the portal at startup (concurrently with `blockHash()`)
- Also resync the tail during `resync_from_portal()` after failed retries
- Added unit test demonstrating the slot index mismatch

## Changes

- `BatchSubmitter::read_portal_withdrawal_queue_tail()` — new method
- `ZoneMonitor::new()` — reads tail from portal instead of hardcoding 0
- `ZoneMonitor::resync_from_portal()` — resyncs both `prev_block_hash` and `portal_withdrawal_queue_tail`
- Updated field doc and `submit_batch_with_retry` doc
- New test: `store_slot_index_must_match_portal_tail`