### PR TITLE
refactor(tip403): remove custom PolicyType serde in favor of upstream feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ codegen-units = 1
 tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
 tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
 tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false, features = ["serde"] }
 tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
 tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
 tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }

--- a/crates/primitives/src/policy.rs
+++ b/crates/primitives/src/policy.rs
@@ -17,3 +17,6 @@ pub enum AuthRole {
     /// Check mint recipient authorization only (compound: uses `mintRecipientPolicyId`).
     MintRecipient,
 }
+
+/// First user-created policy ID. IDs below this are builtins.
+pub const FIRST_USER_POLICY: u64 = 2;

--- a/crates/primitives/src/policy.rs
+++ b/crates/primitives/src/policy.rs
@@ -17,6 +17,3 @@ pub enum AuthRole {
     /// Check mint recipient authorization only (compound: uses `mintRecipientPolicyId`).
     MintRecipient,
 }
-
-/// First user-created policy ID. IDs below this are builtins.
-pub const FIRST_USER_POLICY: u64 = 2;

--- a/crates/tempo-zone/src/l1_state/tip403/cache.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/cache.rs
@@ -449,7 +449,6 @@ pub enum PolicyEvent {
     /// A new simple policy was created on L1 (`PolicyCreated`).
     PolicyCreated {
         policy_id: u64,
-        #[serde(with = "policy_type_serde")]
         policy_type: PolicyType,
     },
     /// A new compound policy was created on L1 (`CompoundPolicyCreated`).
@@ -764,22 +763,6 @@ pub(super) struct MembershipUpdate {
     pub account: Address,
     /// Whether the address was added to or removed from the set.
     pub change: MembershipChange,
-}
-
-/// Serde helper for [`PolicyType`] — the sol!-generated enum lacks serde support,
-/// so we serialize it as its `u8` repr.
-mod policy_type_serde {
-    use super::PolicyType;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub(super) fn serialize<S: Serializer>(val: &PolicyType, s: S) -> Result<S::Ok, S::Error> {
-        (*val as u8).serialize(s)
-    }
-
-    pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<PolicyType, D::Error> {
-        let v = u8::deserialize(d)?;
-        PolicyType::try_from(v).map_err(serde::de::Error::custom)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
tempo-contracts now has a `serde` feature (tempoxyz/tempo#3000) that derives `Serialize`/`Deserialize` on all `sol!` types via a wrapper macro. Enabling it on our dependency removes the need for the manual `policy_type_serde` helper module.

Bumps all tempo deps from `v1.4.1` to `484fe2bed` to pick up the feature.