### PR TITLE
chore: remove unused dependencies and patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11231,7 +11231,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
  "clap",
- "derive_more",
  "reth-cli-util",
  "reth-consensus",
  "reth-ethereum",
@@ -13333,18 +13332,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "vergen"
-version = "9.0.6"
-source = "git+https://github.com/rustyhorde/vergen?rev=0875fb7417586fb42d0ed6ddbfd4de0b35745ecc#0875fb7417586fb42d0ed6ddbfd4de0b35745ecc"
-
-[[patch.unused]]
-name = "vergen-git2"
-version = "1.0.7"
-source = "git+https://github.com/rustyhorde/vergen?rev=0875fb7417586fb42d0ed6ddbfd4de0b35745ecc#0875fb7417586fb42d0ed6ddbfd4de0b35745ecc"
-
-[[patch.unused]]
-name = "vergen-lib"
-version = "0.1.6"
-source = "git+https://github.com/rustyhorde/vergen?rev=0875fb7417586fb42d0ed6ddbfd4de0b35745ecc#0875fb7417586fb42d0ed6ddbfd4de0b35745ecc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,8 +164,4 @@ serde_json = "1.0.142"
 tokio = { version = "1.45.1", features = ["full"] }
 tracing = "0.1.41"
 
-[patch.crates-io]
-vergen = { git = "https://github.com/rustyhorde/vergen", rev = "0875fb7417586fb42d0ed6ddbfd4de0b35745ecc" }
-vergen-git2 = { git = "https://github.com/rustyhorde/vergen", rev = "0875fb7417586fb42d0ed6ddbfd4de0b35745ecc" }
-vergen-lib = { git = "https://github.com/rustyhorde/vergen", rev = "0875fb7417586fb42d0ed6ddbfd4de0b35745ecc" }
 

--- a/bin/tempo-zone/Cargo.toml
+++ b/bin/tempo-zone/Cargo.toml
@@ -30,7 +30,6 @@ alloy-signer-local.workspace = true
 # misc
 clap.workspace = true
 tokio.workspace = true
-derive_more.workspace = true
 tracing.workspace = true
 
 [[bin]]

--- a/crates/tempo-zone/src/engine.rs
+++ b/crates/tempo-zone/src/engine.rs
@@ -16,7 +16,7 @@ use reth_payload_primitives::{
 use reth_primitives_traits::{HeaderTy, SealedHeaderFor};
 use reth_storage_api::BlockReader;
 use std::{collections::VecDeque, time::Duration};
-use tracing::{debug, error, info};
+use tracing::error;
 
 use crate::DepositQueue;
 

--- a/crates/tempo-zone/src/executor.rs
+++ b/crates/tempo-zone/src/executor.rs
@@ -4,7 +4,6 @@
 //! Unlike the Tempo L1 [`TempoBlockExecutor`], this executor does **not** enforce subblock
 //! ordering, shared-gas accounting, or the end-of-block subblock metadata system transaction.
 
-use alloy_consensus::Transaction;
 use alloy_evm::{
     Database, Evm,
     block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, OnStateHook},


### PR DESCRIPTION
## Summary

Remove unused dependencies and patches that generate warnings during compilation.

### Changes
- **Remove unused `[patch.crates-io]` entries**: `vergen`, `vergen-git2`, `vergen-lib` patches targeted v9.0.6 but the dependency tree uses v9.1.0, so they were never applied
- **Remove unused `derive_more`** dependency from `bin/tempo-zone` (not referenced anywhere in the binary crate)
- **Remove unused imports**: `debug`/`info` from `engine.rs`, `alloy_consensus::Transaction` from `executor.rs`

Eliminates all `cargo check` warnings on the workspace.