### PR TITLE
Add same-zone router L1 e2e coverage

### DIFF
--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -25,7 +25,9 @@ use crate::{
     abi::{
         self, EncryptedDeposit as AbiEncryptedDeposit,
         EncryptedDepositPayload as AbiEncryptedDepositPayload,
-        ZonePortal::{self, DepositMade, EncryptedDepositMade, TokenEnabled, ZonePortalEvents},
+        ZonePortal::{
+            self, BounceBack, DepositMade, EncryptedDepositMade, TokenEnabled, ZonePortalEvents,
+        },
     },
     l1_state::tip403::PolicyEvent,
 };
@@ -704,6 +706,18 @@ impl Deposit {
             memo: event.memo,
         }
     }
+
+    /// Create a bounce-back deposit from an event.
+    pub fn from_bounce_back(event: BounceBack, portal_address: Address) -> Self {
+        Self {
+            token: event.token,
+            sender: portal_address,
+            to: event.fallbackRecipient,
+            amount: event.amount,
+            fee: 0,
+            memo: B256::ZERO,
+        }
+    }
 }
 
 /// An encrypted deposit extracted from L1.
@@ -852,9 +866,10 @@ impl EnabledToken {
 
 impl L1PortalEvents {
     /// Event signature hashes that this container knows how to decode.
-    const SIGNATURE_HASHES: [B256; 3] = [
+    const SIGNATURE_HASHES: [B256; 4] = [
         DepositMade::SIGNATURE_HASH,
         EncryptedDepositMade::SIGNATURE_HASH,
+        BounceBack::SIGNATURE_HASH,
         TokenEnabled::SIGNATURE_HASH,
     ];
 
@@ -902,6 +917,20 @@ impl L1PortalEvents {
                 );
                 self.deposits
                     .push(L1Deposit::Encrypted(EncryptedDeposit::from_event(event)));
+            }
+            ZonePortalEvents::BounceBack(event) => {
+                info!(
+                    l1_block = block_number,
+                    token = %event.token,
+                    to = %event.fallbackRecipient,
+                    amount = %event.amount,
+                    "↩️ Bounce-back deposit from L1"
+                );
+                self.deposits
+                    .push(L1Deposit::Regular(Deposit::from_bounce_back(
+                        event,
+                        log.address(),
+                    )));
             }
             ZonePortalEvents::TokenEnabled(event) => {
                 info!(

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -1693,6 +1693,52 @@ mod tests {
     }
 
     #[test]
+    fn test_push_log_decodes_bounce_back_as_regular_deposit() {
+        let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+        let fallback_recipient = address!("0x00000000000000000000000000000000000000F1");
+        let token = address!("0x0000000000000000000000000000000000002000");
+        let event = BounceBack {
+            newCurrentDepositQueueHash: B256::with_last_byte(0x42),
+            fallbackRecipient: fallback_recipient,
+            token,
+            amount: 123_456,
+        };
+        let log = Log {
+            inner: alloy_primitives::Log {
+                address: portal_address,
+                data: event.encode_log_data(),
+            },
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        };
+
+        let mut events = L1PortalEvents::default();
+        events
+            .push_log(&log, 123)
+            .expect("bounce-back should decode");
+
+        assert_eq!(events.deposits.len(), 1, "should enqueue one deposit");
+        let L1Deposit::Regular(deposit) = &events.deposits[0] else {
+            panic!("bounce-back should be mapped to a regular deposit");
+        };
+        assert_eq!(deposit.token, token);
+        assert_eq!(deposit.sender, portal_address);
+        assert_eq!(deposit.to, fallback_recipient);
+        assert_eq!(deposit.amount, event.amount);
+        assert_eq!(deposit.fee, 0, "bounce-back deposits should be fee-free");
+        assert_eq!(
+            deposit.memo,
+            B256::ZERO,
+            "bounce-back deposits should clear memo"
+        );
+    }
+
+    #[test]
     fn test_deposit_queue_hash_chain() {
         let mut queue = PendingDeposits::default();
         assert_eq!(queue.enqueued_head_hash(), B256::ZERO);

--- a/crates/tempo-zone/tests/it/l1_e2e.rs
+++ b/crates/tempo-zone/tests/it/l1_e2e.rs
@@ -4,7 +4,9 @@
 //! Tempo L1 dev node and a Zone L2 node connected via WebSocket. The L1
 //! subscriber naturally receives blocks and deposits — no synthetic injection.
 
-use crate::utils::{L1TestNode, WithdrawalArgs, ZoneAccount, ZoneTestNode, spawn_sequencer};
+use crate::utils::{
+    L1TestNode, STABLECOIN_DEX_ADDRESS, WithdrawalArgs, ZoneAccount, ZoneTestNode, spawn_sequencer,
+};
 use alloy::{
     primitives::{Address, B256, U256},
     providers::Provider,
@@ -16,6 +18,83 @@ use zone::abi::{TEMPO_STATE_ADDRESS, TempoState, ZONE_TOKEN_ADDRESS};
 /// Longer timeout for real L1 tests — the L1 dev node produces blocks every
 /// 500ms and the L1Subscriber needs to connect, backfill, and subscribe.
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const ROUTER_SWAP_TICK: i16 = 0;
+const ROUTER_SWAP_AMOUNT: u128 = 100_000_000;
+const ROUTER_DEX_LIQUIDITY: u128 = 300_000_000;
+
+struct SameZoneSwapFixture {
+    l1: L1TestNode,
+    zone: ZoneTestNode,
+    portal_address: Address,
+    router: Address,
+    alpha: Address,
+    beta: Address,
+    account: ZoneAccount,
+    swap_amount: u128,
+}
+
+async fn setup_same_zone_swap_fixture() -> eyre::Result<SameZoneSwapFixture> {
+    let l1 = L1TestNode::start().await?;
+
+    let alpha = l1
+        .create_tip20("AlphaUSD", "aUSD", B256::with_last_byte(0xA1))
+        .await?;
+    let beta = l1
+        .create_tip20("BetaUSD", "bUSD", B256::with_last_byte(0xB2))
+        .await?;
+
+    let mint_amount = ROUTER_DEX_LIQUIDITY + ROUTER_SWAP_AMOUNT;
+    l1.mint_tip20(alpha, l1.dev_address(), mint_amount).await?;
+    l1.mint_tip20(beta, l1.dev_address(), mint_amount).await?;
+
+    let factory = l1.deploy_zone_factory().await?;
+    let portal_address = l1.create_zone(factory).await?;
+    let router = l1
+        .deploy_router_with_dex(factory, STABLECOIN_DEX_ADDRESS)
+        .await?;
+
+    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
+    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+
+    l1.enable_token_on_portal(portal_address, alpha).await?;
+    l1.enable_token_on_portal(portal_address, beta).await?;
+    let enable_block = l1.provider().get_block_number().await?;
+    zone.wait_for_l2_tempo_finalized(enable_block, L1_TIMEOUT)
+        .await?;
+
+    l1.create_dex_pair(alpha).await?;
+    l1.create_dex_pair(beta).await?;
+    l1.place_dex_bid_order(alpha, ROUTER_DEX_LIQUIDITY, ROUTER_SWAP_TICK)
+        .await?;
+    l1.place_dex_ask_order(beta, ROUTER_DEX_LIQUIDITY, ROUTER_SWAP_TICK)
+        .await?;
+
+    let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
+    l1.fund_user(account.address(), 10_000_000).await?;
+    l1.fund_user_token(alpha, account.address(), ROUTER_SWAP_AMOUNT)
+        .await?;
+    account.deposit(5_000_000, L1_TIMEOUT, &zone).await?;
+
+    let alpha_minted = account
+        .deposit_token(alpha, alpha, ROUTER_SWAP_AMOUNT, L1_TIMEOUT, &zone)
+        .await?;
+    assert_eq!(
+        alpha_minted,
+        U256::from(ROUTER_SWAP_AMOUNT),
+        "AlphaUSD minted balance should equal the deposited amount"
+    );
+
+    Ok(SameZoneSwapFixture {
+        l1,
+        zone,
+        portal_address,
+        router,
+        alpha,
+        beta,
+        account,
+        swap_amount: ROUTER_SWAP_AMOUNT,
+    })
+}
 
 /// Start a real L1 dev node and a zone node connected to it.
 /// Verify the zone advances as L1 blocks arrive — proving the full
@@ -282,6 +361,324 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
         final_zone_b < U256::from(cross_amount),
         "zone_b balance should decrease by at least the reverse amount (got {final_zone_b})"
     );
+
+    Ok(())
+}
+
+/// Same-zone routed withdrawal that takes the real swap branch:
+///
+///  1. Deposit AlphaUSD into the zone.
+///  2. Withdraw AlphaUSD to the router.
+///  3. Swap AlphaUSD -> BetaUSD via the real StablecoinDEX.
+///  4. Deposit BetaUSD back into the same zone.
+///  5. Verify AlphaUSD was consumed and BetaUSD was minted.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut fixture = setup_same_zone_swap_fixture().await?;
+    let expected_beta = fixture
+        .l1
+        .quote_dex_swap_exact_amount_in(fixture.alpha, fixture.beta, fixture.swap_amount)
+        .await?;
+
+    let beta_before = fixture
+        .zone
+        .balance_of(fixture.beta, fixture.account.address())
+        .await?;
+    assert_eq!(
+        beta_before,
+        U256::ZERO,
+        "recipient should start with zero BetaUSD on the zone"
+    );
+
+    let _sequencer = spawn_sequencer(
+        &fixture.l1,
+        &fixture.zone,
+        fixture.portal_address,
+        fixture.l1.dev_signer(),
+    )
+    .await;
+
+    let args = WithdrawalArgs::swap_and_deposit_via_router(
+        fixture.swap_amount,
+        fixture.router,
+        fixture.beta,
+        fixture.portal_address,
+        fixture.account.address(),
+        B256::ZERO,
+        expected_beta,
+    );
+    fixture
+        .account
+        .withdraw_token_with(fixture.alpha, args)
+        .await?;
+
+    let alpha_after_request = fixture
+        .zone
+        .balance_of(fixture.alpha, fixture.account.address())
+        .await?;
+    assert_eq!(
+        alpha_after_request,
+        U256::ZERO,
+        "AlphaUSD should be burned on withdrawal before the routed deposit lands"
+    );
+
+    let timeout = Duration::from_secs(60);
+    fixture
+        .zone
+        .wait_for_balance(
+            fixture.beta,
+            fixture.account.address(),
+            U256::from(expected_beta),
+            timeout,
+        )
+        .await?;
+
+    let beta_after = fixture
+        .zone
+        .balance_of(fixture.beta, fixture.account.address())
+        .await?;
+    assert_eq!(
+        beta_after,
+        U256::from(expected_beta),
+        "BetaUSD minted on the zone should match the routed swap quote"
+    );
+
+    let alpha_after = fixture
+        .zone
+        .balance_of(fixture.alpha, fixture.account.address())
+        .await?;
+    assert_eq!(
+        alpha_after,
+        U256::ZERO,
+        "AlphaUSD should not be bounced back on a successful routed swap"
+    );
+
+    fixture
+        .l1
+        .assert_withdrawal_processed_with_status(
+            fixture.portal_address,
+            fixture.router,
+            fixture.alpha,
+            fixture.swap_amount,
+            true,
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Same-zone routed withdrawal where the downstream plaintext deposit fails.
+///
+/// Deposits for BetaUSD are paused on the target portal so the router callback
+/// reverts and the original AlphaUSD withdrawal bounces back to the sender.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_failure()
+-> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut fixture = setup_same_zone_swap_fixture().await?;
+    let expected_beta = fixture
+        .l1
+        .quote_dex_swap_exact_amount_in(fixture.alpha, fixture.beta, fixture.swap_amount)
+        .await?;
+
+    fixture
+        .l1
+        .pause_deposits_on_portal(fixture.portal_address, fixture.beta)
+        .await?;
+
+    let _sequencer = spawn_sequencer(
+        &fixture.l1,
+        &fixture.zone,
+        fixture.portal_address,
+        fixture.l1.dev_signer(),
+    )
+    .await;
+
+    let args = WithdrawalArgs::swap_and_deposit_via_router(
+        fixture.swap_amount,
+        fixture.router,
+        fixture.beta,
+        fixture.portal_address,
+        fixture.account.address(),
+        B256::ZERO,
+        expected_beta,
+    );
+    fixture
+        .account
+        .withdraw_token_with(fixture.alpha, args)
+        .await?;
+
+    let alpha_after_request = fixture
+        .zone
+        .balance_of(fixture.alpha, fixture.account.address())
+        .await?;
+    assert_eq!(
+        alpha_after_request,
+        U256::ZERO,
+        "AlphaUSD should leave the zone before the bounce-back is processed"
+    );
+
+    let timeout = Duration::from_secs(60);
+    fixture
+        .zone
+        .wait_for_balance(
+            fixture.alpha,
+            fixture.account.address(),
+            U256::from(fixture.swap_amount),
+            timeout,
+        )
+        .await?;
+
+    let alpha_after = fixture
+        .zone
+        .balance_of(fixture.alpha, fixture.account.address())
+        .await?;
+    assert_eq!(
+        alpha_after,
+        U256::from(fixture.swap_amount),
+        "AlphaUSD should bounce back after the router's plaintext deposit reverts"
+    );
+
+    let beta_after = fixture
+        .zone
+        .balance_of(fixture.beta, fixture.account.address())
+        .await?;
+    assert_eq!(
+        beta_after,
+        U256::ZERO,
+        "BetaUSD should not be minted when the routed plaintext deposit fails"
+    );
+
+    fixture
+        .l1
+        .assert_withdrawal_processed_with_status(
+            fixture.portal_address,
+            fixture.router,
+            fixture.alpha,
+            fixture.swap_amount,
+            false,
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Same-zone routed withdrawal where the downstream encrypted deposit fails.
+///
+/// This pins the callback behavior for `depositEncrypted`: even with a valid
+/// encrypted payload and key index, a target-portal deposit failure must revert
+/// the callback and bounce the original token back to the sender.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_failure()
+-> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    use sha2::{Digest, Sha256};
+
+    let mut fixture = setup_same_zone_swap_fixture().await?;
+    let expected_beta = fixture
+        .l1
+        .quote_dex_swap_exact_amount_in(fixture.alpha, fixture.beta, fixture.swap_amount)
+        .await?;
+
+    let enc_key_bytes: [u8; 32] =
+        Sha256::digest(b"swap-and-deposit-router-encrypted-bounceback").into();
+    let encryption_key = k256::SecretKey::from_slice(&enc_key_bytes).expect("valid key");
+
+    fixture
+        .l1
+        .set_sequencer_encryption_key(fixture.portal_address, &encryption_key)
+        .await?;
+    fixture
+        .l1
+        .pause_deposits_on_portal(fixture.portal_address, fixture.beta)
+        .await?;
+
+    let (key_index, encrypted) = fixture
+        .l1
+        .encrypt_deposit_for_portal(
+            fixture.portal_address,
+            fixture.account.address(),
+            B256::ZERO,
+        )
+        .await?;
+
+    let _sequencer = spawn_sequencer(
+        &fixture.l1,
+        &fixture.zone,
+        fixture.portal_address,
+        fixture.l1.dev_signer(),
+    )
+    .await;
+
+    let args = WithdrawalArgs::swap_and_deposit_encrypted_via_router(
+        fixture.swap_amount,
+        fixture.router,
+        fixture.beta,
+        fixture.portal_address,
+        key_index,
+        encrypted,
+        expected_beta,
+    );
+    fixture
+        .account
+        .withdraw_token_with(fixture.alpha, args)
+        .await?;
+
+    let alpha_after_request = fixture
+        .zone
+        .balance_of(fixture.alpha, fixture.account.address())
+        .await?;
+    assert_eq!(
+        alpha_after_request,
+        U256::ZERO,
+        "AlphaUSD should leave the zone before the encrypted callback bounces back"
+    );
+
+    let timeout = Duration::from_secs(60);
+    fixture
+        .zone
+        .wait_for_balance(
+            fixture.alpha,
+            fixture.account.address(),
+            U256::from(fixture.swap_amount),
+            timeout,
+        )
+        .await?;
+
+    let alpha_after = fixture
+        .zone
+        .balance_of(fixture.alpha, fixture.account.address())
+        .await?;
+    assert_eq!(
+        alpha_after,
+        U256::from(fixture.swap_amount),
+        "AlphaUSD should bounce back when the routed encrypted deposit fails"
+    );
+
+    let beta_after = fixture
+        .zone
+        .balance_of(fixture.beta, fixture.account.address())
+        .await?;
+    assert_eq!(
+        beta_after,
+        U256::ZERO,
+        "BetaUSD should not be minted when the routed encrypted deposit fails"
+    );
+
+    fixture
+        .l1
+        .assert_withdrawal_processed_with_status(
+            fixture.portal_address,
+            fixture.router,
+            fixture.alpha,
+            fixture.swap_amount,
+            false,
+        )
+        .await?;
 
     Ok(())
 }

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -1,6 +1,6 @@
 use alloy::genesis::Genesis;
 use alloy_consensus::Header;
-use alloy_primitives::{Address, B256, U256, keccak256};
+use alloy_primitives::{Address, B256, U256, address, keccak256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::Filter;
 use alloy_sol_types::{SolEvent, SolValue};
@@ -44,6 +44,25 @@ pub(crate) const DEFAULT_POLL: std::time::Duration = std::time::Duration::from_m
 
 pub(crate) const TEST_MNEMONIC: &str =
     "test test test test test test test test test test test junk";
+
+pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
+    address!("0xDEc0000000000000000000000000000000000000");
+
+alloy_sol_types::sol! {
+    #[sol(rpc)]
+    contract TestStablecoinDEX {
+        function createPair(address base) external returns (bytes32 key);
+        function place(address token, uint128 amount, bool isBid, int16 tick) external returns (uint128 orderId);
+        function quoteSwapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn) external view returns (uint128 amountOut);
+    }
+
+    #[sol(rpc)]
+    contract TestZonePortalAdmin {
+        function pauseDeposits(address token) external;
+        function resumeDeposits(address token) external;
+        function areDepositsActive(address token) external view returns (bool);
+    }
+}
 
 /// Deterministic salt for the zone test token.
 pub(crate) const ZONE_TEST_TOKEN_SALT: B256 = B256::new([
@@ -638,6 +657,35 @@ impl L1TestNode {
         Ok(())
     }
 
+    /// Assert that a `WithdrawalProcessed` event exists with the expected callback result.
+    pub(crate) async fn assert_withdrawal_processed_with_status(
+        &self,
+        portal_address: Address,
+        to: Address,
+        token: Address,
+        amount: u128,
+        callback_success: bool,
+    ) -> eyre::Result<()> {
+        use zone::abi::ZonePortal;
+        let portal = ZonePortal::new(portal_address, self.provider());
+        let events = portal
+            .WithdrawalProcessed_filter()
+            .from_block(0)
+            .query()
+            .await?;
+        let found = events.iter().any(|(e, _)| {
+            e.to == to
+                && e.token == token
+                && e.amount == amount
+                && e.callbackSuccess == callback_success
+        });
+        eyre::ensure!(
+            found,
+            "expected WithdrawalProcessed event for {to} with token {token} amount {amount} and callbackSuccess={callback_success}"
+        );
+        Ok(())
+    }
+
     /// Returns an HTTP provider with the dev account wallet attached.
     pub(crate) fn dev_provider(&self) -> alloy_provider::DynProvider {
         ProviderBuilder::new()
@@ -694,6 +742,102 @@ impl L1TestNode {
         self.assert_batch_submitted(portal_address).await?;
         self.assert_withdrawal_processed(portal_address, account, amount)
             .await
+    }
+
+    /// Create a StablecoinDEX pair for a base token.
+    pub(crate) async fn create_dex_pair(&self, base_token: Address) -> eyre::Result<()> {
+        let provider = self.dev_provider();
+        let dex = TestStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, &provider);
+        let receipt = dex
+            .createPair(base_token)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(receipt.status(), "createPair failed for {base_token}");
+        Ok(())
+    }
+
+    /// Place a bid order on the StablecoinDEX using the dev account.
+    pub(crate) async fn place_dex_bid_order(
+        &self,
+        base_token: Address,
+        amount: u128,
+        tick: i16,
+    ) -> eyre::Result<()> {
+        use tempo_contracts::precompiles::ITIP20;
+
+        let provider = self.dev_provider();
+        let quote_token = ITIP20::new(base_token, &provider)
+            .quoteToken()
+            .call()
+            .await?;
+
+        ITIP20::new(quote_token, &provider)
+            .approve(STABLECOIN_DEX_ADDRESS, U256::MAX)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        let dex = TestStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, &provider);
+        let receipt = dex
+            .place(base_token, amount, true, tick)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(
+            receipt.status(),
+            "place bid order failed for {base_token} amount {amount} at tick {tick}"
+        );
+        Ok(())
+    }
+
+    /// Place an ask order on the StablecoinDEX using the dev account.
+    pub(crate) async fn place_dex_ask_order(
+        &self,
+        base_token: Address,
+        amount: u128,
+        tick: i16,
+    ) -> eyre::Result<()> {
+        use tempo_contracts::precompiles::ITIP20;
+
+        let provider = self.dev_provider();
+        ITIP20::new(base_token, &provider)
+            .approve(STABLECOIN_DEX_ADDRESS, U256::MAX)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        let dex = TestStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, &provider);
+        let receipt = dex
+            .place(base_token, amount, false, tick)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(
+            receipt.status(),
+            "place ask order failed for {base_token} amount {amount} at tick {tick}"
+        );
+        Ok(())
+    }
+
+    /// Quote a StablecoinDEX swap without executing it.
+    pub(crate) async fn quote_dex_swap_exact_amount_in(
+        &self,
+        token_in: Address,
+        token_out: Address,
+        amount_in: u128,
+    ) -> eyre::Result<u128> {
+        let provider = self.provider();
+        let dex = TestStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, &provider);
+        Ok(dex
+            .quoteSwapExactAmountIn(token_in, token_out, amount_in)
+            .call()
+            .await?)
     }
 
     /// Deploy the ZoneFactory contract on L1 from the Foundry artifact.
@@ -902,6 +1046,28 @@ impl L1TestNode {
         Ok(())
     }
 
+    /// Pause deposits for a token on the ZonePortal.
+    pub(crate) async fn pause_deposits_on_portal(
+        &self,
+        portal_address: Address,
+        token: Address,
+    ) -> eyre::Result<()> {
+        let provider = self.dev_provider();
+        let portal = TestZonePortalAdmin::new(portal_address, &provider);
+        let receipt = portal
+            .pauseDeposits(token)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(receipt.status(), "pauseDeposits failed");
+        eyre::ensure!(
+            !portal.areDepositsActive(token).call().await?,
+            "deposits should be paused for {token}"
+        );
+        Ok(())
+    }
+
     /// Set the sequencer encryption key on the ZonePortal.
     ///
     /// The sequencer must sign a proof-of-possession with the encryption key's
@@ -947,6 +1113,46 @@ impl L1TestNode {
             .await?;
         eyre::ensure!(receipt.status(), "setSequencerEncryptionKey failed");
         Ok(())
+    }
+
+    /// Build a valid encrypted deposit payload for the current portal key.
+    pub(crate) async fn encrypt_deposit_for_portal(
+        &self,
+        portal_address: Address,
+        recipient: Address,
+        memo: B256,
+    ) -> eyre::Result<(U256, zone::abi::EncryptedDepositPayload)> {
+        use zone::{abi::ZonePortal, precompiles::ecies};
+
+        let portal = ZonePortal::new(portal_address, self.provider());
+        let key_result = portal.sequencerEncryptionKey().call().await?;
+        let key_count = portal.encryptionKeyCount().call().await?;
+        eyre::ensure!(
+            key_count > U256::ZERO,
+            "no encryption key registered on portal"
+        );
+        let key_index = key_count - U256::from(1);
+
+        let enc = ecies::encrypt_deposit(
+            &key_result.x,
+            key_result.yParity,
+            recipient,
+            memo,
+            portal_address,
+            key_index,
+        )
+        .ok_or_else(|| eyre::eyre!("ECIES encryption failed"))?;
+
+        Ok((
+            key_index,
+            zone::abi::EncryptedDepositPayload {
+                ephemeralPubkeyX: enc.eph_pub_x,
+                ephemeralPubkeyYParity: enc.eph_pub_y_parity,
+                ciphertext: enc.ciphertext.into(),
+                nonce: alloy_primitives::FixedBytes(enc.nonce),
+                tag: alloy_primitives::FixedBytes(enc.tag),
+            },
+        ))
     }
 
     /// Transfer a specific TIP-20 token from the dev account to a recipient on L1.
@@ -1406,6 +1612,74 @@ impl WithdrawalArgs {
         }
     }
 
+    /// Plaintext router callback: optionally swap, then deposit into `target_portal`.
+    pub(crate) fn swap_and_deposit_via_router(
+        amount: u128,
+        router: Address,
+        token_out: Address,
+        target_portal: Address,
+        recipient: Address,
+        memo: B256,
+        min_amount_out: u128,
+    ) -> Self {
+        use alloy_sol_types::SolValue;
+
+        // SwapAndDepositRouter plaintext callback format:
+        // (bool isEncrypted, address tokenOut, address targetPortal, address recipient, bytes32 memo, uint128 minAmountOut)
+        let callback_data = (
+            false,
+            token_out,
+            target_portal,
+            recipient,
+            memo,
+            min_amount_out,
+        )
+            .abi_encode();
+
+        Self {
+            amount,
+            to: Some(router),
+            memo,
+            gas_limit: 2_000_000,
+            fallback_recipient: None, // defaults to self
+            data: alloy_primitives::Bytes::from(callback_data),
+        }
+    }
+
+    /// Encrypted router callback: optionally swap, then deposit encrypted into `target_portal`.
+    pub(crate) fn swap_and_deposit_encrypted_via_router(
+        amount: u128,
+        router: Address,
+        token_out: Address,
+        target_portal: Address,
+        key_index: U256,
+        encrypted: zone::abi::EncryptedDepositPayload,
+        min_amount_out: u128,
+    ) -> Self {
+        use alloy_sol_types::SolValue;
+
+        // SwapAndDepositRouter encrypted callback format:
+        // (bool isEncrypted, address tokenOut, address targetPortal, uint256 keyIndex, EncryptedDepositPayload encrypted, uint128 minAmountOut)
+        let callback_data = (
+            true,
+            token_out,
+            target_portal,
+            key_index,
+            encrypted,
+            min_amount_out,
+        )
+            .abi_encode();
+
+        Self {
+            amount,
+            to: Some(router),
+            memo: B256::ZERO,
+            gas_limit: 2_000_000,
+            fallback_recipient: None, // defaults to self
+            data: alloy_primitives::Bytes::from(callback_data),
+        }
+    }
+
     /// Cross-zone withdrawal via the [`SwapAndDepositRouter`].
     ///
     /// The withdrawal callback sends tokens to the router, which deposits them
@@ -1418,21 +1692,15 @@ impl WithdrawalArgs {
         token: Address,
         recipient: Address,
     ) -> Self {
-        use alloy_sol_types::SolValue;
-
-        // SwapAndDepositRouter plaintext callback format:
-        // (bool isEncrypted, address tokenOut, address targetPortal, address recipient, bytes32 memo, uint128 minAmountOut)
-        let callback_data =
-            (false, token, target_portal, recipient, B256::ZERO, 0u128).abi_encode();
-
-        Self {
+        Self::swap_and_deposit_via_router(
             amount,
-            to: Some(router),
-            memo: B256::ZERO,
-            gas_limit: 2_000_000,
-            fallback_recipient: None, // defaults to self
-            data: alloy_primitives::Bytes::from(callback_data),
-        }
+            router,
+            token,
+            target_portal,
+            recipient,
+            B256::ZERO,
+            0,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- add same-zone L1 e2e coverage for routed AlphaUSD -> BetaUSD swaps through the real StablecoinDEX
- cover plaintext and encrypted target-portal deposit failures that should bounce AlphaUSD back to the zone
- decode L1 `BounceBack` events as regular deposits so failure-path funds are reminted on L2

## Testing
- `forge build`
- `cargo test -p zone --test it swap_and_deposit_into_same_zone -- --nocapture --test-threads=1`
- `cargo test -p zone --test it l1_e2e::test_cross_zone_withdrawal -- --exact --nocapture --test-threads=1`

Refs #262