### PR TITLE
fix(witness): use code_hash from account proof instead of provider

### DIFF
--- a/crates/tempo-zone/src/witness/generator.rs
+++ b/crates/tempo-zone/src/witness/generator.rs
@@ -174,17 +174,17 @@ impl WitnessGenerator {
                 })
                 .collect();
 
-            // Read code separately (not included in the account proof).
-            let code = state_provider.account_code(&addr).ok().flatten();
-            // Use keccak256(code) if code is available, otherwise fall back to
-            // the bytecode_hash from the account proof. For accounts without
-            // code (EOAs), use KECCAK_EMPTY per Ethereum convention.
+            // The code_hash MUST come from the account proof (which is
+            // consistent with state_root). state_provider.account_code() may
+            // return bytecode from a later block if the contract was upgraded,
+            // causing a mismatch with the proof leaf.
             let keccak_empty = keccak256([]);
-            let code_hash = code
-                .as_ref()
-                .map(|c| keccak256(c.bytes_slice()))
-                .or(code_hash_from_proof)
-                .unwrap_or(keccak_empty);
+            let code_hash = code_hash_from_proof.unwrap_or(keccak_empty);
+
+            // Read code separately (not included in the account proof).
+            // Only include it if its hash matches the proof's code_hash.
+            let code = state_provider.account_code(&addr).ok().flatten();
+            let code = code.filter(|c| keccak256(c.bytes_slice()) == code_hash);
 
             // Read storage values (the proof gives us proof nodes but we also
             // need the actual slot values in the witness).


### PR DESCRIPTION
## Problem

The zone batch prover was failing with `invalid proof: account proof for 0x1C00...0000: value mismatch` errors for system contracts. The `code_hash` in the witness didn't match the `code_hash` in the MPT proof leaf.

## Root Cause

The witness generator in `generate_zone_state_witness()` was computing `code_hash` by calling `state_provider.account_code()` and hashing the result. However, `account_code()` returns the bytecode at the **current tip**, not at the batch's `state_root`. If a system contract was upgraded between the batch's state root and the current block, the computed hash wouldn't match the proof leaf.

## Fix

Always use the `code_hash` from the account proof (via `bytecode_hash` from `StateProofProvider::proof()`), which is guaranteed consistent with the `state_root` the proof was generated against.

Code bytes from the provider are still included, but only if their hash matches the proof's `code_hash`. If the code has changed, the code bytes are omitted from the witness (the prover can still look it up by hash).

## Testing

- All 23 zone-prover unit tests pass
- Tested end-to-end against zone-002 private RPC: witness fetch succeeds and proof verification passes the account proof stage