### PR TITLE
feat(private-rpc): support scoped websocket subscriptions

### DIFF
--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -3,8 +3,11 @@
 //! Each handler calls the underlying EthApi via the [`ZoneRpcApi`] trait,
 //! which performs typed privacy redactions internally before serialization.
 
+use std::{future::Future, pin::Pin};
+
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
+use futures::Stream;
 use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tracing::warn;
@@ -13,6 +16,43 @@ use crate::{
     auth::AuthContext,
     types::{BoxFut, JsonRpcError, JsonRpcRequest, JsonRpcResponse, MethodTier, classify_method},
 };
+
+/// A boxed stream of serialized websocket subscription items.
+pub type WsSubscriptionStream =
+    Pin<Box<dyn Stream<Item = Result<Box<RawValue>, JsonRpcError>> + Send + 'static>>;
+
+/// A boxed future that resolves to a websocket subscription.
+pub type BoxWsSubscriptionFut<'a> =
+    Pin<Box<dyn Future<Output = Result<WsSubscription, JsonRpcError>> + Send + 'a>>;
+
+/// A transport-agnostic websocket subscription returned by [`ZoneRpcApi`].
+pub struct WsSubscription {
+    /// Stream of serialized `eth_subscription` payloads.
+    pub stream: WsSubscriptionStream,
+    /// Optional upstream filter ID that must be cleaned up on unsubscribe.
+    pub upstream_filter_id: Option<FilterId>,
+}
+
+impl WsSubscription {
+    /// Create a subscription backed by a direct event stream.
+    pub fn new(stream: WsSubscriptionStream) -> Self {
+        Self {
+            stream,
+            upstream_filter_id: None,
+        }
+    }
+
+    /// Create a subscription that owns an upstream filter.
+    pub fn with_upstream_filter(
+        stream: WsSubscriptionStream,
+        upstream_filter_id: FilterId,
+    ) -> Self {
+        Self {
+            stream,
+            upstream_filter_id: Some(upstream_filter_id),
+        }
+    }
+}
 
 /// Interface to the underlying reth EthApi for the private zone RPC.
 ///
@@ -147,6 +187,12 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `eth_uninstallFilter(id)` — removes a filter.
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `eth_subscribe("newHeads")` — opens a stream of new block headers.
+    fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_>;
+
+    /// `eth_subscribe("logs", filter)` — opens a stream of matching logs.
+    fn ws_subscribe_logs(&self, filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_>;
 }
 
 /// Deserialize JSON-RPC params, returning an error response on failure.

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -150,10 +150,14 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_>;
 
     /// `eth_subscribe("newHeads")` — opens a stream of new block headers.
-    fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_>;
+    fn ws_subscribe_new_heads(&self, _auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async { Err(JsonRpcError::method_disabled()) })
+    }
 
     /// `eth_subscribe("logs", filter)` — opens a stream of matching logs.
-    fn ws_subscribe_logs(&self, filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_>;
+    fn ws_subscribe_logs(&self, _filter: Filter, _auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async { Err(JsonRpcError::method_disabled()) })
+    }
 }
 
 /// Deserialize JSON-RPC params, returning an error response on failure.

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -3,56 +3,17 @@
 //! Each handler calls the underlying EthApi via the [`ZoneRpcApi`] trait,
 //! which performs typed privacy redactions internally before serialization.
 
-use std::{future::Future, pin::Pin};
-
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
-use futures::Stream;
 use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tracing::warn;
 
 use crate::{
     auth::AuthContext,
+    subscription::BoxWsSubscriptionFut,
     types::{BoxFut, JsonRpcError, JsonRpcRequest, JsonRpcResponse, MethodTier, classify_method},
 };
-
-/// A boxed stream of serialized websocket subscription items.
-pub type WsSubscriptionStream =
-    Pin<Box<dyn Stream<Item = Result<Box<RawValue>, JsonRpcError>> + Send + 'static>>;
-
-/// A boxed future that resolves to a websocket subscription.
-pub type BoxWsSubscriptionFut<'a> =
-    Pin<Box<dyn Future<Output = Result<WsSubscription, JsonRpcError>> + Send + 'a>>;
-
-/// A transport-agnostic websocket subscription returned by [`ZoneRpcApi`].
-pub struct WsSubscription {
-    /// Stream of serialized `eth_subscription` payloads.
-    pub stream: WsSubscriptionStream,
-    /// Optional upstream filter ID that must be cleaned up on unsubscribe.
-    pub upstream_filter_id: Option<FilterId>,
-}
-
-impl WsSubscription {
-    /// Create a subscription backed by a direct event stream.
-    pub fn new(stream: WsSubscriptionStream) -> Self {
-        Self {
-            stream,
-            upstream_filter_id: None,
-        }
-    }
-
-    /// Create a subscription that owns an upstream filter.
-    pub fn with_upstream_filter(
-        stream: WsSubscriptionStream,
-        upstream_filter_id: FilterId,
-    ) -> Self {
-        Self {
-            stream,
-            upstream_filter_id: Some(upstream_filter_id),
-        }
-    }
-}
 
 /// Interface to the underlying reth EthApi for the private zone RPC.
 ///

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -14,6 +14,7 @@ pub mod policy;
 pub mod provider;
 pub mod proxy;
 pub mod server;
+pub mod subscription;
 pub mod types;
 mod ws;
 

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -4,31 +4,21 @@
 //! applies privacy redactions on the responses. This allows the private RPC
 //! service to run as a standalone process without linking against reth.
 
-use std::{
-    collections::{HashMap, VecDeque},
-    future::Future,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use alloy_network::ReceiptResponse;
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, Bytes};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, Log, state::StateOverride};
-use futures::stream;
 use serde::Deserialize;
-use serde_json::{Value, value::RawValue};
+use serde_json::value::RawValue;
 use tempo_alloy::rpc::{TempoTransactionReceipt, TempoTransactionRequest};
-use tokio::{
-    sync::Mutex,
-    time::{self, MissedTickBehavior},
-};
+use tokio::sync::Mutex;
 
 use crate::{
     auth::AuthContext,
     filter,
     handlers::ZoneRpcApi,
     policy,
-    subscription::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream},
     types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 
@@ -113,8 +103,6 @@ impl ProxyZoneRpc {
     }
 }
 
-const WS_SUBSCRIPTION_POLL_INTERVAL: Duration = Duration::from_millis(250);
-
 /// Strip privacy-sensitive fields from a block JSON object for non-sequencer callers.
 ///
 /// Zeroes `logsBloom` and replaces `transactions` with an empty array.
@@ -131,46 +119,6 @@ fn redact_block_json(value: &mut serde_json::Value) {
 /// Extract the `from` address from a JSON transaction or receipt object.
 fn json_from(value: &serde_json::Value) -> Option<Address> {
     value.get("from")?.as_str()?.parse().ok()
-}
-
-fn polling_subscription_stream<F, Fut>(poll: F) -> WsSubscriptionStream
-where
-    F: FnMut() -> Fut + Send + 'static,
-    Fut: Future<Output = Result<Vec<Box<RawValue>>, JsonRpcError>> + Send + 'static,
-{
-    let mut interval = time::interval(WS_SUBSCRIPTION_POLL_INTERVAL);
-    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
-    Box::pin(stream::unfold(
-        (interval, VecDeque::<Box<RawValue>>::new(), poll, false),
-        |(mut interval, mut pending, mut poll, done)| async move {
-            loop {
-                if let Some(item) = pending.pop_front() {
-                    return Some((Ok(item), (interval, pending, poll, done)));
-                }
-
-                if done {
-                    return None;
-                }
-
-                interval.tick().await;
-                match poll().await {
-                    Ok(items) if items.is_empty() => continue,
-                    Ok(items) => pending = items.into_iter().collect(),
-                    Err(err) => return Some((Err(err), (interval, pending, poll, true))),
-                }
-            }
-        },
-    ))
-}
-
-fn strip_new_head_fields(raw: Box<RawValue>) -> Result<Box<RawValue>, JsonRpcError> {
-    let mut header: Value = serde_json::from_str(raw.get()).map_err(internal)?;
-    if let Some(obj) = header.as_object_mut() {
-        obj.remove("transactions");
-        obj.remove("uncles");
-    }
-    to_raw(&header)
 }
 
 impl ZoneRpcApi for ProxyZoneRpc {
@@ -536,59 +484,6 @@ impl ZoneRpcApi for ProxyZoneRpc {
             }
 
             Ok(result)
-        })
-    }
-
-    fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
-        Box::pin(async move {
-            let raw = self.new_block_filter(auth.clone()).await?;
-            let upstream_filter_id: FilterId = serde_json::from_str(raw.get()).map_err(internal)?;
-            let this = self.clone();
-            let filter_id = upstream_filter_id.clone();
-            let stream = polling_subscription_stream(move || {
-                let this = this.clone();
-                let auth = auth.clone();
-                let filter_id = filter_id.clone();
-                async move {
-                    let raw = this.get_filter_changes(filter_id, auth.clone()).await?;
-                    let hashes: Vec<B256> = serde_json::from_str(raw.get()).map_err(internal)?;
-                    let mut headers = Vec::with_capacity(hashes.len());
-                    for hash in hashes {
-                        let block = this.block_by_hash(hash, false, auth.clone()).await?;
-                        headers.push(strip_new_head_fields(block)?);
-                    }
-                    Ok(headers)
-                }
-            });
-
-            Ok(WsSubscription::with_upstream_filter(
-                stream,
-                upstream_filter_id,
-            ))
-        })
-    }
-
-    fn ws_subscribe_logs(&self, filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
-        Box::pin(async move {
-            let raw = self.new_filter(filter, auth.clone()).await?;
-            let upstream_filter_id: FilterId = serde_json::from_str(raw.get()).map_err(internal)?;
-            let this = self.clone();
-            let filter_id = upstream_filter_id.clone();
-            let stream = polling_subscription_stream(move || {
-                let this = this.clone();
-                let auth = auth.clone();
-                let filter_id = filter_id.clone();
-                async move {
-                    let raw = this.get_filter_changes(filter_id, auth).await?;
-                    let logs: Vec<Log> = serde_json::from_str(raw.get()).map_err(internal)?;
-                    logs.into_iter().map(|log| to_raw(&log)).collect()
-                }
-            });
-
-            Ok(WsSubscription::with_upstream_filter(
-                stream,
-                upstream_filter_id,
-            ))
         })
     }
 }

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -26,8 +26,9 @@ use tokio::{
 use crate::{
     auth::AuthContext,
     filter,
-    handlers::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream, ZoneRpcApi},
+    handlers::ZoneRpcApi,
     policy,
+    subscription::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream},
     types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -4,20 +4,29 @@
 //! applies privacy redactions on the responses. This allows the private RPC
 //! service to run as a standalone process without linking against reth.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    future::Future,
+    sync::Arc,
+    time::Duration,
+};
 
 use alloy_network::ReceiptResponse;
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, Log, state::StateOverride};
+use futures::stream;
 use serde::Deserialize;
-use serde_json::value::RawValue;
+use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::{TempoTransactionReceipt, TempoTransactionRequest};
-use tokio::sync::Mutex;
+use tokio::{
+    sync::Mutex,
+    time::{self, MissedTickBehavior},
+};
 
 use crate::{
     auth::AuthContext,
     filter,
-    handlers::ZoneRpcApi,
+    handlers::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream, ZoneRpcApi},
     policy,
     types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
@@ -33,6 +42,7 @@ struct UpstreamResponse {
 ///
 /// Forwards requests to an upstream zone node's standard (non-private) RPC
 /// endpoint and applies per-caller privacy redactions on the responses.
+#[derive(Clone)]
 pub struct ProxyZoneRpc {
     client: reqwest::Client,
     upstream_url: String,
@@ -102,6 +112,8 @@ impl ProxyZoneRpc {
     }
 }
 
+const WS_SUBSCRIPTION_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
 /// Strip privacy-sensitive fields from a block JSON object for non-sequencer callers.
 ///
 /// Zeroes `logsBloom` and replaces `transactions` with an empty array.
@@ -118,6 +130,46 @@ fn redact_block_json(value: &mut serde_json::Value) {
 /// Extract the `from` address from a JSON transaction or receipt object.
 fn json_from(value: &serde_json::Value) -> Option<Address> {
     value.get("from")?.as_str()?.parse().ok()
+}
+
+fn polling_subscription_stream<F, Fut>(poll: F) -> WsSubscriptionStream
+where
+    F: FnMut() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<Vec<Box<RawValue>>, JsonRpcError>> + Send + 'static,
+{
+    let mut interval = time::interval(WS_SUBSCRIPTION_POLL_INTERVAL);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    Box::pin(stream::unfold(
+        (interval, VecDeque::<Box<RawValue>>::new(), poll, false),
+        |(mut interval, mut pending, mut poll, done)| async move {
+            loop {
+                if let Some(item) = pending.pop_front() {
+                    return Some((Ok(item), (interval, pending, poll, done)));
+                }
+
+                if done {
+                    return None;
+                }
+
+                interval.tick().await;
+                match poll().await {
+                    Ok(items) if items.is_empty() => continue,
+                    Ok(items) => pending = items.into_iter().collect(),
+                    Err(err) => return Some((Err(err), (interval, pending, poll, true))),
+                }
+            }
+        },
+    ))
+}
+
+fn strip_new_head_fields(raw: Box<RawValue>) -> Result<Box<RawValue>, JsonRpcError> {
+    let mut header: Value = serde_json::from_str(raw.get()).map_err(internal)?;
+    if let Some(obj) = header.as_object_mut() {
+        obj.remove("transactions");
+        obj.remove("uncles");
+    }
+    to_raw(&header)
 }
 
 impl ZoneRpcApi for ProxyZoneRpc {
@@ -483,6 +535,59 @@ impl ZoneRpcApi for ProxyZoneRpc {
             }
 
             Ok(result)
+        })
+    }
+
+    fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let raw = self.new_block_filter(auth.clone()).await?;
+            let upstream_filter_id: FilterId = serde_json::from_str(raw.get()).map_err(internal)?;
+            let this = self.clone();
+            let filter_id = upstream_filter_id.clone();
+            let stream = polling_subscription_stream(move || {
+                let this = this.clone();
+                let auth = auth.clone();
+                let filter_id = filter_id.clone();
+                async move {
+                    let raw = this.get_filter_changes(filter_id, auth.clone()).await?;
+                    let hashes: Vec<B256> = serde_json::from_str(raw.get()).map_err(internal)?;
+                    let mut headers = Vec::with_capacity(hashes.len());
+                    for hash in hashes {
+                        let block = this.block_by_hash(hash, false, auth.clone()).await?;
+                        headers.push(strip_new_head_fields(block)?);
+                    }
+                    Ok(headers)
+                }
+            });
+
+            Ok(WsSubscription::with_upstream_filter(
+                stream,
+                upstream_filter_id,
+            ))
+        })
+    }
+
+    fn ws_subscribe_logs(&self, filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let raw = self.new_filter(filter, auth.clone()).await?;
+            let upstream_filter_id: FilterId = serde_json::from_str(raw.get()).map_err(internal)?;
+            let this = self.clone();
+            let filter_id = upstream_filter_id.clone();
+            let stream = polling_subscription_stream(move || {
+                let this = this.clone();
+                let auth = auth.clone();
+                let filter_id = filter_id.clone();
+                async move {
+                    let raw = this.get_filter_changes(filter_id, auth).await?;
+                    let logs: Vec<Log> = serde_json::from_str(raw.get()).map_err(internal)?;
+                    logs.into_iter().map(|log| to_raw(&log)).collect()
+                }
+            });
+
+            Ok(WsSubscription::with_upstream_filter(
+                stream,
+                upstream_filter_id,
+            ))
         })
     }
 }

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// Maximum number of requests in a single JSON-RPC batch.
-const MAX_BATCH_SIZE: usize = 100;
+pub(crate) const MAX_BATCH_SIZE: usize = 100;
 
 /// Shared state for the private RPC server.
 #[derive(Clone)]
@@ -70,17 +70,6 @@ pub async fn start_private_rpc(
 pub(crate) enum RpcResult {
     Single(JsonRpcResponse),
     Batch(Vec<JsonRpcResponse>),
-}
-
-impl RpcResult {
-    /// Serialize to a JSON string for the WebSocket transport.
-    pub(crate) fn into_json(self) -> String {
-        match self {
-            Self::Single(resp) => serde_json::to_string(&resp),
-            Self::Batch(resps) => serde_json::to_string(&resps),
-        }
-        .expect("JsonRpcResponse serialization is infallible")
-    }
 }
 
 impl IntoResponse for RpcResult {

--- a/crates/rpc/src/subscription.rs
+++ b/crates/rpc/src/subscription.rs
@@ -1,0 +1,46 @@
+//! Shared websocket subscription types for the private zone RPC.
+
+use std::{future::Future, pin::Pin};
+
+use alloy_rpc_types_eth::FilterId;
+use futures::Stream;
+use serde_json::value::RawValue;
+
+use crate::types::JsonRpcError;
+
+/// A boxed stream of serialized websocket subscription items.
+pub type WsSubscriptionStream =
+    Pin<Box<dyn Stream<Item = Result<Box<RawValue>, JsonRpcError>> + Send + 'static>>;
+
+/// A boxed future that resolves to a websocket subscription.
+pub type BoxWsSubscriptionFut<'a> =
+    Pin<Box<dyn Future<Output = Result<WsSubscription, JsonRpcError>> + Send + 'a>>;
+
+/// A transport-agnostic websocket subscription returned by the RPC API.
+pub struct WsSubscription {
+    /// Stream of serialized `eth_subscription` payloads.
+    pub stream: WsSubscriptionStream,
+    /// Optional upstream filter ID that must be cleaned up on unsubscribe.
+    pub upstream_filter_id: Option<FilterId>,
+}
+
+impl WsSubscription {
+    /// Create a subscription backed by a direct event stream.
+    pub fn new(stream: WsSubscriptionStream) -> Self {
+        Self {
+            stream,
+            upstream_filter_id: None,
+        }
+    }
+
+    /// Create a subscription that owns an upstream filter.
+    pub fn with_upstream_filter(
+        stream: WsSubscriptionStream,
+        upstream_filter_id: FilterId,
+    ) -> Self {
+        Self {
+            stream,
+            upstream_filter_id: Some(upstream_filter_id),
+        }
+    }
+}

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -28,8 +28,9 @@ use tracing::warn;
 
 use crate::{
     auth::{self, AuthContext, AuthError},
-    handlers::{self, WsSubscription, ZoneRpcApi},
+    handlers::{self, ZoneRpcApi},
     server::{MAX_BATCH_SIZE, RpcState, auth_error_status, authenticate_token},
+    subscription::{WsSubscription, WsSubscriptionStream},
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
 };
 
@@ -125,7 +126,7 @@ fn subscription_notification_raw(subscription_id: &FilterId, result: &RawValue) 
 
 fn spawn_subscription(
     subscription_id: FilterId,
-    mut stream: handlers::WsSubscriptionStream,
+    mut stream: WsSubscriptionStream,
     notifications: NotificationTx,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -7,7 +7,6 @@
 //! Auth is validated once during the HTTP upgrade handshake — individual
 //! messages are not re-authenticated since WS frames don't carry auth headers.
 
-use alloy_primitives::B256;
 use alloy_rpc_types_eth::{
     Filter, FilterId,
     pubsub::{Params as SubscriptionParams, SubscriptionKind},
@@ -22,25 +21,20 @@ use axum::{
 };
 use futures::{SinkExt, stream::StreamExt};
 use serde::de::DeserializeOwned;
-use serde_json::Value;
-use std::{collections::HashMap, sync::Arc, time::Duration};
-use tokio::{
-    sync::mpsc,
-    task::JoinHandle,
-    time::{self, MissedTickBehavior},
-};
+use serde_json::{Value, value::RawValue};
+use std::{collections::HashMap, sync::Arc};
+use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::warn;
 
 use crate::{
     auth::{self, AuthContext, AuthError},
-    handlers::{self, ZoneRpcApi},
+    handlers::{self, WsSubscription, ZoneRpcApi},
     server::{MAX_BATCH_SIZE, RpcState, auth_error_status, authenticate_token},
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
 };
 
 /// Maximum WebSocket message size (1 MiB).
 const MAX_WS_MESSAGE_SIZE: usize = 1 << 20;
-const WS_SUBSCRIPTION_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 type NotificationTx = mpsc::UnboundedSender<String>;
 
@@ -52,7 +46,7 @@ pub(crate) struct WsQuery {
 }
 
 struct ActiveSubscription {
-    upstream_filter_id: FilterId,
+    upstream_filter_id: Option<FilterId>,
     task: JoinHandle<()>,
 }
 
@@ -104,166 +98,62 @@ fn parse_ws_params<T: DeserializeOwned>(
         .map_err(|_| JsonRpcResponse::error(req.id.clone(), JsonRpcError::invalid_params(message)))
 }
 
-fn subscription_notification(subscription_id: &FilterId, result: Value) -> String {
-    serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": "eth_subscription",
-        "params": {
-            "subscription": subscription_id,
-            "result": result,
-        }
-    })
-    .to_string()
+#[derive(serde::Serialize)]
+struct SubscriptionNotification<'a> {
+    jsonrpc: &'static str,
+    method: &'static str,
+    params: SubscriptionNotificationParams<'a>,
 }
 
-fn spawn_logs_subscription(
+#[derive(serde::Serialize)]
+struct SubscriptionNotificationParams<'a> {
+    subscription: &'a FilterId,
+    result: &'a RawValue,
+}
+
+fn subscription_notification_raw(subscription_id: &FilterId, result: &RawValue) -> String {
+    serde_json::to_string(&SubscriptionNotification {
+        jsonrpc: "2.0",
+        method: "eth_subscription",
+        params: SubscriptionNotificationParams {
+            subscription: subscription_id,
+            result,
+        },
+    })
+    .expect("subscription notification serialization is infallible")
+}
+
+fn spawn_subscription(
     subscription_id: FilterId,
-    upstream_filter_id: FilterId,
-    auth: AuthContext,
-    api: Arc<dyn ZoneRpcApi>,
+    mut stream: handlers::WsSubscriptionStream,
     notifications: NotificationTx,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let mut interval = time::interval(WS_SUBSCRIPTION_POLL_INTERVAL);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        interval.tick().await;
+        // Let the subscribe response get enqueued before the first notification.
+        tokio::task::yield_now().await;
 
-        loop {
-            interval.tick().await;
+        while let Some(item) = stream.next().await {
+            let result = match item {
+                Ok(result) => result,
+                Err(err) => {
+                    warn!(
+                        target: "zone::rpc",
+                        subscription = ?subscription_id,
+                        err = %err,
+                        "ws subscription stream failed"
+                    );
+                    break;
+                }
+            };
 
-            let changes = match api
-                .get_filter_changes(upstream_filter_id.clone(), auth.clone())
-                .await
+            if notifications
+                .send(subscription_notification_raw(
+                    &subscription_id,
+                    result.as_ref(),
+                ))
+                .is_err()
             {
-                Ok(changes) => changes,
-                Err(err) => {
-                    warn!(
-                        target: "zone::rpc",
-                        subscription = ?subscription_id,
-                        upstream_filter = ?upstream_filter_id,
-                        err = %err,
-                        "ws logs subscription poll failed"
-                    );
-                    break;
-                }
-            };
-
-            let logs: Vec<Value> = match serde_json::from_str(changes.get()) {
-                Ok(logs) => logs,
-                Err(err) => {
-                    warn!(
-                        target: "zone::rpc",
-                        subscription = ?subscription_id,
-                        upstream_filter = ?upstream_filter_id,
-                        err = %err,
-                        "ws logs subscription returned invalid payload"
-                    );
-                    break;
-                }
-            };
-
-            for log in logs {
-                if notifications
-                    .send(subscription_notification(&subscription_id, log))
-                    .is_err()
-                {
-                    return;
-                }
-            }
-        }
-    })
-}
-
-fn spawn_new_heads_subscription(
-    subscription_id: FilterId,
-    upstream_filter_id: FilterId,
-    auth: AuthContext,
-    api: Arc<dyn ZoneRpcApi>,
-    notifications: NotificationTx,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut interval = time::interval(WS_SUBSCRIPTION_POLL_INTERVAL);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        interval.tick().await;
-
-        loop {
-            interval.tick().await;
-
-            let changes = match api
-                .get_filter_changes(upstream_filter_id.clone(), auth.clone())
-                .await
-            {
-                Ok(changes) => changes,
-                Err(err) => {
-                    warn!(
-                        target: "zone::rpc",
-                        subscription = ?subscription_id,
-                        upstream_filter = ?upstream_filter_id,
-                        err = %err,
-                        "ws newHeads subscription poll failed"
-                    );
-                    break;
-                }
-            };
-
-            let hashes: Vec<B256> = match serde_json::from_str(changes.get()) {
-                Ok(hashes) => hashes,
-                Err(err) => {
-                    warn!(
-                        target: "zone::rpc",
-                        subscription = ?subscription_id,
-                        upstream_filter = ?upstream_filter_id,
-                        err = %err,
-                        "ws newHeads subscription returned invalid payload"
-                    );
-                    break;
-                }
-            };
-
-            for hash in hashes {
-                let header = match api.block_by_hash(hash, false, auth.clone()).await {
-                    Ok(header) => header,
-                    Err(err) => {
-                        warn!(
-                            target: "zone::rpc",
-                            subscription = ?subscription_id,
-                            upstream_filter = ?upstream_filter_id,
-                            err = %err,
-                            "ws newHeads subscription failed to load block header"
-                        );
-                        return;
-                    }
-                };
-
-                let mut header_json: Value = match serde_json::from_str(header.get()) {
-                    Ok(value) => value,
-                    Err(err) => {
-                        warn!(
-                            target: "zone::rpc",
-                            subscription = ?subscription_id,
-                            upstream_filter = ?upstream_filter_id,
-                            err = %err,
-                            "ws newHeads subscription returned invalid block payload"
-                        );
-                        return;
-                    }
-                };
-
-                if header_json.is_null() {
-                    continue;
-                }
-
-                if let Some(obj) = header_json.as_object_mut() {
-                    obj.remove("transactions");
-                    obj.remove("uncles");
-                }
-
-                if notifications
-                    .send(subscription_notification(&subscription_id, header_json))
-                    .is_err()
-                {
-                    return;
-                }
+                return;
             }
         }
     })
@@ -291,28 +181,17 @@ async fn handle_subscribe(
                 );
             }
 
-            let raw = match state.api.new_block_filter(auth.clone()).await {
-                Ok(raw) => raw,
+            let subscription = match state.api.ws_subscribe_new_heads(auth.clone()).await {
+                Ok(subscription) => subscription,
                 Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
-            };
-            let upstream_filter_id: FilterId = match serde_json::from_str(raw.get()) {
-                Ok(id) => id,
-                Err(err) => {
-                    return JsonRpcResponse::error(
-                        req.id.clone(),
-                        JsonRpcError::internal(err.to_string()),
-                    );
-                }
             };
 
             let subscription_id = session.next_subscription_id();
-            let task = spawn_new_heads_subscription(
-                subscription_id.clone(),
-                upstream_filter_id.clone(),
-                auth.clone(),
-                state.api.clone(),
-                notifications.clone(),
-            );
+            let WsSubscription {
+                stream,
+                upstream_filter_id,
+            } = subscription;
+            let task = spawn_subscription(subscription_id.clone(), stream, notifications.clone());
             session.subscriptions.insert(
                 subscription_id.clone(),
                 ActiveSubscription {
@@ -334,28 +213,17 @@ async fn handle_subscribe(
                 }
             };
 
-            let raw = match state.api.new_filter(filter, auth.clone()).await {
-                Ok(raw) => raw,
+            let subscription = match state.api.ws_subscribe_logs(filter, auth.clone()).await {
+                Ok(subscription) => subscription,
                 Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
-            };
-            let upstream_filter_id: FilterId = match serde_json::from_str(raw.get()) {
-                Ok(id) => id,
-                Err(err) => {
-                    return JsonRpcResponse::error(
-                        req.id.clone(),
-                        JsonRpcError::internal(err.to_string()),
-                    );
-                }
             };
 
             let subscription_id = session.next_subscription_id();
-            let task = spawn_logs_subscription(
-                subscription_id.clone(),
-                upstream_filter_id.clone(),
-                auth.clone(),
-                state.api.clone(),
-                notifications.clone(),
-            );
+            let WsSubscription {
+                stream,
+                upstream_filter_id,
+            } = subscription;
+            let task = spawn_subscription(subscription_id.clone(), stream, notifications.clone());
             session.subscriptions.insert(
                 subscription_id.clone(),
                 ActiveSubscription {
@@ -388,13 +256,16 @@ async fn handle_unsubscribe(
     };
 
     active.task.abort();
-    let removed = match state
-        .api
-        .uninstall_filter(active.upstream_filter_id, auth.clone())
-        .await
-    {
-        Ok(raw) => serde_json::from_str(raw.get()).unwrap_or(false),
-        Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+    let removed = match active.upstream_filter_id {
+        Some(upstream_filter_id) => match state
+            .api
+            .uninstall_filter(upstream_filter_id, auth.clone())
+            .await
+        {
+            Ok(raw) => serde_json::from_str(raw.get()).unwrap_or(false),
+            Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+        },
+        None => true,
     };
 
     success_response(req.id.clone(), &removed)
@@ -465,9 +336,9 @@ async fn process_ws_text(
 async fn cleanup_ws_session(session: WsSession, auth: &AuthContext, api: Arc<dyn ZoneRpcApi>) {
     for (_, active) in session.subscriptions {
         active.task.abort();
-        let _ = api
-            .uninstall_filter(active.upstream_filter_id, auth.clone())
-            .await;
+        if let Some(upstream_filter_id) = active.upstream_filter_id {
+            let _ = api.uninstall_filter(upstream_filter_id, auth.clone()).await;
+        }
     }
 }
 

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -7,6 +7,11 @@
 //! Auth is validated once during the HTTP upgrade handshake — individual
 //! messages are not re-authenticated since WS frames don't carry auth headers.
 
+use alloy_primitives::B256;
+use alloy_rpc_types_eth::{
+    Filter, FilterId,
+    pubsub::{Params as SubscriptionParams, SubscriptionKind},
+};
 use axum::{
     extract::{
         Query, State,
@@ -15,23 +20,455 @@ use axum::{
     http::HeaderMap,
     response::IntoResponse,
 };
-use futures::stream::StreamExt;
-use std::sync::Arc;
+use futures::{SinkExt, stream::StreamExt};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{
+    sync::mpsc,
+    task::JoinHandle,
+    time::{self, MissedTickBehavior},
+};
 use tracing::warn;
 
 use crate::{
-    auth::{self, AuthError},
-    server::{RpcState, auth_error_status, authenticate_token, process_rpc_text},
+    auth::{self, AuthContext, AuthError},
+    handlers::{self, ZoneRpcApi},
+    server::{MAX_BATCH_SIZE, RpcState, auth_error_status, authenticate_token},
+    types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
 };
 
 /// Maximum WebSocket message size (1 MiB).
 const MAX_WS_MESSAGE_SIZE: usize = 1 << 20;
+const WS_SUBSCRIPTION_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+type NotificationTx = mpsc::UnboundedSender<String>;
 
 /// Query parameters for the WebSocket upgrade endpoint.
 #[derive(serde::Deserialize, Default)]
 pub(crate) struct WsQuery {
     /// Auth token passed as query param (fallback when headers are unavailable).
     token: Option<String>,
+}
+
+struct ActiveSubscription {
+    upstream_filter_id: FilterId,
+    task: JoinHandle<()>,
+}
+
+struct WsSession {
+    next_subscription_id: u64,
+    subscriptions: HashMap<FilterId, ActiveSubscription>,
+}
+
+impl Default for WsSession {
+    fn default() -> Self {
+        Self {
+            next_subscription_id: 1,
+            subscriptions: HashMap::new(),
+        }
+    }
+}
+
+impl WsSession {
+    fn next_subscription_id(&mut self) -> FilterId {
+        let id = FilterId::from(format!("0x{:x}", self.next_subscription_id));
+        self.next_subscription_id += 1;
+        id
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct SubscribeParams(
+    SubscriptionKind,
+    #[serde(default)] Option<SubscriptionParams>,
+);
+
+fn success_response<T: serde::Serialize>(id: Value, result: &T) -> JsonRpcResponse {
+    match to_raw(result) {
+        Ok(raw) => JsonRpcResponse::success(id, raw),
+        Err(err) => JsonRpcResponse::error(id, err),
+    }
+}
+
+fn parse_ws_params<T: DeserializeOwned>(
+    req: &JsonRpcRequest,
+    message: &'static str,
+) -> Result<T, JsonRpcResponse> {
+    let raw = req
+        .params
+        .as_deref()
+        .map(|params| params.get())
+        .unwrap_or("[]");
+    serde_json::from_str(raw)
+        .map_err(|_| JsonRpcResponse::error(req.id.clone(), JsonRpcError::invalid_params(message)))
+}
+
+fn subscription_notification(subscription_id: &FilterId, result: Value) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "eth_subscription",
+        "params": {
+            "subscription": subscription_id,
+            "result": result,
+        }
+    })
+    .to_string()
+}
+
+fn spawn_logs_subscription(
+    subscription_id: FilterId,
+    upstream_filter_id: FilterId,
+    auth: AuthContext,
+    api: Arc<dyn ZoneRpcApi>,
+    notifications: NotificationTx,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = time::interval(WS_SUBSCRIPTION_POLL_INTERVAL);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+
+            let changes = match api
+                .get_filter_changes(upstream_filter_id.clone(), auth.clone())
+                .await
+            {
+                Ok(changes) => changes,
+                Err(err) => {
+                    warn!(
+                        target: "zone::rpc",
+                        subscription = ?subscription_id,
+                        upstream_filter = ?upstream_filter_id,
+                        err = %err,
+                        "ws logs subscription poll failed"
+                    );
+                    break;
+                }
+            };
+
+            let logs: Vec<Value> = match serde_json::from_str(changes.get()) {
+                Ok(logs) => logs,
+                Err(err) => {
+                    warn!(
+                        target: "zone::rpc",
+                        subscription = ?subscription_id,
+                        upstream_filter = ?upstream_filter_id,
+                        err = %err,
+                        "ws logs subscription returned invalid payload"
+                    );
+                    break;
+                }
+            };
+
+            for log in logs {
+                if notifications
+                    .send(subscription_notification(&subscription_id, log))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+    })
+}
+
+fn spawn_new_heads_subscription(
+    subscription_id: FilterId,
+    upstream_filter_id: FilterId,
+    auth: AuthContext,
+    api: Arc<dyn ZoneRpcApi>,
+    notifications: NotificationTx,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = time::interval(WS_SUBSCRIPTION_POLL_INTERVAL);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+
+            let changes = match api
+                .get_filter_changes(upstream_filter_id.clone(), auth.clone())
+                .await
+            {
+                Ok(changes) => changes,
+                Err(err) => {
+                    warn!(
+                        target: "zone::rpc",
+                        subscription = ?subscription_id,
+                        upstream_filter = ?upstream_filter_id,
+                        err = %err,
+                        "ws newHeads subscription poll failed"
+                    );
+                    break;
+                }
+            };
+
+            let hashes: Vec<B256> = match serde_json::from_str(changes.get()) {
+                Ok(hashes) => hashes,
+                Err(err) => {
+                    warn!(
+                        target: "zone::rpc",
+                        subscription = ?subscription_id,
+                        upstream_filter = ?upstream_filter_id,
+                        err = %err,
+                        "ws newHeads subscription returned invalid payload"
+                    );
+                    break;
+                }
+            };
+
+            for hash in hashes {
+                let header = match api.block_by_hash(hash, false, auth.clone()).await {
+                    Ok(header) => header,
+                    Err(err) => {
+                        warn!(
+                            target: "zone::rpc",
+                            subscription = ?subscription_id,
+                            upstream_filter = ?upstream_filter_id,
+                            err = %err,
+                            "ws newHeads subscription failed to load block header"
+                        );
+                        return;
+                    }
+                };
+
+                let mut header_json: Value = match serde_json::from_str(header.get()) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        warn!(
+                            target: "zone::rpc",
+                            subscription = ?subscription_id,
+                            upstream_filter = ?upstream_filter_id,
+                            err = %err,
+                            "ws newHeads subscription returned invalid block payload"
+                        );
+                        return;
+                    }
+                };
+
+                if header_json.is_null() {
+                    continue;
+                }
+
+                if let Some(obj) = header_json.as_object_mut() {
+                    obj.remove("transactions");
+                    obj.remove("uncles");
+                }
+
+                if notifications
+                    .send(subscription_notification(&subscription_id, header_json))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        }
+    })
+}
+
+async fn handle_subscribe(
+    req: &JsonRpcRequest,
+    auth: &AuthContext,
+    state: &Arc<RpcState>,
+    notifications: &NotificationTx,
+    session: &mut WsSession,
+) -> JsonRpcResponse {
+    let SubscribeParams(kind, params) =
+        match parse_ws_params(req, "expected [subscription, params?]") {
+            Ok(params) => params,
+            Err(resp) => return resp,
+        };
+
+    match kind {
+        SubscriptionKind::NewHeads => {
+            if !matches!(params, None | Some(SubscriptionParams::None)) {
+                return JsonRpcResponse::error(
+                    req.id.clone(),
+                    JsonRpcError::invalid_params("eth_subscribe(newHeads) does not accept params"),
+                );
+            }
+
+            let raw = match state.api.new_block_filter(auth.clone()).await {
+                Ok(raw) => raw,
+                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+            };
+            let upstream_filter_id: FilterId = match serde_json::from_str(raw.get()) {
+                Ok(id) => id,
+                Err(err) => {
+                    return JsonRpcResponse::error(
+                        req.id.clone(),
+                        JsonRpcError::internal(err.to_string()),
+                    );
+                }
+            };
+
+            let subscription_id = session.next_subscription_id();
+            let task = spawn_new_heads_subscription(
+                subscription_id.clone(),
+                upstream_filter_id.clone(),
+                auth.clone(),
+                state.api.clone(),
+                notifications.clone(),
+            );
+            session.subscriptions.insert(
+                subscription_id.clone(),
+                ActiveSubscription {
+                    upstream_filter_id,
+                    task,
+                },
+            );
+            success_response(req.id.clone(), &subscription_id)
+        }
+        SubscriptionKind::Logs => {
+            let filter = match params.unwrap_or_default() {
+                SubscriptionParams::None => Filter::default(),
+                SubscriptionParams::Logs(filter) => *filter,
+                SubscriptionParams::Bool(_) => {
+                    return JsonRpcResponse::error(
+                        req.id.clone(),
+                        JsonRpcError::invalid_params("eth_subscribe(logs) expects a filter object"),
+                    );
+                }
+            };
+
+            let raw = match state.api.new_filter(filter, auth.clone()).await {
+                Ok(raw) => raw,
+                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+            };
+            let upstream_filter_id: FilterId = match serde_json::from_str(raw.get()) {
+                Ok(id) => id,
+                Err(err) => {
+                    return JsonRpcResponse::error(
+                        req.id.clone(),
+                        JsonRpcError::internal(err.to_string()),
+                    );
+                }
+            };
+
+            let subscription_id = session.next_subscription_id();
+            let task = spawn_logs_subscription(
+                subscription_id.clone(),
+                upstream_filter_id.clone(),
+                auth.clone(),
+                state.api.clone(),
+                notifications.clone(),
+            );
+            session.subscriptions.insert(
+                subscription_id.clone(),
+                ActiveSubscription {
+                    upstream_filter_id,
+                    task,
+                },
+            );
+            success_response(req.id.clone(), &subscription_id)
+        }
+        SubscriptionKind::NewPendingTransactions | SubscriptionKind::Syncing => {
+            JsonRpcResponse::error(req.id.clone(), JsonRpcError::method_disabled())
+        }
+    }
+}
+
+async fn handle_unsubscribe(
+    req: &JsonRpcRequest,
+    auth: &AuthContext,
+    state: &Arc<RpcState>,
+    session: &mut WsSession,
+) -> JsonRpcResponse {
+    let (subscription_id,) = match parse_ws_params::<(FilterId,)>(req, "expected [subscriptionId]")
+    {
+        Ok(params) => params,
+        Err(resp) => return resp,
+    };
+
+    let Some(active) = session.subscriptions.remove(&subscription_id) else {
+        return success_response(req.id.clone(), &false);
+    };
+
+    active.task.abort();
+    let removed = match state
+        .api
+        .uninstall_filter(active.upstream_filter_id, auth.clone())
+        .await
+    {
+        Ok(raw) => serde_json::from_str(raw.get()).unwrap_or(false),
+        Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+    };
+
+    success_response(req.id.clone(), &removed)
+}
+
+async fn dispatch_ws_request(
+    req: &JsonRpcRequest,
+    auth: &AuthContext,
+    state: &Arc<RpcState>,
+    notifications: &NotificationTx,
+    session: &mut WsSession,
+) -> JsonRpcResponse {
+    match req.method.as_str() {
+        "eth_subscribe" => handle_subscribe(req, auth, state, notifications, session).await,
+        "eth_unsubscribe" => handle_unsubscribe(req, auth, state, session).await,
+        _ => handlers::dispatch(req, auth, state.api.as_ref()).await,
+    }
+}
+
+async fn process_ws_text(
+    text: &str,
+    auth: &AuthContext,
+    state: &Arc<RpcState>,
+    notifications: &NotificationTx,
+    session: &mut WsSession,
+) -> String {
+    let trimmed = text.trim_start();
+
+    let response = if trimmed.starts_with('[') {
+        match serde_json::from_str::<Vec<JsonRpcRequest>>(trimmed) {
+            Ok(requests) if requests.is_empty() => {
+                JsonRpcResponse::error(Value::Null, JsonRpcError::parse_error("empty batch"))
+            }
+            Ok(requests) if requests.len() > MAX_BATCH_SIZE => JsonRpcResponse::error(
+                Value::Null,
+                JsonRpcError::invalid_params(format!(
+                    "batch too large ({} > {MAX_BATCH_SIZE})",
+                    requests.len()
+                )),
+            ),
+            Ok(requests) => {
+                let mut responses = Vec::with_capacity(requests.len());
+                for req in &requests {
+                    responses
+                        .push(dispatch_ws_request(req, auth, state, notifications, session).await);
+                }
+                return serde_json::to_string(&responses)
+                    .expect("JsonRpcResponse serialization is infallible");
+            }
+            Err(err) => JsonRpcResponse::error(
+                Value::Null,
+                JsonRpcError::parse_error(format!("parse error: {err}")),
+            ),
+        }
+    } else {
+        match serde_json::from_str::<JsonRpcRequest>(trimmed) {
+            Ok(request) => dispatch_ws_request(&request, auth, state, notifications, session).await,
+            Err(err) => JsonRpcResponse::error(
+                Value::Null,
+                JsonRpcError::parse_error(format!("parse error: {err}")),
+            ),
+        }
+    };
+
+    serde_json::to_string(&response).expect("JsonRpcResponse serialization is infallible")
+}
+
+async fn cleanup_ws_session(session: WsSession, auth: &AuthContext, api: Arc<dyn ZoneRpcApi>) {
+    for (_, active) in session.subscriptions {
+        active.task.abort();
+        let _ = api
+            .uninstall_filter(active.upstream_filter_id, auth.clone())
+            .await;
+    }
 }
 
 /// WebSocket upgrade handler — authenticates via header or `?token=` query param.
@@ -67,22 +504,32 @@ pub(crate) async fn handle_ws_upgrade(
 
 /// Run a single authenticated WebSocket session, dispatching JSON-RPC
 /// messages through the same pipeline as HTTP.
-async fn handle_ws_session(
-    mut socket: WebSocket,
-    auth: crate::auth::AuthContext,
-    state: Arc<RpcState>,
-) {
-    while let Some(msg) = socket.next().await {
+async fn handle_ws_session(socket: WebSocket, auth: AuthContext, state: Arc<RpcState>) {
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+    let (notifications, mut outbound) = mpsc::unbounded_channel::<String>();
+    let writer = tokio::spawn(async move {
+        while let Some(message) = outbound.recv().await {
+            if ws_sender.send(Message::Text(message.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut session = WsSession::default();
+
+    while let Some(msg) = ws_receiver.next().await {
         let text = match msg {
             Ok(Message::Text(t)) => t,
             Ok(Message::Binary(b)) => match std::str::from_utf8(&b) {
                 Ok(s) => s.into(),
                 Err(_) => {
-                    let _ = socket
-                        .send(Message::Text(
-                            r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"invalid UTF-8"},"id":null}"#.into(),
+                    let _ = notifications.send(
+                        serde_json::to_string(&JsonRpcResponse::error(
+                            Value::Null,
+                            JsonRpcError::parse_error("invalid UTF-8"),
                         ))
-                        .await;
+                        .expect("JsonRpcResponse serialization is infallible"),
+                    );
                     continue;
                 }
             },
@@ -94,16 +541,15 @@ async fn handle_ws_session(
             }
         };
 
-        let response_json = process_rpc_text(&text, &auth, state.api.as_ref())
-            .await
-            .into_json();
+        let response_json =
+            process_ws_text(&text, &auth, &state, &notifications, &mut session).await;
 
-        if socket
-            .send(Message::Text(response_json.into()))
-            .await
-            .is_err()
-        {
+        if notifications.send(response_json).is_err() {
             break;
         }
     }
+
+    cleanup_ws_session(session, &auth, state.api.clone()).await;
+    drop(notifications);
+    let _ = writer.await;
 }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -1,10 +1,18 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256, b256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use futures::{SinkExt, StreamExt};
-use serde_json::Value;
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
 use tokio_tungstenite::{connect_async, tungstenite};
 use zone_rpc::{
     PrivateRpcConfig,
@@ -18,7 +26,25 @@ use zone_rpc::{
 // Mock API
 // ---------------------------------------------------------------------------
 
-struct MockZoneRpcApi;
+#[derive(Default)]
+struct MockZoneRpcApi {
+    next_filter_id: AtomicU64,
+    filters: Mutex<HashMap<alloy_rpc_types_eth::FilterId, MockFilterKind>>,
+}
+
+enum MockFilterKind {
+    Logs { emitted: bool },
+    Blocks { emitted: bool },
+}
+
+impl MockZoneRpcApi {
+    fn next_filter_id(&self, prefix: &str) -> alloy_rpc_types_eth::FilterId {
+        alloy_rpc_types_eth::FilterId::from(format!(
+            "{prefix}-{}",
+            self.next_filter_id.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+}
 
 macro_rules! stub {
     ($method:ident $(, $arg:ident : $ty:ty)*) => {
@@ -44,7 +70,25 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(get_balance, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
     stub!(get_transaction_count, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
     stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _b: bool, _c: zone_rpc::auth::AuthContext);
-    stub!(block_by_hash, _a: alloy_primitives::B256, _b: bool, _c: zone_rpc::auth::AuthContext);
+
+    fn block_by_hash(
+        &self,
+        hash: alloy_primitives::B256,
+        _b: bool,
+        _c: zone_rpc::auth::AuthContext,
+    ) -> BoxFut<'_> {
+        Box::pin(async move {
+            zone_rpc::types::to_raw(&json!({
+                "hash": format!("{hash:#x}"),
+                "number": "0x42",
+                "parentHash": format!("{:#x}", B256::ZERO),
+                "logsBloom": format!("0x{}", "0".repeat(512)),
+                "transactions": [],
+                "uncles": [],
+            }))
+        })
+    }
+
     stub!(transaction_by_hash, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
     stub!(transaction_receipt, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
     stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
@@ -53,11 +97,89 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(send_raw_transaction_sync, _a: alloy_primitives::Bytes, _c: zone_rpc::auth::AuthContext);
     stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: zone_rpc::auth::AuthContext);
     stub!(get_logs, _a: alloy_rpc_types_eth::Filter, _c: zone_rpc::auth::AuthContext);
-    stub!(new_filter, _a: alloy_rpc_types_eth::Filter, _c: zone_rpc::auth::AuthContext);
+
+    fn new_filter(
+        &self,
+        _a: alloy_rpc_types_eth::Filter,
+        _c: zone_rpc::auth::AuthContext,
+    ) -> BoxFut<'_> {
+        Box::pin(async move {
+            let id = self.next_filter_id("logs");
+            self.filters
+                .lock()
+                .await
+                .insert(id.clone(), MockFilterKind::Logs { emitted: false });
+            zone_rpc::types::to_raw(&id)
+        })
+    }
+
     stub!(get_filter_logs, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
-    stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
-    stub!(new_block_filter, _c: zone_rpc::auth::AuthContext);
-    stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
+
+    fn get_filter_changes(
+        &self,
+        id: alloy_rpc_types_eth::FilterId,
+        _c: zone_rpc::auth::AuthContext,
+    ) -> BoxFut<'_> {
+        Box::pin(async move {
+            let mut filters = self.filters.lock().await;
+            let Some(kind) = filters.get_mut(&id) else {
+                return Err(JsonRpcError::invalid_params("filter not found"));
+            };
+
+            match kind {
+                MockFilterKind::Logs { emitted } => {
+                    if *emitted {
+                        zone_rpc::types::to_raw(&Vec::<Value>::new())
+                    } else {
+                        *emitted = true;
+                        zone_rpc::types::to_raw(&vec![json!({
+                            "address": format!("{:#x}", Address::ZERO),
+                            "topics": [format!("{:#x}", b256!("0x1111111111111111111111111111111111111111111111111111111111111111"))],
+                            "data": "0x",
+                            "blockHash": format!("{:#x}", b256!("0x2222222222222222222222222222222222222222222222222222222222222222")),
+                            "blockNumber": "0x42",
+                            "transactionHash": format!("{:#x}", b256!("0x3333333333333333333333333333333333333333333333333333333333333333")),
+                            "transactionIndex": "0x0",
+                            "logIndex": "0x0",
+                            "removed": false
+                        })])
+                    }
+                }
+                MockFilterKind::Blocks { emitted } => {
+                    if *emitted {
+                        zone_rpc::types::to_raw(&Vec::<B256>::new())
+                    } else {
+                        *emitted = true;
+                        zone_rpc::types::to_raw(&vec![b256!(
+                            "0x4444444444444444444444444444444444444444444444444444444444444444"
+                        )])
+                    }
+                }
+            }
+        })
+    }
+
+    fn new_block_filter(&self, _c: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            let id = self.next_filter_id("blocks");
+            self.filters
+                .lock()
+                .await
+                .insert(id.clone(), MockFilterKind::Blocks { emitted: false });
+            zone_rpc::types::to_raw(&id)
+        })
+    }
+
+    fn uninstall_filter(
+        &self,
+        id: alloy_rpc_types_eth::FilterId,
+        _c: zone_rpc::auth::AuthContext,
+    ) -> BoxFut<'_> {
+        Box::pin(async move {
+            let removed = self.filters.lock().await.remove(&id).is_some();
+            zone_rpc::types::to_raw(&removed)
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +205,7 @@ impl TestContext {
             zone_portal: PORTAL,
             sequencer: signer.address(),
         };
-        let addr = start_private_rpc(config, Arc::new(MockZoneRpcApi))
+        let addr = start_private_rpc(config, Arc::new(MockZoneRpcApi::default()))
             .await
             .unwrap();
         Self { addr, signer }
@@ -115,6 +237,10 @@ impl TestContext {
 /// Build a JSON-RPC request string.
 fn jsonrpc(method: &str, id: u64) -> String {
     serde_json::json!({"jsonrpc":"2.0","method":method,"params":[],"id":id}).to_string()
+}
+
+fn jsonrpc_with_params(method: &str, params: Value, id: u64) -> String {
+    serde_json::json!({"jsonrpc":"2.0","method":method,"params":params,"id":id}).to_string()
 }
 
 /// Connect to the WS endpoint using the X-Authorization-Token header.
@@ -293,12 +419,113 @@ async fn ws_unknown_method() {
 }
 
 #[tokio::test]
-async fn ws_disabled_method() {
+async fn ws_subscribe_logs_emits_notifications() {
     let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_subscribe", 1).into(),
+        jsonrpc_with_params("eth_subscribe", json!(["logs", {}]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 1);
+    let subscription_id = resp["result"]
+        .as_str()
+        .expect("subscription id")
+        .to_string();
+
+    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("timed out waiting for log notification")
+        .unwrap()
+        .unwrap();
+    let notification = parse_response(notification);
+
+    assert_eq!(notification["method"], "eth_subscription");
+    assert_eq!(notification["params"]["subscription"], subscription_id);
+    assert_eq!(notification["params"]["result"]["blockNumber"], "0x42");
+}
+
+#[tokio::test]
+async fn ws_subscribe_new_heads_emits_redacted_headers() {
+    let ctx = TestContext::start().await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 1);
+    let subscription_id = resp["result"]
+        .as_str()
+        .expect("subscription id")
+        .to_string();
+
+    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("timed out waiting for newHeads notification")
+        .unwrap()
+        .unwrap();
+    let notification = parse_response(notification);
+
+    assert_eq!(notification["method"], "eth_subscription");
+    assert_eq!(notification["params"]["subscription"], subscription_id);
+    assert_eq!(
+        notification["params"]["result"]["hash"],
+        format!(
+            "{:#x}",
+            b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
+        )
+    );
+    assert!(
+        notification["params"]["result"]
+            .get("transactions")
+            .is_none()
+    );
+    assert!(notification["params"]["result"].get("uncles").is_none());
+}
+
+#[tokio::test]
+async fn ws_unsubscribe_removes_subscription() {
+    let ctx = TestContext::start().await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["logs", {}]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let subscription_id = resp["result"].clone();
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_unsubscribe", json!([subscription_id]), 2).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = loop {
+        let message = parse_response(ws.next().await.unwrap().unwrap());
+        if message["id"] == 2 {
+            break message;
+        }
+    };
+
+    assert_eq!(resp["id"], 2);
+    assert_eq!(resp["result"], true);
+}
+
+#[tokio::test]
+async fn ws_rejects_unsupported_subscription_kind() {
+    let ctx = TestContext::start().await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions"]), 1).into(),
     ))
     .await
     .unwrap();

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -10,14 +10,14 @@ use std::{
 use alloy_primitives::{Address, B256, b256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use futures::{SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt, stream};
 use serde_json::{Value, json};
 use tokio::sync::Mutex;
 use tokio_tungstenite::{connect_async, tungstenite};
 use zone_rpc::{
     PrivateRpcConfig,
     auth::build_token_fields,
-    handlers::ZoneRpcApi,
+    handlers::{BoxWsSubscriptionFut, WsSubscription, ZoneRpcApi},
     start_private_rpc,
     types::{BoxFut, JsonRpcError},
 };
@@ -178,6 +178,61 @@ impl ZoneRpcApi for MockZoneRpcApi {
         Box::pin(async move {
             let removed = self.filters.lock().await.remove(&id).is_some();
             zone_rpc::types::to_raw(&removed)
+        })
+    }
+
+    fn ws_subscribe_new_heads(&self, _c: zone_rpc::auth::AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let id = self.next_filter_id("blocks");
+            self.filters
+                .lock()
+                .await
+                .insert(id.clone(), MockFilterKind::Blocks { emitted: false });
+            let stream = stream::iter(vec![zone_rpc::types::to_raw(&json!({
+                "hash": format!(
+                    "{:#x}",
+                    b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
+                ),
+                "number": "0x42",
+                "parentHash": format!("{:#x}", B256::ZERO),
+                "logsBloom": format!("0x{}", "0".repeat(512)),
+            }))]);
+            Ok(WsSubscription::with_upstream_filter(Box::pin(stream), id))
+        })
+    }
+
+    fn ws_subscribe_logs(
+        &self,
+        _a: alloy_rpc_types_eth::Filter,
+        _c: zone_rpc::auth::AuthContext,
+    ) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let id = self.next_filter_id("logs");
+            self.filters
+                .lock()
+                .await
+                .insert(id.clone(), MockFilterKind::Logs { emitted: false });
+            let stream = stream::iter(vec![zone_rpc::types::to_raw(&json!({
+                "address": format!("{:#x}", Address::ZERO),
+                "topics": [format!(
+                    "{:#x}",
+                    b256!("0x1111111111111111111111111111111111111111111111111111111111111111")
+                )],
+                "data": "0x",
+                "blockHash": format!(
+                    "{:#x}",
+                    b256!("0x2222222222222222222222222222222222222222222222222222222222222222")
+                ),
+                "blockNumber": "0x42",
+                "transactionHash": format!(
+                    "{:#x}",
+                    b256!("0x3333333333333333333333333333333333333333333333333333333333333333")
+                ),
+                "transactionIndex": "0x0",
+                "logIndex": "0x0",
+                "removed": false
+            }))]);
+            Ok(WsSubscription::with_upstream_filter(Box::pin(stream), id))
         })
     }
 }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -17,8 +17,9 @@ use tokio_tungstenite::{connect_async, tungstenite};
 use zone_rpc::{
     PrivateRpcConfig,
     auth::build_token_fields,
-    handlers::{BoxWsSubscriptionFut, WsSubscription, ZoneRpcApi},
+    handlers::ZoneRpcApi,
     start_private_rpc,
+    subscription::{BoxWsSubscriptionFut, WsSubscription},
     types::{BoxFut, JsonRpcError},
 };
 

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -76,6 +76,7 @@ eyre.workspace = true
 serde = { workspace = true, features = ["derive"] }
 futures.workspace = true
 parking_lot.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -13,21 +13,24 @@ use alloy_rpc_types_eth::{
     Block, BlockId, BlockNumberOrTag, BlockTransactions, Filter, FilterChanges, FilterId,
     state::{EvmOverrides, StateOverride},
 };
+use futures::StreamExt;
 use reth_rpc::EthFilter;
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer,
     helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
 };
+use serde_json::value::RawValue;
 use tempo_alloy::{
     TempoNetwork,
     rpc::{TempoHeaderResponse, TempoTransactionRequest},
 };
 use tempo_primitives::TempoTxEnvelope;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc};
 
 use zone_rpc::{
     auth::AuthContext,
+    handlers::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream},
     types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 
@@ -492,6 +495,67 @@ where
             to_raw(&result)
         })
     }
+
+    fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let pubsub = self.eth.pubsub.clone();
+            let redact_logs_bloom = !auth.is_sequencer;
+            let (tx, rx) = mpsc::unbounded_channel();
+            tokio::spawn(async move {
+                let mut stream = Box::pin(pubsub.new_headers_stream());
+                while let Some(header) = stream.next().await {
+                    if tx
+                        .send(serialize_ws_header(&header, redact_logs_bloom))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            });
+            Ok(WsSubscription::new(ws_stream_from_receiver(rx)))
+        })
+    }
+
+    fn ws_subscribe_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let pubsub = self.eth.pubsub.clone();
+
+            if auth.is_sequencer {
+                let (tx, rx) = mpsc::unbounded_channel();
+                tokio::spawn(async move {
+                    let mut stream = Box::pin(pubsub.log_stream(filter));
+                    while let Some(log) = stream.next().await {
+                        if tx.send(to_raw(&log)).is_err() {
+                            break;
+                        }
+                    }
+                });
+                return Ok(WsSubscription::new(ws_stream_from_receiver(rx)));
+            }
+
+            zone_rpc::filter::scope_filter(&mut filter);
+            let caller = auth.caller;
+            let (tx, rx) = mpsc::unbounded_channel();
+            tokio::spawn(async move {
+                let mut stream = Box::pin(pubsub.log_stream(filter));
+                while let Some(log) = stream.next().await {
+                    let allowed = log
+                        .topic0()
+                        .is_some_and(|topic| zone_rpc::filter::WHITELISTED_TOPICS.contains(topic))
+                        && zone_rpc::filter::is_caller_eligible(&log, &caller);
+                    if !allowed {
+                        continue;
+                    }
+
+                    if tx.send(to_raw(&log)).is_err() {
+                        break;
+                    }
+                }
+            });
+
+            Ok(WsSubscription::new(ws_stream_from_receiver(rx)))
+        })
+    }
 }
 
 /// Strip privacy-sensitive fields from a block for non-sequencer callers.
@@ -499,4 +563,31 @@ fn redact_block(block: &mut RpcBlock) {
     // header.inner = alloy Header, .inner = Sealed wrapper, .inner = TempoHeader (contains logs_bloom)
     block.header.inner.inner.inner.logs_bloom = Bloom::ZERO;
     block.transactions = BlockTransactions::Hashes(Vec::new());
+}
+
+/// Serialize a `newHeads` item, optionally redacting `logsBloom`.
+fn serialize_ws_header<T: serde::Serialize>(
+    header: &T,
+    redact_logs_bloom: bool,
+) -> Result<Box<RawValue>, JsonRpcError> {
+    if !redact_logs_bloom {
+        return to_raw(header);
+    }
+
+    let mut value = serde_json::to_value(header).map_err(internal)?;
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "logsBloom".to_string(),
+            serde_json::Value::String(format!("0x{}", "0".repeat(512))),
+        );
+    }
+    to_raw(&value)
+}
+
+fn ws_stream_from_receiver(
+    rx: mpsc::UnboundedReceiver<Result<Box<RawValue>, JsonRpcError>>,
+) -> WsSubscriptionStream {
+    Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+        rx.recv().await.map(|item| (item, rx))
+    }))
 }

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -30,7 +30,7 @@ use tokio::sync::{Mutex, mpsc};
 
 use zone_rpc::{
     auth::AuthContext,
-    handlers::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream},
+    subscription::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream},
     types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 


### PR DESCRIPTION
## Summary
- add WebSocket-only handling for eth_subscribe/eth_unsubscribe while leaving HTTP classification disabled
- support scoped newHeads and logs subscriptions by polling the existing private RPC filter APIs
- cover the new subscription flows with integration tests for subscribe, unsubscribe, and unsupported kinds

## Testing
- cargo test -p zone-rpc --test it ws::
- cargo test -p zone --test it private_rpc::classify_disabled_methods -- --exact

Closes #248