### PR TITLE
feat(docker): only build tempo-zone

### DIFF
--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -25,12 +25,12 @@ jobs:
 
       - uses: depot/setup-action@v1
 
-      - name: Docker metadata for tempo-profiling
-        id: meta-tempo
+      - name: Docker metadata for tempo-zone-profiling
+        id: meta-tempo-zone
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/tempo
-          bake-target: tempo
+          images: ${{ env.REGISTRY }}/tempo-zone
+          bake-target: tempo-zone
           tags: |
             type=raw,value=${{ github.event.inputs.tag }}
             type=sha,prefix=${{ github.event.inputs.tag }}-sha-
@@ -51,8 +51,8 @@ jobs:
           files: |
             docker-bake.hcl
             docker-bake-profiling.hcl
-            ${{ steps.meta-tempo.outputs.bake-file }}
-          targets: tempo
+            ${{ steps.meta-tempo-zone.outputs.bake-file }}
+          targets: tempo-zone
           project: 0c6tg19qsp
           push: true
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,24 @@ jobs:
             type=sha,prefix=sha-
             type=ref,event=pr
 
+      - name: Docker metadata for tempo-zone
+        id: meta-tempo-zone
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/tempo-zone
+          bake-target: tempo-zone
+          tags: |
+            type=schedule,pattern=nightly
+            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=edge,branch=main
+            type=sha,prefix=sha-
+            type=ref,event=pr
+
       - name: Docker metadata for tempo-bench
         id: meta-tempo-bench
         uses: docker/metadata-action@v5
@@ -123,6 +141,7 @@ jobs:
           files: |
             docker-bake.hcl
             ${{ steps.meta-tempo.outputs.bake-file }}
+            ${{ steps.meta-tempo-zone.outputs.bake-file }}
             ${{ steps.meta-tempo-bench.outputs.bake-file }}
             ${{ steps.meta-tempo-sidecar.outputs.bake-file }}
             ${{ steps.meta-tempo-xtask.outputs.bake-file }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - "v*.*.*"
+  pull_request:
   merge_group:
   workflow_dispatch:
     inputs:
@@ -35,84 +36,12 @@ jobs:
 
       - uses: depot/setup-action@v1
 
-      - name: Docker metadata for tempo
-        id: meta-tempo
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/tempo
-          bake-target: tempo
-          tags: |
-            type=schedule,pattern=nightly
-            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=main
-            type=sha,prefix=sha-
-            type=ref,event=pr
-
       - name: Docker metadata for tempo-zone
         id: meta-tempo-zone
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/tempo-zone
           bake-target: tempo-zone
-          tags: |
-            type=schedule,pattern=nightly
-            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=main
-            type=sha,prefix=sha-
-            type=ref,event=pr
-
-      - name: Docker metadata for tempo-bench
-        id: meta-tempo-bench
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/tempo-bench
-          bake-target: tempo-bench
-          tags: |
-            type=schedule,pattern=nightly
-            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=main
-            type=sha,prefix=sha-
-            type=ref,event=pr
-
-      - name: Docker metadata for tempo-sidecar
-        id: meta-tempo-sidecar
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/tempo-sidecar
-          bake-target: tempo-sidecar
-          tags: |
-            type=schedule,pattern=nightly
-            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=main
-            type=sha,prefix=sha-
-            type=ref,event=pr
-
-      - name: Docker metadata for tempo-xtask
-        id: meta-tempo-xtask
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/tempo-xtask
-          bake-target: tempo-xtask
           tags: |
             type=schedule,pattern=nightly
             type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
@@ -140,14 +69,10 @@ jobs:
         with:
           files: |
             docker-bake.hcl
-            ${{ steps.meta-tempo.outputs.bake-file }}
             ${{ steps.meta-tempo-zone.outputs.bake-file }}
-            ${{ steps.meta-tempo-bench.outputs.bake-file }}
-            ${{ steps.meta-tempo-sidecar.outputs.bake-file }}
-            ${{ steps.meta-tempo-xtask.outputs.bake-file }}
           targets: default
           project: 0c6tg19qsp
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}
           VERGEN_GIT_SHA_SHORT: ${{ steps.shortsha.outputs.shortsha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,12 @@ ARG EXTRA_RUSTFLAGS=""
 
 COPY . .
 
-# Build ALL binaries in one pass - they share compiled artifacts
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-registry \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked,id=cargo-git \
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked,id=sccache \
     RUSTFLAGS="-C link-arg=-fuse-ld=mold ${EXTRA_RUSTFLAGS}" \
     cargo build --profile ${RUST_PROFILE} \
-        --bin tempo --features "asm-keccak,jemalloc,otlp" \
-        --bin tempo-zone \
-        --bin tempo-bench \
-        --bin tempo-sidecar \
-        --bin tempo-xtask
+        --bin tempo-zone --features "jemalloc"
 
 FROM debian:bookworm-slim AS base
 
@@ -29,33 +24,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /data
 
-# tempo
-FROM base AS tempo
-ARG RUST_PROFILE=profiling
-COPY --from=builder /app/target/${RUST_PROFILE}/tempo /usr/local/bin/tempo
-ENTRYPOINT ["/usr/local/bin/tempo"]
-
 # tempo-zone
 FROM base AS tempo-zone
 ARG RUST_PROFILE=profiling
 COPY --from=builder /app/target/${RUST_PROFILE}/tempo-zone /usr/local/bin/tempo-zone
 ENTRYPOINT ["/usr/local/bin/tempo-zone"]
-
-# tempo-sidecar
-FROM base AS tempo-sidecar
-ARG RUST_PROFILE=profiling
-COPY --from=builder /app/target/${RUST_PROFILE}/tempo-sidecar /usr/local/bin/tempo-sidecar
-ENTRYPOINT ["/usr/local/bin/tempo-sidecar"]
-
-# tempo-xtask
-FROM base AS tempo-xtask
-ARG RUST_PROFILE=profiling
-COPY --from=builder /app/target/${RUST_PROFILE}/tempo-xtask /usr/local/bin/tempo-xtask
-ENTRYPOINT ["/usr/local/bin/tempo-xtask"]
-
-# tempo-bench (needs nushell)
-FROM base AS tempo-bench
-ARG RUST_PROFILE=profiling
-COPY --from=ghcr.io/nushell/nushell:0.108.0-bookworm /usr/bin/nu /usr/bin/nu
-COPY --from=builder /app/target/${RUST_PROFILE}/tempo-bench /usr/local/bin/tempo-bench
-ENTRYPOINT ["/usr/local/bin/tempo-bench"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-
     RUSTFLAGS="-C link-arg=-fuse-ld=mold ${EXTRA_RUSTFLAGS}" \
     cargo build --profile ${RUST_PROFILE} \
         --bin tempo --features "asm-keccak,jemalloc,otlp" \
+        --bin tempo-zone \
         --bin tempo-bench \
         --bin tempo-sidecar \
         --bin tempo-xtask
@@ -33,6 +34,12 @@ FROM base AS tempo
 ARG RUST_PROFILE=profiling
 COPY --from=builder /app/target/${RUST_PROFILE}/tempo /usr/local/bin/tempo
 ENTRYPOINT ["/usr/local/bin/tempo"]
+
+# tempo-zone
+FROM base AS tempo-zone
+ARG RUST_PROFILE=profiling
+COPY --from=builder /app/target/${RUST_PROFILE}/tempo-zone /usr/local/bin/tempo-zone
+ENTRYPOINT ["/usr/local/bin/tempo-zone"]
 
 # tempo-sidecar
 FROM base AS tempo-sidecar

--- a/Dockerfile.chef
+++ b/Dockerfile.chef
@@ -1,4 +1,4 @@
-FROM rust:1.91-bookworm AS chef
+FROM rust:1.93-bookworm AS chef
 
 RUN cargo install cargo-chef sccache
 

--- a/Dockerfile.chef
+++ b/Dockerfile.chef
@@ -12,7 +12,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 
 ARG RUST_PROFILE=profiling
-ARG RUST_FEATURES="asm-keccak,jemalloc,otlp"
+ARG RUST_FEATURES="jemalloc"
 ARG EXTRA_RUSTFLAGS=""
 
 RUN apt-get update \

--- a/docker-bake-profiling.hcl
+++ b/docker-bake-profiling.hcl
@@ -15,7 +15,7 @@ target "chef" {
   platforms = ["linux/amd64"]
   args = {
     RUST_PROFILE = "profiling"
-    RUST_FEATURES = "jemalloc"
+    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
     EXTRA_RUSTFLAGS = "-C force-frame-pointers=yes"
   }
 }

--- a/docker-bake-profiling.hcl
+++ b/docker-bake-profiling.hcl
@@ -15,7 +15,7 @@ target "chef" {
   platforms = ["linux/amd64"]
   args = {
     RUST_PROFILE = "profiling"
-    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
+    RUST_FEATURES = "jemalloc"
     EXTRA_RUSTFLAGS = "-C force-frame-pointers=yes"
   }
 }

--- a/docker-bake-profiling.hcl
+++ b/docker-bake-profiling.hcl
@@ -15,7 +15,7 @@ target "chef" {
   platforms = ["linux/amd64"]
   args = {
     RUST_PROFILE = "profiling"
-    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
+    RUST_FEATURES = "jemalloc"
     EXTRA_RUSTFLAGS = "-C force-frame-pointers=yes"
   }
 }
@@ -36,7 +36,7 @@ target "_common" {
   platforms = ["linux/amd64"]
 }
 
-target "tempo" {
+target "tempo-zone" {
   inherits = ["_common", "docker-metadata"]
-  target = "tempo"
+  target = "tempo-zone"
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -19,7 +19,7 @@ target "chef" {
   platforms = ["linux/amd64"]
   args = {
     RUST_PROFILE = "profiling"
-    RUST_FEATURES = "jemalloc"
+    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
   }
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "VERGEN_GIT_SHA_SHORT" {
 }
 
 group "default" {
-  targets = ["tempo", "tempo-bench", "tempo-sidecar", "tempo-xtask"]
+  targets = ["tempo", "tempo-zone", "tempo-bench", "tempo-sidecar", "tempo-xtask"]
 }
 
 target "docker-metadata" {}
@@ -41,6 +41,11 @@ target "_common" {
 target "tempo" {
   inherits = ["_common", "docker-metadata"]
   target = "tempo"
+}
+
+target "tempo-zone" {
+  inherits = ["_common", "docker-metadata"]
+  target = "tempo-zone"
 }
 
 target "tempo-bench" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "VERGEN_GIT_SHA_SHORT" {
 }
 
 group "default" {
-  targets = ["tempo", "tempo-zone", "tempo-bench", "tempo-sidecar", "tempo-xtask"]
+  targets = ["tempo-zone"]
 }
 
 target "docker-metadata" {}
@@ -19,7 +19,7 @@ target "chef" {
   platforms = ["linux/amd64"]
   args = {
     RUST_PROFILE = "profiling"
-    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
+    RUST_FEATURES = "jemalloc"
   }
 }
 
@@ -38,27 +38,7 @@ target "_common" {
   platforms = ["linux/amd64"]
 }
 
-target "tempo" {
-  inherits = ["_common", "docker-metadata"]
-  target = "tempo"
-}
-
 target "tempo-zone" {
   inherits = ["_common", "docker-metadata"]
   target = "tempo-zone"
-}
-
-target "tempo-bench" {
-  inherits = ["_common", "docker-metadata"]
-  target = "tempo-bench"
-}
-
-target "tempo-sidecar" {
-  inherits = ["_common", "docker-metadata"]
-  target = "tempo-sidecar"
-}
-
-target "tempo-xtask" {
-  inherits = ["_common", "docker-metadata"]
-  target = "tempo-xtask"
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -19,7 +19,7 @@ target "chef" {
   platforms = ["linux/amd64"]
   args = {
     RUST_PROFILE = "profiling"
-    RUST_FEATURES = "asm-keccak,jemalloc,otlp"
+    RUST_FEATURES = "jemalloc"
   }
 }
 


### PR DESCRIPTION
## Summary
Strip Docker pipeline down to only build `tempo-zone`. Remove tempo, tempo-bench, tempo-sidecar, tempo-xtask targets.

## Changes
- `Dockerfile`: only build + stage `tempo-zone`
- `docker-bake.hcl`: only `tempo-zone` target
- `docker-bake-profiling.hcl`: only `tempo-zone` target
- `.github/workflows/docker.yml`: only `tempo-zone` metadata, add `pull_request` trigger (build-only, no push)
- `.github/workflows/docker-profiling.yml`: only `tempo-zone`

Co-Authored-By: zhygis <5236121+Zygimantass@users.noreply.github.com>

Prompted by: zygis