### PR TITLE
feat(batch): add ancestry header collection and stepping mode for extended downtime

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -12,11 +12,23 @@
 //! Proof validation is currently **skipped**: both `verifierConfig` and `proof`
 //! are submitted as empty bytes. The L1 verifier contract must be configured to
 //! accept empty proofs for this to work.
+//!
+//! # Anchor modes
+//!
+//! Three tiers based on the gap between `tempo_block_number` and the current L1 tip:
+//!
+//! | Gap | Mode | Description |
+//! |-----|------|-------------|
+//! | < 7832 | Direct | Portal reads hash from EIP-2935. |
+//! | 7832–8192 | Ancestry | Collect L1 headers as proof chain. Single submitBatch. |
+//! | > 8192 | Stepping | Split into multiple direct-mode submissions. |
 
-use crate::abi::{BlockTransition, DepositQueueTransition, ZonePortal};
+use crate::abi::{BlockTransition, DepositQueueTransition, TempoState, ZoneInbox, ZonePortal};
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{DynProvider, Provider};
+use alloy_rlp::Encodable;
 use eyre::Result;
+use futures::{StreamExt, TryStreamExt};
 use tempo_alloy::TempoNetwork;
 use tracing::{info, instrument, warn};
 
@@ -56,7 +68,8 @@ pub struct BatchData {
 /// Submits zone batches to the ZonePortal contract on Tempo L1.
 ///
 /// Holds a contract instance pointing at the portal, backed by a shared
-/// [`DynProvider`] with the sequencer's signing wallet.
+/// [`DynProvider`] with the sequencer's signing wallet. Also holds a zone L2
+/// provider for reading intermediate zone state during stepping mode.
 pub struct BatchSubmitter {
     /// ZonePortal contract address on Tempo L1 (used in tracing spans).
     portal_address: Address,
@@ -70,23 +83,41 @@ pub struct BatchSubmitter {
     /// The portal's `genesisTempoBlockNumber` — batches with a
     /// `tempo_block_number` below this value will be rejected on-chain.
     genesis_tempo_block_number: u64,
+    /// Read-only Zone L2 provider for querying intermediate zone state during
+    /// stepping mode.
+    zone_provider: DynProvider<TempoNetwork>,
+    /// TempoState predeploy address on Zone L2.
+    tempo_state_address: Address,
+    /// ZoneInbox contract address on Zone L2.
+    inbox_address: Address,
+    /// Concurrency for pipelined L1 header fetching in ancestry mode.
+    l1_fetch_concurrency: usize,
 }
 
 impl BatchSubmitter {
-    /// Create a new batch submitter from a shared L1 provider.
+    /// Create a new batch submitter from a shared L1 provider and a zone L2 provider.
     ///
-    /// The provider must already include the sequencer wallet for signing.
+    /// The L1 provider must already include the sequencer wallet for signing.
+    /// The zone provider is read-only, used for querying intermediate zone state
+    /// during stepping mode.
     pub fn new(
         portal_address: Address,
-        provider: DynProvider<TempoNetwork>,
+        l1_provider: DynProvider<TempoNetwork>,
+        zone_provider: DynProvider<TempoNetwork>,
         genesis_tempo_block_number: u64,
+        tempo_state_address: Address,
+        inbox_address: Address,
     ) -> Self {
-        let portal = ZonePortal::new(portal_address, provider.clone());
+        let portal = ZonePortal::new(portal_address, l1_provider.clone());
         Self {
             portal_address,
-            l1_provider: provider,
+            l1_provider,
             portal,
             genesis_tempo_block_number,
+            zone_provider,
+            tempo_state_address,
+            inbox_address,
+            l1_fetch_concurrency: 16,
         }
     }
 
@@ -168,33 +199,25 @@ impl BatchSubmitter {
         Ok(tx_hash)
     }
 
-    /// Determine whether to use direct or ancestry mode for the given
-    /// `tempo_block_number`.
+    /// Determine the anchor mode for the given `tempo_block_number`.
     ///
-    /// The ZonePortal's `submitBatch` verifies that the zone committed to a
-    /// real Tempo block by reading its hash from the EIP-2935 system contract,
-    /// which only stores the most recent [`EIP2935_HISTORY_WINDOW`] (8192)
-    /// block hashes. If `tempo_block_number` has already fallen out of that
-    /// window (e.g. the sequencer was offline for >2 hours), a direct lookup
-    /// would return `bytes32(0)` and the transaction would revert.
+    /// Three tiers based on the gap between `tempo_block_number` and L1 tip:
     ///
-    /// **Ancestry mode** solves this by supplying a *recent* L1 block number
-    /// that IS within the EIP-2935 window as the anchor. The portal reads
-    /// that anchor's hash from EIP-2935 instead, and the proof is expected to
-    /// include a chain of block headers linking the anchor back to
-    /// `tempo_block_number`, proving ancestry on-chain.
-    ///
-    /// A safety margin of [`EIP2935_SAFETY_MARGIN`] (360 blocks, ~3 min) is
-    /// applied to guard against the block aging out of the window between our
-    /// check here and the transaction's on-chain execution.
-    async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
+    /// - **Direct** (gap < [`EIP2935_EFFECTIVE_WINDOW`]): the portal reads the
+    ///   hash directly from EIP-2935.
+    /// - **Ancestry** (gap within [`EIP2935_HISTORY_WINDOW`]): a recent L1 block
+    ///   within the window is used as anchor. The proof must include block headers
+    ///   linking the anchor back to `tempo_block_number`.
+    /// - **Stepping** (gap > [`EIP2935_HISTORY_WINDOW`]): the gap is too large
+    ///   for a single ancestry proof. The batch must be split into multiple
+    ///   direct-mode submissions.
+    pub(crate) async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
         let current_l1_block = self.l1_provider.get_block_number().await?;
 
         // EIP-2935 stores the hash of block N when block N+1 is processed, so
         // getBlockHash(N) only returns non-zero when block.number > N. If our
         // tempo_block_number equals the current L1 tip the batch tx would land
         // in the same or next block where getBlockHash would still return zero.
-        // Wait until L1 advances past our anchor block.
         if tempo_block_number >= current_l1_block {
             return Err(eyre::eyre!(
                 "tempo_block_number ({tempo_block_number}) is not yet confirmed on L1 (tip={current_l1_block}), \
@@ -202,23 +225,238 @@ impl BatchSubmitter {
             ));
         }
 
-        if current_l1_block.saturating_sub(tempo_block_number) < EIP2935_EFFECTIVE_WINDOW {
+        let gap = current_l1_block.saturating_sub(tempo_block_number);
+
+        if gap < EIP2935_EFFECTIVE_WINDOW {
             return Ok(AnchorMode::Direct);
         }
 
-        // tempo_block_number is outside the EIP-2935 window — use ancestry mode.
-        // Pick a recent block well within the window as anchor.
-        let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
+        if gap <= EIP2935_HISTORY_WINDOW {
+            // Within ancestry range — collect L1 headers as proof chain.
+            let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
+            let ancestry_headers = self
+                .fetch_ancestry_headers(tempo_block_number, anchor_block)
+                .await?;
 
+            warn!(
+                tempo_block_number,
+                current_l1_block,
+                anchor_block,
+                gap,
+                header_count = ancestry_headers.len(),
+                total_bytes = ancestry_headers.iter().map(|h| h.len()).sum::<usize>(),
+                "tempo_block_number outside EIP-2935 effective window, using ancestry mode"
+            );
+
+            return Ok(AnchorMode::Ancestry {
+                anchor_block,
+                ancestry_headers,
+            });
+        }
+
+        // Gap exceeds EIP-2935 history window — need stepping.
         warn!(
             tempo_block_number,
             current_l1_block,
-            anchor_block,
-            gap = current_l1_block.saturating_sub(tempo_block_number),
-            "tempo_block_number outside EIP-2935 window, using ancestry mode"
+            gap,
+            step_size = EIP2935_EFFECTIVE_WINDOW,
+            "tempo_block_number far outside EIP-2935 window, using stepping mode"
         );
 
-        Ok(AnchorMode::Ancestry { anchor_block })
+        Ok(AnchorMode::Stepping {
+            step_size: EIP2935_EFFECTIVE_WINDOW,
+        })
+    }
+
+    /// Fetch and RLP-encode L1 block headers from `from + 1` to `to` (inclusive),
+    /// validating the parent-hash chain.
+    ///
+    /// Returns headers in ascending block-number order. Uses the same concurrent
+    /// fetching pattern as the L1 subscriber backfill.
+    async fn fetch_ancestry_headers(&self, from: u64, to: u64) -> Result<Vec<Bytes>> {
+        use futures::stream;
+
+        if to <= from {
+            return Ok(Vec::new());
+        }
+
+        let concurrency = self.l1_fetch_concurrency;
+        let range_start = from + 1;
+        let count = (to - from) as usize;
+
+        let mut fetched = stream::iter(range_start..=to)
+            .map(|block_number| {
+                let provider = &self.l1_provider;
+                async move {
+                    let header = provider
+                        .get_header_by_number(block_number.into())
+                        .await?
+                        .ok_or_else(|| {
+                            eyre::eyre!("L1 header not found for block {block_number}")
+                        })?;
+                    Ok::<_, eyre::Report>((block_number, header.inner.inner))
+                }
+            })
+            .buffered(concurrency);
+
+        let mut headers = Vec::with_capacity(count);
+        let mut prev_hash: Option<B256> = None;
+
+        while let Some((block_number, header)) = fetched.try_next().await? {
+            // Validate parent-hash chain: each header's parent_hash must match
+            // the hash of the previous header.
+            if let Some(expected_parent) = prev_hash
+                && header.inner.parent_hash != expected_parent
+            {
+                return Err(eyre::eyre!(
+                    "parent-hash chain broken at block {block_number}: \
+                     expected parent_hash={expected_parent}, got={}",
+                    header.inner.parent_hash
+                ));
+            }
+
+            // Compute this header's hash for the next iteration's check.
+            let mut buf = Vec::with_capacity(600);
+            header.encode(&mut buf);
+            let header_hash = alloy_primitives::keccak256(&buf);
+            prev_hash = Some(header_hash);
+
+            headers.push(Bytes::from(buf));
+        }
+
+        Ok(headers)
+    }
+
+    /// Find zone L2 block numbers whose `tempoBlockNumber` value can serve as
+    /// split points for stepping mode.
+    ///
+    /// Starting from the zone's latest block, walks backwards to find zone blocks
+    /// where `tempoBlockNumber` falls on step boundaries (multiples of `step_size`
+    /// blocks from the target `tempo_block_number`). Returns split points in
+    /// ascending order.
+    pub(crate) async fn find_step_points(
+        &self,
+        tempo_block_number: u64,
+        current_l1_block: u64,
+        step_size: u64,
+    ) -> Result<Vec<StepPoint>> {
+        let tempo_state = TempoState::new(self.tempo_state_address, self.zone_provider.clone());
+
+        // Compute target tempo block numbers for each step boundary.
+        let mut targets = Vec::new();
+        let mut target = tempo_block_number + step_size;
+        while target < current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN) {
+            targets.push(target);
+            target += step_size;
+        }
+
+        if targets.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Walk backwards from the latest zone block to find zone blocks that
+        // match each target tempo_block_number (or the closest one after it).
+        let latest_zone_block = self.zone_provider.get_block_number().await?;
+
+        let mut step_points = Vec::with_capacity(targets.len());
+        let mut target_idx = targets.len() - 1; // start from largest target
+
+        // Binary search for each target: find the first zone block whose
+        // tempoBlockNumber >= target.
+        for &target_tempo in targets.iter().rev() {
+            // Search for the zone block where tempoBlockNumber transitions past this target.
+            let zone_block = self
+                .find_zone_block_for_tempo(&tempo_state, target_tempo, 1, latest_zone_block)
+                .await?;
+
+            if let Some(zone_block) = zone_block {
+                step_points.push(StepPoint {
+                    zone_block,
+                    target_tempo_block: target_tempo,
+                });
+            }
+
+            if target_idx == 0 {
+                break;
+            }
+            target_idx -= 1;
+        }
+
+        step_points.reverse(); // ascending order
+        Ok(step_points)
+    }
+
+    /// Binary search for the smallest zone block whose `tempoBlockNumber >= target`.
+    async fn find_zone_block_for_tempo(
+        &self,
+        tempo_state: &TempoState::TempoStateInstance<DynProvider<TempoNetwork>, TempoNetwork>,
+        target_tempo: u64,
+        lo: u64,
+        hi: u64,
+    ) -> Result<Option<u64>> {
+        if lo > hi {
+            return Ok(None);
+        }
+
+        let mut low = lo;
+        let mut high = hi;
+        let mut result = None;
+
+        while low <= high {
+            let mid = low + (high - low) / 2;
+            let tempo_at_mid: u64 = tempo_state
+                .tempoBlockNumber()
+                .block(mid.into())
+                .call()
+                .await
+                .unwrap_or(0);
+
+            if tempo_at_mid >= target_tempo {
+                result = Some(mid);
+                if mid == 0 {
+                    break;
+                }
+                high = mid - 1;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Read intermediate zone state at the given zone block number for stepping.
+    #[allow(dead_code)]
+    pub(crate) async fn fetch_zone_snapshot(&self, zone_block: u64) -> Result<ZoneBlockSnapshot> {
+        let tempo_state = TempoState::new(self.tempo_state_address, self.zone_provider.clone());
+        let inbox = ZoneInbox::new(self.inbox_address, self.zone_provider.clone());
+
+        let tempo_call = tempo_state.tempoBlockNumber().block(zone_block.into());
+        let deposit_call = inbox.processedDepositQueueHash().block(zone_block.into());
+        let block_fut = async {
+            self.zone_provider
+                .get_block_by_number(zone_block.into())
+                .await
+                .map_err(Into::into)
+        };
+        let (tempo_block_number, processed_deposit_hash, block) =
+            tokio::try_join!(tempo_call.call(), deposit_call.call(), block_fut)?;
+
+        let block_hash = block
+            .ok_or_else(|| eyre::eyre!("zone block {zone_block} not found"))?
+            .header
+            .hash;
+
+        Ok(ZoneBlockSnapshot {
+            tempo_block_number,
+            processed_deposit_hash,
+            block_hash,
+        })
+    }
+
+    /// Returns a reference to the L1 provider.
+    pub(crate) fn l1_provider(&self) -> &DynProvider<TempoNetwork> {
+        &self.l1_provider
     }
 
     /// Read the portal's `genesisTempoBlockNumber` from L1.
@@ -280,30 +518,61 @@ impl BatchSubmitter {
 /// How the batch submitter should anchor `tempoBlockNumber` for EIP-2935
 /// verification on the ZonePortal.
 #[derive(Debug)]
-enum AnchorMode {
+#[allow(dead_code)] // ancestry_headers available for future prover integration
+pub(crate) enum AnchorMode {
     /// `tempoBlockNumber` is within the EIP-2935 window — the portal reads its
     /// hash directly. No extra proof data required.
     Direct,
-    /// `tempoBlockNumber` has expired from EIP-2935. A recent L1 block is used
-    /// as anchor, and the proof must include block headers linking the anchor
-    /// back to `tempoBlockNumber`.
-    // TODO: once the verifier is implemented, ancestry mode must also collect
-    // the intermediate block headers (from `anchor_block` down to
-    // `tempoBlockNumber`) and include them in the proof bytes.
+    /// `tempoBlockNumber` has expired from EIP-2935 but is within the full
+    /// history window. A recent L1 block is used as anchor, and the collected
+    /// headers prove the parent-hash chain from anchor back to `tempoBlockNumber`.
     Ancestry {
         /// Recent L1 block number within the EIP-2935 window, used as the
         /// on-chain anchor for hash verification.
         anchor_block: u64,
+        /// RLP-encoded L1 block headers from `tempo_block_number + 1` to
+        /// `anchor_block`, in ascending order. Available for the prover to
+        /// consume when integrated.
+        ancestry_headers: Vec<Bytes>,
+    },
+    /// The gap exceeds the full EIP-2935 history window. The batch must be split
+    /// into multiple direct-mode submissions, each within the effective window.
+    Stepping {
+        /// Each sub-batch covers at most this many L1 blocks.
+        step_size: u64,
     },
 }
 
 impl AnchorMode {
     /// Returns the `recentTempoBlockNumber` argument for `submitBatch`:
     /// `0` for direct mode, or the anchor block number for ancestry mode.
+    /// Panics if called on `Stepping` — the caller must split before submitting.
     const fn recent_block_number(&self) -> u64 {
         match self {
             Self::Direct => 0,
-            Self::Ancestry { anchor_block } => *anchor_block,
+            Self::Ancestry { anchor_block, .. } => *anchor_block,
+            Self::Stepping { .. } => panic!("Stepping mode must be split before submitting"),
         }
     }
+}
+
+/// A step split point for stepping mode: identifies a zone L2 block at which
+/// to cut an intermediate batch submission.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) struct StepPoint {
+    /// Zone L2 block number at which to cut the intermediate batch.
+    pub zone_block: u64,
+    /// Target `tempoBlockNumber` value at this split point.
+    pub target_tempo_block: u64,
+}
+
+/// Zone L2 state read at a specific block, used to populate [`BatchData`].
+pub(crate) struct ZoneBlockSnapshot {
+    /// Latest Tempo L1 block number as seen by the zone.
+    pub tempo_block_number: u64,
+    /// Cumulative hash of all deposits processed by the zone up to this block.
+    pub processed_deposit_hash: B256,
+    /// Zone L2 block hash.
+    pub block_hash: B256,
 }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -15,15 +15,17 @@
 //!
 //! # Anchor modes
 //!
-//! Three tiers based on the gap between `tempo_block_number` and the current L1 tip:
-//!
 //! | Gap | Mode | Description |
 //! |-----|------|-------------|
-//! | < 7832 | Direct | Portal reads hash from EIP-2935. |
-//! | 7832–8192 | Ancestry | Collect L1 headers as proof chain. Single submitBatch. |
-//! | > 8192 | Stepping | Split into multiple direct-mode submissions. |
+//! | < [`EIP2935_EFFECTIVE_WINDOW`] | Direct | Portal reads hash from EIP-2935. |
+//! | [`EIP2935_EFFECTIVE_WINDOW`]–[`EIP2935_HISTORY_WINDOW`] | Ancestry | Anchor via recent block + header chain. |
+//! | > [`EIP2935_HISTORY_WINDOW`] | Stepping | Split into multiple direct-mode submissions. |
+//!
+//! Stepping is resolved by [`AnchorGapKind`] in the zone monitor before
+//! `submit_batch` is called. Direct vs Ancestry is resolved inside
+//! `submit_batch` by [`AnchorMode`].
 
-use crate::abi::{BlockTransition, DepositQueueTransition, TempoState, ZoneInbox, ZonePortal};
+use crate::abi::{BlockTransition, DepositQueueTransition, ZonePortal};
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{DynProvider, Provider};
 use alloy_rlp::Encodable;
@@ -33,14 +35,15 @@ use tempo_alloy::TempoNetwork;
 use tracing::{info, instrument, warn};
 
 /// EIP-2935 stores the last 8192 block hashes (~68 min at 500ms block time).
-/// Blocks older than this require ancestry mode.
 const EIP2935_HISTORY_WINDOW: u64 = 8192;
 
 /// Safety margin (~3 min at 500ms block time) to avoid race conditions where
 /// the block falls out of the window between our check and on-chain execution.
 const EIP2935_SAFETY_MARGIN: u64 = 360;
 
-/// Effective EIP-2935 window after subtracting the safety margin.
+/// Effective EIP-2935 window after subtracting the safety margin. Batches with
+/// a gap below this threshold use direct mode; gaps at or above it require
+/// stepping (splitting into multiple direct-mode submissions).
 const EIP2935_EFFECTIVE_WINDOW: u64 = EIP2935_HISTORY_WINDOW - EIP2935_SAFETY_MARGIN;
 
 /// Maximum number of pending withdrawal queue slots in the portal ring buffer.
@@ -68,8 +71,7 @@ pub struct BatchData {
 /// Submits zone batches to the ZonePortal contract on Tempo L1.
 ///
 /// Holds a contract instance pointing at the portal, backed by a shared
-/// [`DynProvider`] with the sequencer's signing wallet. Also holds a zone L2
-/// provider for reading intermediate zone state during stepping mode.
+/// [`DynProvider`] with the sequencer's signing wallet.
 pub struct BatchSubmitter {
     /// ZonePortal contract address on Tempo L1 (used in tracing spans).
     portal_address: Address,
@@ -83,30 +85,18 @@ pub struct BatchSubmitter {
     /// The portal's `genesisTempoBlockNumber` — batches with a
     /// `tempo_block_number` below this value will be rejected on-chain.
     genesis_tempo_block_number: u64,
-    /// Read-only Zone L2 provider for querying intermediate zone state during
-    /// stepping mode.
-    zone_provider: DynProvider<TempoNetwork>,
-    /// TempoState predeploy address on Zone L2.
-    tempo_state_address: Address,
-    /// ZoneInbox contract address on Zone L2.
-    inbox_address: Address,
     /// Concurrency for pipelined L1 header fetching in ancestry mode.
     l1_fetch_concurrency: usize,
 }
 
 impl BatchSubmitter {
-    /// Create a new batch submitter from a shared L1 provider and a zone L2 provider.
+    /// Create a new batch submitter from a shared L1 provider.
     ///
-    /// The L1 provider must already include the sequencer wallet for signing.
-    /// The zone provider is read-only, used for querying intermediate zone state
-    /// during stepping mode.
+    /// The provider must already include the sequencer wallet for signing.
     pub fn new(
         portal_address: Address,
         l1_provider: DynProvider<TempoNetwork>,
-        zone_provider: DynProvider<TempoNetwork>,
         genesis_tempo_block_number: u64,
-        tempo_state_address: Address,
-        inbox_address: Address,
     ) -> Self {
         let portal = ZonePortal::new(portal_address, l1_provider.clone());
         Self {
@@ -114,28 +104,23 @@ impl BatchSubmitter {
             l1_provider,
             portal,
             genesis_tempo_block_number,
-            zone_provider,
-            tempo_state_address,
-            inbox_address,
             l1_fetch_concurrency: 16,
         }
     }
 
     /// Submit a batch to the ZonePortal on Tempo L1.
     ///
-    /// Automatically selects **direct mode** or **ancestry mode** based on how
-    /// old `tempoBlockNumber` is relative to the current L1 tip:
+    /// Resolves the anchor mode based on how old `tempo_block_number` is:
     ///
-    /// - **Direct** (`recentTempoBlockNumber = 0`): used when `tempoBlockNumber`
-    ///   is within the EIP-2935 history window (8192 blocks). The portal reads
-    ///   its hash directly from EIP-2935.
-    /// - **Ancestry** (`recentTempoBlockNumber > 0`): used when `tempoBlockNumber`
-    ///   has fallen out of the EIP-2935 window (e.g. sequencer was offline for
-    ///   >2 hours). A recent L1 block within the window is chosen as anchor and
-    ///   the proof must include a block header chain from `recentTempoBlockNumber`
-    ///   back to `tempoBlockNumber`.
+    /// - **Direct** — `tempo_block_number` is within [`EIP2935_EFFECTIVE_WINDOW`],
+    ///   the portal reads its hash directly from EIP-2935.
+    /// - **Ancestry** — `tempo_block_number` is outside the effective window but
+    ///   still within [`EIP2935_HISTORY_WINDOW`]. A recent anchor block is used
+    ///   and ancestry headers are collected (for future prover integration).
     ///
-    /// # POC note
+    /// The caller must ensure `tempo_block_number` is within the
+    /// [`EIP2935_HISTORY_WINDOW`] — use [`classify_anchor_gap`](Self::classify_anchor_gap)
+    /// first and split via stepping if the gap is too large.
     ///
     /// `verifierConfig` and `proof` are set to empty bytes — the verifier
     /// contract must be configured to accept empty proofs.
@@ -172,15 +157,13 @@ impl BatchSubmitter {
 
         let anchor_mode = self.resolve_anchor_mode(batch.tempo_block_number).await?;
 
-        let recent_tempo_block_number = anchor_mode.recent_block_number();
-
         info!(?anchor_mode, "Submitting batch to ZonePortal on L1");
 
         let tx_hash = self
             .portal
             .submitBatch(
                 batch.tempo_block_number,
-                recent_tempo_block_number,
+                anchor_mode.recent_block_number(),
                 block_transition,
                 deposit_transition,
                 batch.withdrawal_queue_hash,
@@ -199,25 +182,20 @@ impl BatchSubmitter {
         Ok(tx_hash)
     }
 
-    /// Determine the anchor mode for the given `tempo_block_number`.
+    /// Classify whether `tempo_block_number` can be submitted directly or
+    /// requires stepping (splitting into sub-batches).
     ///
-    /// Three tiers based on the gap between `tempo_block_number` and L1 tip:
+    /// Only performs a single `get_block_number` RPC call — no header fetching
+    /// or contract reads.
     ///
-    /// - **Direct** (gap < [`EIP2935_EFFECTIVE_WINDOW`]): the portal reads the
-    ///   hash directly from EIP-2935.
-    /// - **Ancestry** (gap within [`EIP2935_HISTORY_WINDOW`]): a recent L1 block
-    ///   within the window is used as anchor. The proof must include block headers
-    ///   linking the anchor back to `tempo_block_number`.
-    /// - **Stepping** (gap > [`EIP2935_HISTORY_WINDOW`]): the gap is too large
-    ///   for a single ancestry proof. The batch must be split into multiple
-    ///   direct-mode submissions.
-    pub(crate) async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
+    /// Returns an error if `tempo_block_number` is not yet confirmed on L1
+    /// (i.e. it equals or exceeds the current L1 tip).
+    pub(crate) async fn classify_anchor_gap(
+        &self,
+        tempo_block_number: u64,
+    ) -> Result<AnchorGapKind> {
         let current_l1_block = self.l1_provider.get_block_number().await?;
 
-        // EIP-2935 stores the hash of block N when block N+1 is processed, so
-        // getBlockHash(N) only returns non-zero when block.number > N. If our
-        // tempo_block_number equals the current L1 tip the batch tx would land
-        // in the same or next block where getBlockHash would still return zero.
         if tempo_block_number >= current_l1_block {
             return Err(eyre::eyre!(
                 "tempo_block_number ({tempo_block_number}) is not yet confirmed on L1 (tip={current_l1_block}), \
@@ -228,51 +206,75 @@ impl BatchSubmitter {
         let gap = current_l1_block.saturating_sub(tempo_block_number);
 
         if gap < EIP2935_EFFECTIVE_WINDOW {
+            Ok(AnchorGapKind::Direct)
+        } else {
+            Ok(AnchorGapKind::Ancestry {
+                step_size: EIP2935_EFFECTIVE_WINDOW,
+            })
+        }
+    }
+
+    /// Resolve the anchor mode for the given `tempo_block_number`.
+    ///
+    /// - **Direct** (gap < [`EIP2935_EFFECTIVE_WINDOW`]): the portal reads the
+    ///   hash directly from EIP-2935.
+    /// - **Ancestry** (gap within [`EIP2935_HISTORY_WINDOW`]): a recent L1 block
+    ///   within the window is used as anchor. Ancestry headers are collected
+    ///   and validated for future prover integration.
+    ///
+    /// Returns an error if the gap exceeds [`EIP2935_HISTORY_WINDOW`] — the
+    /// caller must split via stepping before calling this.
+    async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
+        let current_l1_block = self.l1_provider.get_block_number().await?;
+
+        if tempo_block_number >= current_l1_block {
+            return Err(eyre::eyre!(
+                "tempo_block_number ({tempo_block_number}) is not yet confirmed on L1 \
+                 (tip={current_l1_block}), will retry after L1 advances"
+            ));
+        }
+
+        let gap = current_l1_block.saturating_sub(tempo_block_number);
+
+        if gap < EIP2935_EFFECTIVE_WINDOW {
             return Ok(AnchorMode::Direct);
         }
 
-        if gap <= EIP2935_HISTORY_WINDOW {
-            // Within ancestry range — collect L1 headers as proof chain.
-            let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
-            let ancestry_headers = self
-                .fetch_ancestry_headers(tempo_block_number, anchor_block)
-                .await?;
-
-            warn!(
-                tempo_block_number,
-                current_l1_block,
-                anchor_block,
-                gap,
-                header_count = ancestry_headers.len(),
-                total_bytes = ancestry_headers.iter().map(|h| h.len()).sum::<usize>(),
-                "tempo_block_number outside EIP-2935 effective window, using ancestry mode"
-            );
-
-            return Ok(AnchorMode::Ancestry {
-                anchor_block,
-                ancestry_headers,
-            });
+        if gap > EIP2935_HISTORY_WINDOW {
+            return Err(eyre::eyre!(
+                "tempo_block_number ({tempo_block_number}) is outside the EIP-2935 history \
+                 window (gap={gap}, max={EIP2935_HISTORY_WINDOW}) — must split via stepping"
+            ));
         }
 
-        // Gap exceeds EIP-2935 history window — need stepping.
+        // Within ancestry range — collect L1 headers as proof chain.
+        let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
+        let ancestry_headers = self
+            .fetch_ancestry_headers(tempo_block_number, anchor_block)
+            .await?;
+
         warn!(
             tempo_block_number,
             current_l1_block,
+            anchor_block,
             gap,
-            step_size = EIP2935_EFFECTIVE_WINDOW,
-            "tempo_block_number far outside EIP-2935 window, using stepping mode"
+            header_count = ancestry_headers.len(),
+            total_bytes = ancestry_headers.iter().map(|h| h.len()).sum::<usize>(),
+            "tempo_block_number outside EIP-2935 effective window, using ancestry mode"
         );
 
-        Ok(AnchorMode::Stepping {
-            step_size: EIP2935_EFFECTIVE_WINDOW,
+        Ok(AnchorMode::Ancestry {
+            anchor_block,
+            ancestry_headers,
         })
     }
 
     /// Fetch and RLP-encode L1 block headers from `from + 1` to `to` (inclusive),
     /// validating the parent-hash chain.
     ///
-    /// Returns headers in ascending block-number order. Uses the same concurrent
-    /// fetching pattern as the L1 subscriber backfill.
+    /// Returns headers in ascending block-number order. The first header's
+    /// `parent_hash` is validated against the hash of block `from`, ensuring the
+    /// chain is rooted at the expected block.
     async fn fetch_ancestry_headers(&self, from: u64, to: u64) -> Result<Vec<Bytes>> {
         use futures::stream;
 
@@ -283,6 +285,16 @@ impl BatchSubmitter {
         let concurrency = self.l1_fetch_concurrency;
         let range_start = from + 1;
         let count = (to - from) as usize;
+
+        // Fetch the base block's header to seed the parent-hash chain validation.
+        let base_header = self
+            .l1_provider
+            .get_header_by_number(from.into())
+            .await?
+            .ok_or_else(|| eyre::eyre!("L1 header not found for base block {from}"))?;
+        let mut base_buf = Vec::with_capacity(600);
+        base_header.inner.inner.encode(&mut base_buf);
+        let base_hash = alloy_primitives::keccak256(&base_buf);
 
         let mut fetched = stream::iter(range_start..=to)
             .map(|block_number| {
@@ -300,11 +312,9 @@ impl BatchSubmitter {
             .buffered(concurrency);
 
         let mut headers = Vec::with_capacity(count);
-        let mut prev_hash: Option<B256> = None;
+        let mut prev_hash: Option<B256> = Some(base_hash);
 
         while let Some((block_number, header)) = fetched.try_next().await? {
-            // Validate parent-hash chain: each header's parent_hash must match
-            // the hash of the previous header.
             if let Some(expected_parent) = prev_hash
                 && header.inner.parent_hash != expected_parent
             {
@@ -315,7 +325,6 @@ impl BatchSubmitter {
                 ));
             }
 
-            // Compute this header's hash for the next iteration's check.
             let mut buf = Vec::with_capacity(600);
             header.encode(&mut buf);
             let header_hash = alloy_primitives::keccak256(&buf);
@@ -327,131 +336,40 @@ impl BatchSubmitter {
         Ok(headers)
     }
 
-    /// Find zone L2 block numbers whose `tempoBlockNumber` value can serve as
-    /// split points for stepping mode.
+    /// Compute zone L2 block numbers that serve as split points for stepping mode.
     ///
-    /// Starting from the zone's latest block, walks backwards to find zone blocks
-    /// where `tempoBlockNumber` falls on step boundaries (multiples of `step_size`
-    /// blocks from the target `tempo_block_number`). Returns split points in
-    /// ascending order.
-    pub(crate) async fn find_step_points(
-        &self,
-        tempo_block_number: u64,
+    /// Zone blocks and L1 blocks have a 1:1 mapping (each zone block processes
+    /// exactly one L1 block via `advanceTempo`), so the zone block for a target
+    /// `tempoBlockNumber` can be computed arithmetically:
+    ///
+    /// ```text
+    /// zone_block = from_zone_block + (target_tempo - from_tempo)
+    /// ```
+    ///
+    /// Returns split points in ascending order, all within `[from_zone_block, max_zone_block]`.
+    pub(crate) fn compute_step_points(
+        from_zone_block: u64,
+        from_tempo: u64,
         current_l1_block: u64,
         step_size: u64,
-    ) -> Result<Vec<StepPoint>> {
-        let tempo_state = TempoState::new(self.tempo_state_address, self.zone_provider.clone());
+        max_zone_block: u64,
+    ) -> Vec<StepPoint> {
+        let mut step_points = Vec::new();
+        let mut target = from_tempo + step_size;
 
-        // Compute target tempo block numbers for each step boundary.
-        let mut targets = Vec::new();
-        let mut target = tempo_block_number + step_size;
         while target < current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN) {
-            targets.push(target);
+            let zone_block = from_zone_block + (target - from_tempo);
+            if zone_block > max_zone_block {
+                break;
+            }
+            step_points.push(StepPoint {
+                zone_block,
+                target_tempo_block: target,
+            });
             target += step_size;
         }
 
-        if targets.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Walk backwards from the latest zone block to find zone blocks that
-        // match each target tempo_block_number (or the closest one after it).
-        let latest_zone_block = self.zone_provider.get_block_number().await?;
-
-        let mut step_points = Vec::with_capacity(targets.len());
-        let mut target_idx = targets.len() - 1; // start from largest target
-
-        // Binary search for each target: find the first zone block whose
-        // tempoBlockNumber >= target.
-        for &target_tempo in targets.iter().rev() {
-            // Search for the zone block where tempoBlockNumber transitions past this target.
-            let zone_block = self
-                .find_zone_block_for_tempo(&tempo_state, target_tempo, 1, latest_zone_block)
-                .await?;
-
-            if let Some(zone_block) = zone_block {
-                step_points.push(StepPoint {
-                    zone_block,
-                    target_tempo_block: target_tempo,
-                });
-            }
-
-            if target_idx == 0 {
-                break;
-            }
-            target_idx -= 1;
-        }
-
-        step_points.reverse(); // ascending order
-        Ok(step_points)
-    }
-
-    /// Binary search for the smallest zone block whose `tempoBlockNumber >= target`.
-    async fn find_zone_block_for_tempo(
-        &self,
-        tempo_state: &TempoState::TempoStateInstance<DynProvider<TempoNetwork>, TempoNetwork>,
-        target_tempo: u64,
-        lo: u64,
-        hi: u64,
-    ) -> Result<Option<u64>> {
-        if lo > hi {
-            return Ok(None);
-        }
-
-        let mut low = lo;
-        let mut high = hi;
-        let mut result = None;
-
-        while low <= high {
-            let mid = low + (high - low) / 2;
-            let tempo_at_mid: u64 = tempo_state
-                .tempoBlockNumber()
-                .block(mid.into())
-                .call()
-                .await
-                .unwrap_or(0);
-
-            if tempo_at_mid >= target_tempo {
-                result = Some(mid);
-                if mid == 0 {
-                    break;
-                }
-                high = mid - 1;
-            } else {
-                low = mid + 1;
-            }
-        }
-
-        Ok(result)
-    }
-
-    /// Read intermediate zone state at the given zone block number for stepping.
-    #[allow(dead_code)]
-    pub(crate) async fn fetch_zone_snapshot(&self, zone_block: u64) -> Result<ZoneBlockSnapshot> {
-        let tempo_state = TempoState::new(self.tempo_state_address, self.zone_provider.clone());
-        let inbox = ZoneInbox::new(self.inbox_address, self.zone_provider.clone());
-
-        let tempo_call = tempo_state.tempoBlockNumber().block(zone_block.into());
-        let deposit_call = inbox.processedDepositQueueHash().block(zone_block.into());
-        let block_fut = async {
-            self.zone_provider
-                .get_block_by_number(zone_block.into())
-                .await
-                .map_err(Into::into)
-        };
-        let (tempo_block_number, processed_deposit_hash, block) =
-            tokio::try_join!(tempo_call.call(), deposit_call.call(), block_fut)?;
-
-        let block_hash = block
-            .ok_or_else(|| eyre::eyre!("zone block {zone_block} not found"))?
-            .header
-            .hash;
-
-        Ok(ZoneBlockSnapshot {
-            tempo_block_number,
-            processed_deposit_hash,
-            block_hash,
-        })
+        step_points
     }
 
     /// Returns a reference to the L1 provider.
@@ -515,17 +433,37 @@ impl BatchSubmitter {
     }
 }
 
-/// How the batch submitter should anchor `tempoBlockNumber` for EIP-2935
-/// verification on the ZonePortal.
+/// Classification of the EIP-2935 gap, returned by
+/// [`BatchSubmitter::classify_anchor_gap`].
 #[derive(Debug)]
-#[allow(dead_code)] // ancestry_headers available for future prover integration
-pub(crate) enum AnchorMode {
-    /// `tempoBlockNumber` is within the EIP-2935 window — the portal reads its
-    /// hash directly. No extra proof data required.
+pub(crate) enum AnchorGapKind {
+    /// Gap < [`EIP2935_EFFECTIVE_WINDOW`] — the portal can read the block hash
+    /// directly from EIP-2935. No extra proof data needed.
     Direct,
-    /// `tempoBlockNumber` has expired from EIP-2935 but is within the full
+    /// Gap ≥ [`EIP2935_EFFECTIVE_WINDOW`] — `tempo_block_number` is too old
+    /// for a direct EIP-2935 lookup. The batch must be split into multiple
+    /// direct-mode sub-range submissions (stepping).
+    Ancestry {
+        /// Each sub-batch covers at most this many L1 blocks.
+        step_size: u64,
+    },
+}
+
+/// How the batch submitter anchors `tempoBlockNumber` for EIP-2935 verification.
+///
+/// Resolved by [`BatchSubmitter::resolve_anchor_mode`] inside `submit_batch`.
+/// Stepping is handled at a higher level by [`AnchorGapKind`] — by the time
+/// `submit_batch` is called, the gap must already be within
+/// [`EIP2935_HISTORY_WINDOW`].
+#[derive(Debug)]
+#[allow(dead_code)] // Ancestry::ancestry_headers is collected but not yet consumed — available for prover integration
+enum AnchorMode {
+    /// `tempoBlockNumber` is within the effective EIP-2935 window — the portal
+    /// reads its hash directly. No extra proof data required.
+    Direct,
+    /// `tempoBlockNumber` is outside the effective window but within the full
     /// history window. A recent L1 block is used as anchor, and the collected
-    /// headers prove the parent-hash chain from anchor back to `tempoBlockNumber`.
+    /// headers prove the parent-hash chain.
     Ancestry {
         /// Recent L1 block number within the EIP-2935 window, used as the
         /// on-chain anchor for hash verification.
@@ -535,23 +473,15 @@ pub(crate) enum AnchorMode {
         /// consume when integrated.
         ancestry_headers: Vec<Bytes>,
     },
-    /// The gap exceeds the full EIP-2935 history window. The batch must be split
-    /// into multiple direct-mode submissions, each within the effective window.
-    Stepping {
-        /// Each sub-batch covers at most this many L1 blocks.
-        step_size: u64,
-    },
 }
 
 impl AnchorMode {
     /// Returns the `recentTempoBlockNumber` argument for `submitBatch`:
     /// `0` for direct mode, or the anchor block number for ancestry mode.
-    /// Panics if called on `Stepping` — the caller must split before submitting.
     const fn recent_block_number(&self) -> u64 {
         match self {
             Self::Direct => 0,
             Self::Ancestry { anchor_block, .. } => *anchor_block,
-            Self::Stepping { .. } => panic!("Stepping mode must be split before submitting"),
         }
     }
 }

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -37,7 +37,7 @@ use alloy_sol_types::{ContractError, SolInterface as _};
 
 use crate::{
     abi::{self, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
-    batch::{BatchData, BatchSubmitter, ZoneBlockSnapshot},
+    batch::{AnchorGapKind, BatchData, BatchSubmitter, ZoneBlockSnapshot},
     withdrawals::SharedWithdrawalStore,
 };
 
@@ -144,10 +144,7 @@ impl ZoneMonitor {
         let batch_submitter = BatchSubmitter::new(
             config.portal_address,
             l1_provider,
-            provider.clone(),
             genesis_tempo_block_number,
-            config.tempo_state_address,
-            config.inbox_address,
         );
 
         let (prev_zone_block_hash, portal_withdrawal_queue_tail) = tokio::try_join!(
@@ -319,23 +316,21 @@ impl ZoneMonitor {
         let block_count = to - from + 1;
         info!(from, to, block_count, "Processing zone block range");
 
-        // Read end-of-range state to check the anchor mode.
+        // Read end-of-range state to check the anchor gap class.
         let end_state = self.fetch_block_snapshot(to).await?;
 
-        // Check if stepping is needed by peeking at the anchor mode.
-        let anchor_mode = self
+        // Lightweight gap check — no header fetching, just arithmetic.
+        let gap_kind = self
             .batch_submitter
-            .resolve_anchor_mode(end_state.tempo_block_number)
-            .await;
+            .classify_anchor_gap(end_state.tempo_block_number)
+            .await?;
 
-        if let Ok(crate::batch::AnchorMode::Stepping { step_size }) = &anchor_mode {
-            return self
-                .process_block_range_stepping(from, to, *step_size)
-                .await;
+        match gap_kind {
+            AnchorGapKind::Direct => self.process_block_range_single(from, to, end_state).await,
+            AnchorGapKind::Ancestry { step_size } => {
+                self.process_block_range_stepping(from, to, step_size).await
+            }
         }
-
-        // Direct or ancestry mode — single submission.
-        self.process_block_range_single(from, to, end_state).await
     }
 
     /// Process a block range as a single batch submission (direct or ancestry mode).
@@ -397,21 +392,27 @@ impl ZoneMonitor {
             .get_block_number()
             .await?;
 
-        let step_points = self
-            .batch_submitter
-            .find_step_points(start_state.tempo_block_number, current_l1_block, step_size)
-            .await?;
+        let step_points = BatchSubmitter::compute_step_points(
+            from,
+            start_state.tempo_block_number,
+            current_l1_block,
+            step_size,
+            to,
+        );
 
         if step_points.is_empty() {
-            // Fallback: no valid step points found, try single submission.
-            warn!("No step points found for stepping, falling back to single submission");
-            let end_state = self.fetch_block_snapshot(to).await?;
-            return self.process_block_range_single(from, to, end_state).await;
+            return Err(eyre::eyre!(
+                "stepping mode required (tempo_block_number {} is outside EIP-2935 window) \
+                 but no valid step points found — zone may not have produced enough blocks yet",
+                start_state.tempo_block_number,
+            ));
         }
 
         // Collect all step zone block numbers, plus the final block.
+        // Sort + dedup defensively in case step points are not perfectly ordered.
         let mut boundaries: Vec<u64> = step_points.iter().map(|sp| sp.zone_block).collect();
         boundaries.push(to);
+        boundaries.sort_unstable();
         boundaries.dedup();
 
         let total_steps = boundaries.len();
@@ -427,10 +428,6 @@ impl ZoneMonitor {
         let mut range_start = from;
 
         for (step_idx, &step_end) in boundaries.iter().enumerate() {
-            if step_end < range_start {
-                continue;
-            }
-
             let step_state = self.fetch_block_snapshot(step_end).await?;
 
             // Fetch withdrawal events for this sub-range.

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -37,7 +37,7 @@ use alloy_sol_types::{ContractError, SolInterface as _};
 
 use crate::{
     abi::{self, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
-    batch::{BatchData, BatchSubmitter},
+    batch::{BatchData, BatchSubmitter, ZoneBlockSnapshot},
     withdrawals::SharedWithdrawalStore,
 };
 
@@ -144,7 +144,10 @@ impl ZoneMonitor {
         let batch_submitter = BatchSubmitter::new(
             config.portal_address,
             l1_provider,
+            provider.clone(),
             genesis_tempo_block_number,
+            config.tempo_state_address,
+            config.inbox_address,
         );
 
         let (prev_zone_block_hash, portal_withdrawal_queue_tail) = tokio::try_join!(
@@ -287,10 +290,18 @@ impl ZoneMonitor {
         }
     }
 
-    /// Process a range of zone blocks as a single batch.
+    /// Process a range of zone blocks as a single batch, or split into multiple
+    /// sub-range submissions if stepping mode is required.
     ///
     /// Scans all blocks in `[from, to]`, collects withdrawal events, reads end-of-range
-    /// state, and submits one `submitBatch` call covering the entire range.
+    /// state, and submits `submitBatch` calls to L1.
+    ///
+    /// ## Stepping mode
+    ///
+    /// When the zone's `tempoBlockNumber` has fallen far outside the EIP-2935 window
+    /// (gap > 8192 blocks), a single submission would fail. The monitor splits the
+    /// range into multiple direct-mode submissions at intermediate zone blocks whose
+    /// `tempoBlockNumber` falls within the window relative to the current L1 tip.
     ///
     /// ## Withdrawal handling
     ///
@@ -308,32 +319,40 @@ impl ZoneMonitor {
         let block_count = to - from + 1;
         info!(from, to, block_count, "Processing zone block range");
 
-        // --- 1. Fetch withdrawal events, finalized hashes, and block state concurrently ---
-        let (all_withdrawals, finalized_hashes, end_state) = tokio::try_join!(
+        // Read end-of-range state to check the anchor mode.
+        let end_state = self.fetch_block_snapshot(to).await?;
+
+        // Check if stepping is needed by peeking at the anchor mode.
+        let anchor_mode = self
+            .batch_submitter
+            .resolve_anchor_mode(end_state.tempo_block_number)
+            .await;
+
+        if let Ok(crate::batch::AnchorMode::Stepping { step_size }) = &anchor_mode {
+            return self
+                .process_block_range_stepping(from, to, *step_size)
+                .await;
+        }
+
+        // Direct or ancestry mode — single submission.
+        self.process_block_range_single(from, to, end_state).await
+    }
+
+    /// Process a block range as a single batch submission (direct or ancestry mode).
+    async fn process_block_range_single(
+        &mut self,
+        from: u64,
+        to: u64,
+        end_state: ZoneBlockSnapshot,
+    ) -> Result<()> {
+        // Fetch withdrawal events and finalized hashes concurrently.
+        let (all_withdrawals, finalized_hashes) = tokio::try_join!(
             self.fetch_withdrawals(from, to),
             self.fetch_finalized_hashes(from, to),
-            self.fetch_block_snapshot(to),
         )?;
 
-        // --- 2. Determine the withdrawal queue hash ---
-        let withdrawal_queue_hash = if finalized_hashes.len() == 1 {
-            // Single finalized batch — use the L2-authoritative hash directly.
-            finalized_hashes[0]
-        } else if finalized_hashes.len() > 1 || !all_withdrawals.is_empty() {
-            // Multiple finalized batches or withdrawals present — recompute
-            // a combined hash from all withdrawal structs.
-            abi::Withdrawal::queue_hash(&all_withdrawals)
-        } else {
-            B256::ZERO
-        };
-
-        // --- 3. Validate withdrawal data consistency ---
-        if !withdrawal_queue_hash.is_zero() && all_withdrawals.is_empty() {
-            return Err(eyre::eyre!(
-                "withdrawal_queue_hash is non-zero but no withdrawal events found — \
-                 RPC may have returned incomplete data"
-            ));
-        }
+        let withdrawal_queue_hash =
+            Self::compute_withdrawal_hash(&all_withdrawals, &finalized_hashes)?;
 
         if !all_withdrawals.is_empty() {
             info!(
@@ -342,11 +361,10 @@ impl ZoneMonitor {
                 count = all_withdrawals.len(),
                 finalized_batches = finalized_hashes.len(),
                 withdrawal_queue_hash = %withdrawal_queue_hash,
-                "📤 Collected withdrawal requests from zone"
+                "Collected withdrawal requests from zone"
             );
         }
 
-        // --- 4. Build and submit BatchData ---
         let batch_data = BatchData {
             tempo_block_number: end_state.tempo_block_number,
             prev_block_hash: self.prev_zone_block_hash,
@@ -356,11 +374,122 @@ impl ZoneMonitor {
             withdrawal_queue_hash,
         };
 
-        // Submit — state and withdrawal store only advance on success.
         self.submit_batch_with_retry(&batch_data, to, all_withdrawals)
             .await?;
 
         Ok(())
+    }
+
+    /// Process a block range using stepping mode: split into multiple direct-mode
+    /// sub-range submissions.
+    async fn process_block_range_stepping(
+        &mut self,
+        from: u64,
+        to: u64,
+        step_size: u64,
+    ) -> Result<()> {
+        // Read the tempo_block_number from the start of the range — this is the
+        // oldest value that needs to be anchored.
+        let start_state = self.fetch_block_snapshot(from).await?;
+        let current_l1_block = self
+            .batch_submitter
+            .l1_provider()
+            .get_block_number()
+            .await?;
+
+        let step_points = self
+            .batch_submitter
+            .find_step_points(start_state.tempo_block_number, current_l1_block, step_size)
+            .await?;
+
+        if step_points.is_empty() {
+            // Fallback: no valid step points found, try single submission.
+            warn!("No step points found for stepping, falling back to single submission");
+            let end_state = self.fetch_block_snapshot(to).await?;
+            return self.process_block_range_single(from, to, end_state).await;
+        }
+
+        // Collect all step zone block numbers, plus the final block.
+        let mut boundaries: Vec<u64> = step_points.iter().map(|sp| sp.zone_block).collect();
+        boundaries.push(to);
+        boundaries.dedup();
+
+        let total_steps = boundaries.len();
+        info!(
+            total_steps,
+            from,
+            to,
+            first_step_zone_block = boundaries[0],
+            "Stepping mode: splitting batch into {} sub-range submissions",
+            total_steps
+        );
+
+        let mut range_start = from;
+
+        for (step_idx, &step_end) in boundaries.iter().enumerate() {
+            if step_end < range_start {
+                continue;
+            }
+
+            let step_state = self.fetch_block_snapshot(step_end).await?;
+
+            // Fetch withdrawal events for this sub-range.
+            let (step_withdrawals, step_finalized) = tokio::try_join!(
+                self.fetch_withdrawals(range_start, step_end),
+                self.fetch_finalized_hashes(range_start, step_end),
+            )?;
+
+            let withdrawal_queue_hash =
+                Self::compute_withdrawal_hash(&step_withdrawals, &step_finalized)?;
+
+            let batch_data = BatchData {
+                tempo_block_number: step_state.tempo_block_number,
+                prev_block_hash: self.prev_zone_block_hash,
+                next_block_hash: step_state.block_hash,
+                prev_processed_deposit_hash: self.prev_processed_deposit_hash,
+                next_processed_deposit_hash: step_state.processed_deposit_hash,
+                withdrawal_queue_hash,
+            };
+
+            info!(
+                step = step_idx + 1,
+                total_steps,
+                zone_from = range_start,
+                zone_to = step_end,
+                tempo_block_number = step_state.tempo_block_number,
+                "Submitting stepping sub-batch"
+            );
+
+            self.submit_batch_with_retry(&batch_data, step_end, step_withdrawals)
+                .await?;
+
+            range_start = step_end + 1;
+        }
+
+        Ok(())
+    }
+
+    /// Compute the withdrawal queue hash from withdrawal events and finalized hashes.
+    fn compute_withdrawal_hash(
+        all_withdrawals: &[abi::Withdrawal],
+        finalized_hashes: &[B256],
+    ) -> Result<B256> {
+        let withdrawal_queue_hash = if finalized_hashes.len() == 1 {
+            finalized_hashes[0]
+        } else if finalized_hashes.len() > 1 || !all_withdrawals.is_empty() {
+            abi::Withdrawal::queue_hash(all_withdrawals)
+        } else {
+            B256::ZERO
+        };
+
+        if !withdrawal_queue_hash.is_zero() && all_withdrawals.is_empty() {
+            return Err(eyre::eyre!(
+                "withdrawal_queue_hash is non-zero but no withdrawal events found — \
+                 RPC may have returned incomplete data"
+            ));
+        }
+
+        Ok(withdrawal_queue_hash)
     }
 
     /// Fetch all `WithdrawalRequested` events in the given block range and convert
@@ -642,17 +771,4 @@ fn decode_portal_revert(err: &eyre::Report) -> Option<String> {
     let bytes = alloy_primitives::hex::decode(&msg[start..end]).ok()?;
     let error = ContractError::<ZonePortal::ZonePortalErrors>::abi_decode(&bytes).ok()?;
     Some(error.to_string())
-}
-
-/// Zone L2 state read at the last block of a processed range, used to populate
-/// [`BatchData`] for the `submitBatch` call on L1.
-struct ZoneBlockSnapshot {
-    /// Latest Tempo L1 block number as seen by the zone (from the `TempoState`
-    /// predeploy). Submitted to the portal for EIP-2935 verification.
-    tempo_block_number: u64,
-    /// Cumulative hash of all deposits processed by the zone up to this block
-    /// (from `ZoneInbox.processedDepositQueueHash`).
-    processed_deposit_hash: B256,
-    /// Zone L2 block hash at the end of the range.
-    block_hash: B256,
 }

--- a/crates/tempo-zone/tests/it/main.rs
+++ b/crates/tempo-zone/tests/it/main.rs
@@ -8,6 +8,7 @@ mod l1_e2e;
 mod private_rpc;
 mod private_rpc_e2e;
 mod restart_e2e;
+mod stepping_e2e;
 mod tip403_policy;
 mod tip403_transfers;
 mod utils;

--- a/crates/tempo-zone/tests/it/stepping_e2e.rs
+++ b/crates/tempo-zone/tests/it/stepping_e2e.rs
@@ -32,6 +32,7 @@ const L1_TIMEOUT: Duration = Duration::from_secs(30);
 /// 8. Assert multiple BatchSubmitted events (stepping produces >=2 submissions).
 /// 9. Verify withdrawal works through stepped batches.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "slow: mines >8200 L1 blocks (~82s), run with --ignored or in nightly CI"]
 async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 

--- a/crates/tempo-zone/tests/it/stepping_e2e.rs
+++ b/crates/tempo-zone/tests/it/stepping_e2e.rs
@@ -1,0 +1,144 @@
+//! Stepping mode E2E test: verifies batch submission after extended L1 gap.
+//!
+//! When a zone node goes down for longer than the EIP-2935 history window (8192 blocks),
+//! the batch submitter must split the batch into multiple direct-mode submissions.
+//! This test validates that the stepping logic correctly handles this scenario.
+
+use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
+use alloy::providers::Provider;
+use std::time::Duration;
+use zone::abi::{ZONE_TOKEN_ADDRESS, ZonePortal};
+
+/// Extended timeout for stepping tests — the L1 needs to mine >8200 blocks
+/// and the zone must process them all.
+const STEPPING_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Timeout for L1 operations.
+const L1_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Test that batch submission works after the zone's `tempoBlockNumber` has
+/// fallen outside the EIP-2935 history window (gap > 8192 blocks).
+///
+/// The stepping logic must split the batch into multiple direct-mode
+/// submissions, each within the EIP-2935 effective window.
+///
+/// 1. Start L1 with 10ms block time to mine blocks quickly.
+/// 2. Deploy zone portal on L1.
+/// 3. Wait for L1 to advance >8200 blocks past genesis.
+/// 4. Start zone node connected to L1.
+/// 5. Wait for zone to process all L1 blocks.
+/// 6. Fund user and deposit to create non-trivial state.
+/// 7. Spawn sequencer (monitor + withdrawal processor).
+/// 8. Assert multiple BatchSubmitted events (stepping produces >=2 submissions).
+/// 9. Verify withdrawal works through stepped batches.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    // --- Step 1: Start L1 with fast block time ---
+    let l1 = L1TestNode::start_with(|cfg| {
+        cfg.dev.block_time = Some(Duration::from_millis(10));
+    })
+    .await?;
+
+    // --- Step 2: Deploy zone portal ---
+    let portal_address = l1.deploy_zone().await?;
+
+    // --- Step 3: Wait for L1 to advance past the EIP-2935 window ---
+    // The portal's genesisTempoBlockNumber is set to the current L1 block at
+    // deployment time. We need the L1 to advance >8200 blocks beyond that.
+    let genesis_block = l1.provider().get_block_number().await?;
+    let target_block = genesis_block + 8200;
+
+    tracing::info!(
+        genesis_block,
+        target_block,
+        "Waiting for L1 to advance past EIP-2935 window"
+    );
+
+    // Poll until L1 reaches the target — at 10ms/block this takes ~82 seconds.
+    let poll_start = std::time::Instant::now();
+    loop {
+        let current = l1.provider().get_block_number().await?;
+        if current >= target_block {
+            tracing::info!(
+                current,
+                target_block,
+                elapsed_secs = poll_start.elapsed().as_secs(),
+                "L1 advanced past EIP-2935 window"
+            );
+            break;
+        }
+        if poll_start.elapsed() > Duration::from_secs(120) {
+            return Err(eyre::eyre!(
+                "Timed out waiting for L1 to reach block {target_block} (current: {current})"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // --- Step 4: Start zone node connected to L1 ---
+    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
+
+    // --- Step 5: Wait for zone to catch up ---
+    zone.wait_for_l2_tempo_finalized(0, STEPPING_TIMEOUT)
+        .await?;
+
+    // --- Step 6: Fund user and deposit ---
+    let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
+    l1.fund_user(account.address(), 2_000_000).await?;
+    account.deposit(1_000_000, L1_TIMEOUT, &zone).await?;
+
+    // --- Step 7: Spawn sequencer ---
+    let _seq = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+
+    // --- Step 8: Assert multiple BatchSubmitted events ---
+    // The gap exceeds the EIP-2935 window, so stepping must produce >=2 submitBatch calls.
+    let batch_timeout = Duration::from_secs(60);
+    let batch_start = std::time::Instant::now();
+    let portal = ZonePortal::new(portal_address, l1.provider());
+
+    loop {
+        let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
+
+        let batch_count = events.len();
+        if batch_count >= 2 {
+            tracing::info!(
+                batch_count,
+                elapsed_secs = batch_start.elapsed().as_secs(),
+                "Stepping produced multiple batch submissions"
+            );
+            break;
+        }
+
+        if batch_start.elapsed() > batch_timeout {
+            return Err(eyre::eyre!(
+                "Expected >= 2 BatchSubmitted events from stepping, got {batch_count}"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    // --- Step 9: Verify withdrawal works through stepped batches ---
+    let withdrawal_amount: u128 = 500_000;
+    account.withdraw(withdrawal_amount).await?;
+
+    l1.wait_for_withdrawal_on_l1(
+        portal_address,
+        account.address(),
+        withdrawal_amount,
+        STEPPING_TIMEOUT,
+    )
+    .await?;
+
+    // Verify L2 balance decreased
+    let l2_balance = zone
+        .balance_of(ZONE_TOKEN_ADDRESS, account.address())
+        .await?;
+    assert!(
+        l2_balance <= alloy::primitives::U256::from(1_000_000u128 - withdrawal_amount),
+        "L2 balance should decrease by at least the withdrawal amount (got {l2_balance})"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
When a zone node goes down for more than ~68 minutes, its `tempoBlockNumber` falls outside the EIP-2935 history window (8192 blocks). The batch submitter previously selected ancestry mode but submitted empty proof bytes. This PR adds proper three-tier anchor mode support and stepping for very long gaps.

## Anchor mode tiers

| Gap (L1 blocks) | Mode | Behavior |
|---|---|---|
| < 7832 | Direct | Unchanged — portal reads hash from EIP-2935 |
| 7832–8192 | Ancestry | Collects RLP-encoded L1 headers proving the parent-hash chain from `tempoBlockNumber` to the anchor block. Headers validated during collection. Proof bytes still empty (stub verifier). |
| > 8192 | Stepping | Splits into multiple direct-mode submissions at intermediate zone blocks within the EIP-2935 window |

## Key changes

`BatchSubmitter` now takes a zone L2 provider and contract addresses (`tempo_state_address`, `inbox_address`) for reading intermediate zone state during stepping. New methods:
- `fetch_ancestry_headers` — concurrent L1 header fetching with parent-hash chain validation
- `find_step_points` — binary search for zone blocks at step boundaries  
- `resolve_anchor_mode` made `pub(crate)` so the zone monitor can detect stepping before submitting

The zone monitor's `process_block_range` now detects stepping mode and delegates to `process_block_range_stepping`, which splits the range into sub-ranges. Each sub-batch independently collects withdrawal events, builds batch data, and submits to L1.

## E2E test

`stepping_e2e::test_batch_submission_after_extended_l1_gap` starts an L1 with 10ms block time, waits for >8200 blocks to accumulate past the portal's genesis, starts a zone node, and verifies that stepping produces >=2 `BatchSubmitted` events and that withdrawals work end-to-end through stepped batches.