### PR TITLE
fix: disable auth (Engine API) server on zone node

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -124,6 +124,9 @@ fn main() {
 
             // Disable peer discovery — the zone node has no peering.
             builder.config_mut().network.discovery.disable_discovery = true;
+            // Disable the auth (Engine API) server — the zone node derives blocks
+            // from L1, so no external consensus client or Engine API is needed.
+            builder.config_mut().rpc.disable_auth_server = true;
 
             // Parse the sequencer key early so we can derive the address for block building.
             // The signer is kept for later use when spawning sequencer background tasks.


### PR DESCRIPTION
The zone node derives blocks from L1 — no external consensus client or Engine API is needed. Disabling the auth server avoids port 8551 conflicts with other reth instances on the same machine.