### PR TITLE
refactor(zone): L1-driven engine with peek/confirm and zone-specific payload types

### DIFF
--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -7,6 +7,7 @@ use crate::{
     abi::{self, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS},
     evm::ZoneEvmConfig,
     l1::L1Deposit,
+    payload::ZonePayloadBuilderAttributes,
     precompiles::ecies,
 };
 use alloy_consensus::{Signed, TxLegacy};
@@ -37,7 +38,6 @@ use std::{sync::Arc, time::Instant};
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
 use tempo_evm::TempoNextBlockEnvAttributes;
-use tempo_payload_types::TempoPayloadBuilderAttributes;
 use tempo_primitives::{
     TempoHeader, TempoPrimitives, TempoTxEnvelope,
     transaction::envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
@@ -51,7 +51,6 @@ use super::node::ZoneNode;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ZonePayloadFactory {
-    deposit_queue: crate::DepositQueue,
     sequencer: Address,
     /// Sequencer's secp256k1 secret key for ECIES decryption of encrypted deposits.
     sequencer_key: k256::SecretKey,
@@ -61,13 +60,11 @@ pub struct ZonePayloadFactory {
 
 impl ZonePayloadFactory {
     pub fn new(
-        deposit_queue: crate::DepositQueue,
         sequencer: Address,
         sequencer_key: k256::SecretKey,
         portal_address: Address,
     ) -> Self {
         Self {
-            deposit_queue,
             sequencer,
             sequencer_key,
             portal_address,
@@ -92,7 +89,6 @@ where
             pool,
             provider: ctx.provider().clone(),
             evm_config,
-            deposit_queue: self.deposit_queue,
             _sequencer: self.sequencer,
             sequencer_key: self.sequencer_key,
             portal_address: self.portal_address,
@@ -105,7 +101,6 @@ pub struct ZonePayloadBuilder<Provider> {
     pool: TempoTransactionPool<Provider>,
     provider: Provider,
     evm_config: ZoneEvmConfig,
-    deposit_queue: crate::DepositQueue,
     _sequencer: Address,
     sequencer_key: k256::SecretKey,
     portal_address: Address,
@@ -116,7 +111,6 @@ impl<Provider> ZonePayloadBuilder<Provider> {
         pool: TempoTransactionPool<Provider>,
         provider: Provider,
         evm_config: ZoneEvmConfig,
-        deposit_queue: crate::DepositQueue,
         sequencer: Address,
         sequencer_key: k256::SecretKey,
         portal_address: Address,
@@ -125,7 +119,6 @@ impl<Provider> ZonePayloadBuilder<Provider> {
             pool,
             provider,
             evm_config,
-            deposit_queue,
             _sequencer: sequencer,
             sequencer_key,
             portal_address,
@@ -138,7 +131,7 @@ where
     Provider:
         StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + Clone + 'static,
 {
-    type Attributes = TempoPayloadBuilderAttributes;
+    type Attributes = ZonePayloadBuilderAttributes;
     type BuiltPayload = EthBuiltPayload<TempoPrimitives>;
 
     fn try_build(
@@ -192,19 +185,7 @@ where
             "TempoState current state"
         );
 
-        // Take exactly one L1 block per zone block — advanceTempo advances Tempo state
-        // by exactly one block, maintaining sequential chain continuity.
-        // The ZoneEngine ensures an L1 block is queued before triggering a build.
-        let l1_block = {
-            let mut queue = self.deposit_queue.lock();
-            let Some(block) = queue.pop_next() else {
-                debug!(target: "zone::payload", "No L1 block available, skipping build");
-                return Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
-                    "no L1 block available in deposit queue",
-                )));
-            };
-            block
-        };
+        let l1_block = attributes.l1_block().clone();
 
         // Validate chain continuity: the L1 block must be exactly tempoBlockNumber + 1
         // and its parent hash must match the stored tempoBlockHash.
@@ -308,7 +289,7 @@ where
                         gas_limit: block_gas_limit,
                         parent_beacon_block_root: attributes.parent_beacon_block_root(),
                         withdrawals: Some(attributes.withdrawals().clone()),
-                        extra_data: attributes.extra_data().clone(),
+                        extra_data: attributes.extra_data(),
                     },
                     general_gas_limit,
                     shared_gas_limit,

--- a/crates/tempo-zone/src/engine.rs
+++ b/crates/tempo-zone/src/engine.rs
@@ -1,56 +1,94 @@
 //! Zone Engine — L1-event-driven block production for zone nodes.
 //!
-//! Replaces reth's `LocalMiner` with an engine that advances the zone chain
-//! whenever new L1 blocks arrive in the deposit queue, enabling full-speed
-//! sync during catch-up and instant reaction in steady state.
+//! Advances the zone chain whenever new L1 blocks arrive in the deposit
+//! queue, enabling full-speed sync during catch-up and instant reaction in
+//! steady state.
+//!
+//! ## Block production flow
+//!
+//! ```text
+//! L1Subscriber ──enqueue──► DepositQueue ──notify──► ZoneEngine
+//!                                │                       │
+//!                                │                   1. peek queue → L1 block
+//!                                │                   2. build ZonePayloadAttributes
+//!                                │                      (inner attrs + l1_block)
+//!                                │                   3. FCU w/ payload attributes
+//!                                │                       │
+//!                                │                       ▼
+//!                                │               reth payload service
+//!                                │                       │
+//!                                │               4. build payload
+//!                                │                  (L1 data from attributes)
+//!                                │                       │
+//!                                │                       ▼
+//!                                │                  ZoneEngine
+//!                                │               5. resolve payload
+//!                                │               6. newPayload
+//!                                │               7. FCU (update head)
+//!                                │                       │
+//!                                ◄── confirm ◄───────────┘
+//! ```
+//!
+//! The deposit queue uses a **peek / confirm** pattern: the engine peeks at
+//! the next L1 block, wraps it into [`ZonePayloadAttributes`], and only
+//! confirms (removes) the block after `newPayload` succeeds. A failed build
+//! leaves the block in the queue for retry.
+//!
+//! The zone assumes **instant finality** — head, safe, and finalized all point
+//! to the same block.
 
 use alloy_consensus::BlockHeader as _;
-use alloy_primitives::B256;
-use alloy_rpc_types_engine::ForkchoiceState;
+use alloy_primitives::{Address, B256};
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes as EthPayloadAttributes};
 use eyre::OptionExt;
+use reth_chainspec::EthereumHardforks;
 use reth_node_builder::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_payload_primitives::{
-    BuiltPayload, EngineApiMessageVersion, PayloadAttributesBuilder, PayloadKind, PayloadTypes,
-};
-use reth_primitives_traits::{HeaderTy, SealedHeaderFor};
+use reth_payload_primitives::{EngineApiMessageVersion, PayloadKind, PayloadTypes};
+use reth_primitives_traits::SealedHeader;
+use reth_provider::ChainSpecProvider;
 use reth_storage_api::BlockReader;
-use std::{collections::VecDeque, time::Duration};
-use tracing::error;
+use std::{sync::Arc, time::Duration};
+use tempo_chainspec::spec::TempoChainSpec;
+use tempo_primitives::TempoHeader;
+use tracing::{error, warn};
 
-use crate::DepositQueue;
+use crate::{
+    DepositQueue, L1BlockDeposits,
+    payload::{ZonePayloadAttributes, ZonePayloadTypes},
+};
 
-/// Engine that drives L2 block production on L1 events
+/// Engine that drives L2 block production from L1 events.
+///
+/// Waits for L1 blocks in the [`DepositQueue`], then for each block:
+/// 1. Peeks the L1 block from the queue
+/// 2. Builds [`ZonePayloadAttributes`] wrapping inner Tempo attrs + L1 data
+/// 3. Sends FCU with payload attributes to start a build
+/// 4. Resolves the built payload
+/// 5. Submits via `newPayload`
+/// 6. Confirms the L1 block in the queue (removes it)
+///
+/// On failure the L1 block stays in the queue and is retried.
 #[derive(Debug)]
-pub struct ZoneEngine<T: PayloadTypes, B> {
-    /// Attributes builder for Zone blocks
-    payload_attributes_builder: B,
+pub struct ZoneEngine {
+    /// Chain spec for hardfork checks when building attributes.
+    chain_spec: Arc<TempoChainSpec>,
     /// Engine API handle for FCU and newPayload.
-    // FIXME: do we need the cl handle, fcu new payload
-    to_engine: ConsensusEngineHandle<T>,
+    to_engine: ConsensusEngineHandle<ZonePayloadTypes>,
     /// Payload builder handle.
-    payload_builder: PayloadBuilderHandle<T>,
-    /// Queue of deposit txs from L1
+    payload_builder: PayloadBuilderHandle<ZonePayloadTypes>,
+    /// Queue of L1 blocks with their deposits.
     deposit_queue: DepositQueue,
-    /// Latest block header on L1
-    last_header: SealedHeaderFor<<T::BuiltPayload as BuiltPayload>::Primitives>,
-    /// Recent block hashes for forkchoice state
-    last_block_hashes: VecDeque<B256>,
+    /// Latest block header — used as parent for the next payload and as the
+    /// head/safe/finalized hash in FCU (instant finality).
+    last_header: SealedHeader<TempoHeader>,
 }
 
-impl<T, B> ZoneEngine<T, B>
-where
-    T: PayloadTypes,
-    B: PayloadAttributesBuilder<
-            T::PayloadAttributes,
-            HeaderTy<<T::BuiltPayload as BuiltPayload>::Primitives>,
-        >,
-{
+impl ZoneEngine {
     pub fn new(
-        provider: impl BlockReader<Header = HeaderTy<<T::BuiltPayload as BuiltPayload>::Primitives>>,
-        payload_attributes_builder: B,
-        to_engine: ConsensusEngineHandle<T>,
-        payload_builder: PayloadBuilderHandle<T>,
+        provider: impl BlockReader<Header = TempoHeader> + ChainSpecProvider<ChainSpec = TempoChainSpec>,
+        to_engine: ConsensusEngineHandle<ZonePayloadTypes>,
+        payload_builder: PayloadBuilderHandle<ZonePayloadTypes>,
         deposit_queue: DepositQueue,
     ) -> Self {
         let last_header = provider
@@ -59,17 +97,15 @@ where
             .unwrap();
 
         Self {
-            payload_attributes_builder,
+            chain_spec: provider.chain_spec(),
             to_engine,
             payload_builder,
             deposit_queue,
-            last_block_hashes: VecDeque::from([last_header.hash()]),
             last_header,
         }
     }
 
-    /// Runs the main Zone engine loop
-    ///
+    /// Runs the main Zone engine loop.
     ///
     /// This method never returns under normal operation. It:
     /// 1. Waits for L1 blocks to arrive in the deposit queue
@@ -77,6 +113,7 @@ where
     /// 3. Sends periodic FCU heartbeats
     pub async fn run(mut self) {
         let mut fcu_interval = tokio::time::interval(Duration::from_secs(1));
+        fcu_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         // Send initial FCU to establish head
         if let Err(e) = self.update_forkchoice_state().await {
@@ -89,12 +126,10 @@ where
                 _ = self.deposit_queue.notified() => {
                     self.advance_all_available().await;
                 }
-                // Periodic FCU heartbeat
+                // Periodic FCU heartbeat — also drains any blocks we missed
                 _ = fcu_interval.tick() => {
-                    // Also check if there are confirmed blocks (in case we missed a notify)
-                    if self.deposit_queue.pending_count() > 0 {
-                        self.advance_all_available().await;
-                    } else if let Err(e) = self.update_forkchoice_state().await {
+                    self.advance_all_available().await;
+                    if let Err(e) = self.update_forkchoice_state().await {
                         error!(target: "zone::engine", "Error updating fork choice: {:?}", e);
                     }
                 }
@@ -102,40 +137,11 @@ where
         }
     }
 
-    /// Advance the chain for all available L1 blocks in the queue.
-    ///
-    /// This is the key difference from `LocalMiner`: during catch-up, this
-    /// processes blocks as fast as the EVM can execute them, with no timer
-    /// delays between blocks.
-    ///
-    /// Reorg safety is handled upstream by the L1 subscriber, which only
-    /// enqueues blocks once they are confirmed by a successor.
-    async fn advance_all_available(&mut self) {
-        while self.deposit_queue.pending_count() > 0 {
-            if let Err(e) = self.advance().await {
-                error!(target: "zone::engine", "Error advancing the chain: {:?}", e);
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                break;
-            }
-        }
-    }
-
     /// Returns the current forkchoice state.
+    ///
+    /// The zone has instant finality so head = safe = finalized.
     fn forkchoice_state(&self) -> ForkchoiceState {
-        ForkchoiceState {
-            head_block_hash: *self
-                .last_block_hashes
-                .back()
-                .expect("at least 1 block exists"),
-            safe_block_hash: *self
-                .last_block_hashes
-                .get(self.last_block_hashes.len().saturating_sub(32))
-                .expect("at least 1 block exists"),
-            finalized_block_hash: *self
-                .last_block_hashes
-                .get(self.last_block_hashes.len().saturating_sub(64))
-                .expect("at least 1 block exists"),
-        }
+        ForkchoiceState::same_hash(self.last_header.hash())
     }
 
     /// Send an FCU without payload attributes (heartbeat).
@@ -153,16 +159,63 @@ where
         Ok(())
     }
 
+    /// Advance the chain for all available L1 blocks in the queue.
+    ///
+    /// During catch-up this processes blocks as fast as the EVM can execute
+    /// them, with no timer delays between blocks.
+    ///
+    /// Reorg safety is handled upstream by the L1 subscriber, which only
+    /// enqueues blocks once they are confirmed by a successor.
+    async fn advance_all_available(&mut self) {
+        while let Some(l1_block) = self.deposit_queue.peek() {
+            if let Err(e) = self.advance(l1_block).await {
+                error!(target: "zone::engine", "Error advancing the chain: {:?}", e);
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                break;
+            }
+        }
+    }
+
     /// Advance the chain by one block.
     ///
-    /// Sends FCU with payload attributes, waits for the payload to be built,
-    /// then submits it via newPayload and updates the head.
-    async fn advance(&mut self) -> eyre::Result<()> {
+    /// Wraps the given L1 block into [`ZonePayloadAttributes`], sends FCU
+    /// with those attributes, waits for the payload to be built, then submits
+    /// via `newPayload`. Only confirms (removes) the L1 block from the
+    /// deposit queue after `newPayload` succeeds.
+    async fn advance(&mut self, l1_block: L1BlockDeposits) -> eyre::Result<()> {
+        let l1_num_hash = l1_block.header.num_hash();
+
+        // Zone block timestamp is locked to the L1 block's timestamp so the
+        // two chains stay in lockstep.
+        let timestamp_secs = l1_block.header.timestamp();
+        let timestamp_millis_part = l1_block.header.timestamp_millis_part;
+
+        let attributes = ZonePayloadAttributes {
+            inner: EthPayloadAttributes {
+                timestamp: timestamp_secs,
+                prev_randao: B256::ZERO,
+                suggested_fee_recipient: Address::ZERO,
+                withdrawals: self
+                    .chain_spec
+                    .is_shanghai_active_at_timestamp(timestamp_secs)
+                    .then(Default::default),
+                parent_beacon_block_root: self
+                    .chain_spec
+                    .is_cancun_active_at_timestamp(timestamp_secs)
+                    .then_some(B256::ZERO),
+            },
+            timestamp_millis_part,
+            l1_block,
+        };
+
+        // Send FCU with payload attributes through the engine API to trigger
+        // payload building. The forkchoice state points at the current head;
+        // the attributes carry the L1 block data for the new zone block.
         let res = self
             .to_engine
             .fork_choice_updated(
                 self.forkchoice_state(),
-                Some(self.payload_attributes_builder.build(&self.last_header)),
+                Some(attributes),
                 EngineApiMessageVersion::default(),
             )
             .await?;
@@ -183,18 +236,28 @@ where
 
         let header = payload.block().sealed_header().clone();
         let block_number = header.number();
-        let payload = T::block_to_payload(payload.block().clone());
+        let payload = ZonePayloadTypes::block_to_payload(payload.block().clone());
         let res = self.to_engine.new_payload(payload).await?;
 
         if !res.is_valid() {
             eyre::bail!("Invalid payload for block {block_number}")
         }
 
-        self.last_block_hashes.push_back(header.hash());
+        // newPayload succeeded — confirm the L1 block in the queue so it is
+        // removed. If the queue was reorged between peek and confirm, the
+        // block was already purged; log a warning but still update
+        // last_header since the zone chain has advanced.
+        if self.deposit_queue.confirm(l1_num_hash).is_none() {
+            warn!(target: "zone::engine", ?l1_num_hash, "L1 block was purged from queue during build");
+        }
+
         self.last_header = header;
-        // Keep at most 64 blocks
-        if self.last_block_hashes.len() > 64 {
-            self.last_block_hashes.pop_front();
+
+        // Canonicalize the new head — FCU-with-attrs above only set the
+        // *previous* head as canonical; this bare FCU makes the just-built
+        // block the EL's canonical head.
+        if let Err(e) = self.update_forkchoice_state().await {
+            error!(target: "zone::engine", "Error sending post-newPayload FCU: {:?}", e);
         }
 
         Ok(())

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -386,7 +386,7 @@ impl L1Subscriber {
 }
 
 /// A deposit extracted from L1.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Deposit {
     /// L1 block number where the deposit was included.
     pub l1_block_number: u64,
@@ -423,7 +423,7 @@ impl Deposit {
 }
 
 /// An encrypted deposit extracted from L1.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EncryptedDeposit {
     /// L1 block number where the deposit was included.
     pub l1_block_number: u64,
@@ -472,7 +472,7 @@ impl EncryptedDeposit {
 }
 
 /// A deposit from L1 — either regular (plaintext) or encrypted.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum L1Deposit {
     /// A regular deposit with plaintext recipient and memo.
     Regular(Deposit),
@@ -535,7 +535,7 @@ pub enum EnqueueOutcome {
 }
 
 /// An L1 block's header paired with the deposits found in that block.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct L1BlockDeposits {
     /// The sealed L1 block header (caches the block hash).
     pub header: SealedHeader<TempoHeader>,
@@ -555,8 +555,8 @@ pub struct L1BlockDeposits {
 /// This mirrors the L1 portal's `currentDepositQueueHash`.
 #[derive(Debug)]
 pub struct PendingDeposits {
-    /// Deposit hash chain value after the last block consumed by the builder
-    /// via `pop_next` or `drain`. Serves as the rollback anchor when purging
+    /// Deposit hash chain value after the last block consumed by the engine
+    /// via `confirm` or `drain`. Serves as the rollback anchor when purging
     /// blocks during a reorg.
     processed_head_hash: B256,
     /// Deposit hash chain value after applying all pending deposits. Advances
@@ -565,11 +565,11 @@ pub struct PendingDeposits {
     enqueued_head_hash: B256,
     /// Pending L1 blocks with their deposits, not yet processed by the zone
     pending: Vec<L1BlockDeposits>,
-    /// Highest L1 block ever enqueued (number + hash). Survives `pop_next` /
+    /// Highest L1 block ever enqueued (number + hash). Survives `confirm` /
     /// `drain` so that reconnecting subscribers know where the queue left off,
     /// even if the engine has already consumed the blocks.
     last_enqueued: Option<NumHash>,
-    /// Last L1 block consumed by the engine via `pop_next` or `drain`.
+    /// Last L1 block consumed by the engine via `confirm` or `drain`.
     /// Used as a floor during reorg backfill to prevent re-offering blocks
     /// the zone has already built into zone blocks.
     last_processed: Option<NumHash>,
@@ -750,26 +750,39 @@ impl PendingDeposits {
         self.last_enqueued = self.pending.last().map(|e| e.header.num_hash());
     }
 
-    /// Take the next pending L1 block (oldest first).
+    /// Peek at the next pending L1 block without removing it.
     ///
-    /// Returns `None` if no L1 blocks are queued. The zone builder calls this once per zone
-    /// block to advance Tempo state by exactly one L1 block at a time.
-    pub fn pop_next(&mut self) -> Option<L1BlockDeposits> {
-        if self.pending.is_empty() {
-            None
-        } else {
-            let block = self.pending.remove(0);
-            self.processed_head_hash = block.queue_hash_after;
-            // Keep last_processed monotonic — never regress the floor.
-            let num_hash = block.header.num_hash();
-            if self
-                .last_processed
-                .is_none_or(|lp| num_hash.number > lp.number)
-            {
-                self.last_processed = Some(num_hash);
-            }
-            Some(block)
+    /// Returns `None` if no L1 blocks are queued. Use [`confirm`](Self::confirm)
+    /// after a successful build to advance the queue.
+    pub fn peek(&self) -> Option<&L1BlockDeposits> {
+        self.pending.first()
+    }
+
+    /// Confirm the next pending L1 block was successfully processed and remove it.
+    ///
+    /// The caller must pass the [`NumHash`] of the block being confirmed. If the
+    /// front of the queue no longer matches (e.g. because a reorg purged it
+    /// between `peek` and `confirm`), this returns `None` and the queue is left
+    /// unchanged.
+    ///
+    /// Must be called after a successful payload build + newPayload acceptance.
+    /// Advances `processed_head_hash` and `last_processed`.
+    pub fn confirm(&mut self, expected: NumHash) -> Option<L1BlockDeposits> {
+        let front = self.pending.first()?;
+        if front.header.num_hash() != expected {
+            return None;
         }
+        let block = self.pending.remove(0);
+        self.processed_head_hash = block.queue_hash_after;
+        // Keep last_processed monotonic — never regress the floor.
+        let num_hash = block.header.num_hash();
+        if self
+            .last_processed
+            .is_none_or(|lp| num_hash.number > lp.number)
+        {
+            self.last_processed = Some(num_hash);
+        }
+        Some(block)
     }
 
     /// Drain all pending L1 block deposits.
@@ -891,9 +904,17 @@ impl DepositQueue {
         self.notify.notify_one();
     }
 
-    /// Pop the next L1 block from the queue.
-    pub fn pop_next(&self) -> Option<L1BlockDeposits> {
-        self.inner.lock().pop_next()
+    /// Peek at the next L1 block without removing it.
+    pub fn peek(&self) -> Option<L1BlockDeposits> {
+        self.inner.lock().peek().cloned()
+    }
+
+    /// Confirm the next L1 block was successfully processed and remove it.
+    ///
+    /// Returns `None` if the front of the queue no longer matches `expected`
+    /// (e.g. a reorg purged it between `peek` and `confirm`).
+    pub fn confirm(&self, expected: NumHash) -> Option<L1BlockDeposits> {
+        self.inner.lock().confirm(expected)
     }
 
     /// Returns the number of pending L1 blocks.
@@ -913,7 +934,7 @@ impl DepositQueue {
 
     /// Returns the most recently enqueued L1 block (number + hash), if any.
     ///
-    /// This is a high-water mark that survives `pop_next` / `drain`, so it
+    /// This is a high-water mark that survives `confirm` / `drain`, so it
     /// reflects the last block ever enqueued — not just what's still pending.
     pub fn last_enqueued(&self) -> Option<NumHash> {
         self.inner.lock().last_enqueued()
@@ -966,6 +987,18 @@ mod tests {
 
     fn header_hash(header: &TempoHeader) -> B256 {
         keccak256(alloy_rlp::encode(header))
+    }
+
+    /// Confirm the front of the queue, panicking if it fails.
+    fn confirm(queue: &mut PendingDeposits) -> L1BlockDeposits {
+        let num_hash = queue.peek().expect("queue is empty").header.num_hash();
+        queue.confirm(num_hash).expect("confirm mismatch")
+    }
+
+    /// Confirm the front of a shared `DepositQueue`, panicking if it fails.
+    fn confirm_shared(queue: &DepositQueue) -> L1BlockDeposits {
+        let num_hash = queue.peek().expect("queue is empty").header.num_hash();
+        queue.confirm(num_hash).expect("confirm mismatch")
     }
 
     #[test]
@@ -1301,14 +1334,17 @@ mod tests {
         let last = queue.last_enqueued().unwrap();
         assert_eq!(last.number, 102);
 
-        // Pop all blocks — last_enqueued must still report 102
-        assert!(queue.pop_next().is_some());
-        assert!(queue.pop_next().is_some());
-        assert!(queue.pop_next().is_some());
-        assert!(queue.pop_next().is_none());
+        // Confirm all blocks — last_enqueued must still report 102
+        assert!(queue.peek().is_some());
+        confirm_shared(&queue);
+        assert!(queue.peek().is_some());
+        confirm_shared(&queue);
+        assert!(queue.peek().is_some());
+        confirm_shared(&queue);
+        assert!(queue.peek().is_none());
 
         let last = queue.last_enqueued().unwrap();
-        assert_eq!(last.number, 102, "last_enqueued must survive pop_next");
+        assert_eq!(last.number, 102, "last_enqueued must survive confirm");
 
         // Enqueue more (continuing from 102), then drain — last_enqueued must still track
         let h102_hash = last.hash;
@@ -1535,10 +1571,11 @@ mod tests {
 
         let hash_after_all = queue.enqueued_head_hash();
 
-        // Pop block 1
-        let popped = queue.pop_next().unwrap();
-        assert_eq!(popped.header.number(), 1);
-        assert_eq!(queue.processed_head_hash, popped.queue_hash_after);
+        // Confirm block 1
+        let peeked = queue.peek().unwrap().clone();
+        assert_eq!(peeked.header.number(), 1);
+        confirm(&mut queue);
+        assert_eq!(queue.processed_head_hash, peeked.queue_hash_after);
 
         // queue.enqueued_head_hash() hasn't changed
         assert_eq!(queue.enqueued_head_hash(), hash_after_all);
@@ -1578,8 +1615,8 @@ mod tests {
         queue.enqueue(h5, vec![]);
 
         // Pop blocks 1 and 2
-        queue.pop_next().unwrap();
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
+        confirm(&mut queue);
         assert_eq!(queue.pending_len(), 3); // blocks 3, 4, 5
 
         let hash_after_block3 = queue.pending_block(0).unwrap().queue_hash_after;
@@ -1617,7 +1654,7 @@ mod tests {
         queue.enqueue(h3, vec![make_deposit(3, 300)]);
 
         // Pop block 1 — processed_head_hash advances
-        let popped = queue.pop_next().unwrap();
+        let popped = confirm(&mut queue);
         let base_after_pop = popped.queue_hash_after;
         assert_eq!(queue.processed_head_hash, base_after_pop);
         assert_eq!(queue.pending_len(), 2); // blocks 2, 3
@@ -1755,8 +1792,8 @@ mod tests {
         ));
 
         // Drain everything
-        queue.pop_next().unwrap();
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
+        confirm(&mut queue);
         assert!(queue.pending_len() == 0);
         assert_eq!(queue.last_enqueued().unwrap().number, 11);
 
@@ -1823,7 +1860,7 @@ mod tests {
         ));
 
         // Pop only block 10
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
         assert_eq!(queue.pending_len(), 2); // blocks 11, 12
 
         // Block 13 with wrong parent — this is a normal parent mismatch on the
@@ -1850,7 +1887,7 @@ mod tests {
         ));
 
         // Drain
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
         assert!(queue.pending_len() == 0);
 
         // Wrong parent → NeedBackfill
@@ -1881,7 +1918,7 @@ mod tests {
         ));
 
         // Drain
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
 
         // Block 14 arrives — gap of 11..13 plus wrong parent is moot because
         // the gap check triggers first
@@ -1913,8 +1950,8 @@ mod tests {
         ));
 
         // Drain everything
-        queue.pop_next().unwrap();
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
+        confirm(&mut queue);
         assert!(queue.pending_len() == 0);
 
         // Re-deliver block 10 or 11 — should be Duplicate
@@ -1939,7 +1976,7 @@ mod tests {
         ));
 
         // Pop and record processed_head_hash
-        let popped = queue.pop_next().unwrap();
+        let popped = confirm(&mut queue);
         let base = queue.processed_head_hash;
         assert_eq!(base, popped.queue_hash_after);
 
@@ -1971,7 +2008,7 @@ mod tests {
         queue.enqueue(h1.clone(), vec![]);
 
         // Drain
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
         assert!(queue.pending_len() == 0);
         assert_eq!(queue.last_enqueued().unwrap().number, 10);
 
@@ -2082,8 +2119,8 @@ mod tests {
         queue.enqueue(h11.clone(), vec![]);
 
         // Drain
-        queue.pop_next().unwrap();
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
+        confirm(&mut queue);
 
         // Re-deliver block 11 with same hash — Duplicate, last_enqueued intact
         assert!(matches!(
@@ -2108,11 +2145,11 @@ mod tests {
         let h2 = make_chained_header(11, h1_hash);
         queue.enqueue(h2, vec![]);
 
-        let popped = queue.pop_next().unwrap();
+        let popped = confirm(&mut queue);
         assert_eq!(queue.last_processed().unwrap().number, 10);
         assert_eq!(queue.last_processed().unwrap().hash, popped.header.hash());
 
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
         assert_eq!(queue.last_processed().unwrap().number, 11);
     }
 
@@ -2154,8 +2191,8 @@ mod tests {
         queue.enqueue(h11, vec![]);
 
         // Engine consumes both blocks
-        queue.pop_next().unwrap(); // block 10
-        queue.pop_next().unwrap(); // block 11
+        confirm(&mut queue); // block 10
+        confirm(&mut queue); // block 11
         assert!(queue.pending_len() == 0);
         assert_eq!(queue.last_processed().unwrap().number, 11);
         assert_eq!(queue.last_enqueued().unwrap().number, 11);
@@ -2205,7 +2242,7 @@ mod tests {
         let h10 = make_test_header(10);
         let _h10_hash = header_hash(&h10);
         queue.enqueue(h10, vec![]);
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
 
         // Simulate last_enqueued being cleared (reorg path)
         queue.clear_last_enqueued();
@@ -2238,11 +2275,12 @@ mod tests {
         queue.enqueue(h11, vec![]);
 
         // Builder expects block 11 (tempoBlockNumber=10, expected=11).
-        // Pop loop should skip block 10 and return block 11.
+        // Peek/confirm loop should skip block 10 and use the correct one.
         let expected = 11u64;
         let l1_block = loop {
-            let block = queue.pop_next().expect("queue should not be empty");
+            let block = queue.peek().expect("queue should not be empty");
             if block.header.number() < expected {
+                confirm_shared(&queue);
                 continue;
             }
             break block;
@@ -2269,9 +2307,9 @@ mod tests {
         queue.enqueue(h102, vec![]);
 
         // Engine consumes all 3
-        queue.pop_next().unwrap();
-        queue.pop_next().unwrap();
-        queue.pop_next().unwrap();
+        confirm(&mut queue);
+        confirm(&mut queue);
+        confirm(&mut queue);
         assert_eq!(queue.last_processed().unwrap().number, 102);
 
         // L1 reorgs at 102: new block 103 has different parent

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -19,6 +19,7 @@ mod executor;
 pub mod l1;
 pub mod l1_state;
 mod node;
+pub mod payload;
 pub mod precompiles;
 pub mod rpc;
 pub mod withdrawals;
@@ -32,6 +33,7 @@ pub use l1::{
 };
 pub use l1_state::SharedL1StateCache;
 pub use node::{ZoneExecutorBuilder, ZoneNode};
+pub use payload::{ZonePayloadAttributes, ZonePayloadBuilderAttributes, ZonePayloadTypes};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};
 pub use zonemonitor::{ZoneMonitorConfig, spawn_zone_monitor};
 

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -3,11 +3,13 @@
 //! This is a lightweight L2 node built on reth's node builder infrastructure.
 //! It reuses Tempo's EVM, primitives, and pool, but with noop consensus/network/payload.
 
+use crate::payload::{ZonePayloadAttributes, ZonePayloadTypes};
 use alloy_primitives::U256;
 use reth_eth_wire_types::primitives::BasicNetworkPrimitives;
 use reth_node_api::{
-    AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
-    PayloadAttributesBuilder, PayloadTypes,
+    AddOnsContext, FullNodeComponents, FullNodeTypes, InvalidPayloadAttributesError,
+    NewPayloadError, NodeAddOns, NodeTypes, PayloadAttributesBuilder, PayloadTypes,
+    PayloadValidator,
 };
 use reth_node_builder::{
     BuilderContext, DebugNode, Node, NodeAdapter,
@@ -31,10 +33,8 @@ use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_evm::TempoEvmConfig;
 use tempo_node::{
-    DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator,
-    node::TempoPayloadAttributesBuilder, rpc::TempoReceiptConverter,
+    DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoReceiptConverter,
 };
-use tempo_payload_types::TempoPayloadTypes;
 use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
 use tempo_transaction_pool::{
     AA2dPool, AA2dPoolConfig, TempoTransactionPool,
@@ -140,7 +140,6 @@ impl ZoneNode {
 
     /// Returns a [`ComponentsBuilder`] configured for a Zone node.
     pub fn components<N>(
-        deposit_queue: crate::DepositQueue,
         executor_builder: ZoneExecutorBuilder,
         sequencer: alloy_primitives::Address,
         sequencer_key: k256::SecretKey,
@@ -161,7 +160,6 @@ impl ZoneNode {
             .pool(ZonePoolBuilder)
             .executor(executor_builder)
             .payload(BasicPayloadServiceBuilder::new(ZonePayloadFactory::new(
-                deposit_queue,
                 sequencer,
                 sequencer_key,
                 portal_address,
@@ -175,7 +173,7 @@ impl NodeTypes for ZoneNode {
     type Primitives = TempoPrimitives;
     type ChainSpec = TempoChainSpec;
     type Storage = EmptyBodyStorage<TempoTxEnvelope, TempoHeader>;
-    type Payload = TempoPayloadTypes;
+    type Payload = ZonePayloadTypes;
 }
 
 /// Zone node add-ons (RPC, etc.)
@@ -263,8 +261,6 @@ where
         // Spawn the ZoneEngine — L1-event-driven block production
         {
             let provider = ctx.node.provider().clone();
-            let payload_attributes_builder =
-                TempoPayloadAttributesBuilder::new(provider.chain_spec());
             let to_engine = ctx.beacon_engine_handle.clone();
             let payload_builder = ctx.node.payload_builder_handle().clone();
             let deposit_queue = self.deposit_queue;
@@ -272,15 +268,9 @@ where
             ctx.node
                 .task_executor()
                 .spawn_critical("zone-engine", async move {
-                    ZoneEngine::new(
-                        provider,
-                        payload_attributes_builder,
-                        to_engine,
-                        payload_builder,
-                        deposit_queue,
-                    )
-                    .run()
-                    .await
+                    ZoneEngine::new(provider, to_engine, payload_builder, deposit_queue)
+                        .run()
+                        .await
                 });
             info!(target: "reth::cli", "ZoneEngine spawned — L1-driven block production active");
         }
@@ -334,7 +324,6 @@ where
             self.l1_state_cache.clone(),
         );
         Self::components(
-            self.deposit_queue.clone(),
             executor_builder,
             self.sequencer,
             self.sequencer_key.clone(),
@@ -361,7 +350,27 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for ZoneNode {
         chain_spec: &Self::ChainSpec,
     ) -> impl PayloadAttributesBuilder<<Self::Payload as PayloadTypes>::PayloadAttributes, TempoHeader>
     {
-        TempoPayloadAttributesBuilder::new(Arc::new(chain_spec.clone()))
+        ZonePayloadAttributesBuilder::new(Arc::new(chain_spec.clone()))
+    }
+}
+
+/// Builds [`ZonePayloadAttributes`] with `l1_block: None` — suitable for
+/// debug/test scenarios where no L1 data is available.
+#[derive(Debug)]
+pub(crate) struct ZonePayloadAttributesBuilder;
+
+impl ZonePayloadAttributesBuilder {
+    pub(crate) fn new(_chain_spec: Arc<TempoChainSpec>) -> Self {
+        Self
+    }
+}
+
+impl PayloadAttributesBuilder<ZonePayloadAttributes, TempoHeader> for ZonePayloadAttributesBuilder {
+    fn build(
+        &self,
+        _parent: &reth_primitives_traits::SealedHeader<TempoHeader>,
+    ) -> ZonePayloadAttributes {
+        unimplemented!("zone blocks require L1 data — use ZoneEngine instead")
     }
 }
 
@@ -429,6 +438,34 @@ where
 
     async fn build(self, _ctx: &AddOnsContext<'_, Node>) -> eyre::Result<Self::Validator> {
         Ok(TempoEngineValidator::new())
+    }
+}
+
+impl PayloadValidator<ZonePayloadTypes> for TempoEngineValidator {
+    type Block = tempo_primitives::Block;
+
+    fn convert_payload_to_block(
+        &self,
+        payload: tempo_payload_types::TempoExecutionData,
+    ) -> Result<reth_primitives_traits::SealedBlock<Self::Block>, NewPayloadError> {
+        let tempo_payload_types::TempoExecutionData {
+            block,
+            validator_set: _,
+        } = payload;
+        Ok(Arc::unwrap_or_clone(block))
+    }
+
+    fn validate_payload_attributes_against_header(
+        &self,
+        attr: &crate::payload::ZonePayloadAttributes,
+        header: &TempoHeader,
+    ) -> Result<(), InvalidPayloadAttributesError> {
+        if reth_node_api::PayloadAttributes::timestamp(attr)
+            < reth_primitives_traits::AlloyBlockHeader::timestamp(header)
+        {
+            return Err(InvalidPayloadAttributesError::InvalidTimestamp);
+        }
+        Ok(())
     }
 }
 

--- a/crates/tempo-zone/src/payload.rs
+++ b/crates/tempo-zone/src/payload.rs
@@ -1,0 +1,151 @@
+//! Zone-specific payload types.
+//!
+//! Owns the full payload attribute types for the zone, wrapping
+//! [`EthPayloadBuilderAttributes`] directly and adding L1 block data plus the
+//! millisecond timestamp portion. This avoids pulling in Tempo-specific
+//! concepts the zone doesn't use (interrupts, subblocks, DKG extra-data).
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_rpc_types_engine::PayloadAttributes as EthPayloadAttributes;
+use alloy_rpc_types_eth::Withdrawal;
+use reth_node_api::{PayloadBuilderAttributes, PayloadTypes};
+use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
+use reth_primitives_traits::SealedBlock;
+use serde::{Deserialize, Serialize};
+use tempo_payload_types::TempoExecutionData;
+use tempo_primitives::{Block, TempoPrimitives};
+
+use crate::l1::L1BlockDeposits;
+
+/// Zone RPC payload attributes — the type that flows through FCU.
+///
+/// Carries standard Ethereum attributes, a millisecond timestamp portion, and
+/// optionally the L1 block whose deposits should be included in this zone
+/// block. The L1 data is set by the [`ZoneEngine`](crate::ZoneEngine) before
+/// sending FCU and is skipped during (de)serialisation since it only travels
+/// through in-process channels.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZonePayloadAttributes {
+    /// Standard Ethereum payload attributes.
+    pub inner: EthPayloadAttributes,
+
+    /// Milliseconds portion of the timestamp (0–999).
+    pub timestamp_millis_part: u64,
+
+    /// L1 block to process in this zone block. Every zone block processes
+    /// exactly one L1 block via `advanceTempo`.
+    pub l1_block: L1BlockDeposits,
+}
+
+impl reth_node_api::PayloadAttributes for ZonePayloadAttributes {
+    fn timestamp(&self) -> u64 {
+        self.inner.timestamp()
+    }
+
+    fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        self.inner.withdrawals()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.inner.parent_beacon_block_root()
+    }
+}
+
+/// Zone builder attributes — wraps [`EthPayloadBuilderAttributes`] with L1
+/// data and the millisecond timestamp portion.
+///
+/// The `l1_block` is mandatory: every zone block processes exactly one L1
+/// block via `advanceTempo`.
+#[derive(Debug, Clone)]
+pub struct ZonePayloadBuilderAttributes {
+    inner: EthPayloadBuilderAttributes,
+    timestamp_millis_part: u64,
+    l1_block: L1BlockDeposits,
+}
+
+impl ZonePayloadBuilderAttributes {
+    /// Returns a reference to the L1 block data.
+    pub fn l1_block(&self) -> &L1BlockDeposits {
+        &self.l1_block
+    }
+
+    /// Returns the extra data for the block header (always empty for zones).
+    pub fn extra_data(&self) -> Bytes {
+        Bytes::default()
+    }
+
+    /// Returns the milliseconds portion of the timestamp.
+    pub fn timestamp_millis_part(&self) -> u64 {
+        self.timestamp_millis_part
+    }
+}
+
+impl PayloadBuilderAttributes for ZonePayloadBuilderAttributes {
+    type RpcPayloadAttributes = ZonePayloadAttributes;
+    type Error = std::convert::Infallible;
+
+    fn try_new(
+        parent: B256,
+        rpc_payload_attributes: Self::RpcPayloadAttributes,
+        version: u8,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            inner: EthPayloadBuilderAttributes::try_new(
+                parent,
+                rpc_payload_attributes.inner,
+                version,
+            )?,
+            timestamp_millis_part: rpc_payload_attributes.timestamp_millis_part,
+            l1_block: rpc_payload_attributes.l1_block,
+        })
+    }
+
+    fn payload_id(&self) -> alloy_rpc_types_engine::PayloadId {
+        self.inner.payload_id()
+    }
+
+    fn parent(&self) -> B256 {
+        self.inner.parent()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.inner.timestamp()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<B256> {
+        self.inner.parent_beacon_block_root()
+    }
+
+    fn suggested_fee_recipient(&self) -> Address {
+        self.inner.suggested_fee_recipient()
+    }
+
+    fn prev_randao(&self) -> B256 {
+        self.inner.prev_randao()
+    }
+
+    fn withdrawals(&self) -> &alloy_rpc_types_eth::Withdrawals {
+        self.inner.withdrawals()
+    }
+}
+
+/// Zone payload types.
+#[derive(Debug, Clone, Copy, Default)]
+#[non_exhaustive]
+pub struct ZonePayloadTypes;
+
+impl PayloadTypes for ZonePayloadTypes {
+    type ExecutionData = TempoExecutionData;
+    type BuiltPayload = EthBuiltPayload<TempoPrimitives>;
+    type PayloadAttributes = ZonePayloadAttributes;
+    type PayloadBuilderAttributes = ZonePayloadBuilderAttributes;
+
+    fn block_to_payload(block: SealedBlock<Block>) -> Self::ExecutionData {
+        TempoExecutionData {
+            block: Arc::new(block),
+            validator_set: None,
+        }
+    }
+}


### PR DESCRIPTION
Refactors ZoneEngine and payload building for more robust L1-driven block production.

**Peek/confirm pattern** — L1 blocks are only removed from the deposit queue after `newPayload` succeeds, preventing block loss on execution failures. `confirm()` takes a `NumHash` and returns `Option` to guard against reorg races.

**Zone-specific payload types** — `ZonePayloadTypes`, `ZonePayloadAttributes`, and `ZonePayloadBuilderAttributes` wrap `EthPayloadBuilderAttributes` directly, stripping unused Tempo fields (interrupts, subblocks, DKG). L1 block data flows through payload attributes from engine to builder.

**Timestamp lockstep** — Zone block timestamps come directly from the L1 block header (seconds + millis_part) instead of `SystemTime::now()`.

**Engine improvements**:
- Bare FCU after each `newPayload` to immediately canonicalize the new head
- `MissedTickBehavior::Skip` on heartbeat interval to prevent FCU bursts after catch-up
- Concrete `ZoneEngine` (no generics) with instant finality (`ForkchoiceState::same_hash`)
- `advance()` takes `L1BlockDeposits` directly; `advance_all_available()` is a simple `while let` loop