### PR TITLE
refactor(zone): introduce L1PortalEvents for extensible L1 event ingestion

### DIFF
--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -34,6 +34,10 @@ sol! {
             bytes16 tag
         );
 
+        /// Event emitted when a new TIP-20 token is enabled for bridging.
+        #[derive(Debug)]
+        event TokenEnabled(address indexed token);
+
         /// Last synced Tempo block number.
         function lastSyncedTempoBlockNumber() external view returns (uint64);
 

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -221,7 +221,7 @@ where
             )));
         }
 
-        let total_deposits = l1_block.deposits.len();
+        let total_deposits = l1_block.events.deposits.len();
 
         info!(
             target: "zone::payload",
@@ -230,7 +230,7 @@ where
             deposits = total_deposits,
             "Including advanceTempo system tx (chain continuity OK)"
         );
-        for deposit in &l1_block.deposits {
+        for deposit in &l1_block.events.deposits {
             match deposit {
                 L1Deposit::Regular(d) => {
                     debug!(
@@ -255,6 +255,14 @@ where
                     );
                 }
             }
+        }
+
+        if !l1_block.events.enabled_tokens.is_empty() {
+            info!(
+                target: "zone::payload",
+                tokens = ?l1_block.events.enabled_tokens,
+                "🪙 New tokens enabled on L1"
+            );
         }
 
         let state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
@@ -319,7 +327,7 @@ where
 
             let advance_tx = build_advance_tempo_tx(
                 &l1_block.header,
-                &l1_block.deposits,
+                &l1_block.events.deposits,
                 &self.sequencer_key,
                 self.portal_address,
             );
@@ -330,7 +338,7 @@ where
                     error!(
                         target: "zone::payload",
                         l1_block = l1_block.header.inner.number,
-                        deposits = l1_block.deposits.len(),
+                        deposits = l1_block.events.deposits.len(),
                         is_halt = result.is_halt(),
                         revert_data = %revert_data,
                         "advanceTempo system tx reverted on-chain"
@@ -351,7 +359,7 @@ where
                     error!(
                         ?err,
                         l1_block = l1_block.header.inner.number,
-                        deposits = l1_block.deposits.len(),
+                        deposits = l1_block.events.deposits.len(),
                         "advanceTempo system tx failed"
                     );
                     return Err(PayloadBuilderError::evm(err));

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -23,7 +23,7 @@ use crate::{
         self, EncryptedDeposit as AbiEncryptedDeposit,
         EncryptedDepositPayload as AbiEncryptedDepositPayload,
     },
-    bindings::ZonePortal::{self, DepositMade, EncryptedDepositMade},
+    bindings::ZonePortal::{self, DepositMade, EncryptedDepositMade, TokenEnabled},
 };
 
 /// Configuration for the L1 subscriber.
@@ -192,34 +192,59 @@ impl L1Subscriber {
         from: u64,
         to: u64,
     ) -> eyre::Result<()> {
-        let filter = self.deposit_log_filter();
+        let filter = self.portal_event_filter();
         let mut cursor = from;
         while cursor <= to {
             let end = (cursor + BACKFILL_BATCH_SIZE - 1).min(to);
 
-            // Fetch deposit logs for this batch and index by block number.
+            // Fetch portal event logs for this batch and index by block number.
             let logs = l1_provider
                 .get_logs(&filter.clone().select(cursor..=end))
                 .await?;
 
-            let mut deposits_by_block: BTreeMap<u64, Vec<L1Deposit>> = BTreeMap::new();
+            let mut events_by_block: BTreeMap<u64, L1PortalEvents> = BTreeMap::new();
             for log in logs {
                 let n = log
                     .block_number
                     .ok_or_else(|| eyre::eyre!("log missing block number"))?;
-                deposits_by_block
-                    .entry(n)
-                    .or_default()
-                    .push(self.parse_deposit(log, n)?);
+                let topic0 = log.topic0().copied();
+                match topic0 {
+                    Some(h) if h == TokenEnabled::SIGNATURE_HASH => {
+                        let event = TokenEnabled::decode_log(&log.inner)?;
+                        events_by_block
+                            .entry(n)
+                            .or_default()
+                            .enabled_tokens
+                            .push(event.token);
+                    }
+                    Some(h)
+                        if h == DepositMade::SIGNATURE_HASH
+                            || h == EncryptedDepositMade::SIGNATURE_HASH =>
+                    {
+                        events_by_block
+                            .entry(n)
+                            .or_default()
+                            .deposits
+                            .push(self.parse_deposit(log, n)?);
+                    }
+                    _ => {
+                        warn!(
+                            block = n,
+                            topic0 = ?topic0,
+                            "Ignoring unknown portal event during backfill"
+                        );
+                    }
+                }
             }
 
             for block_number in cursor..=end {
-                let deposits = deposits_by_block.remove(&block_number).unwrap_or_default();
-                if !deposits.is_empty() {
+                let events = events_by_block.remove(&block_number).unwrap_or_default();
+                if !events.deposits.is_empty() || !events.enabled_tokens.is_empty() {
                     info!(
                         block = block_number,
-                        count = deposits.len(),
-                        "💰 Backfill deposits"
+                        deposits = events.deposits.len(),
+                        enabled_tokens = events.enabled_tokens.len(),
+                        "💰 Backfill portal events"
                     );
                 }
                 let header_resp = l1_provider
@@ -227,7 +252,7 @@ impl L1Subscriber {
                     .await?
                     .ok_or_else(|| eyre::eyre!("L1 header not found for block {block_number}"))?;
                 let header: TempoHeader = header_resp.inner.inner;
-                self.deposit_queue.enqueue(header, deposits);
+                self.deposit_queue.enqueue(header, events);
             }
 
             cursor = end + 1;
@@ -265,19 +290,19 @@ impl L1Subscriber {
         // A block is only flushed to the deposit queue once the NEXT block
         // arrives with a matching parent hash, proving the buffered block
         // is on the canonical chain.
-        let mut unconfirmed_tip: Option<(SealedHeader<TempoHeader>, Vec<L1Deposit>)> = None;
+        let mut unconfirmed_tip: Option<(SealedHeader<TempoHeader>, L1PortalEvents)> = None;
 
         while let Some(header) = stream.next().await {
             let block_number = header.number();
             let sealed = SealedHeader::seal_slow(header.inner.into_consensus());
-            let deposits = self.fetch_deposits(&provider, block_number).await?;
+            let events = self.fetch_portal_events(&provider, block_number).await?;
 
             // If we have a buffered tip, check if the new block confirms it.
-            if let Some((tip_header, tip_deposits)) = unconfirmed_tip.take() {
+            if let Some((tip_header, tip_events)) = unconfirmed_tip.take() {
                 if sealed.parent_hash() == tip_header.hash() {
                     // Confirmed — flush the buffered tip to the queue.
                     let tip_number = tip_header.number();
-                    match self.deposit_queue.try_enqueue(tip_header, tip_deposits) {
+                    match self.deposit_queue.try_enqueue(tip_header, tip_events) {
                         EnqueueOutcome::Accepted | EnqueueOutcome::Duplicate => {}
                         EnqueueOutcome::NeedBackfill { from, to } => {
                             // Gap between queue head and confirmed tip — backfill
@@ -305,29 +330,54 @@ impl L1Subscriber {
             }
 
             // Buffer the new block as unconfirmed tip.
-            unconfirmed_tip = Some((sealed, deposits));
+            unconfirmed_tip = Some((sealed, events));
         }
 
         warn!("L1 block subscription stream ended");
         Ok(())
     }
 
-    /// Fetch and parse deposit logs for a single L1 block.
-    async fn fetch_deposits(
+    /// Fetch and parse portal event logs for a single L1 block.
+    async fn fetch_portal_events(
         &self,
         provider: &impl Provider<TempoNetwork>,
         block_number: u64,
-    ) -> eyre::Result<Vec<L1Deposit>> {
+    ) -> eyre::Result<L1PortalEvents> {
         let logs = provider
-            .get_logs(&self.deposit_log_filter().select(block_number))
+            .get_logs(&self.portal_event_filter().select(block_number))
             .await?;
 
-        let deposits: Vec<L1Deposit> = logs
-            .into_iter()
-            .map(|log| self.parse_deposit(log, block_number))
-            .collect::<eyre::Result<_>>()?;
+        let mut events = L1PortalEvents::default();
 
-        for d in &deposits {
+        for log in logs {
+            let topic0 = log.topic0().copied();
+            match topic0 {
+                Some(h) if h == TokenEnabled::SIGNATURE_HASH => {
+                    let event = TokenEnabled::decode_log(&log.inner)?;
+                    info!(
+                        l1_block = block_number,
+                        token = %event.token,
+                        "🪙 Token enabled on L1"
+                    );
+                    events.enabled_tokens.push(event.token);
+                }
+                Some(h)
+                    if h == DepositMade::SIGNATURE_HASH
+                        || h == EncryptedDepositMade::SIGNATURE_HASH =>
+                {
+                    events.deposits.push(self.parse_deposit(log, block_number)?);
+                }
+                _ => {
+                    warn!(
+                        l1_block = block_number,
+                        topic0 = ?topic0,
+                        "Ignoring unknown portal event"
+                    );
+                }
+            }
+        }
+
+        for d in &events.deposits {
             match d {
                 L1Deposit::Regular(d) => {
                     info!(
@@ -351,16 +401,17 @@ impl L1Subscriber {
             }
         }
 
-        Ok(deposits)
+        Ok(events)
     }
 
-    /// Returns a log filter for deposit events emitted by the ZonePortal.
-    fn deposit_log_filter(&self) -> Filter {
+    /// Returns a log filter for portal events emitted by the ZonePortal.
+    fn portal_event_filter(&self) -> Filter {
         Filter::new()
             .address(self.config.portal_address)
             .event_signature(vec![
                 DepositMade::SIGNATURE_HASH,
                 EncryptedDepositMade::SIGNATURE_HASH,
+                TokenEnabled::SIGNATURE_HASH,
             ])
     }
 
@@ -535,13 +586,36 @@ pub(crate) enum EnqueueOutcome {
     NeedBackfill { from: u64, to: u64 },
 }
 
+/// Events extracted from the ZonePortal in a single L1 block.
+///
+/// Bundles all portal-emitted events for one block into a single extensible
+/// type. New event types (e.g. token pausing, sequencer changes) can be
+/// added as fields without restructuring the pipeline.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct L1PortalEvents {
+    /// Deposit events (regular + encrypted).
+    pub deposits: Vec<L1Deposit>,
+    /// Tokens newly enabled for bridging in this block.
+    pub enabled_tokens: Vec<Address>,
+}
+
+impl L1PortalEvents {
+    /// Create portal events from deposits only.
+    pub fn from_deposits(deposits: Vec<L1Deposit>) -> Self {
+        Self {
+            deposits,
+            ..Default::default()
+        }
+    }
+}
+
 /// An L1 block's header paired with the deposits found in that block.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct L1BlockDeposits {
     /// The sealed L1 block header (caches the block hash).
     pub header: SealedHeader<TempoHeader>,
-    /// Deposits extracted from this block.
-    pub deposits: Vec<L1Deposit>,
+    /// Portal events extracted from this block.
+    pub events: L1PortalEvents,
     /// Deposit queue hash chain value before this block's deposits.
     pub queue_hash_before: B256,
     /// Deposit queue hash chain value after this block's deposits.
@@ -603,7 +677,7 @@ impl PendingDeposits {
     pub(crate) fn try_enqueue(
         &mut self,
         header: SealedHeader<TempoHeader>,
-        deposits: Vec<L1Deposit>,
+        events: L1PortalEvents,
     ) -> EnqueueOutcome {
         let block_number = header.number();
         let block_hash = header.hash();
@@ -664,7 +738,7 @@ impl PendingDeposits {
                 // of parent hash — the parent was reorged but the zone already
                 // committed to it. The builder will detect the hash mismatch.
             }
-            self.append(header, deposits);
+            self.append(header, events);
             return EnqueueOutcome::Accepted;
         }
 
@@ -711,30 +785,30 @@ impl PendingDeposits {
             // If new_expected == block_number, fall through to accept (it'll be the anchor)
         }
 
-        self.append(header, deposits);
+        self.append(header, events);
         EnqueueOutcome::Accepted
     }
 
     /// Enqueue a block during backfill. Accepts or skips duplicates.
     ///
     /// Panics on `NeedBackfill` — backfill blocks must be fetched sequentially.
-    pub(crate) fn enqueue(&mut self, header: TempoHeader, deposits: Vec<L1Deposit>) {
-        match self.try_enqueue(SealedHeader::seal_slow(header), deposits) {
+    pub(crate) fn enqueue(&mut self, header: TempoHeader, events: L1PortalEvents) {
+        match self.try_enqueue(SealedHeader::seal_slow(header), events) {
             EnqueueOutcome::Accepted | EnqueueOutcome::Duplicate => {}
             other => panic!("enqueue expected Accepted or Duplicate, got {other:?}"),
         }
     }
 
-    fn append(&mut self, header: SealedHeader<TempoHeader>, deposits: Vec<L1Deposit>) {
+    fn append(&mut self, header: SealedHeader<TempoHeader>, events: L1PortalEvents) {
         let queue_hash_before = self.enqueued_head_hash;
-        for deposit in &deposits {
+        for deposit in &events.deposits {
             self.enqueued_head_hash = deposit.hash_chain(self.enqueued_head_hash);
         }
         let queue_hash_after = self.enqueued_head_hash;
         self.last_enqueued = Some(header.num_hash());
         self.pending.push(L1BlockDeposits {
             header,
-            deposits,
+            events,
             queue_hash_before,
             queue_hash_after,
         });
@@ -897,10 +971,10 @@ impl DepositQueue {
     pub(crate) fn try_enqueue(
         &self,
         header: SealedHeader<TempoHeader>,
-        deposits: Vec<L1Deposit>,
+        events: L1PortalEvents,
     ) -> EnqueueOutcome {
         let mut queue = self.inner.lock();
-        let outcome = queue.try_enqueue(header, deposits);
+        let outcome = queue.try_enqueue(header, events);
         if matches!(outcome, EnqueueOutcome::Accepted) {
             drop(queue);
             self.notify.notify_one();
@@ -909,8 +983,8 @@ impl DepositQueue {
     }
 
     /// Enqueue an L1 block with its deposits and notify waiters.
-    pub fn enqueue(&self, header: TempoHeader, deposits: Vec<L1Deposit>) {
-        self.inner.lock().enqueue(header, deposits);
+    pub fn enqueue(&self, header: TempoHeader, events: L1PortalEvents) {
+        self.inner.lock().enqueue(header, events);
         self.notify.notify_one();
     }
 
@@ -1017,13 +1091,16 @@ mod tests {
             queue_hash: B256::ZERO,
         });
 
-        queue.enqueue(make_test_header(1), vec![d1.clone()]);
+        queue.enqueue(
+            make_test_header(1),
+            L1PortalEvents::from_deposits(vec![d1.clone()]),
+        );
         let hash_after_d1 = queue.enqueued_head_hash();
         assert_ne!(hash_after_d1, B256::ZERO);
 
         // Verify hash is deterministic
         let mut queue2 = PendingDeposits::default();
-        queue2.enqueue(make_test_header(1), vec![d1]);
+        queue2.enqueue(make_test_header(1), L1PortalEvents::from_deposits(vec![d1]));
         assert_eq!(hash_after_d1, queue2.enqueued_head_hash);
 
         let d2 = L1Deposit::Regular(Deposit {
@@ -1037,7 +1114,7 @@ mod tests {
             queue_hash: B256::ZERO,
         });
 
-        queue.enqueue(make_test_header(2), vec![d2]);
+        queue.enqueue(make_test_header(2), L1PortalEvents::from_deposits(vec![d2]));
         let hash_after_d2 = queue.enqueued_head_hash();
         assert_ne!(hash_after_d2, hash_after_d1);
     }
@@ -1099,7 +1176,10 @@ mod tests {
             queue_hash: B256::ZERO,
         })];
 
-        queue.enqueue(make_test_header(1), deposits.clone());
+        queue.enqueue(
+            make_test_header(1),
+            L1PortalEvents::from_deposits(deposits.clone()),
+        );
 
         let transition = PendingDeposits::transition(B256::ZERO, &deposits);
 
@@ -1134,15 +1214,18 @@ mod tests {
 
         let h10 = make_test_header(10);
         let h10_hash = header_hash(&h10);
-        queue.enqueue(h10, vec![d1]);
-        queue.enqueue(make_chained_header(11, h10_hash), vec![d2]);
+        queue.enqueue(h10, L1PortalEvents::from_deposits(vec![d1]));
+        queue.enqueue(
+            make_chained_header(11, h10_hash),
+            L1PortalEvents::from_deposits(vec![d2]),
+        );
 
         let blocks = queue.drain();
         assert_eq!(blocks.len(), 2);
         assert_eq!(blocks[0].header.number(), 10);
-        assert_eq!(blocks[0].deposits.len(), 1);
+        assert_eq!(blocks[0].events.deposits.len(), 1);
         assert_eq!(blocks[1].header.number(), 11);
-        assert_eq!(blocks[1].deposits.len(), 1);
+        assert_eq!(blocks[1].events.deposits.len(), 1);
 
         // After drain, pending is empty
         assert!(queue.drain().is_empty());
@@ -1304,7 +1387,7 @@ mod tests {
         // Path 1: enqueue into PendingDeposits
         let mut pending = PendingDeposits::default();
         let header = make_test_header(1);
-        pending.enqueue(header, deposits.clone());
+        pending.enqueue(header, L1PortalEvents::from_deposits(deposits.clone()));
 
         // Path 2: compute transition directly
         let transition = PendingDeposits::transition(B256::ZERO, &deposits);
@@ -1324,12 +1407,12 @@ mod tests {
 
         let h100 = make_test_header(100);
         let h100_hash = header_hash(&h100);
-        queue.enqueue(h100, vec![]);
+        queue.enqueue(h100, L1PortalEvents::from_deposits(vec![]));
         let h101 = make_chained_header(101, h100_hash);
         let h101_hash = header_hash(&h101);
-        queue.enqueue(h101, vec![]);
+        queue.enqueue(h101, L1PortalEvents::from_deposits(vec![]));
         let h102 = make_chained_header(102, h101_hash);
-        queue.enqueue(h102, vec![]);
+        queue.enqueue(h102, L1PortalEvents::from_deposits(vec![]));
 
         let last = queue.last_enqueued().unwrap();
         assert_eq!(last.number, 102);
@@ -1350,8 +1433,11 @@ mod tests {
         let h102_hash = last.hash;
         let h103 = make_chained_header(103, h102_hash);
         let h103_hash = header_hash(&h103);
-        queue.enqueue(h103, vec![]);
-        queue.enqueue(make_chained_header(104, h103_hash), vec![]);
+        queue.enqueue(h103, L1PortalEvents::from_deposits(vec![]));
+        queue.enqueue(
+            make_chained_header(104, h103_hash),
+            L1PortalEvents::from_deposits(vec![]),
+        );
         assert_eq!(queue.last_enqueued().unwrap().number, 104);
 
         let drained = queue.drain();
@@ -1370,13 +1456,13 @@ mod tests {
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         let h2 = make_chained_header(11, h1_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![]),
+            queue.try_enqueue(seal(h2), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1389,13 +1475,13 @@ mod tests {
 
         let h1 = make_test_header(10);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         // Skip block 11, try to enqueue 12
         let h3 = make_test_header(12);
-        match queue.try_enqueue(seal(h3), vec![]) {
+        match queue.try_enqueue(seal(h3), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 11);
                 assert_eq!(to, 11);
@@ -1410,11 +1496,11 @@ mod tests {
 
         let h1 = make_test_header(10);
         assert!(matches!(
-            queue.try_enqueue(seal(h1.clone()), vec![]),
+            queue.try_enqueue(seal(h1.clone()), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Duplicate
         ));
     }
@@ -1426,20 +1512,20 @@ mod tests {
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         let h2 = make_chained_header(11, h1_hash);
         let h2_hash = header_hash(&h2);
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![]),
+            queue.try_enqueue(seal(h2), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         let h3 = make_chained_header(12, h2_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h3), vec![]),
+            queue.try_enqueue(seal(h3), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1449,7 +1535,7 @@ mod tests {
         let mut h2_reorg = make_chained_header(11, h1_hash);
         h2_reorg.inner.gas_limit = 999;
         assert!(matches!(
-            queue.try_enqueue(seal(h2_reorg), vec![]),
+            queue.try_enqueue(seal(h2_reorg), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1466,19 +1552,19 @@ mod tests {
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         let h2 = make_chained_header(11, h1_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![]),
+            queue.try_enqueue(seal(h2), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         // Block 12 with wrong parent hash — purges block 11, needs backfill
         let h3 = make_chained_header(12, B256::with_last_byte(0xDE));
-        match queue.try_enqueue(seal(h3), vec![]) {
+        match queue.try_enqueue(seal(h3), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 11);
                 assert_eq!(to, 11);
@@ -1505,7 +1591,7 @@ mod tests {
             queue_hash: B256::ZERO,
         });
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![d1]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![d1])),
             EnqueueOutcome::Accepted
         ));
         let hash_after_h1 = queue.enqueued_head_hash();
@@ -1522,7 +1608,7 @@ mod tests {
             queue_hash: B256::ZERO,
         });
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![d2]),
+            queue.try_enqueue(seal(h2), L1PortalEvents::from_deposits(vec![d2])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1533,7 +1619,7 @@ mod tests {
         let mut h2_reorg = make_chained_header(11, h1_hash);
         h2_reorg.inner.gas_limit = 999;
         assert!(matches!(
-            queue.try_enqueue(seal(h2_reorg), vec![]),
+            queue.try_enqueue(seal(h2_reorg), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1560,14 +1646,23 @@ mod tests {
 
         let h1 = make_test_header(1);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1, vec![make_deposit(1, 100)]);
+        queue.enqueue(
+            h1,
+            L1PortalEvents::from_deposits(vec![make_deposit(1, 100)]),
+        );
 
         let h2 = make_chained_header(2, h1_hash);
         let h2_hash = header_hash(&h2);
-        queue.enqueue(h2, vec![make_deposit(2, 200)]);
+        queue.enqueue(
+            h2,
+            L1PortalEvents::from_deposits(vec![make_deposit(2, 200)]),
+        );
 
         let h3 = make_chained_header(3, h2_hash);
-        queue.enqueue(h3, vec![make_deposit(3, 300)]);
+        queue.enqueue(
+            h3,
+            L1PortalEvents::from_deposits(vec![make_deposit(3, 300)]),
+        );
 
         let hash_after_all = queue.enqueued_head_hash();
 
@@ -1584,7 +1679,7 @@ mod tests {
         let remaining_deposits: Vec<L1Deposit> = queue
             .pending_blocks()
             .iter()
-            .flat_map(|b| b.deposits.clone())
+            .flat_map(|b| b.events.deposits.clone())
             .collect();
         let transition =
             PendingDeposits::transition(queue.processed_head_hash, &remaining_deposits);
@@ -1597,22 +1692,25 @@ mod tests {
 
         let h1 = make_test_header(1);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1, vec![make_deposit(1, 100)]);
+        queue.enqueue(
+            h1,
+            L1PortalEvents::from_deposits(vec![make_deposit(1, 100)]),
+        );
 
         let h2 = make_chained_header(2, h1_hash);
         let h2_hash = header_hash(&h2);
-        queue.enqueue(h2, vec![]);
+        queue.enqueue(h2, L1PortalEvents::from_deposits(vec![]));
 
         let h3 = make_chained_header(3, h2_hash);
         let h3_hash = header_hash(&h3);
-        queue.enqueue(h3, vec![]);
+        queue.enqueue(h3, L1PortalEvents::from_deposits(vec![]));
 
         let h4 = make_chained_header(4, h3_hash);
         let h4_hash = header_hash(&h4);
-        queue.enqueue(h4, vec![]);
+        queue.enqueue(h4, L1PortalEvents::from_deposits(vec![]));
 
         let h5 = make_chained_header(5, h4_hash);
-        queue.enqueue(h5, vec![]);
+        queue.enqueue(h5, L1PortalEvents::from_deposits(vec![]));
 
         // Pop blocks 1 and 2
         confirm(&mut queue);
@@ -1625,7 +1723,7 @@ mod tests {
         let mut h4_reorg = make_chained_header(4, h3_hash);
         h4_reorg.inner.gas_limit = 999;
         assert!(matches!(
-            queue.try_enqueue(seal(h4_reorg), vec![]),
+            queue.try_enqueue(seal(h4_reorg), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1644,14 +1742,23 @@ mod tests {
 
         let h1 = make_test_header(1);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1, vec![make_deposit(1, 100)]);
+        queue.enqueue(
+            h1,
+            L1PortalEvents::from_deposits(vec![make_deposit(1, 100)]),
+        );
 
         let h2 = make_chained_header(2, h1_hash);
         let h2_hash = header_hash(&h2);
-        queue.enqueue(h2, vec![make_deposit(2, 200)]);
+        queue.enqueue(
+            h2,
+            L1PortalEvents::from_deposits(vec![make_deposit(2, 200)]),
+        );
 
         let h3 = make_chained_header(3, h2_hash);
-        queue.enqueue(h3, vec![make_deposit(3, 300)]);
+        queue.enqueue(
+            h3,
+            L1PortalEvents::from_deposits(vec![make_deposit(3, 300)]),
+        );
 
         // Pop block 1 — processed_head_hash advances
         let popped = confirm(&mut queue);
@@ -1664,7 +1771,7 @@ mod tests {
         h2_reorg.inner.gas_limit = 777;
         // This block has a different hash at height 2, so purge_from(0) fires.
         // Queue becomes empty, then the new block is accepted as anchor.
-        let outcome = queue.try_enqueue(seal(h2_reorg), vec![]);
+        let outcome = queue.try_enqueue(seal(h2_reorg), L1PortalEvents::from_deposits(vec![]));
         assert!(matches!(outcome, EnqueueOutcome::Accepted));
 
         // After purge and re-anchor, pending has just the new block 2
@@ -1681,14 +1788,20 @@ mod tests {
 
         let h1 = make_test_header(1);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1, vec![make_deposit(1, 100)]);
+        queue.enqueue(
+            h1,
+            L1PortalEvents::from_deposits(vec![make_deposit(1, 100)]),
+        );
 
         // Try to enqueue block 3 (skipping 2) => NeedBackfill
         let h2 = make_chained_header(2, h1_hash);
         let h2_hash = header_hash(&h2);
         let h3 = make_chained_header(3, h2_hash);
         let h3_sealed = seal(h3);
-        match queue.try_enqueue(seal(make_test_header(3)), vec![]) {
+        match queue.try_enqueue(
+            seal(make_test_header(3)),
+            L1PortalEvents::from_deposits(vec![]),
+        ) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 2);
                 assert_eq!(to, 2);
@@ -1697,9 +1810,15 @@ mod tests {
         }
 
         // Backfill: enqueue block 2, then block 3
-        queue.enqueue(h2, vec![make_deposit(2, 200)]);
+        queue.enqueue(
+            h2,
+            L1PortalEvents::from_deposits(vec![make_deposit(2, 200)]),
+        );
         assert!(matches!(
-            queue.try_enqueue(h3_sealed.clone(), vec![make_deposit(3, 300)]),
+            queue.try_enqueue(
+                h3_sealed.clone(),
+                L1PortalEvents::from_deposits(vec![make_deposit(3, 300)])
+            ),
             EnqueueOutcome::Accepted
         ));
 
@@ -1708,7 +1827,10 @@ mod tests {
 
         // Re-deliver block 3 (same sealed header) => Duplicate
         assert!(matches!(
-            queue.try_enqueue(h3_sealed, vec![make_deposit(3, 300)]),
+            queue.try_enqueue(
+                h3_sealed,
+                L1PortalEvents::from_deposits(vec![make_deposit(3, 300)])
+            ),
             EnqueueOutcome::Duplicate
         ));
 
@@ -1722,15 +1844,18 @@ mod tests {
 
         let h1 = make_test_header(1);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1, vec![make_deposit(1, 100)]);
+        queue.enqueue(
+            h1,
+            L1PortalEvents::from_deposits(vec![make_deposit(1, 100)]),
+        );
 
         let h2 = make_chained_header(2, h1_hash);
         let h2_hash = header_hash(&h2);
-        queue.enqueue(h2, vec![]); // no deposits
+        queue.enqueue(h2, L1PortalEvents::from_deposits(vec![])); // no deposits
 
         let h3 = make_chained_header(3, h2_hash);
         let d3 = make_deposit(3, 300);
-        queue.enqueue(h3, vec![d3.clone()]);
+        queue.enqueue(h3, L1PortalEvents::from_deposits(vec![d3.clone()]));
 
         // Block 2 has no deposits => queue_hash_before == queue_hash_after
         assert_eq!(
@@ -1746,7 +1871,7 @@ mod tests {
         h2_reorg.inner.gas_limit = 888;
         let h2_reorg_hash = header_hash(&h2_reorg);
         assert!(matches!(
-            queue.try_enqueue(seal(h2_reorg), vec![]),
+            queue.try_enqueue(seal(h2_reorg), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1759,7 +1884,7 @@ mod tests {
         // Re-enqueue new block 3 with same deposits as original
         let h3_new = make_chained_header(3, h2_reorg_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h3_new), vec![d3]),
+            queue.try_enqueue(seal(h3_new), L1PortalEvents::from_deposits(vec![d3])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1781,13 +1906,13 @@ mod tests {
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         let h2 = make_chained_header(11, h1_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![]),
+            queue.try_enqueue(seal(h2), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1799,7 +1924,7 @@ mod tests {
 
         // Block 12 arrives with wrong parent — consumed block 11 was reorged
         let h3_bad = make_chained_header(12, B256::with_last_byte(0xDE));
-        match queue.try_enqueue(seal(h3_bad), vec![]) {
+        match queue.try_enqueue(seal(h3_bad), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 // Must re-fetch from block 11 (the consumed block that was reorged)
                 assert_eq!(from, 11);
@@ -1819,7 +1944,7 @@ mod tests {
         let h2_reorg = make_test_header(11);
         let h2_reorg_hash = header_hash(&h2_reorg);
         assert!(matches!(
-            queue.try_enqueue(seal(h2_reorg), vec![]),
+            queue.try_enqueue(seal(h2_reorg), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Duplicate
         ));
 
@@ -1828,7 +1953,7 @@ mod tests {
         // the builder will detect it).
         let h3 = make_chained_header(12, h2_reorg_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h3), vec![]),
+            queue.try_enqueue(seal(h3), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
         assert_eq!(queue.pending_len(), 1);
@@ -1842,20 +1967,26 @@ mod tests {
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![make_deposit(10, 100)]),
+            queue.try_enqueue(
+                seal(h1),
+                L1PortalEvents::from_deposits(vec![make_deposit(10, 100)])
+            ),
             EnqueueOutcome::Accepted
         ));
 
         let h2 = make_chained_header(11, h1_hash);
         let h2_hash = header_hash(&h2);
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![make_deposit(11, 200)]),
+            queue.try_enqueue(
+                seal(h2),
+                L1PortalEvents::from_deposits(vec![make_deposit(11, 200)])
+            ),
             EnqueueOutcome::Accepted
         ));
 
         let h3 = make_chained_header(12, h2_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h3), vec![]),
+            queue.try_enqueue(seal(h3), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1866,7 +1997,7 @@ mod tests {
         // Block 13 with wrong parent — this is a normal parent mismatch on the
         // non-empty queue path, should purge block 12 and request backfill
         let h4_bad = make_chained_header(13, B256::with_last_byte(0xAB));
-        match queue.try_enqueue(seal(h4_bad), vec![]) {
+        match queue.try_enqueue(seal(h4_bad), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 12);
                 assert_eq!(to, 12);
@@ -1882,7 +2013,7 @@ mod tests {
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1893,14 +2024,17 @@ mod tests {
         // Wrong parent → NeedBackfill
         let h2_bad = make_chained_header(11, B256::with_last_byte(0xFF));
         assert!(matches!(
-            queue.try_enqueue(seal(h2_bad), vec![]),
+            queue.try_enqueue(seal(h2_bad), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::NeedBackfill { .. }
         ));
 
         // Correct parent → Accepted
         let h2_good = make_chained_header(11, h1_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h2_good), vec![make_deposit(11, 500)]),
+            queue.try_enqueue(
+                seal(h2_good),
+                L1PortalEvents::from_deposits(vec![make_deposit(11, 500)])
+            ),
             EnqueueOutcome::Accepted
         ));
         assert_eq!(queue.pending_len(), 1);
@@ -1913,7 +2047,7 @@ mod tests {
 
         let h1 = make_test_header(10);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1923,7 +2057,7 @@ mod tests {
         // Block 14 arrives — gap of 11..13 plus wrong parent is moot because
         // the gap check triggers first
         let h5 = make_test_header(14);
-        match queue.try_enqueue(seal(h5), vec![]) {
+        match queue.try_enqueue(seal(h5), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 11);
                 assert_eq!(to, 13);
@@ -1939,13 +2073,13 @@ mod tests {
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         let h2 = make_chained_header(11, h1_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![]),
+            queue.try_enqueue(seal(h2), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -1956,11 +2090,17 @@ mod tests {
 
         // Re-deliver block 10 or 11 — should be Duplicate
         assert!(matches!(
-            queue.try_enqueue(seal(make_test_header(10)), vec![]),
+            queue.try_enqueue(
+                seal(make_test_header(10)),
+                L1PortalEvents::from_deposits(vec![])
+            ),
             EnqueueOutcome::Duplicate
         ));
         assert!(matches!(
-            queue.try_enqueue(seal(make_chained_header(11, h1_hash)), vec![]),
+            queue.try_enqueue(
+                seal(make_chained_header(11, h1_hash)),
+                L1PortalEvents::from_deposits(vec![])
+            ),
             EnqueueOutcome::Duplicate
         ));
     }
@@ -1971,7 +2111,10 @@ mod tests {
 
         let h1 = make_test_header(10);
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![make_deposit(10, 100)]),
+            queue.try_enqueue(
+                seal(h1),
+                L1PortalEvents::from_deposits(vec![make_deposit(10, 100)])
+            ),
             EnqueueOutcome::Accepted
         ));
 
@@ -1983,7 +2126,7 @@ mod tests {
         // Disconnected block should not alter processed_head_hash
         let h2_bad = make_chained_header(11, B256::with_last_byte(0xBB));
         assert!(matches!(
-            queue.try_enqueue(seal(h2_bad), vec![]),
+            queue.try_enqueue(seal(h2_bad), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::NeedBackfill { .. }
         ));
         assert_eq!(
@@ -2005,7 +2148,7 @@ mod tests {
         let mut queue = PendingDeposits::default();
 
         let h1 = make_test_header(10);
-        queue.enqueue(h1.clone(), vec![]);
+        queue.enqueue(h1.clone(), L1PortalEvents::from_deposits(vec![]));
 
         // Drain
         confirm(&mut queue);
@@ -2014,7 +2157,7 @@ mod tests {
 
         // Re-deliver same block 10 — must be Duplicate, last_enqueued preserved
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![]),
+            queue.try_enqueue(seal(h1), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Duplicate
         ));
         assert_eq!(
@@ -2032,21 +2175,33 @@ mod tests {
 
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1.clone(), vec![make_deposit(10, 100)]);
+        queue.enqueue(
+            h1.clone(),
+            L1PortalEvents::from_deposits(vec![make_deposit(10, 100)]),
+        );
 
         let h2 = make_chained_header(11, h1_hash);
-        queue.enqueue(h2.clone(), vec![make_deposit(11, 200)]);
+        queue.enqueue(
+            h2.clone(),
+            L1PortalEvents::from_deposits(vec![make_deposit(11, 200)]),
+        );
 
         let hash_before = queue.enqueued_head_hash();
         let len_before = queue.pending_len();
 
         // Re-enqueue both — should be Duplicate, no state change
         assert!(matches!(
-            queue.try_enqueue(seal(h1), vec![make_deposit(10, 100)]),
+            queue.try_enqueue(
+                seal(h1),
+                L1PortalEvents::from_deposits(vec![make_deposit(10, 100)])
+            ),
             EnqueueOutcome::Duplicate
         ));
         assert!(matches!(
-            queue.try_enqueue(seal(h2), vec![make_deposit(11, 200)]),
+            queue.try_enqueue(
+                seal(h2),
+                L1PortalEvents::from_deposits(vec![make_deposit(11, 200)])
+            ),
             EnqueueOutcome::Duplicate
         ));
         assert_eq!(queue.enqueued_head_hash(), hash_before);
@@ -2061,19 +2216,31 @@ mod tests {
 
         let h10 = make_test_header(10);
         let h10_hash = header_hash(&h10);
-        queue.enqueue(h10, vec![make_deposit(10, 100)]);
+        queue.enqueue(
+            h10,
+            L1PortalEvents::from_deposits(vec![make_deposit(10, 100)]),
+        );
         let hash_after_10 = queue.enqueued_head_hash();
 
         let h11 = make_chained_header(11, h10_hash);
         let h11_hash = header_hash(&h11);
-        queue.enqueue(h11, vec![make_deposit(11, 200)]);
+        queue.enqueue(
+            h11,
+            L1PortalEvents::from_deposits(vec![make_deposit(11, 200)]),
+        );
 
         let h12 = make_chained_header(12, h11_hash);
         let h12_hash = header_hash(&h12);
-        queue.enqueue(h12, vec![make_deposit(12, 300)]);
+        queue.enqueue(
+            h12,
+            L1PortalEvents::from_deposits(vec![make_deposit(12, 300)]),
+        );
 
         let h13 = make_chained_header(13, h12_hash);
-        queue.enqueue(h13, vec![make_deposit(13, 400)]);
+        queue.enqueue(
+            h13,
+            L1PortalEvents::from_deposits(vec![make_deposit(13, 400)]),
+        );
 
         assert_eq!(queue.pending_len(), 4);
 
@@ -2083,7 +2250,10 @@ mod tests {
         let h11_reorg_hash = header_hash(&h11_reorg);
 
         assert!(matches!(
-            queue.try_enqueue(seal(h11_reorg), vec![make_deposit(11, 999)]),
+            queue.try_enqueue(
+                seal(h11_reorg),
+                L1PortalEvents::from_deposits(vec![make_deposit(11, 999)])
+            ),
             EnqueueOutcome::Accepted
         ));
 
@@ -2099,7 +2269,7 @@ mod tests {
         // Can continue building on the new fork
         let h12_new = make_chained_header(12, h11_reorg_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h12_new), vec![]),
+            queue.try_enqueue(seal(h12_new), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
         assert_eq!(queue.pending_len(), 3);
@@ -2113,10 +2283,10 @@ mod tests {
 
         let h10 = make_test_header(10);
         let h10_hash = header_hash(&h10);
-        queue.enqueue(h10, vec![]);
+        queue.enqueue(h10, L1PortalEvents::from_deposits(vec![]));
 
         let h11 = make_chained_header(11, h10_hash);
-        queue.enqueue(h11.clone(), vec![]);
+        queue.enqueue(h11.clone(), L1PortalEvents::from_deposits(vec![]));
 
         // Drain
         confirm(&mut queue);
@@ -2124,7 +2294,7 @@ mod tests {
 
         // Re-deliver block 11 with same hash — Duplicate, last_enqueued intact
         assert!(matches!(
-            queue.try_enqueue(seal(h11), vec![]),
+            queue.try_enqueue(seal(h11), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Duplicate
         ));
         assert_eq!(queue.last_enqueued().unwrap().number, 11);
@@ -2140,10 +2310,10 @@ mod tests {
 
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1, vec![]);
+        queue.enqueue(h1, L1PortalEvents::from_deposits(vec![]));
 
         let h2 = make_chained_header(11, h1_hash);
-        queue.enqueue(h2, vec![]);
+        queue.enqueue(h2, L1PortalEvents::from_deposits(vec![]));
 
         let popped = confirm(&mut queue);
         assert_eq!(queue.last_processed().unwrap().number, 10);
@@ -2159,10 +2329,10 @@ mod tests {
 
         let h1 = make_test_header(10);
         let h1_hash = header_hash(&h1);
-        queue.enqueue(h1, vec![]);
+        queue.enqueue(h1, L1PortalEvents::from_deposits(vec![]));
 
         let h2 = make_chained_header(11, h1_hash);
-        queue.enqueue(h2, vec![]);
+        queue.enqueue(h2, L1PortalEvents::from_deposits(vec![]));
 
         let drained = queue.drain();
         assert_eq!(queue.last_processed().unwrap().number, 11);
@@ -2184,11 +2354,11 @@ mod tests {
 
         let h10 = make_test_header(10);
         let h10_hash = header_hash(&h10);
-        queue.enqueue(h10, vec![]);
+        queue.enqueue(h10, L1PortalEvents::from_deposits(vec![]));
 
         let h11 = make_chained_header(11, h10_hash);
         let _h11_hash = header_hash(&h11);
-        queue.enqueue(h11, vec![]);
+        queue.enqueue(h11, L1PortalEvents::from_deposits(vec![]));
 
         // Engine consumes both blocks
         confirm(&mut queue); // block 10
@@ -2199,7 +2369,7 @@ mod tests {
 
         // New block 12 arrives with parent pointing to NEW (reorged) block 11
         let h12_new = make_chained_header(12, B256::with_last_byte(0xDE));
-        match queue.try_enqueue(seal(h12_new), vec![]) {
+        match queue.try_enqueue(seal(h12_new), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 11);
                 assert_eq!(to, 11);
@@ -2215,7 +2385,7 @@ mod tests {
         h11_reorg.inner.gas_limit = 999;
         let h11_reorg_hash = header_hash(&h11_reorg);
         assert!(matches!(
-            queue.try_enqueue(seal(h11_reorg), vec![]),
+            queue.try_enqueue(seal(h11_reorg), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Duplicate
         ));
 
@@ -2224,7 +2394,7 @@ mod tests {
         // expected and will be caught by the builder)
         let h12 = make_chained_header(12, h11_reorg_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h12), vec![]),
+            queue.try_enqueue(seal(h12), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
@@ -2241,7 +2411,7 @@ mod tests {
 
         let h10 = make_test_header(10);
         let _h10_hash = header_hash(&h10);
-        queue.enqueue(h10, vec![]);
+        queue.enqueue(h10, L1PortalEvents::from_deposits(vec![]));
         confirm(&mut queue);
 
         // Simulate last_enqueued being cleared (reorg path)
@@ -2249,7 +2419,7 @@ mod tests {
 
         // Block 13 arrives — gap from 11..12
         let h13 = make_test_header(13);
-        match queue.try_enqueue(seal(h13), vec![]) {
+        match queue.try_enqueue(seal(h13), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 11); // last_processed.number + 1
                 assert_eq!(to, 12);
@@ -2268,11 +2438,11 @@ mod tests {
         // Enqueue block 10 (stale — zone already processed it)
         let h10 = make_test_header(10);
         let h10_hash = header_hash(&h10);
-        queue.enqueue(h10, vec![]);
+        queue.enqueue(h10, L1PortalEvents::from_deposits(vec![]));
 
         // Enqueue block 11 (the one the builder actually needs)
         let h11 = make_chained_header(11, h10_hash);
-        queue.enqueue(h11, vec![]);
+        queue.enqueue(h11, L1PortalEvents::from_deposits(vec![]));
 
         // Builder expects block 11 (tempoBlockNumber=10, expected=11).
         // Peek/confirm loop should skip block 10 and use the correct one.
@@ -2297,14 +2467,14 @@ mod tests {
         // Build a 3-block chain: 100, 101, 102
         let h100 = make_test_header(100);
         let h100_hash = header_hash(&h100);
-        queue.enqueue(h100, vec![]);
+        queue.enqueue(h100, L1PortalEvents::from_deposits(vec![]));
 
         let h101 = make_chained_header(101, h100_hash);
         let h101_hash = header_hash(&h101);
-        queue.enqueue(h101, vec![]);
+        queue.enqueue(h101, L1PortalEvents::from_deposits(vec![]));
 
         let h102 = make_chained_header(102, h101_hash);
-        queue.enqueue(h102, vec![]);
+        queue.enqueue(h102, L1PortalEvents::from_deposits(vec![]));
 
         // Engine consumes all 3
         confirm(&mut queue);
@@ -2315,7 +2485,7 @@ mod tests {
         // L1 reorgs at 102: new block 103 has different parent
         let new_parent = B256::with_last_byte(0xAA);
         let h103 = make_chained_header(103, new_parent);
-        match queue.try_enqueue(seal(h103), vec![]) {
+        match queue.try_enqueue(seal(h103), L1PortalEvents::from_deposits(vec![])) {
             EnqueueOutcome::NeedBackfill { from, to } => {
                 assert_eq!(from, 102);
                 assert_eq!(to, 102);
@@ -2328,7 +2498,7 @@ mod tests {
         h102_new.inner.gas_limit = 42;
         let h102_new_hash = header_hash(&h102_new);
         assert!(matches!(
-            queue.try_enqueue(seal(h102_new), vec![]),
+            queue.try_enqueue(seal(h102_new), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Duplicate
         ));
 
@@ -2336,14 +2506,14 @@ mod tests {
         let h103 = make_chained_header(103, h102_new_hash);
         let h103_hash = header_hash(&h103);
         assert!(matches!(
-            queue.try_enqueue(seal(h103), vec![]),
+            queue.try_enqueue(seal(h103), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 
         // Block 104 continues on the new chain
         let h104 = make_chained_header(104, h103_hash);
         assert!(matches!(
-            queue.try_enqueue(seal(h104), vec![]),
+            queue.try_enqueue(seal(h104), L1PortalEvents::from_deposits(vec![])),
             EnqueueOutcome::Accepted
         ));
 

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -28,8 +28,8 @@ pub mod zonemonitor;
 pub use batch::{BatchData, BatchSubmitter};
 pub use engine::ZoneEngine;
 pub use l1::{
-    Deposit, DepositQueue, EncryptedDeposit, L1BlockDeposits, L1Deposit, L1Subscriber,
-    L1SubscriberConfig,
+    Deposit, DepositQueue, EncryptedDeposit, L1BlockDeposits, L1Deposit, L1PortalEvents,
+    L1Subscriber, L1SubscriberConfig,
 };
 pub use l1_state::SharedL1StateCache;
 pub use node::{ZoneExecutorBuilder, ZoneNode};

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -19,7 +19,10 @@ use std::{
 };
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_primitives::TempoHeader;
-use zone::{Deposit, DepositQueue, EncryptedDeposit, L1Deposit, SharedL1StateCache, ZoneNode};
+use zone::{
+    Deposit, DepositQueue, EncryptedDeposit, L1Deposit, L1PortalEvents, SharedL1StateCache,
+    ZoneNode,
+};
 
 use alloy_provider::{Provider, ProviderBuilder, WalletProvider};
 use alloy_rpc_types_eth::BlockNumberOrTag;
@@ -2170,7 +2173,8 @@ impl L1Fixture {
         deposits: Vec<Deposit>,
     ) {
         let l1_deposits = deposits.into_iter().map(L1Deposit::Regular).collect();
-        queue.enqueue(block.header.clone(), l1_deposits);
+        let events = L1PortalEvents::from_deposits(l1_deposits);
+        queue.enqueue(block.header.clone(), events);
     }
 
     /// Create a [`Deposit`] tied to a specific L1 block number.
@@ -2196,7 +2200,7 @@ impl L1Fixture {
     /// Inject an empty L1 block (no deposits) into the queue.
     pub(crate) fn inject_empty_block(&mut self, queue: &DepositQueue) {
         let header = self.next_header();
-        queue.enqueue(header, vec![]);
+        queue.enqueue(header, L1PortalEvents::default());
     }
 
     /// Inject `n` empty L1 blocks (no deposits) into the queue.
@@ -2210,14 +2214,16 @@ impl L1Fixture {
     pub(crate) fn inject_deposits(&mut self, queue: &DepositQueue, deposits: Vec<Deposit>) {
         let header = self.next_header();
         let l1_deposits = deposits.into_iter().map(L1Deposit::Regular).collect();
-        queue.enqueue(header, l1_deposits);
+        let events = L1PortalEvents::from_deposits(l1_deposits);
+        queue.enqueue(header, events);
     }
 
     /// Inject an L1 block with mixed regular and encrypted deposits.
     #[allow(dead_code)]
     pub(crate) fn inject_l1_deposits(&mut self, queue: &DepositQueue, deposits: Vec<L1Deposit>) {
         let header = self.next_header();
-        queue.enqueue(header, deposits);
+        let events = L1PortalEvents::from_deposits(deposits);
+        queue.enqueue(header, events);
     }
 
     /// Create an [`EncryptedDeposit`] for testing with dummy ECIES parameters.


### PR DESCRIPTION
Prepare for #169 (multi-asset bridging) by generalising the L1 subscriber pipeline to handle portal events beyond deposits.

- Add `L1PortalEvents { deposits, enabled_tokens }` as an extensible container for per-block portal data
- Replace `L1BlockDeposits.deposits` with `L1BlockDeposits.events`
- Add `TokenEnabled` event to ZonePortal bindings and include it in the portal event filter
- Rename `fetch_deposits` → `fetch_portal_events`, `deposit_log_filter` → `portal_event_filter`
- Use explicit `match` on topic0 with a `warn` for unknown events
- Deposit hash chain remains deposit-only (`enabled_tokens` do not affect it)