### PR TITLE
fix(zone): prevent payload builder panic on empty deposit queue

### DIFF
--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -180,8 +180,10 @@ where
         {
             Some(block) => block,
             None => {
-                debug!(target: "zone::payload", "No L1 block available, cancelling build");
-                return Ok(BuildOutcome::Cancelled);
+                debug!(target: "zone::payload", "No L1 block available, skipping build");
+                return Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
+                    "no L1 block available in deposit queue",
+                )));
             }
         };
 
@@ -398,10 +400,10 @@ where
             EthBuiltPayload::new(attributes.payload_id(), sealed_block, total_fees, requests);
 
         drop(db);
-        Ok(BuildOutcome::Better {
-            payload,
-            cached_reads,
-        })
+        // Zone payloads are deterministic (one L1 block = one zone block), so freeze
+        // the payload to prevent reth from re-triggering try_build on the rebuild interval.
+        // Without this, the next rebuild attempt would find the deposit queue empty.
+        Ok(BuildOutcome::Freeze(payload))
     }
 
     fn on_missing_payload(


### PR DESCRIPTION
## Problem

The zone node crashes intermittently with two cascading panics:

1. **Payload builder service**: `unreachable!("the cancel signal never fired")` in reth's `BasicPayloadJob::poll`
2. **Consensus engine**: `SelectNextSome polled after terminated` (channel closed by the first panic)

### Root Cause

The zone payload builder returned `BuildOutcome::Cancelled` when the deposit queue was empty, but reth's `BasicPayloadJob` treats `Cancelled` as an unreachable state (it expects it only from the `CancelOnDrop` token).

The empty queue condition was triggered because:
- After a successful build, `BuildOutcome::Better` was returned, which tells reth to keep rebuilding on its interval timer
- The next rebuild attempt finds the deposit queue already drained → `Cancelled` → `unreachable!()` → panic

## Fix

1. **Return `Err` instead of `BuildOutcome::Cancelled`** when the deposit queue is empty. Reth handles `Err` gracefully (logs the failure and continues).

2. **Return `BuildOutcome::Freeze` instead of `Better`** after a successful build. Zone payloads are deterministic (one L1 block = one zone block), so there's no reason to rebuild. `Freeze` tells reth to stop the rebuild interval, eliminating the race entirely.