### PR TITLE
fix(l1): retry get_logs when HTTP lags behind WS subscription

### DIFF
--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -220,25 +220,15 @@ impl L1Subscriber {
         Ok(())
     }
 
-    /// Derive an HTTP URL from the configured WSS URL for RPC calls that don't
-    /// need a subscription (backfilling, one-off reads).
-    fn http_url(&self) -> String {
-        self.config
-            .l1_rpc_url
-            .replacen("wss://", "https://", 1)
-            .replacen("ws://", "http://", 1)
-    }
-
     /// Start the L1 subscriber.
     ///
-    /// Syncs to the current L1 tip on startup using HTTP, then subscribes to
-    /// new blocks via WebSocket.
+    /// Connects via WebSocket, backfills to the current tip, then subscribes
+    /// to new blocks.
     pub async fn start(self) -> eyre::Result<()> {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
 
         let url: url::Url = self.config.l1_rpc_url.parse()?;
 
-        // Connect WS first so subscription captures blocks during backfill.
         let mut ws = WsConnect::new(self.config.l1_rpc_url.clone());
 
         if !url.username().is_empty() {
@@ -246,38 +236,50 @@ impl L1Subscriber {
             ws = ws.with_auth(auth);
         }
 
-        let ws_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_ws(ws)
             .await?;
 
         info!("Connected to L1 node");
 
-        // Subscribe before backfilling so we don't miss blocks between
-        // sync_to_l1_tip finishing and the stream starting.
-        let sub = ws_provider.subscribe_blocks().await?;
-        let mut stream = sub.into_stream();
-
-        info!(portal = %self.config.portal_address, "Subscribed to L1 blocks");
-
-        // Use HTTP for backfilling — more reliable than hammering a WebSocket
-        // with hundreds of sequential requests.
-        let http_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect_http(self.http_url().parse()?)
-            .erased();
-
         let filter = Filter::new()
             .address(self.config.portal_address)
             .event_signature(DepositMade::SIGNATURE_HASH);
 
-        self.sync_to_l1_tip(&http_provider, &filter).await?;
+        // Backfill to the current tip before subscribing. Subscribing first
+        // would buffer block notifications during the (potentially long)
+        // backfill, risking backpressure deadlocks on the WS transport.
+        self.sync_to_l1_tip(&provider, &filter).await?;
 
-        // Track the last enqueued block so we can detect and backfill gaps
-        // when the WebSocket subscription skips blocks.
+        // Subscribe after backfill, then catch up any blocks produced during
+        // the backfill window.
+        let sub = provider.subscribe_blocks().await?;
+        let mut stream = sub.into_stream();
+        let tip_after_sub = provider.get_block_number().await?;
+
+        let last_backfilled = self
+            .deposit_queue
+            .last_enqueued()
+            .map(|nh| nh.number)
+            .unwrap_or(tip_after_sub);
+
+        if tip_after_sub > last_backfilled {
+            info!(
+                from = last_backfilled + 1,
+                to = tip_after_sub,
+                "Catching up blocks produced during backfill"
+            );
+            self.backfill(&provider, &filter, last_backfilled + 1, tip_after_sub)
+                .await?;
+        }
+
+        info!(portal = %self.config.portal_address, "Subscribed to L1 blocks");
+
         let mut last_enqueued: u64 = self
             .deposit_queue
             .last_enqueued()
             .map(|nh| nh.number)
-            .unwrap_or(http_provider.get_block_number().await?);
+            .unwrap_or(tip_after_sub);
 
         while let Some(header) = stream.next().await {
             let block_number = header.number();
@@ -305,12 +307,11 @@ impl L1Subscriber {
                     skipped = gap_to - gap_from + 1,
                     "Gap detected in L1 subscription, backfilling"
                 );
-                self.backfill(&http_provider, &filter, gap_from, gap_to)
-                    .await?;
+                self.backfill(&provider, &filter, gap_from, gap_to).await?;
             }
 
-            // Fetch deposit logs for this block via HTTP
-            let logs = http_provider
+            // Fetch deposit logs for this block.
+            let logs = provider
                 .get_logs(&filter.clone().select(block_number))
                 .await?;
 


### PR DESCRIPTION
The WS subscription can deliver a block header before the HTTP endpoint has indexed it, causing `block range extends beyond current head` errors that crash the L1 subscriber and trigger a 5s reconnect loop.

Retries once after 500ms before propagating the error.