### PR TITLE
fix(private-rpc): strengthen log filter pre-scoping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13169,6 +13169,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
+ "zone-primitives",
 ]
 
 [[package]]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # tempo
 tempo-alloy = { workspace = true, features = ["tempo-compat"] }
 tempo-primitives.workspace = true
+zone-primitives.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -6,6 +6,7 @@
 
 use alloy_primitives::{Address, B256, b256};
 use alloy_rpc_types_eth::{Filter, FilterSet, Log};
+use zone_primitives::constants::ZONE_TOKEN_ADDRESS;
 
 /// `Transfer(address,address,uint256)`
 pub const TRANSFER_TOPIC: B256 =
@@ -35,6 +36,9 @@ pub const WHITELISTED_TOPICS: [B256; 5] = [
     MINT_TOPIC,
     BURN_TOPIC,
 ];
+
+const DUAL_PARTY_TOPIC_POSITIONS: [usize; 2] = [1, 2];
+const SINGLE_PARTY_TOPIC_POSITIONS: [usize; 1] = [1];
 
 /// Returns `true` if `caller` appears in an eligible indexed-topic position
 /// for the log's event type.
@@ -82,38 +86,96 @@ pub fn filter_logs(logs: Vec<Log>, caller: &Address) -> Vec<Log> {
         .collect()
 }
 
-/// Scopes a user-supplied filter to only match whitelisted TIP-20 event topics.
-///
-/// Intersects the user's requested topic0 with [`WHITELISTED_TOPICS`].
-/// If the user omitted topic0, restricts to the whitelisted set.
-/// If the intersection is empty, sets topic0 to a dummy that will match nothing.
-///
-/// The post-filter in [`filter_logs`] remains the actual privacy enforcement;
-/// this pre-filter reduces DB scan volume and timing side-channels.
-///
-/// TODO: once the enabled-token registry is plumbed through, also scope the
-/// filter's `address` field to only match enabled TIP-20 token addresses.
-pub fn scope_filter(filter: &mut Filter) {
-    // --- Topic0 scoping ---
+/// Removes duplicate logs while preserving the backend's original ordering.
+pub fn dedup_logs(logs: Vec<Log>) -> Vec<Log> {
+    let mut unique = Vec::with_capacity(logs.len());
+    for log in logs {
+        if !unique.iter().any(|existing| existing == &log) {
+            unique.push(log);
+        }
+    }
+    unique
+}
+
+fn relevant_topic_positions(topic0: B256) -> &'static [usize] {
+    match topic0 {
+        TRANSFER_TOPIC | APPROVAL_TOPIC | TRANSFER_WITH_MEMO_TOPIC => &DUAL_PARTY_TOPIC_POSITIONS,
+        MINT_TOPIC | BURN_TOPIC => &SINGLE_PARTY_TOPIC_POSITIONS,
+        _ => &[],
+    }
+}
+
+fn scoped_topic0(filter: &Filter) -> Vec<B256> {
     let user_topic0: Vec<B256> = filter.topics[0].iter().copied().collect();
 
-    let scoped_topic0: Vec<B256> = if user_topic0.is_empty() {
-        // User didn't specify — restrict to whitelisted events
+    if user_topic0.is_empty() {
         WHITELISTED_TOPICS.to_vec()
     } else {
-        // Intersect user's requested topics with whitelist
         user_topic0
             .into_iter()
-            .filter(|t| WHITELISTED_TOPICS.contains(t))
+            .filter(|topic| WHITELISTED_TOPICS.contains(topic))
             .collect()
+    }
+}
+
+fn scoped_address(filter: &Filter) -> Option<FilterSet<Address>> {
+    if filter.address.is_empty() {
+        return Some(FilterSet::from(ZONE_TOKEN_ADDRESS));
+    }
+
+    filter
+        .address
+        .iter()
+        .all(|address| *address == ZONE_TOKEN_ADDRESS)
+        .then_some(FilterSet::from(ZONE_TOKEN_ADDRESS))
+}
+
+fn scoped_topic(filter: &FilterSet<B256>, caller_word: B256) -> Option<FilterSet<B256>> {
+    if filter.is_empty() {
+        return Some(FilterSet::from(caller_word));
+    }
+
+    filter
+        .contains(&caller_word)
+        .then_some(FilterSet::from(caller_word))
+}
+
+/// Scopes a user-supplied log filter to the zone token and the authenticated
+/// caller's relevant TIP-20 event topic positions.
+///
+/// Ethereum filters can express OR within a single topic position, but not
+/// across different topic positions. To encode rules like
+/// `Transfer.from == caller OR Transfer.to == caller`, this returns a small
+/// set of backend filters that can be queried independently and unioned.
+///
+/// The post-filter in [`filter_logs`] remains the final privacy check; these
+/// scoped filters reduce backend scan volume and timing side-channels.
+pub fn scope_filter(filter: &Filter, caller: &Address) -> Vec<Filter> {
+    let Some(address) = scoped_address(filter) else {
+        return Vec::new();
     };
 
-    if scoped_topic0.is_empty() {
-        // No matching topics — use a dummy topic that will never match
-        filter.topics[0] = FilterSet::from(B256::ZERO);
-    } else {
-        filter.topics[0] = FilterSet::from(scoped_topic0);
+    let caller_word = B256::left_padding_from(caller.as_slice());
+    let mut scoped_filters = Vec::new();
+
+    for topic0 in scoped_topic0(filter) {
+        for &position in relevant_topic_positions(topic0) {
+            let Some(topic_filter) = scoped_topic(&filter.topics[position], caller_word) else {
+                continue;
+            };
+
+            let mut scoped = filter.clone();
+            scoped.address = address.clone();
+            scoped.topics[0] = FilterSet::from(topic0);
+            scoped.topics[position] = topic_filter;
+
+            if !scoped_filters.contains(&scoped) {
+                scoped_filters.push(scoped);
+            }
+        }
     }
+
+    scoped_filters
 }
 
 #[cfg(test)]
@@ -381,32 +443,128 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    fn scope_filter_scopes_topic0() {
-        let mut filter = Filter::default();
-        scope_filter(&mut filter);
-        for topic in &WHITELISTED_TOPICS {
-            assert!(filter.topics[0].contains(topic));
-        }
-        assert_eq!(filter.topics[0].len(), WHITELISTED_TOPICS.len());
+    fn scope_filter_expands_all_whitelisted_topics() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let filters = scope_filter(&Filter::default(), &caller);
+
+        assert_eq!(filters.len(), 8);
+        assert!(
+            filters
+                .iter()
+                .all(|filter| filter.address == FilterSet::from(ZONE_TOKEN_ADDRESS))
+        );
     }
 
     #[test]
     fn scope_filter_intersects_topic0() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
         let bogus_topic = B256::with_last_byte(0xff);
         let mut filter = Filter::default();
         filter.topics[0] = FilterSet::from(vec![TRANSFER_TOPIC, bogus_topic]);
-        scope_filter(&mut filter);
-        assert!(filter.topics[0].contains(&TRANSFER_TOPIC));
-        assert!(!filter.topics[0].contains(&bogus_topic));
-        assert_eq!(filter.topics[0].len(), 1);
+        let filters = scope_filter(&filter, &caller);
+
+        assert_eq!(filters.len(), 2);
+        assert!(
+            filters
+                .iter()
+                .all(|filter| filter.topics[0] == FilterSet::from(TRANSFER_TOPIC))
+        );
     }
 
     #[test]
     fn scope_filter_empty_intersection() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
         let bogus = B256::with_last_byte(0xff);
         let mut filter = Filter::default();
         filter.topics[0] = FilterSet::from(bogus);
-        scope_filter(&mut filter);
-        assert_eq!(filter.topics[0], FilterSet::from(B256::ZERO));
+        assert!(scope_filter(&filter, &caller).is_empty());
+    }
+
+    #[test]
+    fn scope_filter_rejects_non_zone_token_addresses() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default();
+        filter.address = FilterSet::from(address!("0x000000000000000000000000000000000000dead"));
+
+        assert!(scope_filter(&filter, &caller).is_empty());
+    }
+
+    #[test]
+    fn scope_filter_rejects_mixed_address_sets() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default();
+        filter.address = FilterSet::from(vec![
+            ZONE_TOKEN_ADDRESS,
+            address!("0x000000000000000000000000000000000000dead"),
+        ]);
+
+        assert!(scope_filter(&filter, &caller).is_empty());
+    }
+
+    #[test]
+    fn scope_filter_injects_caller_into_dual_party_positions() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default();
+        filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
+
+        let filters = scope_filter(&filter, &caller);
+        assert_eq!(filters.len(), 2);
+
+        let caller_word = caller_word(&caller);
+        assert!(
+            filters
+                .iter()
+                .any(|filter| filter.topics[1] == FilterSet::from(caller_word))
+        );
+        assert!(
+            filters
+                .iter()
+                .any(|filter| filter.topics[2] == FilterSet::from(caller_word))
+        );
+    }
+
+    #[test]
+    fn scope_filter_respects_existing_topic_constraints() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let other = address!("0x0000000000000000000000000000000000000002");
+        let mut filter = Filter::default();
+        filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
+        filter.topics[1] = FilterSet::from(caller_word(&other));
+
+        let filters = scope_filter(&filter, &caller);
+
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].topics[1], FilterSet::from(caller_word(&other)));
+        assert_eq!(filters[0].topics[2], FilterSet::from(caller_word(&caller)));
+    }
+
+    #[test]
+    fn scope_filter_dedups_identical_variants() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default();
+        filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
+        filter.topics[1] = FilterSet::from(caller_word(&caller));
+        filter.topics[2] = FilterSet::from(caller_word(&caller));
+
+        let filters = scope_filter(&filter, &caller);
+
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].topics[1], FilterSet::from(caller_word(&caller)));
+        assert_eq!(filters[0].topics[2], FilterSet::from(caller_word(&caller)));
+    }
+
+    #[test]
+    fn dedup_logs_preserves_first_copy() {
+        let log = make_log(
+            ZONE_TOKEN_ADDRESS,
+            vec![
+                TRANSFER_TOPIC,
+                caller_word(&Address::ZERO),
+                caller_word(&Address::ZERO),
+            ],
+        );
+
+        let deduped = dedup_logs(vec![log.clone(), log.clone()]);
+        assert_eq!(deduped, vec![log]);
     }
 }

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -37,9 +37,6 @@ pub const WHITELISTED_TOPICS: [B256; 5] = [
     BURN_TOPIC,
 ];
 
-const DUAL_PARTY_TOPIC_POSITIONS: [usize; 2] = [1, 2];
-const SINGLE_PARTY_TOPIC_POSITIONS: [usize; 1] = [1];
-
 /// Returns `true` if `caller` appears in an eligible indexed-topic position
 /// for the log's event type.
 ///
@@ -80,29 +77,11 @@ pub fn is_caller_eligible(log: &Log, caller: &Address) -> bool {
 pub fn filter_logs(logs: Vec<Log>, caller: &Address) -> Vec<Log> {
     logs.into_iter()
         .filter(|log| {
-            log.topic0().is_some_and(|t| WHITELISTED_TOPICS.contains(t))
+            log.address() == ZONE_TOKEN_ADDRESS
+                && log.topic0().is_some_and(|t| WHITELISTED_TOPICS.contains(t))
                 && is_caller_eligible(log, caller)
         })
         .collect()
-}
-
-/// Removes duplicate logs while preserving the backend's original ordering.
-pub fn dedup_logs(logs: Vec<Log>) -> Vec<Log> {
-    let mut unique = Vec::with_capacity(logs.len());
-    for log in logs {
-        if !unique.iter().any(|existing| existing == &log) {
-            unique.push(log);
-        }
-    }
-    unique
-}
-
-fn relevant_topic_positions(topic0: B256) -> &'static [usize] {
-    match topic0 {
-        TRANSFER_TOPIC | APPROVAL_TOPIC | TRANSFER_WITH_MEMO_TOPIC => &DUAL_PARTY_TOPIC_POSITIONS,
-        MINT_TOPIC | BURN_TOPIC => &SINGLE_PARTY_TOPIC_POSITIONS,
-        _ => &[],
-    }
 }
 
 fn scoped_topic0(filter: &Filter) -> Vec<B256> {
@@ -118,64 +97,31 @@ fn scoped_topic0(filter: &Filter) -> Vec<B256> {
     }
 }
 
-fn scoped_address(filter: &Filter) -> Option<FilterSet<Address>> {
-    if filter.address.is_empty() {
-        return Some(FilterSet::from(ZONE_TOKEN_ADDRESS));
-    }
-
-    filter
-        .address
-        .iter()
-        .all(|address| *address == ZONE_TOKEN_ADDRESS)
-        .then_some(FilterSet::from(ZONE_TOKEN_ADDRESS))
-}
-
-fn scoped_topic(filter: &FilterSet<B256>, caller_word: B256) -> Option<FilterSet<B256>> {
-    if filter.is_empty() {
-        return Some(FilterSet::from(caller_word));
-    }
-
-    filter
-        .contains(&caller_word)
-        .then_some(FilterSet::from(caller_word))
-}
-
-/// Scopes a user-supplied log filter to the zone token and the authenticated
-/// caller's relevant TIP-20 event topic positions.
+/// Scopes a user-supplied log filter to the zone token and whitelisted TIP-20
+/// event topics.
 ///
-/// Ethereum filters can express OR within a single topic position, but not
-/// across different topic positions. To encode rules like
-/// `Transfer.from == caller OR Transfer.to == caller`, this returns a small
-/// set of backend filters that can be queried independently and unioned.
-///
-/// The post-filter in [`filter_logs`] remains the final privacy check; these
-/// scoped filters reduce backend scan volume and timing side-channels.
-pub fn scope_filter(filter: &Filter, caller: &Address) -> Vec<Filter> {
-    let Some(address) = scoped_address(filter) else {
-        return Vec::new();
+/// The post-filter in [`filter_logs`] is the authoritative privacy check; this
+/// pre-scope keeps backend scans aligned with the zone token surface and avoids
+/// storing separate internal filter IDs for private callers.
+pub fn scope_filter(filter: &mut Filter) {
+    filter.address = if filter.address.is_empty()
+        || filter
+            .address
+            .iter()
+            .all(|address| *address == ZONE_TOKEN_ADDRESS)
+    {
+        FilterSet::from(ZONE_TOKEN_ADDRESS)
+    } else {
+        filter.topics[0] = FilterSet::from(B256::ZERO);
+        FilterSet::from(ZONE_TOKEN_ADDRESS)
     };
 
-    let caller_word = B256::left_padding_from(caller.as_slice());
-    let mut scoped_filters = Vec::new();
-
-    for topic0 in scoped_topic0(filter) {
-        for &position in relevant_topic_positions(topic0) {
-            let Some(topic_filter) = scoped_topic(&filter.topics[position], caller_word) else {
-                continue;
-            };
-
-            let mut scoped = filter.clone();
-            scoped.address = address.clone();
-            scoped.topics[0] = FilterSet::from(topic0);
-            scoped.topics[position] = topic_filter;
-
-            if !scoped_filters.contains(&scoped) {
-                scoped_filters.push(scoped);
-            }
-        }
+    let scoped_topic0 = scoped_topic0(filter);
+    if scoped_topic0.is_empty() {
+        filter.topics[0] = FilterSet::from(B256::ZERO);
+    } else {
+        filter.topics[0] = FilterSet::from(scoped_topic0);
     }
-
-    scoped_filters
 }
 
 #[cfg(test)]
@@ -407,24 +353,27 @@ mod tests {
 
     #[test]
     fn filter_logs_keeps_eligible_and_drops_others() {
-        let zone_token = address!("0x000000000000000000000000000000000000aaaa");
         let caller = address!("0x0000000000000000000000000000000000000001");
         let other = address!("0x0000000000000000000000000000000000000002");
 
         let eligible = make_log(
-            zone_token,
+            ZONE_TOKEN_ADDRESS,
             vec![TRANSFER_TOPIC, caller_word(&caller), caller_word(&other)],
         );
         let wrong_topic = make_log(
-            zone_token,
+            ZONE_TOKEN_ADDRESS,
             vec![B256::with_last_byte(0x01), caller_word(&caller)],
         );
+        let wrong_address = make_log(
+            address!("0x000000000000000000000000000000000000dead"),
+            vec![TRANSFER_TOPIC, caller_word(&caller), caller_word(&other)],
+        );
         let not_eligible = make_log(
-            zone_token,
+            ZONE_TOKEN_ADDRESS,
             vec![TRANSFER_TOPIC, caller_word(&other), caller_word(&other)],
         );
 
-        let logs = vec![eligible.clone(), wrong_topic, not_eligible];
+        let logs = vec![eligible.clone(), wrong_topic, wrong_address, not_eligible];
         let result = filter_logs(logs, &caller);
 
         assert_eq!(result.len(), 1);
@@ -443,128 +392,61 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    fn scope_filter_expands_all_whitelisted_topics() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let filters = scope_filter(&Filter::default(), &caller);
+    fn scope_filter_scopes_zone_token_and_whitelisted_topics() {
+        let mut filter = Filter::default();
+        scope_filter(&mut filter);
 
-        assert_eq!(filters.len(), 8);
-        assert!(
-            filters
-                .iter()
-                .all(|filter| filter.address == FilterSet::from(ZONE_TOKEN_ADDRESS))
-        );
+        assert_eq!(filter.address, FilterSet::from(ZONE_TOKEN_ADDRESS));
+        for topic in &WHITELISTED_TOPICS {
+            assert!(filter.topics[0].contains(topic));
+        }
+        assert_eq!(filter.topics[0].len(), WHITELISTED_TOPICS.len());
     }
 
     #[test]
     fn scope_filter_intersects_topic0() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
         let bogus_topic = B256::with_last_byte(0xff);
         let mut filter = Filter::default();
         filter.topics[0] = FilterSet::from(vec![TRANSFER_TOPIC, bogus_topic]);
-        let filters = scope_filter(&filter, &caller);
+        scope_filter(&mut filter);
 
-        assert_eq!(filters.len(), 2);
-        assert!(
-            filters
-                .iter()
-                .all(|filter| filter.topics[0] == FilterSet::from(TRANSFER_TOPIC))
-        );
+        assert_eq!(filter.address, FilterSet::from(ZONE_TOKEN_ADDRESS));
+        assert!(filter.topics[0].contains(&TRANSFER_TOPIC));
+        assert!(!filter.topics[0].contains(&bogus_topic));
+        assert_eq!(filter.topics[0].len(), 1);
     }
 
     #[test]
     fn scope_filter_empty_intersection() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
         let bogus = B256::with_last_byte(0xff);
         let mut filter = Filter::default();
         filter.topics[0] = FilterSet::from(bogus);
-        assert!(scope_filter(&filter, &caller).is_empty());
+        scope_filter(&mut filter);
+
+        assert_eq!(filter.address, FilterSet::from(ZONE_TOKEN_ADDRESS));
+        assert_eq!(filter.topics[0], FilterSet::from(B256::ZERO));
     }
 
     #[test]
     fn scope_filter_rejects_non_zone_token_addresses() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
         let mut filter = Filter::default();
         filter.address = FilterSet::from(address!("0x000000000000000000000000000000000000dead"));
+        scope_filter(&mut filter);
 
-        assert!(scope_filter(&filter, &caller).is_empty());
+        assert_eq!(filter.address, FilterSet::from(ZONE_TOKEN_ADDRESS));
+        assert_eq!(filter.topics[0], FilterSet::from(B256::ZERO));
     }
 
     #[test]
     fn scope_filter_rejects_mixed_address_sets() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
         let mut filter = Filter::default();
         filter.address = FilterSet::from(vec![
             ZONE_TOKEN_ADDRESS,
             address!("0x000000000000000000000000000000000000dead"),
         ]);
+        scope_filter(&mut filter);
 
-        assert!(scope_filter(&filter, &caller).is_empty());
-    }
-
-    #[test]
-    fn scope_filter_injects_caller_into_dual_party_positions() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter::default();
-        filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
-
-        let filters = scope_filter(&filter, &caller);
-        assert_eq!(filters.len(), 2);
-
-        let caller_word = caller_word(&caller);
-        assert!(
-            filters
-                .iter()
-                .any(|filter| filter.topics[1] == FilterSet::from(caller_word))
-        );
-        assert!(
-            filters
-                .iter()
-                .any(|filter| filter.topics[2] == FilterSet::from(caller_word))
-        );
-    }
-
-    #[test]
-    fn scope_filter_respects_existing_topic_constraints() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let other = address!("0x0000000000000000000000000000000000000002");
-        let mut filter = Filter::default();
-        filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
-        filter.topics[1] = FilterSet::from(caller_word(&other));
-
-        let filters = scope_filter(&filter, &caller);
-
-        assert_eq!(filters.len(), 1);
-        assert_eq!(filters[0].topics[1], FilterSet::from(caller_word(&other)));
-        assert_eq!(filters[0].topics[2], FilterSet::from(caller_word(&caller)));
-    }
-
-    #[test]
-    fn scope_filter_dedups_identical_variants() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter::default();
-        filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
-        filter.topics[1] = FilterSet::from(caller_word(&caller));
-        filter.topics[2] = FilterSet::from(caller_word(&caller));
-
-        let filters = scope_filter(&filter, &caller);
-
-        assert_eq!(filters.len(), 1);
-        assert_eq!(filters[0].topics[1], FilterSet::from(caller_word(&caller)));
-        assert_eq!(filters[0].topics[2], FilterSet::from(caller_word(&caller)));
-    }
-
-    #[test]
-    fn dedup_logs_preserves_first_copy() {
-        let log = make_log(
-            ZONE_TOKEN_ADDRESS,
-            vec![
-                TRANSFER_TOPIC,
-                caller_word(&Address::ZERO),
-                caller_word(&Address::ZERO),
-            ],
-        );
-
-        let deduped = dedup_logs(vec![log.clone(), log.clone()]);
-        assert_eq!(deduped, vec![log]);
+        assert_eq!(filter.address, FilterSet::from(ZONE_TOKEN_ADDRESS));
+        assert_eq!(filter.topics[0], FilterSet::from(B256::ZERO));
     }
 }

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -4,10 +4,18 @@
 //! applies privacy redactions on the responses. This allows the private RPC
 //! service to run as a standalone process without linking against reth.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use alloy_primitives::{Address, Bytes};
-use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, Log, state::StateOverride};
+use alloy_rpc_types_eth::{
+    BlockId, BlockNumberOrTag, Filter, FilterChanges, FilterId, Log, state::StateOverride,
+};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 use tempo_alloy::rpc::TempoTransactionRequest;
@@ -37,6 +45,10 @@ pub struct ProxyZoneRpc {
     upstream_url: String,
     /// Maps filter IDs to the authenticated account that created them.
     filter_owners: Arc<Mutex<HashMap<FilterId, Address>>>,
+    /// Maps logical private-RPC filter IDs to the upstream filter IDs that
+    /// encode caller-scoped event matching.
+    scoped_filters: Arc<Mutex<HashMap<FilterId, Vec<FilterId>>>>,
+    next_scoped_filter_id: AtomicU64,
 }
 
 impl ProxyZoneRpc {
@@ -46,6 +58,8 @@ impl ProxyZoneRpc {
             client: reqwest::Client::new(),
             upstream_url,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
+            scoped_filters: Arc::new(Mutex::new(HashMap::new())),
+            next_scoped_filter_id: AtomicU64::new(1),
         }
     }
 
@@ -98,6 +112,17 @@ impl ProxyZoneRpc {
             Some(owner) if *owner == auth.caller => Ok(()),
             _ => Err(JsonRpcError::invalid_params("filter not found")),
         }
+    }
+
+    fn next_scoped_filter_id(&self) -> FilterId {
+        FilterId::from(format!(
+            "zone-scoped-{}",
+            self.next_scoped_filter_id.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    async fn scoped_backend_filters(&self, id: &FilterId) -> Option<Vec<FilterId>> {
+        self.scoped_filters.lock().await.get(id).cloned()
     }
 }
 
@@ -371,7 +396,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
         })
     }
 
-    fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn get_logs(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             if auth.is_sequencer {
                 return self
@@ -379,33 +404,91 @@ impl ZoneRpcApi for ProxyZoneRpc {
                     .await;
             }
 
-            filter::scope_filter(&mut filter);
-            let result = self
-                .forward("eth_getLogs", serde_json::json!([filter]))
-                .await?;
-            let logs: Vec<Log> = serde_json::from_str(result.get()).map_err(internal)?;
-            let filtered = filter::filter_logs(logs, &auth.caller);
+            let scoped_filters = filter::scope_filter(&filter, &auth.caller);
+            if scoped_filters.is_empty() {
+                return to_raw(&Vec::<Log>::new());
+            }
+
+            let mut logs = Vec::new();
+            for scoped_filter in scoped_filters {
+                let result = self
+                    .forward("eth_getLogs", serde_json::json!([scoped_filter]))
+                    .await?;
+                logs.extend(serde_json::from_str::<Vec<Log>>(result.get()).map_err(internal)?);
+            }
+
+            let filtered = filter::filter_logs(filter::dedup_logs(logs), &auth.caller);
             to_raw(&filtered)
         })
     }
 
-    fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn new_filter(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                filter::scope_filter(&mut filter);
+            if auth.is_sequencer {
+                let result = self
+                    .forward("eth_newFilter", serde_json::json!([filter]))
+                    .await?;
+                let id: FilterId = serde_json::from_str(result.get()).map_err(internal)?;
+                self.filter_owners.lock().await.insert(id, auth.caller);
+                return Ok(result);
             }
-            let result = self
-                .forward("eth_newFilter", serde_json::json!([filter]))
-                .await?;
-            let id: FilterId = serde_json::from_str(result.get()).map_err(internal)?;
-            self.filter_owners.lock().await.insert(id, auth.caller);
-            Ok(result)
+
+            let scoped_filters = filter::scope_filter(&filter, &auth.caller);
+            let mut backend_ids = Vec::with_capacity(scoped_filters.len());
+
+            for scoped_filter in scoped_filters {
+                match self
+                    .forward("eth_newFilter", serde_json::json!([scoped_filter]))
+                    .await
+                {
+                    Ok(result) => {
+                        let id: FilterId = serde_json::from_str(result.get()).map_err(internal)?;
+                        backend_ids.push(id);
+                    }
+                    Err(err) => {
+                        for backend_id in backend_ids {
+                            let _ = self
+                                .forward("eth_uninstallFilter", serde_json::json!([backend_id]))
+                                .await;
+                        }
+                        return Err(err);
+                    }
+                }
+            }
+
+            let public_id = self.next_scoped_filter_id();
+            self.filter_owners
+                .lock()
+                .await
+                .insert(public_id.clone(), auth.caller);
+            self.scoped_filters
+                .lock()
+                .await
+                .insert(public_id.clone(), backend_ids);
+            to_raw(&public_id)
         })
     }
 
     fn get_filter_logs(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
+
+            if !auth.is_sequencer {
+                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
+                    let mut logs = Vec::new();
+                    for backend_id in backend_ids {
+                        let result = self
+                            .forward("eth_getFilterLogs", serde_json::json!([backend_id]))
+                            .await?;
+                        logs.extend(
+                            serde_json::from_str::<Vec<Log>>(result.get()).map_err(internal)?,
+                        );
+                    }
+
+                    let filtered = filter::filter_logs(filter::dedup_logs(logs), &auth.caller);
+                    return to_raw(&filtered);
+                }
+            }
 
             let result = self
                 .forward("eth_getFilterLogs", serde_json::json!([id]))
@@ -424,6 +507,34 @@ impl ZoneRpcApi for ProxyZoneRpc {
     fn get_filter_changes(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
+
+            if !auth.is_sequencer {
+                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
+                    let mut logs = Vec::new();
+                    for backend_id in backend_ids {
+                        let result = self
+                            .forward("eth_getFilterChanges", serde_json::json!([backend_id]))
+                            .await?;
+                        let changes: FilterChanges =
+                            serde_json::from_str(result.get()).map_err(internal)?;
+
+                        match changes {
+                            FilterChanges::Logs(new_logs) => logs.extend(new_logs),
+                            FilterChanges::Empty => {}
+                            FilterChanges::Hashes(_) | FilterChanges::Transactions(_) => {}
+                        }
+                    }
+
+                    let filtered = filter::filter_logs(filter::dedup_logs(logs), &auth.caller);
+                    if filtered.is_empty() {
+                        return to_raw(&FilterChanges::<alloy_rpc_types_eth::Transaction>::Empty);
+                    }
+
+                    return to_raw(&FilterChanges::<alloy_rpc_types_eth::Transaction>::Logs(
+                        filtered,
+                    ));
+                }
+            }
 
             let result = self
                 .forward("eth_getFilterChanges", serde_json::json!([id]))
@@ -458,6 +569,20 @@ impl ZoneRpcApi for ProxyZoneRpc {
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
+
+            if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
+                let mut removed = true;
+                for backend_id in backend_ids {
+                    let result = self
+                        .forward("eth_uninstallFilter", serde_json::json!([backend_id]))
+                        .await?;
+                    removed &= serde_json::from_str::<bool>(result.get()).map_err(internal)?;
+                }
+
+                self.scoped_filters.lock().await.remove(&id);
+                self.filter_owners.lock().await.remove(&id);
+                return to_raw(&removed);
+            }
 
             let result = self
                 .forward("eth_uninstallFilter", serde_json::json!([id]))

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -4,18 +4,10 @@
 //! applies privacy redactions on the responses. This allows the private RPC
 //! service to run as a standalone process without linking against reth.
 
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-};
+use std::{collections::HashMap, sync::Arc};
 
 use alloy_primitives::{Address, Bytes};
-use alloy_rpc_types_eth::{
-    BlockId, BlockNumberOrTag, Filter, FilterChanges, FilterId, Log, state::StateOverride,
-};
+use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, Log, state::StateOverride};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 use tempo_alloy::rpc::TempoTransactionRequest;
@@ -45,10 +37,6 @@ pub struct ProxyZoneRpc {
     upstream_url: String,
     /// Maps filter IDs to the authenticated account that created them.
     filter_owners: Arc<Mutex<HashMap<FilterId, Address>>>,
-    /// Maps logical private-RPC filter IDs to the upstream filter IDs that
-    /// encode caller-scoped event matching.
-    scoped_filters: Arc<Mutex<HashMap<FilterId, Vec<FilterId>>>>,
-    next_scoped_filter_id: AtomicU64,
 }
 
 impl ProxyZoneRpc {
@@ -58,8 +46,6 @@ impl ProxyZoneRpc {
             client: reqwest::Client::new(),
             upstream_url,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
-            scoped_filters: Arc::new(Mutex::new(HashMap::new())),
-            next_scoped_filter_id: AtomicU64::new(1),
         }
     }
 
@@ -112,17 +98,6 @@ impl ProxyZoneRpc {
             Some(owner) if *owner == auth.caller => Ok(()),
             _ => Err(JsonRpcError::invalid_params("filter not found")),
         }
-    }
-
-    fn next_scoped_filter_id(&self) -> FilterId {
-        FilterId::from(format!(
-            "zone-scoped-{}",
-            self.next_scoped_filter_id.fetch_add(1, Ordering::Relaxed)
-        ))
-    }
-
-    async fn scoped_backend_filters(&self, id: &FilterId) -> Option<Vec<FilterId>> {
-        self.scoped_filters.lock().await.get(id).cloned()
     }
 }
 
@@ -396,7 +371,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
         })
     }
 
-    fn get_logs(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             if auth.is_sequencer {
                 return self
@@ -404,91 +379,34 @@ impl ZoneRpcApi for ProxyZoneRpc {
                     .await;
             }
 
-            let scoped_filters = filter::scope_filter(&filter, &auth.caller);
-            if scoped_filters.is_empty() {
-                return to_raw(&Vec::<Log>::new());
-            }
-
-            let mut logs = Vec::new();
-            for scoped_filter in scoped_filters {
-                let result = self
-                    .forward("eth_getLogs", serde_json::json!([scoped_filter]))
-                    .await?;
-                logs.extend(serde_json::from_str::<Vec<Log>>(result.get()).map_err(internal)?);
-            }
-
-            let filtered = filter::filter_logs(filter::dedup_logs(logs), &auth.caller);
+            filter::scope_filter(&mut filter);
+            let result = self
+                .forward("eth_getLogs", serde_json::json!([filter]))
+                .await?;
+            let logs: Vec<Log> = serde_json::from_str(result.get()).map_err(internal)?;
+            let filtered = filter::filter_logs(logs, &auth.caller);
             to_raw(&filtered)
         })
     }
 
-    fn new_filter(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if auth.is_sequencer {
-                let result = self
-                    .forward("eth_newFilter", serde_json::json!([filter]))
-                    .await?;
-                let id: FilterId = serde_json::from_str(result.get()).map_err(internal)?;
-                self.filter_owners.lock().await.insert(id, auth.caller);
-                return Ok(result);
+            if !auth.is_sequencer {
+                filter::scope_filter(&mut filter);
             }
 
-            let scoped_filters = filter::scope_filter(&filter, &auth.caller);
-            let mut backend_ids = Vec::with_capacity(scoped_filters.len());
-
-            for scoped_filter in scoped_filters {
-                match self
-                    .forward("eth_newFilter", serde_json::json!([scoped_filter]))
-                    .await
-                {
-                    Ok(result) => {
-                        let id: FilterId = serde_json::from_str(result.get()).map_err(internal)?;
-                        backend_ids.push(id);
-                    }
-                    Err(err) => {
-                        for backend_id in backend_ids {
-                            let _ = self
-                                .forward("eth_uninstallFilter", serde_json::json!([backend_id]))
-                                .await;
-                        }
-                        return Err(err);
-                    }
-                }
-            }
-
-            let public_id = self.next_scoped_filter_id();
-            self.filter_owners
-                .lock()
-                .await
-                .insert(public_id.clone(), auth.caller);
-            self.scoped_filters
-                .lock()
-                .await
-                .insert(public_id.clone(), backend_ids);
-            to_raw(&public_id)
+            let result = self
+                .forward("eth_newFilter", serde_json::json!([filter]))
+                .await?;
+            let id: FilterId = serde_json::from_str(result.get()).map_err(internal)?;
+            self.filter_owners.lock().await.insert(id, auth.caller);
+            Ok(result)
         })
     }
 
     fn get_filter_logs(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
-
-            if !auth.is_sequencer {
-                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
-                    let mut logs = Vec::new();
-                    for backend_id in backend_ids {
-                        let result = self
-                            .forward("eth_getFilterLogs", serde_json::json!([backend_id]))
-                            .await?;
-                        logs.extend(
-                            serde_json::from_str::<Vec<Log>>(result.get()).map_err(internal)?,
-                        );
-                    }
-
-                    let filtered = filter::filter_logs(filter::dedup_logs(logs), &auth.caller);
-                    return to_raw(&filtered);
-                }
-            }
 
             let result = self
                 .forward("eth_getFilterLogs", serde_json::json!([id]))
@@ -507,34 +425,6 @@ impl ZoneRpcApi for ProxyZoneRpc {
     fn get_filter_changes(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
-
-            if !auth.is_sequencer {
-                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
-                    let mut logs = Vec::new();
-                    for backend_id in backend_ids {
-                        let result = self
-                            .forward("eth_getFilterChanges", serde_json::json!([backend_id]))
-                            .await?;
-                        let changes: FilterChanges =
-                            serde_json::from_str(result.get()).map_err(internal)?;
-
-                        match changes {
-                            FilterChanges::Logs(new_logs) => logs.extend(new_logs),
-                            FilterChanges::Empty => {}
-                            FilterChanges::Hashes(_) | FilterChanges::Transactions(_) => {}
-                        }
-                    }
-
-                    let filtered = filter::filter_logs(filter::dedup_logs(logs), &auth.caller);
-                    if filtered.is_empty() {
-                        return to_raw(&FilterChanges::<alloy_rpc_types_eth::Transaction>::Empty);
-                    }
-
-                    return to_raw(&FilterChanges::<alloy_rpc_types_eth::Transaction>::Logs(
-                        filtered,
-                    ));
-                }
-            }
 
             let result = self
                 .forward("eth_getFilterChanges", serde_json::json!([id]))
@@ -569,20 +459,6 @@ impl ZoneRpcApi for ProxyZoneRpc {
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
-
-            if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
-                let mut removed = true;
-                for backend_id in backend_ids {
-                    let result = self
-                        .forward("eth_uninstallFilter", serde_json::json!([backend_id]))
-                        .await?;
-                    removed &= serde_json::from_str::<bool>(result.get()).map_err(internal)?;
-                }
-
-                self.scoped_filters.lock().await.remove(&id);
-                self.filter_owners.lock().await.remove(&id);
-                return to_raw(&removed);
-            }
 
             let result = self
                 .forward("eth_uninstallFilter", serde_json::json!([id]))

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -5,13 +5,7 @@
 
 pub use zone_rpc::*;
 
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-};
+use std::{collections::HashMap, sync::Arc};
 
 use alloy_network::{ReceiptResponse, TransactionResponse};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
@@ -72,10 +66,6 @@ pub struct TempoZoneRpc<Api: EthApiTypes> {
     /// After bumping reth, use its `ActiveFilters` API to periodically sync this
     /// map and remove entries for filters that no longer exist on the reth side.
     filter_owners: Arc<Mutex<HashMap<FilterId, Address>>>,
-    /// Maps logical private-RPC filter IDs to the concrete backend filter IDs
-    /// needed to express caller-scoped event matching.
-    scoped_filters: Arc<Mutex<HashMap<FilterId, Vec<FilterId>>>>,
-    next_scoped_filter_id: AtomicU64,
 }
 
 impl<Api: EthApiTypes> TempoZoneRpc<Api> {
@@ -84,8 +74,6 @@ impl<Api: EthApiTypes> TempoZoneRpc<Api> {
         Self {
             eth,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
-            scoped_filters: Arc::new(Mutex::new(HashMap::new())),
-            next_scoped_filter_id: AtomicU64::new(1),
         }
     }
 
@@ -113,17 +101,6 @@ impl<Api: EthApiTypes> TempoZoneRpc<Api> {
             Some(owner) if *owner == auth.caller => Ok(()),
             _ => Err(JsonRpcError::invalid_params("filter not found")),
         }
-    }
-
-    fn next_scoped_filter_id(&self) -> FilterId {
-        FilterId::from(format!(
-            "zone-scoped-{}",
-            self.next_scoped_filter_id.fetch_add(1, Ordering::Relaxed)
-        ))
-    }
-
-    async fn scoped_backend_filters(&self, id: &FilterId) -> Option<Vec<FilterId>> {
-        self.scoped_filters.lock().await.get(id).cloned()
     }
 }
 
@@ -398,7 +375,7 @@ where
         })
     }
 
-    fn get_logs(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             if auth.is_sequencer {
                 let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
@@ -407,93 +384,35 @@ where
                 return to_raw(&logs);
             }
 
-            let scoped_filters = zone_rpc::filter::scope_filter(&filter, &auth.caller);
-            if scoped_filters.is_empty() {
-                return to_raw(&Vec::<alloy_rpc_types_eth::Log>::new());
-            }
-
-            let mut logs = Vec::new();
-            for scoped_filter in scoped_filters {
-                logs.extend(
-                    EthFilterApiServer::logs(&self.eth.filter, scoped_filter)
-                        .await
-                        .map_err(internal)?,
-                );
-            }
-
-            let filtered =
-                zone_rpc::filter::filter_logs(zone_rpc::filter::dedup_logs(logs), &auth.caller);
+            zone_rpc::filter::scope_filter(&mut filter);
+            let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
+                .await
+                .map_err(internal)?;
+            let filtered = zone_rpc::filter::filter_logs(logs, &auth.caller);
             to_raw(&filtered)
         })
     }
 
-    fn new_filter(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if auth.is_sequencer {
-                let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
-                    .await
-                    .map_err(internal)?;
-                self.filter_owners
-                    .lock()
-                    .await
-                    .insert(id.clone(), auth.caller);
-                return to_raw(&id);
+            if !auth.is_sequencer {
+                zone_rpc::filter::scope_filter(&mut filter);
             }
 
-            let scoped_filters = zone_rpc::filter::scope_filter(&filter, &auth.caller);
-            let mut backend_ids = Vec::with_capacity(scoped_filters.len());
-
-            for scoped_filter in scoped_filters {
-                match EthFilterApiServer::new_filter(&self.eth.filter, scoped_filter).await {
-                    Ok(id) => backend_ids.push(id),
-                    Err(err) => {
-                        for backend_id in backend_ids {
-                            let _ =
-                                EthFilterApiServer::uninstall_filter(&self.eth.filter, backend_id)
-                                    .await;
-                        }
-                        return Err(internal(err));
-                    }
-                }
-            }
-
-            let public_id = self.next_scoped_filter_id();
+            let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
+                .await
+                .map_err(internal)?;
             self.filter_owners
                 .lock()
                 .await
-                .insert(public_id.clone(), auth.caller);
-            self.scoped_filters
-                .lock()
-                .await
-                .insert(public_id.clone(), backend_ids);
-            to_raw(&public_id)
+                .insert(id.clone(), auth.caller);
+            to_raw(&id)
         })
     }
 
     fn get_filter_logs(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
-
-            if !auth.is_sequencer {
-                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
-                    let mut logs = Vec::new();
-                    for backend_id in backend_ids {
-                        logs.extend(
-                            self.eth
-                                .filter
-                                .filter_logs(backend_id)
-                                .await
-                                .map_err(internal)?,
-                        );
-                    }
-
-                    let filtered = zone_rpc::filter::filter_logs(
-                        zone_rpc::filter::dedup_logs(logs),
-                        &auth.caller,
-                    );
-                    return to_raw(&filtered);
-                }
-            }
 
             let logs = self.eth.filter.filter_logs(id).await.map_err(internal)?;
 
@@ -509,41 +428,6 @@ where
     fn get_filter_changes(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
-
-            if !auth.is_sequencer {
-                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
-                    let mut logs = Vec::new();
-                    for backend_id in backend_ids {
-                        let changes = self
-                            .eth
-                            .filter
-                            .filter_changes(backend_id)
-                            .await
-                            .map_err(internal)?;
-
-                        match changes {
-                            FilterChanges::Logs(new_logs) => logs.extend(new_logs),
-                            FilterChanges::Empty => {}
-                            FilterChanges::Hashes(_) | FilterChanges::Transactions(_) => {}
-                        }
-                    }
-
-                    let filtered = zone_rpc::filter::filter_logs(
-                        zone_rpc::filter::dedup_logs(logs),
-                        &auth.caller,
-                    );
-
-                    if filtered.is_empty() {
-                        return to_raw(
-                            &FilterChanges::<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>>::Empty,
-                        );
-                    }
-
-                    return to_raw(&FilterChanges::<
-                        alloy_rpc_types_eth::Transaction<TempoTxEnvelope>,
-                    >::Logs(filtered));
-                }
-            }
 
             let changes = self.eth.filter.filter_changes(id).await.map_err(internal)?;
 
@@ -588,19 +472,6 @@ where
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
-
-            if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
-                let mut removed = true;
-                for backend_id in backend_ids {
-                    removed &= EthFilterApiServer::uninstall_filter(&self.eth.filter, backend_id)
-                        .await
-                        .map_err(internal)?;
-                }
-
-                self.scoped_filters.lock().await.remove(&id);
-                self.filter_owners.lock().await.remove(&id);
-                return to_raw(&removed);
-            }
 
             let result = EthFilterApiServer::uninstall_filter(&self.eth.filter, id.clone())
                 .await

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -5,7 +5,13 @@
 
 pub use zone_rpc::*;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use alloy_network::{ReceiptResponse, TransactionResponse};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
@@ -66,6 +72,10 @@ pub struct TempoZoneRpc<Api: EthApiTypes> {
     /// After bumping reth, use its `ActiveFilters` API to periodically sync this
     /// map and remove entries for filters that no longer exist on the reth side.
     filter_owners: Arc<Mutex<HashMap<FilterId, Address>>>,
+    /// Maps logical private-RPC filter IDs to the concrete backend filter IDs
+    /// needed to express caller-scoped event matching.
+    scoped_filters: Arc<Mutex<HashMap<FilterId, Vec<FilterId>>>>,
+    next_scoped_filter_id: AtomicU64,
 }
 
 impl<Api: EthApiTypes> TempoZoneRpc<Api> {
@@ -74,6 +84,8 @@ impl<Api: EthApiTypes> TempoZoneRpc<Api> {
         Self {
             eth,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
+            scoped_filters: Arc::new(Mutex::new(HashMap::new())),
+            next_scoped_filter_id: AtomicU64::new(1),
         }
     }
 
@@ -101,6 +113,17 @@ impl<Api: EthApiTypes> TempoZoneRpc<Api> {
             Some(owner) if *owner == auth.caller => Ok(()),
             _ => Err(JsonRpcError::invalid_params("filter not found")),
         }
+    }
+
+    fn next_scoped_filter_id(&self) -> FilterId {
+        FilterId::from(format!(
+            "zone-scoped-{}",
+            self.next_scoped_filter_id.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    async fn scoped_backend_filters(&self, id: &FilterId) -> Option<Vec<FilterId>> {
+        self.scoped_filters.lock().await.get(id).cloned()
     }
 }
 
@@ -375,7 +398,7 @@ where
         })
     }
 
-    fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn get_logs(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             if auth.is_sequencer {
                 let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
@@ -384,34 +407,93 @@ where
                 return to_raw(&logs);
             }
 
-            zone_rpc::filter::scope_filter(&mut filter);
-            let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
-                .await
-                .map_err(internal)?;
-            let filtered = zone_rpc::filter::filter_logs(logs, &auth.caller);
+            let scoped_filters = zone_rpc::filter::scope_filter(&filter, &auth.caller);
+            if scoped_filters.is_empty() {
+                return to_raw(&Vec::<alloy_rpc_types_eth::Log>::new());
+            }
+
+            let mut logs = Vec::new();
+            for scoped_filter in scoped_filters {
+                logs.extend(
+                    EthFilterApiServer::logs(&self.eth.filter, scoped_filter)
+                        .await
+                        .map_err(internal)?,
+                );
+            }
+
+            let filtered =
+                zone_rpc::filter::filter_logs(zone_rpc::filter::dedup_logs(logs), &auth.caller);
             to_raw(&filtered)
         })
     }
 
-    fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
+    fn new_filter(&self, filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                zone_rpc::filter::scope_filter(&mut filter);
+            if auth.is_sequencer {
+                let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
+                    .await
+                    .map_err(internal)?;
+                self.filter_owners
+                    .lock()
+                    .await
+                    .insert(id.clone(), auth.caller);
+                return to_raw(&id);
             }
-            let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
-                .await
-                .map_err(internal)?;
+
+            let scoped_filters = zone_rpc::filter::scope_filter(&filter, &auth.caller);
+            let mut backend_ids = Vec::with_capacity(scoped_filters.len());
+
+            for scoped_filter in scoped_filters {
+                match EthFilterApiServer::new_filter(&self.eth.filter, scoped_filter).await {
+                    Ok(id) => backend_ids.push(id),
+                    Err(err) => {
+                        for backend_id in backend_ids {
+                            let _ =
+                                EthFilterApiServer::uninstall_filter(&self.eth.filter, backend_id)
+                                    .await;
+                        }
+                        return Err(internal(err));
+                    }
+                }
+            }
+
+            let public_id = self.next_scoped_filter_id();
             self.filter_owners
                 .lock()
                 .await
-                .insert(id.clone(), auth.caller);
-            to_raw(&id)
+                .insert(public_id.clone(), auth.caller);
+            self.scoped_filters
+                .lock()
+                .await
+                .insert(public_id.clone(), backend_ids);
+            to_raw(&public_id)
         })
     }
 
     fn get_filter_logs(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
+
+            if !auth.is_sequencer {
+                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
+                    let mut logs = Vec::new();
+                    for backend_id in backend_ids {
+                        logs.extend(
+                            self.eth
+                                .filter
+                                .filter_logs(backend_id)
+                                .await
+                                .map_err(internal)?,
+                        );
+                    }
+
+                    let filtered = zone_rpc::filter::filter_logs(
+                        zone_rpc::filter::dedup_logs(logs),
+                        &auth.caller,
+                    );
+                    return to_raw(&filtered);
+                }
+            }
 
             let logs = self.eth.filter.filter_logs(id).await.map_err(internal)?;
 
@@ -427,6 +509,41 @@ where
     fn get_filter_changes(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
+
+            if !auth.is_sequencer {
+                if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
+                    let mut logs = Vec::new();
+                    for backend_id in backend_ids {
+                        let changes = self
+                            .eth
+                            .filter
+                            .filter_changes(backend_id)
+                            .await
+                            .map_err(internal)?;
+
+                        match changes {
+                            FilterChanges::Logs(new_logs) => logs.extend(new_logs),
+                            FilterChanges::Empty => {}
+                            FilterChanges::Hashes(_) | FilterChanges::Transactions(_) => {}
+                        }
+                    }
+
+                    let filtered = zone_rpc::filter::filter_logs(
+                        zone_rpc::filter::dedup_logs(logs),
+                        &auth.caller,
+                    );
+
+                    if filtered.is_empty() {
+                        return to_raw(
+                            &FilterChanges::<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>>::Empty,
+                        );
+                    }
+
+                    return to_raw(&FilterChanges::<
+                        alloy_rpc_types_eth::Transaction<TempoTxEnvelope>,
+                    >::Logs(filtered));
+                }
+            }
 
             let changes = self.eth.filter.filter_changes(id).await.map_err(internal)?;
 
@@ -471,6 +588,19 @@ where
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             self.ensure_filter_owner(&id, &auth).await?;
+
+            if let Some(backend_ids) = self.scoped_backend_filters(&id).await {
+                let mut removed = true;
+                for backend_id in backend_ids {
+                    removed &= EthFilterApiServer::uninstall_filter(&self.eth.filter, backend_id)
+                        .await
+                        .map_err(internal)?;
+                }
+
+                self.scoped_filters.lock().await.remove(&id);
+                self.filter_owners.lock().await.remove(&id);
+                return to_raw(&removed);
+            }
 
             let result = EthFilterApiServer::uninstall_filter(&self.eth.filter, id.clone())
                 .await


### PR DESCRIPTION
## Summary
- expand non-sequencer log filters into caller-scoped backend filter plans
- enforce zone-token address scoping and caller topic injection before backend queries
- store composite filter ids for private RPC log filters so getFilterLogs/getFilterChanges/uninstallFilter keep working

## Testing
- cargo test -p zone-rpc filter --lib
- cargo test -p zone --test it private_rpc::classify_public_methods -- --exact

Closes #249