### PR TITLE
feat(zone-genesis): add AlphaUSD/BetaUSD tokens and remove genesis mints

### DIFF
--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -42,6 +42,8 @@ const ZONE_CONFIG_ADDRESS: Address = address!("0x1c00000000000000000000000000000
 const TEMPO_STATE_READER_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000004");
 
 const DEPLOYER: Address = address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+const ALPHA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000001");
+const BETA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000002");
 
 #[derive(Debug, clap::Parser)]
 pub(crate) struct GenerateZoneGenesis {
@@ -100,7 +102,8 @@ impl GenerateZoneGenesis {
         // This mirrors the L1 genesis setup.
         initialize_tip403_registry(&mut evm)?;
         initialize_tip20_factory(&mut evm)?;
-        create_path_usd_token(&mut evm, self.sequencer)?;
+        create_path_usd_token(&mut evm)?;
+        create_extra_tokens(&mut evm)?;
 
         let tempo_state_bytecode = load_artifact(&self.specs_out, "TempoState")?;
         let tempo_state_args = (Bytes::from(header_rlp),).abi_encode_params();
@@ -396,10 +399,7 @@ fn initialize_tip20_factory(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Resul
 /// This mirrors the L1 genesis setup: the Tempo EVM handler defaults to pathUSD
 /// (`0x20C0...`) as the fee token and validates its `currency == "USD"` storage.
 /// Without this, user transactions on the zone revert with `InvalidFeeToken`.
-fn create_path_usd_token(
-    evm: &mut TempoEvm<CacheDB<EmptyDB>>,
-    sequencer: Option<Address>,
-) -> eyre::Result<()> {
+fn create_path_usd_token(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Result<()> {
     let admin = DEPLOYER;
 
     let ctx = evm.ctx_mut();
@@ -435,21 +435,58 @@ fn create_path_usd_token(
                 },
             )?;
 
-            // If a sequencer is specified, mint some pathUSD for gas fees
-            if let Some(sequencer) = sequencer {
-                token.mint(
-                    admin,
-                    ITIP20::mintCall {
-                        to: sequencer,
-                        amount: U256::from(1_000_000_000_000u128), // 1M pathUSD (6 decimals)
-                    },
-                )?;
-            }
-
             Ok::<(), tempo_precompiles::error::TempoPrecompileError>(())
         },
     )?;
 
     println!("Created pathUSD fee token at {PATH_USD_ADDRESS}");
+    Ok(())
+}
+
+/// Create AlphaUSD and BetaUSD tokens at their reserved TIP20 addresses,
+/// mirroring the L1 genesis setup.
+fn create_extra_tokens(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Result<()> {
+    let admin = DEPLOYER;
+
+    for (address, name) in [
+        (ALPHA_USD_ADDRESS, "AlphaUSD"),
+        (BETA_USD_ADDRESS, "BetaUSD"),
+    ] {
+        let ctx = evm.ctx_mut();
+        StorageCtx::enter_evm(
+            &mut ctx.journaled_state,
+            &ctx.block,
+            &ctx.cfg,
+            &ctx.tx,
+            || {
+                TIP20Factory::new().create_token_reserved_address(
+                    address,
+                    name,
+                    name,
+                    "USD",
+                    PATH_USD_ADDRESS,
+                    admin,
+                )?;
+
+                let mut token = TIP20Token::from_address(address)?;
+                token.grant_role_internal(admin, *ISSUER_ROLE)?;
+                token.grant_role_internal(Address::ZERO, *ISSUER_ROLE)?;
+                token.grant_role_internal(ZONE_INBOX_ADDRESS, *ISSUER_ROLE)?;
+                token.grant_role_internal(ZONE_OUTBOX_ADDRESS, *ISSUER_ROLE)?;
+
+                token.set_supply_cap(
+                    admin,
+                    ITIP20::setSupplyCapCall {
+                        newSupplyCap: U256::from(u128::MAX),
+                    },
+                )?;
+
+                Ok::<(), tempo_precompiles::error::TempoPrecompileError>(())
+            },
+        )?;
+
+        println!("Created {name} token at {address}");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Changes

- **Add AlphaUSD and BetaUSD** to zone genesis at their reserved TIP20 addresses (`0x20C0...0001` and `0x20C0...0002`), mirroring the L1 genesis setup. Both tokens get `ISSUER_ROLE` grants for ZoneInbox (mint on deposit) and ZoneOutbox (burn on withdrawal).

- **Remove pathUSD genesis mint** to sequencer. Zone L2 token supply should start at zero and only increase through real L1 deposits, maintaining 1:1 parity with the portal's escrow balance. System transactions already use `gas_price=0`, so the sequencer doesn't need a genesis balance.

## Motivation

Without AlphaUSD/BetaUSD in the zone genesis, depositing these tokens from L1 causes the `advanceTempo` system transaction to revert (the ZoneInbox can't mint a token that doesn't exist), halting the zone.

The genesis mint was creating unbacked L2 supply that broke the invariant that zone token supply == portal escrow.