### PR TITLE
feat: make fee recipient configurable

### DIFF
--- a/crates/tempo-zone/src/engine.rs
+++ b/crates/tempo-zone/src/engine.rs
@@ -82,6 +82,8 @@ pub struct ZoneEngine {
     /// Latest block header — used as parent for the next payload and as the
     /// head/safe/finalized hash in FCU (instant finality).
     last_header: SealedHeader<TempoHeader>,
+    /// Address that receives block fees.
+    fee_recipient: Address,
 }
 
 impl ZoneEngine {
@@ -90,6 +92,7 @@ impl ZoneEngine {
         to_engine: ConsensusEngineHandle<ZonePayloadTypes>,
         payload_builder: PayloadBuilderHandle<ZonePayloadTypes>,
         deposit_queue: DepositQueue,
+        fee_recipient: Address,
     ) -> Self {
         let last_header = provider
             .sealed_header(provider.best_block_number().unwrap())
@@ -102,6 +105,7 @@ impl ZoneEngine {
             payload_builder,
             deposit_queue,
             last_header,
+            fee_recipient,
         }
     }
 
@@ -194,7 +198,7 @@ impl ZoneEngine {
             inner: EthPayloadAttributes {
                 timestamp: timestamp_secs,
                 prev_randao: B256::ZERO,
-                suggested_fee_recipient: Address::ZERO,
+                suggested_fee_recipient: self.fee_recipient,
                 withdrawals: self
                     .chain_spec
                     .is_shanghai_active_at_timestamp(timestamp_secs)

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -525,7 +525,6 @@ impl L1Deposit {
 
 /// Result of attempting to enqueue an L1 block into the deposit queue.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) enum EnqueueOutcome {
     /// Block was appended to the queue.
     Accepted,

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -525,6 +525,7 @@ impl L1Deposit {
 
 /// Result of attempting to enqueue an L1 block into the deposit queue.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub(crate) enum EnqueueOutcome {
     /// Block was appended to the queue.
     Accepted,

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -188,6 +188,7 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     >,
     deposit_queue: crate::DepositQueue,
     l1_config: crate::L1SubscriberConfig,
+    fee_recipient: alloy_primitives::Address,
 }
 
 impl<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>> std::fmt::Debug
@@ -203,7 +204,11 @@ where
     N: FullNodeTypes<Types = ZoneNode>,
 {
     /// Creates a new instance.
-    pub fn new(deposit_queue: crate::DepositQueue, l1_config: crate::L1SubscriberConfig) -> Self {
+    pub fn new(
+        deposit_queue: crate::DepositQueue,
+        l1_config: crate::L1SubscriberConfig,
+        fee_recipient: alloy_primitives::Address,
+    ) -> Self {
         Self {
             inner: RpcAddOns::new(
                 ZoneEthApiBuilder::default(),
@@ -214,6 +219,7 @@ where
             ),
             deposit_queue,
             l1_config,
+            fee_recipient,
         }
     }
 }
@@ -264,13 +270,20 @@ where
             let to_engine = ctx.beacon_engine_handle.clone();
             let payload_builder = ctx.node.payload_builder_handle().clone();
             let deposit_queue = self.deposit_queue;
+            let fee_recipient = self.fee_recipient;
 
             ctx.node
                 .task_executor()
                 .spawn_critical("zone-engine", async move {
-                    ZoneEngine::new(provider, to_engine, payload_builder, deposit_queue)
-                        .run()
-                        .await
+                    ZoneEngine::new(
+                        provider,
+                        to_engine,
+                        payload_builder,
+                        deposit_queue,
+                        fee_recipient,
+                    )
+                    .run()
+                    .await
                 });
             info!(target: "reth::cli", "ZoneEngine spawned — L1-driven block production active");
         }
@@ -332,7 +345,11 @@ where
     }
 
     fn add_ons(&self) -> Self::AddOns {
-        ZoneAddOns::new(self.deposit_queue.clone(), self.l1_config.clone())
+        ZoneAddOns::new(
+            self.deposit_queue.clone(),
+            self.l1_config.clone(),
+            self.sequencer,
+        )
     }
 }
 


### PR DESCRIPTION
Makes the zone engine fee recipient configurable via `ZoneEngine::new`, defaulting to the sequencer address.