### PR TITLE
feat: private RPC tooling — auth tokens, balance queries, zone ID config

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -132,6 +132,7 @@ zone-up name reset="false" profile="dev" args="":
     fi
     PORTAL=$(jq -r '.portal' "$ZONE_JSON")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$ZONE_JSON")
+    ZONE_ID=$(jq -r '.zoneId' "$ZONE_JSON")
     DATADIR="/tmp/tempo-zone-{{name}}"
     if [[ "{{reset}}" = "true" ]]; then
         rm -rf "$DATADIR" || true
@@ -148,6 +149,7 @@ zone-up name reset="false" profile="dev" args="":
                       --l1.rpc-url "${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}" \
                       --l1.portal-address "$PORTAL" \
                       --l1.genesis-block-number "$ANCHOR_BLOCK" \
+                      --zone.id "$ZONE_ID" \
                       --http \
                       --http.addr 0.0.0.0 \
                       --http.port 8546 \
@@ -195,6 +197,63 @@ send-withdrawal amount="1000000" to="" token="0x20C00000000000000000000000000000
 [doc('Checks TIP-20 token balance for an account on the zone (port 8546)')]
 check-balance account token="0x20C0000000000000000000000000000000000000" rpc="http://localhost:8546":
     @printf "Balance of {{account}}: " && cast call "{{token}}" "balanceOf(address)(uint256)" "{{account}}" --rpc-url "{{rpc}}"
+
+[group('zone')]
+[doc('Generates a signed auth token for the private zone RPC. Requires PRIVATE_KEY env var. Reads zone metadata from generated/<name>/zone.json.')]
+zone-auth-token name:
+    #!/bin/bash
+    set -euo pipefail
+    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
+    ZONE_JSON="generated/{{name}}/zone.json"
+    if [[ ! -f "$ZONE_JSON" ]]; then
+        echo "Error: $ZONE_JSON not found. Run 'just create-zone {{name}}' first." >&2
+        exit 1
+    fi
+    ZONE_ID=$(jq -r '.zoneId' "$ZONE_JSON")
+    PORTAL=$(jq -r '.portal' "$ZONE_JSON")
+    GENESIS_JSON="generated/{{name}}/genesis.json"
+    CHAIN_ID=$(jq -r '.config.chainId' "$GENESIS_JSON")
+    NOW=$(date +%s)
+    EXPIRES=$((NOW + 600))
+    MAGIC="54656d706f5a6f6e655250430000000000000000000000000000000000000000"
+    VERSION="00"
+    ZONE_ID_HEX=$(printf '%016x' "$ZONE_ID")
+    CHAIN_ID_HEX=$(printf '%016x' "$CHAIN_ID")
+    PORTAL_HEX=$(echo "$PORTAL" | sed 's/0x//' | tr '[:upper:]' '[:lower:]')
+    ISSUED_HEX=$(printf '%016x' "$NOW")
+    EXPIRES_HEX=$(printf '%016x' "$EXPIRES")
+    FIELDS="${VERSION}${ZONE_ID_HEX}${CHAIN_ID_HEX}${PORTAL_HEX}${ISSUED_HEX}${EXPIRES_HEX}"
+    DIGEST=$(cast keccak "0x${MAGIC}${FIELDS}")
+    SIG=$(cast wallet sign --no-hash "$DIGEST" --private-key "$PK")
+    SIG_HEX=$(echo "$SIG" | sed 's/0x//')
+    echo "${SIG_HEX}${FIELDS}"
+
+[group('zone')]
+[doc('Checks TIP-20 token balance via the private RPC (with auth token). Requires PRIVATE_KEY env var.')]
+check-balance-private name token="0x20C0000000000000000000000000000000000000" rpc="http://localhost:8544":
+    #!/bin/bash
+    set -euo pipefail
+    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
+    ACCOUNT=$(cast wallet address "$PK")
+    TOKEN=$(just zone-auth-token {{name}})
+    ACCOUNT_LOWER=$(echo "$ACCOUNT" | sed 's/0x//' | tr '[:upper:]' '[:lower:]')
+    RESULT=$(curl -s -X POST "{{rpc}}" \
+        -H "Content-Type: application/json" \
+        -H "x-authorization-token: ${TOKEN}" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"from\":\"$ACCOUNT\",\"to\":\"{{token}}\",\"data\":\"0x70a08231000000000000000000000000${ACCOUNT_LOWER}\"}],\"id\":1}")
+    RAW=$(echo "$RESULT" | jq -r '.result // empty')
+    ERROR=$(echo "$RESULT" | jq -r '.error.message // empty')
+    if [[ -n "$ERROR" ]]; then
+        echo "RPC error: $ERROR"
+        exit 1
+    fi
+    if [[ -z "$RAW" ]]; then
+        echo "No result from RPC"
+        echo "$RESULT"
+        exit 1
+    fi
+    BALANCE=$(cast --to-dec "$RAW")
+    echo "Balance of $ACCOUNT: $BALANCE"
 
 [group('zone')]
 [doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Requires L1_RPC_URL env var.')]
@@ -276,6 +335,7 @@ deploy-zone name:
                       --l1.rpc-url "$L1_RPC" \
                       --l1.portal-address "$PORTAL" \
                       --l1.genesis-block-number "$ANCHOR_BLOCK" \
+                      --zone.id "$ZONE_ID" \
                       --http \
                       --http.addr 0.0.0.0 \
                       --http.port 8546 \

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -83,6 +83,11 @@ struct ZoneArgs {
     #[arg(long = "l1.genesis-block-number", env = "L1_GENESIS_BLOCK_NUMBER")]
     pub l1_genesis_block_number: Option<u64>,
 
+    /// Zone ID for the private RPC auth token validation.
+    /// Must match the zone's on-chain ID from ZoneFactory.
+    #[arg(long = "zone.id", env = "ZONE_ID", default_value_t = 0)]
+    pub zone_id: u64,
+
     /// Port for the private zone RPC server (0 for OS-assigned).
     #[arg(
         long = "private-rpc.port",
@@ -139,7 +144,7 @@ fn main() {
             let eth_handlers = handle.node.eth_handlers().clone();
             let private_rpc_config = zone::rpc::PrivateRpcConfig {
                 listen_addr: ([0, 0, 0, 0], args.private_rpc_port).into(),
-                zone_id: 0, // TODO: hardcoded for now
+                zone_id: args.zone_id,
                 chain_id: handle.node.chain_spec().chain().id(),
                 zone_portal: args.portal_address,
                 sequencer: sequencer_addr.unwrap_or_default(),

--- a/crates/tempo-zone/src/rpc/handlers.rs
+++ b/crates/tempo-zone/src/rpc/handlers.rs
@@ -160,42 +160,39 @@ fn parse_params<T: serde::de::DeserializeOwned>(
         .map_err(|_| JsonRpcResponse::error(id.clone(), JsonRpcError::invalid_params(msg)))
 }
 
-/// Parse `eth_call` / `eth_estimateGas` params: `[request, block?, stateOverride?]`.
-fn parse_call_params(
-    raw: &str,
-    id: &Value,
-) -> Result<
-    (
-        TempoTransactionRequest,
-        Option<BlockId>,
-        Option<StateOverride>,
-    ),
-    JsonRpcResponse,
-> {
-    let err = || {
-        JsonRpcResponse::error(
-            id.clone(),
-            JsonRpcError::invalid_params("expected [request, block?, stateOverride?]"),
-        )
-    };
-    let mut arr: Vec<Value> = serde_json::from_str(raw).map_err(|_| err())?;
-    if arr.is_empty() {
-        return Err(err());
+/// Params for `eth_call` / `eth_estimateGas`: `[request, block?, stateOverride?]`.
+///
+/// Supports 1–3 element arrays with null-as-absent semantics for trailing optionals.
+struct CallParams(
+    TempoTransactionRequest,
+    Option<BlockId>,
+    Option<StateOverride>,
+);
+
+impl<'de> serde::Deserialize<'de> for CallParams {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = CallParams;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("[request, block?, stateOverride?]")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let request = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let block = seq.next_element::<Option<BlockId>>()?.flatten();
+                let state_override = seq.next_element::<Option<StateOverride>>()?.flatten();
+                Ok(CallParams(request, block, state_override))
+            }
+        }
+        deserializer.deserialize_seq(Vis)
     }
-    let request = serde_json::from_value(arr.remove(0)).map_err(|_| err())?;
-    let block = arr
-        .first()
-        .map(|v| serde_json::from_value(v.clone()))
-        .transpose()
-        .map_err(|_| err())?
-        .flatten();
-    let state_override = arr
-        .get(1)
-        .map(|v| serde_json::from_value(v.clone()))
-        .transpose()
-        .map_err(|_| err())?
-        .flatten();
-    Ok((request, block, state_override))
 }
 
 /// Convert an API result into a JSON-RPC response, logging failures.
@@ -399,10 +396,11 @@ async fn handle_call(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
-    let (request, block, state_override) = match parse_call_params(raw, &id) {
-        Ok(v) => v,
-        Err(resp) => return resp,
-    };
+    let CallParams(request, block, state_override) =
+        match parse_params(raw, &id, "expected [request, block?, stateOverride?]") {
+            Ok(v) => v,
+            Err(resp) => return resp,
+        };
 
     if !auth.is_sequencer && state_override.is_some() {
         return JsonRpcResponse::error(
@@ -426,10 +424,11 @@ async fn handle_estimate_gas(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
-    let (request, block, state_override) = match parse_call_params(raw, &id) {
-        Ok(v) => v,
-        Err(resp) => return resp,
-    };
+    let CallParams(request, block, state_override) =
+        match parse_params(raw, &id, "expected [request, block?, stateOverride?]") {
+            Ok(v) => v,
+            Err(resp) => return resp,
+        };
 
     if !auth.is_sequencer && state_override.is_some() {
         return JsonRpcResponse::error(

--- a/crates/tempo-zone/src/rpc/handlers.rs
+++ b/crates/tempo-zone/src/rpc/handlers.rs
@@ -160,6 +160,44 @@ fn parse_params<T: serde::de::DeserializeOwned>(
         .map_err(|_| JsonRpcResponse::error(id.clone(), JsonRpcError::invalid_params(msg)))
 }
 
+/// Parse `eth_call` / `eth_estimateGas` params: `[request, block?, stateOverride?]`.
+fn parse_call_params(
+    raw: &str,
+    id: &Value,
+) -> Result<
+    (
+        TempoTransactionRequest,
+        Option<BlockId>,
+        Option<StateOverride>,
+    ),
+    JsonRpcResponse,
+> {
+    let err = || {
+        JsonRpcResponse::error(
+            id.clone(),
+            JsonRpcError::invalid_params("expected [request, block?, stateOverride?]"),
+        )
+    };
+    let mut arr: Vec<Value> = serde_json::from_str(raw).map_err(|_| err())?;
+    if arr.is_empty() {
+        return Err(err());
+    }
+    let request = serde_json::from_value(arr.remove(0)).map_err(|_| err())?;
+    let block = arr
+        .first()
+        .map(|v| serde_json::from_value(v.clone()))
+        .transpose()
+        .map_err(|_| err())?
+        .flatten();
+    let state_override = arr
+        .get(1)
+        .map(|v| serde_json::from_value(v.clone()))
+        .transpose()
+        .map_err(|_| err())?
+        .flatten();
+    Ok((request, block, state_override))
+}
+
 /// Convert an API result into a JSON-RPC response, logging failures.
 fn api_result(
     id: Value,
@@ -361,16 +399,10 @@ async fn handle_call(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
-    let (request, block, state_override) =
-        match parse_params::<(
-            TempoTransactionRequest,
-            Option<BlockId>,
-            Option<StateOverride>,
-        )>(raw, &id, "expected [request, block?, stateOverride?]")
-        {
-            Ok(v) => v,
-            Err(resp) => return resp,
-        };
+    let (request, block, state_override) = match parse_call_params(raw, &id) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
     if !auth.is_sequencer && state_override.is_some() {
         return JsonRpcResponse::error(
@@ -394,16 +426,10 @@ async fn handle_estimate_gas(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
-    let (request, block, state_override) =
-        match parse_params::<(
-            TempoTransactionRequest,
-            Option<BlockId>,
-            Option<StateOverride>,
-        )>(raw, &id, "expected [request, block?, stateOverride?]")
-        {
-            Ok(v) => v,
-            Err(resp) => return resp,
-        };
+    let (request, block, state_override) = match parse_call_params(raw, &id) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
     if !auth.is_sequencer && state_override.is_some() {
         return JsonRpcResponse::error(

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -23,7 +23,29 @@ This single command will:
 
 > ⚠️ **Save your sequencer key** — it's printed before the node starts. You'll need it to restart the node later.
 
-Once running, see [Interact with the Zone](#6-interact-with-the-zone) to deposit, withdraw, and check balances.
+Once running, generate a user wallet and deposit some tokens:
+
+```bash
+# Generate a wallet
+cast wallet new
+# Save the private key and address
+export PRIVATE_KEY="0x<your-wallet-private-key>"
+ADDR=$(cast wallet address "$PRIVATE_KEY")
+
+# Fund the wallet on L1 (testnet faucet)
+HTTP_RPC=$(echo "$L1_RPC_URL" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
+cast rpc tempo_fundAddress "$ADDR" --rpc-url "$HTTP_RPC"
+
+# Approve the portal and deposit tokens to the zone
+export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
+just max-approve-portal
+just send-deposit 1000000
+
+# Check your balance on the zone (wait a few seconds for the deposit to land)
+just check-balance "$ADDR"
+```
+
+See [Interact with the Zone](#6-interact-with-the-zone) for withdrawals and private RPC usage.
 
 To restart the zone later:
 

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -181,6 +181,22 @@ The sequencer detects the withdrawal, includes it in the next batch submission t
 just check-balance <address>
 ```
 
+#### Check balance via Private RPC
+
+The private RPC (port 8544) requires a signed auth token derived from your private key. This ensures only the account owner can query their own balance.
+
+```bash
+# Check your balance (generates auth token automatically)
+just check-balance-private my-zone
+
+# Generate a reusable auth token (valid for 10 minutes)
+TOKEN=$(just zone-auth-token my-zone)
+curl -s http://localhost:8544 \
+  -H "Content-Type: application/json" \
+  -H "x-authorization-token: $TOKEN" \
+  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+```
+
 #### Check portal status on L1
 
 ```bash
@@ -231,6 +247,7 @@ graph TB
 | `--l1.rpc-url` | (required) | L1 WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
 | `--l1.genesis-block-number` | (from zone.json) | L1 block when the zone was created |
+| `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth) |
 | `--sequencer-key` | (optional) | Sequencer private key for block production |
 | `--block.interval-ms` | 250 | Block building interval |
 | `--zone.batch-interval-secs` | 60 | Max seconds to accumulate zone blocks before submitting a batch to L1 |
@@ -260,3 +277,5 @@ graph TB
 | `just max-approve-outbox` | Approve outbox to spend tokens on zone |
 | `just send-withdrawal [to]` | Withdraw tokens from zone to L1 (defaults to sender) |
 | `just check-balance <addr>` | Check token balance on the zone |
+| `just zone-auth-token <name>` | Generate a signed private RPC auth token (10 min TTL) |
+| `just check-balance-private <name>` | Check balance via the private RPC (auto-generates auth token) |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -33,8 +33,7 @@ export PRIVATE_KEY="0x<your-wallet-private-key>"
 ADDR=$(cast wallet address "$PRIVATE_KEY")
 
 # Fund the wallet on L1 (testnet faucet)
-HTTP_RPC=$(echo "$L1_RPC_URL" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
-cast rpc tempo_fundAddress "$ADDR" --rpc-url "$HTTP_RPC"
+cast rpc tempo_fundAddress "$ADDR" --rpc-url "$L1_RPC_URL"
 
 # Approve the portal and deposit tokens to the zone
 export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)


### PR DESCRIPTION
Adds CLI tooling for interacting with the private zone RPC:

- **`just zone-auth-token <name>`** — generates a signed auth token (10 min TTL) from `PRIVATE_KEY` and zone metadata
- **`just check-balance-private <name>`** — queries token balance via the private RPC with auto-generated auth
- **`--zone.id` CLI arg** — configures the zone's numeric ID for auth token validation (was hardcoded to 0)
- **`eth_call`/`eth_estimateGas` param fix** — trailing optional params (`block`, `stateOverride`) no longer require explicit `null`
- `zone-up` and `deploy-zone` now pass `--zone.id` from `zone.json` automatically
- Documented in ZONES.md