### PR TITLE
feat(zone): reuse built payload execution data in engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13042,6 +13042,7 @@ dependencies = [
  "axum",
  "const-hex",
  "derive_more",
+ "either",
  "eyre",
  "futures",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ aes-gcm = "0.10.3"
 clap = { version = "4.5.45", features = ["derive"] }
 const-hex = { version = "1.15.0" }
 derive_more = { version = "2.0.0" }
+either = "1.15.0"
 eyre = "0.6.12"
 futures = "0.3.31"
 indicatif = "0.18"

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -79,6 +79,7 @@ sha2.workspace = true
 reqwest.workspace = true
 url = "2"
 derive_more = { workspace = true, features = ["deref", "deref_mut"] }
+either.workspace = true
 eyre.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -14,6 +14,7 @@ use alloy_consensus::{Signed, TxLegacy};
 use alloy_primitives::{Bytes, U256};
 use alloy_rlp::Encodable;
 use alloy_sol_types::SolCall;
+use either::Either;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
 };
@@ -21,12 +22,12 @@ use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_errors::ProviderError;
 use reth_evm::{
     ConfigureEvm, Database, NextBlockEnvAttributes,
-    execute::{BlockBuilder, BlockBuilderOutcome},
+    execute::{BlockBuilder, BlockBuilderOutcome, ExecutionOutcome},
 };
 use reth_node_api::FullNodeTypes;
 use reth_node_builder::{BuilderContext, components::PayloadBuilderBuilder};
 use reth_payload_builder::{EthBuiltPayload, PayloadBuilderError};
-use reth_payload_primitives::PayloadBuilderAttributes;
+use reth_payload_primitives::{BuiltPayloadExecutedBlock, PayloadBuilderAttributes};
 use reth_primitives_traits::{AlloyBlockHeader as _, Recovered};
 use reth_revm::{State, database::StateProviderDatabase};
 use reth_storage_api::{StateProvider, StateProviderFactory};
@@ -38,8 +39,9 @@ use std::{sync::Arc, time::Instant};
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
 use tempo_evm::TempoNextBlockEnvAttributes;
+use tempo_payload_types::TempoBuiltPayload;
 use tempo_primitives::{
-    TempoHeader, TempoPrimitives, TempoTxEnvelope,
+    TempoHeader, TempoTxEnvelope,
     transaction::envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
 };
 use tempo_transaction_pool::TempoTransactionPool;
@@ -90,7 +92,7 @@ where
         StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + Clone + 'static,
 {
     type Attributes = ZonePayloadBuilderAttributes;
-    type BuiltPayload = EthBuiltPayload<TempoPrimitives>;
+    type BuiltPayload = TempoBuiltPayload;
 
     fn try_build(
         &self,
@@ -342,13 +344,14 @@ where
 
         let BlockBuilderOutcome {
             execution_result,
+            hashed_state,
+            trie_updates,
             block,
-            ..
         } = builder.finish(&state_provider)?;
 
         let requests = chain_spec
             .is_prague_active_at_timestamp(attributes.timestamp())
-            .then_some(execution_result.requests);
+            .then_some(execution_result.requests.clone());
 
         let sealed_block = Arc::new(block.sealed_block().clone());
         let elapsed = start.elapsed();
@@ -365,8 +368,24 @@ where
             "Built zone payload"
         );
 
-        let payload =
+        let eth_payload =
             EthBuiltPayload::new(attributes.payload_id(), sealed_block, total_fees, requests);
+
+        let execution_outcome = ExecutionOutcome::new(
+            db.take_bundle(),
+            vec![execution_result.receipts],
+            block.number(),
+            vec![execution_result.requests],
+        );
+
+        let executed_block = BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(block),
+            execution_output: Arc::new(execution_outcome),
+            hashed_state: Either::Left(Arc::new(hashed_state)),
+            trie_updates: Either::Left(Arc::new(trie_updates)),
+        };
+
+        let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block));
 
         drop(db);
         // Zone payloads are deterministic (one L1 block = one zone block), so freeze

--- a/crates/tempo-zone/src/engine.rs
+++ b/crates/tempo-zone/src/engine.rs
@@ -44,7 +44,7 @@ use eyre::OptionExt;
 use reth_chainspec::EthereumHardforks;
 use reth_node_builder::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_payload_primitives::{EngineApiMessageVersion, PayloadKind, PayloadTypes};
+use reth_payload_primitives::{BuiltPayload, EngineApiMessageVersion, PayloadKind, PayloadTypes};
 use reth_primitives_traits::SealedHeader;
 use std::{sync::Arc, time::Duration};
 use tempo_chainspec::spec::TempoChainSpec;

--- a/crates/tempo-zone/src/payload.rs
+++ b/crates/tempo-zone/src/payload.rs
@@ -11,11 +11,11 @@ use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_engine::PayloadAttributes as EthPayloadAttributes;
 use alloy_rpc_types_eth::Withdrawal;
 use reth_node_api::{PayloadBuilderAttributes, PayloadTypes};
-use reth_payload_builder::{EthBuiltPayload, EthPayloadBuilderAttributes};
+use reth_payload_builder::EthPayloadBuilderAttributes;
 use reth_primitives_traits::SealedBlock;
 use serde::{Deserialize, Serialize};
-use tempo_payload_types::TempoExecutionData;
-use tempo_primitives::{Block, TempoPrimitives};
+use tempo_payload_types::{TempoBuiltPayload, TempoExecutionData};
+use tempo_primitives::Block;
 
 use crate::l1::PreparedL1Block;
 
@@ -140,7 +140,7 @@ pub struct ZonePayloadTypes;
 
 impl PayloadTypes for ZonePayloadTypes {
     type ExecutionData = TempoExecutionData;
-    type BuiltPayload = EthBuiltPayload<TempoPrimitives>;
+    type BuiltPayload = TempoBuiltPayload;
     type PayloadAttributes = ZonePayloadAttributes;
     type PayloadBuilderAttributes = ZonePayloadBuilderAttributes;
 


### PR DESCRIPTION
The zone payload builder was discarding `hashed_state` and `trie_updates` from `BlockBuilderOutcome` via `..`, forcing the engine tree to re-execute every block it just built. This mirrors the pattern already used by the Tempo L1 payload builder.

Now the builder captures all execution data from `BlockBuilderOutcome`, constructs an `ExecutionOutcome` + `BuiltPayloadExecutedBlock`, and wraps it in `TempoBuiltPayload`. When the engine tree receives the built payload, it finds `executed_block` is `Some` and skips re-execution entirely.

Changes across three files:
- `payload.rs`: `BuiltPayload` associated type changed from `EthBuiltPayload<TempoPrimitives>` to `TempoBuiltPayload`
- `builder.rs`: captures all `BlockBuilderOutcome` fields, constructs `BuiltPayloadExecutedBlock` with execution outcome, hashed state, and trie updates
- `engine.rs`: imports `BuiltPayload` trait so `.block()` resolves on the new type

Closes #201
Closes #183