### PR TITLE
docs(batch): fix anchor mode table to match classify_anchor_gap logic

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -18,12 +18,13 @@
 //! | Gap | Mode | Description |
 //! |-----|------|-------------|
 //! | < [`EIP2935_EFFECTIVE_WINDOW`] | Direct | Portal reads hash from EIP-2935. |
-//! | [`EIP2935_EFFECTIVE_WINDOW`]–[`EIP2935_HISTORY_WINDOW`] | Ancestry | Anchor via recent block + header chain. |
-//! | > [`EIP2935_HISTORY_WINDOW`] | Stepping | Split into multiple direct-mode submissions. |
+//! | ≥ [`EIP2935_EFFECTIVE_WINDOW`] | Stepping | Split into multiple direct-mode submissions. |
 //!
-//! Stepping is resolved by [`AnchorGapKind`] in the zone monitor before
-//! `submit_batch` is called. Direct vs Ancestry is resolved inside
-//! `submit_batch` by [`AnchorMode`].
+//! [`AnchorGapKind`] classifies the gap in the zone monitor before
+//! `submit_batch` is called. Inside `submit_batch`, [`AnchorMode`] handles
+//! the rare case where the gap lands between [`EIP2935_EFFECTIVE_WINDOW`] and
+//! [`EIP2935_HISTORY_WINDOW`] (e.g. due to timing) by falling back to ancestry
+//! mode — a recent anchor block plus a parent-hash header chain.
 
 use crate::abi::{BlockTransition, DepositQueueTransition, ZonePortal};
 use alloy_primitives::{Address, B256, Bytes};


### PR DESCRIPTION
The anchor mode table described three tiers (Direct / Ancestry / Stepping) with Stepping only for gaps > `EIP2935_HISTORY_WINDOW`. In practice, `classify_anchor_gap` returns Stepping for any gap >= `EIP2935_EFFECTIVE_WINDOW` — there is no separate Ancestry tier at the classification level. Ancestry mode is a fallback inside `submit_batch` for the rare case where the gap lands between the two thresholds.

Updated the table to show two tiers matching the actual code, and added a note explaining when ancestry mode applies.