### PR TITLE
feat: add SP1 proving foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -120,7 +140,7 @@ checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "num_enum",
+ "num_enum 0.7.5",
  "serde",
  "strum 0.27.2",
 ]
@@ -141,7 +161,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -214,11 +234,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "derive_more",
+ "derive_more 2.1.1",
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -297,7 +317,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -321,7 +341,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "op-alloy",
  "op-revm",
  "revm",
@@ -403,7 +423,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -434,7 +454,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 2.1.1",
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
@@ -448,7 +468,7 @@ dependencies = [
  "rand 0.9.2",
  "rapidhash",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
 ]
@@ -516,7 +536,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "wasmtimer",
 ]
@@ -563,7 +583,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -630,7 +650,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "serde",
@@ -648,7 +668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b21e1ad18ff1b31ff1030e046462ab8168cf8894e6778cd805c8bdfe2bd649"
 dependencies = [
  "alloy-primitives",
- "derive_more",
+ "derive_more 2.1.1",
  "serde",
  "serde_with",
 ]
@@ -664,7 +684,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "jsonwebtoken",
@@ -840,7 +860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -864,7 +884,7 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64 0.22.1",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
@@ -872,7 +892,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -889,7 +909,7 @@ dependencies = [
  "itertools 0.14.0",
  "reqwest 0.12.28",
  "serde_json",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -942,7 +962,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "derive_arbitrary",
- "derive_more",
+ "derive_more 2.1.1",
  "nybbles",
  "proptest",
  "proptest-derive",
@@ -978,6 +998,15 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "anstream"
@@ -1097,7 +1126,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -1114,7 +1143,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -1134,7 +1163,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -1155,7 +1184,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "zeroize",
@@ -1197,7 +1226,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1209,7 +1238,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1222,7 +1251,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1255,7 +1284,7 @@ dependencies = [
  "ark-relations",
  "ark-std 0.5.0",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "tracing",
@@ -1291,7 +1320,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1304,7 +1333,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1394,6 +1423,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-scoped"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
+dependencies = [
+ "futures",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1475,15 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1495,11 +1544,38 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1509,7 +1585,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1520,10 +1596,30 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1553,6 +1649,22 @@ checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "serde",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1618,6 +1730,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -1629,7 +1761,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1647,7 +1779,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1712,6 +1844,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,7 +1884,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1741,7 +1893,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1750,7 +1902,20 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
+dependencies = [
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1782,7 +1947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1851,6 +2016,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -1922,6 +2101,20 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.9",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2183,7 +2376,7 @@ dependencies = [
  "bs58",
  "const-hex",
  "digest 0.10.7",
- "generic-array",
+ "generic-array 0.14.7",
  "ripemd",
  "serde",
  "sha2 0.10.9",
@@ -2284,7 +2477,7 @@ version = "2026.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b7bdc304661c89e6d294c5581367db81a16cf161b27c036a9f855e317b21b8"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2323,7 +2516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f3c41066ea741c799381b31df729c572705cd27925601db577cd44f9cf0358"
 dependencies = [
  "async-lock",
- "axum",
+ "axum 0.8.8",
  "bytes",
  "cfg-if",
  "commonware-codec",
@@ -2337,7 +2530,7 @@ dependencies = [
  "getrandom 0.2.17",
  "governor",
  "libc",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pin-project",
@@ -2367,7 +2560,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "hashbrown 0.16.1",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-rational",
  "num-traits",
@@ -2428,6 +2621,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2545,7 +2751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2595,6 +2801,19 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -2690,7 +2909,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2702,7 +2921,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2898,6 +3117,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashu"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b3e5ac1e23ff1995ef05b912e2b012a8784506987a2651552db2c73fb3d7e0"
+dependencies = [
+ "dashu-base",
+ "dashu-float",
+ "dashu-int",
+ "dashu-macros",
+ "dashu-ratio",
+ "rustversion",
+]
+
+[[package]]
+name = "dashu-base"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b80bf6b85aa68c58ffea2ddb040109943049ce3fbdf4385d0380aef08ef289"
+
+[[package]]
+name = "dashu-float"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85078445a8dbd2e1bd21f04a816f352db8d333643f0c9b78ca7c3d1df71063e7"
+dependencies = [
+ "dashu-base",
+ "dashu-int",
+ "num-modular",
+ "num-order",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
+name = "dashu-int"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee99d08031ca34a4d044efbbb21dff9b8c54bb9d8c82a189187c0651ffdb9fbf"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "num-order",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
+name = "dashu-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93381c3ef6366766f6e9ed9cf09e4ef9dec69499baf04f0c60e70d653cf0ab10"
+dependencies = [
+ "dashu-base",
+ "dashu-float",
+ "dashu-int",
+ "dashu-ratio",
+ "paste",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+]
+
+[[package]]
+name = "dashu-ratio"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e33b04dd7ce1ccf8a02a69d3419e354f2bbfdf4eb911a0b7465487248764c9"
+dependencies = [
+ "dashu-base",
+ "dashu-float",
+ "dashu-int",
+ "num-modular",
+ "num-order",
+ "rustversion",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,6 +3227,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
+name = "deepsize2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b5184084af9beed35eecbf4c36baf6e26b9dc47b61b74e02f930c72a58e71b"
+dependencies = [
+ "deepsize_derive2",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "deepsize_derive2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f8817865cacf3b93b943ca06b0fc5fd8e99eabfdb7ea5d296efcbc4afc4f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "delay_map"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +3265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -3026,11 +3345,31 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3059,7 +3398,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -3076,11 +3415,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -3091,6 +3439,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3176,6 +3536,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "downloader"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,6 +3572,33 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dynasm"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7d4c414c94bc830797115b8e5f434d58e7e80cb42ba88508c14bc6ea270625"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602f7458a3859195fb840e6e0cce5f4330dd9dfbfece0edaf31fe427af346f55"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
 
 [[package]]
 name = "ecdsa"
@@ -3269,6 +3676,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "elf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,10 +3690,11 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
+ "ff 0.13.1",
+ "generic-array 0.14.7",
+ "group 0.13.0",
  "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -3288,6 +3702,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enr"
@@ -3316,6 +3736,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3439,6 +3880,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,12 +3940,41 @@ dependencies = [
 
 [[package]]
 name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
+ "byteorder",
+ "ff_derive",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
+dependencies = [
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3551,6 +4032,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -3715,6 +4202,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
+name = "gen_ops"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304de19db7028420975a296ab0fcbbc8e69438c4ed254a1e41e2a7f37d5f0e0a"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +4222,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
+dependencies = [
+ "serde",
+ "typenum",
 ]
 
 [[package]]
@@ -3774,6 +4283,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
@@ -3865,11 +4380,23 @@ dependencies = [
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "memuse",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -3905,6 +4432,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "halo2"
+version = "0.1.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
+dependencies = [
+ "halo2_proofs",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pasta_curves 0.4.1",
+ "rand_core 0.6.4",
+ "rayon",
+]
+
+[[package]]
 name = "hash-db"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,6 +4479,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -4436,6 +4988,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,7 +5036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4541,6 +5106,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4695,13 +5269,13 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -4725,7 +5299,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -4736,7 +5310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
 dependencies = [
  "heck",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4765,7 +5339,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -4790,7 +5364,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -4803,7 +5377,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -4820,6 +5394,20 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "jubjub"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
+dependencies = [
+ "bitvec",
+ "bls12_381",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4881,6 +5469,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -5129,15 +5720,40 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memmap2"
@@ -5147,6 +5763,12 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memuse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "metrics"
@@ -5319,6 +5941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
+name = "mti"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9563a7d5556636e74bbd8773241fbcbc5c89b9f6bfdc97b29b56e740c2c74b9"
+dependencies = [
+ "typeid_prefix",
+ "typeid_suffix",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5358,6 +5990,12 @@ dependencies = [
  "core2",
  "unsigned-varint",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nom"
@@ -5426,11 +6064,22 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -5480,12 +6129,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -5512,12 +6176,33 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.7.5",
  "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5526,7 +6211,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5540,6 +6225,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nybbles"
@@ -5573,6 +6264,15 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5624,7 +6324,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "arbitrary",
- "derive_more",
+ "derive_more 2.1.1",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -5673,7 +6373,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -5692,7 +6392,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "op-alloy-consensus",
@@ -5727,6 +6427,20 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -5748,7 +6462,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "reqwest 0.12.28",
 ]
 
@@ -5759,15 +6473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.5",
  "tracing",
 ]
 
@@ -5777,10 +6491,10 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.5",
  "tonic-prost",
 ]
 
@@ -5799,7 +6513,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
@@ -5827,6 +6541,270 @@ dependencies = [
 ]
 
 [[package]]
+name = "p3-air"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d275c27bb81483d669709d7244ce333b51f9743af2474cdc09ba1509f5c290db"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "serde",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a083928c9055f2171e3cb0bb4767969e4955473e71ba61affe46d7a3c98a89"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-bn254-fr"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abf208fbfe540d6e2a6caaa2a9a345b1c8cb23ffdcdfcc6987244525d4fc821"
+dependencies = [
+ "ff 0.13.1",
+ "num-bigint 0.4.6",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b725b453bbb35117a1abf0ddfd900b0676063d6e4231e0fa6bb0d76018d8ad"
+dependencies = [
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518695b56f450f9223bdd8994dda87916b97ebf1d1c03c956807e78522fdb333"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a1f81101bff744b7ebba7f4497e917a2c6716d6e62736e4a56e555a2d98cb7"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36459d4acb03d08097d713f336c7393990bb489ab19920d4f68658c7a5c10968"
+dependencies = [
+ "itertools 0.12.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p3-util",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-fri"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2529a174a04189cfe705d756fb0e33d3c8fb06b167b521ddb877c78407f12a"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-interpolation",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-interpolation"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662049877c802155cdb4863db59899469fc3565d22d9047e1bd22d6b71f28e5"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+]
+
+[[package]]
+name = "p3-keccak-air"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169c96f8f0aaa9042872fdb6bbae0477fd1363b87c23877dbb2ec7fb46f8fcfa"
+dependencies = [
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-koala-bear"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1f52bcb6be38bdc8fa6b38b3434d4eedd511f361d4249fd798c6a5ef817b40"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e9cd136a4095a25c41a9edfdcce2dfae58ef01639317813bdbbd5b55c583"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e524d47a49fb4265611303339c4ef970d892817b006cc330dad18afb91e411b1"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6cb8edcb276033d43769a3725570c340d2ed6f35c3cca4cddeee07718fa376"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-merkle-tree"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e8bc3c224fc70d22f9556393e1482b52539e11c7b82ac6933c436fd82738f4"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-commit",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a26197df2097b98ab7038d59a01e1fe1a0f545e7e04aa9436b2454b1836654f"
+dependencies = [
+ "gcd",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1d3b5202096bca57cde912fbbb9cbaedaf5ac7c42a924c7166b98709d64d21"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
+name = "p3-uni-stark"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef1cdb8285a7adb78df991852d3b66d3b25cf6ffc34f528505d1aee49bdb968"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-air",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5f0388aa6d935ca3a17444086120f393f0b2f0816010b5ff95998c1c4095e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5834,6 +6812,15 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group 0.12.1",
 ]
 
 [[package]]
@@ -5860,7 +6847,7 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5896,6 +6883,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pasta_curves"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5922,6 +6939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5935,6 +6961,16 @@ checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -6186,6 +7222,16 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
@@ -6335,12 +7381,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6354,6 +7443,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -6408,7 +7506,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.2",
  "thiserror 2.0.18",
@@ -6429,7 +7527,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -6561,6 +7659,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-set-blaze"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8421b5d459262eabbe49048d362897ff3e3830b44eac6cfe341d6acb2f0f13d2"
+dependencies = [
+ "gen_ops",
+ "itertools 0.12.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6618,6 +7728,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rayon-scan"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f87cc11a0140b4b0da0ffc889885760c61b13672d80a908920b2c0df078fa14"
+dependencies = [
+ "rayon",
 ]
 
 [[package]]
@@ -6747,7 +7866,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6784,7 +7903,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6833,7 +7952,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "derive_more",
+ "derive_more 2.1.1",
  "metrics",
  "parking_lot",
  "pin-project",
@@ -6867,7 +7986,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -7078,7 +8197,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-transport",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "eyre",
  "futures",
  "reqwest 0.12.28",
@@ -7097,7 +8216,7 @@ version = "1.10.0"
 source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
 dependencies = [
  "alloy-primitives",
- "derive_more",
+ "derive_more 2.1.1",
  "eyre",
  "metrics",
  "page_size",
@@ -7110,7 +8229,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "strum 0.27.2",
  "sysinfo 0.33.1",
  "tempfile",
@@ -7127,7 +8246,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "metrics",
  "modular-bitfield",
  "parity-scale-codec",
@@ -7222,7 +8341,7 @@ source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d5
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.1.1",
  "discv5",
  "enr",
  "futures",
@@ -7410,7 +8529,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "crossbeam-channel",
  "dashmap 6.1.0",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "metrics",
  "mini-moka",
@@ -7554,7 +8673,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "pin-project",
  "reth-codecs",
@@ -7585,7 +8704,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
@@ -7700,7 +8819,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -7772,7 +8891,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-util",
  "metrics",
  "rayon",
@@ -7796,7 +8915,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.1.1",
  "parking_lot",
  "reth-chainspec",
  "reth-ethereum-forks",
@@ -7830,7 +8949,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
@@ -7945,7 +9064,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -7957,7 +9076,7 @@ dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "dashmap 6.1.0",
- "derive_more",
+ "derive_more 2.1.1",
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
@@ -8020,7 +9139,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "discv5",
  "enr",
  "futures",
@@ -8054,7 +9173,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8076,7 +9195,7 @@ dependencies = [
  "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "enr",
  "futures",
  "reth-eth-wire-types",
@@ -8100,7 +9219,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "parking_lot",
  "reth-consensus",
@@ -8150,7 +9269,7 @@ source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d5
 dependencies = [
  "anyhow",
  "bincode",
- "derive_more",
+ "derive_more 2.1.1",
  "lz4_flex",
  "memmap2",
  "reth-fs-util",
@@ -8262,7 +9381,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
- "derive_more",
+ "derive_more 2.1.1",
  "dirs-next",
  "eyre",
  "futures",
@@ -8379,7 +9498,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "humantime",
  "pin-project",
@@ -8414,7 +9533,7 @@ dependencies = [
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -8527,7 +9646,7 @@ dependencies = [
  "auto_impl",
  "byteorder",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
  "op-alloy-consensus",
@@ -8609,7 +9728,7 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file-types",
  "reth-tokio-util",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8622,7 +9741,7 @@ source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d5
 dependencies = [
  "alloy-primitives",
  "arbitrary",
- "derive_more",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "reth-codecs",
  "serde",
@@ -8671,7 +9790,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
- "derive_more",
+ "derive_more 2.1.1",
  "dyn-clone",
  "futures",
  "http",
@@ -8720,7 +9839,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-futures",
 ]
@@ -8792,7 +9911,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -8906,7 +10025,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core",
@@ -8949,7 +10068,7 @@ dependencies = [
  "http",
  "jsonrpsee-http-client",
  "pin-project",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -9087,7 +10206,7 @@ source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d5
 dependencies = [
  "alloy-primitives",
  "clap",
- "derive_more",
+ "derive_more 2.1.1",
  "fixed-map",
  "serde",
  "strum 0.27.2",
@@ -9125,7 +10244,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
@@ -9202,7 +10321,7 @@ source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d5
 dependencies = [
  "clap",
  "eyre",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -9245,7 +10364,7 @@ dependencies = [
  "revm",
  "revm-interpreter",
  "revm-primitives",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schnellru",
  "serde",
  "serde_json",
@@ -9296,7 +10415,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "hash-db",
  "itertools 0.14.0",
  "nybbles",
@@ -9333,7 +10452,7 @@ dependencies = [
  "alloy-rlp",
  "crossbeam-channel",
  "dashmap 6.1.0",
- "derive_more",
+ "derive_more 2.1.1",
  "itertools 0.14.0",
  "metrics",
  "rayon",
@@ -9585,7 +10704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
- "num_enum",
+ "num_enum 0.7.5",
  "once_cell",
  "serde",
 ]
@@ -9706,6 +10825,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rrs-succinct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd079cd303257a4cb4e5aadfa79a7fe23f3c8301aa4740ccc3a99673485a352"
+dependencies = [
+ "downcast-rs",
+ "num_enum 0.5.11",
+ "paste",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9719,7 +10849,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -9739,6 +10869,18 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -9825,6 +10967,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -9931,6 +11082,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "cfg-if",
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9987,6 +11171,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9994,7 +11184,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "serdect",
  "subtle",
@@ -10116,6 +11306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrays"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10232,6 +11431,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10241,6 +11466,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -10301,7 +11532,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -10363,7 +11594,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "thiserror 2.0.18",
  "time",
@@ -10403,6 +11634,442 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slop-air"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242539aba9e5424923d7bd629775570c7d10ec28584e96ea599575a51bedcde8"
+dependencies = [
+ "p3-air",
+]
+
+[[package]]
+name = "slop-algebra"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
+name = "slop-alloc"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58b7800cba9b31377f9353174d13fd8e39608b6f1d1531f0e92b8ce4af49ae0"
+dependencies = [
+ "serde",
+ "slop-algebra",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-baby-bear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949e3c822532a87b4ad04f7280283c256621b0a83aee1b40cbd721df29df641d"
+dependencies = [
+ "lazy_static",
+ "p3-baby-bear",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-basefold"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58984f92091a668a006b6895487079d99209e599b02d636f061fe4ae26977fb5"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-primitives",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-basefold-prover"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86eb8581b52f97860242fe5e8d6b49d2a37e1b38d4a647adf24acaa2965ee7d"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-fri",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-bn254"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+dependencies = [
+ "ff 0.13.1",
+ "p3-bn254-fr",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-challenger"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+dependencies = [
+ "futures",
+ "p3-challenger",
+ "serde",
+ "slop-algebra",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-commit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584339690d20fb6b34b0dc957cbd267221ba2ab7b0c1292c118378f3498979c4"
+dependencies = [
+ "p3-commit",
+ "serde",
+ "slop-alloc",
+]
+
+[[package]]
+name = "slop-dft"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148281e1611ca570d016a733aac2f3ec9867241cc800a96d15bc6ecfd010daf7"
+dependencies = [
+ "p3-dft",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-fri"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0857a346ea28496ee56b1dcad192db8c7ff0455a18bfd67ce6513323b594b746"
+dependencies = [
+ "p3-fri",
+]
+
+[[package]]
+name = "slop-futures"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbfea5447d243572da7aae8d5e57856229a97fb8bc6a42439d4c5f4de951ee0"
+dependencies = [
+ "crossbeam",
+ "futures",
+ "pin-project",
+ "rayon",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "slop-jagged"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc420430b93d38e9aae903bc4bc11c342f8d49d015cca26eeb36a6ea3f7a0f1f"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "slop-keccak-air"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288abf40d9901f79e221ece87f11324826289bf5d694fde07dd785bdb4afda38"
+dependencies = [
+ "p3-keccak-air",
+]
+
+[[package]]
+name = "slop-koala-bear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+dependencies = [
+ "lazy_static",
+ "p3-koala-bear",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-matrix"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1117c395388bd172826115ac4f9a7e09bf9c937ceafa82194132a058e27c0d"
+dependencies = [
+ "p3-matrix",
+]
+
+[[package]]
+name = "slop-maybe-rayon"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81316cfe721c3f47cd0af63002a8b6557c951ff9588fa7db0f4f3b99af091486"
+dependencies = [
+ "p3-maybe-rayon",
+]
+
+[[package]]
+name = "slop-merkle-tree"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e700652778c15320f6269362103b87a3787a7c9d70fb05d9742dbce66c46f764"
+dependencies = [
+ "derive-where",
+ "ff 0.13.1",
+ "itertools 0.14.0",
+ "p3-merkle-tree",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "slop-tensor",
+ "thiserror 1.0.69",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-multilinear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6151db452ace0d960314f46c61a2b8d45e1fa4dfd5830447c67fc1e1e1e823b5"
+dependencies = [
+ "derive-where",
+ "futures",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-poseidon2"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+dependencies = [
+ "p3-poseidon2",
+]
+
+[[package]]
+name = "slop-primitives"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+dependencies = [
+ "slop-algebra",
+]
+
+[[package]]
+name = "slop-stacked"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c9fb9c908a2d10037934e2c299d30f98a2146f6ded87a7b529b05ddbfda27"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-sumcheck"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c691f34c05e933777059a10804e00f77834b927abc2701f5f394e9c2b49c1c"
+dependencies = [
+ "futures",
+ "itertools 0.14.0",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-challenger",
+ "slop-multilinear",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-symmetric"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+dependencies = [
+ "p3-symmetric",
+]
+
+[[package]]
+name = "slop-tensor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1796e5ff7dcdcd2c15f423a27550a4688e25009bd5ca648d9593d66f243950d6"
+dependencies = [
+ "arrayvec",
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-futures",
+ "slop-matrix",
+ "thiserror 1.0.69",
+ "transpose",
+]
+
+[[package]]
+name = "slop-uni-stark"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504f32330985e48a6aa9c9e0985641a4dc084d3843ff59075591b24b818f2a67"
+dependencies = [
+ "p3-uni-stark",
+]
+
+[[package]]
+name = "slop-utils"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba510663661800990c1207ddbf3a1e67a551f05d882a60197adbb19c6824754f"
+dependencies = [
+ "p3-util",
+ "tracing-forest",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
+name = "slop-whir"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71f6a16450fc701450831121810da91c6ee3ac50e4705327dcd4957b046015a"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10417,6 +12084,16 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snowbridge-amcl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460a9ed63cdf03c1b9847e8a12a5f5ba19c4efd5869e4a737e05be25d7c427e5"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
 
 [[package]]
 name = "socket2"
@@ -10455,6 +12132,546 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-build"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fe5854ea3054c20b34fe85b08437583174e8cd71e612fcfef67ea841daea14"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.18.1",
+ "chrono",
+ "clap",
+ "dirs 5.0.1",
+ "sp1-primitives",
+]
+
+[[package]]
+name = "sp1-core-executor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc9268de48a534ccb82287a517c0a07ee594136bc9fce6c7eb438c69e7917be"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "cfg-if",
+ "clap",
+ "deepsize2",
+ "elf",
+ "enum-map",
+ "eyre",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools 0.14.0",
+ "memmap2",
+ "num",
+ "rrs-succinct",
+ "serde",
+ "serde_arrays",
+ "serde_json",
+ "slop-air",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-symmetric",
+ "sp1-curves",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives",
+ "strum 0.27.2",
+ "subenum",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tracing",
+ "typenum",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-core-machine"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d436300d3052341854e58c88a9b5444a6f45689ee8933f9bec047ac367693182"
+dependencies = [
+ "bincode",
+ "cfg-if",
+ "enum-map",
+ "futures",
+ "generic-array 1.1.0",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "num",
+ "num_cpus",
+ "rayon",
+ "rayon-scan",
+ "rrs-succinct",
+ "serde",
+ "serde_json",
+ "slop-air",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-futures",
+ "slop-keccak-air",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-uni-stark",
+ "snowbridge-amcl",
+ "sp1-core-executor",
+ "sp1-curves",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives",
+ "static_assertions",
+ "strum 0.27.2",
+ "sysinfo 0.30.13",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-forest",
+ "tracing-subscriber 0.3.22",
+ "typenum",
+]
+
+[[package]]
+name = "sp1-cuda"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a03bb846daaabe6e94af5e5199aa110b42c68482d6380b7e765d9d6b65119d52"
+dependencies = [
+ "bincode",
+ "bytes",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-primitives",
+ "sp1-prover",
+ "sp1-prover-types",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-curves"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3ad4fc0f5ea7286fbe5c788d97125dc0cb40eb81f15becb432a65f350cd2f9"
+dependencies = [
+ "cfg-if",
+ "dashu",
+ "elliptic-curve",
+ "generic-array 1.1.0",
+ "itertools 0.14.0",
+ "k256",
+ "num",
+ "p256",
+ "serde",
+ "slop-algebra",
+ "snowbridge-amcl",
+ "sp1-primitives",
+ "typenum",
+]
+
+[[package]]
+name = "sp1-derive"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f111a90749619066fbd7ba102b22375bc6c824abb66804c3184ba0f650d017a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sp1-hypercube"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff340db83b2c38b01f022624b8b792c38f201417581d6855dbe9a445d2485f"
+dependencies = [
+ "arrayref",
+ "deepsize2",
+ "derive-where",
+ "futures",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "rayon-scan",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-poseidon2",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-uni-stark",
+ "slop-whir",
+ "sp1-derive",
+ "sp1-primitives",
+ "strum 0.27.2",
+ "thiserror 1.0.69",
+ "thousands",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-jit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcadaa9206d36ae953c1b4390373879281ef1423115aa180e7ef0e82259d92aa"
+dependencies = [
+ "dynasmrt",
+ "hashbrown 0.14.5",
+ "memfd",
+ "memmap2",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-primitives"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
+dependencies = [
+ "bincode",
+ "blake3",
+ "elf",
+ "hex",
+ "itertools 0.14.0",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "serde",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-poseidon2",
+ "slop-primitives",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "sp1-prover"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64545387a6b5ee58155d75183223a8f19961e23d76a13a49c16514896e52ff7"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "clap",
+ "dirs 5.0.1",
+ "downloader",
+ "either",
+ "enum-map",
+ "eyre",
+ "futures",
+ "hashbrown 0.14.5",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "lru 0.12.5",
+ "mti",
+ "num-bigint 0.4.6",
+ "opentelemetry 0.23.0",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha2 0.10.9",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-futures",
+ "slop-jagged",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-symmetric",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives",
+ "sp1-prover-types",
+ "sp1-recursion-circuit",
+ "sp1-recursion-compiler",
+ "sp1-recursion-executor",
+ "sp1-recursion-gnark-ffi",
+ "sp1-recursion-machine",
+ "sp1-verifier",
+ "static_assertions",
+ "sysinfo 0.30.13",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic 0.12.3",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
+name = "sp1-prover-types"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834512266314b8dd35fd52b921d62abb113c3c35b27358acdbc178b3a17ec72e"
+dependencies = [
+ "anyhow",
+ "async-scoped",
+ "bincode",
+ "chrono",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "mti",
+ "prost 0.13.5",
+ "serde",
+ "tokio",
+ "tonic 0.12.3",
+ "tonic-build",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-circuit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105531a782d66030eab608832e0829e4699053a6d41cd3c2c7931def9c9540fb"
+dependencies = [
+ "bincode",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-whir",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-compiler",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-compiler"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab98d241444285539b0d4203288fbe9887707c355e346cfb176b461524c58d"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-symmetric",
+ "sp1-core-machine",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "tracing",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-recursion-executor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc69767dce218874edbef09515ccc5fb32d5e6b857a95a99944a66f6f405f5b1"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "range-set-blaze",
+ "serde",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "smallvec",
+ "sp1-derive",
+ "sp1-hypercube",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-gnark-ffi"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f526cb636baa1ad67f1410884e7a5580b7068beee3ee88609fb39f906bab27b3"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bindgen 0.70.1",
+ "cfg-if",
+ "hex",
+ "num-bigint 0.4.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-compiler",
+ "sp1-verifier",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-machine"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ec6719240b0933289332d730be328d3a3e4f9e6ff9ee2e20ec2b4a99aeed9"
+dependencies = [
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-symmetric",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "strum 0.27.2",
+ "tracing",
+ "zkhash",
+]
+
+[[package]]
+name = "sp1-sdk"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "cfg-if",
+ "dirs 5.0.1",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "k256",
+ "num-bigint 0.4.6",
+ "serde",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-commit",
+ "slop-jagged",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-tensor",
+ "sp1-build",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-cuda",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-prover",
+ "sp1-prover-types",
+ "sp1-recursion-executor",
+ "sp1-recursion-gnark-ffi",
+ "sp1-verifier",
+ "strum 0.27.2",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-verifier"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11dd15bf0dc2325ced1f3bb58bfed84efc5228a09127ab6787ee5103514f09e"
+dependencies = [
+ "bincode",
+ "blake3",
+ "cfg-if",
+ "dirs 5.0.1",
+ "hex",
+ "lazy_static",
+ "serde",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-primitives",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
+ "strum 0.27.2",
+ "substrate-bn-succinct-rs",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10490,6 +12707,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -10538,6 +12761,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "subenum"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3d08fe7078c57309d5c3d938e50eba95ba1d33b9c3a101a8465fc6861a5416"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "substrate-bn-succinct-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a241fd7c1016fb8ad30fcf5a20986c0c4538e8f15a1b41a1761516299e377ec1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -10604,6 +12855,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -10685,7 +12951,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-evm",
  "reth-primitives-traits",
  "reth-rpc-convert",
@@ -10755,7 +13021,7 @@ dependencies = [
  "alloy-rlp",
  "commonware-codec",
  "commonware-cryptography",
- "derive_more",
+ "derive_more 2.1.1",
  "rayon",
  "reth-chainspec",
  "reth-consensus",
@@ -10869,7 +13135,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
  "reth-payload-primitives",
@@ -10887,7 +13153,7 @@ dependencies = [
  "alloy-evm",
  "commonware-codec",
  "commonware-cryptography",
- "derive_more",
+ "derive_more 2.1.1",
  "revm",
  "scoped-tls",
  "tempo-chainspec",
@@ -10921,7 +13187,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "base64 0.22.1",
- "derive_more",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
  "p256",
@@ -10946,7 +13212,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-evm",
  "reth-rpc-eth-types",
  "reth-storage-api",
@@ -11083,6 +13349,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11162,6 +13434,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -11305,7 +13586,7 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -11337,6 +13618,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -11346,7 +13638,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -11358,7 +13650,7 @@ dependencies = [
  "indexmap 2.13.0",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -11367,7 +13659,7 @@ version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -11381,6 +13673,38 @@ name = "toml_writer"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tonic"
@@ -11402,10 +13726,24 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11415,8 +13753,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.5",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -11463,7 +13821,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -11528,6 +13886,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-forest"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
+dependencies = [
+ "ansi_term",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11578,7 +13949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -11641,6 +14012,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -11707,6 +14088,21 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "typeid_prefix"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9da1387307fdee46aa441e4f08a1b491e659fcac1aca9cd71f2c624a0de5d1b"
+
+[[package]]
+name = "typeid_suffix"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b55e96f110c6db5d1a2f24072552537f0091dc90cebeaa679540bac93e7405"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -11863,8 +14259,11 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "md-5",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -11879,6 +14278,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "vergen"
@@ -12205,6 +14613,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -12254,6 +14672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12754,6 +15181,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -13039,6 +15475,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "zkhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+ "bitvec",
+ "blake2",
+ "bls12_381",
+ "byteorder",
+ "cfg-if",
+ "group 0.12.1",
+ "group 0.13.0",
+ "halo2",
+ "hex",
+ "jubjub",
+ "lazy_static",
+ "pasta_curves 0.5.1",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "sha3",
+ "subtle",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13066,7 +15529,7 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "const-hex",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "eyre",
  "futures",
@@ -13116,7 +15579,31 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "zone-primitives",
+ "zone-prover",
  "zone-rpc",
+]
+
+[[package]]
+name = "zone-primitives"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+ "serde",
+]
+
+[[package]]
+name = "zone-prover"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "eyre",
+ "sp1-sdk",
+ "tokio",
+ "tracing",
+ "zone-primitives",
 ]
 
 [[package]]
@@ -13131,7 +15618,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
- "axum",
+ "axum 0.8.8",
  "eyre",
  "parking_lot",
  "reqwest 0.12.28",
@@ -13143,6 +15630,17 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "zone-stf"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+ "revm",
+ "zone-primitives",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,14 @@ members = [
   "bin/tempo-zone",
   "crates/tempo-zone",
   "crates/rpc",
+  "crates/zone-primitives",
+  "crates/zone-prover",
+  "crates/zone-stf",
   "xtask",
 ]
+# The SP1 guest program is excluded from the default workspace build because
+# it targets riscv32im and requires sp1-build tooling to compile.
+exclude = ["programs/zone-batch"]
 
 # Resolver 3 is available with edition 2024
 resolver = "3"
@@ -95,7 +101,12 @@ tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0", defaul
 tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0", default-features = false }
 
 # zones
+zone-primitives = { path = "crates/zone-primitives" }
+zone-prover = { path = "crates/zone-prover" }
 zone-rpc = { path = "crates/rpc" }
+
+# SP1
+sp1-sdk = "6.0.2"
 
 # reth
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
@@ -177,5 +188,4 @@ tokio = { version = "1.45.1", features = ["full"] }
 axum = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tracing = "0.1.41"
-
-
+bincode = "1"

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -24,6 +24,8 @@ tempo-alloy = { workspace = true, features = ["tempo-compat"] }
 tempo-contracts.workspace = true
 tempo-precompiles.workspace = true
 tempo-precompiles-macros.workspace = true
+zone-primitives.workspace = true
+zone-prover.workspace = true
 zone-rpc.workspace = true
 
 # reth

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -19,6 +19,7 @@ use alloy_provider::{DynProvider, Provider};
 use eyre::Result;
 use tempo_alloy::TempoNetwork;
 use tracing::{info, instrument, warn};
+use zone_prover::ProofResult;
 
 /// EIP-2935 stores the last 8192 block hashes (~68 min at 500ms block time).
 /// Blocks older than this require ancestry mode.
@@ -104,19 +105,23 @@ impl BatchSubmitter {
     ///   the proof must include a block header chain from `recentTempoBlockNumber`
     ///   back to `tempoBlockNumber`.
     ///
-    /// # POC note
-    ///
-    /// `verifierConfig` and `proof` are set to empty bytes — the verifier
-    /// contract must be configured to accept empty proofs.
-    // TODO: pass real proof bytes once proof generation is implemented.
+    /// When `proof` is `None`, empty bytes are used for `verifierConfig` and
+    /// `proof` (POC mode — the verifier contract must accept empty proofs).
+    /// When `proof` is `Some`, the proof bytes from SP1 (or another backend)
+    /// are passed to the portal's verifier contract.
     #[instrument(skip_all, fields(
         portal = %self.portal_address,
         tempo_block = batch.tempo_block_number,
         prev_block_hash = %batch.prev_block_hash,
         next_block_hash = %batch.next_block_hash,
         withdrawal_queue_hash = %batch.withdrawal_queue_hash,
+        has_proof = proof.is_some(),
     ))]
-    pub async fn submit_batch(&self, batch: &BatchData) -> Result<B256> {
+    pub async fn submit_batch(
+        &self,
+        batch: &BatchData,
+        proof: Option<&ProofResult>,
+    ) -> Result<B256> {
         if batch.tempo_block_number < self.genesis_tempo_block_number {
             return Err(eyre::eyre!(
                 "tempo_block_number ({}) is below genesis ({})",
@@ -145,6 +150,11 @@ impl BatchSubmitter {
 
         info!(?anchor_mode, "Submitting batch to ZonePortal on L1");
 
+        let (verifier_config, proof_bytes) = match proof {
+            Some(p) => (p.verifier_config.clone(), p.proof.clone()),
+            None => (Bytes::new(), Bytes::new()),
+        };
+
         let tx_hash = self
             .portal
             .submitBatch(
@@ -153,8 +163,8 @@ impl BatchSubmitter {
                 block_transition,
                 deposit_transition,
                 batch.withdrawal_queue_hash,
-                Bytes::new(),
-                Bytes::new(),
+                verifier_config,
+                proof_bytes,
             )
             .send()
             .await?

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(unnameable_types)]
 #![allow(clippy::too_many_arguments)]
 use eyre as _;
+use zone_primitives as _;
 
 // Required by the `#[contract]` proc macro expansion (references `crate::storage` / `crate::error`).
 pub(crate) use tempo_precompiles::{error, storage};

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -488,7 +488,7 @@ impl ZoneMonitor {
         let mut delay = INITIAL_RETRY_DELAY;
 
         for attempt in 1..=MAX_RETRIES {
-            match self.batch_submitter.submit_batch(batch_data).await {
+            match self.batch_submitter.submit_batch(batch_data, None).await {
                 Ok(tx_hash) => {
                     let blocks_in_batch = last_zone_block - self.last_submitted_zone_block;
                     info!(

--- a/crates/zone-primitives/Cargo.toml
+++ b/crates/zone-primitives/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "zone-primitives"
+description = "Shared types for zone batch proving (no_std compatible)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives = { version = "1.5.4", default-features = false, features = ["serde"] }
+alloy-sol-types = { version = "1.5.7", default-features = false }
+alloy-rlp = { version = "0.3.13", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+
+[features]
+default = ["std"]
+std = [
+    "alloy-primitives/std",
+    "alloy-sol-types/std",
+    "alloy-rlp/std",
+    "serde/std",
+]

--- a/crates/zone-primitives/src/constants.rs
+++ b/crates/zone-primitives/src/constants.rs
@@ -1,0 +1,72 @@
+//! Zone protocol constants shared between host and guest.
+
+use alloy_primitives::{Address, B256, U256, address};
+
+/// Sentinel value for empty withdrawal queue slots.
+pub const EMPTY_SENTINEL: B256 = B256::new([0xff; 32]);
+
+/// TempoState predeploy address on Zone L2.
+pub const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
+
+/// TempoState storage slot for `tempoBlockHash` (slot 0).
+pub const TEMPO_BLOCK_HASH_SLOT: B256 = B256::ZERO;
+
+/// TempoState storage slot for packed
+/// `(tempoBlockNumber, tempoGasLimit, tempoGasUsed, tempoTimestamp)` (slot 7).
+pub const TEMPO_PACKED_SLOT: B256 = {
+    let mut bytes = [0u8; 32];
+    bytes[31] = 7;
+    B256::new(bytes)
+};
+
+/// ZoneInbox predeploy address on Zone L2.
+pub const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
+
+/// ZoneOutbox predeploy address on Zone L2.
+pub const ZONE_OUTBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000002");
+
+/// ZoneConfig predeploy address on Zone L2.
+pub const ZONE_CONFIG_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000003");
+
+/// TempoStateReader precompile address on Zone L2.
+pub const TEMPO_STATE_READER_ADDRESS: Address =
+    address!("0x1c00000000000000000000000000000000000004");
+
+/// Chaum-Pedersen verification precompile address.
+pub const CHAUM_PEDERSEN_VERIFY_ADDRESS: Address =
+    address!("0x1C00000000000000000000000000000000000100");
+
+/// AES-GCM decryption precompile address.
+pub const AES_GCM_DECRYPT_ADDRESS: Address =
+    address!("0x1C00000000000000000000000000000000000101");
+
+/// TIP-20 zone token factory precompile address.
+pub const ZONE_TIP20_FACTORY_ADDRESS: Address =
+    address!("0x20Fc000000000000000000000000000000000000");
+
+/// Default zone token address (pathUSD TIP-20).
+pub const ZONE_TOKEN_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000000");
+
+// ---------------------------------------------------------------------------
+//  Storage slot constants for the proof system
+// ---------------------------------------------------------------------------
+
+/// ZoneInbox storage slot 0: `processedDepositQueueHash` (bytes32).
+pub const ZONE_INBOX_PROCESSED_HASH_SLOT: U256 = U256::ZERO;
+
+/// ZoneOutbox storage slot 1: `_lastBatch.withdrawalQueueHash` (bytes32).
+///
+/// Slot 0 is packed `(tempoGasRate, nextWithdrawalIndex, withdrawalBatchIndex)`.
+/// The `_lastBatch` struct starts at slot 1 with `withdrawalQueueHash` occupying the full slot.
+pub const ZONE_OUTBOX_LAST_BATCH_HASH_SLOT: U256 = {
+    let mut le = [0u8; 32];
+    le[0] = 1;
+    U256::from_le_bytes(le)
+};
+
+/// ZoneOutbox storage slot 2: `_lastBatch.withdrawalBatchIndex` (uint64, lower 8 bytes).
+pub const ZONE_OUTBOX_LAST_BATCH_INDEX_SLOT: U256 = {
+    let mut le = [0u8; 32];
+    le[0] = 2;
+    U256::from_le_bytes(le)
+};

--- a/crates/zone-primitives/src/lib.rs
+++ b/crates/zone-primitives/src/lib.rs
@@ -1,0 +1,269 @@
+//! Shared types for zone batch proving.
+//!
+//! This crate is `no_std` compatible so it can be used inside SP1 (RISC-V) guest
+//! programs and TEE enclaves, as well as in the host-side prover.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use alloy_primitives::{Address, B256, U256};
+use alloy_rlp::Encodable as _;
+use serde::{Deserialize, Serialize};
+
+pub mod constants;
+mod sol_types;
+pub use sol_types::{BlockTransition, DepositQueueTransition};
+
+/// Public inputs committed by the proof system.
+///
+/// These values are passed to the verifier contract on L1 and must match
+/// the on-chain state for the proof to be accepted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublicInputs {
+    /// Previous batch's block hash (must equal `portal.blockHash()`).
+    pub prev_block_hash: B256,
+    /// Tempo block number the batch committed to.
+    pub tempo_block_number: u64,
+    /// Anchor Tempo block number (same as `tempo_block_number` for direct mode,
+    /// or a recent block within the EIP-2935 window for ancestry mode).
+    pub anchor_block_number: u64,
+    /// Anchor Tempo block hash (verified via EIP-2935 on-chain).
+    pub anchor_block_hash: B256,
+    /// Expected withdrawal batch index (portal's `withdrawalBatchIndex + 1`).
+    pub expected_withdrawal_batch_index: u64,
+    /// Registered sequencer address — zone block beneficiary must match.
+    pub sequencer: Address,
+}
+
+/// Complete witness for proving a zone batch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchWitness {
+    /// Public inputs committed by the proof system.
+    pub public_inputs: PublicInputs,
+    /// Previous batch's block header (for state-root binding).
+    pub prev_block_header: ZoneHeader,
+    /// Zone blocks to execute.
+    pub zone_blocks: Vec<ZoneBlock>,
+    /// Initial zone state with MPT proofs.
+    pub initial_zone_state: ZoneStateWitness,
+    /// Tempo state proofs for L1 reads (deduplicated node pool).
+    pub tempo_state_proofs: BatchStateProof,
+    /// Tempo headers for ancestry verification (only in ancestry mode).
+    /// Ordered from `tempo_block_number + 1` to `anchor_block_number`.
+    pub tempo_ancestry_headers: Vec<Vec<u8>>,
+}
+
+/// Output produced by `prove_zone_batch`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchOutput {
+    /// Zone block hash transition (prev -> final).
+    pub block_transition: BlockTransition,
+    /// Deposit queue processing transition.
+    pub deposit_queue_transition: DepositQueueTransition,
+    /// Withdrawal queue hash chain for this batch (`B256::ZERO` if no withdrawals).
+    pub withdrawal_queue_hash: B256,
+    /// Withdrawal batch commitment read from zone state.
+    pub last_batch: LastBatchCommitment,
+}
+
+/// Withdrawal batch index read from `ZoneOutbox.lastBatch()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LastBatchCommitment {
+    pub withdrawal_batch_index: u64,
+}
+
+/// Simplified zone block header for hash computation.
+///
+/// The zone block hash is `keccak256(rlp_encode(header))`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZoneHeader {
+    pub parent_hash: B256,
+    pub beneficiary: Address,
+    pub state_root: B256,
+    pub transactions_root: B256,
+    pub receipts_root: B256,
+    pub number: u64,
+    pub timestamp: u64,
+}
+
+impl alloy_rlp::Encodable for ZoneHeader {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        alloy_rlp::Header {
+            list: true,
+            payload_length: self.fields_len(),
+        }
+        .encode(out);
+        self.parent_hash.encode(out);
+        self.beneficiary.encode(out);
+        self.state_root.encode(out);
+        self.transactions_root.encode(out);
+        self.receipts_root.encode(out);
+        self.number.encode(out);
+        self.timestamp.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        alloy_rlp::Header {
+            list: true,
+            payload_length: self.fields_len(),
+        }
+        .length()
+            + self.fields_len()
+    }
+}
+
+impl ZoneHeader {
+    fn fields_len(&self) -> usize {
+        self.parent_hash.length()
+            + self.beneficiary.length()
+            + self.state_root.length()
+            + self.transactions_root.length()
+            + self.receipts_root.length()
+            + self.number.length()
+            + self.timestamp.length()
+    }
+
+    /// Compute the block hash: `keccak256(rlp_encode(self))`.
+    pub fn hash(&self) -> B256 {
+        use alloy_rlp::Encodable;
+        let mut buf = Vec::with_capacity(self.length());
+        self.encode(&mut buf);
+        alloy_primitives::keccak256(&buf)
+    }
+}
+
+/// A zone block to execute inside the prover.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZoneBlock {
+    /// Block number.
+    pub number: u64,
+    /// Parent block hash.
+    pub parent_hash: B256,
+    /// Block timestamp.
+    pub timestamp: u64,
+    /// Beneficiary (must match registered sequencer).
+    pub beneficiary: Address,
+    /// Tempo header RLP for `ZoneInbox.advanceTempo`.
+    /// `None` if this block does not advance Tempo.
+    pub tempo_header_rlp: Option<Vec<u8>>,
+    /// Deposits processed by the system tx (oldest first).
+    pub deposits: Vec<QueuedDeposit>,
+    /// Decryption data for encrypted deposits.
+    pub decryptions: Vec<DecryptionData>,
+    /// If `Some`, finalize a withdrawal batch in the final block.
+    pub finalize_withdrawal_batch_count: Option<U256>,
+    /// User transactions to execute (serialized).
+    pub transactions: Vec<Vec<u8>>,
+}
+
+/// Deposit type discriminator for the unified deposit queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DepositType {
+    Regular,
+    Encrypted,
+}
+
+/// A queued deposit entry (regular or encrypted).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueuedDeposit {
+    pub deposit_type: DepositType,
+    /// ABI-encoded deposit data (`Deposit` or `EncryptedDeposit`).
+    pub deposit_data: Vec<u8>,
+}
+
+/// Decryption data provided by the sequencer for encrypted deposits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecryptionData {
+    /// ECDH shared secret (x-coordinate).
+    pub shared_secret: B256,
+    /// Y coordinate parity of the shared secret point.
+    pub shared_secret_y_parity: u8,
+    /// Decrypted recipient.
+    pub to: Address,
+    /// Decrypted memo.
+    pub memo: B256,
+    /// Chaum-Pedersen proof of correct shared secret derivation.
+    pub cp_proof: ChaumPedersenProof,
+}
+
+/// Chaum-Pedersen proof for ECDH shared secret derivation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChaumPedersenProof {
+    /// Response: `s = r + c * privSeq (mod n)`.
+    pub s: B256,
+    /// Challenge: `c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)`.
+    pub c: B256,
+}
+
+/// Initial zone state with MPT proofs for accessed accounts/slots.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ZoneStateWitness {
+    /// Account data with storage and MPT proofs.
+    pub accounts: Vec<(Address, AccountWitness)>,
+    /// Zone state root at start of batch.
+    pub state_root: B256,
+}
+
+/// Witness data for a single account in the zone state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountWitness {
+    pub nonce: u64,
+    pub balance: U256,
+    pub code_hash: B256,
+    pub code: Option<Vec<u8>>,
+    /// Storage slot values.
+    pub storage: Vec<(U256, U256)>,
+    /// MPT proof for the account in the state trie.
+    pub account_proof: Vec<Vec<u8>>,
+    /// MPT proofs for storage slots in the storage trie.
+    pub storage_proofs: Vec<(U256, Vec<Vec<u8>>)>,
+}
+
+/// Deduplicated Tempo state proofs for cross-domain reads.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BatchStateProof {
+    /// Deduplicated pool of all MPT nodes, keyed by `keccak256(rlp(node))`.
+    pub node_pool: Vec<(B256, Vec<u8>)>,
+    /// Tempo state reads with proof paths referencing the node pool.
+    pub reads: Vec<L1StateRead>,
+}
+
+/// A single Tempo L1 state read with its proof path through the node pool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct L1StateRead {
+    /// Which zone block performed this read.
+    pub zone_block_index: u64,
+    /// Which Tempo block to read from.
+    pub tempo_block_number: u64,
+    /// Tempo account address.
+    pub account: Address,
+    /// Storage slot.
+    pub slot: U256,
+    /// Path through `node_pool` from state root to leaf.
+    pub node_path: Vec<B256>,
+    /// Expected storage value.
+    pub value: U256,
+}
+
+/// Errors from the zone batch STF.
+#[derive(Debug, Clone)]
+pub enum Error {
+    /// MPT proof verification failed.
+    InvalidProof,
+    /// EVM execution error.
+    ExecutionError(alloc::string::String),
+    /// State or input consistency violation.
+    InconsistentState,
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidProof => write!(f, "invalid proof"),
+            Self::ExecutionError(msg) => write!(f, "execution error: {msg}"),
+            Self::InconsistentState => write!(f, "inconsistent state"),
+        }
+    }
+}

--- a/crates/zone-primitives/src/sol_types.rs
+++ b/crates/zone-primitives/src/sol_types.rs
@@ -1,0 +1,22 @@
+//! Solidity-compatible types used in proof public values and on-chain verification.
+
+use alloy_primitives::B256;
+use serde::{Deserialize, Serialize};
+
+/// Zone block hash transition (prev -> next).
+///
+/// Mirrors the Solidity `BlockTransition` struct.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BlockTransition {
+    pub prev_block_hash: B256,
+    pub next_block_hash: B256,
+}
+
+/// Deposit queue processing transition.
+///
+/// Mirrors the Solidity `DepositQueueTransition` struct.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DepositQueueTransition {
+    pub prev_processed_hash: B256,
+    pub next_processed_hash: B256,
+}

--- a/crates/zone-prover/Cargo.toml
+++ b/crates/zone-prover/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "zone-prover"
+description = "Host-side zone batch prover using SP1"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+zone-primitives = { path = "../zone-primitives" }
+
+# SP1
+sp1-sdk = { workspace = true }
+
+# alloy
+alloy-primitives.workspace = true
+
+# misc
+eyre.workspace = true
+tokio.workspace = true
+tracing.workspace = true

--- a/crates/zone-prover/src/lib.rs
+++ b/crates/zone-prover/src/lib.rs
@@ -1,0 +1,12 @@
+//! Host-side zone batch prover using SP1.
+//!
+//! Constructs [`BatchWitness`] from zone node data and orchestrates SP1 proving
+//! to generate validity proofs for zone state transitions.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+pub mod prover;
+pub mod witness;
+
+pub use prover::{ProofResult, ProverMode, ZoneBatchProver};
+pub use witness::WitnessBuilder;

--- a/crates/zone-prover/src/prover.rs
+++ b/crates/zone-prover/src/prover.rs
@@ -1,0 +1,188 @@
+//! SP1 proving orchestration for zone batches.
+
+use alloy_primitives::Bytes;
+use eyre::Result;
+use sp1_sdk::{Elf, ProveRequest as _, Prover as _, SP1Stdin};
+use tracing::{info, instrument};
+use zone_primitives::BatchWitness;
+
+/// The compiled SP1 ELF binary for the zone batch program.
+///
+/// Once the guest program is compiled to RISC-V ELF via `sp1-build`, replace this
+/// with `include_bytes!` or `sp1_sdk::include_elf!`.
+const ZONE_BATCH_ELF: &[u8] = &[];
+
+/// Proving mode for the zone batch prover.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ProverMode {
+    /// Mock mode: validates STF logic without generating a real proof.
+    /// Returns empty proof bytes. Useful for development and testing.
+    #[default]
+    Mock,
+    /// CPU mode: generates a real proof using local CPU.
+    /// Slow but does not require network access.
+    Cpu,
+    /// Network mode: submits proving to the Succinct Prover Network.
+    /// Fast but requires network access and a valid API key.
+    Network,
+}
+
+/// Result of a zone batch proof generation.
+#[derive(Debug, Clone)]
+pub struct ProofResult {
+    /// The proof bytes to submit on-chain.
+    pub proof: Bytes,
+    /// The verifier configuration bytes (e.g., vkey commitment).
+    pub verifier_config: Bytes,
+}
+
+impl ProofResult {
+    /// Create an empty proof result (for POC/mock mode).
+    pub fn empty() -> Self {
+        Self {
+            proof: Bytes::new(),
+            verifier_config: Bytes::new(),
+        }
+    }
+}
+
+/// Zone batch prover that orchestrates SP1 proof generation.
+pub struct ZoneBatchProver {
+    mode: ProverMode,
+}
+
+impl ZoneBatchProver {
+    /// Create a new prover with the given mode.
+    pub fn new(mode: ProverMode) -> Self {
+        Self { mode }
+    }
+
+    /// Generate a proof for the given batch witness.
+    ///
+    /// In mock mode, validates the STF logic and returns empty proof bytes.
+    /// In CPU/network mode, generates a real SP1 proof.
+    #[instrument(skip_all, fields(mode = ?self.mode))]
+    pub async fn prove(&self, witness: &BatchWitness) -> Result<ProofResult> {
+        match self.mode {
+            ProverMode::Mock => self.prove_mock(witness),
+            ProverMode::Cpu => self.prove_sp1(witness).await,
+            ProverMode::Network => Err(eyre::eyre!("Network proving not yet implemented")),
+        }
+    }
+
+    /// Mock proof: validate witness structure without generating a real proof.
+    fn prove_mock(&self, witness: &BatchWitness) -> Result<ProofResult> {
+        info!(
+            zone_blocks = witness.zone_blocks.len(),
+            "Generating mock proof (no real proof)"
+        );
+
+        validate_witness_structure(witness)?;
+
+        info!("Mock proof validation passed");
+        Ok(ProofResult::empty())
+    }
+
+    /// Generate a real SP1 proof using local CPU.
+    async fn prove_sp1(&self, witness: &BatchWitness) -> Result<ProofResult> {
+        if ZONE_BATCH_ELF.is_empty() {
+            return Err(eyre::eyre!(
+                "SP1 guest ELF not available. Compile the zone-batch program first, \
+                 or use ProverMode::Mock for testing."
+            ));
+        }
+
+        let witness = witness.clone();
+
+        // Run proving in a blocking task since SP1 proving is CPU-intensive
+        let proof_result = tokio::task::spawn_blocking(move || -> Result<ProofResult> {
+            let runtime = tokio::runtime::Handle::current();
+
+            let prover = runtime.block_on(sp1_sdk::ProverClient::builder().cpu().build());
+            let elf = Elf::from(ZONE_BATCH_ELF);
+            let pk = runtime.block_on(prover.setup(elf))?;
+
+            let mut stdin = SP1Stdin::new();
+            stdin.write(&witness);
+
+            info!("Starting SP1 proof generation...");
+            let proof = runtime.block_on(async { prover.prove(&pk, stdin).compressed().await })?;
+
+            let proof_bytes = proof.bytes();
+            info!(
+                proof_size = proof_bytes.len(),
+                "SP1 proof generated successfully"
+            );
+
+            Ok(ProofResult {
+                proof: Bytes::from(proof_bytes),
+                verifier_config: Bytes::new(),
+            })
+        })
+        .await??;
+
+        Ok(proof_result)
+    }
+}
+
+/// Validate the structural correctness of a batch witness.
+fn validate_witness_structure(witness: &BatchWitness) -> Result<()> {
+    let public_inputs = &witness.public_inputs;
+
+    // Verify previous block header matches public inputs
+    let prev_header_hash = witness.prev_block_header.hash();
+    eyre::ensure!(
+        prev_header_hash == public_inputs.prev_block_hash,
+        "prev_block_header hash ({prev_header_hash}) does not match \
+         public_inputs.prev_block_hash ({})",
+        public_inputs.prev_block_hash,
+    );
+
+    // Must have at least one zone block
+    eyre::ensure!(
+        !witness.zone_blocks.is_empty(),
+        "batch must contain at least one zone block"
+    );
+
+    // Validate block chain continuity
+    let mut prev_hash = public_inputs.prev_block_hash;
+    let mut prev_number = witness.prev_block_header.number;
+
+    for (idx, block) in witness.zone_blocks.iter().enumerate() {
+        let is_last = idx + 1 == witness.zone_blocks.len();
+
+        eyre::ensure!(
+            block.parent_hash == prev_hash,
+            "block {} parent_hash mismatch",
+            block.number,
+        );
+        eyre::ensure!(
+            block.number == prev_number + 1,
+            "block {} number not sequential (expected {})",
+            block.number,
+            prev_number + 1,
+        );
+        eyre::ensure!(
+            block.beneficiary == public_inputs.sequencer,
+            "block {} beneficiary does not match sequencer",
+            block.number,
+        );
+
+        if is_last {
+            eyre::ensure!(
+                block.finalize_withdrawal_batch_count.is_some(),
+                "final block must have finalize_withdrawal_batch_count",
+            );
+        } else {
+            eyre::ensure!(
+                block.finalize_withdrawal_batch_count.is_none(),
+                "only the final block may have finalize_withdrawal_batch_count",
+            );
+        }
+
+        prev_hash = block.parent_hash;
+        prev_number = block.number;
+    }
+
+    Ok(())
+}

--- a/crates/zone-prover/src/witness.rs
+++ b/crates/zone-prover/src/witness.rs
@@ -1,0 +1,97 @@
+//! Witness construction for zone batch proving.
+//!
+//! Builds a [`BatchWitness`] from zone node data by fetching zone blocks,
+//! reading state proofs, and constructing the complete witness structure.
+
+use alloy_primitives::{Address, B256};
+use eyre::Result;
+use zone_primitives::{
+    BatchStateProof, BatchWitness, PublicInputs, ZoneBlock, ZoneHeader, ZoneStateWitness,
+};
+
+/// Builds a [`BatchWitness`] for proof generation.
+///
+/// TODO: Fetch full zone state proofs via `eth_getProof`, collect Tempo state
+/// proofs, and build the complete witness. Currently uses empty placeholders.
+pub struct WitnessBuilder {
+    /// Previous block hash (from portal state).
+    prev_block_hash: B256,
+    /// Previous block header.
+    prev_block_header: ZoneHeader,
+    /// Zone blocks in this batch.
+    zone_blocks: Vec<ZoneBlock>,
+    /// Tempo block number for this batch.
+    tempo_block_number: u64,
+    /// Anchor block number (same as tempo for direct mode).
+    anchor_block_number: u64,
+    /// Anchor block hash.
+    anchor_block_hash: B256,
+    /// Expected withdrawal batch index.
+    expected_withdrawal_batch_index: u64,
+    /// Registered sequencer address.
+    sequencer: Address,
+}
+
+impl WitnessBuilder {
+    /// Create a new witness builder with required public inputs.
+    pub fn new(
+        prev_block_hash: B256,
+        prev_block_header: ZoneHeader,
+        sequencer: Address,
+        tempo_block_number: u64,
+    ) -> Self {
+        Self {
+            prev_block_hash,
+            prev_block_header,
+            zone_blocks: Vec::new(),
+            tempo_block_number,
+            anchor_block_number: tempo_block_number,
+            anchor_block_hash: B256::ZERO,
+            expected_withdrawal_batch_index: 0,
+            sequencer,
+        }
+    }
+
+    /// Set the anchor block for ancestry mode.
+    pub fn with_anchor(mut self, anchor_block_number: u64, anchor_block_hash: B256) -> Self {
+        self.anchor_block_number = anchor_block_number;
+        self.anchor_block_hash = anchor_block_hash;
+        self
+    }
+
+    /// Set the expected withdrawal batch index.
+    pub fn with_expected_withdrawal_batch_index(mut self, index: u64) -> Self {
+        self.expected_withdrawal_batch_index = index;
+        self
+    }
+
+    /// Add a zone block to the witness.
+    pub fn add_zone_block(&mut self, block: ZoneBlock) {
+        self.zone_blocks.push(block);
+    }
+
+    /// Build the complete [`BatchWitness`].
+    pub fn build(self) -> Result<BatchWitness> {
+        eyre::ensure!(
+            !self.zone_blocks.is_empty(),
+            "batch must contain at least one zone block"
+        );
+
+        Ok(BatchWitness {
+            public_inputs: PublicInputs {
+                prev_block_hash: self.prev_block_hash,
+                tempo_block_number: self.tempo_block_number,
+                anchor_block_number: self.anchor_block_number,
+                anchor_block_hash: self.anchor_block_hash,
+                expected_withdrawal_batch_index: self.expected_withdrawal_batch_index,
+                sequencer: self.sequencer,
+            },
+            prev_block_header: self.prev_block_header,
+            zone_blocks: self.zone_blocks,
+            // TODO: populate via eth_getProof
+            initial_zone_state: ZoneStateWitness::default(),
+            tempo_state_proofs: BatchStateProof::default(),
+            tempo_ancestry_headers: Vec::new(),
+        })
+    }
+}

--- a/crates/zone-stf/Cargo.toml
+++ b/crates/zone-stf/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "zone-stf"
+description = "Zone batch state transition function for proving (no_std compatible)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+zone-primitives = { path = "../zone-primitives", default-features = false }
+
+# alloy (no_std compatible)
+alloy-primitives = { version = "1.5.4", default-features = false }
+alloy-sol-types = { version = "1.5.7", default-features = false }
+alloy-rlp = { version = "0.3.13", default-features = false }
+
+# revm (no_std compatible)
+revm = { version = "34.0.0", default-features = false, features = ["hashbrown"] }
+
+[features]
+default = ["std"]
+std = [
+    "zone-primitives/std",
+    "alloy-primitives/std",
+    "alloy-sol-types/std",
+    "alloy-rlp/std",
+    "revm/std",
+]

--- a/crates/zone-stf/src/db.rs
+++ b/crates/zone-stf/src/db.rs
@@ -1,0 +1,191 @@
+//! Witness-backed [`Database`] for revm execution inside the prover.
+//!
+//! [`WitnessDb`] serves account info and storage values from a
+//! [`ZoneStateWitness`] that was pre-collected on the host. State changes
+//! are accumulated in-memory via [`DatabaseCommit`] so that later
+//! transactions see the effects of earlier ones.
+
+use alloc::collections::BTreeMap;
+use alloy_primitives::{Address, B256, Bytes, U256};
+use revm::{
+    Database, DatabaseCommit,
+    bytecode::Bytecode,
+    state::AccountInfo,
+};
+use zone_primitives::ZoneStateWitness;
+
+/// Error returned by [`WitnessDb`] when the EVM accesses data that was not
+/// included in the witness.
+#[derive(Debug)]
+pub enum WitnessDbError {
+    /// The requested code hash has no corresponding bytecode in the witness.
+    MissingCode(B256),
+}
+
+impl core::fmt::Display for WitnessDbError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingCode(h) => write!(f, "code hash {h} not in witness"),
+        }
+    }
+}
+
+impl core::error::Error for WitnessDbError {}
+impl revm::database_interface::DBErrorMarker for WitnessDbError {}
+
+// ---------------------------------------------------------------------------
+//  Internal types
+// ---------------------------------------------------------------------------
+
+/// Cached account data built from the witness.
+struct WitnessAccount {
+    nonce: u64,
+    balance: U256,
+    code_hash: B256,
+    code: Option<Bytecode>,
+    storage: BTreeMap<U256, U256>,
+}
+
+// ---------------------------------------------------------------------------
+//  WitnessDb
+// ---------------------------------------------------------------------------
+
+/// Revm [`Database`] backed by a [`ZoneStateWitness`].
+///
+/// Reads return data from the witness. Commits from EVM execution are
+/// stored in-memory so subsequent reads reflect accumulated state changes.
+pub struct WitnessDb {
+    /// Account data indexed by address.
+    accounts: BTreeMap<Address, WitnessAccount>,
+    /// Bytecode indexed by code hash (for `code_by_hash` lookups).
+    code_by_hash: BTreeMap<B256, Bytecode>,
+    /// Zone state root at the start of the batch.
+    state_root: B256,
+}
+
+impl WitnessDb {
+    /// Build from the initial zone state witness.
+    pub fn from_witness(witness: &ZoneStateWitness) -> Self {
+        let mut accounts = BTreeMap::new();
+        let mut code_by_hash = BTreeMap::new();
+
+        for (addr, aw) in &witness.accounts {
+            let bytecode = aw.code.as_ref().map(|c| {
+                Bytecode::new_raw(Bytes::copy_from_slice(c))
+            });
+            if let Some(ref bc) = bytecode {
+                code_by_hash.insert(aw.code_hash, bc.clone());
+            }
+
+            let storage = aw.storage.iter().map(|(k, v)| (*k, *v)).collect();
+
+            accounts.insert(
+                *addr,
+                WitnessAccount {
+                    nonce: aw.nonce,
+                    balance: aw.balance,
+                    code_hash: aw.code_hash,
+                    code: bytecode,
+                    storage,
+                },
+            );
+        }
+
+        Self {
+            accounts,
+            code_by_hash,
+            state_root: witness.state_root,
+        }
+    }
+
+    /// Current zone state root.
+    ///
+    /// TODO: recompute from committed changes via MPT update. Currently returns
+    /// the initial state root.
+    pub fn state_root(&self) -> B256 {
+        self.state_root
+    }
+
+    /// Read a storage value from the current (possibly committed) state.
+    pub fn read_storage(&self, address: Address, slot: U256) -> U256 {
+        self.accounts
+            .get(&address)
+            .and_then(|a| a.storage.get(&slot))
+            .copied()
+            .unwrap_or(U256::ZERO)
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  Database impl
+// ---------------------------------------------------------------------------
+
+impl Database for WitnessDb {
+    type Error = WitnessDbError;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        let Some(account) = self.accounts.get(&address) else {
+            return Ok(None);
+        };
+        Ok(Some(AccountInfo {
+            balance: account.balance,
+            nonce: account.nonce,
+            code_hash: account.code_hash,
+            code: account.code.clone(),
+            ..Default::default()
+        }))
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        if code_hash == B256::ZERO || code_hash == revm::primitives::KECCAK_EMPTY {
+            return Ok(Bytecode::default());
+        }
+        self.code_by_hash
+            .get(&code_hash)
+            .cloned()
+            .ok_or(WitnessDbError::MissingCode(code_hash))
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        if let Some(account) = self.accounts.get(&address) {
+            return Ok(account.storage.get(&index).copied().unwrap_or(U256::ZERO));
+        }
+        Ok(U256::ZERO)
+    }
+
+    fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+        // Zone blocks don't rely on the BLOCKHASH opcode.
+        Ok(B256::ZERO)
+    }
+}
+
+// ---------------------------------------------------------------------------
+//  DatabaseCommit impl
+// ---------------------------------------------------------------------------
+
+impl DatabaseCommit for WitnessDb {
+    fn commit(&mut self, changes: revm::primitives::HashMap<Address, revm::state::Account>) {
+        for (addr, account) in changes {
+            let entry = self.accounts.entry(addr).or_insert_with(|| WitnessAccount {
+                nonce: 0,
+                balance: U256::ZERO,
+                code_hash: revm::primitives::KECCAK_EMPTY,
+                code: None,
+                storage: BTreeMap::new(),
+            });
+
+            entry.nonce = account.info.nonce;
+            entry.balance = account.info.balance;
+            entry.code_hash = account.info.code_hash;
+
+            if let Some(code) = account.info.code {
+                self.code_by_hash.insert(entry.code_hash, code.clone());
+                entry.code = Some(code);
+            }
+
+            for (slot, evm_slot) in account.storage {
+                entry.storage.insert(slot, evm_slot.present_value);
+            }
+        }
+    }
+}

--- a/crates/zone-stf/src/lib.rs
+++ b/crates/zone-stf/src/lib.rs
@@ -1,0 +1,324 @@
+//! Zone batch state transition function for proving.
+//!
+//! Implements `prove_zone_batch`, a pure function that takes a [`BatchWitness`]
+//! containing all data needed to re-execute a batch of zone blocks, and produces
+//! a [`BatchOutput`] with the commitments the on-chain verifier checks.
+//!
+//! This crate is `no_std` compatible so it can run inside SP1 (RISC-V) and
+//! TEE (SGX/TDX) environments.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+mod db;
+
+use alloc::format;
+use alloc::vec::Vec;
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_sol_types::SolCall;
+use revm::{
+    Context,
+    handler::{ExecuteEvm, MainBuilder, MainContext, SystemCallCommitEvm},
+};
+use zone_primitives::{
+    BatchOutput, BatchWitness, BlockTransition, DecryptionData, DepositQueueTransition,
+    DepositType, Error, LastBatchCommitment, QueuedDeposit, ZoneBlock, ZoneHeader,
+    constants::{
+        ZONE_INBOX_ADDRESS, ZONE_INBOX_PROCESSED_HASH_SLOT, ZONE_OUTBOX_ADDRESS,
+        ZONE_OUTBOX_LAST_BATCH_HASH_SLOT, ZONE_OUTBOX_LAST_BATCH_INDEX_SLOT,
+    },
+};
+
+pub use db::{WitnessDb, WitnessDbError};
+
+// ---------------------------------------------------------------------------
+//  ABI types for system call calldata construction
+// ---------------------------------------------------------------------------
+
+alloy_sol_types::sol! {
+    enum SolDepositType {
+        Regular,
+        Encrypted,
+    }
+
+    struct SolQueuedDeposit {
+        SolDepositType depositType;
+        bytes depositData;
+    }
+
+    struct SolChaumPedersenProof {
+        bytes32 s;
+        bytes32 c;
+    }
+
+    struct SolDecryptionData {
+        bytes32 sharedSecret;
+        uint8 sharedSecretYParity;
+        address to;
+        bytes32 memo;
+        SolChaumPedersenProof cpProof;
+    }
+
+    struct SolEnabledToken {
+        address token;
+        string name;
+        string symbol;
+        string currency;
+    }
+
+    function advanceTempo(
+        bytes calldata header,
+        SolQueuedDeposit[] calldata deposits,
+        SolDecryptionData[] calldata decryptions,
+        SolEnabledToken[] calldata enabledTokens
+    ) external;
+
+    function finalizeWithdrawalBatch(
+        uint256 count,
+        uint64 blockNumber
+    ) external returns (bytes32 withdrawalQueueHash);
+}
+
+// ---------------------------------------------------------------------------
+//  Core STF
+// ---------------------------------------------------------------------------
+
+/// Pure state transition function for zone batch proving.
+///
+/// Given a complete [`BatchWitness`], re-executes all zone blocks using revm
+/// and produces a [`BatchOutput`] containing the commitments that the
+/// on-chain verifier will check.
+pub fn prove_zone_batch(witness: BatchWitness) -> Result<BatchOutput, Error> {
+    let public_inputs = &witness.public_inputs;
+
+    // ------------------------------------------------------------------
+    // Verify previous block header
+    // ------------------------------------------------------------------
+
+    let prev_header_hash = witness.prev_block_header.hash();
+    if prev_header_hash != public_inputs.prev_block_hash {
+        return Err(Error::InconsistentState);
+    }
+
+    if witness.initial_zone_state.state_root != witness.prev_block_header.state_root {
+        return Err(Error::InconsistentState);
+    }
+
+    // ------------------------------------------------------------------
+    // Initialize zone state
+    // ------------------------------------------------------------------
+
+    let db = WitnessDb::from_witness(&witness.initial_zone_state);
+
+    // Capture the deposit queue hash at the start of the batch.
+    let deposit_prev = B256::from(
+        db.read_storage(ZONE_INBOX_ADDRESS, ZONE_INBOX_PROCESSED_HASH_SLOT)
+            .to_be_bytes::<32>(),
+    );
+
+    // Create the EVM. We reuse a single instance across all blocks — only the
+    // block environment changes between blocks.
+    let ctx = Context::mainnet()
+        .modify_cfg_chained(|cfg| {
+            cfg.set_spec_and_mainnet_gas_params(revm::primitives::hardfork::SpecId::PRAGUE);
+        })
+        .with_db(db);
+    let mut evm = ctx.build_mainnet();
+
+    // ------------------------------------------------------------------
+    // Execute zone blocks
+    // ------------------------------------------------------------------
+
+    let mut prev_block_hash = public_inputs.prev_block_hash;
+    let mut prev_number = witness.prev_block_header.number;
+    let num_blocks = witness.zone_blocks.len();
+
+    for (idx, block) in witness.zone_blocks.iter().enumerate() {
+        let is_last = idx + 1 == num_blocks;
+
+        // --- Block property validation ---
+
+        if block.parent_hash != prev_block_hash {
+            return Err(Error::InconsistentState);
+        }
+        if block.number != prev_number + 1 {
+            return Err(Error::InconsistentState);
+        }
+        if block.beneficiary != public_inputs.sequencer {
+            return Err(Error::InconsistentState);
+        }
+        if is_last {
+            if block.finalize_withdrawal_batch_count.is_none() {
+                return Err(Error::InconsistentState);
+            }
+        } else if block.finalize_withdrawal_batch_count.is_some() {
+            return Err(Error::InconsistentState);
+        }
+
+        // --- Set block environment ---
+
+        evm.set_block(block_env(block));
+
+        // --- System tx: advanceTempo ---
+
+        if let Some(ref tempo_header_rlp) = block.tempo_header_rlp {
+            let calldata =
+                advance_tempo_calldata(tempo_header_rlp, &block.deposits, &block.decryptions);
+            evm.system_call_with_caller_commit(
+                Address::ZERO,
+                ZONE_INBOX_ADDRESS,
+                calldata.into(),
+            )
+            .map_err(|e| Error::ExecutionError(format!("{e:?}")))?;
+        } else if !block.deposits.is_empty() || !block.decryptions.is_empty() {
+            return Err(Error::InconsistentState);
+        }
+
+        // --- User transactions ---
+
+        // TODO: Decode serialized transactions from `block.transactions`,
+        // build TxEnv for each, and execute via `transact_commit`.
+
+        // --- System tx: finalizeWithdrawalBatch (final block only) ---
+
+        if let Some(count) = block.finalize_withdrawal_batch_count {
+            let calldata = finalize_withdrawal_batch_calldata(count, block.number);
+            evm.system_call_with_caller_commit(
+                Address::ZERO,
+                ZONE_OUTBOX_ADDRESS,
+                calldata.into(),
+            )
+            .map_err(|e| Error::ExecutionError(format!("{e:?}")))?;
+        }
+
+        // --- Compute zone block hash ---
+
+        // TODO: The state root should be recomputed from committed changes
+        // via MPT update. For now we use the initial state root which is only
+        // correct for the first block before any state changes.
+        let state_root = evm.ctx.journaled_state.database.state_root();
+
+        // TODO: Compute proper transactions_root and receipts_root from the
+        // ordered trie of all transactions / receipts in this block.
+        let header = ZoneHeader {
+            parent_hash: prev_block_hash,
+            beneficiary: block.beneficiary,
+            state_root,
+            transactions_root: B256::ZERO,
+            receipts_root: B256::ZERO,
+            number: block.number,
+            timestamp: block.timestamp,
+        };
+        prev_block_hash = header.hash();
+        prev_number = block.number;
+    }
+
+    // ------------------------------------------------------------------
+    // Extract output commitments
+    // ------------------------------------------------------------------
+
+    let db = &evm.ctx.journaled_state.database;
+
+    // Read processedDepositQueueHash after all blocks executed.
+    let deposit_next = B256::from(
+        db.read_storage(ZONE_INBOX_ADDRESS, ZONE_INBOX_PROCESSED_HASH_SLOT)
+            .to_be_bytes::<32>(),
+    );
+
+    // Read _lastBatch from ZoneOutbox state.
+    let withdrawal_queue_hash = B256::from(
+        db.read_storage(ZONE_OUTBOX_ADDRESS, ZONE_OUTBOX_LAST_BATCH_HASH_SLOT)
+            .to_be_bytes::<32>(),
+    );
+    let withdrawal_batch_index: u64 = db
+        .read_storage(ZONE_OUTBOX_ADDRESS, ZONE_OUTBOX_LAST_BATCH_INDEX_SLOT)
+        .to::<u64>();
+
+    // TODO: Verify Tempo state binding
+    // - Read tempoBlockNumber from TempoState storage
+    // - Verify it matches public_inputs.tempo_block_number
+    // - Verify anchor block hash (direct or ancestry mode)
+
+    Ok(BatchOutput {
+        block_transition: BlockTransition {
+            prev_block_hash: public_inputs.prev_block_hash,
+            next_block_hash: prev_block_hash,
+        },
+        deposit_queue_transition: DepositQueueTransition {
+            prev_processed_hash: deposit_prev,
+            next_processed_hash: deposit_next,
+        },
+        withdrawal_queue_hash,
+        last_batch: LastBatchCommitment {
+            withdrawal_batch_index,
+        },
+    })
+}
+
+// ---------------------------------------------------------------------------
+//  Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a [`revm::context::BlockEnv`] from a [`ZoneBlock`].
+fn block_env(block: &ZoneBlock) -> revm::context::BlockEnv {
+    revm::context::BlockEnv {
+        number: U256::from(block.number),
+        beneficiary: block.beneficiary,
+        timestamp: U256::from(block.timestamp),
+        gas_limit: 30_000_000,
+        basefee: 0,
+        difficulty: U256::ZERO,
+        prevrandao: Some(B256::ZERO),
+        blob_excess_gas_and_price: None,
+    }
+}
+
+/// ABI-encode the `advanceTempo(header, deposits, decryptions, enabledTokens)` calldata.
+fn advance_tempo_calldata(
+    tempo_header_rlp: &[u8],
+    deposits: &[QueuedDeposit],
+    decryptions: &[DecryptionData],
+) -> Vec<u8> {
+    let sol_deposits: Vec<SolQueuedDeposit> = deposits
+        .iter()
+        .map(|d| SolQueuedDeposit {
+            depositType: match d.deposit_type {
+                DepositType::Regular => SolDepositType::Regular,
+                DepositType::Encrypted => SolDepositType::Encrypted,
+            },
+            depositData: Bytes::copy_from_slice(&d.deposit_data),
+        })
+        .collect();
+
+    let sol_decryptions: Vec<SolDecryptionData> = decryptions
+        .iter()
+        .map(|d| SolDecryptionData {
+            sharedSecret: d.shared_secret,
+            sharedSecretYParity: d.shared_secret_y_parity,
+            to: d.to,
+            memo: d.memo,
+            cpProof: SolChaumPedersenProof {
+                s: d.cp_proof.s,
+                c: d.cp_proof.c,
+            },
+        })
+        .collect();
+
+    advanceTempoCall {
+        header: Bytes::copy_from_slice(tempo_header_rlp),
+        deposits: sol_deposits,
+        decryptions: sol_decryptions,
+        enabledTokens: Vec::new(),
+    }
+    .abi_encode()
+}
+
+/// ABI-encode the `finalizeWithdrawalBatch(count, blockNumber)` calldata.
+fn finalize_withdrawal_batch_calldata(count: U256, block_number: u64) -> Vec<u8> {
+    finalizeWithdrawalBatchCall {
+        count,
+        blockNumber: block_number,
+    }
+    .abi_encode()
+}

--- a/docs/specs/src/zone/SP1ZoneVerifier.sol
+++ b/docs/specs/src/zone/SP1ZoneVerifier.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { BlockTransition, DepositQueueTransition, IVerifier } from "./IZone.sol";
+
+/// @title ISP1Verifier
+/// @notice Interface for Succinct's on-chain SP1 proof verifier
+interface ISP1Verifier {
+
+    /// @notice Verify an SP1 proof
+    /// @param programVKey The verification key of the SP1 program
+    /// @param publicValues The public values committed by the proof
+    /// @param proofBytes The encoded SP1 proof
+    function verifyProof(bytes32 programVKey, bytes calldata publicValues, bytes calldata proofBytes) external view;
+
+}
+
+/// @title SP1ZoneVerifier
+/// @notice Verifies zone batch proofs using Succinct's SP1 zkVM.
+///         Implements the IVerifier interface so it can be used as a drop-in
+///         replacement for the stub verifier.
+contract SP1ZoneVerifier is IVerifier {
+
+    /// @notice Succinct's on-chain SP1 proof verifier contract
+    ISP1Verifier public immutable sp1Verifier;
+
+    /// @notice SP1 verification key for the zone batch program
+    bytes32 public zoneBatchVkey;
+
+    /// @notice Address authorized to update the verification key
+    address public owner;
+
+    error Unauthorized();
+    error VerificationFailed();
+
+    event VkeyUpdated(bytes32 indexed oldVkey, bytes32 indexed newVkey);
+
+    constructor(address _sp1Verifier, bytes32 _zoneBatchVkey) {
+        sp1Verifier = ISP1Verifier(_sp1Verifier);
+        zoneBatchVkey = _zoneBatchVkey;
+        owner = msg.sender;
+    }
+
+    /// @notice Update the SP1 verification key (e.g., after recompiling the guest program)
+    function setVkey(bytes32 _zoneBatchVkey) external {
+        if (msg.sender != owner) revert Unauthorized();
+        bytes32 oldVkey = zoneBatchVkey;
+        zoneBatchVkey = _zoneBatchVkey;
+        emit VkeyUpdated(oldVkey, _zoneBatchVkey);
+    }
+
+    /// @inheritdoc IVerifier
+    function verify(
+        uint64 tempoBlockNumber,
+        uint64 anchorBlockNumber,
+        bytes32 anchorBlockHash,
+        uint64 expectedWithdrawalBatchIndex,
+        address sequencer,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata,
+        bytes calldata proof
+    )
+        external
+        view
+        override
+        returns (bool)
+    {
+        // Encode the public values that the SP1 proof committed to.
+        // This must match the BatchOutput encoding in the guest program.
+        bytes memory publicValues = abi.encode(
+            tempoBlockNumber,
+            anchorBlockNumber,
+            anchorBlockHash,
+            expectedWithdrawalBatchIndex,
+            sequencer,
+            blockTransition.prevBlockHash,
+            blockTransition.nextBlockHash,
+            depositQueueTransition.prevProcessedHash,
+            depositQueueTransition.nextProcessedHash,
+            withdrawalQueueHash
+        );
+
+        sp1Verifier.verifyProof(zoneBatchVkey, publicValues, proof);
+
+        return true;
+    }
+
+}

--- a/programs/zone-batch/Cargo.toml
+++ b/programs/zone-batch/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "zone-batch-program"
+description = "SP1 guest program for zone batch proving"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+zone-primitives = { path = "../../crates/zone-primitives", default-features = false }
+zone-stf = { path = "../../crates/zone-stf", default-features = false }
+sp1-zkvm = "6.0.2"
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+
+# SP1 crypto acceleration patches — replaces standard crypto crates with
+# versions that use SP1's hardware-accelerated RISC-V precompiles.
+[patch.crates-io]
+sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
+sha3 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha3", tag = "patch-sha3-0.10.8-sp1-4.0.0" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
+k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }

--- a/programs/zone-batch/src/main.rs
+++ b/programs/zone-batch/src/main.rs
@@ -1,0 +1,20 @@
+//! SP1 guest program for zone batch proving.
+//!
+//! This program runs inside the SP1 zkVM and proves correct execution of the
+//! zone state transition function. It reads a [`BatchWitness`] from the host,
+//! re-executes all zone blocks via revm, and commits the [`BatchOutput`] as
+//! public values.
+
+#![no_main]
+sp1_zkvm::entrypoint!(main);
+
+use zone_primitives::BatchWitness;
+use zone_stf::prove_zone_batch;
+
+pub fn main() {
+    let witness: BatchWitness = sp1_zkvm::io::read();
+
+    let output = prove_zone_batch(witness).expect("zone batch STF failed");
+
+    sp1_zkvm::io::commit(&output);
+}


### PR DESCRIPTION
## Summary

Introduces the core crates for SP1-based validity proving of zone batch state transitions. The STF re-executes zone blocks using revm with a witness-backed database inside the SP1 zkVM, replacing the current empty-proof POC mode.

### New crates

- **`zone-primitives`** (`no_std`): shared types — `BatchWitness`, `BatchOutput`, `ZoneBlock`, `ZoneHeader`, `ZoneStateWitness`, storage slot constants
- **`zone-stf`** (`no_std`): core `prove_zone_batch` function — revm EVM execution with `WitnessDb` (custom `Database` + `DatabaseCommit` impl), system tx calldata encoding (`advanceTempo`, `finalizeWithdrawalBatch`), block validation, output commitment extraction
- **`zone-prover`**: host-side SP1 orchestration (mock/cpu/network proving modes) and `WitnessBuilder` for constructing `BatchWitness`
- **`programs/zone-batch`**: SP1 guest entrypoint calling `zone_stf::prove_zone_batch`
- **`SP1ZoneVerifier.sol`**: on-chain verifier contract spec

### Changes to existing code

`BatchSubmitter::submit_batch` now accepts an optional `ProofResult` so real proof bytes can be forwarded to the portal's verifier contract. Current callers pass `None` (empty proof, unchanged behavior).

### Not yet implemented

- User transaction decoding and execution
- State root recomputation via MPT update
- Transactions/receipts root computation
- Tempo state verification (tempoBlockNumber, anchor block hash)
- Witness construction from live state (`eth_getProof`)
- Custom precompiles in `no_std` (TempoStateReader, ChaumPedersen, AES-GCM, TIP-20)
- SP1 guest ELF compilation
- BatchSubmitter integration with real proof generation