### PR TITLE
feat(withdrawals): restore pending withdrawals from zone L2 events on restart

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -496,24 +496,13 @@ impl BatchSubmitter {
             zone_end_by_slot.insert(portal_slot, block.number());
         }
 
+        // Step 4: fetch WithdrawalRequested events from zone L2 for each pending slot.
         let outbox = ZoneOutbox::new(outbox_address, zone_provider.clone());
-        let mut total_restored = 0u64;
-
-        // Steps 4+5: for each pending L1 portal queue slot, fetch the
-        // WithdrawalRequested events from zone L2, verify, and store.
+        let mut slot_withdrawals: BTreeMap<u64, Vec<abi::Withdrawal>> = BTreeMap::new();
         for portal_slot in head..tail {
-            let Some(event) = events.get(&portal_slot) else {
-                warn!(
-                    portal_slot,
-                    "no BatchSubmitted event found for pending portal slot"
-                );
+            if !events.contains_key(&portal_slot) {
                 continue;
-            };
-
-            // Zone L2 block range: from the previous slot's end + 1 to this
-            // slot's end. May be wider than the exact batch when non-withdrawal
-            // batches exist in between, but those blocks have no
-            // WithdrawalRequested events so the result is the same.
+            }
             let zone_end = zone_end_by_slot[&portal_slot];
             let zone_start = if portal_slot > 0 {
                 zone_end_by_slot
@@ -523,88 +512,37 @@ impl BatchSubmitter {
             } else {
                 1
             };
+            let withdrawals = fetch_slot_withdrawals(&outbox, zone_start, zone_end).await?;
+            slot_withdrawals.insert(portal_slot, withdrawals);
+        }
 
-            let is_head_slot = portal_slot == head;
-            let withdrawals = self
-                .restore_slot(
-                    portal_slot,
-                    is_head_slot,
-                    event,
-                    &outbox,
-                    zone_start,
-                    zone_end,
-                )
-                .await?;
+        // Step 5: read the head slot's current on-chain hash (for partial processing detection).
+        let head_slot_hash = if head < tail {
+            self.portal
+                .withdrawalQueueSlot(U256::from(head % WITHDRAWAL_QUEUE_CAPACITY))
+                .call()
+                .await?
+        } else {
+            B256::ZERO
+        };
 
-            if !withdrawals.is_empty() {
-                let count = withdrawals.len();
-                store.lock().add_batch(portal_slot, withdrawals);
-                info!(
-                    portal_slot,
-                    count, "Restored withdrawals for portal queue slot"
-                );
-                total_restored += count as u64;
-            }
+        // Step 6: resolve all fetched data into verified withdrawal sets.
+        let resolved =
+            resolve_pending_slots(head, tail, &events, &slot_withdrawals, head_slot_hash);
+
+        // Step 7: store the resolved withdrawals.
+        let mut total_restored = 0u64;
+        for (portal_slot, withdrawals) in resolved {
+            let count = withdrawals.len();
+            store.lock().add_batch(portal_slot, withdrawals);
+            info!(
+                portal_slot,
+                count, "Restored withdrawals for portal queue slot"
+            );
+            total_restored += count as u64;
         }
 
         Ok(total_restored)
-    }
-
-    /// Fetch and verify withdrawals for a single pending L1 portal slot.
-    ///
-    /// Queries `WithdrawalRequested` events from zone L2 blocks `[zone_start, zone_end]`
-    /// and verifies the hash chain against the L1 event.
-    ///
-    /// The head slot requires special handling: the L1 portal processes
-    /// withdrawals one-by-one, updating the slot's on-chain hash after each.
-    /// If the sequencer crashed mid-slot, some withdrawals were already
-    /// processed but `head` hasn't advanced (it only advances when the entire
-    /// slot is consumed). We read the current slot hash from L1 and trim
-    /// already-processed withdrawals so the processor doesn't re-submit them
-    /// (which would fail — the hash chain wouldn't match).
-    /// Non-head slots are always fully unprocessed.
-    async fn restore_slot(
-        &self,
-        slot: u64,
-        is_head_slot: bool,
-        event: &abi::ZonePortal::BatchSubmitted,
-        outbox: &ZoneOutbox::ZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
-        zone_start: u64,
-        zone_end: u64,
-    ) -> Result<Vec<abi::Withdrawal>> {
-        // Fetch WithdrawalRequested events from zone L2.
-        let withdrawals = fetch_slot_withdrawals(outbox, zone_start, zone_end).await?;
-
-        // Verify the hash chain matches the L1 event.
-        if withdrawals.is_empty()
-            || abi::Withdrawal::queue_hash(&withdrawals) != event.withdrawalQueueHash
-        {
-            warn!(
-                slot,
-                zone_start, zone_end, "withdrawal hash mismatch or empty"
-            );
-            return Ok(vec![]);
-        }
-
-        // The head slot may be partially processed — the L1 withdrawal
-        // processor could have consumed some withdrawals before the restart.
-        // Compare against the current on-chain slot hash to find the offset.
-        if is_head_slot {
-            let slot_hash: B256 = self
-                .portal
-                .withdrawalQueueSlot(U256::from(slot % WITHDRAWAL_QUEUE_CAPACITY))
-                .call()
-                .await?;
-            match find_processed_offset(&withdrawals, slot_hash) {
-                Some(offset) => Ok(withdrawals[offset..].to_vec()),
-                None => {
-                    warn!(slot, %slot_hash, "cannot determine processed offset");
-                    Ok(vec![])
-                }
-            }
-        } else {
-            Ok(withdrawals)
-        }
     }
 
     /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find
@@ -655,6 +593,70 @@ impl BatchSubmitter {
 
         Ok(found)
     }
+}
+
+/// Pure function that resolves pre-fetched data into verified withdrawal sets
+/// ready to be stored.
+///
+/// For each pending portal slot in `[head, tail)`:
+/// 1. Skips slots with no `BatchSubmitted` event or no fetched withdrawals.
+/// 2. Verifies the hash chain of fetched withdrawals matches the L1 event's
+///    `withdrawalQueueHash`.
+/// 3. For the head slot, trims already-processed withdrawals using
+///    `head_slot_hash` (the current on-chain slot hash). The L1 portal
+///    processes withdrawals one-by-one, updating the slot hash after each.
+///    If the sequencer crashed mid-slot, some are already consumed but `head`
+///    hasn't advanced yet.
+/// 4. Non-head slots are always fully unprocessed.
+///
+/// Returns a map of portal_slot → verified withdrawals to store.
+fn resolve_pending_slots(
+    head: u64,
+    tail: u64,
+    events: &BTreeMap<u64, abi::ZonePortal::BatchSubmitted>,
+    slot_withdrawals: &BTreeMap<u64, Vec<abi::Withdrawal>>,
+    head_slot_hash: B256,
+) -> BTreeMap<u64, Vec<abi::Withdrawal>> {
+    let mut result: BTreeMap<u64, Vec<abi::Withdrawal>> = BTreeMap::new();
+
+    for portal_slot in head..tail {
+        let Some(event) = events.get(&portal_slot) else {
+            warn!(
+                portal_slot,
+                "no BatchSubmitted event found for pending portal slot"
+            );
+            continue;
+        };
+
+        let Some(withdrawals) = slot_withdrawals.get(&portal_slot) else {
+            continue;
+        };
+
+        if withdrawals.is_empty()
+            || abi::Withdrawal::queue_hash(withdrawals) != event.withdrawalQueueHash
+        {
+            warn!(portal_slot, "withdrawal hash mismatch or empty");
+            continue;
+        }
+
+        if portal_slot == head {
+            match find_processed_offset(withdrawals, head_slot_hash) {
+                Some(offset) => {
+                    let remaining = withdrawals[offset..].to_vec();
+                    if !remaining.is_empty() {
+                        result.insert(portal_slot, remaining);
+                    }
+                }
+                None => {
+                    warn!(portal_slot, %head_slot_hash, "cannot determine processed offset");
+                }
+            }
+        } else {
+            result.insert(portal_slot, withdrawals.clone());
+        }
+    }
+
+    result
 }
 
 /// Find the offset into `withdrawals` where the remaining hash chain matches
@@ -859,5 +861,133 @@ mod tests {
         let withdrawals = vec![w0, w1, w2];
         let hash = abi::Withdrawal::queue_hash(&withdrawals[2..]);
         assert_eq!(find_processed_offset(&withdrawals, hash), Some(2));
+    }
+
+    fn test_batch_event(withdrawal_queue_hash: B256) -> abi::ZonePortal::BatchSubmitted {
+        abi::ZonePortal::BatchSubmitted {
+            withdrawalBatchIndex: 0,
+            nextProcessedDepositQueueHash: B256::ZERO,
+            nextBlockHash: B256::ZERO,
+            withdrawalQueueHash: withdrawal_queue_hash,
+        }
+    }
+
+    #[test]
+    fn resolve_empty_range() {
+        let result = resolve_pending_slots(5, 5, &BTreeMap::new(), &BTreeMap::new(), B256::ZERO);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_single_slot_unprocessed() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
+        let withdrawals = vec![w0, w1];
+        let full_hash = abi::Withdrawal::queue_hash(&withdrawals);
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(full_hash));
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, withdrawals);
+
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, full_hash);
+        let returned = result.get(&5).unwrap();
+        assert_eq!(returned.len(), 2);
+        assert_eq!(abi::Withdrawal::queue_hash(returned), full_hash);
+    }
+
+    #[test]
+    fn resolve_single_slot_partially_processed() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
+        let w2 = test_withdrawal(address!("0x0000000000000000000000000000000000000003"), 300);
+        let withdrawals = vec![w0, w1, w2];
+        let full_hash = abi::Withdrawal::queue_hash(&withdrawals);
+        // head_slot_hash reflects that w0 has been processed (hash of remaining [w1, w2])
+        let head_slot_hash = abi::Withdrawal::queue_hash(&withdrawals[1..]);
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(full_hash));
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, withdrawals);
+
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, head_slot_hash);
+        let returned = result.get(&5).unwrap();
+        assert_eq!(returned.len(), 2);
+        assert_eq!(abi::Withdrawal::queue_hash(returned), head_slot_hash);
+    }
+
+    #[test]
+    fn resolve_single_slot_fully_processed() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let withdrawals = vec![w0];
+        let full_hash = abi::Withdrawal::queue_hash(&withdrawals);
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(full_hash));
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, withdrawals);
+
+        // B256::ZERO means all consumed; find_processed_offset returns None
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_multiple_slots() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
+        let w2 = test_withdrawal(address!("0x0000000000000000000000000000000000000003"), 300);
+
+        let head_withdrawals = vec![w0];
+        let tail_withdrawals = vec![w1, w2];
+
+        let head_hash = abi::Withdrawal::queue_hash(&head_withdrawals);
+        let tail_hash = abi::Withdrawal::queue_hash(&tail_withdrawals);
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(head_hash));
+        events.insert(6, test_batch_event(tail_hash));
+
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, head_withdrawals);
+        slot_withdrawals.insert(6, tail_withdrawals);
+
+        // head slot fully unprocessed (head_slot_hash == full hash of slot 5)
+        let result = resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_hash);
+        let slot5 = result.get(&5).unwrap();
+        let slot6 = result.get(&6).unwrap();
+        assert_eq!(slot5.len(), 1);
+        assert_eq!(slot6.len(), 2);
+        assert_eq!(abi::Withdrawal::queue_hash(slot5), head_hash);
+        assert_eq!(abi::Withdrawal::queue_hash(slot6), tail_hash);
+    }
+
+    #[test]
+    fn resolve_hash_mismatch_skipped() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let withdrawals = vec![w0];
+        let wrong_hash = B256::from([0xabu8; 32]);
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(wrong_hash));
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, withdrawals);
+
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_missing_event_skipped() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let withdrawals = vec![w0];
+
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, withdrawals);
+
+        // No event for slot 5
+        let result = resolve_pending_slots(5, 6, &BTreeMap::new(), &slot_withdrawals, B256::ZERO);
+        assert!(result.is_empty());
     }
 }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -527,10 +527,7 @@ impl BatchSubmitter {
 
             if !withdrawals.is_empty() {
                 let count = withdrawals.len();
-                let mut guard = store.lock();
-                for w in &withdrawals {
-                    guard.add_withdrawal(slot, w.clone());
-                }
+                store.lock().add_batch(slot, withdrawals);
                 info!(slot, count, "Restored withdrawals for portal queue slot");
                 total_restored += count as u64;
             }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -504,13 +504,16 @@ impl BatchSubmitter {
                 continue;
             }
             let zone_end = zone_end_by_slot[&portal_slot];
-            let zone_start = if portal_slot > 0 {
-                zone_end_by_slot
-                    .get(&(portal_slot - 1))
-                    .map(|n| n + 1)
-                    .unwrap_or(1)
-            } else {
+            let zone_start = if portal_slot == 0 {
                 1
+            } else if let Some(prev_end) = zone_end_by_slot.get(&(portal_slot - 1)) {
+                prev_end + 1
+            } else {
+                warn!(
+                    portal_slot,
+                    "predecessor event missing, cannot determine zone block range start"
+                );
+                continue;
             };
             let withdrawals = fetch_slot_withdrawals(&outbox, zone_start, zone_end).await?;
             slot_withdrawals.insert(portal_slot, withdrawals);
@@ -548,7 +551,9 @@ impl BatchSubmitter {
     /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find
     /// `BatchSubmitted` events for portal slots `[head, tail)` plus the
     /// predecessor slot `head - 1` (used to determine the zone L2 block
-    /// range start of the first slot).
+    /// range start of the first pending slot). When `head == 0` the
+    /// predecessor does not exist and is omitted; the caller falls back to
+    /// zone block 1.
     ///
     /// Portal queue slots are assigned by position: the n-th non-zero-hash
     /// `BatchSubmitted` event (0-indexed, chronologically) corresponds to
@@ -1071,6 +1076,37 @@ mod tests {
         slot_withdrawals.insert(5, vec![]);
 
         let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_missing_withdrawals_data_skipped() {
+        let w = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let hash = abi::Withdrawal::queue_hash(std::slice::from_ref(&w));
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(hash));
+        // slot_withdrawals has no entry for slot 5
+        let slot_withdrawals = BTreeMap::new();
+
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, hash);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_head_slot_corrupted_hash_skipped() {
+        let w = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let withdrawals = vec![w];
+        let full_hash = abi::Withdrawal::queue_hash(&withdrawals);
+        // head_slot_hash doesn't match any tail of the withdrawal list
+        let corrupted_hash = B256::from([0xdeu8; 32]);
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(full_hash));
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, withdrawals);
+
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, corrupted_hash);
         assert!(result.is_empty());
     }
 }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -487,7 +487,10 @@ impl BatchSubmitter {
                 .get_block_by_hash(event.nextBlockHash)
                 .await?
                 .ok_or_else(|| {
-                    eyre::eyre!("zone block not found for hash {} (L1 slot {slot})", event.nextBlockHash)
+                    eyre::eyre!(
+                        "zone block not found for hash {} (L1 slot {slot})",
+                        event.nextBlockHash
+                    )
                 })?;
             zone_blocks.insert(slot, block.number());
         }
@@ -506,59 +509,98 @@ impl BatchSubmitter {
                 continue;
             };
 
+            // Zone L2 block range: from the previous slot's end + 1 to this
+            // slot's end. May be wider than the exact batch when non-withdrawal
+            // batches exist in between, but those blocks have no
+            // WithdrawalRequested events so the result is the same.
             let zone_end = zone_blocks[&slot];
-            // Previous slot's zone_end + 1. May be wider than the exact batch
-            // range when non-withdrawal batches exist in between, but those
-            // zone blocks have no WithdrawalRequested events so the result is
-            // the same.
             let zone_start = if slot > 0 {
                 zone_blocks.get(&(slot - 1)).map(|n| n + 1).unwrap_or(1)
             } else {
                 1
             };
 
-            let withdrawals = fetch_slot_withdrawals(&outbox, zone_start, zone_end).await?;
-
-            if withdrawals.is_empty()
-                || abi::Withdrawal::queue_hash(&withdrawals) != event.withdrawalQueueHash
-            {
-                warn!(
+            let is_head_slot = slot == head;
+            let restored = self
+                .restore_slot(
                     slot,
-                    zone_start, zone_end, "withdrawal hash mismatch or empty"
-                );
-                continue;
-            }
-
-            // For the head slot, trim already-processed withdrawals.
-            let to_store = if slot == head {
-                let slot_hash: B256 = self
-                    .portal
-                    .withdrawalQueueSlot(U256::from(slot % WITHDRAWAL_QUEUE_CAPACITY))
-                    .call()
-                    .await?;
-                match find_processed_offset(&withdrawals, slot_hash) {
-                    Some(offset) => &withdrawals[offset..],
-                    None => {
-                        warn!(slot, %slot_hash, "cannot determine processed offset");
-                        continue;
-                    }
-                }
-            } else {
-                &withdrawals[..]
-            };
-
-            if !to_store.is_empty() {
-                let count = to_store.len();
-                let mut guard = store.lock();
-                for w in to_store {
-                    guard.add_withdrawal(slot, w.clone());
-                }
-                info!(slot, count, "Restored withdrawals for portal queue slot");
-                total_restored += count as u64;
-            }
+                    is_head_slot,
+                    event,
+                    &outbox,
+                    zone_start,
+                    zone_end,
+                    store,
+                )
+                .await?;
+            total_restored += restored;
         }
 
         Ok(total_restored)
+    }
+
+    /// Fetch, verify, and store withdrawals for a single pending L1 portal slot.
+    ///
+    /// Queries `WithdrawalRequested` events from zone L2 blocks `[zone_start, zone_end]`,
+    /// verifies the hash chain against the L1 event, and stores the withdrawal structs.
+    /// For the head slot, already-processed withdrawals are trimmed by comparing
+    /// against the current on-chain slot hash.
+    ///
+    /// Returns the number of withdrawals stored.
+    async fn restore_slot(
+        &self,
+        slot: u64,
+        is_head_slot: bool,
+        event: &abi::ZonePortal::BatchSubmitted,
+        outbox: &ZoneOutbox::ZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
+        zone_start: u64,
+        zone_end: u64,
+        store: &SharedWithdrawalStore,
+    ) -> Result<u64> {
+        // Fetch WithdrawalRequested events from zone L2.
+        let withdrawals = fetch_slot_withdrawals(outbox, zone_start, zone_end).await?;
+
+        // Verify the hash chain matches the L1 event.
+        if withdrawals.is_empty()
+            || abi::Withdrawal::queue_hash(&withdrawals) != event.withdrawalQueueHash
+        {
+            warn!(
+                slot,
+                zone_start, zone_end, "withdrawal hash mismatch or empty"
+            );
+            return Ok(0);
+        }
+
+        // The head slot may be partially processed — the L1 withdrawal
+        // processor could have consumed some withdrawals before the restart.
+        // Compare against the current on-chain slot hash to find the offset.
+        let to_store = if is_head_slot {
+            let slot_hash: B256 = self
+                .portal
+                .withdrawalQueueSlot(U256::from(slot % WITHDRAWAL_QUEUE_CAPACITY))
+                .call()
+                .await?;
+            match find_processed_offset(&withdrawals, slot_hash) {
+                Some(offset) => &withdrawals[offset..],
+                None => {
+                    warn!(slot, %slot_hash, "cannot determine processed offset");
+                    return Ok(0);
+                }
+            }
+        } else {
+            &withdrawals[..]
+        };
+
+        if !to_store.is_empty() {
+            let count = to_store.len();
+            let mut guard = store.lock();
+            for w in to_store {
+                guard.add_withdrawal(slot, w.clone());
+            }
+            info!(slot, count, "Restored withdrawals for portal queue slot");
+            return Ok(count as u64);
+        }
+
+        Ok(0)
     }
 
     /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -462,6 +462,7 @@ impl BatchSubmitter {
         outbox_address: Address,
         store: &SharedWithdrawalStore,
     ) -> Result<u64> {
+        // Step 1: read pending slot range from the L1 portal.
         let (head, tail) = tokio::try_join!(
             self.read_portal_withdrawal_queue_head(),
             self.read_portal_withdrawal_queue_tail(),

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -481,18 +481,19 @@ impl BatchSubmitter {
         let events = self.find_batch_events_backwards(l1_tip, head, tail).await?;
 
         // Step 3: resolve each L1 event's nextBlockHash to a zone L2 block number.
-        let mut zone_blocks: BTreeMap<u64, u64> = BTreeMap::new();
-        for (&slot, event) in &events {
+        // Maps portal_slot → last zone L2 block in that batch.
+        let mut zone_end_by_slot: BTreeMap<u64, u64> = BTreeMap::new();
+        for (&portal_slot, event) in &events {
             let block = zone_provider
                 .get_block_by_hash(event.nextBlockHash)
                 .await?
                 .ok_or_else(|| {
                     eyre::eyre!(
-                        "zone block not found for hash {} (L1 slot {slot})",
+                        "zone block not found for hash {} (portal slot {portal_slot})",
                         event.nextBlockHash
                     )
                 })?;
-            zone_blocks.insert(slot, block.number());
+            zone_end_by_slot.insert(portal_slot, block.number());
         }
 
         let outbox = ZoneOutbox::new(outbox_address, zone_provider.clone());
@@ -500,10 +501,10 @@ impl BatchSubmitter {
 
         // Steps 4+5: for each pending L1 portal queue slot, fetch the
         // WithdrawalRequested events from zone L2, verify, and store.
-        for l1_slot in head..tail {
-            let Some(event) = events.get(&l1_slot) else {
+        for portal_slot in head..tail {
+            let Some(event) = events.get(&portal_slot) else {
                 warn!(
-                    l1_slot,
+                    portal_slot,
                     "no BatchSubmitted event found for pending portal slot"
                 );
                 continue;
@@ -513,22 +514,35 @@ impl BatchSubmitter {
             // slot's end. May be wider than the exact batch when non-withdrawal
             // batches exist in between, but those blocks have no
             // WithdrawalRequested events so the result is the same.
-            let zone_end = zone_blocks[&l1_slot];
-            let zone_start = if l1_slot > 0 {
-                zone_blocks.get(&(l1_slot - 1)).map(|n| n + 1).unwrap_or(1)
+            let zone_end = zone_end_by_slot[&portal_slot];
+            let zone_start = if portal_slot > 0 {
+                zone_end_by_slot
+                    .get(&(portal_slot - 1))
+                    .map(|n| n + 1)
+                    .unwrap_or(1)
             } else {
                 1
             };
 
-            let is_head_slot = l1_slot == head;
+            let is_head_slot = portal_slot == head;
             let withdrawals = self
-                .restore_slot(l1_slot, is_head_slot, event, &outbox, zone_start, zone_end)
+                .restore_slot(
+                    portal_slot,
+                    is_head_slot,
+                    event,
+                    &outbox,
+                    zone_start,
+                    zone_end,
+                )
                 .await?;
 
             if !withdrawals.is_empty() {
                 let count = withdrawals.len();
-                store.lock().add_batch(l1_slot, withdrawals);
-                info!(l1_slot, count, "Restored withdrawals for portal queue slot");
+                store.lock().add_batch(portal_slot, withdrawals);
+                info!(
+                    portal_slot,
+                    count, "Restored withdrawals for portal queue slot"
+                );
                 total_restored += count as u64;
             }
         }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -538,18 +538,15 @@ impl BatchSubmitter {
         if head2 != head || tail2 != tail {
             eyre::bail!(
                 "withdrawal queue changed during restore ({}..{} -> {}..{}), retry on next startup",
-                head, tail, head2, tail2
+                head,
+                tail,
+                head2,
+                tail2
             );
         }
 
         // Step 6: resolve all fetched data into verified withdrawal sets.
-        resolve_pending_slots(
-            head,
-            tail,
-            &events,
-            &slot_withdrawals,
-            head_slot_hash,
-        )
+        resolve_pending_slots(head, tail, &events, &slot_withdrawals, head_slot_hash)
     }
 
     /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find
@@ -913,7 +910,8 @@ mod tests {
 
     #[test]
     fn resolve_empty_range() {
-        let result = resolve_pending_slots(5, 5, &BTreeMap::new(), &BTreeMap::new(), B256::ZERO).unwrap();
+        let result =
+            resolve_pending_slots(5, 5, &BTreeMap::new(), &BTreeMap::new(), B256::ZERO).unwrap();
         assert!(result.is_empty());
     }
 
@@ -950,7 +948,8 @@ mod tests {
         let mut slot_withdrawals = BTreeMap::new();
         slot_withdrawals.insert(5, withdrawals);
 
-        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, head_slot_hash).unwrap();
+        let result =
+            resolve_pending_slots(5, 6, &events, &slot_withdrawals, head_slot_hash).unwrap();
         let returned = result.get(&5).unwrap();
         assert_eq!(returned.len(), 2);
         assert_eq!(abi::Withdrawal::queue_hash(returned), head_slot_hash);
@@ -1053,7 +1052,8 @@ mod tests {
         slot_withdrawals.insert(5, head_withdrawals);
         slot_withdrawals.insert(6, non_head_withdrawals);
 
-        let result = resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_slot_hash).unwrap();
+        let result =
+            resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_slot_hash).unwrap();
         // Head slot trimmed to 1 remaining withdrawal
         assert_eq!(result.get(&5).unwrap().len(), 1);
         assert_eq!(

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -529,14 +529,27 @@ impl BatchSubmitter {
             .call()
             .await?;
 
+        // Guard: verify the queue didn't change during the multi-RPC replay.
+        let (head2, tail2) = tokio::try_join!(
+            self.read_portal_withdrawal_queue_head(),
+            self.read_portal_withdrawal_queue_tail(),
+        )?;
+
+        if head2 != head || tail2 != tail {
+            eyre::bail!(
+                "withdrawal queue changed during restore ({}..{} -> {}..{}), retry on next startup",
+                head, tail, head2, tail2
+            );
+        }
+
         // Step 6: resolve all fetched data into verified withdrawal sets.
-        Ok(resolve_pending_slots(
+        resolve_pending_slots(
             head,
             tail,
             &events,
             &slot_withdrawals,
             head_slot_hash,
-        ))
+        )
     }
 
     /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find
@@ -605,6 +618,12 @@ impl BatchSubmitter {
 
         // Assign portal slots: if we found M events total, the last M
         // correspond to slots [tail - M, tail). Keep only [start, tail).
+        // Truncate to at most `needed` events (the most recent ones) to
+        // guard against extra events from race conditions.
+        if all_events.len() > needed {
+            all_events.drain(..all_events.len() - needed);
+        }
+
         let mut found = BTreeMap::new();
         let first_slot = tail.saturating_sub(all_events.len() as u64);
         for (i, event) in all_events.into_iter().enumerate() {
@@ -639,31 +658,22 @@ fn resolve_pending_slots(
     events: &BTreeMap<u64, abi::ZonePortal::BatchSubmitted>,
     slot_withdrawals: &BTreeMap<u64, Vec<abi::Withdrawal>>,
     head_slot_hash: B256,
-) -> BTreeMap<u64, Vec<abi::Withdrawal>> {
+) -> Result<BTreeMap<u64, Vec<abi::Withdrawal>>> {
     let mut result: BTreeMap<u64, Vec<abi::Withdrawal>> = BTreeMap::new();
 
     for portal_slot in head..tail {
         let Some(event) = events.get(&portal_slot) else {
-            warn!(
-                portal_slot,
-                "no BatchSubmitted event found for pending portal slot"
-            );
-            continue;
+            eyre::bail!("no BatchSubmitted event found for pending portal slot {portal_slot}");
         };
 
         let Some(withdrawals) = slot_withdrawals.get(&portal_slot) else {
-            warn!(
-                portal_slot,
-                "no withdrawal data fetched for pending portal slot"
-            );
-            continue;
+            eyre::bail!("no withdrawal data fetched for pending portal slot {portal_slot}");
         };
 
         if withdrawals.is_empty()
             || abi::Withdrawal::queue_hash(withdrawals) != event.withdrawalQueueHash
         {
-            warn!(portal_slot, "withdrawal hash mismatch or empty");
-            continue;
+            eyre::bail!("withdrawal hash mismatch or empty for portal slot {portal_slot}");
         }
 
         if portal_slot == head {
@@ -675,7 +685,7 @@ fn resolve_pending_slots(
                     }
                 }
                 None => {
-                    warn!(portal_slot, %head_slot_hash, "cannot determine processed offset for head slot — slot may be fully consumed or hash chain corrupted");
+                    eyre::bail!("cannot determine processed offset for head slot {portal_slot}");
                 }
             }
         } else {
@@ -683,7 +693,7 @@ fn resolve_pending_slots(
         }
     }
 
-    result
+    Ok(result)
 }
 
 /// Find the offset into `withdrawals` where the remaining hash chain matches
@@ -903,7 +913,7 @@ mod tests {
 
     #[test]
     fn resolve_empty_range() {
-        let result = resolve_pending_slots(5, 5, &BTreeMap::new(), &BTreeMap::new(), B256::ZERO);
+        let result = resolve_pending_slots(5, 5, &BTreeMap::new(), &BTreeMap::new(), B256::ZERO).unwrap();
         assert!(result.is_empty());
     }
 
@@ -919,7 +929,7 @@ mod tests {
         let mut slot_withdrawals = BTreeMap::new();
         slot_withdrawals.insert(5, withdrawals);
 
-        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, full_hash);
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, full_hash).unwrap();
         let returned = result.get(&5).unwrap();
         assert_eq!(returned.len(), 2);
         assert_eq!(abi::Withdrawal::queue_hash(returned), full_hash);
@@ -940,7 +950,7 @@ mod tests {
         let mut slot_withdrawals = BTreeMap::new();
         slot_withdrawals.insert(5, withdrawals);
 
-        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, head_slot_hash);
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, head_slot_hash).unwrap();
         let returned = result.get(&5).unwrap();
         assert_eq!(returned.len(), 2);
         assert_eq!(abi::Withdrawal::queue_hash(returned), head_slot_hash);
@@ -959,7 +969,7 @@ mod tests {
 
         // B256::ZERO = queue_hash(&[]), all consumed. find_processed_offset returns
         // Some(1) (offset == len), so remaining is empty and slot is not stored.
-        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO).unwrap();
         assert!(result.is_empty());
     }
 
@@ -984,7 +994,7 @@ mod tests {
         slot_withdrawals.insert(6, tail_withdrawals);
 
         // head slot fully unprocessed (head_slot_hash == full hash of slot 5)
-        let result = resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_hash);
+        let result = resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_hash).unwrap();
         let slot5 = result.get(&5).unwrap();
         let slot6 = result.get(&6).unwrap();
         assert_eq!(slot5.len(), 1);
@@ -1005,7 +1015,7 @@ mod tests {
         slot_withdrawals.insert(5, withdrawals);
 
         let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
-        assert!(result.is_empty());
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1018,7 +1028,7 @@ mod tests {
 
         // No event for slot 5
         let result = resolve_pending_slots(5, 6, &BTreeMap::new(), &slot_withdrawals, B256::ZERO);
-        assert!(result.is_empty());
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1043,7 +1053,7 @@ mod tests {
         slot_withdrawals.insert(5, head_withdrawals);
         slot_withdrawals.insert(6, non_head_withdrawals);
 
-        let result = resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_slot_hash);
+        let result = resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_slot_hash).unwrap();
         // Head slot trimmed to 1 remaining withdrawal
         assert_eq!(result.get(&5).unwrap().len(), 1);
         assert_eq!(
@@ -1067,7 +1077,7 @@ mod tests {
         slot_withdrawals.insert(5, vec![]);
 
         let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
-        assert!(result.is_empty());
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1081,7 +1091,7 @@ mod tests {
         let slot_withdrawals = BTreeMap::new();
 
         let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, hash);
-        assert!(result.is_empty());
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1098,6 +1108,6 @@ mod tests {
         slot_withdrawals.insert(5, withdrawals);
 
         let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, corrupted_hash);
-        assert!(result.is_empty());
+        assert!(result.is_err());
     }
 }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -500,10 +500,10 @@ impl BatchSubmitter {
 
         // Steps 4+5: for each pending L1 portal queue slot, fetch the
         // WithdrawalRequested events from zone L2, verify, and store.
-        for slot in head..tail {
-            let Some(event) = events.get(&slot) else {
+        for l1_slot in head..tail {
+            let Some(event) = events.get(&l1_slot) else {
                 warn!(
-                    slot,
+                    l1_slot,
                     "no BatchSubmitted event found for pending portal slot"
                 );
                 continue;
@@ -513,22 +513,22 @@ impl BatchSubmitter {
             // slot's end. May be wider than the exact batch when non-withdrawal
             // batches exist in between, but those blocks have no
             // WithdrawalRequested events so the result is the same.
-            let zone_end = zone_blocks[&slot];
-            let zone_start = if slot > 0 {
-                zone_blocks.get(&(slot - 1)).map(|n| n + 1).unwrap_or(1)
+            let zone_end = zone_blocks[&l1_slot];
+            let zone_start = if l1_slot > 0 {
+                zone_blocks.get(&(l1_slot - 1)).map(|n| n + 1).unwrap_or(1)
             } else {
                 1
             };
 
-            let is_head_slot = slot == head;
+            let is_head_slot = l1_slot == head;
             let withdrawals = self
-                .restore_slot(slot, is_head_slot, event, &outbox, zone_start, zone_end)
+                .restore_slot(l1_slot, is_head_slot, event, &outbox, zone_start, zone_end)
                 .await?;
 
             if !withdrawals.is_empty() {
                 let count = withdrawals.len();
-                store.lock().add_batch(slot, withdrawals);
-                info!(slot, count, "Restored withdrawals for portal queue slot");
+                store.lock().add_batch(l1_slot, withdrawals);
+                info!(l1_slot, count, "Restored withdrawals for portal queue slot");
                 total_restored += count as u64;
             }
         }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -542,9 +542,16 @@ impl BatchSubmitter {
     /// Fetch and verify withdrawals for a single pending L1 portal slot.
     ///
     /// Queries `WithdrawalRequested` events from zone L2 blocks `[zone_start, zone_end]`
-    /// and verifies the hash chain against the L1 event. For the head slot,
-    /// already-processed withdrawals are trimmed by comparing against the
-    /// current on-chain slot hash.
+    /// and verifies the hash chain against the L1 event.
+    ///
+    /// The head slot requires special handling: the L1 portal processes
+    /// withdrawals one-by-one, updating the slot's on-chain hash after each.
+    /// If the sequencer crashed mid-slot, some withdrawals were already
+    /// processed but `head` hasn't advanced (it only advances when the entire
+    /// slot is consumed). We read the current slot hash from L1 and trim
+    /// already-processed withdrawals so the processor doesn't re-submit them
+    /// (which would fail — the hash chain wouldn't match).
+    /// Non-head slots are always fully unprocessed.
     async fn restore_slot(
         &self,
         slot: u64,

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -28,10 +28,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::{
-    abi::{self, BlockTransition, DepositQueueTransition, ZoneOutbox, ZonePortal},
-    withdrawals::SharedWithdrawalStore,
-};
+use crate::abi::{self, BlockTransition, DepositQueueTransition, ZoneOutbox, ZonePortal};
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::{DynProvider, Provider};
 use alloy_rlp::Encodable;
@@ -452,16 +449,17 @@ impl BatchSubmitter {
     /// 3. Resolving each event's `nextBlockHash` to a **zone L2** block number.
     /// 4. Fetching `WithdrawalRequested` events from the **zone L2** outbox in
     ///    the corresponding block range.
-    /// 5. Verifying the hash chain and storing the withdrawal structs.
+    /// 5. Reading the head slot's current on-chain hash for partial processing
+    ///    detection.
+    /// 6. Verifying the hash chain and trimming already-processed withdrawals.
     ///
-    /// Returns the number of restored withdrawals.
+    /// Returns a map of portal_slot → verified withdrawals ready to be stored.
     #[instrument(skip_all, fields(portal = %self.portal_address))]
-    pub async fn restore_pending_withdrawals(
+    pub async fn fetch_pending_withdrawals(
         &self,
         zone_provider: &DynProvider<TempoNetwork>,
         outbox_address: Address,
-        store: &SharedWithdrawalStore,
-    ) -> Result<u64> {
+    ) -> Result<BTreeMap<u64, Vec<abi::Withdrawal>>> {
         // Step 1: read pending slot range from the L1 portal.
         let (head, tail) = tokio::try_join!(
             self.read_portal_withdrawal_queue_head(),
@@ -470,7 +468,7 @@ impl BatchSubmitter {
 
         if head >= tail {
             info!(head, tail, "No pending withdrawals to restore");
-            return Ok(0);
+            return Ok(BTreeMap::new());
         }
 
         info!(
@@ -525,32 +523,20 @@ impl BatchSubmitter {
         }
 
         // Step 5: read the head slot's current on-chain hash (for partial processing detection).
-        let head_slot_hash = if head < tail {
-            self.portal
-                .withdrawalQueueSlot(U256::from(head % WITHDRAWAL_QUEUE_CAPACITY))
-                .call()
-                .await?
-        } else {
-            B256::ZERO
-        };
+        let head_slot_hash = self
+            .portal
+            .withdrawalQueueSlot(U256::from(head % WITHDRAWAL_QUEUE_CAPACITY))
+            .call()
+            .await?;
 
         // Step 6: resolve all fetched data into verified withdrawal sets.
-        let resolved =
-            resolve_pending_slots(head, tail, &events, &slot_withdrawals, head_slot_hash);
-
-        // Step 7: store the resolved withdrawals.
-        let mut total_restored = 0u64;
-        for (portal_slot, withdrawals) in resolved {
-            let count = withdrawals.len();
-            store.lock().add_batch(portal_slot, withdrawals);
-            info!(
-                portal_slot,
-                count, "Restored withdrawals for portal queue slot"
-            );
-            total_restored += count as u64;
-        }
-
-        Ok(total_restored)
+        Ok(resolve_pending_slots(
+            head,
+            tail,
+            &events,
+            &slot_withdrawals,
+            head_slot_hash,
+        ))
     }
 
     /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -550,8 +550,17 @@ impl BatchSubmitter {
     /// predecessor slot `head - 1` (used to determine the zone L2 block
     /// range start of the first slot).
     ///
-    /// Stops as soon as all needed events are found — pending slots are
-    /// recent, so the first chunk typically covers them all.
+    /// Portal queue slots are assigned by position: the n-th non-zero-hash
+    /// `BatchSubmitted` event (0-indexed, chronologically) corresponds to
+    /// portal queue slot n. This is because the L1 portal increments
+    /// `withdrawalBatchIndex` on every `submitBatch` call, but only advances
+    /// the withdrawal queue `tail` for batches with non-zero
+    /// `withdrawalQueueHash`. The two counters diverge whenever a batch has
+    /// no withdrawals, so we cannot use `withdrawalBatchIndex` as the slot
+    /// index.
+    ///
+    /// Stops as soon as enough events are found — pending slots are recent,
+    /// so the first chunk typically covers them all.
     async fn find_batch_events_backwards(
         &self,
         l1_tip: u64,
@@ -560,35 +569,53 @@ impl BatchSubmitter {
     ) -> Result<BTreeMap<u64, abi::ZonePortal::BatchSubmitted>> {
         let start = head.saturating_sub(1);
         let needed = (tail - start) as usize;
-        let mut found: BTreeMap<u64, abi::ZonePortal::BatchSubmitted> = BTreeMap::new();
+        if needed == 0 {
+            return Ok(BTreeMap::new());
+        }
+
+        let mut all_events: Vec<abi::ZonePortal::BatchSubmitted> = Vec::new();
         let mut hi = l1_tip;
 
-        while found.len() < needed && hi >= self.genesis_tempo_block_number {
+        while hi >= self.genesis_tempo_block_number {
             let lo = hi
                 .saturating_sub(10_000)
                 .max(self.genesis_tempo_block_number);
 
-            for (event, _) in self
+            let chunk: Vec<_> = self
                 .portal
                 .BatchSubmitted_filter()
                 .from_block(lo)
                 .to_block(hi)
                 .query()
                 .await?
-            {
-                if event.withdrawalQueueHash.is_zero() {
-                    continue;
-                }
-                let idx = event.withdrawalBatchIndex;
-                if idx >= start && idx < tail {
-                    found.insert(idx, event);
-                }
-            }
+                .into_iter()
+                .filter(|(event, _)| !event.withdrawalQueueHash.is_zero())
+                .map(|(event, _)| event)
+                .collect();
 
+            all_events.extend(chunk);
+
+            if all_events.len() >= needed {
+                break;
+            }
             if lo == self.genesis_tempo_block_number {
                 break;
             }
             hi = lo - 1;
+        }
+
+        // Sort chronologically — the n-th event = portal queue slot n.
+        all_events.sort_by_key(|e| e.withdrawalBatchIndex);
+
+        // Assign portal slots: if we found M events total, the last M
+        // correspond to slots [tail - M, tail). Keep only [start, tail).
+        let mut found = BTreeMap::new();
+        let first_slot = tail.saturating_sub(all_events.len() as u64);
+        for (i, event) in all_events.into_iter().enumerate() {
+            let portal_slot = first_slot + i as u64;
+            if portal_slot >= start && portal_slot < tail {
+                found.insert(portal_slot, event);
+            }
         }
 
         Ok(found)
@@ -629,6 +656,10 @@ fn resolve_pending_slots(
         };
 
         let Some(withdrawals) = slot_withdrawals.get(&portal_slot) else {
+            warn!(
+                portal_slot,
+                "no withdrawal data fetched for pending portal slot"
+            );
             continue;
         };
 
@@ -648,7 +679,7 @@ fn resolve_pending_slots(
                     }
                 }
                 None => {
-                    warn!(portal_slot, %head_slot_hash, "cannot determine processed offset");
+                    warn!(portal_slot, %head_slot_hash, "cannot determine processed offset for head slot — slot may be fully consumed or hash chain corrupted");
                 }
             }
         } else {
@@ -661,12 +692,15 @@ fn resolve_pending_slots(
 
 /// Find the offset into `withdrawals` where the remaining hash chain matches
 /// `current_slot_hash`. Returns `Some(0)` if no withdrawals have been processed,
-/// `Some(n)` if n have been processed, or `None` if no match is found.
+/// `Some(n)` if n have been processed (n remaining), or `None` if no match is
+/// found.
+///
+/// Also checks `offset == len` (all consumed, hash chain = `B256::ZERO`).
 fn find_processed_offset(
     withdrawals: &[abi::Withdrawal],
     current_slot_hash: B256,
 ) -> Option<usize> {
-    for offset in 0..withdrawals.len() {
+    for offset in 0..=withdrawals.len() {
         let hash = abi::Withdrawal::queue_hash(&withdrawals[offset..]);
         if hash == current_slot_hash {
             return Some(offset);
@@ -832,9 +866,8 @@ mod tests {
     fn find_offset_all_processed() {
         let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
         let withdrawals = vec![w0];
-        // B256::ZERO matches an empty slice, but the loop only checks offsets 0..len,
-        // so offset == len (the empty tail) is never tested.
-        assert_eq!(find_processed_offset(&withdrawals, B256::ZERO), None);
+        // B256::ZERO = queue_hash(&[]), meaning all withdrawals have been consumed.
+        assert_eq!(find_processed_offset(&withdrawals, B256::ZERO), Some(1));
     }
 
     #[test]
@@ -928,7 +961,8 @@ mod tests {
         let mut slot_withdrawals = BTreeMap::new();
         slot_withdrawals.insert(5, withdrawals);
 
-        // B256::ZERO means all consumed; find_processed_offset returns None
+        // B256::ZERO = queue_hash(&[]), all consumed. find_processed_offset returns
+        // Some(1) (offset == len), so remaining is empty and slot is not stored.
         let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
         assert!(result.is_empty());
     }
@@ -988,6 +1022,55 @@ mod tests {
 
         // No event for slot 5
         let result = resolve_pending_slots(5, 6, &BTreeMap::new(), &slot_withdrawals, B256::ZERO);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolve_head_partial_with_non_head_slot() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
+        let w2 = test_withdrawal(address!("0x0000000000000000000000000000000000000003"), 300);
+
+        let head_withdrawals = vec![w0, w1];
+        let non_head_withdrawals = vec![w2];
+
+        let head_hash = abi::Withdrawal::queue_hash(&head_withdrawals);
+        let non_head_hash = abi::Withdrawal::queue_hash(&non_head_withdrawals);
+        // w0 already processed, head_slot_hash = hash of [w1] only
+        let head_slot_hash = abi::Withdrawal::queue_hash(&head_withdrawals[1..]);
+
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(head_hash));
+        events.insert(6, test_batch_event(non_head_hash));
+
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, head_withdrawals);
+        slot_withdrawals.insert(6, non_head_withdrawals);
+
+        let result = resolve_pending_slots(5, 7, &events, &slot_withdrawals, head_slot_hash);
+        // Head slot trimmed to 1 remaining withdrawal
+        assert_eq!(result.get(&5).unwrap().len(), 1);
+        assert_eq!(
+            abi::Withdrawal::queue_hash(result.get(&5).unwrap()),
+            head_slot_hash
+        );
+        // Non-head slot fully present
+        assert_eq!(result.get(&6).unwrap().len(), 1);
+        assert_eq!(
+            abi::Withdrawal::queue_hash(result.get(&6).unwrap()),
+            non_head_hash
+        );
+    }
+
+    #[test]
+    fn resolve_empty_withdrawals_vec_skipped() {
+        let mut events = BTreeMap::new();
+        events.insert(5, test_batch_event(B256::from([0x11u8; 32])));
+
+        let mut slot_withdrawals = BTreeMap::new();
+        slot_withdrawals.insert(5, vec![]);
+
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
         assert!(result.is_empty());
     }
 }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -487,7 +487,7 @@ impl BatchSubmitter {
                 .get_block_by_hash(event.nextBlockHash)
                 .await?
                 .ok_or_else(|| {
-                    eyre::eyre!("zone block not found for hash {}", event.nextBlockHash)
+                    eyre::eyre!("zone block not found for hash {} (L1 slot {slot})", event.nextBlockHash)
                 })?;
             zone_blocks.insert(slot, block.number());
         }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -495,6 +495,8 @@ impl BatchSubmitter {
         let outbox = ZoneOutbox::new(outbox_address, zone_provider.clone());
         let mut total_restored = 0u64;
 
+        // Steps 4+5: for each pending L1 portal queue slot, fetch the
+        // WithdrawalRequested events from zone L2, verify, and store.
         for slot in head..tail {
             let Some(event) = events.get(&slot) else {
                 warn!(

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -26,8 +26,13 @@
 //! [`EIP2935_HISTORY_WINDOW`] (e.g. due to timing) by falling back to ancestry
 //! mode — a recent anchor block plus a parent-hash header chain.
 
-use crate::abi::{BlockTransition, DepositQueueTransition, ZonePortal};
-use alloy_primitives::{Address, B256, Bytes};
+use std::collections::BTreeMap;
+
+use crate::{
+    abi::{self, BlockTransition, DepositQueueTransition, ZoneOutbox, ZonePortal},
+    withdrawals::SharedWithdrawalStore,
+};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::{DynProvider, Provider};
 use alloy_rlp::Encodable;
 use eyre::Result;
@@ -432,6 +437,211 @@ impl BatchSubmitter {
         }
         Ok(())
     }
+
+    /// Restore pending withdrawal data into the store by replaying L1 portal
+    /// `BatchSubmitted` events and fetching `WithdrawalRequested` events from
+    /// the zone L2 outbox.
+    ///
+    /// Returns the number of restored withdrawals.
+    #[instrument(skip_all, fields(portal = %self.portal_address))]
+    pub async fn restore_pending_withdrawals(
+        &self,
+        zone_provider: &DynProvider<TempoNetwork>,
+        outbox_address: Address,
+        store: &SharedWithdrawalStore,
+    ) -> Result<u64> {
+        let (head, tail) = tokio::try_join!(
+            self.read_portal_withdrawal_queue_head(),
+            self.read_portal_withdrawal_queue_tail(),
+        )?;
+
+        if head >= tail {
+            return Ok(0);
+        }
+
+        info!(
+            head,
+            tail,
+            pending = tail - head,
+            "Restoring pending withdrawals from zone L2 events"
+        );
+
+        // Fetch all BatchSubmitted events from the portal.
+        let all_batch_events = self
+            .portal
+            .BatchSubmitted_filter()
+            .from_block(0)
+            .query()
+            .await?;
+
+        if all_batch_events.is_empty() {
+            return Ok(0);
+        }
+
+        // Resolve each event's nextBlockHash to a zone block number.
+        let mut zone_end_blocks = Vec::with_capacity(all_batch_events.len());
+        for (event, _) in &all_batch_events {
+            let block = zone_provider
+                .get_block_by_hash(event.nextBlockHash)
+                .await?
+                .ok_or_else(|| {
+                    eyre::eyre!("zone block not found for hash {}", event.nextBlockHash)
+                })?;
+            zone_end_blocks.push(block.number());
+        }
+
+        // Build per-slot info for events with non-zero withdrawalQueueHash.
+        // The j-th such event corresponds to portal slot j.
+        struct SlotInfo {
+            zone_start: u64,
+            zone_end: u64,
+            withdrawal_queue_hash: B256,
+        }
+
+        let mut slot_infos: BTreeMap<u64, SlotInfo> = BTreeMap::new();
+        for (i, (event, _)) in all_batch_events.iter().enumerate() {
+            if event.withdrawalQueueHash.is_zero() {
+                continue;
+            }
+            let zone_start = if i == 0 {
+                1
+            } else {
+                zone_end_blocks[i - 1] + 1
+            };
+            slot_infos.insert(
+                event.withdrawalBatchIndex,
+                SlotInfo {
+                    zone_start,
+                    zone_end: zone_end_blocks[i],
+                    withdrawal_queue_hash: event.withdrawalQueueHash,
+                },
+            );
+        }
+
+        let outbox = ZoneOutbox::new(outbox_address, zone_provider.clone());
+        let mut total_restored = 0u64;
+
+        for slot in head..tail {
+            let Some(info) = slot_infos.get(&slot) else {
+                warn!(
+                    slot,
+                    "no BatchSubmitted event found for pending portal slot"
+                );
+                continue;
+            };
+
+            // Fetch WithdrawalRequested events from zone L2 in the batch's block range.
+            let events = outbox
+                .WithdrawalRequested_filter()
+                .from_block(info.zone_start)
+                .to_block(info.zone_end)
+                .query()
+                .await?;
+
+            // Sort by (block_number, tx_index, log_index) — same pattern as ZoneMonitor::fetch_withdrawals.
+            let mut events_sorted: Vec<_> = events
+                .into_iter()
+                .map(|(event, log)| {
+                    let key = (
+                        log.block_number.unwrap_or(0),
+                        log.transaction_index.unwrap_or(0),
+                        log.log_index.unwrap_or(0),
+                    );
+                    (key, event)
+                })
+                .collect();
+            events_sorted.sort_by_key(|(key, _)| *key);
+
+            let withdrawals: Vec<abi::Withdrawal> = events_sorted
+                .into_iter()
+                .map(|(_, e)| abi::Withdrawal {
+                    token: e.token,
+                    sender: e.sender,
+                    to: e.to,
+                    amount: e.amount,
+                    fee: e.fee,
+                    memo: e.memo,
+                    gasLimit: e.gasLimit,
+                    fallbackRecipient: e.fallbackRecipient,
+                    callbackData: e.data,
+                })
+                .collect();
+
+            if withdrawals.is_empty() {
+                warn!(
+                    slot,
+                    zone_start = info.zone_start,
+                    zone_end = info.zone_end,
+                    "no withdrawal events found for slot with non-zero hash"
+                );
+                continue;
+            }
+
+            // Verify hash chain matches the on-chain value.
+            let computed = abi::Withdrawal::queue_hash(&withdrawals);
+            if computed != info.withdrawal_queue_hash {
+                warn!(
+                    slot,
+                    computed = %computed,
+                    expected = %info.withdrawal_queue_hash,
+                    "withdrawal hash mismatch, skipping slot"
+                );
+                continue;
+            }
+
+            // For the head slot, determine how many withdrawals have already been
+            // processed by comparing against the current on-chain slot hash.
+            let to_store = if slot == head {
+                let slot_hash: B256 = self
+                    .portal
+                    .withdrawalQueueSlot(U256::from(slot % WITHDRAWAL_QUEUE_CAPACITY))
+                    .call()
+                    .await?;
+
+                match find_processed_offset(&withdrawals, slot_hash) {
+                    Some(offset) => &withdrawals[offset..],
+                    None => {
+                        warn!(
+                            slot,
+                            %slot_hash,
+                            "could not determine processed offset for head slot"
+                        );
+                        continue;
+                    }
+                }
+            } else {
+                &withdrawals[..]
+            };
+
+            if !to_store.is_empty() {
+                let count = to_store.len();
+                let mut guard = store.lock();
+                for w in to_store {
+                    guard.add_withdrawal(slot, w.clone());
+                }
+                info!(slot, count, "Restored withdrawals for portal queue slot");
+                total_restored += count as u64;
+            }
+        }
+
+        Ok(total_restored)
+    }
+}
+
+/// Find the offset into `withdrawals` where the remaining hash chain matches
+/// `current_slot_hash`. Returns `Some(0)` if no withdrawals have been processed,
+/// `Some(n)` if n have been processed, or `None` if no match is found.
+fn find_processed_offset(
+    withdrawals: &[abi::Withdrawal],
+    current_slot_hash: B256,
+) -> Option<usize> {
+    for offset in 0..withdrawals.len() {
+        let hash = abi::Withdrawal::queue_hash(&withdrawals[offset..]);
+        if hash == current_slot_hash {
+            return Some(offset);
+        }
+    }
+    None
 }
 
 /// Classification of the EIP-2935 gap, returned by

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -455,14 +455,11 @@ impl BatchSubmitter {
             self.read_portal_withdrawal_queue_head(),
             self.read_portal_withdrawal_queue_tail(),
         )?;
-        if head >= tail {
-            return Ok(0);
-        }
 
         info!(
             head,
             tail,
-            pending = tail - head,
+            pending = tail.saturating_sub(head),
             "Restoring pending withdrawals"
         );
 

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -466,54 +466,98 @@ impl BatchSubmitter {
             "Restoring pending withdrawals from zone L2 events"
         );
 
-        // Fetch all BatchSubmitted events from the portal.
-        let all_batch_events = self
-            .portal
-            .BatchSubmitted_filter()
-            .from_block(0)
-            .query()
-            .await?;
-
-        if all_batch_events.is_empty() {
-            return Ok(0);
-        }
-
-        // Resolve each event's nextBlockHash to a zone block number.
-        let mut zone_end_blocks = Vec::with_capacity(all_batch_events.len());
-        for (event, _) in &all_batch_events {
-            let block = zone_provider
-                .get_block_by_hash(event.nextBlockHash)
-                .await?
-                .ok_or_else(|| {
-                    eyre::eyre!("zone block not found for hash {}", event.nextBlockHash)
-                })?;
-            zone_end_blocks.push(block.number());
-        }
-
-        // Build per-slot info for events with non-zero withdrawalQueueHash.
-        // The j-th such event corresponds to portal slot j.
+        // For each pending slot, fetch its BatchSubmitted event using the
+        // indexed withdrawalBatchIndex — O(1) per slot, no full-chain scan.
+        //
+        // Also fetch the preceding slot (head - 1) to determine where the
+        // first pending batch's zone block range starts.
         struct SlotInfo {
             zone_start: u64,
             zone_end: u64,
             withdrawal_queue_hash: B256,
         }
 
+        let mut zone_ends: BTreeMap<u64, (B256, B256)> = BTreeMap::new(); // slot → (nextBlockHash, withdrawalQueueHash)
+
+        // Fetch the event for head-1 to determine zone_start of the first pending slot.
+        if head > 0
+            && let Some((event, _)) = self
+                .portal
+                .BatchSubmitted_filter()
+                .topic1(U256::from(head - 1))
+                .from_block(self.genesis_tempo_block_number)
+                .query()
+                .await?
+                .into_iter()
+                .next()
+        {
+            zone_ends.insert(head - 1, (event.nextBlockHash, B256::ZERO));
+        }
+
+        for slot in head..tail {
+            let events = self
+                .portal
+                .BatchSubmitted_filter()
+                .topic1(U256::from(slot))
+                .from_block(self.genesis_tempo_block_number)
+                .query()
+                .await?;
+
+            let Some((event, _)) = events.into_iter().next() else {
+                warn!(
+                    slot,
+                    "no BatchSubmitted event found for pending portal slot"
+                );
+                continue;
+            };
+
+            zone_ends.insert(slot, (event.nextBlockHash, event.withdrawalQueueHash));
+        }
+
+        // Resolve nextBlockHash → zone block number for each event.
+        let mut zone_block_numbers: BTreeMap<u64, u64> = BTreeMap::new();
+        for (&slot, &(next_block_hash, _)) in &zone_ends {
+            let block = zone_provider
+                .get_block_by_hash(next_block_hash)
+                .await?
+                .ok_or_else(|| eyre::eyre!("zone block not found for hash {next_block_hash}"))?;
+            zone_block_numbers.insert(slot, block.number());
+        }
+
+        // Build SlotInfo for each pending slot with withdrawals.
+        // zone_start = previous slot's zone_end + 1 (using the wider
+        // withdrawal-bearing slot boundary, which is safe because
+        // non-withdrawal batches in between produce no WithdrawalRequested events).
         let mut slot_infos: BTreeMap<u64, SlotInfo> = BTreeMap::new();
-        for (i, (event, _)) in all_batch_events.iter().enumerate() {
-            if event.withdrawalQueueHash.is_zero() {
+
+        for slot in head..tail {
+            let Some(&(_, withdrawal_queue_hash)) = zone_ends.get(&slot) else {
+                continue;
+            };
+            if withdrawal_queue_hash.is_zero() {
                 continue;
             }
-            let zone_start = if i == 0 {
-                1
+            let zone_end = *zone_block_numbers.get(&slot).expect("resolved above");
+
+            // Use the previous slot's zone_end + 1 as zone_start.
+            // This may be wider than the exact batch range (if non-withdrawal
+            // batches existed in between), but that's correct — those intermediate
+            // zone blocks had no WithdrawalRequested events.
+            let zone_start = if slot > 0 {
+                zone_block_numbers
+                    .get(&(slot - 1))
+                    .map(|n| n + 1)
+                    .unwrap_or(1)
             } else {
-                zone_end_blocks[i - 1] + 1
+                1
             };
+
             slot_infos.insert(
-                event.withdrawalBatchIndex,
+                slot,
                 SlotInfo {
                     zone_start,
-                    zone_end: zone_end_blocks[i],
-                    withdrawal_queue_hash: event.withdrawalQueueHash,
+                    zone_end,
+                    withdrawal_queue_hash,
                 },
             );
         }

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -438,10 +438,21 @@ impl BatchSubmitter {
         Ok(())
     }
 
-    /// Restore pending withdrawal data into the store by walking L1 backwards
-    /// from the chain tip to find `BatchSubmitted` events for pending portal
-    /// slots, then fetching the corresponding `WithdrawalRequested` events
-    /// from zone L2.
+    /// Re-populate the in-memory [`WithdrawalStore`](crate::withdrawals::WithdrawalStore)
+    /// after a sequencer restart.
+    ///
+    /// The L1 portal stores only hash chains, not the actual [`Withdrawal`](abi::Withdrawal)
+    /// structs. This method reconstructs them by:
+    ///
+    /// 1. Reading `withdrawalQueueHead` / `withdrawalQueueTail` from the **L1 portal**
+    ///    to determine which slots are still pending.
+    /// 2. Walking **L1** backwards from the chain tip to find the `BatchSubmitted`
+    ///    event for each pending slot (plus the predecessor for zone block range
+    ///    boundaries).
+    /// 3. Resolving each event's `nextBlockHash` to a **zone L2** block number.
+    /// 4. Fetching `WithdrawalRequested` events from the **zone L2** outbox in
+    ///    the corresponding block range.
+    /// 5. Verifying the hash chain and storing the withdrawal structs.
     ///
     /// Returns the number of restored withdrawals.
     #[instrument(skip_all, fields(portal = %self.portal_address))]
@@ -463,13 +474,12 @@ impl BatchSubmitter {
             "Restoring pending withdrawals"
         );
 
-        // Walk L1 backwards from the tip to find BatchSubmitted events for
-        // pending slots [head, tail) plus the predecessor (head-1) for
-        // determining the zone block start of the first slot.
-        let tip = self.l1_provider.get_block_number().await?;
-        let events = self.find_batch_events_backwards(tip, head, tail).await?;
+        // Step 2: walk L1 backwards from the L1 tip to find BatchSubmitted
+        // events for pending slots [head, tail) plus the predecessor (head-1).
+        let l1_tip = self.l1_provider.get_block_number().await?;
+        let events = self.find_batch_events_backwards(l1_tip, head, tail).await?;
 
-        // Resolve each event's nextBlockHash to a zone block number.
+        // Step 3: resolve each L1 event's nextBlockHash to a zone L2 block number.
         let mut zone_blocks: BTreeMap<u64, u64> = BTreeMap::new();
         for (&slot, event) in &events {
             let block = zone_provider
@@ -548,19 +558,20 @@ impl BatchSubmitter {
         Ok(total_restored)
     }
 
-    /// Walk L1 backwards from `tip` in 10k-block chunks to find
+    /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find
     /// `BatchSubmitted` events for portal slots `[head, tail)` plus the
-    /// predecessor slot `head - 1` (used for zone_start of the first slot).
+    /// predecessor slot `head - 1` (used to determine the zone L2 block
+    /// range start of the first slot).
     async fn find_batch_events_backwards(
         &self,
-        tip: u64,
+        l1_tip: u64,
         head: u64,
         tail: u64,
     ) -> Result<BTreeMap<u64, abi::ZonePortal::BatchSubmitted>> {
         let start = head.saturating_sub(1);
         let needed = (tail - start) as usize;
         let mut found: BTreeMap<u64, abi::ZonePortal::BatchSubmitted> = BTreeMap::new();
-        let mut hi = tip;
+        let mut hi = l1_tip;
 
         while found.len() < needed && hi >= self.genesis_tempo_block_number {
             let lo = hi

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -438,9 +438,10 @@ impl BatchSubmitter {
         Ok(())
     }
 
-    /// Restore pending withdrawal data into the store by replaying L1 portal
-    /// `BatchSubmitted` events and fetching `WithdrawalRequested` events from
-    /// the zone L2 outbox.
+    /// Restore pending withdrawal data into the store by walking L1 backwards
+    /// from the chain tip to find `BatchSubmitted` events for pending portal
+    /// slots, then fetching the corresponding `WithdrawalRequested` events
+    /// from zone L2.
     ///
     /// Returns the number of restored withdrawals.
     #[instrument(skip_all, fields(portal = %self.portal_address))]
@@ -454,7 +455,6 @@ impl BatchSubmitter {
             self.read_portal_withdrawal_queue_head(),
             self.read_portal_withdrawal_queue_tail(),
         )?;
-
         if head >= tail {
             return Ok(0);
         }
@@ -463,110 +463,32 @@ impl BatchSubmitter {
             head,
             tail,
             pending = tail - head,
-            "Restoring pending withdrawals from zone L2 events"
+            "Restoring pending withdrawals"
         );
 
-        // For each pending slot, fetch its BatchSubmitted event using the
-        // indexed withdrawalBatchIndex — O(1) per slot, no full-chain scan.
-        //
-        // Also fetch the preceding slot (head - 1) to determine where the
-        // first pending batch's zone block range starts.
-        struct SlotInfo {
-            zone_start: u64,
-            zone_end: u64,
-            withdrawal_queue_hash: B256,
-        }
+        // Walk L1 backwards from the tip to find BatchSubmitted events for
+        // pending slots [head, tail) plus the predecessor (head-1) for
+        // determining the zone block start of the first slot.
+        let tip = self.l1_provider.get_block_number().await?;
+        let events = self.find_batch_events_backwards(tip, head, tail).await?;
 
-        let mut zone_ends: BTreeMap<u64, (B256, B256)> = BTreeMap::new(); // slot → (nextBlockHash, withdrawalQueueHash)
-
-        // Fetch the event for head-1 to determine zone_start of the first pending slot.
-        if head > 0
-            && let Some((event, _)) = self
-                .portal
-                .BatchSubmitted_filter()
-                .topic1(U256::from(head - 1))
-                .from_block(self.genesis_tempo_block_number)
-                .query()
-                .await?
-                .into_iter()
-                .next()
-        {
-            zone_ends.insert(head - 1, (event.nextBlockHash, B256::ZERO));
-        }
-
-        for slot in head..tail {
-            let events = self
-                .portal
-                .BatchSubmitted_filter()
-                .topic1(U256::from(slot))
-                .from_block(self.genesis_tempo_block_number)
-                .query()
-                .await?;
-
-            let Some((event, _)) = events.into_iter().next() else {
-                warn!(
-                    slot,
-                    "no BatchSubmitted event found for pending portal slot"
-                );
-                continue;
-            };
-
-            zone_ends.insert(slot, (event.nextBlockHash, event.withdrawalQueueHash));
-        }
-
-        // Resolve nextBlockHash → zone block number for each event.
-        let mut zone_block_numbers: BTreeMap<u64, u64> = BTreeMap::new();
-        for (&slot, &(next_block_hash, _)) in &zone_ends {
+        // Resolve each event's nextBlockHash to a zone block number.
+        let mut zone_blocks: BTreeMap<u64, u64> = BTreeMap::new();
+        for (&slot, event) in &events {
             let block = zone_provider
-                .get_block_by_hash(next_block_hash)
+                .get_block_by_hash(event.nextBlockHash)
                 .await?
-                .ok_or_else(|| eyre::eyre!("zone block not found for hash {next_block_hash}"))?;
-            zone_block_numbers.insert(slot, block.number());
-        }
-
-        // Build SlotInfo for each pending slot with withdrawals.
-        // zone_start = previous slot's zone_end + 1 (using the wider
-        // withdrawal-bearing slot boundary, which is safe because
-        // non-withdrawal batches in between produce no WithdrawalRequested events).
-        let mut slot_infos: BTreeMap<u64, SlotInfo> = BTreeMap::new();
-
-        for slot in head..tail {
-            let Some(&(_, withdrawal_queue_hash)) = zone_ends.get(&slot) else {
-                continue;
-            };
-            if withdrawal_queue_hash.is_zero() {
-                continue;
-            }
-            let zone_end = *zone_block_numbers.get(&slot).expect("resolved above");
-
-            // Use the previous slot's zone_end + 1 as zone_start.
-            // This may be wider than the exact batch range (if non-withdrawal
-            // batches existed in between), but that's correct — those intermediate
-            // zone blocks had no WithdrawalRequested events.
-            let zone_start = if slot > 0 {
-                zone_block_numbers
-                    .get(&(slot - 1))
-                    .map(|n| n + 1)
-                    .unwrap_or(1)
-            } else {
-                1
-            };
-
-            slot_infos.insert(
-                slot,
-                SlotInfo {
-                    zone_start,
-                    zone_end,
-                    withdrawal_queue_hash,
-                },
-            );
+                .ok_or_else(|| {
+                    eyre::eyre!("zone block not found for hash {}", event.nextBlockHash)
+                })?;
+            zone_blocks.insert(slot, block.number());
         }
 
         let outbox = ZoneOutbox::new(outbox_address, zone_provider.clone());
         let mut total_restored = 0u64;
 
         for slot in head..tail {
-            let Some(info) = slot_infos.get(&slot) else {
+            let Some(event) = events.get(&slot) else {
                 warn!(
                     slot,
                     "no BatchSubmitted event found for pending portal slot"
@@ -574,82 +496,40 @@ impl BatchSubmitter {
                 continue;
             };
 
-            // Fetch WithdrawalRequested events from zone L2 in the batch's block range.
-            let events = outbox
-                .WithdrawalRequested_filter()
-                .from_block(info.zone_start)
-                .to_block(info.zone_end)
-                .query()
-                .await?;
+            let zone_end = zone_blocks[&slot];
+            // Previous slot's zone_end + 1. May be wider than the exact batch
+            // range when non-withdrawal batches exist in between, but those
+            // zone blocks have no WithdrawalRequested events so the result is
+            // the same.
+            let zone_start = if slot > 0 {
+                zone_blocks.get(&(slot - 1)).map(|n| n + 1).unwrap_or(1)
+            } else {
+                1
+            };
 
-            // Sort by (block_number, tx_index, log_index) — same pattern as ZoneMonitor::fetch_withdrawals.
-            let mut events_sorted: Vec<_> = events
-                .into_iter()
-                .map(|(event, log)| {
-                    let key = (
-                        log.block_number.unwrap_or(0),
-                        log.transaction_index.unwrap_or(0),
-                        log.log_index.unwrap_or(0),
-                    );
-                    (key, event)
-                })
-                .collect();
-            events_sorted.sort_by_key(|(key, _)| *key);
+            let withdrawals = fetch_slot_withdrawals(&outbox, zone_start, zone_end).await?;
 
-            let withdrawals: Vec<abi::Withdrawal> = events_sorted
-                .into_iter()
-                .map(|(_, e)| abi::Withdrawal {
-                    token: e.token,
-                    sender: e.sender,
-                    to: e.to,
-                    amount: e.amount,
-                    fee: e.fee,
-                    memo: e.memo,
-                    gasLimit: e.gasLimit,
-                    fallbackRecipient: e.fallbackRecipient,
-                    callbackData: e.data,
-                })
-                .collect();
-
-            if withdrawals.is_empty() {
+            if withdrawals.is_empty()
+                || abi::Withdrawal::queue_hash(&withdrawals) != event.withdrawalQueueHash
+            {
                 warn!(
                     slot,
-                    zone_start = info.zone_start,
-                    zone_end = info.zone_end,
-                    "no withdrawal events found for slot with non-zero hash"
+                    zone_start, zone_end, "withdrawal hash mismatch or empty"
                 );
                 continue;
             }
 
-            // Verify hash chain matches the on-chain value.
-            let computed = abi::Withdrawal::queue_hash(&withdrawals);
-            if computed != info.withdrawal_queue_hash {
-                warn!(
-                    slot,
-                    computed = %computed,
-                    expected = %info.withdrawal_queue_hash,
-                    "withdrawal hash mismatch, skipping slot"
-                );
-                continue;
-            }
-
-            // For the head slot, determine how many withdrawals have already been
-            // processed by comparing against the current on-chain slot hash.
+            // For the head slot, trim already-processed withdrawals.
             let to_store = if slot == head {
                 let slot_hash: B256 = self
                     .portal
                     .withdrawalQueueSlot(U256::from(slot % WITHDRAWAL_QUEUE_CAPACITY))
                     .call()
                     .await?;
-
                 match find_processed_offset(&withdrawals, slot_hash) {
                     Some(offset) => &withdrawals[offset..],
                     None => {
-                        warn!(
-                            slot,
-                            %slot_hash,
-                            "could not determine processed offset for head slot"
-                        );
+                        warn!(slot, %slot_hash, "cannot determine processed offset");
                         continue;
                     }
                 }
@@ -670,6 +550,51 @@ impl BatchSubmitter {
 
         Ok(total_restored)
     }
+
+    /// Walk L1 backwards from `tip` in 10k-block chunks to find
+    /// `BatchSubmitted` events for portal slots `[head, tail)` plus the
+    /// predecessor slot `head - 1` (used for zone_start of the first slot).
+    async fn find_batch_events_backwards(
+        &self,
+        tip: u64,
+        head: u64,
+        tail: u64,
+    ) -> Result<BTreeMap<u64, abi::ZonePortal::BatchSubmitted>> {
+        let start = head.saturating_sub(1);
+        let needed = (tail - start) as usize;
+        let mut found: BTreeMap<u64, abi::ZonePortal::BatchSubmitted> = BTreeMap::new();
+        let mut hi = tip;
+
+        while found.len() < needed && hi >= self.genesis_tempo_block_number {
+            let lo = hi
+                .saturating_sub(10_000)
+                .max(self.genesis_tempo_block_number);
+
+            for (event, _) in self
+                .portal
+                .BatchSubmitted_filter()
+                .from_block(lo)
+                .to_block(hi)
+                .query()
+                .await?
+            {
+                if event.withdrawalQueueHash.is_zero() {
+                    continue;
+                }
+                let idx = event.withdrawalBatchIndex;
+                if idx >= start && idx < tail {
+                    found.insert(idx, event);
+                }
+            }
+
+            if lo == self.genesis_tempo_block_number {
+                break;
+            }
+            hi = lo - 1;
+        }
+
+        Ok(found)
+    }
 }
 
 /// Find the offset into `withdrawals` where the remaining hash chain matches
@@ -686,6 +611,47 @@ fn find_processed_offset(
         }
     }
     None
+}
+
+/// Fetch `WithdrawalRequested` events from zone L2 in the given block range,
+/// sorted by log order, and convert to [`abi::Withdrawal`] structs.
+async fn fetch_slot_withdrawals(
+    outbox: &ZoneOutbox::ZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
+    from: u64,
+    to: u64,
+) -> Result<Vec<abi::Withdrawal>> {
+    let mut events: Vec<_> = outbox
+        .WithdrawalRequested_filter()
+        .from_block(from)
+        .to_block(to)
+        .query()
+        .await?
+        .into_iter()
+        .map(|(e, log)| {
+            let key = (
+                log.block_number.unwrap_or(0),
+                log.transaction_index.unwrap_or(0),
+                log.log_index.unwrap_or(0),
+            );
+            (key, e)
+        })
+        .collect();
+    events.sort_by_key(|(k, _)| *k);
+
+    Ok(events
+        .into_iter()
+        .map(|(_, e)| abi::Withdrawal {
+            token: e.token,
+            sender: e.sender,
+            to: e.to,
+            amount: e.amount,
+            fee: e.fee,
+            memo: e.memo,
+            gasLimit: e.gasLimit,
+            fallbackRecipient: e.fallbackRecipient,
+            callbackData: e.data,
+        })
+        .collect())
 }
 
 /// Classification of the EIP-2935 gap, returned by

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -787,3 +787,77 @@ pub(crate) struct ZoneBlockSnapshot {
     /// Zone L2 block hash.
     pub block_hash: B256,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abi;
+    use alloy_primitives::{B256, address};
+
+    fn test_withdrawal(to: Address, amount: u128) -> abi::Withdrawal {
+        abi::Withdrawal {
+            token: address!("0x0000000000000000000000000000000000001000"),
+            sender: address!("0x0000000000000000000000000000000000000001"),
+            to,
+            amount,
+            fee: 0,
+            memo: B256::ZERO,
+            gasLimit: 0,
+            fallbackRecipient: to,
+            callbackData: Default::default(),
+        }
+    }
+
+    #[test]
+    fn find_offset_no_withdrawals_processed() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
+        let withdrawals = vec![w0, w1];
+        let full_hash = abi::Withdrawal::queue_hash(&withdrawals);
+        assert_eq!(find_processed_offset(&withdrawals, full_hash), Some(0));
+    }
+
+    #[test]
+    fn find_offset_one_processed() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
+        let withdrawals = vec![w0, w1];
+        let hash = abi::Withdrawal::queue_hash(&withdrawals[1..]);
+        assert_eq!(find_processed_offset(&withdrawals, hash), Some(1));
+    }
+
+    #[test]
+    fn find_offset_all_processed() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let withdrawals = vec![w0];
+        // B256::ZERO matches an empty slice, but the loop only checks offsets 0..len,
+        // so offset == len (the empty tail) is never tested.
+        assert_eq!(find_processed_offset(&withdrawals, B256::ZERO), None);
+    }
+
+    #[test]
+    fn find_offset_no_match() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let withdrawals = vec![w0];
+        let random_hash = B256::from([0xdeu8; 32]);
+        assert_eq!(find_processed_offset(&withdrawals, random_hash), None);
+    }
+
+    #[test]
+    fn find_offset_single_withdrawal_unprocessed() {
+        let w = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 999);
+        let withdrawals = vec![w];
+        let hash = abi::Withdrawal::queue_hash(&withdrawals);
+        assert_eq!(find_processed_offset(&withdrawals, hash), Some(0));
+    }
+
+    #[test]
+    fn find_offset_partial_three_withdrawals() {
+        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
+        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
+        let w2 = test_withdrawal(address!("0x0000000000000000000000000000000000000003"), 300);
+        let withdrawals = vec![w0, w1, w2];
+        let hash = abi::Withdrawal::queue_hash(&withdrawals[2..]);
+        assert_eq!(find_processed_offset(&withdrawals, hash), Some(2));
+    }
+}

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -563,6 +563,9 @@ impl BatchSubmitter {
     /// `BatchSubmitted` events for portal slots `[head, tail)` plus the
     /// predecessor slot `head - 1` (used to determine the zone L2 block
     /// range start of the first slot).
+    ///
+    /// Stops as soon as all needed events are found — pending slots are
+    /// recent, so the first chunk typically covers them all.
     async fn find_batch_events_backwards(
         &self,
         l1_tip: u64,

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -468,10 +468,15 @@ impl BatchSubmitter {
             self.read_portal_withdrawal_queue_tail(),
         )?;
 
+        if head >= tail {
+            info!(head, tail, "No pending withdrawals to restore");
+            return Ok(0);
+        }
+
         info!(
             head,
             tail,
-            pending = tail.saturating_sub(head),
+            pending = tail - head,
             "Restoring pending withdrawals"
         );
 

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -521,31 +521,30 @@ impl BatchSubmitter {
             };
 
             let is_head_slot = slot == head;
-            let restored = self
-                .restore_slot(
-                    slot,
-                    is_head_slot,
-                    event,
-                    &outbox,
-                    zone_start,
-                    zone_end,
-                    store,
-                )
+            let withdrawals = self
+                .restore_slot(slot, is_head_slot, event, &outbox, zone_start, zone_end)
                 .await?;
-            total_restored += restored;
+
+            if !withdrawals.is_empty() {
+                let count = withdrawals.len();
+                let mut guard = store.lock();
+                for w in &withdrawals {
+                    guard.add_withdrawal(slot, w.clone());
+                }
+                info!(slot, count, "Restored withdrawals for portal queue slot");
+                total_restored += count as u64;
+            }
         }
 
         Ok(total_restored)
     }
 
-    /// Fetch, verify, and store withdrawals for a single pending L1 portal slot.
+    /// Fetch and verify withdrawals for a single pending L1 portal slot.
     ///
-    /// Queries `WithdrawalRequested` events from zone L2 blocks `[zone_start, zone_end]`,
-    /// verifies the hash chain against the L1 event, and stores the withdrawal structs.
-    /// For the head slot, already-processed withdrawals are trimmed by comparing
-    /// against the current on-chain slot hash.
-    ///
-    /// Returns the number of withdrawals stored.
+    /// Queries `WithdrawalRequested` events from zone L2 blocks `[zone_start, zone_end]`
+    /// and verifies the hash chain against the L1 event. For the head slot,
+    /// already-processed withdrawals are trimmed by comparing against the
+    /// current on-chain slot hash.
     async fn restore_slot(
         &self,
         slot: u64,
@@ -554,8 +553,7 @@ impl BatchSubmitter {
         outbox: &ZoneOutbox::ZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
         zone_start: u64,
         zone_end: u64,
-        store: &SharedWithdrawalStore,
-    ) -> Result<u64> {
+    ) -> Result<Vec<abi::Withdrawal>> {
         // Fetch WithdrawalRequested events from zone L2.
         let withdrawals = fetch_slot_withdrawals(outbox, zone_start, zone_end).await?;
 
@@ -567,40 +565,28 @@ impl BatchSubmitter {
                 slot,
                 zone_start, zone_end, "withdrawal hash mismatch or empty"
             );
-            return Ok(0);
+            return Ok(vec![]);
         }
 
         // The head slot may be partially processed — the L1 withdrawal
         // processor could have consumed some withdrawals before the restart.
         // Compare against the current on-chain slot hash to find the offset.
-        let to_store = if is_head_slot {
+        if is_head_slot {
             let slot_hash: B256 = self
                 .portal
                 .withdrawalQueueSlot(U256::from(slot % WITHDRAWAL_QUEUE_CAPACITY))
                 .call()
                 .await?;
             match find_processed_offset(&withdrawals, slot_hash) {
-                Some(offset) => &withdrawals[offset..],
+                Some(offset) => Ok(withdrawals[offset..].to_vec()),
                 None => {
                     warn!(slot, %slot_hash, "cannot determine processed offset");
-                    return Ok(0);
+                    Ok(vec![])
                 }
             }
         } else {
-            &withdrawals[..]
-        };
-
-        if !to_store.is_empty() {
-            let count = to_store.len();
-            let mut guard = store.lock();
-            for w in to_store {
-                guard.add_withdrawal(slot, w.clone());
-            }
-            info!(slot, count, "Restored withdrawals for portal queue slot");
-            return Ok(count as u64);
+            Ok(withdrawals)
         }
-
-        Ok(0)
     }
 
     /// Walk **L1** backwards from `l1_tip` in 10k-block chunks to find

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -125,9 +125,6 @@ impl Default for WithdrawalStore {
 /// This value is passed as `remainingQueue` to `processWithdrawal` on the portal contract.
 ///
 /// - If `processed_count >= withdrawals.len()`, returns `B256::ZERO` (no remaining items).
-/// - If `processed_count == withdrawals.len() - 1` (last item in the slot), returns `B256::ZERO`.
-///   The portal interprets `remainingQueue == 0` as the last withdrawal in the slot and internally
-///   converts it to `EMPTY_SENTINEL` before hash verification.
 /// - Otherwise, computes the hash chain over `withdrawals[processed_count..]` via
 ///   [`abi::Withdrawal::queue_hash`].
 pub fn compute_remaining_queue(withdrawals: &[abi::Withdrawal], processed_count: usize) -> B256 {
@@ -136,10 +133,6 @@ pub fn compute_remaining_queue(withdrawals: &[abi::Withdrawal], processed_count:
     }
 
     let remaining = &withdrawals[processed_count..];
-
-    if remaining.len() == 1 {
-        return B256::ZERO;
-    }
 
     abi::Withdrawal::queue_hash(remaining)
 }
@@ -438,9 +431,10 @@ mod tests {
     }
 
     #[test]
-    fn remaining_queue_last_item_is_zero() {
+    fn remaining_queue_single_item_is_hash() {
         let w = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 1000);
-        assert_eq!(compute_remaining_queue(&[w], 0), B256::ZERO);
+        let expected = abi::Withdrawal::queue_hash(std::slice::from_ref(&w));
+        assert_eq!(compute_remaining_queue(&[w], 0), expected);
     }
 
     #[test]

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -95,12 +95,9 @@ impl WithdrawalStore {
             .push(withdrawal);
     }
 
-    /// Add all withdrawals for a batch at once.
+    /// Set all withdrawals for a batch at once, replacing any existing data.
     pub fn add_batch(&mut self, batch_index: u64, withdrawals: Vec<abi::Withdrawal>) {
-        self.batches
-            .entry(batch_index)
-            .or_default()
-            .extend(withdrawals);
+        self.batches.insert(batch_index, withdrawals);
     }
 
     /// Get all withdrawals for a batch.
@@ -520,9 +517,10 @@ mod tests {
         assert!(store.has_batch(0));
         assert_eq!(store.get_batch(0).unwrap().len(), 3);
 
+        // Calling add_batch again replaces existing data (idempotent).
         let more: Vec<_> = (0..2).map(|i| test_withdrawal(addr, i * 200)).collect();
         store.add_batch(0, more);
-        assert_eq!(store.get_batch(0).unwrap().len(), 5);
+        assert_eq!(store.get_batch(0).unwrap().len(), 2);
 
         store.add_batch(1, vec![test_withdrawal(addr, 999)]);
         assert_eq!(store.batch_count(), 2);

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -509,4 +509,22 @@ mod tests {
         store.add_withdrawal(portal_tail, w);
         assert!(store.has_batch(portal_tail));
     }
+
+    #[test]
+    fn store_add_batch() {
+        let mut store = WithdrawalStore::new();
+        let addr = address!("0x0000000000000000000000000000000000000042");
+        let batch: Vec<_> = (0..3).map(|i| test_withdrawal(addr, i * 100)).collect();
+
+        store.add_batch(0, batch);
+        assert!(store.has_batch(0));
+        assert_eq!(store.get_batch(0).unwrap().len(), 3);
+
+        let more: Vec<_> = (0..2).map(|i| test_withdrawal(addr, i * 200)).collect();
+        store.add_batch(0, more);
+        assert_eq!(store.get_batch(0).unwrap().len(), 5);
+
+        store.add_batch(1, vec![test_withdrawal(addr, 999)]);
+        assert_eq!(store.batch_count(), 2);
+    }
 }

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -95,6 +95,14 @@ impl WithdrawalStore {
             .push(withdrawal);
     }
 
+    /// Add all withdrawals for a batch at once.
+    pub fn add_batch(&mut self, batch_index: u64, withdrawals: Vec<abi::Withdrawal>) {
+        self.batches
+            .entry(batch_index)
+            .or_default()
+            .extend(withdrawals);
+    }
+
     /// Get all withdrawals for a batch.
     pub fn get_batch(&self, batch_index: u64) -> Option<&Vec<abi::Withdrawal>> {
         self.batches.get(&batch_index)

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -198,6 +198,22 @@ impl ZoneMonitor {
             "Initialized from portal state"
         );
 
+        // Restore pending withdrawal data from zone L2 events so the
+        // withdrawal processor can pick up where it left off.
+        match batch_submitter
+            .restore_pending_withdrawals(&provider, config.outbox_address, &withdrawal_store)
+            .await
+        {
+            Ok(count) if count > 0 => {
+                info!(count, "Restored pending withdrawals from zone L2 events");
+                withdrawal_notify.notify_one();
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!(error = %e, "Failed to restore pending withdrawals");
+            }
+        }
+
         Self {
             config,
             provider,

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -200,13 +200,25 @@ impl ZoneMonitor {
 
         // Restore pending withdrawal data from zone L2 events so the
         // withdrawal processor can pick up where it left off.
-        let restored = batch_submitter
-            .restore_pending_withdrawals(&provider, config.outbox_address, &withdrawal_store)
+        let pending = batch_submitter
+            .fetch_pending_withdrawals(&provider, config.outbox_address)
             .await
-            .expect("failed to restore pending withdrawals");
+            .expect("failed to fetch pending withdrawals");
 
-        if restored > 0 {
-            info!(restored, "Restored pending withdrawals from zone L2 events");
+        if !pending.is_empty() {
+            let mut store = withdrawal_store.lock();
+            let mut total = 0usize;
+            for (portal_slot, withdrawals) in pending {
+                let count = withdrawals.len();
+                store.add_batch(portal_slot, withdrawals);
+                info!(
+                    portal_slot,
+                    count, "Restored withdrawals for portal queue slot"
+                );
+                total += count;
+            }
+            drop(store);
+            info!(total, "Restored pending withdrawals from zone L2 events");
             withdrawal_notify.notify_one();
         } else {
             info!("No pending withdrawals to restore");

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -200,18 +200,16 @@ impl ZoneMonitor {
 
         // Restore pending withdrawal data from zone L2 events so the
         // withdrawal processor can pick up where it left off.
-        match batch_submitter
+        let restored = batch_submitter
             .restore_pending_withdrawals(&provider, config.outbox_address, &withdrawal_store)
             .await
-        {
-            Ok(count) if count > 0 => {
-                info!(count, "Restored pending withdrawals from zone L2 events");
-                withdrawal_notify.notify_one();
-            }
-            Ok(_) => {}
-            Err(e) => {
-                warn!(error = %e, "Failed to restore pending withdrawals");
-            }
+            .expect("failed to restore pending withdrawals");
+
+        if restored > 0 {
+            info!(restored, "Restored pending withdrawals from zone L2 events");
+            withdrawal_notify.notify_one();
+        } else {
+            info!("No pending withdrawals to restore");
         }
 
         Self {

--- a/crates/tempo-zone/tests/it/restart_e2e.rs
+++ b/crates/tempo-zone/tests/it/restart_e2e.rs
@@ -130,7 +130,7 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
 /// 1. Deposit, spawn sequencer, request withdrawal.
 /// 2. Wait for the batch to be submitted (withdrawal enqueued on L1 portal).
 /// 3. Abort the sequencer BEFORE the withdrawal is processed.
-/// 4. Respawn the sequencer — `restore_pending_withdrawals` restores the data.
+/// 4. Respawn the sequencer — `fetch_pending_withdrawals` restores the data.
 /// 5. The OLD withdrawal from before the restart is processed on L1.
 /// 6. A NEW withdrawal after restart also works.
 #[tokio::test(flavor = "multi_thread")]
@@ -175,7 +175,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     seq_handle.withdrawal_handle.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-    // --- Respawn sequencer (restore_pending_withdrawals runs during init) ---
+    // --- Respawn sequencer (fetch_pending_withdrawals runs during init) ---
     let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
     // The OLD withdrawal from before the restart should be processed via

--- a/crates/tempo-zone/tests/it/restart_e2e.rs
+++ b/crates/tempo-zone/tests/it/restart_e2e.rs
@@ -168,21 +168,23 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     )
     .await?;
 
-    let (_, tail_before) = portal_queue_state(&l1, portal_address).await?;
+    let (head_before, tail_before) = portal_queue_state(&l1, portal_address).await?;
+    assert!(
+        tail_before > head_before,
+        "expected pending withdrawal slot: tail={tail_before} head={head_before}"
+    );
 
     // --- Abort sequencer BEFORE the withdrawal is processed ---
-    seq_handle.monitor_handle.abort();
+    // Abort withdrawal processor first so it can't race to process the pending slot.
     seq_handle.withdrawal_handle.abort();
+    seq_handle.monitor_handle.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // --- Respawn sequencer (fetch_pending_withdrawals runs during init) ---
     let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
-    // The OLD withdrawal from before the restart should be processed — either
-    // it was already processed before the abort, or the restored data lets the
-    // processor pick it up after restart. Wait for portal head to advance past
-    // it (don't use wait_for_withdrawal_on_l1 which captures balance_before at
-    // call time and would double-count if already processed).
+    // The OLD withdrawal from before the restart should be processed via
+    // restored data (withdrawal processor was aborted before head advanced).
     crate::utils::poll_until(
         WITHDRAWAL_TIMEOUT,
         std::time::Duration::from_millis(200),

--- a/crates/tempo-zone/tests/it/restart_e2e.rs
+++ b/crates/tempo-zone/tests/it/restart_e2e.rs
@@ -168,7 +168,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     )
     .await?;
 
-    let (head_before, tail_before) = portal_queue_state(&l1, portal_address).await?;
+    let (_, tail_before) = portal_queue_state(&l1, portal_address).await?;
 
     // --- Abort sequencer BEFORE the withdrawal is processed ---
     seq_handle.monitor_handle.abort();
@@ -178,13 +178,26 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     // --- Respawn sequencer (fetch_pending_withdrawals runs during init) ---
     let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
-    // The OLD withdrawal from before the restart should be processed via
-    // restored data (or was already processed before abort — either way this succeeds).
-    l1.wait_for_withdrawal_on_l1(
-        portal_address,
-        account.address(),
-        withdrawal_amount,
+    // The OLD withdrawal from before the restart should be processed — either
+    // it was already processed before the abort, or the restored data lets the
+    // processor pick it up after restart. Wait for portal head to advance past
+    // it (don't use wait_for_withdrawal_on_l1 which captures balance_before at
+    // call time and would double-count if already processed).
+    crate::utils::poll_until(
         WITHDRAWAL_TIMEOUT,
+        std::time::Duration::from_millis(200),
+        "portal head advances past first withdrawal",
+        || {
+            let l1 = &l1;
+            async move {
+                let (head, _) = portal_queue_state(l1, portal_address).await?;
+                if head >= tail_before {
+                    Ok(Some(head))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
     )
     .await?;
 
@@ -199,15 +212,15 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     )
     .await?;
 
-    // Portal queue should have advanced
+    // Portal queue should have advanced further
     let (head_after, tail_after) = portal_queue_state(&l1, portal_address).await?;
     assert!(
         tail_after > tail_before,
         "portal tail should advance after second withdrawal (before={tail_before}, after={tail_after})"
     );
     assert!(
-        head_after > head_before,
-        "portal head should advance as withdrawals are processed (before={head_before}, after={head_after})"
+        head_after >= tail_before,
+        "portal head should have processed at least the first withdrawal"
     );
 
     Ok(())

--- a/crates/tempo-zone/tests/it/restart_e2e.rs
+++ b/crates/tempo-zone/tests/it/restart_e2e.rs
@@ -130,15 +130,9 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
 /// 1. Deposit, spawn sequencer, request withdrawal.
 /// 2. Wait for the batch to be submitted (withdrawal enqueued on L1 portal).
 /// 3. Abort the sequencer BEFORE the withdrawal is processed.
-/// 4. Verify the portal queue has pending slots (tail > head).
-/// 5. Respawn the sequencer.
-/// 6. The withdrawal processor should process the pending slot.
-///
-/// NOTE: After restart the in-memory WithdrawalStore is empty, so the
-/// withdrawal processor won't find data for the pending slot. This test
-/// documents the current behavior — the pending withdrawal from before
-/// the restart will NOT be processed until restore logic is implemented.
-/// The NEW withdrawal requested after restart WILL be processed.
+/// 4. Respawn the sequencer — `restore_pending_withdrawals` restores the data.
+/// 5. The OLD withdrawal from before the restart is processed on L1.
+/// 6. A NEW withdrawal after restart also works.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -174,7 +168,18 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     )
     .await?;
 
-    // Wait for the first withdrawal to be fully processed before restarting
+    let (head_before, tail_before) = portal_queue_state(&l1, portal_address).await?;
+
+    // --- Abort sequencer BEFORE the withdrawal is processed ---
+    seq_handle.monitor_handle.abort();
+    seq_handle.withdrawal_handle.abort();
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // --- Respawn sequencer (restore_pending_withdrawals runs during init) ---
+    let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+
+    // The OLD withdrawal from before the restart should be processed via
+    // restored data (or was already processed before abort — either way this succeeds).
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
@@ -183,18 +188,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     )
     .await?;
 
-    let (head_before, tail_before) = portal_queue_state(&l1, portal_address).await?;
-
-    // --- Abort sequencer ---
-    seq_handle.monitor_handle.abort();
-    seq_handle.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-    // --- Respawn sequencer ---
-    let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-
-    // Request a NEW withdrawal after restart — this one should work because the
-    // monitor will enqueue it into the store before submission.
+    // Request a NEW withdrawal after restart to verify normal operation continues.
     let second_withdrawal: u128 = 400_000;
     account.withdraw(second_withdrawal).await?;
     l1.wait_for_withdrawal_on_l1(


### PR DESCRIPTION
## Summary

The `WithdrawalStore` is an in-memory `BTreeMap` that maps portal queue slot indices to withdrawal data. When the sequencer restarts this data is lost, leaving pending withdrawals stuck in the portal queue until new ones are submitted.

This adds `restore_pending_withdrawals` on `BatchSubmitter` which runs during `ZoneMonitor::new()`. It replays L1 portal `BatchSubmitted` events and fetches `WithdrawalRequested` events from the zone L2 outbox to reconstruct withdrawal data for any pending portal queue slots. For the head slot, it reads the current on-chain slot hash to determine how many withdrawals have already been processed and only stores the remaining ones.

Also fixes a bug in `compute_remaining_queue` that returned `B256::ZERO` when a single withdrawal remained in a batch. This caused `InvalidWithdrawalHash` reverts on the portal for batches with 2+ withdrawals — the portal expects `queue_hash([last_withdrawal])` (i.e. `H(w, EMPTY_SENTINEL)`), not zero.

Closes #184