### PR TITLE
chore: update license copyright year to 2026

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2025 Tempo Contributors
+Copyright 2026 Tempo Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 Tempo Contributors
+Copyright (c) 2026 Tempo Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- update the copyright year from 2025 to 2026 in LICENSE-MIT
- update the copyright year from 2025 to 2026 in LICENSE-APACHE

## Testing
- not run (text-only change)