### PR TITLE
chore: use default_value_t for typed CLI args

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -36,7 +36,7 @@ struct ZoneArgs {
     #[arg(
         long = "block.interval-ms",
         env = "BLOCK_INTERVAL_MS",
-        default_value = "250"
+        default_value_t = 250
     )]
     pub block_interval_ms: u64,
 
@@ -49,7 +49,7 @@ struct ZoneArgs {
     #[arg(
         long = "zone.poll-interval-secs",
         env = "ZONE_POLL_INTERVAL_SECS",
-        default_value = "1"
+        default_value_t = 1
     )]
     pub zone_poll_interval_secs: u64,
 
@@ -58,7 +58,7 @@ struct ZoneArgs {
     #[arg(
         long = "zone.batch-interval-secs",
         env = "ZONE_BATCH_INTERVAL_SECS",
-        default_value = "60"
+        default_value_t = 60
     )]
     pub zone_batch_interval_secs: u64,
 
@@ -66,7 +66,7 @@ struct ZoneArgs {
     #[arg(
         long = "withdrawal-poll-interval-secs",
         env = "WITHDRAWAL_POLL_INTERVAL_SECS",
-        default_value = "5"
+        default_value_t = 5
     )]
     pub poll_interval_secs: u64,
 

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -3,7 +3,7 @@ use alloy::{
         EthereumWallet,
         primitives::{HeaderResponse, ReceiptResponse},
     },
-    primitives::{Address, B256},
+    primitives::{Address, B256, address},
     providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
     sol,
@@ -62,12 +62,12 @@ pub(crate) struct CreateZone {
 
     /// ZoneFactory contract address on Tempo L1.
     /// Default is the ZoneFactory deployed on moderato.
-    #[arg(long, default_value = "0x7F4528b1a555D704bC20f8328557240BED29488D")]
+    #[arg(long, default_value_t = address!("0x7F4528b1a555D704bC20f8328557240BED29488D"))]
     zone_factory: Address,
 
     /// Initial TIP-20 token address for the zone (additional tokens can be enabled later).
     /// Defaults to pathUSD (0x20C0000000000000000000000000000000000000).
-    #[arg(long, default_value = "0x20C0000000000000000000000000000000000000")]
+    #[arg(long, default_value_t = address!("0x20C0000000000000000000000000000000000000"))]
     initial_token: Address,
 
     /// Sequencer address that will operate the zone.

--- a/xtask/src/encrypted_deposit.rs
+++ b/xtask/src/encrypted_deposit.rs
@@ -5,7 +5,7 @@
 
 use alloy::{
     network::{EthereumWallet, primitives::ReceiptResponse},
-    primitives::{Address, B256, Bytes, U256},
+    primitives::{Address, B256, Bytes, U256, address},
     providers::{Provider, ProviderBuilder},
     rpc::types::Filter,
     signers::local::PrivateKeySigner,
@@ -33,7 +33,7 @@ pub(crate) struct EncryptedDeposit {
     private_key: String,
 
     /// TIP-20 token address to deposit.
-    #[arg(long, default_value = "0x20C0000000000000000000000000000000000000")]
+    #[arg(long, default_value_t = address!("0x20C0000000000000000000000000000000000000"))]
     token: Address,
 
     /// Amount to deposit.
@@ -45,10 +45,7 @@ pub(crate) struct EncryptedDeposit {
     to: Option<Address>,
 
     /// Memo bytes32 (encrypted on-chain).
-    #[arg(
-        long,
-        default_value = "0x0000000000000000000000000000000000000000000000000000000000000000"
-    )]
+    #[arg(long, default_value_t = B256::ZERO)]
     memo: B256,
 
     /// Zone L2 RPC URL. If set, waits for the deposit to be processed on L2.

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -1,5 +1,5 @@
 use alloy::{
-    primitives::{Address, U256},
+    primitives::{Address, U256, address},
     providers::ProviderBuilder,
 };
 use eyre::eyre;
@@ -19,7 +19,7 @@ pub(crate) struct ZoneInfoCmd {
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.
-    #[arg(long, default_value = "0x7F4528b1a555D704bC20f8328557240BED29488D")]
+    #[arg(long, default_value_t = address!("0x7F4528b1a555D704bC20f8328557240BED29488D"))]
     zone_factory: Address,
 }
 


### PR DESCRIPTION
Replace string-based `default_value` with `default_value_t` for CLI args where the
field type is not `String` or `PathBuf`. This gives clap native type awareness for
defaults, avoiding redundant string parsing at startup.

Changes across `tempo-zone` and `xtask`:
- Numeric `u64` defaults (block interval, poll intervals) use integer literals
- `Address` defaults use the `address!()` macro
- `B256::ZERO` replaces the 66-char zero hex string