### PR TITLE
refactor(tip403): use upstream builtin policy ID constants

### DIFF
--- a/crates/precompiles/src/tip403_proxy.rs
+++ b/crates/precompiles/src/tip403_proxy.rs
@@ -19,8 +19,9 @@ use tempo_contracts::precompiles::{
     ITIP403Registry::{self, PolicyType},
     TIP403_REGISTRY_ADDRESS,
 };
+use tempo_precompiles::tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID};
 use tracing::{debug, warn};
-use zone_primitives::policy::{AuthRole, FIRST_USER_POLICY, POLICY_REJECT_ALL};
+use zone_primitives::policy::AuthRole;
 
 use crate::policy::PolicyCheck;
 
@@ -191,13 +192,13 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
         let call = ITIP403Registry::policyDataCall::abi_decode(data)
             .map_err(|_| PrecompileError::other("ABI decode failed"))?;
 
-        // Builtins
-        if call.policyId < FIRST_USER_POLICY {
-            let policy_type = if call.policyId == POLICY_REJECT_ALL {
-                PolicyType::WHITELIST
-            } else {
-                PolicyType::BLACKLIST
-            };
+        // Builtins: reject-all is an empty whitelist, allow-all is an empty blacklist
+        let builtin_type = match call.policyId {
+            REJECT_ALL_POLICY_ID => Some(PolicyType::WHITELIST),
+            ALLOW_ALL_POLICY_ID => Some(PolicyType::BLACKLIST),
+            _ => None,
+        };
+        if let Some(policy_type) = builtin_type {
             let ret = ITIP403Registry::policyDataReturn {
                 policyType: policy_type,
                 admin: Address::ZERO,
@@ -239,7 +240,7 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
             .map_err(|_| PrecompileError::other("ABI decode failed"))?;
 
         // Builtins always exist
-        if call.policyId < FIRST_USER_POLICY {
+        if matches!(call.policyId, REJECT_ALL_POLICY_ID | ALLOW_ALL_POLICY_ID) {
             let encoded = ITIP403Registry::policyExistsCall::abi_encode_returns(&true);
             return Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()));
         }

--- a/crates/primitives/src/policy.rs
+++ b/crates/primitives/src/policy.rs
@@ -1,8 +1,7 @@
 //! TIP-403 policy types shared between the zone node and the prover.
 //!
 //! These are extracted here so that `zone-precompiles` (which is `no_std`) can
-//! reference `AuthRole` and the builtin policy constants without pulling in the
-//! full `tempo-zone` dependency tree.
+//! reference `AuthRole` without pulling in the full `tempo-zone` dependency tree.
 
 /// Authorization role for TIP-403 policy checks.
 ///
@@ -18,12 +17,3 @@ pub enum AuthRole {
     /// Check mint recipient authorization only (compound: uses `mintRecipientPolicyId`).
     MintRecipient,
 }
-
-/// Builtin policy ID that rejects all addresses (whitelist with no members).
-pub const POLICY_REJECT_ALL: u64 = 0;
-
-/// Builtin policy ID that allows all addresses (blacklist with no members).
-pub const POLICY_ALLOW_ALL: u64 = 1;
-
-/// First user-created policy ID. IDs below this are builtins.
-pub const FIRST_USER_POLICY: u64 = 2;

--- a/crates/tempo-zone/src/l1_state/tip403/cache.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/cache.rs
@@ -50,7 +50,7 @@ use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP403Registry::PolicyType;
 use tracing::info;
 
-use zone_primitives::policy::{FIRST_USER_POLICY, POLICY_ALLOW_ALL};
+use super::builtin_authorization;
 
 use crate::l1_state::versioned::HeightVersioned;
 
@@ -185,9 +185,8 @@ impl PolicyCache {
         block_number: u64,
         role: AuthRole,
     ) -> Option<bool> {
-        if policy_id < FIRST_USER_POLICY {
-            // Policy 0 = reject all (empty whitelist), policy 1 = allow all (empty blacklist).
-            return Some(policy_id == POLICY_ALLOW_ALL);
+        if let Some(authorized) = builtin_authorization(policy_id) {
+            return Some(authorized);
         }
 
         let policy = self.policies.get(&policy_id)?;
@@ -238,8 +237,8 @@ impl PolicyCache {
     /// Handles builtins and whitelist/blacklist. Returns `None` for compound sub-policies
     /// (compound-of-compound is invalid on L1).
     pub fn check_simple(&self, policy_id: u64, user: Address, block_number: u64) -> Option<bool> {
-        if policy_id < FIRST_USER_POLICY {
-            return Some(policy_id == POLICY_ALLOW_ALL);
+        if let Some(authorized) = builtin_authorization(policy_id) {
+            return Some(authorized);
         }
 
         let policy = self.policies.get(&policy_id)?;

--- a/crates/tempo-zone/src/l1_state/tip403/mod.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/mod.rs
@@ -71,7 +71,18 @@ pub mod task;
 pub use cache::{
     CachedPolicy, CompoundData, MembershipSet, PolicyCache, PolicyEvent, SharedPolicyCache,
 };
+use tempo_precompiles::tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID};
 pub use zone_primitives::policy::AuthRole;
+
+/// Returns authorization result for built-in policies, `None` for user-created ones.
+#[inline]
+fn builtin_authorization(policy_id: u64) -> Option<bool> {
+    match policy_id {
+        ALLOW_ALL_POLICY_ID => Some(true),
+        REJECT_ALL_POLICY_ID => Some(false),
+        _ => None,
+    }
+}
 
 pub use metrics::Tip403Metrics;
 pub use pool_prefetch::spawn_pool_prefetch_task;

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -20,7 +20,7 @@ use tempo_contracts::precompiles::{
 use tracing::{debug, info, warn};
 use zone_precompiles::policy::PolicyCheck;
 
-use zone_primitives::policy::{FIRST_USER_POLICY, POLICY_ALLOW_ALL};
+use super::builtin_authorization;
 
 use super::{AuthRole, CompoundData, SharedPolicyCache, metrics::Tip403Metrics};
 
@@ -154,14 +154,14 @@ impl PolicyProvider {
         let policy_id = self.resolve_policy_id(token, block_number).await?;
 
         // Builtins — no RPC needed
-        if policy_id < FIRST_USER_POLICY {
+        if let Some(authorized) = builtin_authorization(policy_id) {
             self.cache
                 .write()
                 .set_token_policy(token, block_number, policy_id);
             self.metrics
                 .rpc_resolution_duration_seconds
                 .record(start.elapsed().as_secs_f64());
-            return Ok(policy_id == POLICY_ALLOW_ALL);
+            return Ok(authorized);
         }
 
         let result = self
@@ -262,8 +262,8 @@ impl PolicyProvider {
         block_number: u64,
     ) -> Result<bool> {
         // Builtins
-        if policy_id < FIRST_USER_POLICY {
-            return Ok(policy_id == POLICY_ALLOW_ALL);
+        if let Some(authorized) = builtin_authorization(policy_id) {
+            return Ok(authorized);
         }
 
         // Check cache first for this sub-policy.
@@ -410,9 +410,9 @@ impl PolicyProvider {
         self.metrics.authorization_checks_total.increment(1);
 
         // Builtins
-        if policy_id < FIRST_USER_POLICY {
+        if let Some(authorized) = builtin_authorization(policy_id) {
             self.metrics.cache_hits.increment(1);
-            return Ok(policy_id == POLICY_ALLOW_ALL);
+            return Ok(authorized);
         }
 
         // Try cache first
@@ -551,7 +551,7 @@ impl PolicyProvider {
     ///
     /// Panics if called from within an async context on the same tokio runtime.
     pub fn policy_exists_sync(&self, policy_id: u64) -> Result<bool> {
-        if policy_id < FIRST_USER_POLICY {
+        if builtin_authorization(policy_id).is_some() {
             return Ok(true);
         }
 


### PR DESCRIPTION
Replace local policy constants (`POLICY_REJECT_ALL`, `POLICY_ALLOW_ALL`, `FIRST_USER_POLICY`) with `REJECT_ALL_POLICY_ID` and `ALLOW_ALL_POLICY_ID` from `tempo-precompiles` v1.4.1 (tempoxyz/tempo#2916).

Adds a shared `builtin_authorization()` helper mirroring tempo's pattern, eliminating the need for `FIRST_USER_POLICY` entirely.