### PR TITLE
feat(zone): adaptive batch submission with withdrawal flush

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -61,6 +61,15 @@ struct ZoneArgs {
     )]
     pub zone_poll_interval_secs: u64,
 
+    /// Maximum time (in seconds) to accumulate zone blocks before submitting a
+    /// batch to L1. Batches are flushed early when withdrawals are pending.
+    #[arg(
+        long = "zone.batch-interval-secs",
+        env = "ZONE_BATCH_INTERVAL_SECS",
+        default_value = "60"
+    )]
+    pub zone_batch_interval_secs: u64,
+
     /// How often (in seconds) the withdrawal processor polls the L1 queue.
     #[arg(
         long = "withdrawal-poll-interval-secs",
@@ -161,6 +170,7 @@ fn main() {
                     tempo_state_address: zone::abi::TEMPO_STATE_ADDRESS,
                     zone_rpc_url: args.zone_rpc_url,
                     zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
+                    batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
                 };
 
                 let seq_handle = zone::spawn_zone_sequencer(sequencer_config, signer).await;

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -61,6 +61,8 @@ pub struct ZoneSequencerConfig {
     pub zone_rpc_url: String,
     /// How often the zone monitor polls for new L2 blocks.
     pub zone_poll_interval: Duration,
+    /// Maximum time to accumulate zone blocks before submitting a batch to L1.
+    pub batch_interval: Duration,
 }
 
 /// Handles returned by [`spawn_zone_sequencer`] for managing background tasks.
@@ -117,6 +119,7 @@ pub async fn spawn_zone_sequencer(
         tempo_state_address: config.tempo_state_address,
         zone_rpc_url: config.zone_rpc_url,
         poll_interval: config.zone_poll_interval,
+        batch_interval: config.batch_interval,
         portal_address: config.portal_address,
     };
 

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -56,8 +56,12 @@ pub struct ZoneMonitorConfig {
     pub tempo_state_address: Address,
     /// Zone L2 RPC URL (HTTP).
     pub zone_rpc_url: String,
-    /// How often to poll for new zone blocks.
+    /// How often to poll the zone L2 for new blocks (cheap RPC call).
     pub poll_interval: Duration,
+    /// Maximum time to accumulate zone blocks before submitting a batch to L1.
+    /// Blocks are aggregated during this window to reduce L1 tx count.
+    /// A batch is submitted early if pending withdrawals are detected.
+    pub batch_interval: Duration,
     /// ZonePortal contract address on Tempo L1.
     pub portal_address: Address,
 }
@@ -177,6 +181,11 @@ impl ZoneMonitor {
     }
 
     /// Run the monitor loop. This method never returns under normal operation.
+    ///
+    /// Polls the zone L2 frequently (`poll_interval`) but only submits a batch
+    /// to L1 when:
+    /// - The `batch_interval` deadline has elapsed, OR
+    /// - Pending withdrawals are detected (flush immediately for user experience)
     #[instrument(skip_all, fields(
         outbox = %self.config.outbox_address,
         inbox = %self.config.inbox_address,
@@ -184,25 +193,63 @@ impl ZoneMonitor {
     pub async fn run(&mut self) -> Result<()> {
         info!(
             zone_rpc = %self.config.zone_rpc_url,
+            batch_interval = ?self.config.batch_interval,
+            poll_interval = ?self.config.poll_interval,
             "Zone monitor started"
         );
 
+        let mut poll = tokio::time::interval(self.config.poll_interval);
+        let mut batch_deadline = tokio::time::Instant::now();
+
         loop {
-            match self.provider.get_block_number().await {
-                Ok(latest) => {
-                    if latest > self.last_processed_block {
-                        let from = self.last_processed_block + 1;
-                        if let Err(e) = self.process_block_range(from, latest).await {
-                            error!(from, to = latest, error = %e, "Failed to process zone block range");
-                        }
-                    }
-                }
-                Err(e) => {
-                    warn!(error = %e, "Failed to query zone L2 block number");
-                }
+            poll.tick().await;
+
+            let Ok(latest) = self.provider.get_block_number().await else {
+                continue;
+            };
+            if latest <= self.last_processed_block {
+                continue;
             }
 
-            tokio::time::sleep(self.config.poll_interval).await;
+            let deadline_elapsed = tokio::time::Instant::now() >= batch_deadline;
+            // Skip the eth_getLogs call when we'd submit anyway.
+            if !deadline_elapsed && !self.has_pending_withdrawals(latest).await {
+                continue;
+            }
+
+            let from = self.last_processed_block + 1;
+            if let Err(e) = self.process_block_range(from, latest).await {
+                error!(from, to = latest, error = %e, "Failed to process zone block range");
+                continue;
+            }
+
+            batch_deadline = tokio::time::Instant::now() + self.config.batch_interval;
+        }
+    }
+
+    /// Check if any zone blocks since `last_processed_block` contain finalized
+    /// withdrawal batches that need to be submitted to L1.
+    ///
+    /// `pendingWithdrawalsCount()` is always 0 on committed blocks because
+    /// `finalizeWithdrawalBatch` runs as the last tx in every zone block. The
+    /// correct signal is `BatchFinalized` events with non-zero withdrawal hashes.
+    async fn has_pending_withdrawals(&self, latest_block: u64) -> bool {
+        let from = self.last_processed_block + 1;
+        match self
+            .outbox
+            .BatchFinalized_filter()
+            .from_block(from)
+            .to_block(latest_block)
+            .query()
+            .await
+        {
+            Ok(events) => events
+                .iter()
+                .any(|(event, _)| !event.withdrawalQueueHash.is_zero()),
+            Err(e) => {
+                warn!(error = %e, "Failed to check for finalized withdrawal batches");
+                false
+            }
         }
     }
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -1429,6 +1429,7 @@ impl ZoneAccount {
             tempo_state_address: TEMPO_STATE_ADDRESS,
             zone_rpc_url: zone.http_url().to_string(),
             zone_poll_interval: Duration::from_millis(500),
+            batch_interval: Duration::from_millis(500),
         };
 
         zone::spawn_zone_sequencer(config, sequencer_signer).await


### PR DESCRIPTION
## Problem

The zone monitor submitted a batch to L1 every poll cycle (~1s), even if only 1-2 zone blocks existed. This wastes L1 gas in steady state.

## Solution

Accumulate zone blocks and submit on a configurable interval (default 60s). Batches are flushed early when withdrawal events are detected to keep withdrawal UX fast.

### Batching rules

| Trigger | Behavior |
|---------|----------|
| Batch interval elapsed | Submit all accumulated blocks |
| `BatchFinalized` event with non-zero withdrawal hash | Flush immediately |

### Design details

- **Lazy deadline** — only starts counting when unprocessed blocks are first detected, so startup/restart submits immediately if there is a backlog
- **Short-circuit** — skips the `BatchFinalized` event query when the deadline has already elapsed (saves an `eth_getLogs` call per cycle)
- **Configurable** — `--zone.batch-interval-secs` / `ZONE_BATCH_INTERVAL_SECS` (default 60s, set to 1 for old behavior)

### Why not `pendingWithdrawalsCount()`?

`finalizeWithdrawalBatch` runs as the last tx in every zone block, so `pendingWithdrawalsCount()` is always 0 on committed blocks. The correct signal is `BatchFinalized` events with non-zero withdrawal queue hashes.

### Impact

~60x fewer L1 transactions in steady state. Withdrawal detection latency remains at ~1s (the poll interval).