### PR TITLE
fix: derive zone monitor RPC URL from node's HTTP address

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -214,11 +214,13 @@ send-withdrawal amount="1000000" to="" token="0x20C00000000000000000000000000000
         FALLBACK="$TO"
     fi
     echo "Requesting withdrawal of {{amount}} to $TO (fallback: $FALLBACK)..."
-    L2_TX=$(cast send "$OUTBOX" \
+    L2_OUTPUT=$(cast send "$OUTBOX" \
         "requestWithdrawal(address,address,uint128,bytes32,uint64,address,bytes)" \
         "{{token}}" "$TO" "{{amount}}" "{{memo}}" "{{gas-limit}}" "$FALLBACK" "{{data}}" \
-        --rpc-url "{{rpc}}" --private-key "$PK" --gas-limit 500000 --json | jq -r '.transactionHash')
-    echo "Withdrawal requested on L2! tx: $L2_TX"
+        --rpc-url "{{rpc}}" --private-key "$PK" --gas-limit 500000 --json)
+    L2_TX=$(echo "$L2_OUTPUT" | jq -r '.transactionHash')
+    L2_BLOCK=$(echo "$L2_OUTPUT" | jq -r '.blockNumber')
+    echo "Withdrawal requested on L2! tx: $L2_TX (block $(printf '%d' "$L2_BLOCK"))"
 
     # Wait for the withdrawal to be processed on L1
     L1_RPC="${L1_RPC_URL:-}"

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -45,15 +45,6 @@ struct ZoneArgs {
     #[arg(long = "sequencer-key", env = "SEQUENCER_KEY")]
     pub sequencer_key: String,
 
-    /// Zone L2 HTTP RPC URL for the zone monitor to poll.
-    /// Only used when sequencer mode is enabled.
-    #[arg(
-        long = "zone.rpc-url",
-        env = "ZONE_RPC_URL",
-        default_value = "http://localhost:8546"
-    )]
-    pub zone_rpc_url: String,
-
     /// How often (in seconds) the zone monitor polls for new L2 blocks.
     #[arg(
         long = "zone.poll-interval-secs",
@@ -173,6 +164,12 @@ fn main() {
                 "Starting sequencer background tasks"
             );
 
+            let zone_rpc_url = handle
+                .node
+                .rpc_server_handle()
+                .http_url()
+                .expect("HTTP RPC server must be enabled for sequencer mode");
+
             let sequencer_config = zone::ZoneSequencerConfig {
                 portal_address: args.portal_address,
                 l1_rpc_url: args.l1_rpc_url,
@@ -182,7 +179,7 @@ fn main() {
                 outbox_address: zone::abi::ZONE_OUTBOX_ADDRESS,
                 inbox_address: zone::abi::ZONE_INBOX_ADDRESS,
                 tempo_state_address: zone::abi::TEMPO_STATE_ADDRESS,
-                zone_rpc_url: args.zone_rpc_url,
+                zone_rpc_url,
                 zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
                 batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
             };


### PR DESCRIPTION
The zone monitor polls the node's own HTTP RPC to detect new blocks for batch submission. Previously this was a separate `--zone.rpc-url` CLI arg defaulting to `http://localhost:8546`, which silently broke batch submission when `--http.port` was set to a different port (the monitor would poll a non-existent endpoint and silently skip every tick).

Now the monitor derives its RPC URL from `handle.node.rpc_server_handle().http_local_addr()`, so it always matches the actual HTTP server. The `--zone.rpc-url` arg is removed.