### PR TITLE
fix: install rustls CryptoProvider for WSS L1 connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11228,6 +11228,7 @@ dependencies = [
  "reth-consensus",
  "reth-ethereum",
  "reth-tracing",
+ "rustls",
  "tempo-chainspec",
  "tokio",
  "tracing",

--- a/bin/tempo-zone/Cargo.toml
+++ b/bin/tempo-zone/Cargo.toml
@@ -27,6 +27,9 @@ reth-tracing.workspace = true
 alloy-primitives.workspace = true
 alloy-signer-local.workspace = true
 
+# tls
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+
 # misc
 clap.workspace = true
 tokio.workspace = true

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -86,6 +86,11 @@ struct ZoneArgs {
 fn main() {
     reth_cli_util::sigsegv_handler::install();
 
+    // Install the default rustls CryptoProvider for WSS connections to L1.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
     if std::env::var_os("RUST_BACKTRACE").is_none() {
         unsafe { std::env::set_var("RUST_BACKTRACE", "1") };


### PR DESCRIPTION
The zone node panics at startup when connecting to L1 via `wss://` because no rustls `CryptoProvider` is installed:

```
thread 'main' panicked at rustls/src/crypto/mod.rs:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

This adds `rustls` with the `aws-lc-rs` feature to the zone binary and calls `install_default()` in `main()` before any TLS connections are made.