### PR TITLE
fix(zone): add EIP-150 cushion to withdrawal callback gas override

### DIFF
--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -274,11 +274,37 @@ impl WithdrawalProcessor {
                 "Submitting processWithdrawal to L1"
             );
 
-            let tx_result = self
-                .portal
-                .processWithdrawal(withdrawal.clone(), remaining_queue)
-                .send()
-                .await;
+            let call =
+                self.portal.processWithdrawal(withdrawal.clone(), remaining_queue);
+
+            // When the withdrawal has a callback (`gasLimit > 0`), we must
+            // override `eth_estimateGas` because the estimate only covers the
+            // revert / bounce-back path, which is much cheaper than the happy
+            // path where the callback actually executes.
+            //
+            // The tx gas limit is composed of three parts:
+            //
+            //   txGas = gasLimit + CALLBACK_OVERHEAD + eip150_cushion
+            //
+            // 1. `gasLimit`          — gas the user requested for their callback.
+            // 2. `CALLBACK_OVERHEAD` — fixed cost for the portal + messenger
+            //    logic that runs *around* the callback: queue dequeue & hash
+            //    verification, TIP-20 transferFrom (~500k), messenger relay
+            //    setup, fee payment, event emission, and the bounce-back path
+            //    if the callback reverts.
+            // 3. EIP-150 cushion     — the 63/64 forwarding rule means the
+            //    caller must hold back 1/64 of remaining gas. To guarantee
+            //    the inner CALL receives at least `gasLimit`, the outer frame
+            //    needs an extra `ceil(gasLimit / 63)`.
+            let call = if withdrawal.gasLimit > 0 {
+                const CALLBACK_OVERHEAD: u64 = 1_000_000;
+                let eip150_cushion = withdrawal.gasLimit.div_ceil(63);
+                call.gas(withdrawal.gasLimit + CALLBACK_OVERHEAD + eip150_cushion)
+            } else {
+                call
+            };
+
+            let tx_result = call.send().await;
 
             match tx_result {
                 Ok(pending) => {

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -274,8 +274,9 @@ impl WithdrawalProcessor {
                 "Submitting processWithdrawal to L1"
             );
 
-            let call =
-                self.portal.processWithdrawal(withdrawal.clone(), remaining_queue);
+            let call = self
+                .portal
+                .processWithdrawal(withdrawal.clone(), remaining_queue);
 
             // When the withdrawal has a callback (`gasLimit > 0`), we must
             // override `eth_estimateGas` because the estimate only covers the


### PR DESCRIPTION
## Problem

When processing withdrawals with callbacks, the tx gas limit was set to `gasLimit + 1M overhead` but did not account for the EIP-150 63/64 forwarding rule. The EVM retains 1/64 of remaining gas at each `CALL` depth, so the inner callback could receive less gas than the user requested.

## Fix

The gas override now has three components:

```
txGas = gasLimit + CALLBACK_OVERHEAD + ceil(gasLimit / 63)
```

| Component | Purpose |
|-----------|---------|
| `gasLimit` | Gas the user requested for their callback |
| `CALLBACK_OVERHEAD` (1M) | Fixed cost for portal + messenger logic: queue dequeue, hash verification, TIP-20 transferFrom, fee payment, event emission, bounce-back path |
| EIP-150 cushion | `ceil(gasLimit / 63)` ensures the inner CALL receives the full `gasLimit` despite the 63/64 retention rule |

Also adds detailed documentation explaining why `eth_estimateGas` is insufficient (it estimates the revert/bounce-back path, not the happy path with callback execution).