### PR TITLE
chore: bump tempo to v1.4.0-rc1, reth to tempo/v1.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
+checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2947,7 +2947,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -3282,7 +3281,6 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -5923,15 +5921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6800,7 +6789,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6824,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6855,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6875,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6889,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6967,7 +6956,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6977,7 +6966,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6995,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7015,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7025,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7041,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7054,7 +7043,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7066,7 +7055,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7092,7 +7081,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7118,7 +7107,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7146,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7176,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7191,7 +7180,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7216,7 +7205,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7240,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7264,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7299,7 +7288,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7327,7 +7316,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7350,7 +7339,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7375,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "futures",
  "pin-project",
@@ -7397,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7454,7 +7443,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7482,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7497,7 +7486,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7513,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7535,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7546,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7574,7 +7563,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7595,7 +7584,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -7635,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "clap",
  "eyre",
@@ -7657,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7673,7 +7662,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7691,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7704,7 +7693,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7733,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7753,7 +7742,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7763,7 +7752,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7787,7 +7776,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7809,7 +7798,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7822,7 +7811,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7840,7 +7829,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7878,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7892,7 +7881,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "serde",
  "serde_json",
@@ -7902,7 +7891,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7930,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "bytes",
  "futures",
@@ -7950,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -7966,7 +7955,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -7975,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "futures",
  "metrics",
@@ -7987,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -7996,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8010,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8067,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8092,7 +8081,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8115,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8130,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8144,7 +8133,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8161,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8185,7 +8174,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8253,7 +8242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8309,7 +8298,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8347,7 +8336,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8371,7 +8360,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8395,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "bytes",
  "eyre",
@@ -8419,7 +8408,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8431,7 +8420,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8446,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8467,7 +8456,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8479,7 +8468,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8502,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8512,7 +8501,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8545,7 +8534,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8588,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8616,7 +8605,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8631,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8644,7 +8633,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8726,7 +8715,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -8757,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8798,7 +8787,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8819,7 +8808,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8849,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8893,7 +8882,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8941,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8955,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8971,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9020,7 +9009,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9047,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9061,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9081,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9094,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9118,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9135,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9153,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,7 +9158,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9179,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "clap",
  "eyre",
@@ -9196,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "clap",
  "eyre",
@@ -9213,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9257,7 +9246,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9283,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9310,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9325,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9350,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9369,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9387,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=0ce23d76#0ce23d76714c63fa7614915c35daae2f64db53b7"
+source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "zstd",
 ]
@@ -10669,8 +10658,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10689,6 +10678,7 @@ dependencies = [
  "reth-rpc-convert",
  "reth-rpc-eth-types",
  "serde",
+ "tempo-chainspec",
  "tempo-contracts",
  "tempo-evm",
  "tempo-primitives",
@@ -10698,8 +10688,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10717,8 +10707,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10733,8 +10723,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10743,8 +10733,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10773,8 +10763,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -10825,12 +10815,13 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
+ "either",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -10838,6 +10829,7 @@ dependencies = [
  "reth-engine-tree",
  "reth-errors",
  "reth-evm",
+ "reth-execution-types",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-primitives",
@@ -10856,9 +10848,10 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10866,6 +10859,7 @@ dependencies = [
  "derive_more",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
  "tempo-primitives",
@@ -10873,11 +10867,13 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy",
  "alloy-evm",
+ "commonware-codec",
+ "commonware-cryptography",
  "derive_more",
  "revm",
  "scoped-tls",
@@ -10890,8 +10886,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10901,8 +10897,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10914,6 +10910,7 @@ dependencies = [
  "base64 0.22.1",
  "derive_more",
  "modular-bitfield",
+ "once_cell",
  "p256",
  "reth-codecs",
  "reth-db-api",
@@ -10928,8 +10925,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10951,8 +10948,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.2.0#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+version = "1.4.0-rc1"
+source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.0-rc1#df88553d7b62d26af4f2427ba21ccfff1be8fbb6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,52 +75,52 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.2.0", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0-rc1", default-features = false }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76", features = [
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0ce23d76" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
 revm = { version = "34.0.0", features = ["optional_fee_charge"] }
 
 # alloy
@@ -128,7 +128,7 @@ alloy = { version = "1.6.1", default-features = false }
 alloy-consensus = { version = "1.6.1", default-features = false }
 alloy-contract = { version = "1.6.1", default-features = false }
 alloy-eips = { version = "1.6.1", default-features = false }
-alloy-evm = "0.27.0"
+alloy-evm = "0.27.3"
 alloy-network = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.5.4", default-features = false }
 alloy-provider = { version = "1.6.1", default-features = false }
@@ -138,7 +138,7 @@ alloy-rpc-types-engine = "1.6.1"
 alloy-rpc-types-eth = { version = "1.6.1" }
 alloy-signer = "1.6.1"
 alloy-signer-local = "1.6.1"
-alloy-sol-types = "1.5.4"
+alloy-sol-types = "1.5.7"
 alloy-transport = "1.6.1"
 
 # commonware


### PR DESCRIPTION
Bumps all upstream dependencies to match tempo v1.4.0-rc1:

- tempo crates: v1.2.0 → v1.4.0-rc1
- reth crates: rev `0ce23d76` → branch `tempo/v1.10.2`
- alloy-evm: 0.27.0 → 0.27.3
- alloy-sol-types: 1.5.4 → 1.5.7