### PR TITLE
fix(rpc): filter private receipt logs

### DIFF
--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -4,8 +4,11 @@
 //! the caller's address appears in an eligible indexed topic position for that
 //! event type. This prevents users from observing other users' token activity.
 
+use alloy_consensus::TxReceipt;
+use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, B256, b256};
 use alloy_rpc_types_eth::{Filter, FilterSet, Log};
+use tempo_alloy::rpc::TempoTransactionReceipt;
 
 /// `Transfer(address,address,uint256)`
 pub const TRANSFER_TOPIC: B256 =
@@ -82,6 +85,15 @@ pub fn filter_logs(logs: Vec<Log>, caller: &Address) -> Vec<Log> {
         .collect()
 }
 
+/// Filters a receipt's logs for its sender and recomputes `logsBloom`.
+pub fn filter_receipt_logs(mut receipt: TempoTransactionReceipt) -> TempoTransactionReceipt {
+    let caller = receipt.from();
+    let logs = core::mem::take(&mut receipt.inner.inner.receipt.logs);
+    receipt.inner.inner.receipt.logs = filter_logs(logs, &caller);
+    receipt.inner.inner.logs_bloom = receipt.inner.inner.receipt.bloom();
+    receipt
+}
+
 /// Scopes a user-supplied filter to only match whitelisted TIP-20 event topics.
 ///
 /// Intersects the user's requested topic0 with [`WHITELISTED_TOPICS`].
@@ -119,7 +131,11 @@ pub fn scope_filter(filter: &mut Filter) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Address, Bytes, LogData, address, keccak256};
+    use alloy_consensus::ReceiptWithBloom;
+    use alloy_primitives::{Address, Bytes, LogData, TxHash, address, keccak256};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use tempo_alloy::rpc::TempoTransactionReceipt;
+    use tempo_primitives::{TempoReceipt, TempoTxType};
 
     /// Build a test `Log` with the given emitting address and topics.
     fn make_log(emitter: Address, topics: Vec<B256>) -> Log {
@@ -140,6 +156,34 @@ mod tests {
 
     fn caller_word(addr: &Address) -> B256 {
         B256::left_padding_from(addr.as_slice())
+    }
+
+    fn make_receipt(from: Address, logs: Vec<Log>) -> TempoTransactionReceipt {
+        let receipt = TempoReceipt {
+            tx_type: TempoTxType::Legacy,
+            success: true,
+            cumulative_gas_used: 21_000,
+            logs,
+        };
+
+        TempoTransactionReceipt {
+            inner: TransactionReceipt {
+                inner: ReceiptWithBloom::from(receipt),
+                transaction_hash: TxHash::with_last_byte(1),
+                transaction_index: Some(0),
+                block_hash: Some(B256::with_last_byte(2)),
+                block_number: Some(1),
+                gas_used: 21_000,
+                effective_gas_price: 1,
+                blob_gas_used: None,
+                blob_gas_price: None,
+                from,
+                to: Some(Address::ZERO),
+                contract_address: None,
+            },
+            fee_token: None,
+            fee_payer: from,
+        }
     }
 
     // ---------------------------------------------------------------
@@ -374,6 +418,47 @@ mod tests {
         let caller = address!("0x0000000000000000000000000000000000000001");
         let result = filter_logs(vec![], &caller);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_receipt_logs_recomputes_logs_and_bloom() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let other = address!("0x0000000000000000000000000000000000000002");
+        let third = address!("0x0000000000000000000000000000000000000003");
+        let hidden_topic = keccak256(b"PolicyUpdated(address,uint256)");
+
+        let visible = make_log(
+            Address::ZERO,
+            vec![TRANSFER_TOPIC, caller_word(&caller), caller_word(&other)],
+        );
+        let hidden_transfer = make_log(
+            Address::ZERO,
+            vec![TRANSFER_TOPIC, caller_word(&other), caller_word(&third)],
+        );
+        let hidden_event = make_log(Address::ZERO, vec![hidden_topic, caller_word(&caller)]);
+
+        let filtered = filter_receipt_logs(make_receipt(
+            caller,
+            vec![
+                visible.clone(),
+                hidden_transfer.clone(),
+                hidden_event.clone(),
+            ],
+        ));
+
+        assert_eq!(filtered.inner.logs(), std::slice::from_ref(&visible));
+        assert_eq!(
+            filtered.inner.inner.logs_bloom,
+            alloy_primitives::logs_bloom(filtered.inner.logs().iter().map(|log| log.as_ref())),
+        );
+        assert_ne!(
+            filtered.inner.inner.logs_bloom,
+            alloy_primitives::logs_bloom(
+                [visible, hidden_transfer, hidden_event]
+                    .iter()
+                    .map(|log| log.as_ref())
+            ),
+        );
     }
 
     // ---------------------------------------------------------------

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -6,11 +6,12 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, Bytes};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, Log, state::StateOverride};
 use serde::Deserialize;
 use serde_json::value::RawValue;
-use tempo_alloy::rpc::TempoTransactionRequest;
+use tempo_alloy::rpc::{TempoTransactionReceipt, TempoTransactionRequest};
 use tokio::sync::Mutex;
 
 use crate::{
@@ -271,18 +272,22 @@ impl ZoneRpcApi for ProxyZoneRpc {
                 .forward("eth_getTransactionReceipt", serde_json::json!([hash]))
                 .await?;
 
-            let receipt: serde_json::Value =
+            let receipt: Option<TempoTransactionReceipt> =
                 serde_json::from_str(result.get()).map_err(internal)?;
 
-            if receipt.is_null() {
+            let Some(receipt) = receipt else {
+                return Ok(result);
+            };
+
+            if auth.is_sequencer {
                 return Ok(result);
             }
 
-            if !auth.is_sequencer && json_from(&receipt) != Some(auth.caller) {
+            if receipt.from() != auth.caller {
                 return Ok(raw_null());
             }
 
-            Ok(result)
+            to_raw(&filter::filter_receipt_logs(receipt))
         })
     }
 
@@ -351,8 +356,17 @@ impl ZoneRpcApi for ProxyZoneRpc {
                 policy::verify_raw_tx_sender(&data, &auth)?;
             }
 
-            self.forward("eth_sendRawTransactionSync", serde_json::json!([data]))
-                .await
+            let result = self
+                .forward("eth_sendRawTransactionSync", serde_json::json!([data]))
+                .await?;
+
+            if auth.is_sequencer {
+                return Ok(result);
+            }
+
+            let receipt: TempoTransactionReceipt =
+                serde_json::from_str(result.get()).map_err(internal)?;
+            to_raw(&filter::filter_receipt_logs(receipt))
         })
     }
 
@@ -470,5 +484,142 @@ impl ZoneRpcApi for ProxyZoneRpc {
 
             Ok(result)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::ReceiptWithBloom;
+    use alloy_primitives::{B256, Bytes as PrimitiveBytes, LogData, TxHash, address};
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use axum::{Json, Router, routing::post};
+    use tempo_primitives::{TempoReceipt, TempoTxType};
+
+    fn make_log(emitter: Address, topics: Vec<B256>) -> Log {
+        Log {
+            inner: alloy_primitives::Log {
+                address: emitter,
+                data: LogData::new_unchecked(topics, PrimitiveBytes::new()),
+            },
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        }
+    }
+
+    fn caller_word(addr: &Address) -> B256 {
+        B256::left_padding_from(addr.as_slice())
+    }
+
+    fn make_receipt(from: Address, logs: Vec<Log>) -> TempoTransactionReceipt {
+        let receipt = TempoReceipt {
+            tx_type: TempoTxType::Legacy,
+            success: true,
+            cumulative_gas_used: 21_000,
+            logs,
+        };
+
+        TempoTransactionReceipt {
+            inner: TransactionReceipt {
+                inner: ReceiptWithBloom::from(receipt),
+                transaction_hash: TxHash::with_last_byte(1),
+                transaction_index: Some(0),
+                block_hash: Some(B256::with_last_byte(2)),
+                block_number: Some(1),
+                gas_used: 21_000,
+                effective_gas_price: 1,
+                blob_gas_used: None,
+                blob_gas_price: None,
+                from,
+                to: Some(Address::ZERO),
+                contract_address: None,
+            },
+            fee_token: None,
+            fee_payer: from,
+        }
+    }
+
+    async fn spawn_upstream(result: serde_json::Value) -> String {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": result,
+        });
+
+        let app = Router::new().route(
+            "/",
+            post(move || {
+                let response = response.clone();
+                async move { Json(response) }
+            }),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind upstream test server");
+        let addr = listener.local_addr().expect("read upstream addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve upstream test server");
+        });
+
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn transaction_receipt_filters_logs_for_non_sequencer() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let other = address!("0x0000000000000000000000000000000000000002");
+        let third = address!("0x0000000000000000000000000000000000000003");
+
+        let visible = make_log(
+            Address::ZERO,
+            vec![
+                filter::TRANSFER_TOPIC,
+                caller_word(&caller),
+                caller_word(&other),
+            ],
+        );
+        let hidden = make_log(
+            Address::ZERO,
+            vec![
+                filter::TRANSFER_TOPIC,
+                caller_word(&other),
+                caller_word(&third),
+            ],
+        );
+        let upstream = make_receipt(caller, vec![visible.clone(), hidden]);
+        let proxy =
+            ProxyZoneRpc::new(spawn_upstream(serde_json::to_value(&upstream).unwrap()).await);
+
+        let raw = proxy
+            .transaction_receipt(
+                TxHash::with_last_byte(1),
+                AuthContext {
+                    caller,
+                    is_sequencer: false,
+                    expires_at: u64::MAX,
+                },
+            )
+            .await
+            .expect("proxy should return receipt");
+
+        let receipt: TempoTransactionReceipt =
+            serde_json::from_str(raw.get()).expect("deserialize filtered receipt");
+        assert_eq!(receipt.inner.logs(), std::slice::from_ref(&visible));
+        assert_eq!(
+            receipt.inner.inner.logs_bloom,
+            alloy_primitives::logs_bloom(receipt.inner.logs().iter().map(|log| log.as_ref())),
+        );
+        assert_ne!(
+            receipt.inner.inner.logs_bloom,
+            upstream.inner.inner.logs_bloom
+        );
     }
 }

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -262,12 +262,16 @@ where
                 .await
                 .map_err(internal)?;
 
-            let Some(receipt) = receipt else {
+            let Some(mut receipt) = receipt else {
                 return Ok(raw_null());
             };
 
-            if !auth.is_sequencer && receipt.from() != auth.caller {
-                return Ok(raw_null());
+            if !auth.is_sequencer {
+                if receipt.from() != auth.caller {
+                    return Ok(raw_null());
+                }
+
+                receipt = zone_rpc::filter::filter_receipt_logs(receipt);
             }
 
             to_raw(&receipt)
@@ -351,9 +355,14 @@ where
                 zone_rpc::policy::verify_raw_tx_sender(&data, &auth)?;
             }
 
-            let receipt = EthTransactions::send_raw_transaction_sync(&self.eth.api, data)
+            let mut receipt = EthTransactions::send_raw_transaction_sync(&self.eth.api, data)
                 .await
                 .map_err(internal)?;
+
+            if !auth.is_sequencer {
+                receipt = zone_rpc::filter::filter_receipt_logs(receipt);
+            }
+
             to_raw(&receipt)
         })
     }


### PR DESCRIPTION
## Summary
- filter private transaction receipt logs through the shared TIP-20 privacy helper and recompute `logsBloom`
- apply the same receipt redaction in both the in-process RPC and the standalone proxy implementation
- redact `eth_sendRawTransactionSync` receipts the same way so every non-sequencer receipt path stays consistent

## Testing
- cargo test -p zone-rpc --lib
- cargo test -p zone --test it --no-run

Closes #247