### PR TITLE
feat: add zone-precompiles crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13000,7 +13000,6 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 name = "zone"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
  "alloy",
  "alloy-consensus",
  "alloy-contract",
@@ -13025,7 +13024,6 @@ dependencies = [
  "k256",
  "metrics",
  "parking_lot",
- "rand 0.8.5",
  "reqwest 0.12.28",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -13060,7 +13058,6 @@ dependencies = [
  "tempo-node",
  "tempo-payload-types",
  "tempo-precompiles",
- "tempo-precompiles-macros",
  "tempo-primitives",
  "tempo-revm",
  "tempo-transaction-pool",
@@ -13068,8 +13065,31 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "zone-precompiles",
  "zone-primitives",
  "zone-rpc",
+]
+
+[[package]]
+name = "zone-precompiles"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "alloy",
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "const-hex",
+ "k256",
+ "rand 0.8.5",
+ "revm",
+ "sha2 0.10.9",
+ "tempo-chainspec",
+ "tempo-contracts",
+ "tempo-precompiles",
+ "tempo-precompiles-macros",
+ "tracing",
+ "zone-primitives",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [workspace]
 members = [
   "bin/tempo-zone",
+  "crates/precompiles",
   "crates/primitives",
   "crates/tempo-zone",
   "crates/rpc",
@@ -96,7 +97,8 @@ tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0", defaul
 tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.0", default-features = false }
 
 # zones
-zone-primitives = { path = "crates/primitives" }
+zone-precompiles = { path = "crates/precompiles", default-features = false }
+zone-primitives = { path = "crates/primitives", default-features = false }
 zone-rpc = { path = "crates/rpc" }
 
 # reth

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+name = "zone-precompiles"
+description = "Zone-specific precompile implementations"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# zones
+zone-primitives = { workspace = true, default-features = false }
+
+# tempo (workspace deps already have default-features = false)
+tempo-chainspec = { workspace = true, default-features = false }
+tempo-contracts = { workspace = true, default-features = false }
+tempo-precompiles = { workspace = true, default-features = false }
+tempo-precompiles-macros.workspace = true
+
+# alloy (direct versions for no_std — workspace versions have default-features = true)
+alloy = { version = "1.6.1", default-features = false }
+alloy-evm = { version = "0.27.3", default-features = false }
+alloy-primitives = { version = "1.5.4", default-features = false }
+alloy-sol-types = { version = "1.5.7", default-features = false }
+
+# revm
+revm = { version = "34.0.0", default-features = false }
+
+# crypto
+aes-gcm = { version = "0.10.3", default-features = false, features = ["aes", "alloc"] }
+k256 = { version = "0.13.4", default-features = false, features = ["arithmetic", "ecdh"] }
+sha2 = { version = "0.10.9", default-features = false }
+rand = { version = "0.8.5", default-features = false }
+
+# misc
+tracing = { version = "0.1.41", default-features = false }
+
+[dev-dependencies]
+const-hex.workspace = true
+tempo-precompiles = { workspace = true, features = ["test-utils"] }
+
+[features]
+default = ["std"]
+test-utils = ["tempo-precompiles/test-utils"]
+std = [
+    "zone-primitives/std",
+    "alloy-evm/std",
+    "alloy-primitives/std",
+    "alloy-sol-types/std",
+    "revm/std",
+    "aes-gcm/std",
+    "k256/std",
+    "sha2/std",
+    "rand/std",
+    "tracing/std",
+]

--- a/crates/precompiles/src/aes_gcm.rs
+++ b/crates/precompiles/src/aes_gcm.rs
@@ -7,7 +7,7 @@
 //!
 //! Uses the NCC-audited [`aes-gcm`] crate (v0.10.3).
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 use aes_gcm::{
     Aes256Gcm, KeyInit, Nonce,
@@ -109,7 +109,7 @@ impl From<AesGcmDecrypt> for DynPrecompile {
 ///
 /// The ciphertext, AAD, and tag are passed separately (matching the Solidity interface).
 /// Returns `(plaintext, true)` on success, or `(empty, false)` on failure.
-pub(crate) fn decrypt_aes_gcm(
+pub fn decrypt_aes_gcm(
     key: &[u8; 32],
     nonce: &[u8; 12],
     ciphertext: &[u8],

--- a/crates/precompiles/src/chaum_pedersen.rs
+++ b/crates/precompiles/src/chaum_pedersen.rs
@@ -8,7 +8,7 @@
 //!
 //! Uses the NCC-audited [`k256`] crate (v0.13.4) for secp256k1 operations.
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 use alloy_evm::precompiles::{DynPrecompile, Precompile, PrecompileInput};
 use alloy_primitives::{Address, Bytes, address};
@@ -122,7 +122,7 @@ impl From<ChaumPedersenVerify> for DynPrecompile {
 /// Recover a secp256k1 affine point from compressed form (x coordinate + y parity).
 ///
 /// `y_parity` follows SEC1: `0x02` for even y, `0x03` for odd y.
-pub(crate) fn recover_point(x_bytes: &[u8; 32], y_parity: u8) -> Option<AffinePoint> {
+pub fn recover_point(x_bytes: &[u8; 32], y_parity: u8) -> Option<AffinePoint> {
     let mut encoded = [0u8; 33];
     encoded[0] = y_parity;
     encoded[1..].copy_from_slice(x_bytes);
@@ -136,7 +136,7 @@ pub(crate) fn recover_point(x_bytes: &[u8; 32], y_parity: u8) -> Option<AffinePo
 /// `c = keccak256(G || ephemeralPub || pubSeq || sharedSecretPoint || R1 || R2)`
 ///
 /// Shared between the verifier (precompile) and prover (ecies module).
-pub(crate) fn challenge_hash(
+pub fn challenge_hash(
     ephemeral_pub: &AffinePoint,
     sequencer_pub: &AffinePoint,
     shared_secret: &AffinePoint,

--- a/crates/precompiles/src/ecies.rs
+++ b/crates/precompiles/src/ecies.rs
@@ -1,8 +1,10 @@
 //! Sequencer-side ECIES operations for encrypted deposit decryption.
 //!
 //! These functions run **off-chain** in the payload builder to produce the
-//! [`DecryptionData`](crate::abi::DecryptionData) that the on-chain ZoneInbox
-//! contract verifies via the Chaum-Pedersen and AES-GCM precompiles.
+//! [`DecryptionData`] that the on-chain ZoneInbox contract verifies via the
+//! Chaum-Pedersen and AES-GCM precompiles.
+
+use alloc::vec::Vec;
 
 use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
 use alloy_primitives::{Address, B256};
@@ -11,7 +13,7 @@ use k256::{
     elliptic_curve::{PrimeField, sec1::ToEncodedPoint},
 };
 
-use super::{
+use crate::{
     aes_gcm::decrypt_aes_gcm,
     chaum_pedersen::{challenge_hash, recover_point},
 };
@@ -227,7 +229,7 @@ fn generate_chaum_pedersen_proof(
 }
 
 /// HMAC-SHA256 implementation matching ZoneInbox._hmacSha256.
-pub(crate) fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+pub fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
     use sha2::{Digest, Sha256};
 
     // Pad/hash key to 64 bytes
@@ -291,7 +293,7 @@ pub fn build_plaintext(to: &Address, memo: &B256) -> [u8; ENCRYPTED_PAYLOAD_PLAI
 }
 
 /// Build the 84-byte HKDF info parameter: `[portal(20) | key_index(32) | eph_pub_x(32)]`.
-pub(crate) fn hkdf_info(
+pub fn hkdf_info(
     portal: &Address,
     key_index: &alloy_primitives::U256,
     eph_pub_x: &B256,
@@ -318,10 +320,8 @@ pub fn encrypt_plaintext(aes_key: &[u8; 32], plaintext: &[u8]) -> (Vec<u8>, [u8;
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        super::test_utils::{EncryptedDepositFixture, assert_cp_proof_valid},
-        compressed_x_and_parity, decrypt_deposit, hkdf_sha256, hmac_sha256,
-    };
+    use super::{compressed_x_and_parity, decrypt_deposit, hkdf_sha256, hmac_sha256};
+    use crate::test_utils::{EncryptedDepositFixture, assert_cp_proof_valid};
     use alloy_primitives::{Address, B256, U256};
 
     #[test]
@@ -500,8 +500,7 @@ mod tests {
             let info = super::hkdf_info(&f.portal, &f.key_index, &f.eph_pub_x);
             hkdf_sha256(&ss_x, b"ecies-aes-key", &info)
         };
-        let (ct, nonce, tag) =
-            super::super::test_utils::encrypt_plaintext(&aes_key, &short_plaintext);
+        let (ct, nonce, tag) = crate::test_utils::encrypt_plaintext(&aes_key, &short_plaintext);
 
         let result = decrypt_deposit(
             &f.seq_key,

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -1,0 +1,43 @@
+//! Zone-specific precompile implementations.
+//!
+//! This crate is `no_std` compatible so these precompiles can run inside the
+//! SP1 prover guest (RISC-V) as well as in the zone node.
+//!
+//! ## Crypto precompiles
+//!
+//! - **Chaum-Pedersen Verify** ([`chaum_pedersen`]) — verifies DLOG equality proofs
+//!   for ECDH shared secret derivation.
+//! - **AES-256-GCM Decrypt** ([`aes_gcm`]) — decrypts ECIES ciphertext and verifies
+//!   the GCM authentication tag.
+//! - **ECIES** ([`ecies`]) — sequencer-side ECIES decryption logic.
+//!
+//! ## Policy/token precompiles
+//!
+//! - **TIP-20 Factory** ([`tip20_factory`]) — zone-side TIP-20 token factory.
+//! - **TIP-403 Proxy** ([`tip403_proxy`]) — read-only TIP-403 registry proxy.
+//! - **Zone TIP-20** ([`ztip20`]) — policy-aware TIP-20 wrapper.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::too_many_arguments)]
+
+extern crate alloc;
+
+// Required by the `#[contract]` proc macro expansion (references `crate::storage` / `crate::error`).
+pub(crate) use tempo_precompiles::{error, storage};
+
+pub mod aes_gcm;
+pub mod chaum_pedersen;
+pub mod ecies;
+pub mod policy;
+pub mod tip20_factory;
+pub mod tip403_proxy;
+pub mod ztip20;
+
+pub use aes_gcm::{AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt};
+pub use chaum_pedersen::{CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify};
+pub use tip20_factory::{ZONE_TIP20_FACTORY_ADDRESS, ZoneTokenFactory};
+pub use tip403_proxy::{ZONE_TIP403_PROXY_ADDRESS, ZoneTip403ProxyRegistry};
+pub use ztip20::ZoneTip20Token;
+
+#[cfg(test)]
+mod test_utils;

--- a/crates/precompiles/src/policy.rs
+++ b/crates/precompiles/src/policy.rs
@@ -1,0 +1,45 @@
+//! Policy authorization trait for zone precompiles.
+//!
+//! Defines [`PolicyCheck`], an abstraction over the concrete `PolicyProvider`
+//! so that the policy/token precompiles in this crate don't depend on tokio,
+//! alloy providers, or any std-only infrastructure.
+
+use alloy_primitives::Address;
+use revm::precompile::PrecompileError;
+use zone_primitives::policy::AuthRole;
+
+/// Authorization provider used by the TIP-403 proxy and zone TIP-20 precompiles.
+///
+/// Implementors resolve policy queries — either from an in-memory cache with
+/// RPC fallback (zone node) or from a witness database (SP1 prover guest).
+pub trait PolicyCheck {
+    /// Check whether `user` is authorized under `policy_id` for the given `role`.
+    fn is_authorized(
+        &self,
+        policy_id: u64,
+        user: Address,
+        role: AuthRole,
+    ) -> Result<bool, PrecompileError>;
+
+    /// Resolve the `transferPolicyId` for a token.
+    fn resolve_transfer_policy_id(&self, token: Address) -> Result<u64, PrecompileError>;
+
+    /// Resolve policy type and admin for a policy ID.
+    ///
+    /// Returns `Ok(Some((policy_type, admin)))` if the policy exists, `Ok(None)` otherwise.
+    fn policy_type_sync(
+        &self,
+        policy_id: u64,
+    ) -> Result<tempo_contracts::precompiles::ITIP403Registry::PolicyType, PrecompileError>;
+
+    /// Resolve compound policy sub-IDs.
+    ///
+    /// Returns `(sender_policy_id, recipient_policy_id, mint_recipient_policy_id)`.
+    fn compound_policy_data(&self, policy_id: u64) -> Result<(u64, u64, u64), PrecompileError>;
+
+    /// Check whether a policy exists.
+    fn policy_exists(&self, policy_id: u64) -> Result<bool, PrecompileError>;
+
+    /// Return the highest known policy ID counter.
+    fn policy_id_counter(&self) -> u64;
+}

--- a/crates/precompiles/src/test_utils.rs
+++ b/crates/precompiles/src/test_utils.rs
@@ -6,12 +6,12 @@ use k256::{
     elliptic_curve::{ops::Reduce, sec1::ToEncodedPoint},
 };
 
-use super::{
+use crate::{
     chaum_pedersen::{challenge_hash, recover_point},
     ecies::DecryptedDeposit,
 };
 
-pub(crate) use super::ecies::{build_plaintext, compressed_x_and_parity, encrypt_plaintext};
+pub(crate) use crate::ecies::{build_plaintext, compressed_x_and_parity, encrypt_plaintext};
 
 /// Assert that the Chaum-Pedersen proof inside a [`DecryptedDeposit`] is valid.
 pub(crate) fn assert_cp_proof_valid(
@@ -56,7 +56,7 @@ pub(crate) struct EncryptedDepositFixture {
 
 impl EncryptedDepositFixture {
     /// Create a fixture with deterministic keys for reproducible tests.
-    pub(super) fn new() -> Self {
+    pub(crate) fn new() -> Self {
         use sha2::{Digest, Sha256};
 
         // Deterministic sequencer key
@@ -82,8 +82,8 @@ impl EncryptedDepositFixture {
         let key_index = U256::from(42u64);
 
         // HKDF key derivation
-        let info = super::ecies::hkdf_info(&portal, &key_index, &eph_pub_x);
-        let aes_key = super::ecies::hkdf_sha256(&shared_secret_x, b"ecies-aes-key", &info);
+        let info = crate::ecies::hkdf_info(&portal, &key_index, &eph_pub_x);
+        let aes_key = crate::ecies::hkdf_sha256(&shared_secret_x, b"ecies-aes-key", &info);
 
         // Build and encrypt plaintext
         let to = Address::repeat_byte(0xBB);
@@ -108,8 +108,8 @@ impl EncryptedDepositFixture {
     }
 
     /// Decrypt using the fixture's sequencer key.
-    pub(super) fn decrypt(&self) -> Option<DecryptedDeposit> {
-        super::ecies::decrypt_deposit(
+    pub(crate) fn decrypt(&self) -> Option<DecryptedDeposit> {
+        crate::ecies::decrypt_deposit(
             &self.seq_key,
             &self.eph_pub_x,
             self.eph_pub_y_parity,

--- a/crates/precompiles/src/tip20_factory.rs
+++ b/crates/precompiles/src/tip20_factory.rs
@@ -5,8 +5,7 @@
 //! `enableToken(address, string, string, string)` entrypoint.
 //!
 //! When the sequencer bridges a new TIP-20 token to the zone, the
-//! [`ZoneInbox`](crate::abi::ZoneInbox) contract calls `enableToken` during
-//! `advanceTempo` to:
+//! [`ZoneInbox`] contract calls `enableToken` during `advanceTempo` to:
 //!
 //! 1. Initialize the TIP-20 storage at the given address (name, symbol, currency).
 //! 2. Grant [`ISSUER_ROLE`] to both [`ZONE_INBOX_ADDRESS`] (for minting on
@@ -14,6 +13,8 @@
 //!
 //! Only [`ZONE_INBOX_ADDRESS`] may call this precompile; all other callers are
 //! reverted with `OnlyZoneInbox()`.
+
+use alloc::format;
 
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolError};
@@ -23,8 +24,7 @@ use tempo_precompiles::{
     tip20::{ISSUER_ROLE, TIP20Token},
 };
 use tempo_precompiles_macros::contract;
-
-use crate::abi::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
+use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
 alloy_sol_types::sol! {
     /// Initialize a TIP20 token on the zone and grant issuer roles.
@@ -40,8 +40,8 @@ pub const ZONE_TIP20_FACTORY_ADDRESS: Address = TIP20_FACTORY_ADDRESS;
 ///
 /// Replaces the L1 [`TIP20Factory`] at the same address (`0x20FC…0000`) with a
 /// zone-specific implementation that only supports [`enableToken`](enableTokenCall).
-/// This is called by [`ZoneInbox`](crate::abi::ZoneInbox) during `advanceTempo`
-/// to create matching TIP-20 tokens for assets bridged from L1.
+/// This is called by [`ZoneInbox`] during `advanceTempo` to create matching
+/// TIP-20 tokens for assets bridged from L1.
 #[contract(addr = TIP20_FACTORY_ADDRESS)]
 pub struct ZoneTokenFactory {}
 

--- a/crates/precompiles/src/tip403_proxy.rs
+++ b/crates/precompiles/src/tip403_proxy.rs
@@ -2,12 +2,11 @@
 //!
 //! Deployed at the same address as the L1 [`TIP403Registry`] (`0x403C…0000`), this
 //! precompile intercepts external EVM calls to the registry and serves authorization
-//! queries from the zone's [`PolicyProvider`] (cache-first, L1 RPC fallback).
+//! queries from the zone's [`PolicyCheck`] provider (cache-first, L1 RPC fallback).
 //!
 //! **Read-only calls** (`isAuthorized`, `isAuthorizedSender`, `isAuthorizedRecipient`,
 //! `isAuthorizedMintRecipient`, `policyData`, `compoundPolicyData`, `policyExists`)
-//! are resolved cache-first from the [`SharedPolicyCache`]. On cache miss,
-//! all queries fall back to L1 RPC (via `block_in_place`) and populate the cache.
+//! are resolved via the [`PolicyCheck`] trait.
 //!
 //! **Mutating calls** (`createPolicy`, `modifyPolicyWhitelist`, etc.) are reverted —
 //! policy state is managed on L1, not on the zone.
@@ -21,17 +20,15 @@ use tempo_contracts::precompiles::{
     TIP403_REGISTRY_ADDRESS,
 };
 use tracing::{debug, warn};
+use zone_primitives::policy::{AuthRole, FIRST_USER_POLICY, POLICY_REJECT_ALL};
 
-use crate::l1_state::{
-    PolicyProvider,
-    tip403::{AuthRole, FIRST_USER_POLICY, POLICY_REJECT_ALL},
-};
+use crate::policy::PolicyCheck;
 
 /// The precompile address — same as the L1 TIP403Registry.
 pub const ZONE_TIP403_PROXY_ADDRESS: Address = TIP403_REGISTRY_ADDRESS;
 
 /// Fixed gas cost for authorization checks.
-pub(crate) const AUTH_CHECK_GAS: u64 = 200;
+pub const AUTH_CHECK_GAS: u64 = 200;
 
 /// Fixed gas cost for policy data lookups.
 const POLICY_DATA_GAS: u64 = 200;
@@ -45,42 +42,30 @@ alloy_sol_types::sol! {
 ///
 /// Unlike the L1 [`TIP403Registry`] (which is a storage-backed `#[contract]`
 /// precompile), this proxy has **no on-chain storage**. It intercepts EVM calls
-/// at the same address (`0x403C…0000`) and resolves authorization queries from
-/// the in-memory [`PolicyProvider`] (cache-first, L1 RPC fallback). The
-/// underlying cache is populated by the unified [`L1Subscriber`](crate::l1::L1Subscriber)
-/// which extracts events from L1 block receipts.
+/// at the same address (`0x403C…0000`) and resolves authorization queries via
+/// the [`PolicyCheck`] trait.
 ///
 /// All mutating calls (`createPolicy`, `modifyPolicyWhitelist`, etc.) are
 /// rejected with `ReadOnlyRegistry` — policy state lives exclusively on L1.
-///
-/// Genesis initializes the L1 `TIP403Registry` at this address solely to set
-/// `0xef` bytecode so Solidity's `EXTCODESIZE` guard passes; the storage it
-/// writes is unused.
 ///
 /// The struct also exposes [`is_authorized`](Self::is_authorized) and
 /// [`is_transfer_authorized`](Self::is_transfer_authorized) for use by the
 /// [`ZoneTip20Token`](super::ZoneTip20Token) precompile, which needs the same
 /// authorization logic during transfer/mint pre-checks.
 #[derive(Debug, Clone)]
-pub struct ZoneTip403ProxyRegistry {
-    provider: PolicyProvider,
+pub struct ZoneTip403ProxyRegistry<P> {
+    provider: P,
 }
 
-impl ZoneTip403ProxyRegistry {
+impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
     /// Create a new proxy registry backed by the given policy provider.
-    pub fn new(provider: PolicyProvider) -> Self {
+    pub fn new(provider: P) -> Self {
         Self { provider }
     }
 
-    /// Resolve the `transferPolicyId` for a token — cache first, RPC fallback.
+    /// Resolve the `transferPolicyId` for a token.
     pub fn resolve_transfer_policy_id(&self, token: Address) -> Result<u64, PrecompileError> {
-        self.provider
-            .resolve_transfer_policy_id(token)
-            .map_err(|e| {
-                PrecompileError::other(format!(
-                    "failed to resolve transfer_policy_id for {token}: {e}"
-                ))
-            })
+        self.provider.resolve_transfer_policy_id(token)
     }
 
     /// Check whether `user` is authorized under `policy_id` for the given `role`.
@@ -90,13 +75,7 @@ impl ZoneTip403ProxyRegistry {
         user: Address,
         role: AuthRole,
     ) -> Result<bool, PrecompileError> {
-        self.provider
-            .is_authorized_by_policy(policy_id, user, role)
-            .map_err(|e| {
-                PrecompileError::other(format!(
-                    "auth check failed for policy {policy_id} user {user}: {e}"
-                ))
-            })
+        self.provider.is_authorized(policy_id, user, role)
     }
 
     /// Check sender + recipient authorization for a transfer.
@@ -113,10 +92,12 @@ impl ZoneTip403ProxyRegistry {
         }
         self.is_authorized(policy_id, to, AuthRole::Recipient)
     }
+}
 
+impl<P: PolicyCheck + Clone + Send + Sync + 'static> ZoneTip403ProxyRegistry<P> {
     /// Create a [`DynPrecompile`] that dispatches TIP-403 registry calls
-    /// to the zone's policy cache / L1 RPC fallback.
-    pub fn create(provider: PolicyProvider) -> DynPrecompile {
+    /// to the zone's policy provider.
+    pub fn create(provider: P) -> DynPrecompile {
         let registry = Self::new(provider);
         DynPrecompile::new_stateful(
             PrecompileId::Custom("ZoneTip403ProxyRegistry".into()),
@@ -141,7 +122,9 @@ impl ZoneTip403ProxyRegistry {
             },
         )
     }
+}
 
+impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
     /// Dispatch based on the 4-byte selector.
     fn dispatch(&self, selector: [u8; 4], data: &[u8]) -> PrecompileResult {
         // View functions — served from cache/RPC
@@ -223,16 +206,7 @@ impl ZoneTip403ProxyRegistry {
             return Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()));
         }
 
-        // Cache-first, RPC-fallback resolution.
-        let policy_type = self
-            .provider
-            .resolve_policy_type_sync(call.policyId)
-            .map_err(|e| {
-                PrecompileError::other(format!(
-                    "policyData failed for policy {}: {e}",
-                    call.policyId
-                ))
-            })?;
+        let policy_type = self.provider.policy_type_sync(call.policyId)?;
 
         let ret = ITIP403Registry::policyDataReturn {
             policyType: policy_type,
@@ -247,31 +221,19 @@ impl ZoneTip403ProxyRegistry {
         let call = ITIP403Registry::compoundPolicyDataCall::abi_decode(data)
             .map_err(|_| PrecompileError::other("ABI decode failed"))?;
 
-        // Cache-first, RPC-fallback resolution.
-        let compound = self
-            .provider
-            .resolve_compound_data_sync(call.policyId)
-            .map_err(|e| {
-                PrecompileError::other(format!(
-                    "compoundPolicyData failed for policy {}: {e}",
-                    call.policyId
-                ))
-            })?;
+        let (sender, recipient, mint_recipient) =
+            self.provider.compound_policy_data(call.policyId)?;
 
         let ret = ITIP403Registry::compoundPolicyDataReturn {
-            senderPolicyId: compound.sender_policy_id,
-            recipientPolicyId: compound.recipient_policy_id,
-            mintRecipientPolicyId: compound.mint_recipient_policy_id,
+            senderPolicyId: sender,
+            recipientPolicyId: recipient,
+            mintRecipientPolicyId: mint_recipient,
         };
         let encoded = ITIP403Registry::compoundPolicyDataCall::abi_encode_returns(&ret);
         Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
     }
 
     /// Handle `policyExists(policyId) → bool`.
-    ///
-    /// Cache-first, RPC-fallback: attempts to resolve the policy type via
-    /// [`PolicyProvider::resolve_policy_type_sync`]. If resolution succeeds
-    /// the policy exists; if the RPC call itself fails, the error propagates.
     fn handle_policy_exists(&self, data: &[u8]) -> PrecompileResult {
         let call = ITIP403Registry::policyExistsCall::abi_decode(data)
             .map_err(|_| PrecompileError::other("ABI decode failed"))?;
@@ -282,24 +244,14 @@ impl ZoneTip403ProxyRegistry {
             return Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()));
         }
 
-        // Cache-first, RPC-fallback — reuse policy type resolution.
-        let exists = self
-            .provider
-            .resolve_policy_type_sync(call.policyId)
-            .is_ok();
+        let exists = self.provider.policy_exists(call.policyId)?;
         let encoded = ITIP403Registry::policyExistsCall::abi_encode_returns(&exists);
         Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
     }
 
     /// Handle `policyIdCounter() → uint64`.
-    ///
-    /// **Cache-only**: returns the highest cached policy ID + 1 (minimum 2).
-    /// This may be lower than the actual L1 counter if the cache is incomplete.
     fn handle_policy_id_counter(&self) -> PrecompileResult {
-        let counter = {
-            let cache = self.provider.cache().read();
-            cache.policies().keys().max().map_or(2, |max| max + 1)
-        };
+        let counter = self.provider.policy_id_counter();
         let encoded = ITIP403Registry::policyIdCounterCall::abi_encode_returns(&counter);
         Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
     }

--- a/crates/precompiles/src/ztip20.rs
+++ b/crates/precompiles/src/ztip20.rs
@@ -1,4 +1,4 @@
-//! Zone-specific TIP-20 token precompile with PolicyProvider-backed authorization.
+//! Zone-specific TIP-20 token precompile with PolicyCheck-backed authorization.
 //!
 //! On L1, the vanilla [`TIP20Token`] checks transfer/mint authorization by
 //! instantiating a `TIP403Registry` in Rust which reads EVM storage at
@@ -7,13 +7,8 @@
 //!
 //! This wrapper intercepts transfer and mint calls, checks authorization
 //! against the zone's [`ZoneTip403ProxyRegistry`] (which delegates to
-//! [`PolicyProvider`] — cache-first, L1 RPC fallback), and only then delegates
-//! to the vanilla `TIP20Token` implementation. The vanilla call's internal
-//! `TIP403Registry::new()` check still runs but always passes (empty storage →
-//! allow-all), so the real enforcement has already happened.
-//!
-//! NOTE: This is a temporary solution until the vanilla TIP-20 implementation
-//! is made configurable to accept an external authorization provider.
+//! [`PolicyCheck`] — cache-first, L1 RPC fallback), and only then delegates
+//! to the vanilla `TIP20Token` implementation.
 
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::{Address, Bytes};
@@ -25,9 +20,12 @@ use tempo_precompiles::{
     tip20::{ITIP20, TIP20Token},
 };
 use tracing::{debug, trace};
+use zone_primitives::policy::AuthRole;
 
-use super::tip403_proxy::{AUTH_CHECK_GAS, ZoneTip403ProxyRegistry};
-use crate::l1_state::tip403::AuthRole;
+use crate::{
+    policy::PolicyCheck,
+    tip403_proxy::{AUTH_CHECK_GAS, ZoneTip403ProxyRegistry},
+};
 
 /// Decode ABI args or return a reverted precompile output.
 ///
@@ -48,67 +46,17 @@ macro_rules! decode_or_revert {
 /// Zone-specific TIP-20 token precompile.
 ///
 /// Wraps the vanilla [`TIP20Token`] and the [`ZoneTip403ProxyRegistry`] to add
-/// PolicyProvider-backed authorization for transfers and mints. All other calls
+/// PolicyCheck-backed authorization for transfers and mints. All other calls
 /// (balanceOf, approve, metadata, roles, rewards, etc.) are passed through
 /// unmodified to the vanilla implementation.
-pub struct ZoneTip20Token {
-    registry: ZoneTip403ProxyRegistry,
+pub struct ZoneTip20Token<P> {
+    registry: ZoneTip403ProxyRegistry<P>,
 }
 
-impl ZoneTip20Token {
+impl<P: PolicyCheck> ZoneTip20Token<P> {
     /// Create a new wrapper with the given registry.
-    pub fn new(registry: ZoneTip403ProxyRegistry) -> Self {
+    pub fn new(registry: ZoneTip403ProxyRegistry<P>) -> Self {
         Self { registry }
-    }
-
-    /// Create a [`DynPrecompile`] for a zone-side TIP-20 token at `address`.
-    ///
-    /// The returned precompile:
-    /// 1. Checks the 4-byte selector for transfer/mint calls.
-    /// 2. For those calls, reads `transfer_policy_id` from EVM storage and
-    ///    checks authorization via the [`ZoneTip403ProxyRegistry`].
-    /// 3. Delegates to the vanilla `TIP20Token::call()` for execution.
-    pub fn create(
-        address: Address,
-        cfg: &revm::context::CfgEnv<tempo_chainspec::hardfork::TempoHardfork>,
-        registry: ZoneTip403ProxyRegistry,
-    ) -> DynPrecompile {
-        let spec = cfg.spec;
-        let gas_params = cfg.gas_params.clone();
-        let token = Self::new(registry);
-
-        DynPrecompile::new_stateful(
-            PrecompileId::Custom("ZoneTip20Token".into()),
-            move |input| {
-                if !input.is_direct_call() {
-                    return Ok(PrecompileOutput::new_reverted(
-                        0,
-                        SolError::abi_encode(&DelegateCallNotAllowed {}).into(),
-                    ));
-                }
-
-                let mut storage = EvmPrecompileStorageProvider::new(
-                    input.internals,
-                    input.gas,
-                    spec,
-                    input.is_static,
-                    gas_params.clone(),
-                );
-
-                StorageCtx::enter(&mut storage, || {
-                    // Pre-check: enforce zone policy for transfer/mint calls.
-                    // Returns Some(reverted output) if policy forbids, None if allowed.
-                    if let Some(revert) = token.check_policy(address, input.data, input.caller) {
-                        return revert;
-                    }
-
-                    // Policy passed (or non-transfer call) — delegate to vanilla TIP20Token
-                    let mut tip20 =
-                        TIP20Token::from_address(address).expect("TIP20 prefix already verified");
-                    tip20.call(input.data, input.caller)
-                })
-            },
-        )
     }
 
     /// Check policy authorization for transfer/mint selectors.
@@ -169,9 +117,6 @@ impl ZoneTip20Token {
         let policy_id = match self.resolve_transfer_policy_id(token) {
             Ok(id) => id,
             Err(e) => {
-                // Can't resolve policy — token may be uninitialized or RPC
-                // unreachable. Fall through to vanilla TIP20Token which will
-                // handle it (revert for uninitialized, or read from EVM storage).
                 debug!(
                     target: "zone::precompile",
                     %token, error = %e,
@@ -239,7 +184,7 @@ impl ZoneTip20Token {
         }
     }
 
-    /// Resolve the `transfer_policy_id` for a token — cache first, L1 RPC fallback.
+    /// Resolve the `transfer_policy_id` for a token.
     fn resolve_transfer_policy_id(&self, token: Address) -> Result<u64, PrecompileError> {
         self.registry.resolve_transfer_policy_id(token)
     }
@@ -251,6 +196,57 @@ impl ZoneTip20Token {
             tempo_contracts::precompiles::TIP20Error::policy_forbids()
                 .selector()
                 .into(),
+        )
+    }
+}
+
+impl<P: PolicyCheck + Clone + Send + Sync + 'static> ZoneTip20Token<P> {
+    /// Create a [`DynPrecompile`] for a zone-side TIP-20 token at `address`.
+    ///
+    /// The returned precompile:
+    /// 1. Checks the 4-byte selector for transfer/mint calls.
+    /// 2. For those calls, reads `transfer_policy_id` from EVM storage and
+    ///    checks authorization via the [`ZoneTip403ProxyRegistry`].
+    /// 3. Delegates to the vanilla `TIP20Token::call()` for execution.
+    pub fn create(
+        address: Address,
+        cfg: &revm::context::CfgEnv<tempo_chainspec::hardfork::TempoHardfork>,
+        registry: ZoneTip403ProxyRegistry<P>,
+    ) -> DynPrecompile {
+        let spec = cfg.spec;
+        let gas_params = cfg.gas_params.clone();
+        let token = Self::new(registry);
+
+        DynPrecompile::new_stateful(
+            PrecompileId::Custom("ZoneTip20Token".into()),
+            move |input| {
+                if !input.is_direct_call() {
+                    return Ok(PrecompileOutput::new_reverted(
+                        0,
+                        SolError::abi_encode(&DelegateCallNotAllowed {}).into(),
+                    ));
+                }
+
+                let mut storage = EvmPrecompileStorageProvider::new(
+                    input.internals,
+                    input.gas,
+                    spec,
+                    input.is_static,
+                    gas_params.clone(),
+                );
+
+                StorageCtx::enter(&mut storage, || {
+                    // Pre-check: enforce zone policy for transfer/mint calls.
+                    if let Some(revert) = token.check_policy(address, input.data, input.caller) {
+                        return revert;
+                    }
+
+                    // Policy passed (or non-transfer call) — delegate to vanilla TIP20Token
+                    let mut tip20 =
+                        TIP20Token::from_address(address).expect("TIP20 prefix already verified");
+                    tip20.call(input.data, input.caller)
+                })
+            },
         )
     }
 }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -10,4 +10,5 @@ extern crate alloc;
 pub mod abi;
 pub mod constants;
 mod header;
+pub mod policy;
 pub use header::ZoneHeader;

--- a/crates/primitives/src/policy.rs
+++ b/crates/primitives/src/policy.rs
@@ -1,0 +1,29 @@
+//! TIP-403 policy types shared between the zone node and the prover.
+//!
+//! These are extracted here so that `zone-precompiles` (which is `no_std`) can
+//! reference `AuthRole` and the builtin policy constants without pulling in the
+//! full `tempo-zone` dependency tree.
+
+/// Authorization role for TIP-403 policy checks.
+///
+/// Determines which sub-policy is evaluated for compound policies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AuthRole {
+    /// Check both sender AND recipient. For compound policies, short-circuits on sender failure.
+    Transfer,
+    /// Check sender authorization only (compound: uses `senderPolicyId`).
+    Sender,
+    /// Check recipient authorization only (compound: uses `recipientPolicyId`).
+    Recipient,
+    /// Check mint recipient authorization only (compound: uses `mintRecipientPolicyId`).
+    MintRecipient,
+}
+
+/// Builtin policy ID that rejects all addresses (whitelist with no members).
+pub const POLICY_REJECT_ALL: u64 = 0;
+
+/// Builtin policy ID that allows all addresses (blacklist with no members).
+pub const POLICY_ALLOW_ALL: u64 = 1;
+
+/// First user-created policy ID. IDs below this are builtins.
+pub const FIRST_USER_POLICY: u64 = 2;

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -23,8 +23,8 @@ tempo-transaction-pool.workspace = true
 tempo-alloy = { workspace = true, features = ["tempo-compat"] }
 tempo-contracts.workspace = true
 tempo-precompiles.workspace = true
-tempo-precompiles-macros.workspace = true
-zone-primitives.workspace = true
+zone-precompiles = { workspace = true, features = ["std"] }
+zone-primitives = { workspace = true, features = ["std", "serde", "rpc"] }
 zone-rpc.workspace = true
 
 # reth
@@ -49,7 +49,6 @@ reth-storage-api.workspace = true
 reth-transaction-pool.workspace = true
 
 # alloy
-alloy.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-evm.workspace = true
@@ -69,10 +68,7 @@ revm.workspace = true
 
 # misc
 metrics.workspace = true
-aes-gcm.workspace = true
 k256.workspace = true
-rand.workspace = true
-sha2.workspace = true
 url = "2"
 derive_more = { workspace = true, features = ["deref", "deref_mut"] }
 either.workspace = true
@@ -111,6 +107,7 @@ thiserror.workspace = true
 tempo-chainspec.workspace = true
 tempo-contracts.workspace = true
 tempo-payload-types.workspace = true
+sha2.workspace = true
 tempo-precompiles = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -82,10 +82,11 @@ impl ZoneEvmFactory {
             Some(ZoneTokenFactory::create(&cfg))
         });
         if let Some(ref policy_provider) = self.policy_provider {
-            let registry = ZoneTip403ProxyRegistry::new(policy_provider.clone());
+            let provider = policy_provider.clone();
+            let registry = ZoneTip403ProxyRegistry::new(provider.clone());
 
             precompiles.apply_precompile(&ZONE_TIP403_PROXY_ADDRESS, |_| {
-                Some(ZoneTip403ProxyRegistry::create(policy_provider.clone()))
+                Some(ZoneTip403ProxyRegistry::create(provider.clone()))
             });
 
             // Override the TIP-20 precompile lookup so that all TIP-20 token

--- a/crates/tempo-zone/src/l1_state/tip403/cache.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/cache.rs
@@ -50,16 +50,9 @@ use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP403Registry::PolicyType;
 use tracing::info;
 
+use zone_primitives::policy::{FIRST_USER_POLICY, POLICY_ALLOW_ALL};
+
 use crate::l1_state::versioned::HeightVersioned;
-
-/// Built-in "always reject" policy (policy ID 0). All addresses are unauthorized.
-pub(crate) const POLICY_REJECT_ALL: u64 = 0;
-
-/// Built-in "always allow" policy (policy ID 1). All addresses are authorized.
-pub(crate) const POLICY_ALLOW_ALL: u64 = 1;
-
-/// First user-created policy ID. IDs below this are reserved builtins.
-pub(crate) const FIRST_USER_POLICY: u64 = 2;
 
 /// Block-versioned cache of TIP-403 policy state from Tempo L1.
 ///
@@ -603,22 +596,7 @@ impl PolicyEvent {
     }
 }
 
-/// Authorization role for policy checks.
-///
-/// For simple policies (whitelist/blacklist), the role is ignored — the same membership set
-/// applies regardless. For compound policies (TIP-1015), the role selects which sub-policy
-/// to check.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AuthRole {
-    /// Check both sender AND recipient. For compound policies, short-circuits on sender failure.
-    Transfer,
-    /// Check sender authorization only (compound: uses `senderPolicyId`).
-    Sender,
-    /// Check recipient authorization only (compound: uses `recipientPolicyId`).
-    Recipient,
-    /// Check mint recipient authorization only (compound: uses `mintRecipientPolicyId`).
-    MintRecipient,
-}
+pub(super) use zone_primitives::policy::AuthRole;
 
 /// Per-policy-ID cached record, mirroring `TIP403Registry.policy_records[id]`.
 #[derive(Debug, Default)]

--- a/crates/tempo-zone/src/l1_state/tip403/mod.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/mod.rs
@@ -69,10 +69,10 @@ pub mod provider;
 pub mod task;
 
 pub use cache::{
-    AuthRole, CachedPolicy, CompoundData, MembershipSet, PolicyCache, PolicyEvent,
-    SharedPolicyCache,
+    CachedPolicy, CompoundData, MembershipSet, PolicyCache, PolicyEvent, SharedPolicyCache,
 };
-pub(crate) use cache::{FIRST_USER_POLICY, POLICY_ALLOW_ALL, POLICY_REJECT_ALL};
+pub use zone_primitives::policy::AuthRole;
+
 pub use metrics::Tip403Metrics;
 pub use pool_prefetch::spawn_pool_prefetch_task;
 pub use provider::PolicyProvider;

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -12,16 +12,17 @@ use alloy_primitives::Address;
 use alloy_provider::DynProvider;
 use alloy_rpc_types_eth::BlockId;
 use eyre::Result;
+use revm::precompile::PrecompileError;
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::{
     ITIP20, ITIP403Registry, ITIP403Registry::PolicyType, TIP403_REGISTRY_ADDRESS,
 };
 use tracing::{debug, info, warn};
+use zone_precompiles::policy::PolicyCheck;
 
-use super::{
-    AuthRole, CompoundData, FIRST_USER_POLICY, POLICY_ALLOW_ALL, SharedPolicyCache,
-    metrics::Tip403Metrics,
-};
+use zone_primitives::policy::{FIRST_USER_POLICY, POLICY_ALLOW_ALL};
+
+use super::{AuthRole, CompoundData, SharedPolicyCache, metrics::Tip403Metrics};
 
 /// Cache-first, RPC-fallback provider for TIP-403 policy authorization.
 ///
@@ -561,5 +562,60 @@ impl PolicyProvider {
             })?;
 
         Ok(authorized)
+    }
+}
+
+impl PolicyCheck for PolicyProvider {
+    fn is_authorized(
+        &self,
+        policy_id: u64,
+        user: Address,
+        role: AuthRole,
+    ) -> Result<bool, PrecompileError> {
+        self.is_authorized_by_policy(policy_id, user, role)
+            .map_err(|e| {
+                PrecompileError::other(format!(
+                    "auth check failed for policy {policy_id} user {user}: {e}"
+                ))
+            })
+    }
+
+    fn resolve_transfer_policy_id(&self, token: Address) -> Result<u64, PrecompileError> {
+        Self::resolve_transfer_policy_id(self, token).map_err(|e| {
+            PrecompileError::other(format!(
+                "failed to resolve transfer_policy_id for {token}: {e}"
+            ))
+        })
+    }
+
+    fn policy_type_sync(&self, policy_id: u64) -> Result<PolicyType, PrecompileError> {
+        self.resolve_policy_type_sync(policy_id).map_err(|e| {
+            PrecompileError::other(format!("policyData failed for policy {policy_id}: {e}"))
+        })
+    }
+
+    fn compound_policy_data(&self, policy_id: u64) -> Result<(u64, u64, u64), PrecompileError> {
+        let compound = self.resolve_compound_data_sync(policy_id).map_err(|e| {
+            PrecompileError::other(format!(
+                "compoundPolicyData failed for policy {policy_id}: {e}"
+            ))
+        })?;
+        Ok((
+            compound.sender_policy_id,
+            compound.recipient_policy_id,
+            compound.mint_recipient_policy_id,
+        ))
+    }
+
+    fn policy_exists(&self, policy_id: u64) -> Result<bool, PrecompileError> {
+        if policy_id < FIRST_USER_POLICY {
+            return Ok(true);
+        }
+        Ok(self.resolve_policy_type_sync(policy_id).is_ok())
+    }
+
+    fn policy_id_counter(&self) -> u64 {
+        let cache = self.cache.read();
+        cache.policies().keys().max().map_or(2, |max| max + 1)
     }
 }

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -5,9 +5,6 @@
 #![allow(clippy::too_many_arguments)]
 use eyre as _;
 
-// Required by the `#[contract]` proc macro expansion (references `crate::storage` / `crate::error`).
-pub(crate) use tempo_precompiles::{error, storage};
-
 pub mod abi;
 pub mod ext;
 pub use ext::{ChainTempoStateExt, TempoStateExt};

--- a/crates/tempo-zone/src/precompiles/mod.rs
+++ b/crates/tempo-zone/src/precompiles/mod.rs
@@ -1,33 +1,3 @@
-//! Cryptographic precompiles for encrypted deposit processing.
-//!
-//! Two precompiles that enable the [`ZoneInbox`](crate::abi::ZoneInbox) contract
-//! to verify and decrypt encrypted deposits during `advanceTempo`:
-//!
-//! - **Chaum-Pedersen Verify** (`0x1C00...0100`) — verifies a DLOG equality proof
-//!   for ECDH shared secret derivation.
-//!
-//! - **AES-256-GCM Decrypt** (`0x1C00...0101`) — decrypts ECIES ciphertext and
-//!   verifies the GCM authentication tag.
-//!
-//! Both use NCC-audited RustCrypto implementations:
-//! - [`k256`] v0.13.4 for secp256k1 elliptic curve operations
-//! - [`aes-gcm`] v0.10.3 for AES-256-GCM authenticated decryption
-//!
-//! The [`ecies`] submodule provides the sequencer-side ECIES decryption logic
-//! that produces [`DecryptionData`](crate::abi::DecryptionData) verified on-chain.
+//! Zone-specific precompiles — re-exported from [`zone_precompiles`].
 
-pub mod aes_gcm;
-pub mod chaum_pedersen;
-pub mod ecies;
-pub mod tip20_factory;
-pub mod tip403_proxy;
-pub mod ztip20;
-
-pub use aes_gcm::{AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt};
-pub use chaum_pedersen::{CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify};
-pub use tip20_factory::{ZONE_TIP20_FACTORY_ADDRESS, ZoneTokenFactory};
-pub use tip403_proxy::{ZONE_TIP403_PROXY_ADDRESS, ZoneTip403ProxyRegistry};
-pub use ztip20::ZoneTip20Token;
-
-#[cfg(test)]
-mod test_utils;
+pub use zone_precompiles::*;


### PR DESCRIPTION
Extracts zone-specific precompile implementations from `tempo-zone` into a standalone `zone-precompiles` crate. The crate is `no_std` compatible so these precompiles can run inside the SP1 prover guest (RISC-V).

**What moves to `zone-precompiles`:**
- Crypto precompiles: Chaum-Pedersen, AES-GCM, ECIES
- Policy/token precompiles: TIP-20 Factory, TIP-403 Proxy, Zone TIP-20
- Supporting test utilities

**Dependency decoupling:**
- `AuthRole` enum and policy constants (`FIRST_USER_POLICY`, `POLICY_ALLOW_ALL`, `POLICY_REJECT_ALL`) move to `zone-primitives`
- A `PolicyCheck` trait in `zone-precompiles` abstracts the policy authorization interface, replacing the direct dependency on `PolicyProvider`
- `PolicyProviderAdapter` in `tempo-zone` bridges `PolicyProvider` to `PolicyCheck`

**What stays in `tempo-zone`:**
- EVM factory (`evm.rs`), policy cache, `PolicyProvider`, `TempoStateReader` (L1 state precompile)

Depends on #229