### PR TITLE
xtask: make CreateX and SafeDeployer opt-in at genesis

### DIFF
--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -194,6 +194,8 @@ impl CreateZone {
             tempo_genesis_header_rlp: header_rlp_hex,
             sequencer: Some(self.sequencer),
             specs_out: self.specs_out.clone(),
+            with_createx: true,
+            with_safe_deployer: true,
         };
         genesis_cmd.run().await?;
 

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -196,6 +196,7 @@ impl CreateZone {
             specs_out: self.specs_out.clone(),
             with_createx: true,
             with_safe_deployer: true,
+            with_create2_factory: true,
         };
         genesis_cmd.run().await?;
 

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -86,6 +86,12 @@ pub(crate) struct GenerateZoneGenesis {
     /// Include Safe Singleton Factory in genesis.
     #[arg(long)]
     pub(crate) with_safe_deployer: bool,
+
+    /// Include Arachnid CREATE2 factory in genesis.
+    /// The factory is always used internally to deploy Permit2; this flag
+    /// controls whether it remains in the final genesis state.
+    #[arg(long)]
+    pub(crate) with_create2_factory: bool,
 }
 
 #[derive(serde::Deserialize)]
@@ -226,6 +232,9 @@ impl GenerateZoneGenesis {
             .accounts
             .iter()
             .filter(|(addr, _)| **addr != DEPLOYER)
+            .filter(|(addr, _)| {
+                self.with_create2_factory || **addr != ARACHNID_CREATE2_FACTORY_ADDRESS
+            })
             .map(|(address, account)| {
                 let storage: Option<BTreeMap<_, _>> = if !account.storage.is_empty() {
                     Some(

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -78,6 +78,14 @@ pub(crate) struct GenerateZoneGenesis {
 
     #[arg(long, default_value = "docs/specs/out")]
     pub(crate) specs_out: PathBuf,
+
+    /// Include CreateX factory in genesis.
+    #[arg(long)]
+    pub(crate) with_createx: bool,
+
+    /// Include Safe Singleton Factory in genesis.
+    #[arg(long)]
+    pub(crate) with_safe_deployer: bool,
 }
 
 #[derive(serde::Deserialize)]
@@ -256,22 +264,26 @@ impl GenerateZoneGenesis {
                 ..Default::default()
             },
         );
-        genesis_alloc.insert(
-            CREATEX_ADDRESS,
-            GenesisAccount {
-                code: Some(Bytes::from_static(&CreateX::DEPLOYED_BYTECODE)),
-                nonce: Some(1),
-                ..Default::default()
-            },
-        );
-        genesis_alloc.insert(
-            SAFE_DEPLOYER_ADDRESS,
-            GenesisAccount {
-                code: Some(Bytes::from_static(&SafeDeployer::DEPLOYED_BYTECODE)),
-                nonce: Some(1),
-                ..Default::default()
-            },
-        );
+        if self.with_createx {
+            genesis_alloc.insert(
+                CREATEX_ADDRESS,
+                GenesisAccount {
+                    code: Some(Bytes::from_static(&CreateX::DEPLOYED_BYTECODE)),
+                    nonce: Some(1),
+                    ..Default::default()
+                },
+            );
+        }
+        if self.with_safe_deployer {
+            genesis_alloc.insert(
+                SAFE_DEPLOYER_ADDRESS,
+                GenesisAccount {
+                    code: Some(Bytes::from_static(&SafeDeployer::DEPLOYED_BYTECODE)),
+                    nonce: Some(1),
+                    ..Default::default()
+                },
+            );
+        }
 
         if let Some(sequencer) = self.sequencer {
             genesis_alloc.entry(sequencer).or_default().balance =


### PR DESCRIPTION
Add `--with-createx` and `--with-safe-deployer` flags to `generate-zone-genesis`. Both default to false so these contracts are no longer included unless explicitly requested. `create-zone` passes both flags to preserve existing behavior.