### PR TITLE
fix(zone): handle missing portal block hash and spawn monitor as critical task

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -118,8 +118,8 @@ fn main() {
             // Disable the auth (Engine API) server — the zone node derives blocks
             // from L1, so no external consensus client or Engine API is needed.
             builder.config_mut().rpc.disable_auth_server = true;
-            // Allow up to 100k log entries per `eth_getLogs` response (default is 20k).
-            builder.config_mut().rpc.rpc_max_logs_per_response = 100_000u64.into();
+            builder.config_mut().rpc.rpc_max_logs_per_response = 1_000_000u64.into();
+            builder.config_mut().rpc.rpc_max_blocks_per_filter = 1_000_000u64.into();
 
             // Parse the sequencer key to derive the address for block building
             // and the k256 secret key for ECIES decryption of encrypted deposits.
@@ -193,8 +193,8 @@ fn main() {
                 "Sequencer tasks spawned: zone monitor (with batch submission), withdrawal processor"
             );
 
-            // If any sequencer task exits, log it.
-            tokio::spawn(async move {
+            // Spawn as critical tasks — node shuts down if either exits.
+            handle.node.task_executor.spawn_critical("zone-monitor", async move {
                 tokio::select! {
                     res = seq_handle.withdrawal_handle => {
                         tracing::error!(target: "reth::cli", ?res, "Withdrawal processor task exited");

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -134,12 +134,12 @@ impl ZoneMonitor {
         let inbox = ZoneInbox::new(config.inbox_address, provider.clone());
         let tempo_state = TempoState::new(config.tempo_state_address, provider.clone());
 
-        let portal_for_init = ZonePortal::new(config.portal_address, l1_provider.clone());
-        let genesis_tempo_block_number: u64 = portal_for_init
-            .genesisTempoBlockNumber()
-            .call()
-            .await
-            .expect("failed to read genesisTempoBlockNumber");
+        let genesis_tempo_block_number: u64 =
+            ZonePortal::new(config.portal_address, l1_provider.clone())
+                .genesisTempoBlockNumber()
+                .call()
+                .await
+                .expect("failed to read genesisTempoBlockNumber");
 
         let batch_submitter = BatchSubmitter::new(
             config.portal_address,
@@ -158,12 +158,25 @@ impl ZoneMonitor {
         let last_submitted_zone_block = if prev_zone_block_hash.is_zero() {
             0
         } else {
-            let block = provider
-                .get_block_by_hash(prev_zone_block_hash)
-                .await
-                .expect("failed to look up zone block by hash from portal")
-                .expect("portal blockHash not found on zone L2 — chain mismatch?");
-            block.number()
+            match provider.get_block_by_hash(prev_zone_block_hash).await {
+                Ok(Some(block)) => block.number(),
+                Ok(None) => {
+                    warn!(
+                        %prev_zone_block_hash,
+                        "Portal blockHash not found on zone L2 — zone may have been reset. \
+                         Starting from genesis."
+                    );
+                    0
+                }
+                Err(e) => {
+                    warn!(
+                        %prev_zone_block_hash,
+                        error = %e,
+                        "Failed to look up zone block by hash, starting from genesis"
+                    );
+                    0
+                }
+            }
         };
 
         let prev_processed_deposit_hash = if last_submitted_zone_block == 0 {


### PR DESCRIPTION
- Gracefully handle portal `blockHash()` not found on zone L2 (e.g. after zone reset) by falling back to genesis instead of panicking the task.
- Spawn sequencer tasks via `task_executor.spawn_critical` so the node shuts down if the zone monitor or withdrawal processor exits unexpectedly.