### PR TITLE
feat: add ZoneTransactionPolicy to reject CREATE transactions

### DIFF
--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -7,6 +7,7 @@ use crate::{
     abi::{self, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS},
     evm::ZoneEvmConfig,
     l1::L1Deposit,
+    pool::ZoneTransactionPool,
     precompiles::ecies,
 };
 use alloy_consensus::{Signed, TxLegacy};
@@ -42,7 +43,6 @@ use tempo_primitives::{
     TempoHeader, TempoPrimitives, TempoTxEnvelope,
     transaction::envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
 };
-use tempo_transaction_pool::TempoTransactionPool;
 use tracing::{debug, error, info, warn};
 
 use super::node::ZoneNode;
@@ -75,7 +75,7 @@ impl ZonePayloadFactory {
     }
 }
 
-impl<Node> PayloadBuilderBuilder<Node, TempoTransactionPool<Node::Provider>, ZoneEvmConfig>
+impl<Node> PayloadBuilderBuilder<Node, ZoneTransactionPool<Node::Provider>, ZoneEvmConfig>
     for ZonePayloadFactory
 where
     Node: FullNodeTypes<Types = ZoneNode>,
@@ -85,7 +85,7 @@ where
     async fn build_payload_builder(
         self,
         ctx: &BuilderContext<Node>,
-        pool: TempoTransactionPool<Node::Provider>,
+        pool: ZoneTransactionPool<Node::Provider>,
         evm_config: ZoneEvmConfig,
     ) -> eyre::Result<Self::PayloadBuilder> {
         Ok(ZonePayloadBuilder {
@@ -102,7 +102,7 @@ where
 /// Zone payload builder that executes `advanceTempo` system txs + pool txs.
 #[derive(Debug, Clone)]
 pub struct ZonePayloadBuilder<Provider> {
-    pool: TempoTransactionPool<Provider>,
+    pool: ZoneTransactionPool<Provider>,
     provider: Provider,
     evm_config: ZoneEvmConfig,
     deposit_queue: crate::DepositQueue,
@@ -113,7 +113,7 @@ pub struct ZonePayloadBuilder<Provider> {
 
 impl<Provider> ZonePayloadBuilder<Provider> {
     pub fn new(
-        pool: TempoTransactionPool<Provider>,
+        pool: ZoneTransactionPool<Provider>,
         provider: Provider,
         evm_config: ZoneEvmConfig,
         deposit_queue: crate::DepositQueue,

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -19,6 +19,7 @@ mod executor;
 pub mod l1;
 pub mod l1_state;
 mod node;
+pub mod pool;
 pub mod precompiles;
 pub mod rpc;
 pub mod withdrawals;
@@ -32,6 +33,7 @@ pub use l1::{
 };
 pub use l1_state::SharedL1StateCache;
 pub use node::{ZoneExecutorBuilder, ZoneNode};
+pub use pool::{ZoneTransactionPolicy, ZoneTransactionPool};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};
 pub use zonemonitor::{ZoneMonitorConfig, spawn_zone_monitor};
 

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -51,6 +51,7 @@ use crate::{
         L1StateListenerConfig, L1StateProvider, L1StateProviderConfig, SharedL1StateCache,
         spawn_l1_state_listener,
     },
+    pool::{ZoneTransactionPolicy, ZoneTransactionPool},
 };
 
 use crate::builder::ZonePayloadFactory;
@@ -158,7 +159,7 @@ impl ZoneNode {
     {
         ComponentsBuilder::default()
             .node_types::<N>()
-            .pool(ZonePoolBuilder)
+            .pool(ZonePoolBuilder::default())
             .executor(executor_builder)
             .payload(BasicPayloadServiceBuilder::new(ZonePayloadFactory::new(
                 deposit_queue,
@@ -432,16 +433,23 @@ where
     }
 }
 
-/// Transaction pool builder for Zone - uses Tempo pool with defaults.
-#[derive(Debug, Default, Clone, Copy)]
+/// Transaction pool builder for Zone.
+///
+/// Builds a [`ZoneTransactionPool`] that wraps the standard [`TempoTransactionPool`]
+/// with a [`ZoneTransactionPolicy`] to enforce zone-specific transaction restrictions
+/// (e.g. rejecting contract creation).
+#[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct ZonePoolBuilder;
+pub struct ZonePoolBuilder {
+    /// Transaction policy enforced by the pool on every submission.
+    pub policy: ZoneTransactionPolicy,
+}
 
 impl<Node> PoolBuilder<Node, ZoneEvmConfig> for ZonePoolBuilder
 where
     Node: FullNodeTypes<Types = ZoneNode>,
 {
-    type Pool = TempoTransactionPool<Node::Provider>;
+    type Pool = ZoneTransactionPool<Node::Provider>;
 
     async fn build_pool(
         self,
@@ -491,7 +499,8 @@ where
             .with_validator(validator)
             .build(blob_store, pool_config.clone());
 
-        let transaction_pool = TempoTransactionPool::new(protocol_pool, aa_2d_pool);
+        let tempo_pool = TempoTransactionPool::new(protocol_pool, aa_2d_pool);
+        let transaction_pool = ZoneTransactionPool::new(tempo_pool, self.policy);
 
         spawn_maintenance_tasks(ctx, transaction_pool.clone(), &pool_config)?;
 
@@ -499,7 +508,7 @@ where
         // This consolidates: expired AA txs, 2D nonce updates, AMM cache, and keychain revocations
         ctx.task_executor().spawn_critical(
             "txpool maintenance - tempo pool",
-            tempo_transaction_pool::maintain::maintain_tempo_pool(transaction_pool.clone()),
+            tempo_transaction_pool::maintain::maintain_tempo_pool(transaction_pool.tempo_pool()),
         );
 
         info!(target: "reth::cli", "Transaction pool initialized");

--- a/crates/tempo-zone/src/pool.rs
+++ b/crates/tempo-zone/src/pool.rs
@@ -1,0 +1,630 @@
+//! Zone-level transaction pool and validation policy.
+//!
+//! [`ZoneTransactionPool`] wraps [`TempoTransactionPool`] and enforces a
+//! [`ZoneTransactionPolicy`] on every transaction submission. Transactions that
+//! violate the policy are rejected before they reach the inner pool.
+//!
+//! [`ZoneTransactionValidator`] is an alternative integration point that enforces
+//! the same policy at the validator layer (requires `TempoTransactionPool` to be
+//! made generic over the validator type).
+
+use std::{any::Any, sync::Arc};
+
+use alloy_consensus::Transaction;
+use alloy_primitives::{Address, B256};
+use reth_eth_wire_types::HandleMempoolData;
+use reth_provider::ChangedAccount;
+use reth_transaction_pool::{
+    AddedTransactionOutcome, AllPoolTransactions, BestTransactions, BestTransactionsAttributes,
+    BlockInfo, CanonicalStateUpdate, GetPooledTransactionLimit, NewBlobSidecar, PoolResult,
+    PoolSize, PoolTransaction, PropagatedTransactions, TransactionEvents, TransactionOrigin,
+    TransactionPool, TransactionPoolExt, TransactionValidationOutcome, TransactionValidator,
+    ValidPoolTransaction,
+    error::{InvalidPoolTransactionError, PoolError, PoolErrorKind, PoolTransactionError},
+};
+use tempo_transaction_pool::{TempoTransactionPool, validator::TempoTransactionValidator};
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+/// Policy flags that control which transaction types a zone accepts.
+///
+/// Applied by [`ZoneTransactionPool`] on every submission and by
+/// [`ZoneTransactionValidator`] during validation.
+#[derive(Debug, Clone)]
+pub struct ZoneTransactionPolicy {
+    /// When `true`, reject transactions whose [`TxKind`](alloy_primitives::TxKind) is
+    /// [`Create`](alloy_primitives::TxKind::Create), preventing bare `CREATE` / `CREATE2`
+    /// contract deployments via the transaction pool.
+    pub deny_contract_creation: bool,
+}
+
+impl Default for ZoneTransactionPolicy {
+    fn default() -> Self {
+        Self {
+            deny_contract_creation: true,
+        }
+    }
+}
+
+impl ZoneTransactionPolicy {
+    /// Returns an error if `tx` violates this policy, `None` otherwise.
+    fn check<T: Transaction + PoolTransaction>(&self, tx: &T) -> Option<PoolError> {
+        if self.deny_contract_creation && tx.is_create() {
+            return Some(PoolError::new(
+                *tx.hash(),
+                PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::other(
+                    ContractCreationDenied,
+                )),
+            ));
+        }
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ZoneTransactionPool
+// ---------------------------------------------------------------------------
+
+/// Transaction pool wrapper that enforces a [`ZoneTransactionPolicy`] on every
+/// submission before delegating to the inner [`TempoTransactionPool`].
+///
+/// All query / listener / removal methods delegate directly to the inner pool.
+pub struct ZoneTransactionPool<Client> {
+    /// The wrapped Tempo transaction pool that handles AA routing and standard
+    /// pool operations.
+    inner: TempoTransactionPool<Client>,
+    /// Policy applied to every incoming transaction.
+    policy: ZoneTransactionPolicy,
+}
+
+impl<Client> ZoneTransactionPool<Client> {
+    /// Create a new pool wrapping `inner` with the given `policy`.
+    pub fn new(inner: TempoTransactionPool<Client>, policy: ZoneTransactionPolicy) -> Self {
+        Self { inner, policy }
+    }
+
+    /// Returns a reference to the inner [`TempoTransactionPool`].
+    pub fn inner(&self) -> &TempoTransactionPool<Client> {
+        &self.inner
+    }
+
+    /// Returns a clone of the inner [`TempoTransactionPool`].
+    ///
+    /// Useful for passing to [`maintain_tempo_pool`](tempo_transaction_pool::maintain::maintain_tempo_pool)
+    /// which requires `TempoTransactionPool<Client>` directly.
+    pub fn tempo_pool(&self) -> TempoTransactionPool<Client>
+    where
+        Client: Clone,
+    {
+        self.inner.clone()
+    }
+}
+
+impl<Client> Clone for ZoneTransactionPool<Client> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            policy: self.policy.clone(),
+        }
+    }
+}
+
+impl<Client> std::fmt::Debug for ZoneTransactionPool<Client> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZoneTransactionPool")
+            .field("inner", &self.inner)
+            .field("policy", &self.policy)
+            .finish()
+    }
+}
+
+impl<Client> TransactionPool for ZoneTransactionPool<Client>
+where
+    Client: reth_storage_api::StateProviderFactory
+        + reth_chainspec::ChainSpecProvider<ChainSpec = tempo_chainspec::TempoChainSpec>
+        + Send
+        + Sync
+        + 'static,
+    tempo_transaction_pool::transaction::TempoPooledTransaction:
+        reth_transaction_pool::EthPoolTransaction,
+{
+    type Transaction = <TempoTransactionPool<Client> as TransactionPool>::Transaction;
+
+    fn pool_size(&self) -> PoolSize {
+        self.inner.pool_size()
+    }
+
+    fn block_info(&self) -> BlockInfo {
+        self.inner.block_info()
+    }
+
+    // -- Submission methods (policy-checked) ----------------------------------
+
+    async fn add_transaction_and_subscribe(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> PoolResult<TransactionEvents> {
+        if let Some(err) = self.policy.check(&transaction) {
+            return Err(err);
+        }
+        self.inner
+            .add_transaction_and_subscribe(origin, transaction)
+            .await
+    }
+
+    async fn add_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> PoolResult<AddedTransactionOutcome> {
+        if let Some(err) = self.policy.check(&transaction) {
+            return Err(err);
+        }
+        self.inner.add_transaction(origin, transaction).await
+    }
+
+    async fn add_transactions(
+        &self,
+        origin: TransactionOrigin,
+        transactions: Vec<Self::Transaction>,
+    ) -> Vec<PoolResult<AddedTransactionOutcome>> {
+        if !self.policy.deny_contract_creation {
+            return self.inner.add_transactions(origin, transactions).await;
+        }
+
+        let total = transactions.len();
+        let mut output: Vec<Option<PoolResult<AddedTransactionOutcome>>> =
+            (0..total).map(|_| None).collect();
+        let mut allowed = Vec::with_capacity(total);
+        let mut allowed_idx = Vec::with_capacity(total);
+
+        for (i, tx) in transactions.into_iter().enumerate() {
+            if let Some(err) = self.policy.check(&tx) {
+                output[i] = Some(Err(err));
+            } else {
+                allowed_idx.push(i);
+                allowed.push(tx);
+            }
+        }
+
+        let inner_results = self.inner.add_transactions(origin, allowed).await;
+        for (idx, result) in allowed_idx.into_iter().zip(inner_results) {
+            output[idx] = Some(result);
+        }
+
+        output
+            .into_iter()
+            .map(|o| o.expect("all slots filled"))
+            .collect()
+    }
+
+    // -- Listeners & events ---------------------------------------------------
+
+    fn transaction_event_listener(&self, tx_hash: B256) -> Option<TransactionEvents> {
+        self.inner.transaction_event_listener(tx_hash)
+    }
+
+    fn all_transactions_event_listener(
+        &self,
+    ) -> reth_transaction_pool::AllTransactionsEvents<Self::Transaction> {
+        self.inner.all_transactions_event_listener()
+    }
+
+    fn pending_transactions_listener_for(
+        &self,
+        kind: reth_transaction_pool::TransactionListenerKind,
+    ) -> tokio::sync::mpsc::Receiver<B256> {
+        self.inner.pending_transactions_listener_for(kind)
+    }
+
+    fn blob_transaction_sidecars_listener(&self) -> tokio::sync::mpsc::Receiver<NewBlobSidecar> {
+        self.inner.blob_transaction_sidecars_listener()
+    }
+
+    fn new_transactions_listener_for(
+        &self,
+        kind: reth_transaction_pool::TransactionListenerKind,
+    ) -> tokio::sync::mpsc::Receiver<reth_transaction_pool::NewTransactionEvent<Self::Transaction>>
+    {
+        self.inner.new_transactions_listener_for(kind)
+    }
+
+    // -- Pooled transaction queries -------------------------------------------
+
+    fn pooled_transaction_hashes(&self) -> Vec<B256> {
+        self.inner.pooled_transaction_hashes()
+    }
+
+    fn pooled_transaction_hashes_max(&self, max: usize) -> Vec<B256> {
+        self.inner.pooled_transaction_hashes_max(max)
+    }
+
+    fn pooled_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.pooled_transactions()
+    }
+
+    fn pooled_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.pooled_transactions_max(max)
+    }
+
+    fn get_pooled_transaction_elements(
+        &self,
+        tx_hashes: Vec<B256>,
+        limit: GetPooledTransactionLimit,
+    ) -> Vec<<Self::Transaction as PoolTransaction>::Pooled> {
+        self.inner.get_pooled_transaction_elements(tx_hashes, limit)
+    }
+
+    fn append_pooled_transaction_elements(
+        &self,
+        tx_hashes: &[B256],
+        limit: GetPooledTransactionLimit,
+        out: &mut Vec<<Self::Transaction as PoolTransaction>::Pooled>,
+    ) {
+        self.inner
+            .append_pooled_transaction_elements(tx_hashes, limit, out)
+    }
+
+    fn get_pooled_transaction_element(
+        &self,
+        tx_hash: B256,
+    ) -> Option<reth_primitives_traits::Recovered<<Self::Transaction as PoolTransaction>::Pooled>>
+    {
+        self.inner.get_pooled_transaction_element(tx_hash)
+    }
+
+    // -- Best / pending / queued ----------------------------------------------
+
+    fn best_transactions(
+        &self,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        self.inner.best_transactions()
+    }
+
+    fn best_transactions_with_attributes(
+        &self,
+        best_transactions_attributes: BestTransactionsAttributes,
+    ) -> Box<dyn BestTransactions<Item = Arc<ValidPoolTransaction<Self::Transaction>>>> {
+        self.inner
+            .best_transactions_with_attributes(best_transactions_attributes)
+    }
+
+    fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.pending_transactions()
+    }
+
+    fn pending_transactions_max(
+        &self,
+        max: usize,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.pending_transactions_max(max)
+    }
+
+    fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.queued_transactions()
+    }
+
+    fn pending_and_queued_txn_count(&self) -> (usize, usize) {
+        self.inner.pending_and_queued_txn_count()
+    }
+
+    // -- All transactions -----------------------------------------------------
+
+    fn all_transactions(&self) -> AllPoolTransactions<Self::Transaction> {
+        self.inner.all_transactions()
+    }
+
+    fn all_transaction_hashes(&self) -> Vec<B256> {
+        self.inner.all_transaction_hashes()
+    }
+
+    // -- Removal --------------------------------------------------------------
+
+    fn remove_transactions(
+        &self,
+        hashes: Vec<B256>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.remove_transactions(hashes)
+    }
+
+    fn remove_transactions_and_descendants(
+        &self,
+        hashes: Vec<B256>,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.remove_transactions_and_descendants(hashes)
+    }
+
+    fn remove_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.remove_transactions_by_sender(sender)
+    }
+
+    fn retain_unknown<A: HandleMempoolData>(&self, announcement: &mut A) {
+        self.inner.retain_unknown(announcement)
+    }
+
+    fn contains(&self, tx_hash: &B256) -> bool {
+        self.inner.contains(tx_hash)
+    }
+
+    // -- Getters --------------------------------------------------------------
+
+    fn get(&self, tx_hash: &B256) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get(tx_hash)
+    }
+
+    fn get_all(&self, txs: Vec<B256>) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get_all(txs)
+    }
+
+    fn on_propagated(&self, txs: PropagatedTransactions) {
+        self.inner.on_propagated(txs)
+    }
+
+    fn get_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get_transactions_by_sender(sender)
+    }
+
+    fn get_pending_transactions_with_predicate(
+        &self,
+        predicate: impl FnMut(&ValidPoolTransaction<Self::Transaction>) -> bool,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner
+            .get_pending_transactions_with_predicate(predicate)
+    }
+
+    fn get_pending_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get_pending_transactions_by_sender(sender)
+    }
+
+    fn get_queued_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get_queued_transactions_by_sender(sender)
+    }
+
+    fn get_highest_transaction_by_sender(
+        &self,
+        sender: Address,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get_highest_transaction_by_sender(sender)
+    }
+
+    fn get_highest_consecutive_transaction_by_sender(
+        &self,
+        sender: Address,
+        on_chain_nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner
+            .get_highest_consecutive_transaction_by_sender(sender, on_chain_nonce)
+    }
+
+    fn get_transaction_by_sender_and_nonce(
+        &self,
+        sender: Address,
+        nonce: u64,
+    ) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner
+            .get_transaction_by_sender_and_nonce(sender, nonce)
+    }
+
+    fn get_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get_transactions_by_origin(origin)
+    }
+
+    fn get_pending_transactions_by_origin(
+        &self,
+        origin: TransactionOrigin,
+    ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
+        self.inner.get_pending_transactions_by_origin(origin)
+    }
+
+    fn unique_senders(&self) -> std::collections::HashSet<Address> {
+        self.inner.unique_senders()
+    }
+
+    // -- Blob store -----------------------------------------------------------
+
+    fn get_blob(
+        &self,
+        tx_hash: B256,
+    ) -> Result<
+        Option<Arc<alloy_eips::eip7594::BlobTransactionSidecarVariant>>,
+        reth_transaction_pool::blobstore::BlobStoreError,
+    > {
+        self.inner.get_blob(tx_hash)
+    }
+
+    fn get_all_blobs(
+        &self,
+        tx_hashes: Vec<B256>,
+    ) -> Result<
+        Vec<(
+            B256,
+            Arc<alloy_eips::eip7594::BlobTransactionSidecarVariant>,
+        )>,
+        reth_transaction_pool::blobstore::BlobStoreError,
+    > {
+        self.inner.get_all_blobs(tx_hashes)
+    }
+
+    fn get_all_blobs_exact(
+        &self,
+        tx_hashes: Vec<B256>,
+    ) -> Result<
+        Vec<Arc<alloy_eips::eip7594::BlobTransactionSidecarVariant>>,
+        reth_transaction_pool::blobstore::BlobStoreError,
+    > {
+        self.inner.get_all_blobs_exact(tx_hashes)
+    }
+
+    fn get_blobs_for_versioned_hashes_v1(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<
+        Vec<Option<alloy_eips::eip4844::BlobAndProofV1>>,
+        reth_transaction_pool::blobstore::BlobStoreError,
+    > {
+        self.inner
+            .get_blobs_for_versioned_hashes_v1(versioned_hashes)
+    }
+
+    fn get_blobs_for_versioned_hashes_v2(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<
+        Option<Vec<alloy_eips::eip4844::BlobAndProofV2>>,
+        reth_transaction_pool::blobstore::BlobStoreError,
+    > {
+        self.inner
+            .get_blobs_for_versioned_hashes_v2(versioned_hashes)
+    }
+
+    fn get_blobs_for_versioned_hashes_v3(
+        &self,
+        versioned_hashes: &[B256],
+    ) -> Result<
+        Vec<Option<alloy_eips::eip4844::BlobAndProofV2>>,
+        reth_transaction_pool::blobstore::BlobStoreError,
+    > {
+        self.inner
+            .get_blobs_for_versioned_hashes_v3(versioned_hashes)
+    }
+}
+
+impl<Client> TransactionPoolExt for ZoneTransactionPool<Client>
+where
+    Client: reth_storage_api::StateProviderFactory
+        + reth_chainspec::ChainSpecProvider<ChainSpec = tempo_chainspec::TempoChainSpec>
+        + Send
+        + Sync
+        + 'static,
+    tempo_transaction_pool::transaction::TempoPooledTransaction:
+        reth_transaction_pool::EthPoolTransaction,
+{
+    type Block = <TempoTransactionPool<Client> as TransactionPoolExt>::Block;
+
+    fn set_block_info(&self, info: BlockInfo) {
+        self.inner.set_block_info(info)
+    }
+
+    fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_, Self::Block>) {
+        self.inner.on_canonical_state_change(update)
+    }
+
+    fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
+        self.inner.update_accounts(accounts)
+    }
+
+    fn delete_blob(&self, tx: B256) {
+        self.inner.delete_blob(tx)
+    }
+
+    fn delete_blobs(&self, txs: Vec<B256>) {
+        self.inner.delete_blobs(txs)
+    }
+
+    fn cleanup_blobs(&self) {
+        self.inner.cleanup_blobs()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ZoneTransactionValidator
+// ---------------------------------------------------------------------------
+
+/// Transaction validator that enforces a [`ZoneTransactionPolicy`] on top of the standard
+/// Tempo validation pipeline.
+///
+/// The default implementations of `validate_transactions` and
+/// `validate_transactions_with_origin` delegate to `validate_transaction`, so the policy
+/// check applies to batch submissions as well.
+///
+/// **Note:** This validator is not currently wired into the node because
+/// [`TempoTransactionPool`] is hardcoded to [`TempoTransactionValidator`]. Use
+/// [`ZoneTransactionPool`] for the pool-level integration instead.
+#[derive(Debug)]
+pub struct ZoneTransactionValidator<Client> {
+    /// The inner Tempo validator that performs standard Ethereum + Tempo-specific
+    /// validation (nonce, balance, gas, AA authorizations, AMM liquidity, etc.).
+    inner: TempoTransactionValidator<Client>,
+    /// Policy applied before the inner validator runs — a failing check short-circuits
+    /// with [`TransactionValidationOutcome::Invalid`].
+    policy: ZoneTransactionPolicy,
+}
+
+impl<Client> ZoneTransactionValidator<Client> {
+    /// Create a new validator wrapping `inner` with the given `policy`.
+    pub fn new(inner: TempoTransactionValidator<Client>, policy: ZoneTransactionPolicy) -> Self {
+        Self { inner, policy }
+    }
+
+    /// Returns a reference to the inner [`TempoTransactionValidator`].
+    pub fn inner(&self) -> &TempoTransactionValidator<Client> {
+        &self.inner
+    }
+}
+
+impl<Client> TransactionValidator for ZoneTransactionValidator<Client>
+where
+    Client: reth_provider::ChainSpecProvider<ChainSpec = tempo_chainspec::spec::TempoChainSpec>
+        + reth_storage_api::StateProviderFactory,
+{
+    type Transaction = <TempoTransactionValidator<Client> as TransactionValidator>::Transaction;
+    type Block = <TempoTransactionValidator<Client> as TransactionValidator>::Block;
+
+    async fn validate_transaction(
+        &self,
+        origin: TransactionOrigin,
+        transaction: Self::Transaction,
+    ) -> TransactionValidationOutcome<Self::Transaction> {
+        if self.policy.deny_contract_creation && transaction.is_create() {
+            return TransactionValidationOutcome::Invalid(
+                transaction,
+                InvalidPoolTransactionError::other(ContractCreationDenied),
+            );
+        }
+        self.inner.validate_transaction(origin, transaction).await
+    }
+
+    fn on_new_head_block(&self, new_tip_block: &reth_primitives_traits::SealedBlock<Self::Block>) {
+        self.inner.on_new_head_block(new_tip_block)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+/// Error returned when a transaction attempts contract creation but the zone policy forbids it.
+#[derive(Debug, thiserror::Error)]
+#[error("contract creation transactions are not permitted by zone policy")]
+pub struct ContractCreationDenied;
+
+impl PoolTransactionError for ContractCreationDenied {
+    fn is_bad_transaction(&self) -> bool {
+        true
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/tempo-zone/src/pool.rs
+++ b/crates/tempo-zone/src/pool.rs
@@ -24,10 +24,6 @@ use reth_transaction_pool::{
 };
 use tempo_transaction_pool::{TempoTransactionPool, validator::TempoTransactionValidator};
 
-// ---------------------------------------------------------------------------
-// Policy
-// ---------------------------------------------------------------------------
-
 /// Policy flags that control which transaction types a zone accepts.
 ///
 /// Applied by [`ZoneTransactionPool`] on every submission and by
@@ -62,10 +58,6 @@ impl ZoneTransactionPolicy {
         None
     }
 }
-
-// ---------------------------------------------------------------------------
-// ZoneTransactionPool
-// ---------------------------------------------------------------------------
 
 /// Transaction pool wrapper that enforces a [`ZoneTransactionPolicy`] on every
 /// submission before delegating to the inner [`TempoTransactionPool`].
@@ -547,10 +539,6 @@ where
     }
 }
 
-// ---------------------------------------------------------------------------
-// ZoneTransactionValidator
-// ---------------------------------------------------------------------------
-
 /// Transaction validator that enforces a [`ZoneTransactionPolicy`] on top of the standard
 /// Tempo validation pipeline.
 ///
@@ -609,10 +597,6 @@ where
         self.inner.on_new_head_block(new_tip_block)
     }
 }
-
-// ---------------------------------------------------------------------------
-// Error
-// ---------------------------------------------------------------------------
 
 /// Error returned when a transaction attempts contract creation but the zone policy forbids it.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Adds a `ZoneTransactionPool` wrapper around `TempoTransactionPool` that enforces a configurable `ZoneTransactionPolicy` on every transaction submission. The default policy rejects contract creation (`CREATE`/`CREATE2`) transactions.

### Changes

- **`pool.rs`** — new module with `ZoneTransactionPolicy`, `ZoneTransactionPool` (full `TransactionPool` + `TransactionPoolExt` delegation with policy checks on the `add_*` methods), `ZoneTransactionValidator` (validator-layer alternative for when `TempoTransactionPool` is made generic), and `ContractCreationDenied` error type.
- **`node.rs`** — `ZonePoolBuilder` now carries a `ZoneTransactionPolicy` field and returns `ZoneTransactionPool` from `build_pool`. The inner `TempoTransactionPool` is passed to `maintain_tempo_pool` via `tempo_pool()`.
- **`builder.rs`** — `ZonePayloadFactory` and `ZonePayloadBuilder` updated to use `ZoneTransactionPool`.