### PR TITLE
fix: configure infinite WebSocket reconnection for L1 providers

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -84,6 +84,14 @@ struct ZoneArgs {
     )]
     pub l1_fetch_concurrency: usize,
 
+    /// Interval in milliseconds between WebSocket reconnection attempts to L1.
+    #[arg(
+        long = "l1.retry-connection-interval",
+        env = "L1_RETRY_CONNECTION_INTERVAL_MS",
+        default_value_t = 100
+    )]
+    pub l1_retry_connection_interval_ms: u64,
+
     /// Zone ID for the private RPC auth token validation.
     /// Must match the zone's on-chain ID from ZoneFactory.
     #[arg(long = "zone.id", env = "ZONE_ID", default_value_t = 0)]
@@ -150,6 +158,7 @@ fn main() {
                 sequencer_addr,
                 sequencer_secret_key,
                 args.l1_fetch_concurrency,
+                Duration::from_millis(args.l1_retry_connection_interval_ms),
             );
 
             let handle = builder.node(node).launch_with_debug_capabilities().await?;

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -52,6 +52,8 @@ pub struct L1SubscriberConfig {
     /// Maximum number of concurrent L1 RPC receipt fetches. Used directly for
     /// the live stream and halved for backfill (which sends 2 requests per block).
     pub l1_fetch_concurrency: usize,
+    /// Interval between WebSocket reconnection attempts.
+    pub retry_connection_interval: std::time::Duration,
 }
 
 /// L1 chain subscriber that listens for new blocks and extracts deposit events.
@@ -101,7 +103,9 @@ impl L1Subscriber {
     async fn connect(&self) -> eyre::Result<impl Provider<TempoNetwork> + use<>> {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
         let url: url::Url = self.config.l1_rpc_url.parse()?;
-        let mut ws = WsConnect::new(self.config.l1_rpc_url.clone());
+        let mut ws = WsConnect::new(self.config.l1_rpc_url.clone())
+            .with_max_retries(u32::MAX)
+            .with_retry_interval(self.config.retry_connection_interval);
         if !url.username().is_empty() {
             let auth = Authorization::basic(url.username(), url.password().unwrap_or_default());
             ws = ws.with_auth(auth);

--- a/crates/tempo-zone/src/l1_state/provider.rs
+++ b/crates/tempo-zone/src/l1_state/provider.rs
@@ -12,7 +12,7 @@
 
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
-use alloy_rpc_client::RpcClient;
+use alloy_rpc_client::{ConnectionConfig, RpcClient};
 use alloy_rpc_types_eth::BlockId;
 use alloy_transport::layers::RetryBackoffLayer;
 use eyre::Result;
@@ -32,6 +32,9 @@ pub struct L1StateProviderConfig {
     /// Initial backoff in milliseconds for the transport-level retry layer.
     /// Defaults to 20ms.
     pub initial_backoff_ms: u64,
+    /// Interval between WebSocket reconnection attempts.
+    /// Defaults to 100ms.
+    pub retry_connection_interval: std::time::Duration,
 }
 
 impl Default for L1StateProviderConfig {
@@ -40,6 +43,7 @@ impl Default for L1StateProviderConfig {
             l1_rpc_url: String::new(),
             max_retries: 10,
             initial_backoff_ms: 20,
+            retry_connection_interval: std::time::Duration::from_millis(100),
         }
     }
 }
@@ -87,9 +91,13 @@ impl L1StateProvider {
         let retry_layer =
             RetryBackoffLayer::new(config.max_retries, config.initial_backoff_ms, u64::MAX);
 
+        let conn_config = ConnectionConfig::new()
+            .with_max_retries(u32::MAX)
+            .with_retry_interval(config.retry_connection_interval);
+
         let client = RpcClient::builder()
             .layer(retry_layer)
-            .connect(&config.l1_rpc_url)
+            .connect_with_config(&config.l1_rpc_url, conn_config)
             .await
             .map_err(|e| {
                 eyre::eyre!(

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -105,6 +105,7 @@ impl ZoneNode {
         sequencer: alloy_primitives::Address,
         sequencer_key: k256::SecretKey,
         l1_fetch_concurrency: usize,
+        retry_connection_interval: std::time::Duration,
     ) -> Self {
         let deposit_queue = crate::DepositQueue::default();
 
@@ -119,10 +120,12 @@ impl ZoneNode {
             policy_cache: policy_cache.clone(),
             l1_state_cache: l1_state_cache.clone(),
             l1_fetch_concurrency,
+            retry_connection_interval,
         };
 
         let l1_state_provider_config = L1StateProviderConfig {
             l1_rpc_url,
+            retry_connection_interval,
             ..Default::default()
         };
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -421,6 +421,7 @@ impl ZoneTestNode {
             Address::ZERO, // sequencer address (overridden by sequencer_key)
             sequencer_key,
             4,
+            std::time::Duration::from_millis(100),
         )
         .with_initial_tokens(vec![]);
 


### PR DESCRIPTION
The default alloy WsConnect retries reconnection only 10 times at 3-second intervals before permanently killing the backend task. Once dead, the L1StateProvider's `get_storage` retry loop spins indefinitely on the dead transport, producing millions of warn logs per second without ever recovering.

This configures both the L1StateProvider and L1Subscriber WebSocket connections with `max_retries = u32::MAX` so alloy's built-in pubsub reconnection layer keeps retrying indefinitely. The retry interval is configurable via `--l1.retry-connection-interval` (default 100ms, env `L1_RETRY_CONNECTION_INTERVAL_MS`).