### PR TITLE
chore: update zone docs, Justfile, and fix L1 backfill bug

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -73,16 +73,19 @@ max-approve-portal:
 
 [group('zone')]
 [doc('Sends a test deposit to the ZonePortal on L1 (moderato). Requires L1_RPC_URL and PRIVATE_KEY env vars. Run max-approve-portal first.')]
-send-deposit to amount="1000000" token="0x20C0000000000000000000000000000000000000" memo="0x0000000000000000000000000000000000000000000000000000000000000000":
+send-deposit amount="1000000" to="" token="0x20C0000000000000000000000000000000000000" memo="0x0000000000000000000000000000000000000000000000000000000000000000":
     #!/bin/bash
     set -euo pipefail
     RPC="${L1_RPC_URL:?Set L1_RPC_URL env var}"
     PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
     PORTAL="${L1_PORTAL_ADDRESS:?Set L1_PORTAL_ADDRESS env var}"
-    HTTP_RPC=$(echo "$RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
-    echo "Depositing {{amount}} to {{to}}..."
-    cast send "$PORTAL" "deposit(address,address,uint128,bytes32)" "{{token}}" "{{to}}" "{{amount}}" "{{memo}}" \
-        --rpc-url "$HTTP_RPC" --private-key "$PK"
+    TO="{{to}}"
+    if [[ -z "$TO" ]]; then
+        TO=$(cast wallet address "$PK")
+    fi
+    echo "Depositing {{amount}} to $TO..."
+    cast send "$PORTAL" "deposit(address,address,uint128,bytes32)" "{{token}}" "$TO" "{{amount}}" "{{memo}}" \
+        --rpc-url "$RPC" --private-key "$PK"
     echo "Deposit sent!"
 
 [group('zone')]
@@ -112,8 +115,8 @@ create-zone name:
     echo "Zone '{{name}}' created. Artifacts in $OUTPUT/"
 
 [group('zone')]
-[doc('Starts a Tempo Zone L2 node, subscribing to L1 deposits. Pass the zone name used in create-zone.')]
-zone-up name reset="false" args="":
+[doc('Starts a Tempo Zone L2 node, subscribing to L1 deposits. Pass the zone name used in create-zone. Use profile=release for production.')]
+zone-up name reset="false" profile="dev" args="":
     #!/bin/bash
     set -euo pipefail
     ZONE_DIR="generated/{{name}}"
@@ -133,7 +136,13 @@ zone-up name reset="false" args="":
     if [[ "{{reset}}" = "true" ]]; then
         rm -rf "$DATADIR" || true
     fi
-    cargo run --bin tempo-zone -- \
+    PROFILE_FLAG=""
+    if [[ "{{profile}}" == "release" ]]; then
+        PROFILE_FLAG="--release"
+    elif [[ "{{profile}}" != "dev" ]]; then
+        PROFILE_FLAG="--profile {{profile}}"
+    fi
+    cargo run $PROFILE_FLAG --bin tempo-zone -- \
                       node \
                       --chain "$GENESIS_JSON" \
                       --l1.rpc-url "${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}" \
@@ -157,26 +166,29 @@ max-approve-outbox token="0x20C0000000000000000000000000000000000000" rpc="http:
     OUTBOX="0x1c00000000000000000000000000000000000002"
     echo "Approving ZoneOutbox for max zone tokens..."
     cast send "{{token}}" "approve(address,uint256)" "$OUTBOX" "$(cast max-uint)" \
-        --rpc-url "{{rpc}}" --private-key "$PK"
+        --rpc-url "{{rpc}}" --private-key "$PK" --gas-limit 100000
     echo "Approved!"
 
 [group('zone')]
 [doc('Sends a withdrawal request on the zone (L2) back to Tempo L1. Requires PRIVATE_KEY env var. Run max-approve-outbox first.')]
-send-withdrawal to amount="1000000" token="0x20C0000000000000000000000000000000000000" memo="0x0000000000000000000000000000000000000000000000000000000000000000" gas-limit="0" fallback-recipient="" data="0x" rpc="http://localhost:8546":
+send-withdrawal amount="1000000" to="" token="0x20C0000000000000000000000000000000000000" memo="0x0000000000000000000000000000000000000000000000000000000000000000" gas-limit="0" fallback-recipient="" data="0x" rpc="http://localhost:8546":
     #!/bin/bash
     set -euo pipefail
     PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
     OUTBOX="0x1c00000000000000000000000000000000000002"
-    # Default fallback-recipient to sender if not provided
+    TO="{{to}}"
+    if [[ -z "$TO" ]]; then
+        TO=$(cast wallet address "$PK")
+    fi
     FALLBACK="{{fallback-recipient}}"
     if [[ -z "$FALLBACK" ]]; then
-        FALLBACK=$(cast wallet address "$PK")
+        FALLBACK="$TO"
     fi
-    echo "Requesting withdrawal of {{amount}} to {{to}} (fallback: $FALLBACK)..."
+    echo "Requesting withdrawal of {{amount}} to $TO (fallback: $FALLBACK)..."
     cast send "$OUTBOX" \
         "requestWithdrawal(address,address,uint128,bytes32,uint64,address,bytes)" \
-        "{{token}}" "{{to}}" "{{amount}}" "{{memo}}" "{{gas-limit}}" "$FALLBACK" "{{data}}" \
-        --rpc-url "{{rpc}}" --private-key "$PK"
+        "{{token}}" "$TO" "{{amount}}" "{{memo}}" "{{gas-limit}}" "$FALLBACK" "{{data}}" \
+        --rpc-url "{{rpc}}" --private-key "$PK" --gas-limit 500000
     echo "Withdrawal requested!"
 
 [group('zone')]
@@ -251,10 +263,26 @@ deploy-zone name:
     echo "  ⚠️  SAVE YOUR SEQUENCER KEY:"
     echo "  export SEQUENCER_KEY=$SEQUENCER_KEY"
     echo ""
-    echo "  To start the zone node:"
-    echo "  export L1_RPC_URL=\"$L1_RPC\""
-    echo "  export SEQUENCER_KEY=\"$SEQUENCER_KEY\""
-    echo "  just zone-up {{name}}"
+
+    # Step 6: Build and start the zone node
+    echo "Step 6: Building and starting zone node (release)..."
+    echo ""
+    cargo build --bin tempo-zone --release
+    DATADIR="/tmp/tempo-zone-{{name}}"
+    rm -rf "$DATADIR" || true
+    exec cargo run --release --bin tempo-zone -- \
+                      node \
+                      --chain "$OUTPUT/genesis.json" \
+                      --l1.rpc-url "$L1_RPC" \
+                      --l1.portal-address "$PORTAL" \
+                      --l1.genesis-block-number "$ANCHOR_BLOCK" \
+                      --http \
+                      --http.addr 0.0.0.0 \
+                      --http.port 8546 \
+                      --http.api all \
+                      --datadir "$DATADIR" \
+                      --log.file.directory "$DATADIR/logs" \
+                      --sequencer-key "$SEQUENCER_KEY"
 
 # Docs commands
 [group('docs')]

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -85,22 +85,15 @@ impl L1Subscriber {
     ) -> eyre::Result<()> {
         let tip = l1_provider.get_block_number().await?;
 
-        // When genesis_tempo_block_number is set and portal is Address::ZERO,
-        // skip portal queries entirely — no portal is deployed.
+        // When genesis_tempo_block_number is set via CLI, always use it as the
+        // starting point. The portal's `lastSyncedTempoBlockNumber` tracks batch
+        // submissions and may be ahead of where the zone chain actually is
+        // (e.g. after a restart where batches were submitted but the zone has
+        // no local blocks yet). The zone engine needs ALL L1 blocks from genesis
+        // to maintain chain continuity.
         let from = if let Some(genesis) = self.config.genesis_tempo_block_number {
-            if self.config.portal_address.is_zero() {
-                info!(genesis, "Using genesis block number override (no portal)");
-                genesis + 1
-            } else {
-                let portal = ZonePortal::new(self.config.portal_address, l1_provider);
-                let last_synced = portal.lastSyncedTempoBlockNumber().call().await?;
-                if last_synced > 0 {
-                    last_synced + 1
-                } else {
-                    info!(genesis, "Using CLI genesis block number override");
-                    genesis + 1
-                }
-            }
+            info!(genesis, "Using CLI genesis block number override");
+            genesis + 1
         } else {
             if self.config.portal_address.is_zero() {
                 warn!(

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -6,7 +6,7 @@ Zones are L2 chains anchored to Tempo L1. Each zone has its own sequencer, genes
 
 ## Quick Start (One Command)
 
-The fastest way to deploy a zone on moderato:
+The fastest way to deploy and run a zone on moderato:
 
 ```bash
 export L1_RPC_URL="wss://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
@@ -19,9 +19,18 @@ This single command will:
 3. Build the Solidity specs
 4. Deploy a zone on L1 via ZoneFactory (`createZone`)
 5. Generate the zone's `genesis.json` and `zone.json`
-6. Print the sequencer key and instructions to start the node
+6. Build and start the zone node
 
-> ⚠️ **Save your sequencer key** — it's printed at the end. You'll need it to run the zone node.
+> ⚠️ **Save your sequencer key** — it's printed before the node starts. You'll need it to restart the node later.
+
+Once running, see [Interact with the Zone](#6-interact-with-the-zone) to deposit, withdraw, and check balances.
+
+To restart the zone later:
+
+```bash
+export SEQUENCER_KEY="0x<your-sequencer-private-key>"
+just zone-up my-zone false release
+```
 
 ## Step-by-Step Guide
 
@@ -65,10 +74,7 @@ SEQUENCER_ADDR=$(cast wallet address "$SEQUENCER_KEY")
 The sequencer needs pathUSD on L1 to pay for the `createZone` transaction and deposit fees.
 
 ```bash
-# Convert to HTTP for cast commands
-HTTP_RPC=$(echo "$L1_RPC_URL" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
-
-cast rpc tempo_fundAddress "$SEQUENCER_ADDR" --rpc-url "$HTTP_RPC"
+cast rpc tempo_fundAddress "$SEQUENCER_ADDR" --rpc-url "$L1_RPC_URL"
 ```
 
 Verify the balance:
@@ -76,7 +82,7 @@ Verify the balance:
 ```bash
 cast call 0x20C0000000000000000000000000000000000000 \
   "balanceOf(address)(uint256)" "$SEQUENCER_ADDR" \
-  --rpc-url "$HTTP_RPC"
+  --rpc-url "$L1_RPC_URL"
 ```
 
 View on explorer: `https://explore.moderato.tempo.xyz/address/<SEQUENCER_ADDR>`
@@ -106,22 +112,25 @@ cargo run -p tempo-xtask -- create-zone \
 ### 5. Start the Zone Node
 
 ```bash
-export SEQUENCER_KEY="0x<your-sequencer-private-key>"
-just zone-up my-zone
+just zone-up my-zone false release
 ```
+
+Use `release` profile for production (recommended). Omit it for debug builds during development.
 
 The zone node will:
 - Listen on `http://localhost:8546` for JSON-RPC
-- Subscribe to L1 for deposit events
-- Build blocks every 250ms (configurable via `--block.interval-ms`)
-- Submit batch proofs to L1
+- Subscribe to L1 for deposit events and backfill from the genesis anchor block
+- Build one zone block per L1 block (catches up at full speed during sync)
+- Submit batch proofs to L1 every 60s (or immediately when withdrawals are pending)
 - Process withdrawals from the zone back to L1
 
 To reset the zone's datadir and start fresh:
 
 ```bash
-just zone-up my-zone reset=true
+just zone-up my-zone true release
 ```
+
+The zone node stores data in `/tmp/tempo-zone-<name>/`.
 
 ### 6. Interact with the Zone
 
@@ -129,8 +138,8 @@ just zone-up my-zone reset=true
 
 ```bash
 just check-balance <address>
-# or with a custom token/rpc:
-just check-balance <address> token=0x20C0000000000000000000000000000000000000 rpc=http://localhost:8546
+# or with a custom token and rpc (positional args):
+just check-balance <address> <token> <rpc>
 ```
 
 #### Deposit from L1 to Zone
@@ -142,10 +151,11 @@ export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
 just max-approve-portal
 ```
 
-Then send a deposit:
+Then send a deposit (pathUSD by default):
 
 ```bash
-just send-deposit <recipient-address> amount=1000000
+just send-deposit 1000000                       # deposit 1M pathUSD to your own address
+just send-deposit 1000000 <recipient-address>   # deposit 1M pathUSD to a specific address
 ```
 
 #### Withdraw from Zone to L1
@@ -159,36 +169,50 @@ just max-approve-outbox
 Then request a withdrawal:
 
 ```bash
-just send-withdrawal <recipient-address> amount=1000000
+just send-withdrawal 1000000                       # withdraw 1M to your own address
+just send-withdrawal 1000000 <recipient-address>   # withdraw 1M to a specific address
+```
+
+The sequencer detects the withdrawal, includes it in the next batch submission to L1, and then processes it on L1 automatically.
+
+#### Check balance on Zone L2
+
+```bash
+just check-balance <address>
+```
+
+#### Check portal status on L1
+
+```bash
+PORTAL=$(jq -r '.portal' generated/my-zone/zone.json)
+HTTP_RPC=$(echo "$L1_RPC_URL" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
+
+# Last L1 block synced by the zone
+cast call "$PORTAL" "lastSyncedTempoBlockNumber()(uint64)" --rpc-url "$HTTP_RPC"
+
+# Withdrawal queue status (head == tail means empty)
+cast call "$PORTAL" "withdrawalQueueHead()(uint256)" --rpc-url "$HTTP_RPC"
+cast call "$PORTAL" "withdrawalQueueTail()(uint256)" --rpc-url "$HTTP_RPC"
 ```
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────┐
-│                Tempo L1 (Moderato)          │
-│                                             │
-│  ┌──────────────┐    ┌──────────────────┐   │
-│  │ ZoneFactory   │    │ ZonePortal       │   │
-│  │ (shared)      │───>│ (per-zone)       │   │
-│  └──────────────┘    │  - deposits       │   │
-│                      │  - withdrawals    │   │
-│                      │  - batch proofs   │   │
-│                      └──────────────────┘   │
-└─────────────────────────────────────────────┘
-                    │ WSS subscription
-                    ▼
-┌─────────────────────────────────────────────┐
-│              Zone L2 Node                   │
-│                                             │
-│  Predeploys:                                │
-│  0x1c00...0000  TempoState                  │
-│  0x1c00...0001  ZoneInbox                   │
-│  0x1c00...0002  ZoneOutbox                  │
-│  0x1c00...0003  ZoneConfig                  │
-│  0x1c00...0004  TempoStateReader            │
-│  0x20C0...0000  pathUSD (fee token)         │
-└─────────────────────────────────────────────┘
+```mermaid
+graph TB
+    subgraph L1["Tempo L1 (Moderato)"]
+        Factory["ZoneFactory (shared)"]
+        Portal["ZonePortal (per-zone)<br/>deposits · batch proofs · withdrawals"]
+        Factory -->|createZone| Portal
+    end
+
+    subgraph L2["Zone L2 Node"]
+        direction TB
+        Tasks["Sequencer Tasks<br/>• L1 subscriber (deposit backfill + live)<br/>• Zone engine (L1-driven block building)<br/>• Zone monitor (batch submission to L1)<br/>• Withdrawal processor (L1 queue drain)"]
+        Predeploys["Predeploys<br/>0x1c00…0000 TempoState<br/>0x1c00…0001 ZoneInbox<br/>0x1c00…0002 ZoneOutbox<br/>0x1c00…0003 ZoneConfig<br/>0x1c00…0004 TempoStateReader<br/>0x20C0…0000 pathUSD"]
+    end
+
+    Portal -- "WSS subscription<br/>(deposits, headers)" --> Tasks
+    Tasks -- "submitBatch / processWithdrawal" --> Portal
 ```
 
 ## Configuration
@@ -198,7 +222,7 @@ just send-withdrawal <recipient-address> amount=1000000
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0x86A7Ca9816806B59C7172015D04F9C2EF5F5D8E0` |
+| ZoneFactory (moderato) | `0xb2D823504d3caa517e9cB42017404f316e0f8312` |
 
 ### Zone Node CLI Options
 
@@ -209,6 +233,9 @@ just send-withdrawal <recipient-address> amount=1000000
 | `--l1.genesis-block-number` | (from zone.json) | L1 block when the zone was created |
 | `--sequencer-key` | (optional) | Sequencer private key for block production |
 | `--block.interval-ms` | 250 | Block building interval |
+| `--zone.batch-interval-secs` | 60 | Max seconds to accumulate zone blocks before submitting a batch to L1 |
+| `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |
+| `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
 | `--private-rpc.port` | 8544 | Private RPC server port |
 
@@ -225,11 +252,11 @@ just send-withdrawal <recipient-address> amount=1000000
 
 | Command | Description |
 |---------|-------------|
-| `just deploy-zone <name>` | One-shot: keygen → fund → create → genesis |
+| `just deploy-zone <name>` | One-shot: keygen → fund → create → genesis → start node |
 | `just create-zone <name>` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`) |
-| `just zone-up <name>` | Start the zone node |
+| `just zone-up <name> [reset] [profile]` | Start the zone node. `reset=true` wipes datadir. `profile=release` for production. |
 | `just max-approve-portal` | Approve portal to spend tokens on L1 |
-| `just send-deposit <to>` | Deposit tokens from L1 to zone |
+| `just send-deposit [to]` | Deposit tokens from L1 to zone (defaults to sender) |
 | `just max-approve-outbox` | Approve outbox to spend tokens on zone |
-| `just send-withdrawal <to>` | Withdraw tokens from zone to L1 |
+| `just send-withdrawal [to]` | Withdraw tokens from zone to L1 (defaults to sender) |
 | `just check-balance <addr>` | Check token balance on the zone |

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -61,7 +61,7 @@ pub(crate) struct CreateZone {
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.
-    #[arg(long, default_value = "0x86A7Ca9816806B59C7172015D04F9C2EF5F5D8E0")]
+    #[arg(long, default_value = "0xb2D823504d3caa517e9cB42017404f316e0f8312")]
     zone_factory: Address,
 
     /// Initial TIP-20 token address for the zone (additional tokens can be enabled later).


### PR DESCRIPTION
- Update ZoneFactory default address to new deployment (`0xb2D8...`)
- **Fix L1 backfill bug**: always use `--l1.genesis-block-number` from CLI instead of the portal's `lastSyncedTempoBlockNumber`, which can be ahead of the zone's actual chain state after a restart
- `deploy-zone` now builds and starts the node (true one-command setup)
- `zone-up` supports `profile` param (`release`/`dev`)
- `send-deposit` / `send-withdrawal` default `to` to sender's address
- Add `--gas-limit` to L2 commands (`max-approve-outbox`, `send-withdrawal`)
- Update ZONES.md: accurate instructions, mermaid architecture diagram, new CLI flags, L1 portal status commands