### PR TITLE
fix(rpc): classify 65-byte auth signatures as secp256k1

### DIFF
--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -145,12 +145,14 @@ impl AuthorizationToken {
             return Err(AuthError::InvalidSignature);
         }
 
-        match self.signature[0] {
-            0x01 if self.signature.len() == 130 => Ok(SignatureType::P256),
-            0x02 => Ok(SignatureType::WebAuthn),
-            0x03 => Ok(SignatureType::Keychain),
-            _ if self.signature.len() == 65 => Ok(SignatureType::Secp256k1),
-            _ => Err(AuthError::UnsupportedSignatureType),
+        match self.signature.len() {
+            65 => Ok(SignatureType::Secp256k1),
+            130 if self.signature[0] == 0x01 => Ok(SignatureType::P256),
+            _ => match self.signature[0] {
+                0x02 => Ok(SignatureType::WebAuthn),
+                0x03 => Ok(SignatureType::Keychain),
+                _ => Err(AuthError::UnsupportedSignatureType),
+            },
         }
     }
 }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -95,29 +95,16 @@ impl TestContext {
             .unwrap()
             .as_secs();
 
-        // Retry with shifted timestamps to avoid signatures whose first byte
-        // of `r` is 0x01/0x02/0x03 — the server classifies those as
-        // P256/WebAuthn/Keychain instead of secp256k1.
-        for offset in 0u64..64 {
-            let issued = now + offset;
-            let (fields, digest) =
-                build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, issued, issued + 600);
-            let sig = self.signer.sign_hash_sync(&digest).expect("signing failed");
+        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+        let sig = self.signer.sign_hash_sync(&digest).expect("signing failed");
 
-            let r_bytes = sig.r().to_be_bytes::<32>();
-            if matches!(r_bytes[0], 0x01..=0x03) {
-                continue;
-            }
+        let mut blob = Vec::with_capacity(65 + fields.len());
+        blob.extend_from_slice(&sig.r().to_be_bytes::<32>());
+        blob.extend_from_slice(&sig.s().to_be_bytes::<32>());
+        blob.push(sig.v() as u8);
+        blob.extend_from_slice(&fields);
 
-            let mut blob = Vec::with_capacity(65 + fields.len());
-            blob.extend_from_slice(&r_bytes);
-            blob.extend_from_slice(&sig.s().to_be_bytes::<32>());
-            blob.push(sig.v() as u8);
-            blob.extend_from_slice(&fields);
-
-            return alloy_primitives::hex::encode(&blob);
-        }
-        panic!("could not produce a secp256k1-typed signature after 64 attempts");
+        alloy_primitives::hex::encode(&blob)
     }
 
     fn ws_url(&self) -> String {

--- a/crates/tempo-zone/tests/it/private_rpc.rs
+++ b/crates/tempo-zone/tests/it/private_rpc.rs
@@ -68,6 +68,29 @@ fn parse_token_fields() {
 }
 
 #[test]
+fn parse_secp256k1_signature_type_with_reserved_prefix_bytes() {
+    let now = now_secs();
+
+    for prefix in [0x02, 0x03] {
+        let mut blob = vec![prefix];
+        blob.extend_from_slice(&[0u8; 64]);
+        blob.push(0);
+        blob.extend_from_slice(&1u64.to_be_bytes());
+        blob.extend_from_slice(&1u64.to_be_bytes());
+        blob.extend_from_slice(&[0u8; 20]);
+        blob.extend_from_slice(&now.to_be_bytes());
+        blob.extend_from_slice(&(now + 600).to_be_bytes());
+
+        let token = AuthorizationToken::parse(&blob).unwrap();
+        assert_eq!(
+            token.signature_type().unwrap(),
+            SignatureType::Secp256k1,
+            "65-byte signatures must remain secp256k1 even when starting with {prefix:#04x}",
+        );
+    }
+}
+
+#[test]
 fn parse_token_too_short() {
     // 53 bytes = exactly the message length, no room for a signature
     let blob = vec![0u8; 53];


### PR DESCRIPTION
## Summary

- classify any 65-byte authorization signature as secp256k1 before checking variable-length prefixed signature types
- remove the WebSocket test workaround that avoided `0x01`/`0x02`/`0x03`-prefixed secp256k1 signatures
- add a regression test covering 65-byte signatures that start with `0x02` or `0x03`

## Testing

- `cargo test -p zone-rpc`
- `cargo test -p zone --test it private_rpc::parse_secp256k1_signature_type_with_reserved_prefix_bytes -- --exact`