### PR TITLE
refactor: move `enabled_tokens` to a method on `ZonePortalInstance`

### DIFF
--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -71,7 +71,10 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
         let count = self.enabledTokenCount().call().await?;
         let mut tokens = Vec::with_capacity(count.to::<usize>());
         for i in 0..count.to::<u64>() {
-            let token = self.enabledTokenAt(alloy_primitives::U256::from(i)).call().await?;
+            let token = self
+                .enabledTokenAt(alloy_primitives::U256::from(i))
+                .call()
+                .await?;
             tokens.push(token);
         }
         Ok(tokens)

--- a/crates/tempo-zone/src/bindings.rs
+++ b/crates/tempo-zone/src/bindings.rs
@@ -58,20 +58,22 @@ sol! {
     function mint(address to, uint256 amount);
 }
 
-/// Query all enabled tokens from a ZonePortal contract.
-pub async fn enabled_tokens(
-    portal_address: alloy_primitives::Address,
-    provider: &impl alloy_provider::Provider<tempo_alloy::TempoNetwork>,
-) -> eyre::Result<Vec<alloy_primitives::Address>> {
-    let portal = ZonePortal::new(portal_address, provider);
-    let count: u64 = portal.enabledTokenCount().call().await?.try_into()?;
-    let mut tokens = Vec::with_capacity(count as usize);
-    for i in 0..count {
-        let token = portal
-            .enabledTokenAt(alloy_primitives::U256::from(i))
-            .call()
-            .await?;
-        tokens.push(token);
+impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
+    ZonePortal::ZonePortalInstance<P, N>
+{
+    /// Returns all token addresses currently enabled for bridging on this [`ZonePortal`].
+    ///
+    /// Calls [`enabledTokenCount`](ZonePortal::enabledTokenCountCall) followed by
+    /// [`enabledTokenAt`](ZonePortal::enabledTokenAtCall) for each index.
+    pub async fn enabled_tokens(
+        &self,
+    ) -> Result<Vec<alloy_primitives::Address>, alloy_contract::Error> {
+        let count = self.enabledTokenCount().call().await?;
+        let mut tokens = Vec::with_capacity(count.to::<usize>());
+        for i in 0..count.to::<u64>() {
+            let token = self.enabledTokenAt(alloy_primitives::U256::from(i)).call().await?;
+            tokens.push(token);
+        }
+        Ok(tokens)
     }
-    Ok(tokens)
 }

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -338,7 +338,9 @@ where
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Using pre-configured initial tokens");
             tokens
         } else {
-            let tokens = crate::bindings::ZonePortal::new(portal_address, &l1_provider).enabled_tokens().await?;
+            let tokens = crate::bindings::ZonePortal::new(portal_address, &l1_provider)
+                .enabled_tokens()
+                .await?;
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Discovered enabled tokens from L1");
             tokens
         };

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -338,7 +338,7 @@ where
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Using pre-configured initial tokens");
             tokens
         } else {
-            let tokens = crate::bindings::enabled_tokens(portal_address, &l1_provider).await?;
+            let tokens = crate::bindings::ZonePortal::new(portal_address, &l1_provider).enabled_tokens().await?;
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Discovered enabled tokens from L1");
             tokens
         };


### PR DESCRIPTION
Moves the standalone `enabled_tokens(portal_address, provider)` function into an `impl` block on `ZonePortal::ZonePortalInstance`, so callers can write `ZonePortal::new(addr, provider).enabled_tokens().await?` instead.

The method is now generic over `Provider<N>` + `Network` (instead of being hardcoded to `TempoNetwork`) and returns `alloy_contract::Error` directly rather than going through `eyre`.