### PR TITLE
feat(xtask): add spam-deposits command for deposit throughput testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10999,11 +10999,13 @@ name = "tempo-xtask"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-eips",
  "alloy-rlp",
  "clap",
  "const-hex",
  "eyre",
  "k256",
+ "rand 0.8.5",
  "reth-evm",
  "rustls",
  "serde",
@@ -11013,6 +11015,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles",
+ "tempo-primitives",
  "tempo-revm",
  "tokio",
  "zone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11004,6 +11004,7 @@ dependencies = [
  "clap",
  "const-hex",
  "eyre",
+ "futures",
  "k256",
  "rand 0.8.5",
  "reth-evm",

--- a/Justfile
+++ b/Justfile
@@ -656,8 +656,8 @@ deploy-zone name:
                       --sequencer-key "$SEQUENCER_KEY"
 
 [group('zone')]
-[doc('Spam deposit transactions to measure portal throughput. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and PRIVATE_KEY env vars.')]
-spam-deposits total="20" per-block="10" amount="1000000" token="0x20C0000000000000000000000000000000000000" encrypted="" lead-time="3":
+[doc('Spam deposit transactions to measure portal throughput. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and PRIVATE_KEY env vars. Example: just spam-deposits 10 10 200000 1 (10 txs, 10 per block, 200000 amount, encrypted)')]
+spam-deposits total="20" per-block="10" amount="1000000" encrypted="" token="0x20C0000000000000000000000000000000000000" lead-time="3":
     #!/bin/bash
     set -euo pipefail
     PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"

--- a/Justfile
+++ b/Justfile
@@ -657,15 +657,14 @@ deploy-zone name:
 
 [group('zone')]
 [doc('Spam deposit transactions to measure portal throughput. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and PRIVATE_KEY env vars.')]
-spam-deposits total="20" per-block="10" amount="1000000" token="0x20C0000000000000000000000000000000000000" encrypted="" lead-time="5" rpc=zone_rpc:
+spam-deposits total="20" per-block="10" amount="1000000" token="0x20C0000000000000000000000000000000000000" encrypted="" lead-time="3":
     #!/bin/bash
     set -euo pipefail
     PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
     ARGS="--total {{total}} --per-block {{per-block}} --amount {{amount}} --token {{token}} --lead-time {{lead-time}}"
-    if [[ -n "{{encrypted}}" ]]; then
+    if [[ "{{encrypted}}" == "true" || "{{encrypted}}" == "1" ]]; then
         ARGS="$ARGS --encrypted"
     fi
-    ARGS="$ARGS --zone-rpc-url {{rpc}}"
     cargo run -p tempo-xtask -- spam-deposits --private-key "$PK" $ARGS
 
 [group('zone')]

--- a/Justfile
+++ b/Justfile
@@ -656,6 +656,19 @@ deploy-zone name:
                       --sequencer-key "$SEQUENCER_KEY"
 
 [group('zone')]
+[doc('Spam deposit transactions to measure portal throughput. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and PRIVATE_KEY env vars.')]
+spam-deposits total="20" per-block="10" amount="1000000" token="0x20C0000000000000000000000000000000000000" encrypted="" lead-time="5" rpc=zone_rpc:
+    #!/bin/bash
+    set -euo pipefail
+    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
+    ARGS="--total {{total}} --per-block {{per-block}} --amount {{amount}} --token {{token}} --lead-time {{lead-time}}"
+    if [[ -n "{{encrypted}}" ]]; then
+        ARGS="$ARGS --encrypted"
+    fi
+    ARGS="$ARGS --zone-rpc-url {{rpc}}"
+    cargo run -p tempo-xtask -- spam-deposits --private-key "$PK" $ARGS
+
+[group('zone')]
 [doc('Runs the full TIP-20 + TIP-403 blacklist demo: creates token, enables on zone, blacklists address, shows deposit bounce, unblacklists, shows deposit success, withdraws. Requires PRIVATE_KEY (sequencer key) and L1_PORTAL_ADDRESS env vars.')]
 demo-blacklist amount="500000" rpc=zone_rpc:
     cargo run -p tempo-xtask -- demo-blacklist --zone-rpc-url {{rpc}} --amount {{amount}}

--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -528,7 +528,13 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
     /// `key_index` is the zero-based index of the current key.
     pub async fn encryption_key(
         &self,
-    ) -> Result<(ZonePortal::sequencerEncryptionKeyReturn, alloy_primitives::U256), alloy_contract::Error> {
+    ) -> Result<
+        (
+            ZonePortal::sequencerEncryptionKeyReturn,
+            alloy_primitives::U256,
+        ),
+        alloy_contract::Error,
+    > {
         let key_call = self.sequencerEncryptionKey();
         let count_call = self.encryptionKeyCount();
         let (key, count) = tokio::try_join!(key_call.call(), count_call.call())?;

--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -505,6 +505,39 @@ sol! {
     }
 }
 
+impl ZonePortal::sequencerEncryptionKeyReturn {
+    /// Normalize `yParity` to SEC1 compressed prefix (`0x02` or `0x03`).
+    ///
+    /// The contract may return `0`/`1` (parity bit) or `0x02`/`0x03` (SEC1 prefix).
+    pub fn normalized_y_parity(&self) -> Option<u8> {
+        match self.yParity {
+            0x02 | 0x03 => Some(self.yParity),
+            0 | 1 => Some(0x02 + self.yParity),
+            _ => None,
+        }
+    }
+}
+
+impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
+    ZonePortal::ZonePortalInstance<P, N>
+{
+    /// Fetches the active sequencer encryption key and its index.
+    ///
+    /// Returns `(key, key_index)` where `key` is the
+    /// [`sequencerEncryptionKeyReturn`](ZonePortal::sequencerEncryptionKeyReturn) and
+    /// `key_index` is the zero-based index of the current key.
+    pub async fn encryption_key(
+        &self,
+    ) -> Result<(ZonePortal::sequencerEncryptionKeyReturn, alloy_primitives::U256), alloy_contract::Error> {
+        let (key, count) = tokio::try_join!(
+            self.sequencerEncryptionKey().call(),
+            self.encryptionKeyCount().call(),
+        )?;
+        let key_index = count.saturating_sub(alloy_primitives::U256::from(1));
+        Ok((key, key_index))
+    }
+}
+
 impl std::fmt::Display for ZonePortal::ZonePortalErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/tempo-zone/src/abi.rs
+++ b/crates/tempo-zone/src/abi.rs
@@ -529,10 +529,9 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
     pub async fn encryption_key(
         &self,
     ) -> Result<(ZonePortal::sequencerEncryptionKeyReturn, alloy_primitives::U256), alloy_contract::Error> {
-        let (key, count) = tokio::try_join!(
-            self.sequencerEncryptionKey().call(),
-            self.encryptionKeyCount().call(),
-        )?;
+        let key_call = self.sequencerEncryptionKey();
+        let count_call = self.encryptionKeyCount();
+        let (key, count) = tokio::try_join!(key_call.call(), count_call.call())?;
         let key_index = count.saturating_sub(alloy_primitives::U256::from(1));
         Ok((key, key_index))
     }

--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -50,6 +50,12 @@ sol! {
 
         /// Enabled token by index.
         function enabledTokenAt(uint256 index) external view returns (address);
+
+        /// Active sequencer encryption key (compressed secp256k1 point).
+        function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+
+        /// Total number of encryption keys ever registered.
+        function encryptionKeyCount() external view returns (uint256);
     }
 }
 
@@ -78,5 +84,24 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
             tokens.push(token);
         }
         Ok(tokens)
+    }
+
+    /// Fetches the active sequencer encryption key and its index.
+    ///
+    /// Returns `(key, key_index)` where `key` is the
+    /// [`sequencerEncryptionKeyReturn`](ZonePortal::sequencerEncryptionKeyReturn) and
+    /// `key_index` is the zero-based index of the current key.
+    pub async fn encryption_key(
+        &self,
+    ) -> Result<
+        (ZonePortal::sequencerEncryptionKeyReturn, alloy_primitives::U256),
+        alloy_contract::Error,
+    > {
+        let (key, count) = tokio::try_join!(
+            self.sequencerEncryptionKey().call(),
+            self.encryptionKeyCount().call(),
+        )?;
+        let key_index = count.saturating_sub(alloy_primitives::U256::from(1));
+        Ok((key, key_index))
     }
 }

--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -94,7 +94,10 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
     pub async fn encryption_key(
         &self,
     ) -> Result<
-        (ZonePortal::sequencerEncryptionKeyReturn, alloy_primitives::U256),
+        (
+            ZonePortal::sequencerEncryptionKeyReturn,
+            alloy_primitives::U256,
+        ),
         alloy_contract::Error,
     > {
         let key_call = self.sequencerEncryptionKey();

--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -58,24 +58,25 @@ sol! {
     function mint(address to, uint256 amount);
 }
 
-/// Query all enabled tokens from a [`ZonePortal`] contract.
-///
-/// Calls `enabledTokenCount()` followed by `enabledTokenAt(i)` for each index
-/// to collect the full list of TIP-20 token addresses that are enabled for
-/// bridging on this portal.
-pub async fn enabled_tokens(
-    portal_address: alloy_primitives::Address,
-    provider: &impl alloy_provider::Provider<tempo_alloy::TempoNetwork>,
-) -> eyre::Result<Vec<alloy_primitives::Address>> {
-    let portal = ZonePortal::new(portal_address, provider);
-    let count: u64 = portal.enabledTokenCount().call().await?.try_into()?;
-    let mut tokens = Vec::with_capacity(count as usize);
-    for i in 0..count {
-        let token = portal
-            .enabledTokenAt(alloy_primitives::U256::from(i))
-            .call()
-            .await?;
-        tokens.push(token);
+impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
+    ZonePortal::ZonePortalInstance<P, N>
+{
+    /// Returns all token addresses currently enabled for bridging on this [`ZonePortal`].
+    ///
+    /// Calls [`enabledTokenCount`](ZonePortal::enabledTokenCountCall) followed by
+    /// [`enabledTokenAt`](ZonePortal::enabledTokenAtCall) for each index.
+    pub async fn enabled_tokens(
+        &self,
+    ) -> Result<Vec<alloy_primitives::Address>, alloy_contract::Error> {
+        let count = self.enabledTokenCount().call().await?;
+        let mut tokens = Vec::with_capacity(count.to::<usize>());
+        for i in 0..count.to::<u64>() {
+            let token = self
+                .enabledTokenAt(alloy_primitives::U256::from(i))
+                .call()
+                .await?;
+            tokens.push(token);
+        }
+        Ok(tokens)
     }
-    Ok(tokens)
 }

--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -58,25 +58,24 @@ sol! {
     function mint(address to, uint256 amount);
 }
 
-impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
-    ZonePortal::ZonePortalInstance<P, N>
-{
-    /// Returns all token addresses currently enabled for bridging on this [`ZonePortal`].
-    ///
-    /// Calls [`enabledTokenCount`](ZonePortal::enabledTokenCountCall) followed by
-    /// [`enabledTokenAt`](ZonePortal::enabledTokenAtCall) for each index.
-    pub async fn enabled_tokens(
-        &self,
-    ) -> Result<Vec<alloy_primitives::Address>, alloy_contract::Error> {
-        let count = self.enabledTokenCount().call().await?;
-        let mut tokens = Vec::with_capacity(count.to::<usize>());
-        for i in 0..count.to::<u64>() {
-            let token = self
-                .enabledTokenAt(alloy_primitives::U256::from(i))
-                .call()
-                .await?;
-            tokens.push(token);
-        }
-        Ok(tokens)
+/// Query all enabled tokens from a [`ZonePortal`] contract.
+///
+/// Calls `enabledTokenCount()` followed by `enabledTokenAt(i)` for each index
+/// to collect the full list of TIP-20 token addresses that are enabled for
+/// bridging on this portal.
+pub async fn enabled_tokens(
+    portal_address: alloy_primitives::Address,
+    provider: &impl alloy_provider::Provider<tempo_alloy::TempoNetwork>,
+) -> eyre::Result<Vec<alloy_primitives::Address>> {
+    let portal = ZonePortal::new(portal_address, provider);
+    let count: u64 = portal.enabledTokenCount().call().await?.try_into()?;
+    let mut tokens = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let token = portal
+            .enabledTokenAt(alloy_primitives::U256::from(i))
+            .call()
+            .await?;
+        tokens.push(token);
     }
+    Ok(tokens)
 }

--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -97,10 +97,9 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
         (ZonePortal::sequencerEncryptionKeyReturn, alloy_primitives::U256),
         alloy_contract::Error,
     > {
-        let (key, count) = tokio::try_join!(
-            self.sequencerEncryptionKey().call(),
-            self.encryptionKeyCount().call(),
-        )?;
+        let key_call = self.sequencerEncryptionKey();
+        let count_call = self.encryptionKeyCount();
+        let (key, count) = tokio::try_join!(key_call.call(), count_call.call())?;
         let key_index = count.saturating_sub(alloy_primitives::U256::from(1));
         Ok((key, key_index))
     }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,6 +17,7 @@ zone = { path = "../crates/tempo-zone" }
 tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true
+tempo-primitives.workspace = true
 tempo-revm.workspace = true
 
 alloy = { workspace = true, features = [
@@ -32,10 +33,12 @@ alloy = { workspace = true, features = [
   "signer-mnemonic",
   "sol-types",
 ] }
+alloy-eips.workspace = true
 alloy-rlp.workspace = true
 clap = { version = "4.5.45", features = ["derive", "env"] }
 const-hex.workspace = true
 eyre.workspace = true
+rand.workspace = true
 reth-evm.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -38,6 +38,7 @@ alloy-rlp.workspace = true
 clap = { version = "4.5.45", features = ["derive", "env"] }
 const-hex.workspace = true
 eyre.workspace = true
+futures.workspace = true
 rand.workspace = true
 reth-evm.workspace = true
 serde.workspace = true

--- a/xtask/src/demo_blacklist.rs
+++ b/xtask/src/demo_blacklist.rs
@@ -644,18 +644,6 @@ fn check(receipt: &impl ReceiptResponse, label: &str) -> eyre::Result<()> {
     Ok(())
 }
 
-/// Normalize the Y-parity byte to the SEC1 compressed prefix format (`0x02` / `0x03`).
-///
-/// The portal may return parity as `0` / `1` (boolean) or already as `0x02` / `0x03`.
-/// The ECIES encryption function expects the SEC1 form.
-fn normalize_y_parity(y: u8) -> Option<u8> {
-    match y {
-        0x02 | 0x03 => Some(y),
-        0 | 1 => Some(0x02 + y),
-        _ => None,
-    }
-}
-
 /// Send an ECIES-encrypted deposit through the portal.
 ///
 /// Fetches the sequencer's current encryption public key, encrypts the
@@ -668,17 +656,13 @@ async fn send_encrypted_deposit<P: Provider<TempoNetwork>>(
     to: Address,
     amount: u128,
 ) -> eyre::Result<()> {
-    let key = portal
-        .sequencerEncryptionKey()
-        .call()
+    let (key, key_index) = portal
+        .encryption_key()
         .await
-        .wrap_err("sequencerEncryptionKey() failed")?;
-    let key_count: U256 = portal.encryptionKeyCount().call().await?;
-    let key_index = key_count
-        .checked_sub(U256::from(1))
-        .ok_or_else(|| eyre!("no encryption keys set"))?;
+        .wrap_err("failed to fetch encryption key")?;
 
-    let y_parity = normalize_y_parity(key.yParity)
+    let y_parity = key
+        .normalized_y_parity()
         .ok_or_else(|| eyre!("unexpected yParity {:#x}", key.yParity))?;
 
     let enc = encrypt_deposit(&key.x, y_parity, to, B256::ZERO, portal_addr, key_index)

--- a/xtask/src/encrypted_deposit.rs
+++ b/xtask/src/encrypted_deposit.rs
@@ -5,7 +5,7 @@
 
 use alloy::{
     network::{EthereumWallet, primitives::ReceiptResponse},
-    primitives::{Address, B256, Bytes, U256, address},
+    primitives::{Address, B256, Bytes, address},
     providers::{Provider, ProviderBuilder},
     rpc::types::Filter,
     signers::local::PrivateKeySigner,
@@ -80,22 +80,13 @@ impl EncryptedDeposit {
 
         // Fetch sequencer encryption key
         println!("Fetching sequencer encryption key...");
-        let key = portal
-            .sequencerEncryptionKey()
-            .call()
+        let (key, key_index) = portal
+            .encryption_key()
             .await
-            .wrap_err("sequencerEncryptionKey() failed — is an encryption key set?")?;
-        let key_count: U256 = portal
-            .encryptionKeyCount()
-            .call()
-            .await
-            .wrap_err("encryptionKeyCount() failed")?;
-        let key_index = key_count
-            .checked_sub(U256::from(1))
-            .ok_or_else(|| eyre!("no encryption keys set on portal"))?;
+            .wrap_err("failed to fetch encryption key — is one set?")?;
 
         let seq_pub_x = key.x;
-        let seq_pub_y_parity = normalize_y_parity(key.yParity).ok_or_else(|| {
+        let seq_pub_y_parity = key.normalized_y_parity().ok_or_else(|| {
             eyre!(
                 "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
                 key.yParity
@@ -212,16 +203,5 @@ impl EncryptedDeposit {
 
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         }
-    }
-}
-
-/// Normalize yParity to SEC1 compressed prefix (0x02 or 0x03).
-///
-/// The contract may return 0/1 (parity bit) or 0x02/0x03 (SEC1 prefix).
-fn normalize_y_parity(y: u8) -> Option<u8> {
-    match y {
-        0x02 | 0x03 => Some(y),
-        0 | 1 => Some(0x02 + y),
-        _ => None,
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@
 use crate::{
     create_zone::CreateZone, demo_blacklist::DemoBlacklist, encrypted_deposit::EncryptedDeposit,
     generate_zone_genesis::GenerateZoneGenesis, set_encryption_key::SetEncryptionKey,
-    zone_info::ZoneInfoCmd,
+    spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;
@@ -12,6 +12,7 @@ mod demo_blacklist;
 mod encrypted_deposit;
 mod generate_zone_genesis;
 mod set_encryption_key;
+mod spam_deposits;
 mod zone_info;
 
 #[tokio::main]
@@ -32,6 +33,7 @@ async fn main() -> eyre::Result<()> {
             args.run().await.wrap_err("failed to generate zone genesis")
         }
         Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
+        Action::SpamDeposits(args) => args.run().await.wrap_err("failed to spam deposits"),
         Action::ZoneInfo(args) => args.run().await.wrap_err("failed to fetch zone info"),
     }
 }
@@ -53,5 +55,6 @@ enum Action {
     EncryptedDeposit(EncryptedDeposit),
     GenerateZoneGenesis(GenerateZoneGenesis),
     SetEncryptionKey(SetEncryptionKey),
+    SpamDeposits(SpamDeposits),
     ZoneInfo(ZoneInfoCmd),
 }

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -1,0 +1,362 @@
+//! Spam deposit transactions to a zone's L1 portal for throughput testing.
+//!
+//! Uses multiple funded signers and Tempo's `valid_after` field to queue
+//! deposits in the mempool, making them all eligible for inclusion at the
+//! same block.
+
+use alloy::{
+    network::{EthereumWallet, primitives::ReceiptResponse},
+    primitives::{Address, B256, Bytes, TxKind, U256},
+    providers::{Provider, ProviderBuilder},
+    signers::{SignerSync, local::PrivateKeySigner},
+    sol_types::SolCall,
+};
+use alloy_eips::Encodable2718;
+use eyre::{Context as _, eyre};
+use std::{collections::BTreeMap, time::Instant};
+use tempo_alloy::TempoNetwork;
+use tempo_contracts::precompiles::ITIP20;
+use tempo_primitives::{
+    TempoSignature,
+    transaction::{Call, PrimitiveSignature},
+};
+use zone::{
+    abi::{EncryptedDepositPayload, ZonePortal},
+    precompiles::ecies::encrypt_deposit,
+};
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SpamDeposits {
+    /// Tempo L1 RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, env = "L1_PORTAL_ADDRESS")]
+    portal: Address,
+
+    /// Private key (hex) of the funding/whale account.
+    #[arg(long, env = "PRIVATE_KEY")]
+    private_key: String,
+
+    /// Total number of deposits to send.
+    #[arg(long)]
+    total: usize,
+
+    /// Target deposits per block (= number of signers).
+    #[arg(long)]
+    per_block: usize,
+
+    /// Amount per deposit (in smallest token units, includes fee).
+    #[arg(long, default_value_t = 1_000_000)]
+    amount: u128,
+
+    /// TIP-20 token address to deposit.
+    #[arg(long, default_value = "0x20C0000000000000000000000000000000000000")]
+    token: Address,
+
+    /// Use encrypted deposits (ECIES).
+    #[arg(long)]
+    encrypted: bool,
+
+    /// Zone L2 RPC URL (optional, for verification).
+    #[arg(long, env = "ZONE_RPC_URL")]
+    zone_rpc_url: Option<String>,
+
+    /// Seconds into the future for the valid_after timestamp.
+    #[arg(long, default_value_t = 5)]
+    lead_time: u64,
+}
+
+struct EncryptionSetup {
+    seq_pub_x: B256,
+    seq_pub_y_parity: u8,
+    key_index: U256,
+}
+
+impl SpamDeposits {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let start = Instant::now();
+
+        // Parse whale key & create provider
+        let key_str = self
+            .private_key
+            .strip_prefix("0x")
+            .unwrap_or(&self.private_key);
+        let whale: PrivateKeySigner = key_str.parse()?;
+        let whale_addr = whale.address();
+        let wallet = EthereumWallet::from(whale);
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(wallet)
+            .connect(&self.l1_rpc_url)
+            .await?;
+
+        let chain_id = provider.get_chain_id().await?;
+        let gas_price = provider.get_gas_price().await?;
+        let portal = ZonePortal::new(self.portal, &provider);
+        let deposit_fee = portal.calculateDepositFee().call().await?;
+
+        println!("Chain ID: {chain_id}");
+        println!("Gas price: {gas_price}");
+        println!("Deposit fee: {deposit_fee}");
+
+        if self.amount <= deposit_fee {
+            return Err(eyre!(
+                "amount ({}) must exceed deposit fee ({deposit_fee})",
+                self.amount
+            ));
+        }
+
+        // ── Phase 1: Setup signers ──────────────────────────────────────
+
+        let num_signers = self.per_block;
+        let deposits_per_signer = self.total.div_ceil(num_signers);
+
+        println!("Generating {num_signers} signers ({deposits_per_signer} deposits each)...");
+        let signers: Vec<PrivateKeySigner> = (0..num_signers)
+            .map(|_| PrivateKeySigner::random())
+            .collect();
+
+        // Budget: tokens for deposits + gas headroom
+        let gas_budget =
+            U256::from(deposits_per_signer + 1) * U256::from(500_000u64) * U256::from(gas_price);
+        let token_budget = U256::from(self.amount) * U256::from(deposits_per_signer);
+        let funding_per_signer = token_budget + gas_budget;
+
+        println!("Funding {num_signers} signers with {funding_per_signer} tokens each...");
+        let token_contract = ITIP20::new(self.token, &provider);
+        for (i, signer) in signers.iter().enumerate() {
+            token_contract
+                .transfer(signer.address(), funding_per_signer)
+                .send()
+                .await
+                .wrap_err_with(|| format!("failed to fund signer {i}"))?
+                .get_receipt()
+                .await?;
+        }
+
+        println!("Approving portal for all signers...");
+        for (i, signer) in signers.iter().enumerate() {
+            let w = EthereumWallet::from(signer.clone());
+            let p = ProviderBuilder::new_with_network::<TempoNetwork>()
+                .wallet(w)
+                .connect(&self.l1_rpc_url)
+                .await?;
+            let token = ITIP20::new(self.token, &p);
+            token
+                .approve(self.portal, U256::MAX)
+                .send()
+                .await
+                .wrap_err_with(|| format!("failed to approve for signer {i}"))?
+                .get_receipt()
+                .await?;
+        }
+
+        // Fetch encryption key if needed
+        let enc_setup = if self.encrypted {
+            let key = portal
+                .sequencerEncryptionKey()
+                .call()
+                .await
+                .wrap_err("sequencerEncryptionKey() failed — is an encryption key set?")?;
+            let key_count: U256 = portal
+                .encryptionKeyCount()
+                .call()
+                .await
+                .wrap_err("encryptionKeyCount() failed")?;
+            let key_index = key_count
+                .checked_sub(U256::from(1))
+                .ok_or_else(|| eyre!("no encryption keys set on portal"))?;
+            let seq_pub_y_parity = normalize_y_parity(key.yParity).ok_or_else(|| {
+                eyre!(
+                    "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
+                    key.yParity
+                )
+            })?;
+            println!(
+                "Encryption key index: {key_index}, x: {}, parity: {seq_pub_y_parity:#x}",
+                key.x
+            );
+            Some(EncryptionSetup {
+                seq_pub_x: key.x,
+                seq_pub_y_parity,
+                key_index,
+            })
+        } else {
+            None
+        };
+
+        let setup_elapsed = start.elapsed();
+        println!("Setup complete in {:.1}s\n", setup_elapsed.as_secs_f64());
+
+        // ── Phase 2: Spam waves ─────────────────────────────────────────
+
+        let num_waves = deposits_per_signer;
+        let mut total_sent = 0usize;
+        let mut total_confirmed = 0usize;
+        let mut block_counts: BTreeMap<u64, usize> = BTreeMap::new();
+        let spam_start = Instant::now();
+
+        for wave in 0..num_waves {
+            let remaining = self.total - total_sent;
+            let batch_size = remaining.min(num_signers);
+            if batch_size == 0 {
+                break;
+            }
+
+            // Target timestamp: current time + lead_time
+            let target_ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + self.lead_time;
+
+            println!(
+                "Wave {}/{num_waves}: sending {batch_size} deposits (valid_after: {target_ts})...",
+                wave + 1
+            );
+
+            // Build, sign, and send all deposits in this wave
+            let mut pending_txs = Vec::with_capacity(batch_size);
+            for (i, signer) in signers.iter().enumerate().take(batch_size) {
+                let nonce_key = U256::from(rand::random::<u128>());
+
+                let calldata = self.build_deposit_calldata(whale_addr, &enc_setup)?;
+
+                let tx = tempo_primitives::TempoTransaction {
+                    chain_id,
+                    max_fee_per_gas: gas_price * 3,
+                    max_priority_fee_per_gas: gas_price,
+                    gas_limit: 500_000,
+                    calls: vec![Call {
+                        to: TxKind::Call(self.portal),
+                        value: U256::ZERO,
+                        input: Bytes::from(calldata),
+                    }],
+                    nonce_key,
+                    nonce: 0,
+                    valid_after: Some(target_ts),
+                    ..Default::default()
+                };
+
+                let sig_hash = tx.signature_hash();
+                let sig = signer.sign_hash_sync(&sig_hash)?;
+                let tempo_sig = TempoSignature::Primitive(PrimitiveSignature::Secp256k1(sig));
+                let signed = tx.into_signed(tempo_sig);
+                let encoded = signed.encoded_2718();
+
+                match provider.send_raw_transaction(&encoded).await {
+                    Ok(pending) => {
+                        pending_txs.push(pending);
+                        total_sent += 1;
+                    }
+                    Err(e) => {
+                        eprintln!("  failed to send deposit {i}: {e}");
+                    }
+                }
+            }
+
+            // Wait for all receipts
+            for pending in pending_txs {
+                match pending.get_receipt().await {
+                    Ok(receipt) => {
+                        if receipt.status() {
+                            total_confirmed += 1;
+                            if let Some(block_num) = receipt.block_number {
+                                *block_counts.entry(block_num).or_default() += 1;
+                            }
+                        } else {
+                            eprintln!("  deposit reverted: {}", receipt.transaction_hash);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("  failed to get receipt: {e}");
+                    }
+                }
+            }
+        }
+
+        // ── Phase 3: Report ─────────────────────────────────────────────
+
+        let spam_elapsed = spam_start.elapsed();
+        let total_elapsed = start.elapsed();
+
+        println!("\n== Results ==");
+        println!("  Total sent:      {total_sent}");
+        println!("  Total confirmed: {total_confirmed}");
+        println!("  Spam duration:   {:.1}s", spam_elapsed.as_secs_f64());
+        println!("  Total elapsed:   {:.1}s", total_elapsed.as_secs_f64());
+        if spam_elapsed.as_millis() > 0 {
+            println!(
+                "  Throughput:      {:.2} deposits/s",
+                total_confirmed as f64 / spam_elapsed.as_secs_f64()
+            );
+        }
+
+        if !block_counts.is_empty() {
+            println!("\n  Block Distribution:");
+            for (block, count) in &block_counts {
+                println!("    Block {block}: {count} deposits");
+            }
+
+            let counts: Vec<usize> = block_counts.values().copied().collect();
+            let avg = counts.iter().sum::<usize>() as f64 / counts.len() as f64;
+            let max = counts.iter().max().unwrap_or(&0);
+            let min = counts.iter().min().unwrap_or(&0);
+            println!("\n  Avg/Max/Min deposits per block: {avg:.1} / {max} / {min}");
+        }
+
+        Ok(())
+    }
+
+    /// Build the calldata for a single deposit (plain or encrypted).
+    fn build_deposit_calldata(
+        &self,
+        recipient: Address,
+        enc_setup: &Option<EncryptionSetup>,
+    ) -> eyre::Result<Vec<u8>> {
+        if let Some(enc) = enc_setup {
+            let encrypted = encrypt_deposit(
+                &enc.seq_pub_x,
+                enc.seq_pub_y_parity,
+                recipient,
+                B256::ZERO,
+                self.portal,
+                enc.key_index,
+            )
+            .ok_or_else(|| eyre!("ECIES encryption failed"))?;
+
+            let payload = EncryptedDepositPayload {
+                ephemeralPubkeyX: encrypted.eph_pub_x,
+                ephemeralPubkeyYParity: encrypted.eph_pub_y_parity,
+                ciphertext: Bytes::from(encrypted.ciphertext),
+                nonce: encrypted.nonce.into(),
+                tag: encrypted.tag.into(),
+            };
+
+            Ok(ZonePortal::depositEncryptedCall {
+                token: self.token,
+                amount: self.amount,
+                keyIndex: enc.key_index,
+                encrypted: payload,
+            }
+            .abi_encode())
+        } else {
+            Ok(ZonePortal::depositCall {
+                token: self.token,
+                to: recipient,
+                amount: self.amount,
+                memo: B256::ZERO,
+            }
+            .abi_encode())
+        }
+    }
+}
+
+fn normalize_y_parity(y: u8) -> Option<u8> {
+    match y {
+        0x02 | 0x03 => Some(y),
+        0 | 1 => Some(0x02 + y),
+        _ => None,
+    }
+}

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -59,12 +59,8 @@ pub(crate) struct SpamDeposits {
     #[arg(long)]
     encrypted: bool,
 
-    /// Zone L2 RPC URL (optional, for verification).
-    #[arg(long, env = "ZONE_RPC_URL")]
-    zone_rpc_url: Option<String>,
-
     /// Seconds into the future for the valid_after timestamp.
-    #[arg(long, default_value_t = 5)]
+    #[arg(long, default_value_t = 3)]
     lead_time: u64,
 }
 
@@ -76,6 +72,10 @@ struct EncryptionSetup {
 
 impl SpamDeposits {
     pub(crate) async fn run(self) -> eyre::Result<()> {
+        if self.per_block == 0 {
+            return Err(eyre!("--per-block must be at least 1"));
+        }
+
         let start = Instant::now();
 
         // Parse whale key & create provider
@@ -154,20 +154,11 @@ impl SpamDeposits {
 
         // Fetch encryption key if needed
         let enc_setup = if self.encrypted {
-            let key = portal
-                .sequencerEncryptionKey()
-                .call()
+            let (key, key_index) = portal
+                .encryption_key()
                 .await
-                .wrap_err("sequencerEncryptionKey() failed — is an encryption key set?")?;
-            let key_count: U256 = portal
-                .encryptionKeyCount()
-                .call()
-                .await
-                .wrap_err("encryptionKeyCount() failed")?;
-            let key_index = key_count
-                .checked_sub(U256::from(1))
-                .ok_or_else(|| eyre!("no encryption keys set on portal"))?;
-            let seq_pub_y_parity = normalize_y_parity(key.yParity).ok_or_else(|| {
+                .wrap_err("failed to fetch encryption key — is one set?")?;
+            let seq_pub_y_parity = key.normalized_y_parity().ok_or_else(|| {
                 eyre!(
                     "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
                     key.yParity
@@ -216,11 +207,10 @@ impl SpamDeposits {
                 wave + 1
             );
 
-            // Build, sign, and send all deposits in this wave
-            let mut pending_txs = Vec::with_capacity(batch_size);
-            for (i, signer) in signers.iter().enumerate().take(batch_size) {
+            // Build and sign all deposits (pure computation, no IO)
+            let mut encoded_txs = Vec::with_capacity(batch_size);
+            for signer in signers.iter().take(batch_size) {
                 let nonce_key = U256::from(rand::random::<u128>());
-
                 let calldata = self.build_deposit_calldata(whale_addr, &enc_setup)?;
 
                 let tx = tempo_primitives::TempoTransaction {
@@ -243,22 +233,32 @@ impl SpamDeposits {
                 let sig = signer.sign_hash_sync(&sig_hash)?;
                 let tempo_sig = TempoSignature::Primitive(PrimitiveSignature::Secp256k1(sig));
                 let signed = tx.into_signed(tempo_sig);
-                let encoded = signed.encoded_2718();
-
-                match provider.send_raw_transaction(&encoded).await {
-                    Ok(pending) => {
-                        pending_txs.push(pending);
-                        total_sent += 1;
-                    }
-                    Err(e) => {
-                        eprintln!("  failed to send deposit {i}: {e}");
-                    }
-                }
+                encoded_txs.push(signed.encoded_2718());
             }
 
-            // Wait for all receipts
-            for pending in pending_txs {
-                match pending.get_receipt().await {
+            // Fire all sends concurrently
+            let send_results: Vec<_> = futures::future::join_all(
+                encoded_txs.iter().enumerate().map(|(i, encoded)| async move {
+                    provider
+                        .send_raw_transaction(encoded)
+                        .await
+                        .map_err(|e| {
+                            eprintln!("  failed to send deposit {i}: {e}");
+                            e
+                        })
+                }),
+            )
+            .await;
+
+            let pending_txs: Vec<_> = send_results.into_iter().flatten().collect();
+            total_sent += pending_txs.len();
+
+            // Wait for all receipts concurrently
+            let receipts: Vec<_> =
+                futures::future::join_all(pending_txs.into_iter().map(|p| p.get_receipt())).await;
+
+            for result in receipts {
+                match result {
                     Ok(receipt) => {
                         if receipt.status() {
                             total_confirmed += 1;
@@ -350,13 +350,5 @@ impl SpamDeposits {
             }
             .abi_encode())
         }
-    }
-}
-
-fn normalize_y_parity(y: u8) -> Option<u8> {
-    match y {
-        0x02 | 0x03 => Some(y),
-        0 | 1 => Some(0x02 + y),
-        _ => None,
     }
 }

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -238,14 +238,17 @@ impl SpamDeposits {
 
             // Fire all sends concurrently
             let send_results: Vec<_> = futures::future::join_all(
-                encoded_txs.iter().enumerate().map(|(i, encoded)| async move {
-                    provider
-                        .send_raw_transaction(encoded)
-                        .await
-                        .map_err(|e| {
-                            eprintln!("  failed to send deposit {i}: {e}");
-                            e
-                        })
+                encoded_txs.iter().enumerate().map(|(i, encoded)| {
+                    let provider = &provider;
+                    async move {
+                        provider
+                            .send_raw_transaction(encoded)
+                            .await
+                            .map_err(|e| {
+                                eprintln!("  failed to send deposit {i}: {e}");
+                                e
+                            })
+                    }
                 }),
             )
             .await;

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -64,12 +64,6 @@ pub(crate) struct SpamDeposits {
     lead_time: u64,
 }
 
-struct EncryptionSetup {
-    seq_pub_x: B256,
-    seq_pub_y_parity: u8,
-    key_index: U256,
-}
-
 impl SpamDeposits {
     pub(crate) async fn run(self) -> eyre::Result<()> {
         if self.per_block == 0 {
@@ -117,13 +111,11 @@ impl SpamDeposits {
             .map(|_| PrivateKeySigner::random())
             .collect();
 
-        // Budget: tokens for deposits + gas headroom
-        let gas_budget =
-            U256::from(deposits_per_signer + 1) * U256::from(500_000u64) * U256::from(gas_price);
+        // Budget: tokens for deposits + 10% headroom for gas (Tempo L1 pays gas in TIP-20)
         let token_budget = U256::from(self.amount) * U256::from(deposits_per_signer);
-        let funding_per_signer = token_budget + gas_budget;
+        let funding_per_signer = token_budget * U256::from(150) / U256::from(100);
 
-        println!("Funding {num_signers} signers with {funding_per_signer} tokens each...");
+        println!("Funding {num_signers} signers with {funding_per_signer} each...");
         let token_contract = ITIP20::new(self.token, &provider);
         for (i, signer) in signers.iter().enumerate() {
             token_contract
@@ -152,27 +144,23 @@ impl SpamDeposits {
                 .await?;
         }
 
-        // Fetch encryption key if needed
+        // Fetch encryption key if needed: (pub_x, y_parity, key_index)
         let enc_setup = if self.encrypted {
             let (key, key_index) = portal
                 .encryption_key()
                 .await
                 .wrap_err("failed to fetch encryption key — is one set?")?;
-            let seq_pub_y_parity = key.normalized_y_parity().ok_or_else(|| {
+            let y_parity = key.normalized_y_parity().ok_or_else(|| {
                 eyre!(
                     "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
                     key.yParity
                 )
             })?;
             println!(
-                "Encryption key index: {key_index}, x: {}, parity: {seq_pub_y_parity:#x}",
+                "Encryption key index: {key_index}, x: {}, parity: {y_parity:#x}",
                 key.x
             );
-            Some(EncryptionSetup {
-                seq_pub_x: key.x,
-                seq_pub_y_parity,
-                key_index,
-            })
+            Some((key.x, y_parity, key_index))
         } else {
             None
         };
@@ -208,20 +196,20 @@ impl SpamDeposits {
             );
 
             // Build and sign all deposits (pure computation, no IO)
+            let calldata = self.build_deposit_calldata(whale_addr, enc_setup.as_ref())?;
             let mut encoded_txs = Vec::with_capacity(batch_size);
             for signer in signers.iter().take(batch_size) {
                 let nonce_key = U256::from(rand::random::<u128>());
-                let calldata = self.build_deposit_calldata(whale_addr, &enc_setup)?;
 
                 let tx = tempo_primitives::TempoTransaction {
                     chain_id,
                     max_fee_per_gas: gas_price * 3,
                     max_priority_fee_per_gas: gas_price,
-                    gas_limit: 500_000,
+                    gas_limit: 2_000_000,
                     calls: vec![Call {
                         to: TxKind::Call(self.portal),
                         value: U256::ZERO,
-                        input: Bytes::from(calldata),
+                        input: Bytes::from(calldata.clone()),
                     }],
                     nonce_key,
                     nonce: 0,
@@ -260,7 +248,7 @@ impl SpamDeposits {
             let receipts: Vec<_> =
                 futures::future::join_all(pending_txs.into_iter().map(|p| p.get_receipt())).await;
 
-            for result in receipts {
+            for (i, result) in receipts.into_iter().enumerate() {
                 match result {
                     Ok(receipt) => {
                         if receipt.status() {
@@ -269,7 +257,11 @@ impl SpamDeposits {
                                 *block_counts.entry(block_num).or_default() += 1;
                             }
                         } else {
-                            eprintln!("  deposit reverted: {}", receipt.transaction_hash);
+                            let signer = signers.get(i).map(|s| s.address()).unwrap_or_default();
+                            eprintln!(
+                                "  deposit reverted: tx={} signer={signer}",
+                                receipt.transaction_hash,
+                            );
                         }
                     }
                     Err(e) => {
@@ -316,16 +308,11 @@ impl SpamDeposits {
     fn build_deposit_calldata(
         &self,
         recipient: Address,
-        enc_setup: &Option<EncryptionSetup>,
+        enc_setup: Option<&(B256, u8, U256)>,
     ) -> eyre::Result<Vec<u8>> {
-        if let Some(enc) = enc_setup {
+        if let Some(&(pub_x, y_parity, key_index)) = enc_setup {
             let encrypted = encrypt_deposit(
-                &enc.seq_pub_x,
-                enc.seq_pub_y_parity,
-                recipient,
-                B256::ZERO,
-                self.portal,
-                enc.key_index,
+                &pub_x, y_parity, recipient, B256::ZERO, self.portal, key_index,
             )
             .ok_or_else(|| eyre!("ECIES encryption failed"))?;
 
@@ -340,7 +327,7 @@ impl SpamDeposits {
             Ok(ZonePortal::depositEncryptedCall {
                 token: self.token,
                 amount: self.amount,
-                keyIndex: enc.key_index,
+                keyIndex: key_index,
                 encrypted: payload,
             }
             .abi_encode())

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -225,21 +225,17 @@ impl SpamDeposits {
             }
 
             // Fire all sends concurrently
-            let send_results: Vec<_> = futures::future::join_all(
-                encoded_txs.iter().enumerate().map(|(i, encoded)| {
+            let send_results: Vec<_> =
+                futures::future::join_all(encoded_txs.iter().enumerate().map(|(i, encoded)| {
                     let provider = &provider;
                     async move {
-                        provider
-                            .send_raw_transaction(encoded)
-                            .await
-                            .map_err(|e| {
-                                eprintln!("  failed to send deposit {i}: {e}");
-                                e
-                            })
+                        provider.send_raw_transaction(encoded).await.map_err(|e| {
+                            eprintln!("  failed to send deposit {i}: {e}");
+                            e
+                        })
                     }
-                }),
-            )
-            .await;
+                }))
+                .await;
 
             let pending_txs: Vec<_> = send_results.into_iter().flatten().collect();
             total_sent += pending_txs.len();
@@ -312,7 +308,12 @@ impl SpamDeposits {
     ) -> eyre::Result<Vec<u8>> {
         if let Some(&(pub_x, y_parity, key_index)) = enc_setup {
             let encrypted = encrypt_deposit(
-                &pub_x, y_parity, recipient, B256::ZERO, self.portal, key_index,
+                &pub_x,
+                y_parity,
+                recipient,
+                B256::ZERO,
+                self.portal,
+                key_index,
             )
             .ok_or_else(|| eyre!("ECIES encryption failed"))?;
 


### PR DESCRIPTION
Adds a `spam-deposits` xtask command that measures deposit throughput by spamming
a zone's L1 portal with concurrent deposit transactions.

The tool uses multiple funded signers and Tempo's `valid_after` field to queue
all deposit transactions in the mempool with a future validity timestamp, so they
all become eligible for inclusion at the same time. This bypasses per-sender pool
limits (`max_account_slots`) which would otherwise cap how many txs a single
sender can have pending.

Each wave of deposits uses unique 2D nonce keys (`nonce_key = random, nonce = 0`)
to avoid nonce conflicts. After all waves complete, it prints a summary with
throughput, confirmation counts, and per-block distribution.

```
cargo run -p tempo-xtask -- spam-deposits \
  --l1-rpc-url $L1_RPC_URL \
  --portal $L1_PORTAL_ADDRESS \
  --private-key $PRIVATE_KEY \
  --total 20 --per-block 10 --amount 1000000
```

Supports `--encrypted` for ECIES-encrypted deposits using the sequencer's
public key.

Also improves the doc comment on `enabled_tokens()` in `bindings.rs`.