### PR TITLE
ci: pin nightly to 2026-02-21

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,9 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          # Pin nightly to avoid breakage from str::as_str() stabilization
+          # which breaks shellexpand 3.1.1 method resolution.
+          toolchain: nightly-2026-02-21
           components: clippy
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -62,6 +65,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2026-02-21
           components: rustfmt
       - run: cargo fmt --all --check
 


### PR DESCRIPTION
Pin nightly toolchain to avoid breakage from `str::as_str()` stabilization which breaks `shellexpand 3.1.1` method resolution.

Same fix as https://github.com/tempoxyz/tempo/pull/2808.