### PR TITLE
zone: add TempoStateExt trait for reading L1 block state

### DIFF
--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -113,14 +113,20 @@ impl<N: reth_primitives_traits::NodePrimitives> ChainTempoStateExt for reth_prov
     fn tempo_block_number(&self) -> u64 {
         let slot7 = self
             .execution_outcome()
-            .storage(&TEMPO_STATE_ADDRESS, U256::from_be_bytes(TEMPO_PACKED_SLOT.0))
+            .storage(
+                &TEMPO_STATE_ADDRESS,
+                U256::from_be_bytes(TEMPO_PACKED_SLOT.0),
+            )
             .unwrap_or_default();
         (slot7 & U256::from(u64::MAX)).to::<u64>()
     }
 
     fn tempo_block_hash(&self) -> B256 {
         self.execution_outcome()
-            .storage(&TEMPO_STATE_ADDRESS, U256::from_be_bytes(TEMPO_BLOCK_HASH_SLOT.0))
+            .storage(
+                &TEMPO_STATE_ADDRESS,
+                U256::from_be_bytes(TEMPO_BLOCK_HASH_SLOT.0),
+            )
             .map(|v| B256::from(v.to_be_bytes()))
             .unwrap_or_default()
     }

--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -8,8 +8,10 @@
 //! - **ZoneOutbox** — deployed on the Zone L2. Collects user withdrawal requests, builds
 //!   withdrawal hash chains, and exposes [`LastBatch`] state for proof generation.
 
-use alloy_primitives::{Address, B256, address, keccak256};
+use alloy_primitives::{Address, B256, U256, address, keccak256};
 use alloy_sol_types::{SolValue, sol};
+use reth_provider::ProviderResult;
+use reth_storage_api::StateProvider;
 
 /// Sentinel value for empty withdrawal queue slots.
 /// Using 0xff...ff instead of 0x00 to avoid clearing storage.
@@ -49,6 +51,33 @@ pub const TEMPO_STATE_READER_ADDRESS: Address =
 /// This is the same TIP20 precompile address as on Tempo L1, initialized in zone genesis
 /// with the TIP20Factory so that `is_valid_fee_token` passes for user transactions.
 pub const ZONE_TOKEN_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000000");
+
+/// Extension trait for reading TempoState fields from zone storage.
+pub trait TempoStateExt {
+    /// Returns the current `tempoBlockNumber` (the latest L1 block processed by the zone).
+    ///
+    /// Reads the packed slot 7 of `TempoState` and extracts the lowest `uint64`.
+    fn tempo_block_number(&self) -> ProviderResult<u64>;
+
+    /// Returns the current `tempoBlockHash` (the hash of the latest L1 block processed).
+    fn tempo_block_hash(&self) -> ProviderResult<B256>;
+}
+
+impl<T: StateProvider + ?Sized> TempoStateExt for T {
+    fn tempo_block_number(&self) -> ProviderResult<u64> {
+        let slot7 = self
+            .storage(TEMPO_STATE_ADDRESS, TEMPO_PACKED_SLOT)?
+            .unwrap_or_default();
+        Ok((slot7 & U256::from(u64::MAX)).to::<u64>())
+    }
+
+    fn tempo_block_hash(&self) -> ProviderResult<B256> {
+        Ok(self
+            .storage(TEMPO_STATE_ADDRESS, TEMPO_BLOCK_HASH_SLOT)?
+            .map(|v| B256::from(v.to_be_bytes()))
+            .unwrap_or_default())
+    }
+}
 
 sol! {
     // ---------------------------------------------------------------

--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -8,6 +8,7 @@
 //! - **ZoneOutbox** — deployed on the Zone L2. Collects user withdrawal requests, builds
 //!   withdrawal hash chains, and exposes [`LastBatch`] state for proof generation.
 
+use alloy_eips::NumHash;
 use alloy_primitives::{Address, B256, U256, address, keccak256};
 use alloy_sol_types::{SolValue, sol};
 use reth_provider::ProviderResult;
@@ -61,6 +62,14 @@ pub trait TempoStateExt {
 
     /// Returns the current `tempoBlockHash` (the hash of the latest L1 block processed).
     fn tempo_block_hash(&self) -> ProviderResult<B256>;
+
+    /// Returns the current L1 block as a [`NumHash`] (number + hash).
+    fn tempo_num_hash(&self) -> ProviderResult<NumHash> {
+        Ok(NumHash {
+            number: self.tempo_block_number()?,
+            hash: self.tempo_block_hash()?,
+        })
+    }
 }
 
 impl<T: StateProvider + ?Sized> TempoStateExt for T {
@@ -76,6 +85,44 @@ impl<T: StateProvider + ?Sized> TempoStateExt for T {
             .storage(TEMPO_STATE_ADDRESS, TEMPO_BLOCK_HASH_SLOT)?
             .map(|v| B256::from(v.to_be_bytes()))
             .unwrap_or_default())
+    }
+}
+
+/// Extension trait for reading TempoState fields from a [`reth_provider::Chain`]'s execution
+/// outcome.
+///
+/// Separate from [`TempoStateExt`] because `Chain` does not implement [`StateProvider`] — it
+/// reads from the bundled [`ExecutionOutcome`](reth_provider::ExecutionOutcome) instead.
+pub trait ChainTempoStateExt {
+    /// Returns the current `tempoBlockNumber` from the chain's execution outcome.
+    fn tempo_block_number(&self) -> u64;
+
+    /// Returns the current `tempoBlockHash` from the chain's execution outcome.
+    fn tempo_block_hash(&self) -> B256;
+
+    /// Returns the current L1 block as a [`NumHash`] (number + hash).
+    fn tempo_num_hash(&self) -> NumHash {
+        NumHash {
+            number: self.tempo_block_number(),
+            hash: self.tempo_block_hash(),
+        }
+    }
+}
+
+impl<N: reth_primitives_traits::NodePrimitives> ChainTempoStateExt for reth_provider::Chain<N> {
+    fn tempo_block_number(&self) -> u64 {
+        let slot7 = self
+            .execution_outcome()
+            .storage(&TEMPO_STATE_ADDRESS, U256::from_be_bytes(TEMPO_PACKED_SLOT.0))
+            .unwrap_or_default();
+        (slot7 & U256::from(u64::MAX)).to::<u64>()
+    }
+
+    fn tempo_block_hash(&self) -> B256 {
+        self.execution_outcome()
+            .storage(&TEMPO_STATE_ADDRESS, U256::from_be_bytes(TEMPO_BLOCK_HASH_SLOT.0))
+            .map(|v| B256::from(v.to_be_bytes()))
+            .unwrap_or_default()
     }
 }
 

--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -8,11 +8,8 @@
 //! - **ZoneOutbox** — deployed on the Zone L2. Collects user withdrawal requests, builds
 //!   withdrawal hash chains, and exposes [`LastBatch`] state for proof generation.
 
-use alloy_eips::NumHash;
-use alloy_primitives::{Address, B256, U256, address, keccak256};
+use alloy_primitives::{Address, B256, address, keccak256};
 use alloy_sol_types::{SolValue, sol};
-use reth_provider::ProviderResult;
-use reth_storage_api::StateProvider;
 
 /// Sentinel value for empty withdrawal queue slots.
 /// Using 0xff...ff instead of 0x00 to avoid clearing storage.
@@ -52,85 +49,6 @@ pub const TEMPO_STATE_READER_ADDRESS: Address =
 /// This is the same TIP20 precompile address as on Tempo L1, initialized in zone genesis
 /// with the TIP20Factory so that `is_valid_fee_token` passes for user transactions.
 pub const ZONE_TOKEN_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000000");
-
-/// Extension trait for reading TempoState fields from zone storage.
-pub trait TempoStateExt {
-    /// Returns the current `tempoBlockNumber` (the latest L1 block processed by the zone).
-    ///
-    /// Reads the packed slot 7 of `TempoState` and extracts the lowest `uint64`.
-    fn tempo_block_number(&self) -> ProviderResult<u64>;
-
-    /// Returns the current `tempoBlockHash` (the hash of the latest L1 block processed).
-    fn tempo_block_hash(&self) -> ProviderResult<B256>;
-
-    /// Returns the current L1 block as a [`NumHash`] (number + hash).
-    fn tempo_num_hash(&self) -> ProviderResult<NumHash> {
-        Ok(NumHash {
-            number: self.tempo_block_number()?,
-            hash: self.tempo_block_hash()?,
-        })
-    }
-}
-
-impl<T: StateProvider + ?Sized> TempoStateExt for T {
-    fn tempo_block_number(&self) -> ProviderResult<u64> {
-        let slot7 = self
-            .storage(TEMPO_STATE_ADDRESS, TEMPO_PACKED_SLOT)?
-            .unwrap_or_default();
-        Ok((slot7 & U256::from(u64::MAX)).to::<u64>())
-    }
-
-    fn tempo_block_hash(&self) -> ProviderResult<B256> {
-        Ok(self
-            .storage(TEMPO_STATE_ADDRESS, TEMPO_BLOCK_HASH_SLOT)?
-            .map(|v| B256::from(v.to_be_bytes()))
-            .unwrap_or_default())
-    }
-}
-
-/// Extension trait for reading TempoState fields from a [`reth_provider::Chain`]'s execution
-/// outcome.
-///
-/// Separate from [`TempoStateExt`] because `Chain` does not implement [`StateProvider`] — it
-/// reads from the bundled [`ExecutionOutcome`](reth_provider::ExecutionOutcome) instead.
-pub trait ChainTempoStateExt {
-    /// Returns the current `tempoBlockNumber` from the chain's execution outcome.
-    fn tempo_block_number(&self) -> u64;
-
-    /// Returns the current `tempoBlockHash` from the chain's execution outcome.
-    fn tempo_block_hash(&self) -> B256;
-
-    /// Returns the current L1 block as a [`NumHash`] (number + hash).
-    fn tempo_num_hash(&self) -> NumHash {
-        NumHash {
-            number: self.tempo_block_number(),
-            hash: self.tempo_block_hash(),
-        }
-    }
-}
-
-impl<N: reth_primitives_traits::NodePrimitives> ChainTempoStateExt for reth_provider::Chain<N> {
-    fn tempo_block_number(&self) -> u64 {
-        let slot7 = self
-            .execution_outcome()
-            .storage(
-                &TEMPO_STATE_ADDRESS,
-                U256::from_be_bytes(TEMPO_PACKED_SLOT.0),
-            )
-            .unwrap_or_default();
-        (slot7 & U256::from(u64::MAX)).to::<u64>()
-    }
-
-    fn tempo_block_hash(&self) -> B256 {
-        self.execution_outcome()
-            .storage(
-                &TEMPO_STATE_ADDRESS,
-                U256::from_be_bytes(TEMPO_BLOCK_HASH_SLOT.0),
-            )
-            .map(|v| B256::from(v.to_be_bytes()))
-            .unwrap_or_default()
-    }
-}
 
 sol! {
     // ---------------------------------------------------------------

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -154,7 +154,7 @@ where
         // Read the current tempoBlockHash and tempoBlockNumber from TempoState storage
         // to validate the next L1 block we process is the expected successor.
         let (stored_l1_block_hash, expected_tempo_block_number) = {
-            use crate::abi::TempoStateExt;
+            use crate::ext::TempoStateExt;
             let sp = self.provider.state_by_block_hash(parent_header.hash())?;
             let hash = sp
                 .tempo_block_hash()

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -154,28 +154,15 @@ where
         // Read the current tempoBlockHash and tempoBlockNumber from TempoState storage
         // to validate the next L1 block we process is the expected successor.
         let (stored_l1_block_hash, expected_tempo_block_number) = {
+            use crate::abi::TempoStateExt;
             let sp = self.provider.state_by_block_hash(parent_header.hash())?;
             let hash = sp
-                .storage(
-                    crate::abi::TEMPO_STATE_ADDRESS,
-                    crate::abi::TEMPO_BLOCK_HASH_SLOT,
-                )
-                .map_err(|e| PayloadBuilderError::Internal(e.into()))?
-                .map(|v| alloy_primitives::B256::from(v.to_be_bytes()))
-                .unwrap_or_default();
-            // tempoBlockNumber is at slot 7, offset 0 (packed as lowest uint64 in the slot,
-            // alongside tempoGasLimit, tempoGasUsed, tempoTimestamp)
-            let slot7 = sp
-                .storage(
-                    crate::abi::TEMPO_STATE_ADDRESS,
-                    crate::abi::TEMPO_PACKED_SLOT,
-                )
-                .map_err(|e| PayloadBuilderError::Internal(e.into()))?
-                .unwrap_or_default();
-            // Extract lowest 8 bytes (uint64 at offset 0)
-            let tempo_block_number: u64 = (slot7 & U256::from(u64::MAX)).to::<u64>();
-            let expected: u64 = tempo_block_number + 1;
-            (hash, expected)
+                .tempo_block_hash()
+                .map_err(|e| PayloadBuilderError::Internal(e.into()))?;
+            let tempo_block_number = sp
+                .tempo_block_number()
+                .map_err(|e| PayloadBuilderError::Internal(e.into()))?;
+            (hash, tempo_block_number + 1)
         };
 
         info!(

--- a/crates/tempo-zone/src/ext.rs
+++ b/crates/tempo-zone/src/ext.rs
@@ -1,0 +1,87 @@
+//! Extension traits for reading TempoState fields from zone storage.
+
+use alloy_eips::NumHash;
+use alloy_primitives::{B256, U256};
+use reth_provider::ProviderResult;
+use reth_storage_api::StateProvider;
+
+use crate::abi::{TEMPO_BLOCK_HASH_SLOT, TEMPO_PACKED_SLOT, TEMPO_STATE_ADDRESS};
+
+/// Extension trait for reading TempoState fields from zone storage.
+pub trait TempoStateExt {
+    /// Returns the current `tempoBlockNumber` (the latest L1 block processed by the zone).
+    ///
+    /// Reads the packed slot 7 of `TempoState` and extracts the lowest `uint64`.
+    fn tempo_block_number(&self) -> ProviderResult<u64>;
+
+    /// Returns the current `tempoBlockHash` (the hash of the latest L1 block processed).
+    fn tempo_block_hash(&self) -> ProviderResult<B256>;
+
+    /// Returns the current L1 block as a [`NumHash`] (number + hash).
+    fn tempo_num_hash(&self) -> ProviderResult<NumHash> {
+        Ok(NumHash {
+            number: self.tempo_block_number()?,
+            hash: self.tempo_block_hash()?,
+        })
+    }
+}
+
+impl<T: StateProvider + ?Sized> TempoStateExt for T {
+    fn tempo_block_number(&self) -> ProviderResult<u64> {
+        let slot7 = self
+            .storage(TEMPO_STATE_ADDRESS, TEMPO_PACKED_SLOT)?
+            .unwrap_or_default();
+        Ok((slot7 & U256::from(u64::MAX)).to::<u64>())
+    }
+
+    fn tempo_block_hash(&self) -> ProviderResult<B256> {
+        Ok(self
+            .storage(TEMPO_STATE_ADDRESS, TEMPO_BLOCK_HASH_SLOT)?
+            .map(|v| B256::from(v.to_be_bytes()))
+            .unwrap_or_default())
+    }
+}
+
+/// Extension trait for reading TempoState fields from a [`reth_provider::Chain`]'s execution
+/// outcome.
+///
+/// Separate from [`TempoStateExt`] because `Chain` does not implement [`StateProvider`] — it
+/// reads from the bundled [`ExecutionOutcome`](reth_provider::ExecutionOutcome) instead.
+pub trait ChainTempoStateExt {
+    /// Returns the current `tempoBlockNumber` from the chain's execution outcome.
+    fn tempo_block_number(&self) -> u64;
+
+    /// Returns the current `tempoBlockHash` from the chain's execution outcome.
+    fn tempo_block_hash(&self) -> B256;
+
+    /// Returns the current L1 block as a [`NumHash`] (number + hash).
+    fn tempo_num_hash(&self) -> NumHash {
+        NumHash {
+            number: self.tempo_block_number(),
+            hash: self.tempo_block_hash(),
+        }
+    }
+}
+
+impl<N: reth_primitives_traits::NodePrimitives> ChainTempoStateExt for reth_provider::Chain<N> {
+    fn tempo_block_number(&self) -> u64 {
+        let slot7 = self
+            .execution_outcome()
+            .storage(
+                &TEMPO_STATE_ADDRESS,
+                U256::from_be_bytes(TEMPO_PACKED_SLOT.0),
+            )
+            .unwrap_or_default();
+        (slot7 & U256::from(u64::MAX)).to::<u64>()
+    }
+
+    fn tempo_block_hash(&self) -> B256 {
+        self.execution_outcome()
+            .storage(
+                &TEMPO_STATE_ADDRESS,
+                U256::from_be_bytes(TEMPO_BLOCK_HASH_SLOT.0),
+            )
+            .map(|v| B256::from(v.to_be_bytes()))
+            .unwrap_or_default()
+    }
+}

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -10,7 +10,7 @@
 use eyre as _;
 
 pub mod abi;
-pub use abi::TempoStateExt;
+pub use abi::{ChainTempoStateExt, TempoStateExt};
 pub mod batch;
 pub mod bindings;
 pub mod builder;

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -10,7 +10,8 @@
 use eyre as _;
 
 pub mod abi;
-pub use abi::{ChainTempoStateExt, TempoStateExt};
+pub mod ext;
+pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub mod batch;
 pub mod bindings;
 pub mod builder;

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -10,6 +10,7 @@
 use eyre as _;
 
 pub mod abi;
+pub use abi::TempoStateExt;
 pub mod batch;
 pub mod bindings;
 pub mod builder;

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -242,7 +242,7 @@ where
         // Read the zone's current tempoBlockNumber from local state so the L1
         // subscriber knows exactly where to resume backfill.
         {
-            use crate::abi::TempoStateExt;
+            use crate::ext::TempoStateExt;
             use reth_storage_api::StateProviderFactory;
             let sp = ctx.node.provider().latest()?;
             let tempo_block_number = sp.tempo_block_number()?;

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -242,16 +242,10 @@ where
         // Read the zone's current tempoBlockNumber from local state so the L1
         // subscriber knows exactly where to resume backfill.
         {
+            use crate::abi::TempoStateExt;
             use reth_storage_api::StateProviderFactory;
             let sp = ctx.node.provider().latest()?;
-            let slot7 = sp
-                .storage(
-                    crate::abi::TEMPO_STATE_ADDRESS,
-                    crate::abi::TEMPO_PACKED_SLOT,
-                )
-                .unwrap_or_default()
-                .unwrap_or_default();
-            let tempo_block_number = (slot7 & U256::from(u64::MAX)).to::<u64>();
+            let tempo_block_number = sp.tempo_block_number()?;
             self.l1_config.local_tempo_block_number = tempo_block_number;
             info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber");
         }

--- a/crates/tempo-zone/tests/it/e2e.rs
+++ b/crates/tempo-zone/tests/it/e2e.rs
@@ -6,11 +6,13 @@
 //! exercised via queue injection (with the L1 state cache seeded for precompile reads).
 
 use alloy::primitives::{Address, B256, U256, address};
+use alloy_eips::NumHash;
 use tempo_contracts::precompiles::ITIP20;
 use tempo_precompiles::PATH_USD_ADDRESS;
 use zone::abi::{
     TEMPO_STATE_ADDRESS, TempoState, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox,
 };
+use zone::ChainTempoStateExt;
 
 use crate::utils::{
     DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, ZoneTestNode, poll_until, seed_fixture_for_zone,
@@ -436,6 +438,71 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
         last_batch.withdrawalQueueHash,
         B256::ZERO,
         "lastBatch.withdrawalQueueHash should be zero with no withdrawals"
+    );
+
+    Ok(())
+}
+
+/// Verify that `ChainTempoStateExt` on the committed `Chain` from a canon state
+/// notification returns the correct L1 block NumHash after zone blocks are mined.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_chain_tempo_state_ext_from_canon_notification() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
+    let mut canon_rx = zone.subscribe_to_canonical_state();
+
+    // Inject 3 empty L1 blocks — each produces a zone block.
+    fixture.inject_empty_blocks(zone.deposit_queue(), 3);
+
+    // Wait for tempoBlockNumber to reach 3 via RPC (ensures blocks are mined).
+    zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
+
+    // Drain canon notifications and collect the L1 NumHash from each committed chain.
+    let mut num_hashes: Vec<NumHash> = Vec::new();
+    while let Ok(notification) = canon_rx.try_recv() {
+        let chain = notification.committed();
+        let nh = chain.tempo_num_hash();
+        if nh.number > 0 {
+            num_hashes.push(nh);
+        }
+    }
+
+    // We should have received notifications for blocks 1, 2, 3.
+    assert!(
+        num_hashes.len() >= 3,
+        "expected at least 3 canon notifications with non-zero tempoBlockNumber, got {}",
+        num_hashes.len()
+    );
+
+    // Verify the L1 block numbers are monotonically increasing.
+    for window in num_hashes.windows(2) {
+        assert!(
+            window[1].number > window[0].number,
+            "L1 block numbers should be increasing: {} -> {}",
+            window[0].number,
+            window[1].number
+        );
+    }
+
+    // The last notification should match the final L1 block number (3).
+    let last = num_hashes.last().unwrap();
+    assert_eq!(
+        last.number, 3,
+        "last canon notification should have tempoBlockNumber == 3"
+    );
+    assert_ne!(
+        last.hash,
+        B256::ZERO,
+        "tempoBlockHash should be non-zero"
+    );
+
+    // Cross-check against the on-chain TempoState.
+    let tempo_state = TempoState::new(TEMPO_STATE_ADDRESS, zone.provider());
+    let on_chain_hash = tempo_state.tempoBlockHash().call().await?;
+    assert_eq!(
+        last.hash, on_chain_hash,
+        "Chain ext hash should match on-chain tempoBlockHash"
     );
 
     Ok(())

--- a/crates/tempo-zone/tests/it/e2e.rs
+++ b/crates/tempo-zone/tests/it/e2e.rs
@@ -9,10 +9,13 @@ use alloy::primitives::{Address, B256, U256, address};
 use alloy_eips::NumHash;
 use tempo_contracts::precompiles::ITIP20;
 use tempo_precompiles::PATH_USD_ADDRESS;
-use zone::abi::{
-    TEMPO_STATE_ADDRESS, TempoState, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox,
+use zone::{
+    ChainTempoStateExt,
+    abi::{
+        TEMPO_STATE_ADDRESS, TempoState, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZoneInbox,
+        ZoneOutbox,
+    },
 };
-use zone::ChainTempoStateExt;
 
 use crate::utils::{
     DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, ZoneTestNode, poll_until, seed_fixture_for_zone,
@@ -491,11 +494,7 @@ async fn test_chain_tempo_state_ext_from_canon_notification() -> eyre::Result<()
         last.number, 3,
         "last canon notification should have tempoBlockNumber == 3"
     );
-    assert_ne!(
-        last.hash,
-        B256::ZERO,
-        "tempoBlockHash should be non-zero"
-    );
+    assert_ne!(last.hash, B256::ZERO, "tempoBlockHash should be non-zero");
 
     // Cross-check against the on-chain TempoState.
     let tempo_state = TempoState::new(TEMPO_STATE_ADDRESS, zone.provider());

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -92,13 +92,23 @@ pub(crate) fn compute_tip20_address(sender: Address, salt: B256) -> Address {
     Address::from(address_bytes)
 }
 
-pub(crate) trait TestNodeHandle: Send {}
+pub(crate) trait TestNodeHandle: Send {
+    fn subscribe_to_canonical_state(
+        &self,
+    ) -> reth_provider::CanonStateNotifications<tempo_primitives::TempoPrimitives>;
+}
 
 impl<Node, AddOns> TestNodeHandle for NodeHandle<Node, AddOns>
 where
-    Node: FullNodeComponents,
+    Node: FullNodeComponents<Types: reth_node_api::NodeTypes<Primitives = tempo_primitives::TempoPrimitives>>,
     AddOns: RethRpcAddOns<Node>,
 {
+    fn subscribe_to_canonical_state(
+        &self,
+    ) -> reth_provider::CanonStateNotifications<tempo_primitives::TempoPrimitives> {
+        use reth_provider::CanonStateSubscriptions;
+        self.node.provider().subscribe_to_canonical_state()
+    }
 }
 
 /// A self-contained Tempo Zone L2 node for integration testing.
@@ -121,8 +131,7 @@ pub(crate) struct ZoneTestNode {
     deposit_queue: DepositQueue,
     l1_state_cache: SharedL1StateCache,
     rpc_api: Arc<dyn zone::rpc::ZoneRpcApi>,
-    canon_state_tx: reth_provider::CanonStateNotificationSender<tempo_primitives::TempoPrimitives>,
-    _node_handle: Box<dyn TestNodeHandle>,
+    node_handle: Box<dyn TestNodeHandle>,
     _tasks: TaskManager,
 }
 
@@ -158,7 +167,7 @@ impl ZoneTestNode {
     pub(crate) fn subscribe_to_canonical_state(
         &self,
     ) -> reth_provider::CanonStateNotifications<tempo_primitives::TempoPrimitives> {
-        self.canon_state_tx.subscribe()
+        self.node_handle.subscribe_to_canonical_state()
     }
 
     /// Wait for a TIP-20 token balance to reach at least `min_balance` on this zone.
@@ -517,28 +526,12 @@ impl ZoneTestNode {
         let rpc_api: Arc<dyn zone::rpc::ZoneRpcApi> =
             Arc::new(zone::rpc::TempoZoneRpc::new(eth_handlers));
 
-        // Create a relay broadcast channel for canon state notifications.
-        // We subscribe to the node's provider and forward into our own sender
-        // so test code can subscribe after the concrete node type is erased.
-        let (canon_state_tx, _) = tokio::sync::broadcast::channel(64);
-        {
-            use reth_provider::CanonStateSubscriptions;
-            let mut rx = node_handle.node.provider().subscribe_to_canonical_state();
-            let tx = canon_state_tx.clone();
-            tokio::spawn(async move {
-                while let Ok(notification) = rx.recv().await {
-                    let _ = tx.send(notification);
-                }
-            });
-        }
-
         Ok(Self {
             deposit_queue,
             http_url,
             l1_state_cache,
             rpc_api,
-            canon_state_tx,
-            _node_handle: Box::new(node_handle),
+            node_handle: Box::new(node_handle),
             _tasks: tasks,
         })
     }

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -100,7 +100,9 @@ pub(crate) trait TestNodeHandle: Send {
 
 impl<Node, AddOns> TestNodeHandle for NodeHandle<Node, AddOns>
 where
-    Node: FullNodeComponents<Types: reth_node_api::NodeTypes<Primitives = tempo_primitives::TempoPrimitives>>,
+    Node: FullNodeComponents<
+        Types: reth_node_api::NodeTypes<Primitives = tempo_primitives::TempoPrimitives>,
+    >,
     AddOns: RethRpcAddOns<Node>,
 {
     fn subscribe_to_canonical_state(

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -121,6 +121,7 @@ pub(crate) struct ZoneTestNode {
     deposit_queue: DepositQueue,
     l1_state_cache: SharedL1StateCache,
     rpc_api: Arc<dyn zone::rpc::ZoneRpcApi>,
+    canon_state_tx: reth_provider::CanonStateNotificationSender<tempo_primitives::TempoPrimitives>,
     _node_handle: Box<dyn TestNodeHandle>,
     _tasks: TaskManager,
 }
@@ -151,6 +152,13 @@ impl ZoneTestNode {
     /// Returns the real private RPC API backed by the node's EthHandlers.
     pub(crate) fn rpc_api(&self) -> Arc<dyn zone::rpc::ZoneRpcApi> {
         self.rpc_api.clone()
+    }
+
+    /// Subscribe to canonical state notifications.
+    pub(crate) fn subscribe_to_canonical_state(
+        &self,
+    ) -> reth_provider::CanonStateNotifications<tempo_primitives::TempoPrimitives> {
+        self.canon_state_tx.subscribe()
     }
 
     /// Wait for a TIP-20 token balance to reach at least `min_balance` on this zone.
@@ -509,11 +517,27 @@ impl ZoneTestNode {
         let rpc_api: Arc<dyn zone::rpc::ZoneRpcApi> =
             Arc::new(zone::rpc::TempoZoneRpc::new(eth_handlers));
 
+        // Create a relay broadcast channel for canon state notifications.
+        // We subscribe to the node's provider and forward into our own sender
+        // so test code can subscribe after the concrete node type is erased.
+        let (canon_state_tx, _) = tokio::sync::broadcast::channel(64);
+        {
+            use reth_provider::CanonStateSubscriptions;
+            let mut rx = node_handle.node.provider().subscribe_to_canonical_state();
+            let tx = canon_state_tx.clone();
+            tokio::spawn(async move {
+                while let Ok(notification) = rx.recv().await {
+                    let _ = tx.send(notification);
+                }
+            });
+        }
+
         Ok(Self {
             deposit_queue,
             http_url,
             l1_state_cache,
             rpc_api,
+            canon_state_tx,
             _node_handle: Box::new(node_handle),
             _tasks: tasks,
         })


### PR DESCRIPTION
Add an extension trait on `StateProvider` that provides reusable helpers for reading `tempoBlockNumber` and `tempoBlockHash` from `TempoState` storage. Refactors the builder and node startup to use the new trait instead of duplicating the raw slot read logic.

Closes #199