### PR TITLE
feat: use Tempo 2D nonce keys for sequencer L1 operations

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -34,8 +34,10 @@ use alloy_provider::{DynProvider, Provider};
 use alloy_rlp::Encodable;
 use eyre::Result;
 use futures::{StreamExt, TryStreamExt};
-use tempo_alloy::TempoNetwork;
+use tempo_alloy::{TempoNetwork, rpc::TempoCallBuilderExt};
 use tracing::{info, instrument, warn};
+
+use crate::nonce_keys::SUBMIT_BATCH_NONCE_KEY;
 
 /// EIP-2935 stores the last 8192 block hashes (~68 min at 500ms block time).
 const EIP2935_HISTORY_WINDOW: u64 = 8192;
@@ -173,6 +175,7 @@ impl BatchSubmitter {
                 Bytes::new(),
                 Bytes::new(),
             )
+            .nonce_key(SUBMIT_BATCH_NONCE_KEY)
             .send()
             .await?
             .with_required_confirmations(1)

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -16,6 +16,7 @@ mod executor;
 pub mod l1;
 pub mod l1_state;
 mod node;
+pub mod nonce_keys;
 pub mod payload;
 pub mod precompiles;
 pub mod rpc;
@@ -39,7 +40,7 @@ use std::{sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
-use tempo_alloy::TempoNetwork;
+use tempo_alloy::{TempoNetwork, fillers::NonceKeyFiller};
 use tokio::sync::Notify;
 
 /// Configuration for all zone sequencer background tasks.
@@ -94,10 +95,14 @@ pub async fn spawn_zone_sequencer(
     // Build a single shared L1 provider with the sequencer wallet.
     // Both the batch submitter (inside the zone monitor) and the withdrawal
     // processor use this provider, ensuring nonces are tracked in one place.
+    //
+    // `NonceKeyFiller` reads initial nonce values from the L1 NonceManager
+    // precompile on first use per (address, nonce_key) pair and caches them
+    // locally for subsequent sends.
     let wallet = alloy_network::EthereumWallet::from(signer);
-    // FIXME: dyn provider, check if not needed
     let l1_provider: DynProvider<TempoNetwork> =
         ProviderBuilder::new_with_network::<TempoNetwork>()
+            .filler(NonceKeyFiller::default())
             .wallet(wallet)
             .connect(&config.l1_rpc_url)
             .await

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -40,7 +40,7 @@ use std::{sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
-use tempo_alloy::{TempoNetwork, fillers::NonceKeyFiller};
+use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 use tokio::sync::Notify;
 
 /// Configuration for all zone sequencer background tasks.
@@ -102,7 +102,7 @@ pub async fn spawn_zone_sequencer(
     let wallet = alloy_network::EthereumWallet::from(signer);
     let l1_provider: DynProvider<TempoNetwork> =
         ProviderBuilder::new_with_network::<TempoNetwork>()
-            .filler(NonceKeyFiller::default())
+            .with_nonce_key_filler()
             .wallet(wallet)
             .connect(&config.l1_rpc_url)
             .await

--- a/crates/tempo-zone/src/nonce_keys.rs
+++ b/crates/tempo-zone/src/nonce_keys.rs
@@ -1,0 +1,23 @@
+//! Nonce key constants for zone sequencer L1 operations.
+//!
+//! Tempo's 2D nonce system allows each account to maintain independent nonce
+//! counters ("lanes") keyed by a `U256` nonce key. Each sequencer operation
+//! type uses a dedicated lane so that `submitBatch`, `processWithdrawal`, and
+//! admin transactions can be submitted concurrently without nonce contention.
+//!
+//! Nonce management is handled by [`NonceKeyFiller`](tempo_alloy::fillers::NonceKeyFiller)
+//! in the provider pipeline — callers only need to set `.nonce_key(KEY)` on
+//! each contract call.
+
+use alloy_primitives::{U256, uint};
+
+/// Nonce key for `submitBatch` calls (highest throughput, one per batch cycle).
+pub const SUBMIT_BATCH_NONCE_KEY: U256 = uint!(1_U256);
+
+/// Nonce key for `processWithdrawal` calls (high throughput, N per batch).
+pub const PROCESS_WITHDRAWAL_NONCE_KEY: U256 = uint!(2_U256);
+
+/// Nonce key for admin operations (`enableToken`, `setZoneGasRate`,
+/// `setSequencerEncryptionKey`, `pauseDeposits`, `resumeDeposits`,
+/// `transferSequencer`). Low frequency, shared key.
+pub const ADMIN_OPS_NONCE_KEY: U256 = uint!(3_U256);

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -34,7 +34,11 @@ use tempo_alloy::TempoNetwork;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::abi::{self, ZonePortal};
+use crate::{
+    abi::{self, ZonePortal},
+    nonce_keys::PROCESS_WITHDRAWAL_NONCE_KEY,
+};
+use tempo_alloy::rpc::TempoCallBuilderExt;
 
 /// Shared handle to the withdrawal store.
 #[derive(Clone)]
@@ -274,7 +278,8 @@ impl WithdrawalProcessor {
 
             let call = self
                 .portal
-                .processWithdrawal(withdrawal.clone(), remaining_queue);
+                .processWithdrawal(withdrawal.clone(), remaining_queue)
+                .nonce_key(PROCESS_WITHDRAWAL_NONCE_KEY);
 
             // When the withdrawal has a callback (`gasLimit > 0`), we must
             // override `eth_estimateGas` because the estimate only covers the


### PR DESCRIPTION
Assigns dedicated nonce lanes to each sequencer operation type so that `submitBatch`, `processWithdrawal`, and admin transactions can be submitted concurrently without nonce contention.

Uses the upstream `NonceKeyFiller` from tempo-alloy v1.4.1 which automatically reads initial nonces from the L1 `NonceManager` precompile on first use and caches them per `(address, nonce_key)` pair. Callers only need to set `.nonce_key(KEY)` on each contract call.

**Nonce key partitioning:**
- Key 1: `submitBatch` (highest throughput, one per batch cycle)
- Key 2: `processWithdrawal` (high throughput, N per batch)
- Key 3: admin ops (shared, low frequency)

Closes #196