### PR TITLE
spec: clarify zone TIP-20 token model, remove ISSUER_ROLE, fix encrypted deposit prose

### DIFF
--- a/docs/pages/protocol/privacy/execution.md
+++ b/docs/pages/protocol/privacy/execution.md
@@ -64,22 +64,20 @@ By fixing the gas cost:
 
 ### System mint and burn permissions
 
-On Tempo, `mint()` and `burn()` on a TIP-20 require the caller to hold `ISSUER_ROLE`. On a privacy zone, the zone token is a bridged representation — tokens are minted when deposits arrive from Tempo and burned when withdrawals are requested. The zone's system contracts need to perform these operations without holding `ISSUER_ROLE`.
+On Tempo, `mint()` and `burn()` on a TIP-20 require the caller to hold `ISSUER_ROLE`. On a zone, the token is a bridged representation — tokens are minted when deposits arrive from Tempo and burned when withdrawals are requested. `ISSUER_ROLE` is not used on zones. The sole mint/burn authorities are the zone system contracts:
 
-The TIP-20 precompile on a privacy zone extends the mint/burn authorization to include the zone system contracts:
-
-| Operation | Standard TIP-20 access | Privacy zone access |
-|-----------|----------------------|-------------------|
-| `mint(to, amount)` | `ISSUER_ROLE` only | `ISSUER_ROLE` **or** ZoneInbox (`0x1c...0001`) |
-| `burn(from, amount)` | `ISSUER_ROLE` only | `ISSUER_ROLE` **or** ZoneOutbox (`0x1c...0002`) |
+| Operation | Standard TIP-20 (Tempo) | Zone access |
+|-----------|------------------------|-------------|
+| `mint(to, amount)` | `ISSUER_ROLE` only | ZoneInbox (`0x1c...0001`) only |
+| `burn(from, amount)` | `ISSUER_ROLE` only | ZoneOutbox (`0x1c...0002`) only |
 
 Authorization is **operation-specific**: ZoneInbox access applies to `mint` only, and ZoneOutbox access applies to `burn` only. Implementations MUST NOT use a shared "inbox-or-outbox" check for both operations.
 
 **ZoneInbox mints** during deposit processing in `advanceTempo()`:
 
-- Regular deposit: `mint(deposit.to, deposit.amount)` — credits the recipient.
-- Encrypted deposit (decryption succeeded): `mint(decrypted.to, deposit.amount)` — credits the decrypted recipient.
-- Encrypted deposit (decryption failed): `mint(deposit.sender, deposit.amount)` — refunds the sender.
+- Regular deposit: `mint(deposit.to, deposit.amount)` — credits the recipient on the zone.
+- Encrypted deposit (decryption succeeded): `mint(decrypted.to, deposit.amount)` — credits the decrypted recipient on the zone.
+- Encrypted deposit (decryption failed): `mint(deposit.sender, deposit.amount)` — credits the depositor's address on the zone (same address as their L1 account). The L1 funds remain escrowed in the portal.
 
 **ZoneOutbox burns** during withdrawal requests in `requestWithdrawal()`:
 
@@ -88,8 +86,6 @@ Authorization is **operation-specific**: ZoneInbox access applies to `mint` only
 - The burned tokens are released on Tempo when the sequencer processes the withdrawal.
 
 **Gas costs**: `mint` and `burn` retain standard variable gas costs (not the fixed 100,000). These functions are only called by system contracts during sequencer operations, so there is no user-exploitable gas side channel.
-
-**`ISSUER_ROLE` is preserved** for forward compatibility but is not expected to be granted to any external party on a zone — the zone token supply is entirely controlled by the bridge mechanism.
 
 ## EVM restrictions
 

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -714,9 +714,18 @@ Zones have four system contract predeploys at fixed addresses:
 - **ZoneOutbox** (0x1c00000000000000000000000000000000000002) - Handles withdrawal requests back to Tempo
 - **ZoneConfig** (0x1c00000000000000000000000000000000000003) - Central configuration that reads sequencer from L1
 
-#### Zone tokens
+#### Zone token model
 
-Each enabled TIP-20 token is bridged from Tempo to the zone. Each is deployed at the **same address** on the zone as on Tempo. Users interact with them via the standard TIP-20 interface for transfers and approvals. The zone sequencer mints the correct token when processing deposits and burns the correct token when withdrawals are requested. The zone node must deploy/configure zone-side representations for each enabled token.
+Zones have **no TIP-20 factory**. All TIP-20 tokens on a zone are bridged representations of Tempo tokens — there is no mechanism to create or issue new tokens on the zone itself. Contract creation is disabled (`CREATE` and `CREATE2` revert), so users cannot deploy token contracts either.
+
+Each enabled TIP-20 token is deployed on the zone at the **same address** as on Tempo. When the sequencer calls `enableToken(token)` on the L1 portal, the zone node provisions a zone-side TIP-20 precompile at that address in the next genesis or state update. Users interact with zone tokens via the standard TIP-20 interface for transfers and approvals.
+
+The total supply of each zone token is controlled exclusively by the bridge:
+
+- **Mint on deposit**: `ZoneInbox` mints tokens when processing deposits from Tempo.
+- **Burn on withdrawal**: `ZoneOutbox` burns tokens when users request withdrawals back to Tempo.
+
+The zone-side supply of each token always equals the net deposits minus net withdrawals for that token. The corresponding Tempo-side tokens are held in escrow by the `ZonePortal`. No other actor can mint or burn zone tokens — system contracts (`ZoneInbox`, `ZoneOutbox`) are the sole mint/burn authorities.
 
 #### ZoneConfig predeploy
 
@@ -1130,7 +1139,7 @@ Notes:
 - The portal only stores `currentDepositQueueHash`, not individual deposits. The sequencer must track deposits off-chain.
 - Tempo state advancement is combined with deposit processing in `ZoneInbox.advanceTempo()`, which calls `TempoState.finalizeTempo()` internally.
 - The proof validates an exact match to `currentDepositQueueHash` from Tempo state, ensuring it cannot claim to process fake deposits.
-- Each enabled TIP-20 is deployed at the **same address** on the zone as on Tempo. The zone node must deploy/configure zone-side representations for each enabled token.
+- Each enabled TIP-20 is deployed at the **same address** on the zone as on Tempo. Zone tokens are precompiles provisioned by the zone node — there is no TIP-20 factory on zones.
 
 ### Encrypted deposits
 
@@ -1203,7 +1212,7 @@ This ensures deposits are processed in the exact order they were made, regardles
 - **Sequencer trust**: Users trust the sequencer to decrypt correctly and credit the right recipient. A malicious sequencer could steal encrypted deposits.
 - **On-chain verification**: The sequencer provides the ECDH shared secret, which enables on-chain decryption verification via GCM tag validation without revealing the private key. See "On-chain decryption verification" below.
 - **Key rotation**: The portal maintains a history of encryption keys. Each encrypted deposit includes the `keyIndex` the user encrypted to, allowing the prover to look up the correct key for decryption. See "Encryption key history" below.
-- **Malformed ciphertext**: If decryption fails, the sequencer may refund to `sender` or hold funds pending resolution.
+- **Malformed ciphertext**: If decryption fails (invalid ciphertext, wrong key, corrupted data), the zone mints tokens to `sender`'s address on the zone — the same address as their L1 account. The L1 funds remain escrowed in the portal. This ensures chain progress is never blocked by invalid encrypted deposits.
 
 **On-chain decryption verification:**
 
@@ -1258,7 +1267,7 @@ bytes32 aesKey = _hkdfSha256(dec.sharedSecret, "ecies-aes-key", "");
 // Step 4: Try to decrypt using AES-GCM precompile
 (bytes memory plaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(...);
 
-// Step 5: If decryption fails, return funds to sender (don't block chain)
+// Step 5: If decryption fails, credit depositor's address on zone (L1 funds stay escrowed)
 if (!valid) {
     IZoneToken(ed.token).mint(ed.sender, ed.amount);
     emit EncryptedDepositFailed(...);
@@ -1367,7 +1376,7 @@ if (valid && decryptedPlaintext.length == ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
 
 // Step 6: Handle success or failure
 if (!valid) {
-    // Decryption failed - return funds to sender
+    // Decryption failed - credit depositor's address on zone (L1 funds stay escrowed)
     IZoneToken(ed.token).mint(ed.sender, ed.amount);
     emit EncryptedDepositFailed(currentHash, ed.sender, ed.token, ed.amount);
 } else {

--- a/docs/specs/src/zone/PrivateZoneToken.sol
+++ b/docs/specs/src/zone/PrivateZoneToken.sol
@@ -15,8 +15,8 @@ import { IZoneConfig, ZONE_INBOX, ZONE_OUTBOX } from "./IZone.sol";
  *   1. **Balance privacy**: balanceOf() is restricted to the account owner and sequencer.
  *   2. **Allowance privacy**: allowance() is restricted to the owner, spender, and sequencer.
  *   3. **Fixed gas**: All transfer-family calls and approve() cost exactly FIXED_TRANSFER_GAS.
- *   4. **System mint/burn**: ZoneInbox can mint (deposits), ZoneOutbox can burn (withdrawals),
- *      without requiring the standard ISSUER_ROLE.
+ *   4. **System mint/burn**: ZoneInbox is the sole mint authority (deposits), ZoneOutbox is
+ *      the sole burn authority (withdrawals). ISSUER_ROLE is not used on zones.
  *
  * All other TIP-20 behavior (transfer logic, approval logic, events, roles, TIP-403 enforcement,
  * pause controls, rewards) is identical to the standard TIP-20 spec.
@@ -155,67 +155,33 @@ abstract contract PrivateZoneToken {
 
     /**
      * @notice Mint tokens to `to`.
-     * @dev On Tempo, mint() requires the caller to have ISSUER_ROLE. On a privacy zone,
-     *      mint is additionally callable by the ZoneInbox system contract (for deposit
-     *      processing). The ZoneInbox needs to mint when:
+     * @dev On a zone, only ZoneInbox can mint. The ZoneInbox mints when:
      *        - A regular deposit is processed (mint to recipient)
      *        - An encrypted deposit is successfully decrypted (mint to decrypted recipient)
-     *        - An encrypted deposit fails decryption (refund mint to sender)
+     *        - An encrypted deposit fails decryption (mint to sender's address on zone)
      *
-     *      Access: ISSUER_ROLE holders OR ZoneInbox (0x1c...0001).
+     *      Access: ZoneInbox (0x1c...0001) only.
      *      Gas: standard (not fixed) — only the sequencer calls this.
      */
     function mint(address to, uint256 amount) external {
-        _requireMintAuth();
+        if (msg.sender != ZONE_INBOX) revert Unauthorized();
         revert(); // precompile stub
     }
 
     /**
      * @notice Burn tokens from `from`.
-     * @dev On Tempo, burn() requires the caller to have ISSUER_ROLE. On a privacy zone,
-     *      burn is additionally callable by the ZoneOutbox system contract (for withdrawal
-     *      processing). The ZoneOutbox flow is:
+     * @dev On a zone, only ZoneOutbox can burn. The ZoneOutbox flow is:
      *        1. User approves ZoneOutbox to spend (amount + fee)
      *        2. ZoneOutbox calls transferFrom(user, self, amount + fee)
      *        3. ZoneOutbox calls burn(self, amount + fee)
      *      The burned tokens are released on Tempo when the withdrawal is processed.
      *
-     *      Access: ISSUER_ROLE holders OR ZoneOutbox (0x1c...0002).
+     *      Access: ZoneOutbox (0x1c...0002) only.
      *      Gas: standard (not fixed) — only the sequencer/outbox calls this.
      */
     function burn(address from, uint256 amount) external {
-        _requireBurnAuth();
+        if (msg.sender != ZONE_OUTBOX) revert Unauthorized();
         revert(); // precompile stub
-    }
-
-    /**
-     * @dev Check that the caller is authorized to mint.
-     *      On a privacy zone, this is: ISSUER_ROLE OR ZoneInbox.
-     *
-     *      Note: On a zone, no external party typically holds ISSUER_ROLE (the zone token
-     *      is a bridged representation). The system contracts are the primary minters/burners.
-     *      ISSUER_ROLE is preserved for forward compatibility.
-     */
-    function _requireMintAuth() internal view {
-        if (
-            msg.sender != ZONE_INBOX
-            // && !hasRole(ISSUER_ROLE, msg.sender)  // standard role check preserved
-        ) {
-            revert Unauthorized();
-        }
-    }
-
-    /**
-     * @dev Check that the caller is authorized to burn.
-     *      On a privacy zone, this is: ISSUER_ROLE OR ZoneOutbox.
-     */
-    function _requireBurnAuth() internal view {
-        if (
-            msg.sender != ZONE_OUTBOX
-            // && !hasRole(ISSUER_ROLE, msg.sender)  // standard role check preserved
-        ) {
-            revert Unauthorized();
-        }
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/zone/ZoneInbox.sol
+++ b/docs/specs/src/zone/ZoneInbox.sol
@@ -284,8 +284,8 @@ contract ZoneInbox is IZoneInbox {
                 currentHash = keccak256(abi.encode(DepositType.Encrypted, ed, currentHash));
 
                 if (!valid) {
-                    // Decryption failed (user encrypted garbage or corrupted data)
-                    // Return funds to sender instead of blocking chain progress
+                    // Decryption failed: credit the depositor's address on the zone.
+                    // L1 funds remain escrowed in the portal.
                     IZoneToken(ed.token).mint(ed.sender, ed.amount);
                     emit EncryptedDepositFailed(currentHash, ed.sender, ed.token, ed.amount);
                 } else {


### PR DESCRIPTION
## Summary

- **Zone token model**: Added explicit section to `overview.md` stating that zones have no TIP-20 factory — all tokens are bridged representations with supply controlled exclusively by mint-on-deposit (ZoneInbox) and burn-on-withdrawal (ZoneOutbox). CREATE/CREATE2 disabled.
- **Remove ISSUER_ROLE on zones**: ZoneInbox is the sole mint authority, ZoneOutbox is the sole burn authority. Removed commented-out ISSUER_ROLE checks and "forward compatibility" language from `PrivateZoneToken.sol` and `execution.md`.
- **Encrypted deposit failure clarity**: Fixed prose that incorrectly said "may refund to sender or hold funds pending resolution." On decryption failure the zone mints to the depositor's address *on the zone* (same key controls both chains); L1 funds remain escrowed in the portal. Updated code comments in `ZoneInbox.sol` and inline snippets in `overview.md`.

Closes https://github.com/tempoxyz/zones/issues/135

## Test plan

- [ ] Review spec prose in `docs/pages/protocol/privacy/overview.md` (zone token model section, encrypted deposit notes)
- [ ] Review `docs/pages/protocol/privacy/execution.md` mint/burn table and prose
- [ ] Review `docs/specs/src/zone/PrivateZoneToken.sol` — sole ZoneInbox/ZoneOutbox auth, no ISSUER_ROLE
- [ ] Review `docs/specs/src/zone/ZoneInbox.sol` — updated comments on encrypted deposit failure path

Made with [Cursor](https://cursor.com)