### PR TITLE
chore: update tempo to v1.2.0 and reth to 0ce23d76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b99ba7b74a87176f31ee1cd26768f7155b0eeff61ed925f59b13085ffe5f891"
+checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6978,7 +6978,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7002,7 +7002,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7033,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7053,7 +7053,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7067,7 +7067,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7145,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7155,7 +7155,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7173,7 +7173,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7193,7 +7193,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7232,7 +7232,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7354,7 +7354,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7369,7 +7369,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7394,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7418,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7442,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7505,7 +7505,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7528,7 +7528,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7553,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "futures",
  "pin-project",
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7632,7 +7632,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7691,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7713,7 +7713,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7724,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7752,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7773,7 +7773,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -7813,7 +7813,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "clap",
  "eyre",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7851,7 +7851,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7882,7 +7882,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7911,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7941,7 +7941,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7965,7 +7965,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7987,7 +7987,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8000,7 +8000,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8018,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "serde",
  "serde_json",
@@ -8080,7 +8080,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "bytes",
  "futures",
@@ -8128,7 +8128,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8144,7 +8144,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8153,7 +8153,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "futures",
  "metrics",
@@ -8165,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8174,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8188,7 +8188,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8217,6 +8217,7 @@ dependencies = [
  "reth-eth-wire-types",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
+ "reth-evm-ethereum",
  "reth-fs-util",
  "reth-metrics",
  "reth-net-banlist",
@@ -8244,7 +8245,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8269,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8292,7 +8293,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8307,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8321,7 +8322,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8338,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8362,7 +8363,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8430,7 +8431,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8486,7 +8487,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8524,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8548,7 +8549,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8572,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "bytes",
  "eyre",
@@ -8596,7 +8597,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8608,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8623,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8644,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8656,7 +8657,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8679,7 +8680,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8689,7 +8690,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8722,7 +8723,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8765,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8793,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8808,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8821,7 +8822,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8903,7 +8904,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -8934,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8975,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8996,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9026,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9070,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9118,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9132,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9148,7 +9149,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9197,7 +9198,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9224,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9238,7 +9239,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9258,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9271,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9295,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9312,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9330,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9346,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9356,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "clap",
  "eyre",
@@ -9373,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "clap",
  "eyre",
@@ -9390,7 +9391,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9409,12 +9410,15 @@ dependencies = [
  "reth-chainspec",
  "reth-eth-wire-types",
  "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-evm-ethereum",
  "reth-execution-types",
  "reth-fs-util",
  "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-tasks",
+ "revm",
  "revm-interpreter",
  "revm-primitives",
  "rustc-hash",
@@ -9431,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9457,7 +9461,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9484,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9499,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9524,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9543,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9561,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
+source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
 dependencies = [
  "zstd",
 ]
@@ -10843,8 +10847,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10872,8 +10876,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10891,8 +10895,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-commonware-node-config"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -10902,8 +10906,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10918,8 +10922,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10928,8 +10932,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -10940,8 +10944,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10970,8 +10974,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11022,8 +11026,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11053,8 +11057,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -11070,8 +11074,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11087,8 +11091,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11098,8 +11102,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11125,8 +11129,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11148,8 +11152,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.1.4"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.1.4#7e2c66842c2ef99e3f0670c63d9b92df20195af6"
+version = "1.2.0"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11172,6 +11176,7 @@ dependencies = [
  "revm",
  "tempo-chainspec",
  "tempo-contracts",
+ "tempo-evm",
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,53 +75,53 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-commonware-node-config = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-dkg-onchain-artifacts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-commonware-node-config = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-dkg-onchain-artifacts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.1.4", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120", features = [
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c59a120" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
 revm = { version = "34.0.0", features = ["optional_fee_charge"] }
 
 # alloy
@@ -129,7 +129,7 @@ alloy = { version = "1.6.1", default-features = false }
 alloy-consensus = { version = "1.6.1", default-features = false }
 alloy-contract = { version = "1.6.1", default-features = false }
 alloy-eips = { version = "1.6.1", default-features = false }
-alloy-evm = "0.26.4"
+alloy-evm = "0.27.0"
 alloy-network = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.5.4", default-features = false }
 alloy-provider = { version = "1.6.1", default-features = false }

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -155,7 +155,7 @@ impl ZoneEvmConfig {
     /// Create a new zone EVM config with the given chain spec and L1 state provider.
     pub fn new(chain_spec: Arc<TempoChainSpec>, l1_provider: L1StateProvider) -> Self {
         let zone_factory = ZoneEvmFactory::new(l1_provider);
-        let inner = TempoEvmConfig::new_with_default_factory(chain_spec.clone());
+        let inner = TempoEvmConfig::new(chain_spec.clone());
         let block_assembler = ZoneBlockAssembler::new(chain_spec);
         Self {
             inner,

--- a/crates/tempo-zone/src/executor.rs
+++ b/crates/tempo-zone/src/executor.rs
@@ -26,10 +26,7 @@ impl ReceiptBuilder for ZoneReceiptBuilder {
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
 
-    fn build_receipt<E: Evm>(
-        &self,
-        ctx: ReceiptBuilderCtx<'_, TempoTxType, E>,
-    ) -> Self::Receipt {
+    fn build_receipt<E: Evm>(&self, ctx: ReceiptBuilderCtx<'_, TempoTxType, E>) -> Self::Receipt {
         let ReceiptBuilderCtx {
             tx_type,
             result,
@@ -95,10 +92,7 @@ where
         self.inner.execute_transaction_without_commit(tx)
     }
 
-    fn commit_transaction(
-        &mut self,
-        output: Self::Result,
-    ) -> Result<u64, BlockExecutionError> {
+    fn commit_transaction(&mut self, output: Self::Result) -> Result<u64, BlockExecutionError> {
         let gas_used = self.inner.commit_transaction(output)?;
 
         // Collect revert logs (same as Tempo L1 executor).

--- a/crates/tempo-zone/src/executor.rs
+++ b/crates/tempo-zone/src/executor.rs
@@ -8,14 +8,14 @@ use alloy_evm::{
     Database, Evm,
     block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, OnStateHook},
     eth::{
-        EthBlockExecutor,
+        EthBlockExecutor, EthTxResult,
         receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
     },
 };
-use reth_revm::{Inspector, State, context::result::ResultAndState};
+use reth_revm::{Inspector, State};
 use tempo_chainspec::TempoChainSpec;
-use tempo_evm::{TempoBlockExecutionCtx, TempoHaltReason, evm::TempoEvm};
-use tempo_primitives::{TempoReceipt, TempoTxEnvelope};
+use tempo_evm::{TempoBlockExecutionCtx, evm::TempoEvm};
+use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::evm::TempoContext;
 
 /// Local receipt builder for zone execution, mirrors the upstream `TempoReceiptBuilder`.
@@ -28,16 +28,16 @@ impl ReceiptBuilder for ZoneReceiptBuilder {
 
     fn build_receipt<E: Evm>(
         &self,
-        ctx: ReceiptBuilderCtx<'_, Self::Transaction, E>,
+        ctx: ReceiptBuilderCtx<'_, TempoTxType, E>,
     ) -> Self::Receipt {
         let ReceiptBuilderCtx {
-            tx,
+            tx_type,
             result,
             cumulative_gas_used,
             ..
         } = ctx;
         TempoReceipt {
-            tx_type: tx.tx_type(),
+            tx_type,
             success: result.is_success(),
             cumulative_gas_used,
             logs: result.into_logs(),
@@ -82,6 +82,7 @@ where
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
     type Evm = TempoEvm<&'a mut State<DB>, I>;
+    type Result = EthTxResult<<Self::Evm as Evm>::HaltReason, TempoTxType>;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
         self.inner.apply_pre_execution_changes()
@@ -90,16 +91,15 @@ where
     fn execute_transaction_without_commit(
         &mut self,
         tx: impl ExecutableTx<Self>,
-    ) -> Result<ResultAndState<TempoHaltReason>, BlockExecutionError> {
+    ) -> Result<Self::Result, BlockExecutionError> {
         self.inner.execute_transaction_without_commit(tx)
     }
 
     fn commit_transaction(
         &mut self,
-        output: ResultAndState<TempoHaltReason>,
-        tx: impl ExecutableTx<Self>,
+        output: Self::Result,
     ) -> Result<u64, BlockExecutionError> {
-        let gas_used = self.inner.commit_transaction(output, tx)?;
+        let gas_used = self.inner.commit_transaction(output)?;
 
         // Collect revert logs (same as Tempo L1 executor).
         let logs = self.inner.evm.take_revert_logs();

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -473,7 +473,11 @@ where
 {
     type Pool = TempoTransactionPool<Node::Provider>;
 
-    async fn build_pool(self, ctx: &BuilderContext<Node>, _evm_config: ZoneEvmConfig) -> eyre::Result<Self::Pool> {
+    async fn build_pool(
+        self,
+        ctx: &BuilderContext<Node>,
+        _evm_config: ZoneEvmConfig,
+    ) -> eyre::Result<Self::Pool> {
         let mut pool_config = ctx.pool_config();
         pool_config.minimal_protocol_basefee = TempoHardfork::default().base_fee();
         pool_config.max_inflight_delegated_slot_limit = pool_config.max_account_slots;
@@ -484,16 +488,16 @@ where
             ctx.provider().clone(),
             tempo_evm_config,
         )
-            .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
-            .with_local_transactions_config(pool_config.local_transactions_config.clone())
-            .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
-            .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
-            .disable_balance_check()
-            .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
-            .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
-            .with_custom_tx_type(TempoTxType::AA as u8)
-            .no_eip4844()
-            .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
+        .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
+        .with_local_transactions_config(pool_config.local_transactions_config.clone())
+        .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
+        .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
+        .disable_balance_check()
+        .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
+        .with_additional_tasks(ctx.config().txpool.additional_validation_tasks)
+        .with_custom_tx_type(TempoTxType::AA as u8)
+        .no_eip4844()
+        .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
         let aa_2d_config = AA2dPoolConfig {
             price_bump_config: pool_config.price_bumps,

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -31,6 +31,7 @@ use reth_transaction_pool::{TransactionValidationTaskExecutor, blobstore::InMemo
 use std::{default::Default, sync::Arc};
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::{hardfork::TempoHardfork, spec::TempoChainSpec};
+use tempo_evm::TempoEvmConfig;
 use tempo_node::{DEFAULT_AA_VALID_AFTER_MAX_SECS, rpc::TempoReceiptConverter};
 use tempo_payload_types::{TempoExecutionData, TempoPayloadAttributes, TempoPayloadTypes};
 use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
@@ -466,20 +467,23 @@ impl PayloadValidator<TempoPayloadTypes> for ZonePayloadValidator {
 #[non_exhaustive]
 pub struct ZonePoolBuilder;
 
-impl<Node> PoolBuilder<Node> for ZonePoolBuilder
+impl<Node> PoolBuilder<Node, ZoneEvmConfig> for ZonePoolBuilder
 where
     Node: FullNodeTypes<Types = ZoneNode>,
 {
     type Pool = TempoTransactionPool<Node::Provider>;
 
-    async fn build_pool(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Pool> {
+    async fn build_pool(self, ctx: &BuilderContext<Node>, _evm_config: ZoneEvmConfig) -> eyre::Result<Self::Pool> {
         let mut pool_config = ctx.pool_config();
         pool_config.minimal_protocol_basefee = TempoHardfork::default().base_fee();
         pool_config.max_inflight_delegated_slot_limit = pool_config.max_account_slots;
 
         let blob_store = InMemoryBlobStore::default();
-        let validator = TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone())
-            .with_head_timestamp(ctx.head().timestamp)
+        let tempo_evm_config = TempoEvmConfig::new(ctx.chain_spec());
+        let validator = TransactionValidationTaskExecutor::eth_builder(
+            ctx.provider().clone(),
+            tempo_evm_config,
+        )
             .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
             .with_local_transactions_config(pool_config.local_transactions_config.clone())
             .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)


### PR DESCRIPTION
Update tempo tag from v1.1.4 to v1.2.0 and reth rev from c59a120 to 0ce23d76 (matching upstream).

Also bumps alloy-evm to 0.27.0 and adapts to API changes in BlockExecutor, ReceiptBuilder, PoolBuilder, and TempoEvmConfig.