### PR TITLE
fix: skip pool txs on transient L1 RPC errors

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -39,5 +39,22 @@ pub use tip20_factory::{ZONE_TIP20_FACTORY_ADDRESS, ZoneTokenFactory};
 pub use tip403_proxy::{ZONE_TIP403_PROXY_ADDRESS, ZoneTip403ProxyRegistry};
 pub use ztip20::ZoneTip20Token;
 
+use revm::precompile::PrecompileError;
+
+const ZONE_RPC_ERROR_PREFIX: &str = "[zone rpc]";
+
+/// Create a [`PrecompileError::Fatal`] for transient L1 RPC errors.
+///
+/// Fatal errors propagate out of the EVM as `Err` (instead of a revert),
+/// allowing the builder to skip the pool transaction rather than charging gas.
+pub fn zone_rpc_error(msg: impl core::fmt::Display) -> PrecompileError {
+    PrecompileError::Fatal(alloc::format!("{ZONE_RPC_ERROR_PREFIX} {msg}"))
+}
+
+/// Returns `true` if the error string was produced by [`zone_rpc_error`].
+pub fn is_zone_rpc_error(err: &str) -> bool {
+    err.starts_with(ZONE_RPC_ERROR_PREFIX)
+}
+
 #[cfg(test)]
 mod test_utils;

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -312,6 +312,12 @@ where
                     }
                     continue;
                 }
+                Err(reth_evm::block::BlockExecutionError::Internal(
+                    reth_evm::block::InternalBlockExecutionError::EVM { ref error, .. },
+                )) if zone_precompiles::is_zone_rpc_error(&error.to_string()) => {
+                    warn!(target: "zone::payload", %error, ?pool_tx, "skipping pool tx due to transient RPC error");
+                    continue;
+                }
                 Err(err) => return Err(PayloadBuilderError::evm(err)),
             }
         }

--- a/crates/tempo-zone/src/l1_state/precompile.rs
+++ b/crates/tempo-zone/src/l1_state/precompile.rs
@@ -134,7 +134,7 @@ impl TempoStateReader {
         let value = provider
             .get_storage(call.account, call.slot, call.blockNumber)
             .map_err(|e| {
-                PrecompileError::other(format!(
+                zone_precompiles::zone_rpc_error(format!(
                     "L1 storage unavailable for account={} slot={} block={}: {e}",
                     call.account, call.slot, call.blockNumber
                 ))
@@ -162,7 +162,7 @@ impl TempoStateReader {
             let value = provider
                 .get_storage(call.account, *slot, call.blockNumber)
                 .map_err(|e| {
-                    PrecompileError::other(format!(
+                    zone_precompiles::zone_rpc_error(format!(
                         "L1 storage unavailable for account={} slot={} block={}: {e}",
                         call.account, slot, call.blockNumber
                     ))

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -616,7 +616,7 @@ impl PolicyCheck for PolicyProvider {
     ) -> Result<bool, PrecompileError> {
         self.is_authorized_by_policy(policy_id, user, role)
             .map_err(|e| {
-                PrecompileError::other(format!(
+                zone_precompiles::zone_rpc_error(format!(
                     "auth check failed for policy {policy_id} user {user}: {e}"
                 ))
             })
@@ -624,7 +624,7 @@ impl PolicyCheck for PolicyProvider {
 
     fn resolve_transfer_policy_id(&self, token: Address) -> Result<u64, PrecompileError> {
         Self::resolve_transfer_policy_id(self, token).map_err(|e| {
-            PrecompileError::other(format!(
+            zone_precompiles::zone_rpc_error(format!(
                 "failed to resolve transfer_policy_id for {token}: {e}"
             ))
         })
@@ -632,13 +632,15 @@ impl PolicyCheck for PolicyProvider {
 
     fn policy_type_sync(&self, policy_id: u64) -> Result<PolicyType, PrecompileError> {
         self.resolve_policy_type_sync(policy_id).map_err(|e| {
-            PrecompileError::other(format!("policyData failed for policy {policy_id}: {e}"))
+            zone_precompiles::zone_rpc_error(format!(
+                "policyData failed for policy {policy_id}: {e}"
+            ))
         })
     }
 
     fn compound_policy_data(&self, policy_id: u64) -> Result<(u64, u64, u64), PrecompileError> {
         let compound = self.resolve_compound_data_sync(policy_id).map_err(|e| {
-            PrecompileError::other(format!(
+            zone_precompiles::zone_rpc_error(format!(
                 "compoundPolicyData failed for policy {policy_id}: {e}"
             ))
         })?;


### PR DESCRIPTION
When a zone precompile (TIP-403 proxy, zone TIP-20, TempoStateReader) hits a transient L1 RPC error during pool transaction execution, the error was returned as `PrecompileError::Other` which revm silently converts to a revert — charging the user gas for an infrastructure failure.

This switches RPC errors to `PrecompileError::Fatal` so they propagate as `Err` from the EVM instead of reverting. A new match arm in the builder's pool tx loop catches these via a `[zone rpc]` prefix in the error message and skips the transaction instead of aborting the block. ABI decode errors (user input) remain as `PrecompileError::other` and still revert normally.

System transactions (advanceTempo, finalizeWithdrawalBatch) are unaffected — they use separate error handling paths that already abort on any error.

Closes #235