### PR TITLE
feat(xtask): zone tooling — encrypted deposits, encryption key registration, zone info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10993,7 +10993,9 @@ dependencies = [
  "clap",
  "const-hex",
  "eyre",
+ "k256",
  "reth-evm",
+ "rustls",
  "serde",
  "serde_json",
  "tempo-alloy",
@@ -11003,6 +11005,7 @@ dependencies = [
  "tempo-precompiles",
  "tempo-revm",
  "tokio",
+ "zone",
 ]
 
 [[package]]

--- a/Justfile
+++ b/Justfile
@@ -85,9 +85,29 @@ send-deposit amount="1000000" to="" token="0x20C00000000000000000000000000000000
         TO=$(cast wallet address "$PK")
     fi
     echo "Depositing {{amount}} to $TO..."
-    cast send "$PORTAL" "deposit(address,address,uint128,bytes32)" "{{token}}" "$TO" "{{amount}}" "{{memo}}" \
-        --rpc-url "$RPC" --private-key "$PK"
+    TX_OUTPUT=$(cast send "$PORTAL" "deposit(address,address,uint128,bytes32)" "{{token}}" "$TO" "{{amount}}" "{{memo}}" \
+        --rpc-url "$RPC" --private-key "$PK" --json)
+    TX_HASH=$(echo "$TX_OUTPUT" | jq -r '.transactionHash')
     echo "Deposit sent!"
+    echo "Explorer: https://explore.moderato.tempo.xyz/tx/$TX_HASH"
+
+[group('zone')]
+[doc('Sends an encrypted deposit to the ZonePortal on L1 (recipient and memo are hidden on-chain). Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and PRIVATE_KEY env vars. Run max-approve-portal first.')]
+send-deposit-encrypted amount="1000000" to="" memo="0x0000000000000000000000000000000000000000000000000000000000000000" token="0x20C0000000000000000000000000000000000000" rpc=zone_rpc:
+    #!/bin/bash
+    set -euo pipefail
+    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
+    TO="{{to}}"
+    if [[ -z "$TO" ]]; then
+        TO=$(cast wallet address "$PK")
+    fi
+    ARGS="--amount {{amount}} --token {{token}} --memo {{memo}} --to $TO --zone-rpc-url {{rpc}}"
+    cargo run -p tempo-xtask -- encrypted-deposit --private-key "$PK" $ARGS
+
+[group('zone')]
+[doc('Fetches and prints zone info from the ZoneFactory. Pass a zone ID (integer) or portal address (0x...).')]
+zone-info identifier:
+    cargo run -p tempo-xtask -- zone-info {{identifier}}
 
 [group('zone')]
 [doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars.')]
@@ -188,11 +208,36 @@ send-withdrawal amount="1000000" to="" token="0x20C00000000000000000000000000000
         FALLBACK="$TO"
     fi
     echo "Requesting withdrawal of {{amount}} to $TO (fallback: $FALLBACK)..."
-    cast send "$OUTBOX" \
+    L2_TX=$(cast send "$OUTBOX" \
         "requestWithdrawal(address,address,uint128,bytes32,uint64,address,bytes)" \
         "{{token}}" "$TO" "{{amount}}" "{{memo}}" "{{gas-limit}}" "$FALLBACK" "{{data}}" \
-        --rpc-url "{{rpc}}" --private-key "$PK" --gas-limit 500000
-    echo "Withdrawal requested!"
+        --rpc-url "{{rpc}}" --private-key "$PK" --gas-limit 500000 --json | jq -r '.transactionHash')
+    echo "Withdrawal requested on L2! tx: $L2_TX"
+
+    # Wait for the withdrawal to be processed on L1
+    L1_RPC="${L1_RPC_URL:-}"
+    PORTAL="${L1_PORTAL_ADDRESS:-}"
+    if [[ -z "$L1_RPC" || -z "$PORTAL" ]]; then
+        echo "Set L1_RPC_URL and L1_PORTAL_ADDRESS env vars to wait for L1 processing."
+        exit 0
+    fi
+    HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
+    FROM_BLOCK=$(cast block-number --rpc-url "$HTTP_RPC")
+    echo "Waiting for withdrawal to be processed on L1 (from block $FROM_BLOCK)..."
+    while true; do
+        LOGS=$(cast logs --address "$PORTAL" --from-block "$FROM_BLOCK" --rpc-url "$HTTP_RPC" \
+            "WithdrawalProcessed(address indexed to, address token, uint128 amount, bool callbackSuccess)" \
+            "$TO" --json 2>/dev/null || echo "[]")
+        if [[ "$LOGS" != "[]" && "$LOGS" != "" && "$LOGS" != "null" ]]; then
+            L1_TX=$(echo "$LOGS" | jq -r '.[-1].transactionHash')
+            L1_BLOCK=$(echo "$LOGS" | jq -r '.[-1].blockNumber')
+            L1_BLOCK_DEC=$(printf '%d' "$L1_BLOCK")
+            echo "Withdrawal processed on L1! (block $L1_BLOCK_DEC)"
+            echo "Explorer: https://explore.moderato.tempo.xyz/tx/$L1_TX"
+            break
+        fi
+        sleep 0.25
+    done
 
 [group('zone')]
 [doc('Checks TIP-20 token balance for an account on the zone (port 8546)')]
@@ -299,11 +344,19 @@ deploy-zone name:
         --private-key "$SEQUENCER_KEY"
     echo ""
 
-    # Step 5: Display summary
     PORTAL=$(jq -r '.portal' "$OUTPUT/zone.json")
     ZONE_ID=$(jq -r '.zoneId' "$OUTPUT/zone.json")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$OUTPUT/zone.json")
 
+    # Step 5: Register sequencer encryption key on the portal
+    echo "Step 5: Registering sequencer encryption key on ZonePortal..."
+    cargo run -p tempo-xtask -- set-encryption-key \
+        --l1-rpc-url "$HTTP_RPC" \
+        --portal "$PORTAL" \
+        --private-key "$SEQUENCER_KEY"
+    echo ""
+
+    # Step 6: Display summary
     echo "============================================"
     echo "  Zone Deployed Successfully!"
     echo "============================================"
@@ -324,8 +377,8 @@ deploy-zone name:
     echo "  export SEQUENCER_KEY=$SEQUENCER_KEY"
     echo ""
 
-    # Step 6: Build and start the zone node
-    echo "Step 6: Building and starting zone node (release)..."
+    # Step 7: Build and start the zone node
+    echo "Step 7: Building and starting zone node (release)..."
     echo ""
     cargo build --bin tempo-zone --release
     DATADIR="/tmp/tempo-zone-{{name}}"

--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,7 @@ cross_compile := "false"
 cargo_build_binary := if cross_compile == "true" { "cross" } else { "cargo" }
 act_debug_mode := env("ACT", "false")
 zone_rpc := env("ZONE_RPC_URL", "http://localhost:8546")
+zone_http_port := env("ZONE_HTTP_PORT", "8546")
 
 [group('deps')]
 install-cross:
@@ -173,7 +174,7 @@ zone-up name reset="false" profile="dev" args="":
                       --zone.id "$ZONE_ID" \
                       --http \
                       --http.addr 0.0.0.0 \
-                      --http.port 8546 \
+                      --http.port {{zone_http_port}} \
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \
@@ -392,7 +393,7 @@ deploy-zone name:
                       --zone.id "$ZONE_ID" \
                       --http \
                       --http.addr 0.0.0.0 \
-                      --http.port 8546 \
+                      --http.port {{zone_http_port}} \
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \

--- a/Justfile
+++ b/Justfile
@@ -155,6 +155,11 @@ zone-up name reset="false" profile="dev" args="":
     PORTAL=$(jq -r '.portal' "$ZONE_JSON")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$ZONE_JSON")
     ZONE_ID=$(jq -r '.zoneId' "$ZONE_JSON")
+    SEQ_KEY="${SEQUENCER_KEY:-$(jq -r '.sequencerKey // empty' "$ZONE_JSON")}"
+    if [[ -z "$SEQ_KEY" ]]; then
+        echo "Error: SEQUENCER_KEY env var not set and not found in $ZONE_JSON" >&2
+        exit 1
+    fi
     DATADIR="/tmp/tempo-zone-{{name}}"
     if [[ "{{reset}}" = "true" ]]; then
         rm -rf "$DATADIR" || true
@@ -178,7 +183,7 @@ zone-up name reset="false" profile="dev" args="":
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \
-                      --sequencer-key "${SEQUENCER_KEY:?Set SEQUENCER_KEY env var}" \
+                      --sequencer-key "$SEQ_KEY" \
                       {{args}}
 
 [group('zone')]
@@ -345,6 +350,11 @@ deploy-zone name:
         --private-key "$SEQUENCER_KEY"
     echo ""
 
+    # Save sequencer key into zone.json for later use
+    jq --arg sk "$SEQUENCER_KEY" --arg sa "$SEQUENCER_ADDR" \
+        '. + {sequencerKey: $sk, sequencerAddress: $sa}' "$OUTPUT/zone.json" > "$OUTPUT/zone.json.tmp" \
+        && mv "$OUTPUT/zone.json.tmp" "$OUTPUT/zone.json"
+
     PORTAL=$(jq -r '.portal' "$OUTPUT/zone.json")
     ZONE_ID=$(jq -r '.zoneId' "$OUTPUT/zone.json")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$OUTPUT/zone.json")
@@ -374,8 +384,7 @@ deploy-zone name:
     echo ""
     echo "  Explorer:        https://explore.moderato.tempo.xyz/address/$PORTAL"
     echo ""
-    echo "  ⚠️  SAVE YOUR SEQUENCER KEY:"
-    echo "  export SEQUENCER_KEY=$SEQUENCER_KEY"
+    echo "  Sequencer key saved to $OUTPUT/zone.json"
     echo ""
 
     # Step 7: Build and start the zone node

--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -217,6 +217,10 @@ sol! {
         // -- View functions (token management) --
 
         function isTokenEnabled(address token) external view returns (bool);
+        function enabledTokenCount() external view returns (uint256);
+        function enabledTokenAt(uint256 index) external view returns (address);
+        function zoneGasRate() external view returns (uint128);
+        function pendingSequencer() external view returns (address);
 
         function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
 
@@ -358,6 +362,19 @@ sol! {
     //  ZoneFactory — deployed on Tempo L1
     // ---------------------------------------------------------------
 
+    #[derive(Debug)]
+    struct ZoneInfo {
+        uint64 zoneId;
+        address portal;
+        address messenger;
+        address initialToken;
+        address sequencer;
+        address verifier;
+        bytes32 genesisBlockHash;
+        bytes32 genesisTempoBlockHash;
+        uint64 genesisTempoBlockNumber;
+    }
+
     #[sol(rpc)]
     contract ZoneFactory {
         struct ZoneParams {
@@ -385,6 +402,8 @@ sol! {
         );
         function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
         function verifier() external view returns (address);
+        function zones(uint64 zoneId) external view returns (ZoneInfo memory);
+        function zoneCount() external view returns (uint64);
         function isZonePortal(address portal) external view returns (bool);
         function isZoneMessenger(address messenger) external view returns (bool);
     }

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -244,6 +244,7 @@ where
 
         info!(
             target: "zone::payload",
+            zone_block = parent_header.number() + 1,
             l1_block = l1_block.header.inner.number,
             deposits = total_deposits,
             "Including advanceTempo system tx (chain continuity OK)"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 tempo-alloy.workspace = true
 tempo-chainspec.workspace = true
+zone = { path = "../crates/tempo-zone" }
 tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true
@@ -22,18 +23,25 @@ alloy = { workspace = true, features = [
   "contract",
   "genesis",
   "providers",
+  "provider-ws",
   "reqwest",
   "reqwest-rustls-tls",
+  "rpc-types",
   "signers",
   "signer-local",
   "signer-mnemonic",
   "sol-types",
 ] }
 alloy-rlp.workspace = true
-clap = { version = "4.5.45", features = ["derive"] }
+clap = { version = "4.5.45", features = ["derive", "env"] }
 const-hex.workspace = true
 eyre.workspace = true
 reth-evm.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+
+# crypto (for encryption key registration)
+k256.workspace = true

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -105,7 +105,8 @@ impl CreateZone {
         let wallet = EthereumWallet::from(signer);
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
-            .connect_http(self.l1_rpc_url.parse()?);
+            .connect(&self.l1_rpc_url)
+            .await?;
 
         let factory = ZoneFactory::new(self.zone_factory, &provider);
         println!("Fetching verifier address from ZoneFactory...");

--- a/xtask/src/encrypted_deposit.rs
+++ b/xtask/src/encrypted_deposit.rs
@@ -1,0 +1,230 @@
+//! Sends an encrypted deposit to the ZonePortal on Tempo L1.
+//!
+//! Encrypts `(to, memo)` using the sequencer's ECIES public key so the
+//! recipient and memo are hidden from on-chain observers.
+
+use alloy::{
+    network::{EthereumWallet, primitives::ReceiptResponse},
+    primitives::{Address, B256, Bytes, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::Filter,
+    signers::local::PrivateKeySigner,
+    sol_types::SolEvent,
+};
+use eyre::{WrapErr as _, eyre};
+use tempo_alloy::TempoNetwork;
+use zone::{
+    abi::{EncryptedDepositPayload, ZoneInbox, ZonePortal},
+    precompiles::ecies::encrypt_deposit,
+};
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct EncryptedDeposit {
+    /// Tempo L1 RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, env = "L1_PORTAL_ADDRESS")]
+    portal: Address,
+
+    /// Private key (hex) for signing the deposit transaction.
+    #[arg(long, env = "PRIVATE_KEY")]
+    private_key: String,
+
+    /// TIP-20 token address to deposit.
+    #[arg(long, default_value = "0x20C0000000000000000000000000000000000000")]
+    token: Address,
+
+    /// Amount to deposit.
+    #[arg(long)]
+    amount: u128,
+
+    /// Recipient address on the zone (encrypted on-chain).
+    #[arg(long)]
+    to: Option<Address>,
+
+    /// Memo bytes32 (encrypted on-chain).
+    #[arg(
+        long,
+        default_value = "0x0000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    memo: B256,
+
+    /// Zone L2 RPC URL. If set, waits for the deposit to be processed on L2.
+    #[arg(long, env = "ZONE_RPC_URL")]
+    zone_rpc_url: Option<String>,
+}
+
+impl EncryptedDeposit {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let key_str = self
+            .private_key
+            .strip_prefix("0x")
+            .unwrap_or(&self.private_key);
+        let signer: PrivateKeySigner = key_str.parse()?;
+        let sender = signer.address();
+        let to = self.to.unwrap_or(sender);
+        let wallet = EthereumWallet::from(signer);
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(wallet)
+            .connect(&self.l1_rpc_url)
+            .await?;
+
+        // Capture L2 block before sending so we don't miss the event
+        let l2_from_block = if let Some(ref zone_rpc) = self.zone_rpc_url {
+            let l2 = ProviderBuilder::new().connect(zone_rpc).await?;
+            Some(l2.get_block_number().await.unwrap_or(0))
+        } else {
+            None
+        };
+
+        let portal = ZonePortal::new(self.portal, &provider);
+
+        // Fetch sequencer encryption key
+        println!("Fetching sequencer encryption key...");
+        let key = portal
+            .sequencerEncryptionKey()
+            .call()
+            .await
+            .wrap_err("sequencerEncryptionKey() failed — is an encryption key set?")?;
+        let key_count: U256 = portal
+            .encryptionKeyCount()
+            .call()
+            .await
+            .wrap_err("encryptionKeyCount() failed")?;
+        let key_index = key_count
+            .checked_sub(U256::from(1))
+            .ok_or_else(|| eyre!("no encryption keys set on portal"))?;
+
+        let seq_pub_x = key.x;
+        let seq_pub_y_parity = normalize_y_parity(key.yParity).ok_or_else(|| {
+            eyre!(
+                "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
+                key.yParity
+            )
+        })?;
+        println!(
+            "Encryption key index: {key_index}, x: {seq_pub_x}, parity: {seq_pub_y_parity:#x}"
+        );
+
+        // Encrypt (to, memo) to the sequencer's public key
+        let enc = encrypt_deposit(
+            &seq_pub_x,
+            seq_pub_y_parity,
+            to,
+            self.memo,
+            self.portal,
+            key_index,
+        )
+        .ok_or_else(|| eyre!("ECIES encryption failed — invalid sequencer public key?"))?;
+
+        let payload = EncryptedDepositPayload {
+            ephemeralPubkeyX: enc.eph_pub_x,
+            ephemeralPubkeyYParity: enc.eph_pub_y_parity,
+            ciphertext: Bytes::from(enc.ciphertext),
+            nonce: enc.nonce.into(),
+            tag: enc.tag.into(),
+        };
+
+        println!("Sending encrypted deposit of {} to {to}...", self.amount);
+        let pending = portal
+            .depositEncrypted(self.token, self.amount, key_index, payload)
+            .send()
+            .await
+            .wrap_err("failed to send depositEncrypted transaction")?;
+        let receipt = pending.get_receipt().await?;
+        let tx_hash = receipt.transaction_hash;
+        let block_number = receipt.block_number.unwrap_or_default();
+
+        if !receipt.status() {
+            return Err(eyre!("depositEncrypted reverted (tx: {tx_hash})"));
+        }
+
+        println!("Encrypted deposit sent! (block {block_number})");
+        println!("Explorer: https://explore.moderato.tempo.xyz/tx/{tx_hash}");
+
+        // Wait for L2 processing if zone RPC is provided
+        if let (Some(zone_rpc), Some(from_block)) = (&self.zone_rpc_url, l2_from_block) {
+            self.wait_for_l2_processing(zone_rpc, from_block, sender, to)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Poll the zone L2 for the `EncryptedDepositProcessed` or `EncryptedDepositFailed` event.
+    async fn wait_for_l2_processing(
+        &self,
+        zone_rpc: &str,
+        from_block: u64,
+        sender: Address,
+        to: Address,
+    ) -> eyre::Result<()> {
+        use zone::abi::ZONE_INBOX_ADDRESS;
+
+        println!("Waiting for encrypted deposit to be processed on L2...");
+        let l2 = ProviderBuilder::new().connect(zone_rpc).await?;
+
+        let processed_filter = Filter::new()
+            .address(ZONE_INBOX_ADDRESS)
+            .event_signature(ZoneInbox::EncryptedDepositProcessed::SIGNATURE_HASH)
+            .from_block(from_block);
+
+        let failed_filter = Filter::new()
+            .address(ZONE_INBOX_ADDRESS)
+            .event_signature(ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH)
+            .from_block(from_block);
+
+        loop {
+            // Check for successful processing
+            let logs = l2.get_logs(&processed_filter).await.unwrap_or_default();
+            for log in &logs {
+                if let Ok(event) = ZoneInbox::EncryptedDepositProcessed::decode_log(&log.inner)
+                    && event.data.sender == sender
+                    && event.data.to == to
+                {
+                    let block = log.block_number.unwrap_or(0);
+                    println!("Encrypted deposit processed on L2! (block {block})");
+                    println!("  Token:  {}", event.data.token);
+                    println!("  Sender: {}", event.data.sender);
+                    println!("  To:     {}", event.data.to);
+                    println!("  Amount: {}", event.data.amount);
+                    println!("  Memo:   {}", event.data.memo);
+                    return Ok(());
+                }
+            }
+
+            // Check for failure
+            let failed_logs = l2.get_logs(&failed_filter).await.unwrap_or_default();
+            for log in &failed_logs {
+                if let Ok(event) = ZoneInbox::EncryptedDepositFailed::decode_log(&log.inner)
+                    && event.data.sender == sender
+                {
+                    let block = log.block_number.unwrap_or(0);
+                    println!(
+                        "WARNING: Encrypted deposit FAILED on L2 (block {block}). \
+                         Funds returned to sender."
+                    );
+                    println!("  Token:  {}", event.data.token);
+                    println!("  Sender: {}", event.data.sender);
+                    println!("  Amount: {}", event.data.amount);
+                    return Ok(());
+                }
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+    }
+}
+
+/// Normalize yParity to SEC1 compressed prefix (0x02 or 0x03).
+///
+/// The contract may return 0/1 (parity bit) or 0x02/0x03 (SEC1 prefix).
+fn normalize_y_parity(y: u8) -> Option<u8> {
+    match y {
+        0x02 | 0x03 => Some(y),
+        0 | 1 => Some(0x02 + y),
+        _ => None,
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,19 +1,36 @@
 //! xtask is a Swiss army knife of tools that help with running and testing tempo.
-use crate::{create_zone::CreateZone, generate_zone_genesis::GenerateZoneGenesis};
+use crate::{
+    create_zone::CreateZone, encrypted_deposit::EncryptedDeposit,
+    generate_zone_genesis::GenerateZoneGenesis, set_encryption_key::SetEncryptionKey,
+    zone_info::ZoneInfoCmd,
+};
 use clap::Parser as _;
 use eyre::Context;
 
 mod create_zone;
+mod encrypted_deposit;
 mod generate_zone_genesis;
+mod set_encryption_key;
+mod zone_info;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
     let args = Args::parse();
     match args.action {
         Action::CreateZone(args) => args.run().await.wrap_err("failed to create zone"),
+        Action::EncryptedDeposit(args) => args
+            .run()
+            .await
+            .wrap_err("failed to send encrypted deposit"),
         Action::GenerateZoneGenesis(args) => {
             args.run().await.wrap_err("failed to generate zone genesis")
         }
+        Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
+        Action::ZoneInfo(args) => args.run().await.wrap_err("failed to fetch zone info"),
     }
 }
 
@@ -30,5 +47,8 @@ struct Args {
 #[derive(Debug, clap::Subcommand)]
 enum Action {
     CreateZone(CreateZone),
+    EncryptedDeposit(EncryptedDeposit),
     GenerateZoneGenesis(GenerateZoneGenesis),
+    SetEncryptionKey(SetEncryptionKey),
+    ZoneInfo(ZoneInfoCmd),
 }

--- a/xtask/src/set_encryption_key.rs
+++ b/xtask/src/set_encryption_key.rs
@@ -1,0 +1,95 @@
+//! Registers the sequencer's encryption key on the ZonePortal.
+//!
+//! Derives the secp256k1 public key from the private key, constructs a
+//! proof-of-possession (POP) ECDSA signature, and calls
+//! `setSequencerEncryptionKey` on the portal contract.
+
+use alloy::{
+    network::{EthereumWallet, primitives::ReceiptResponse},
+    primitives::{Address, B256, U256, keccak256},
+    providers::ProviderBuilder,
+    signers::{Signer, local::PrivateKeySigner},
+    sol_types::SolValue,
+};
+use eyre::{WrapErr as _, eyre};
+use k256::{AffinePoint, ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
+use tempo_alloy::TempoNetwork;
+use zone::abi::ZonePortal;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SetEncryptionKey {
+    /// Tempo L1 RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, env = "L1_PORTAL_ADDRESS")]
+    portal: Address,
+
+    /// Sequencer private key (hex). Used both as the signing key for the
+    /// transaction and as the encryption key to register.
+    #[arg(long, env = "PRIVATE_KEY")]
+    private_key: String,
+}
+
+impl SetEncryptionKey {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let key_str = self
+            .private_key
+            .strip_prefix("0x")
+            .unwrap_or(&self.private_key);
+
+        // The sequencer key is used both to sign the tx and as the encryption key
+        let signer: PrivateKeySigner = key_str.parse()?;
+
+        // Derive compressed public key coordinates
+        let enc_key = k256::SecretKey::from_slice(&const_hex::decode(key_str)?)?;
+        let scalar: Scalar = *enc_key.to_nonzero_scalar();
+        let pub_point = AffinePoint::from(ProjectivePoint::GENERATOR * scalar);
+        let encoded = pub_point.to_encoded_point(true);
+        let x = B256::from_slice(encoded.x().unwrap().as_slice());
+        let y_parity: u8 = encoded.as_bytes()[0]; // 0x02 or 0x03
+
+        println!("Encryption key x: {x}");
+        println!("Encryption key yParity: {y_parity:#x}");
+
+        // Build POP message and sign BEFORE moving signer into wallet
+        let message = keccak256((self.portal, x, U256::from(y_parity)).abi_encode());
+        let sig = signer.sign_hash(&message).await?;
+
+        let pop_v = sig.v() as u8 + 27;
+        let pop_r = B256::from(sig.r().to_be_bytes::<32>());
+        let pop_s = B256::from(sig.s().to_be_bytes::<32>());
+
+        // Now move signer into wallet (no clone needed)
+        let wallet = EthereumWallet::from(signer);
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(wallet)
+            .connect(&self.l1_rpc_url)
+            .await?;
+
+        println!(
+            "Sending setSequencerEncryptionKey to portal {}...",
+            self.portal
+        );
+        let portal = ZonePortal::new(self.portal, &provider);
+        let receipt = portal
+            .setSequencerEncryptionKey(x, y_parity, pop_v, pop_r, pop_s)
+            .send()
+            .await
+            .wrap_err("failed to send setSequencerEncryptionKey")?
+            .get_receipt()
+            .await
+            .wrap_err("failed to get receipt")?;
+
+        let tx_hash = receipt.transaction_hash;
+        if !receipt.status() {
+            return Err(eyre!("setSequencerEncryptionKey reverted (tx: {tx_hash})"));
+        }
+
+        println!("Encryption key registered!");
+        println!("Explorer: https://explore.moderato.tempo.xyz/tx/{tx_hash}");
+
+        Ok(())
+    }
+}

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -1,0 +1,111 @@
+use alloy::{
+    primitives::{Address, U256},
+    providers::ProviderBuilder,
+};
+use eyre::eyre;
+use tempo_alloy::TempoNetwork;
+use zone::abi::{ZoneFactory, ZonePortal};
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct ZoneInfoCmd {
+    /// Zone ID (integer) or portal address (0x...) to look up.
+    identifier: String,
+
+    /// Tempo L1 HTTP RPC URL.
+    #[arg(
+        long,
+        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+    )]
+    l1_rpc_url: String,
+
+    /// ZoneFactory contract address on Tempo L1.
+    #[arg(long, default_value = "0x8F3F0d21D01648d9373B3688CAc91b5253D3874C")]
+    zone_factory: Address,
+}
+
+impl ZoneInfoCmd {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&self.l1_rpc_url)
+            .await?;
+
+        let factory = ZoneFactory::new(self.zone_factory, &provider);
+
+        let zone_id = if self.identifier.starts_with("0x") {
+            // Look up by portal address — scan all zones
+            let portal: Address = self.identifier.parse()?;
+            let count = factory.zoneCount().call().await?;
+
+            let mut found = None;
+            for id in 1..=count {
+                let info = factory.zones(id).call().await?;
+                if info.portal == portal {
+                    found = Some(id);
+                    break;
+                }
+            }
+            found.ok_or_else(|| eyre!("no zone found with portal address {portal}"))?
+        } else {
+            self.identifier
+                .parse::<u64>()
+                .map_err(|_| eyre!("expected a zone ID (integer) or portal address (0x...)"))?
+        };
+
+        let info = factory.zones(zone_id).call().await?;
+        if info.portal == Address::ZERO {
+            return Err(eyre!("zone {zone_id} does not exist"));
+        }
+
+        println!("Zone {}", info.zoneId);
+        println!("  Portal:                {}", info.portal);
+        println!("  Messenger:             {}", info.messenger);
+        println!("  Initial Token:         {}", info.initialToken);
+        println!("  Sequencer:             {}", info.sequencer);
+        println!("  Verifier:              {}", info.verifier);
+        println!("  Genesis Block Hash:    {}", info.genesisBlockHash);
+        println!("  Genesis Tempo Hash:    {}", info.genesisTempoBlockHash);
+        println!("  Genesis Tempo Block:   {}", info.genesisTempoBlockNumber);
+
+        // Query live portal state
+        let portal = ZonePortal::new(info.portal, &provider);
+
+        let sequencer = portal.sequencer().call().await?;
+        let pending = portal.pendingSequencer().call().await?;
+        let gas_rate = portal.zoneGasRate().call().await?;
+        let batch_index = portal.withdrawalBatchIndex().call().await?;
+        let block_hash = portal.blockHash().call().await?;
+        let deposit_queue = portal.currentDepositQueueHash().call().await?;
+        let last_synced = portal.lastSyncedTempoBlockNumber().call().await?;
+
+        println!("\nPortal State");
+        println!("  Sequencer (live):      {sequencer}");
+        if pending != Address::ZERO {
+            println!("  Pending Sequencer:     {pending}");
+        }
+        println!("  Zone Gas Rate:         {gas_rate}");
+        println!("  Withdrawal Batch:      {batch_index}");
+        println!("  Block Hash:            {block_hash}");
+        println!("  Deposit Queue Hash:    {deposit_queue}");
+        println!("  Last Synced Block:     {last_synced}");
+
+        // Encryption key
+        match portal.sequencerEncryptionKey().call().await {
+            Ok(key) => {
+                println!("\nEncryption Key");
+                println!("  X:                     {}", key.x);
+                println!("  Y Parity:              0x{:02x}", key.yParity);
+            }
+            Err(_) => println!("\nEncryption Key:          (not set)"),
+        }
+
+        // Enabled tokens
+        let token_count = portal.enabledTokenCount().call().await?;
+        println!("\nEnabled Tokens ({token_count})");
+        for i in 0..token_count.to::<u64>() {
+            let token = portal.enabledTokenAt(U256::from(i)).call().await?;
+            println!("  [{i}] {token}");
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds xtask subcommands and Justfile recipes for zone operations:

- **encrypted-deposit**: ECIES-encrypts recipient/memo to sequencer pubkey, sends `depositEncrypted` on L1, polls L2 for processing
- **set-encryption-key**: registers sequencer encryption key on portal with POP signature
- **zone-info**: queries ZoneFactory for zone metadata by ID or portal address
- **deploy-zone**: now includes encryption key registration step
- **send-deposit / send-withdrawal**: enhanced with explorer URLs and L1 wait loops
- **send-deposit-encrypted**: new Justfile recipe wrapping the xtask

Reuses `zone::precompiles::ecies` for ECIES crypto instead of duplicating.