### PR TITLE
fix(sequencer): batch submission and withdrawal processing robustness

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -29,10 +29,6 @@ const EIP2935_HISTORY_WINDOW: u64 = 8192;
 /// the block falls out of the window between our check and on-chain execution.
 const EIP2935_SAFETY_MARGIN: u64 = 360;
 
-/// Finality margin for L1 anchor blocks. Using 64 blocks (~32s at 500ms
-/// block time) to avoid anchoring to blocks that may be reorged.
-const FINALITY_MARGIN: u64 = 64;
-
 /// Data required to submit a single batch to the ZonePortal on L1.
 ///
 /// Produced by the zone block builder and sent to [`BatchSubmitter`] via channel.
@@ -201,11 +197,8 @@ impl BatchSubmitter {
         }
 
         // tempo_block_number is outside the EIP-2935 window — use ancestry mode.
-        // Pick a recent block well within the window as anchor. Use the larger
-        // of the two margins to ensure the anchor is both within EIP-2935 and
-        // past the finality horizon.
-        let anchor_offset = EIP2935_SAFETY_MARGIN.max(FINALITY_MARGIN);
-        let anchor_block = current_l1_block.saturating_sub(anchor_offset);
+        // Pick a recent block well within the window as anchor.
+        let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
 
         warn!(
             tempo_block_number,

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -29,6 +29,10 @@ const EIP2935_HISTORY_WINDOW: u64 = 8192;
 /// the block falls out of the window between our check and on-chain execution.
 const EIP2935_SAFETY_MARGIN: u64 = 360;
 
+/// Finality margin for L1 anchor blocks. Using 64 blocks (~32s at 500ms
+/// block time) to avoid anchoring to blocks that may be reorged.
+const FINALITY_MARGIN: u64 = 64;
+
 /// Data required to submit a single batch to the ZonePortal on L1.
 ///
 /// Produced by the zone block builder and sent to [`BatchSubmitter`] via channel.
@@ -61,18 +65,26 @@ pub struct BatchSubmitter {
     /// ZonePortal contract instance for calling `submitBatch` and reading
     /// on-chain state such as `blockHash()`.
     portal: ZonePortal::ZonePortalInstance<DynProvider<TempoNetwork>, TempoNetwork>,
+    /// The portal's `genesisTempoBlockNumber` — batches with a
+    /// `tempo_block_number` below this value will be rejected on-chain.
+    genesis_tempo_block_number: u64,
 }
 
 impl BatchSubmitter {
     /// Create a new batch submitter from a shared L1 provider.
     ///
     /// The provider must already include the sequencer wallet for signing.
-    pub fn new(portal_address: Address, provider: DynProvider<TempoNetwork>) -> Self {
+    pub fn new(
+        portal_address: Address,
+        provider: DynProvider<TempoNetwork>,
+        genesis_tempo_block_number: u64,
+    ) -> Self {
         let portal = ZonePortal::new(portal_address, provider.clone());
         Self {
             portal_address,
             l1_provider: provider,
             portal,
+            genesis_tempo_block_number,
         }
     }
 
@@ -103,6 +115,18 @@ impl BatchSubmitter {
         withdrawal_queue_hash = %batch.withdrawal_queue_hash,
     ))]
     pub async fn submit_batch(&self, batch: &BatchData) -> Result<B256> {
+        if batch.tempo_block_number < self.genesis_tempo_block_number {
+            return Err(eyre::eyre!(
+                "tempo_block_number ({}) is below genesis ({})",
+                batch.tempo_block_number,
+                self.genesis_tempo_block_number
+            ));
+        }
+
+        if !batch.withdrawal_queue_hash.is_zero() {
+            self.check_withdrawal_queue_capacity().await?;
+        }
+
         let block_transition = BlockTransition {
             prevBlockHash: batch.prev_block_hash,
             nextBlockHash: batch.next_block_hash,
@@ -164,6 +188,12 @@ impl BatchSubmitter {
     async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
         let current_l1_block = self.l1_provider.get_block_number().await?;
 
+        if tempo_block_number > current_l1_block {
+            return Err(eyre::eyre!(
+                "tempo_block_number ({tempo_block_number}) is ahead of current L1 block ({current_l1_block})"
+            ));
+        }
+
         let effective_window = EIP2935_HISTORY_WINDOW.saturating_sub(EIP2935_SAFETY_MARGIN);
 
         if current_l1_block.saturating_sub(tempo_block_number) < effective_window {
@@ -171,8 +201,11 @@ impl BatchSubmitter {
         }
 
         // tempo_block_number is outside the EIP-2935 window — use ancestry mode.
-        // Pick a recent block well within the window as anchor.
-        let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
+        // Pick a recent block well within the window as anchor. Use the larger
+        // of the two margins to ensure the anchor is both within EIP-2935 and
+        // past the finality horizon.
+        let anchor_offset = EIP2935_SAFETY_MARGIN.max(FINALITY_MARGIN);
+        let anchor_block = current_l1_block.saturating_sub(anchor_offset);
 
         warn!(
             tempo_block_number,
@@ -183,6 +216,12 @@ impl BatchSubmitter {
         );
 
         Ok(AnchorMode::Ancestry { anchor_block })
+    }
+
+    /// Read the portal's `genesisTempoBlockNumber` from L1.
+    pub async fn read_genesis_tempo_block_number(&self) -> Result<u64> {
+        let n = self.portal.genesisTempoBlockNumber().call().await?;
+        Ok(n)
     }
 
     /// Read the current `blockHash` from the ZonePortal on L1.
@@ -205,6 +244,35 @@ impl BatchSubmitter {
             .try_into()
             .map_err(|_| eyre::eyre!("withdrawal queue tail overflow"))?;
         Ok(tail)
+    }
+
+    /// Read the current withdrawal queue head from the ZonePortal on L1.
+    pub async fn read_portal_withdrawal_queue_head(&self) -> Result<u64> {
+        let head = self.portal.withdrawalQueueHead().call().await?;
+        let head: u64 = head
+            .try_into()
+            .map_err(|_| eyre::eyre!("withdrawal queue head overflow"))?;
+        Ok(head)
+    }
+
+    /// Check if the withdrawal queue has capacity for another batch.
+    ///
+    /// The portal uses a ring buffer with 100 slots. Returns an error if the
+    /// queue is full (`tail - head >= 100`).
+    pub async fn check_withdrawal_queue_capacity(&self) -> Result<()> {
+        let (head, tail) = tokio::try_join!(
+            self.read_portal_withdrawal_queue_head(),
+            self.read_portal_withdrawal_queue_tail(),
+        )?;
+        const WITHDRAWAL_QUEUE_CAPACITY: u64 = 100;
+        if tail.saturating_sub(head) >= WITHDRAWAL_QUEUE_CAPACITY {
+            return Err(eyre::eyre!(
+                "withdrawal queue full ({} pending slots, capacity {})",
+                tail.saturating_sub(head),
+                WITHDRAWAL_QUEUE_CAPACITY
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -157,8 +157,8 @@ pub fn compute_remaining_queue(withdrawals: &[abi::Withdrawal], processed_count:
 ///
 /// ## POC limitations
 ///
-/// - Transactions are submitted to L1 but the processor does not wait for confirmation receipts
-///   in a production-ready way. Failures are logged and the processor continues.
+/// - Transactions are submitted sequentially and the processor waits for each confirmation.
+///   On failure, processing stops and remaining withdrawals are retried on the next cycle.
 /// - The portal automatically pays the processing fee to the sequencer; this processor does not
 ///   handle fee accounting.
 pub struct WithdrawalProcessor {
@@ -274,21 +274,44 @@ impl WithdrawalProcessor {
                 "Submitting processWithdrawal to L1"
             );
 
-            match self
+            let tx_result = self
                 .portal
                 .processWithdrawal(withdrawal.clone(), remaining_queue)
                 .send()
-                .await
-            {
+                .await;
+
+            match tx_result {
                 Ok(pending) => {
-                    info!(
-                        slot = head_val,
-                        index = i,
-                        tx_hash = %pending.tx_hash(),
-                        to = %withdrawal.to,
-                        amount = %withdrawal.amount,
-                        "processWithdrawal tx submitted to L1"
-                    );
+                    let tx_hash = *pending.tx_hash();
+                    match pending
+                        .with_required_confirmations(1)
+                        .with_timeout(Some(std::time::Duration::from_secs(30)))
+                        .watch()
+                        .await
+                    {
+                        Ok(_) => {
+                            info!(
+                                slot = head_val,
+                                index = i,
+                                %tx_hash,
+                                to = %withdrawal.to,
+                                amount = %withdrawal.amount,
+                                "processWithdrawal confirmed on L1"
+                            );
+                        }
+                        Err(e) => {
+                            error!(
+                                slot = head_val,
+                                index = i,
+                                %tx_hash,
+                                to = %withdrawal.to,
+                                amount = %withdrawal.amount,
+                                error = %e,
+                                "processWithdrawal tx not confirmed, stopping batch processing"
+                            );
+                            return Ok(());
+                        }
+                    }
                 }
                 Err(e) => {
                     error!(
@@ -297,12 +320,14 @@ impl WithdrawalProcessor {
                         to = %withdrawal.to,
                         amount = %withdrawal.amount,
                         error = %e,
-                        "processWithdrawal tx failed"
+                        "processWithdrawal tx failed to send, stopping batch processing"
                     );
+                    return Ok(());
                 }
             }
         }
 
+        // All withdrawals in this slot confirmed — safe to remove.
         self.store.lock().remove_batch(head_val);
 
         info!(

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -34,7 +34,7 @@ use tokio::sync::Notify;
 use tracing::{error, info, instrument, warn};
 
 use crate::{
-    abi::{self, TempoState, ZoneInbox, ZoneOutbox},
+    abi::{self, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
     batch::{BatchData, BatchSubmitter},
     withdrawals::SharedWithdrawalStore,
 };
@@ -128,7 +128,18 @@ impl ZoneMonitor {
         let inbox = ZoneInbox::new(config.inbox_address, provider.clone());
         let tempo_state = TempoState::new(config.tempo_state_address, provider.clone());
 
-        let batch_submitter = BatchSubmitter::new(config.portal_address, l1_provider);
+        let portal_for_init = ZonePortal::new(config.portal_address, l1_provider.clone());
+        let genesis_tempo_block_number: u64 = portal_for_init
+            .genesisTempoBlockNumber()
+            .call()
+            .await
+            .expect("failed to read genesisTempoBlockNumber");
+
+        let batch_submitter = BatchSubmitter::new(
+            config.portal_address,
+            l1_provider,
+            genesis_tempo_block_number,
+        );
 
         let (prev_block_hash, portal_withdrawal_queue_tail) = tokio::try_join!(
             batch_submitter.read_portal_block_hash(),
@@ -136,8 +147,15 @@ impl ZoneMonitor {
         )
         .expect("failed to read portal state at startup");
 
+        let prev_processed_deposit_hash = inbox
+            .processedDepositQueueHash()
+            .call()
+            .await
+            .unwrap_or(B256::ZERO);
+
         info!(
             %prev_block_hash,
+            %prev_processed_deposit_hash,
             portal_withdrawal_queue_tail,
             "Initialized from portal state"
         );
@@ -152,7 +170,7 @@ impl ZoneMonitor {
             batch_submitter,
             withdrawal_notify,
             last_processed_block: 0,
-            prev_processed_deposit_hash: B256::ZERO,
+            prev_processed_deposit_hash,
             prev_block_hash,
             portal_withdrawal_queue_tail,
         }
@@ -228,6 +246,14 @@ impl ZoneMonitor {
             B256::ZERO
         };
 
+        // --- 3. Validate withdrawal data consistency ---
+        if !withdrawal_queue_hash.is_zero() && all_withdrawals.is_empty() {
+            return Err(eyre::eyre!(
+                "withdrawal_queue_hash is non-zero but no withdrawal events found — \
+                 RPC may have returned incomplete data"
+            ));
+        }
+
         if !all_withdrawals.is_empty() {
             info!(
                 from,
@@ -239,21 +265,7 @@ impl ZoneMonitor {
             );
         }
 
-        // --- 3. Store withdrawals under the next portal queue slot ---
-        if !withdrawal_queue_hash.is_zero() {
-            let portal_slot = self.portal_withdrawal_queue_tail;
-            let mut store = self.withdrawal_store.lock();
-            for w in &all_withdrawals {
-                store.add_withdrawal(portal_slot, w.clone());
-            }
-            info!(
-                portal_slot,
-                count = all_withdrawals.len(),
-                "Stored withdrawals for portal queue slot"
-            );
-        }
-
-        // --- 5. Build and submit BatchData ---
+        // --- 4. Build and submit BatchData ---
         let batch_data = BatchData {
             tempo_block_number: end_state.tempo_block_number,
             prev_block_hash: self.prev_block_hash,
@@ -263,8 +275,9 @@ impl ZoneMonitor {
             withdrawal_queue_hash,
         };
 
-        // Submit — state only advances on success.
-        self.submit_batch_with_retry(&batch_data, to).await?;
+        // Submit — state and withdrawal store only advance on success.
+        self.submit_batch_with_retry(&batch_data, to, all_withdrawals)
+            .await?;
 
         Ok(())
     }
@@ -280,9 +293,23 @@ impl ZoneMonitor {
             .query()
             .await?;
 
-        Ok(events
+        let mut events_with_order: Vec<_> = events
             .into_iter()
-            .map(|(event, _log)| abi::Withdrawal {
+            .map(|(event, log)| {
+                let sort_key = (
+                    log.block_number.unwrap_or(0),
+                    log.transaction_index.unwrap_or(0),
+                    log.log_index.unwrap_or(0),
+                );
+                (sort_key, event)
+            })
+            .collect();
+
+        events_with_order.sort_by_key(|(key, _)| *key);
+
+        Ok(events_with_order
+            .into_iter()
+            .map(|(_, event)| abi::Withdrawal {
                 sender: event.sender,
                 to: event.to,
                 amount: event.amount,
@@ -357,7 +384,25 @@ impl ZoneMonitor {
         &mut self,
         batch_data: &BatchData,
         last_block_number: u64,
+        withdrawals: Vec<abi::Withdrawal>,
     ) -> Result<()> {
+        // Preflight: verify prev_block_hash matches portal state.
+        match self.batch_submitter.read_portal_block_hash().await {
+            Ok(portal_hash) if portal_hash != batch_data.prev_block_hash => {
+                warn!(
+                    local_prev = %batch_data.prev_block_hash,
+                    portal_hash = %portal_hash,
+                    "prev_block_hash mismatch with portal, resyncing"
+                );
+                self.resync_from_portal().await;
+                return Ok(());
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed preflight portal hash check, continuing with submission");
+            }
+            _ => {}
+        }
+
         let mut delay = INITIAL_RETRY_DELAY;
 
         for attempt in 1..=MAX_RETRIES {
@@ -378,8 +423,20 @@ impl ZoneMonitor {
                     self.prev_processed_deposit_hash = batch_data.next_processed_deposit_hash;
                     self.last_processed_block = last_block_number;
 
-                    // Advance portal queue tail if this batch had withdrawals.
+                    // Store withdrawals and advance portal queue tail if this batch had withdrawals.
                     if !batch_data.withdrawal_queue_hash.is_zero() {
+                        if !withdrawals.is_empty() {
+                            let portal_slot = self.portal_withdrawal_queue_tail;
+                            let mut store = self.withdrawal_store.lock();
+                            for w in &withdrawals {
+                                store.add_withdrawal(portal_slot, w.clone());
+                            }
+                            info!(
+                                portal_slot,
+                                count = withdrawals.len(),
+                                "Stored withdrawals for portal queue slot"
+                            );
+                        }
                         self.portal_withdrawal_queue_tail += 1;
                     }
 
@@ -414,17 +471,19 @@ impl ZoneMonitor {
         }
 
         // All retries exhausted — resync from portal.
-        self.resync_from_portal(last_block_number).await;
+        self.resync_from_portal().await;
 
         Ok(())
     }
 
-    /// Resync `prev_block_hash` and `portal_withdrawal_queue_tail` from the
-    /// portal's on-chain `blockHash()` and `withdrawalQueueTail()`.
+    /// Resync `prev_block_hash`, `prev_processed_deposit_hash`, and
+    /// `portal_withdrawal_queue_tail` from on-chain state.
     ///
-    /// Called after exhausting retries so subsequent batches start from the
-    /// portal's actual state rather than stale local values.
-    async fn resync_from_portal(&mut self, block_number: u64) {
+    /// Called after exhausting retries or when a preflight hash mismatch is
+    /// detected, so subsequent batches start from the portal's actual state
+    /// rather than stale local values. Does NOT advance `last_processed_block`
+    /// — the same block range will be retried on the next poll cycle.
+    async fn resync_from_portal(&mut self) {
         let old_hash = self.prev_block_hash;
         let old_tail = self.portal_withdrawal_queue_tail;
         match tokio::try_join!(
@@ -432,25 +491,31 @@ impl ZoneMonitor {
             self.batch_submitter.read_portal_withdrawal_queue_tail(),
         ) {
             Ok((portal_hash, portal_tail)) => {
+                // Also resync prev_processed_deposit_hash from ZoneInbox.
+                let deposit_hash = self
+                    .inbox
+                    .processedDepositQueueHash()
+                    .call()
+                    .await
+                    .unwrap_or(self.prev_processed_deposit_hash);
+
                 warn!(
                     old_prev_block_hash = %old_hash,
                     new_block_hash = %portal_hash,
                     old_portal_tail = old_tail,
                     new_portal_tail = portal_tail,
-                    block_number,
-                    "Resynced prev_block_hash and portal_withdrawal_queue_tail from portal after max retries"
+                    %deposit_hash,
+                    "Resynced from portal and zone state"
                 );
                 self.prev_block_hash = portal_hash;
                 self.portal_withdrawal_queue_tail = portal_tail;
-                // Skip this block — the monitor will pick up from the next one.
-                self.last_processed_block = block_number;
+                self.prev_processed_deposit_hash = deposit_hash;
             }
             Err(e) => {
                 error!(
                     error = %e,
                     "Failed to read portal state during resync"
                 );
-                // Don't advance last_processed_block so we retry this block.
             }
         }
     }


### PR DESCRIPTION
Stacked on #123 (which is stacked on #122).

## Summary

Comprehensive robustness fixes for the batch submission pipeline, zone monitor, and withdrawal processor.

### Batch submission (`batch.rs`)
- **#227**: Reject future `tempoBlockNumber` in `resolve_anchor_mode` (would cause guaranteed revert)
- **#229**: Validate `tempoBlockNumber >= genesisTempoBlockNumber` (read once at startup)
- **#230**: Apply finality margin (64 blocks) on anchor block selection to avoid reorg risk
- **#238**: Check withdrawal queue capacity (100 slots) before submitting batches with withdrawals

### Zone monitor (`zonemonitor.rs`)
- **#228**: Preflight `prevBlockHash` check before retry loop — resync immediately on mismatch instead of burning 3 retries
- **#232**: `resync_from_portal()` no longer advances `last_processed_block` — blocks retry on next poll instead of being permanently skipped
- **#234**: Withdrawal store writes moved to success path (after confirmed L1 submission) to prevent orphaned entries
- **#235**: Initialize `prev_processed_deposit_hash` from `ZoneInbox.processedDepositQueueHash()` at startup and during resync
- **#236**: Sort withdrawal events by `(block_number, tx_index, log_index)` to ensure deterministic hash chain ordering
- **#237**: Validate non-zero `withdrawalQueueHash` has matching withdrawal data before submission

### Withdrawal processor (`withdrawals.rs`)
- **#233 CRITICAL**: Process withdrawals sequentially with `.watch()` receipt confirmation. Only remove batch from store after ALL withdrawals confirmed on L1. On any failure, stop and retain data for retry on next cycle. Previously, all txs were fire-and-forget then the batch was unconditionally deleted — if any tx failed, data was lost and the queue slot was permanently bricked.