### PR TITLE
Implement zone-specific private RPC methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enr"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5166,11 +5172,15 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.13.0",
  "metrics",
+ "ordered-float",
  "quanta",
+ "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
@@ -5318,6 +5328,15 @@ checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "unsigned-varint",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -5773,6 +5792,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "p256"
@@ -6434,6 +6462,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -13052,6 +13090,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "alloy-transport",
+ "base64 0.22.1",
  "const-hex",
  "derive_more",
  "either",
@@ -13059,7 +13098,10 @@ dependencies = [
  "futures",
  "k256",
  "metrics",
+ "metrics-util",
+ "p256",
  "parking_lot",
+ "rand 0.8.5",
  "reqwest 0.12.28",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -13155,14 +13197,23 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-sol-types",
  "axum",
+ "base64 0.22.1",
  "eyre",
  "futures",
+ "metrics",
+ "metrics-util",
+ "p256",
  "parking_lot",
+ "rand 0.8.5",
  "reqwest 0.12.28",
+ "reth-metrics",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempo-alloy",
+ "tempo-contracts",
  "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ commonware-utils = "2026.2.0"
 
 # misc
 aes-gcm = "0.10.3"
+base64 = "0.22.1"
 clap = { version = "4.5.45", features = ["derive"] }
 const-hex = { version = "1.15.0" }
 derive_more = { version = "2.0.0" }
@@ -168,8 +169,10 @@ futures = "0.3.31"
 indicatif = "0.18"
 itertools = "0.14.0"
 metrics = "0.24.3"
+metrics-util = "0.20.1"
 k256 = { version = "0.13.4", features = ["arithmetic", "ecdh"] }
 parking_lot = "0.12.4"
+p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
 rand = "0.8.5"
 sha2 = "0.10.9"
 rayon = "1.10"
@@ -182,5 +185,3 @@ axum = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio-tungstenite = "0.28"
 tracing = "0.1.41"
-
-

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -9,6 +9,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
+use alloy_provider::ProviderBuilder;
 use clap::Parser;
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
@@ -173,8 +174,24 @@ fn main() {
                 zone_portal: args.portal_address,
                 sequencer: sequencer_addr,
             };
-            let api: Arc<dyn zone::rpc::ZoneRpcApi> =
-                Arc::new(zone::rpc::TempoZoneRpc::new(eth_handlers));
+            let zone_rpc_url = handle
+                .node
+                .rpc_server_handle()
+                .http_url()
+                .expect("HTTP RPC server must be enabled for sequencer mode");
+            let l1_provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect(&args.l1_rpc_url)
+                .await?
+                .erased();
+            let zone_provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http(zone_rpc_url.clone())
+                .erased();
+            let api: Arc<dyn zone::rpc::ZoneRpcApi> = Arc::new(zone::rpc::TempoZoneRpc::new(
+                eth_handlers,
+                private_rpc_config.clone(),
+                l1_provider,
+                zone_provider,
+            ));
             let local_addr = zone::rpc::start_private_rpc(private_rpc_config, api).await?;
             info!(target: "reth::cli", %local_addr, "Private zone RPC server started");
 
@@ -184,12 +201,6 @@ fn main() {
                 %sequencer_addr,
                 "Starting sequencer background tasks"
             );
-
-            let zone_rpc_url = handle
-                .node
-                .rpc_server_handle()
-                .http_url()
-                .expect("HTTP RPC server must be enabled for sequencer mode");
 
             let sequencer_config = zone::ZoneSequencerConfig {
                 portal_address: args.portal_address,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # tempo
 tempo-alloy = { workspace = true, features = ["tempo-compat"] }
+tempo-contracts.workspace = true
 tempo-primitives.workspace = true
 
 # alloy
@@ -24,6 +25,7 @@ alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
+alloy-sol-types.workspace = true
 
 # rpc server
 axum = { workspace = true, features = ["ws"] }
@@ -31,7 +33,9 @@ axum = { workspace = true, features = ["ws"] }
 # misc
 eyre.workspace = true
 futures.workspace = true
+metrics.workspace = true
 parking_lot.workspace = true
+reth-metrics.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -41,5 +45,10 @@ tracing.workspace = true
 url = "2"
 
 [dev-dependencies]
+base64.workspace = true
+metrics-util.workspace = true
+p256.workspace = true
+rand.workspace = true
+sha2.workspace = true
 tokio-tungstenite.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -150,7 +150,7 @@ impl AuthorizationToken {
             130 if self.signature[0] == 0x01 => Ok(SignatureType::P256),
             _ => match self.signature[0] {
                 0x02 => Ok(SignatureType::WebAuthn),
-                0x03 => Ok(SignatureType::Keychain),
+                0x03 | 0x04 => Ok(SignatureType::Keychain),
                 _ => Err(AuthError::UnsupportedSignatureType),
             },
         }
@@ -193,6 +193,14 @@ pub enum AuthError {
     InvalidSignature,
     #[error("unsupported signature type")]
     UnsupportedSignatureType,
+    #[error("keychain key not authorized")]
+    UnauthorizedKeychainKey,
+    #[error("keychain key revoked")]
+    RevokedKeychainKey,
+    #[error("keychain key expired")]
+    ExpiredKeychainKey,
+    #[error("keychain signature type mismatch")]
+    KeychainSignatureTypeMismatch,
 }
 
 /// Build the unsigned token fields and their signing digest.

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -7,11 +7,15 @@ use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
 use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
+use tempo_contracts::precompiles::account_keychain::IAccountKeychain::KeyInfo;
 use tracing::warn;
 
 use crate::{
     auth::AuthContext,
-    types::{BoxFut, JsonRpcError, JsonRpcRequest, JsonRpcResponse, MethodTier, classify_method},
+    types::{
+        BoxEyreFut, BoxFut, JsonRpcError, JsonRpcRequest, JsonRpcResponse, MethodTier,
+        classify_method,
+    },
 };
 
 /// Interface to the underlying reth EthApi for the private zone RPC.
@@ -23,6 +27,10 @@ use crate::{
 ///   `logsBloom`, clearing transaction lists) on typed responses *before*
 ///   serializing to JSON.
 pub trait ZoneRpcApi: Send + Sync + 'static {
+    /// `AccountKeychain.getKey(account, keyId)` — returns the current keychain
+    /// authorization for a recovered access key.
+    fn get_keychain_key(&self, account: Address, key_id: Address) -> BoxEyreFut<'_, KeyInfo>;
+
     /// `eth_blockNumber` — returns the latest block number.
     fn block_number(&self) -> BoxFut<'_>;
 
@@ -752,6 +760,7 @@ mod tests {
 
     use alloy_primitives::Address;
     use serde_json::json;
+    use tempo_contracts::precompiles::account_keychain::IAccountKeychain::KeyInfo;
 
     use super::*;
     use crate::types::to_raw;
@@ -777,6 +786,10 @@ mod tests {
     }
 
     impl ZoneRpcApi for MockZoneRpcApi {
+        fn get_keychain_key(&self, _account: Address, _key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
+            Box::pin(async { Err(eyre::eyre!("not implemented")) })
+        }
+
         stub!(block_number);
         stub!(chain_id);
         stub!(net_version);

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -147,6 +147,17 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `eth_uninstallFilter(id)` — removes a filter.
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `zone_getAuthorizationTokenInfo()` — returns the authenticated account
+    /// and token expiry.
+    fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `zone_getZoneInfo()` — returns zone metadata.
+    fn zone_get_zone_info(&self, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `zone_getDepositStatus(tempoBlockNumber)` — returns per-caller deposit
+    /// processing state for a Tempo L1 block.
+    fn zone_get_deposit_status(&self, tempo_block_number: u64, auth: AuthContext) -> BoxFut<'_>;
 }
 
 /// Deserialize JSON-RPC params, returning an error response on failure.
@@ -168,6 +179,38 @@ struct CallParams(
     Option<BlockId>,
     Option<StateOverride>,
 );
+
+/// `u64` JSON-RPC param that accepts either a JSON number or a hex quantity.
+#[derive(Debug)]
+enum QuantityU64 {
+    Number(u64),
+    Quantity(alloy_primitives::U64),
+}
+
+impl QuantityU64 {
+    fn into_u64(self) -> u64 {
+        match self {
+            Self::Number(value) => value,
+            Self::Quantity(value) => value.to(),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for QuantityU64 {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Number(u64),
+            Quantity(alloy_primitives::U64),
+        }
+
+        match Repr::deserialize(deserializer)? {
+            Repr::Number(value) => Ok(Self::Number(value)),
+            Repr::Quantity(value) => Ok(Self::Quantity(value)),
+        }
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for CallParams {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -290,6 +333,17 @@ pub async fn dispatch(
         "eth_getFilterChanges" => handle_get_filter_changes(id, raw, auth, api).await,
         "eth_newBlockFilter" => handle_new_block_filter(id, auth, api).await,
         "eth_uninstallFilter" => handle_uninstall_filter(id, raw, auth, api).await,
+        "zone_getAuthorizationTokenInfo" => api_result(
+            id,
+            "zone_getAuthorizationTokenInfo",
+            api.zone_get_authorization_token_info(auth.clone()).await,
+        ),
+        "zone_getZoneInfo" => api_result(
+            id,
+            "zone_getZoneInfo",
+            api.zone_get_zone_info(auth.clone()).await,
+        ),
+        "zone_getDepositStatus" => handle_zone_get_deposit_status(id, raw, auth, api).await,
         _ => {
             // Method is whitelisted but not yet implemented via direct API
             JsonRpcResponse::error(
@@ -669,4 +723,188 @@ async fn handle_uninstall_filter(
         "eth_uninstallFilter",
         api.uninstall_filter(filter_id, auth.clone()).await,
     )
+}
+
+/// Handle `zone_getDepositStatus(tempoBlockNumber)`.
+async fn handle_zone_get_deposit_status(
+    id: Value,
+    raw: &str,
+    auth: &AuthContext,
+    api: &dyn ZoneRpcApi,
+) -> JsonRpcResponse {
+    let (tempo_block_number,) =
+        match parse_params::<(QuantityU64,)>(raw, &id, "expected [tempoBlockNumber]") {
+            Ok((tempo_block_number,)) => (tempo_block_number.into_u64(),),
+            Err(resp) => return resp,
+        };
+
+    api_result(
+        id,
+        "zone_getDepositStatus",
+        api.zone_get_deposit_status(tempo_block_number, auth.clone())
+            .await,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use alloy_primitives::Address;
+    use serde_json::json;
+
+    use super::*;
+    use crate::types::to_raw;
+
+    struct MockZoneRpcApi {
+        last_tempo_block_number: AtomicU64,
+    }
+
+    impl Default for MockZoneRpcApi {
+        fn default() -> Self {
+            Self {
+                last_tempo_block_number: AtomicU64::new(0),
+            }
+        }
+    }
+
+    macro_rules! stub {
+        ($method:ident $(, $arg:ident : $ty:ty)*) => {
+            fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
+                Box::pin(async { Err(JsonRpcError::internal("not implemented")) })
+            }
+        };
+    }
+
+    impl ZoneRpcApi for MockZoneRpcApi {
+        stub!(block_number);
+        stub!(chain_id);
+        stub!(net_version);
+        stub!(gas_price);
+        stub!(max_priority_fee_per_gas);
+        stub!(fee_history, _block_count: u64, _newest_block: BlockNumberOrTag, _reward_percentiles: Option<Vec<f64>>);
+        stub!(get_balance, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
+        stub!(get_transaction_count, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
+        stub!(block_by_number, _number: BlockNumberOrTag, _full: bool, _auth: AuthContext);
+        stub!(block_by_hash, _hash: B256, _full: bool, _auth: AuthContext);
+        stub!(transaction_by_hash, _hash: B256, _auth: AuthContext);
+        stub!(transaction_receipt, _hash: B256, _auth: AuthContext);
+        stub!(call, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
+        stub!(estimate_gas, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
+        stub!(send_raw_transaction, _data: Bytes, _auth: AuthContext);
+        stub!(send_raw_transaction_sync, _data: Bytes, _auth: AuthContext);
+        stub!(fill_transaction, _request: TempoTransactionRequest, _auth: AuthContext);
+        stub!(get_logs, _filter: Filter, _auth: AuthContext);
+        stub!(new_filter, _filter: Filter, _auth: AuthContext);
+        stub!(get_filter_logs, _id: FilterId, _auth: AuthContext);
+        stub!(get_filter_changes, _id: FilterId, _auth: AuthContext);
+        stub!(new_block_filter, _auth: AuthContext);
+        stub!(uninstall_filter, _id: FilterId, _auth: AuthContext);
+
+        fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
+            Box::pin(async move {
+                to_raw(&json!({
+                    "account": auth.caller,
+                    "expiresAt": alloy_primitives::U64::from(auth.expires_at),
+                }))
+            })
+        }
+
+        fn zone_get_zone_info(&self, auth: AuthContext) -> BoxFut<'_> {
+            Box::pin(async move {
+                to_raw(&json!({
+                    "zoneId": "0x1",
+                    "zoneToken": format!("{:#x}", Address::repeat_byte(0x11)),
+                    "sequencer": format!("{:#x}", auth.caller),
+                    "chainId": "0x2a",
+                }))
+            })
+        }
+
+        fn zone_get_deposit_status(
+            &self,
+            tempo_block_number: u64,
+            _auth: AuthContext,
+        ) -> BoxFut<'_> {
+            self.last_tempo_block_number
+                .store(tempo_block_number, Ordering::Relaxed);
+            Box::pin(async move {
+                to_raw(&json!({
+                    "tempoBlockNumber": alloy_primitives::U64::from(tempo_block_number),
+                    "zoneProcessedThrough": alloy_primitives::U64::from(tempo_block_number),
+                    "processed": true,
+                    "deposits": [],
+                }))
+            })
+        }
+    }
+
+    fn auth() -> AuthContext {
+        AuthContext {
+            caller: Address::repeat_byte(0xaa),
+            is_sequencer: false,
+            expires_at: 1_700_000_000,
+        }
+    }
+
+    fn request(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1
+        }))
+        .expect("request should deserialize")
+    }
+
+    #[tokio::test]
+    async fn dispatches_zone_get_authorization_token_info() {
+        let api = MockZoneRpcApi::default();
+        let resp = dispatch(
+            &request("zone_getAuthorizationTokenInfo", json!([])),
+            &auth(),
+            &api,
+        )
+        .await;
+
+        assert!(resp.error.is_none());
+        let body: serde_json::Value =
+            serde_json::from_str(resp.result.as_ref().unwrap().get()).unwrap();
+        assert_eq!(
+            body["account"].as_str().unwrap(),
+            format!("{:#x}", Address::repeat_byte(0xaa)),
+        );
+        assert_eq!(body["expiresAt"], "0x6553f100");
+    }
+
+    #[tokio::test]
+    async fn dispatches_zone_get_zone_info() {
+        let api = MockZoneRpcApi::default();
+        let resp = dispatch(&request("zone_getZoneInfo", json!([])), &auth(), &api).await;
+
+        assert!(resp.error.is_none());
+        let body: serde_json::Value =
+            serde_json::from_str(resp.result.as_ref().unwrap().get()).unwrap();
+        assert_eq!(body["zoneId"], "0x1");
+        assert_eq!(body["chainId"], "0x2a");
+    }
+
+    #[tokio::test]
+    async fn dispatches_zone_get_deposit_status_for_hex_and_numeric_quantities() {
+        let api = MockZoneRpcApi::default();
+
+        let hex_resp = dispatch(
+            &request("zone_getDepositStatus", json!(["0x2a"])),
+            &auth(),
+            &api,
+        )
+        .await;
+        assert!(hex_resp.error.is_none());
+        assert_eq!(api.last_tempo_block_number.load(Ordering::Relaxed), 42);
+
+        let numeric_resp =
+            dispatch(&request("zone_getDepositStatus", json!([7])), &auth(), &api).await;
+        assert!(numeric_resp.error.is_none());
+        assert_eq!(api.last_tempo_block_number.load(Ordering::Relaxed), 7);
+    }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -10,6 +10,7 @@ pub mod auth;
 pub mod config;
 pub mod filter;
 pub mod handlers;
+mod metrics;
 pub mod policy;
 pub mod provider;
 pub mod proxy;

--- a/crates/rpc/src/metrics.rs
+++ b/crates/rpc/src/metrics.rs
@@ -1,0 +1,194 @@
+use reth_metrics::{
+    Metrics,
+    metrics::{Counter, Gauge, Histogram},
+};
+
+use crate::auth::AuthError;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum RpcTransport {
+    Http,
+    Ws,
+}
+
+impl RpcTransport {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Http => "http",
+            Self::Ws => "ws",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum WsDisconnectReason {
+    ClientClose,
+    StreamEnded,
+    RecvError,
+    SendError,
+}
+
+impl WsDisconnectReason {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::ClientClose => "client_close",
+            Self::StreamEnded => "stream_ended",
+            Self::RecvError => "recv_error",
+            Self::SendError => "send_error",
+        }
+    }
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "zone_private_rpc.calls")]
+pub(crate) struct PrivateRpcCallMetrics {
+    /// Count of RPC calls started.
+    pub(crate) started_total: Counter,
+    /// Count of successful RPC calls.
+    pub(crate) successful_total: Counter,
+    /// Count of failed RPC calls.
+    pub(crate) failed_total: Counter,
+    /// End-to-end RPC call latency.
+    pub(crate) time_seconds: Histogram,
+}
+
+impl PrivateRpcCallMetrics {
+    pub(crate) fn new_for(transport: RpcTransport, method: &str) -> Self {
+        Self::new_with_labels(&[
+            ("transport", transport.as_str()),
+            ("method", canonical_method_label(method)),
+        ])
+    }
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "zone_private_rpc.auth")]
+pub(crate) struct PrivateRpcAuthMetrics {
+    /// Count of authentication failures grouped by reason.
+    pub(crate) failures_total: Counter,
+}
+
+impl PrivateRpcAuthMetrics {
+    fn new_for(transport: RpcTransport, reason: &'static str) -> Self {
+        Self::new_with_labels(&[("transport", transport.as_str()), ("reason", reason)])
+    }
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "zone_private_rpc.ws")]
+pub(crate) struct PrivateRpcWsSessionMetrics {
+    /// Number of active WebSocket sessions.
+    pub(crate) sessions_active: Gauge,
+    /// Count of WebSocket sessions opened.
+    pub(crate) sessions_opened_total: Counter,
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "zone_private_rpc.ws")]
+pub(crate) struct PrivateRpcWsDisconnectMetrics {
+    /// Count of WebSocket disconnects grouped by reason.
+    pub(crate) disconnects_total: Counter,
+}
+
+impl PrivateRpcWsDisconnectMetrics {
+    pub(crate) fn new_for(reason: WsDisconnectReason) -> Self {
+        Self::new_with_labels(&[("reason", reason.as_str())])
+    }
+}
+
+#[derive(Metrics, Clone)]
+#[metrics(scope = "zone_private_rpc.provider")]
+pub(crate) struct ZoneProviderMetrics {
+    /// Count of authorization-token refresh attempts.
+    pub(crate) token_refresh_attempts_total: Counter,
+    /// Count of authorization-token refresh failures.
+    pub(crate) token_refresh_failures_total: Counter,
+}
+
+pub(crate) fn canonical_method_label(method: &str) -> &'static str {
+    match method {
+        "eth_blockNumber" => "eth_blockNumber",
+        "eth_chainId" => "eth_chainId",
+        "eth_gasPrice" => "eth_gasPrice",
+        "eth_getBalance" => "eth_getBalance",
+        "eth_getTransactionCount" => "eth_getTransactionCount",
+        "eth_call" => "eth_call",
+        "eth_estimateGas" => "eth_estimateGas",
+        "eth_feeHistory" => "eth_feeHistory",
+        "eth_maxPriorityFeePerGas" => "eth_maxPriorityFeePerGas",
+        "eth_getBlockByNumber" => "eth_getBlockByNumber",
+        "eth_getBlockByHash" => "eth_getBlockByHash",
+        "eth_syncing" => "eth_syncing",
+        "eth_coinbase" => "eth_coinbase",
+        "net_version" => "net_version",
+        "net_listening" => "net_listening",
+        "web3_clientVersion" => "web3_clientVersion",
+        "web3_sha3" => "web3_sha3",
+        "zone_getAuthorizationTokenInfo" => "zone_getAuthorizationTokenInfo",
+        "zone_getZoneInfo" => "zone_getZoneInfo",
+        "zone_getDepositStatus" => "zone_getDepositStatus",
+        "eth_getTransactionByHash" => "eth_getTransactionByHash",
+        "eth_getTransactionReceipt" => "eth_getTransactionReceipt",
+        "eth_getLogs" => "eth_getLogs",
+        "eth_getFilterLogs" => "eth_getFilterLogs",
+        "eth_getFilterChanges" => "eth_getFilterChanges",
+        "eth_newFilter" => "eth_newFilter",
+        "eth_newBlockFilter" => "eth_newBlockFilter",
+        "eth_uninstallFilter" => "eth_uninstallFilter",
+        "eth_fillTransaction" => "eth_fillTransaction",
+        "eth_sendRawTransaction" => "eth_sendRawTransaction",
+        "eth_sendRawTransactionSync" => "eth_sendRawTransactionSync",
+        "eth_getCode" => "eth_getCode",
+        "eth_getStorageAt" => "eth_getStorageAt",
+        "eth_getBlockReceipts" => "eth_getBlockReceipts",
+        "eth_sendTransaction" => "eth_sendTransaction",
+        "debug_traceTransaction" => "debug_traceTransaction",
+        "debug_traceBlockByNumber" => "debug_traceBlockByNumber",
+        "debug_traceBlockByHash" => "debug_traceBlockByHash",
+        "eth_createAccessList" => "eth_createAccessList",
+        "eth_getBlockTransactionCountByNumber" => "eth_getBlockTransactionCountByNumber",
+        "eth_getBlockTransactionCountByHash" => "eth_getBlockTransactionCountByHash",
+        "eth_getTransactionByBlockNumberAndIndex" => "eth_getTransactionByBlockNumberAndIndex",
+        "eth_getTransactionByBlockHashAndIndex" => "eth_getTransactionByBlockHashAndIndex",
+        "eth_getUncleCountByBlockNumber" => "eth_getUncleCountByBlockNumber",
+        "eth_getUncleCountByBlockHash" => "eth_getUncleCountByBlockHash",
+        "txpool_content" => "txpool_content",
+        "txpool_status" => "txpool_status",
+        "txpool_inspect" => "txpool_inspect",
+        "eth_mining" => "eth_mining",
+        "eth_hashrate" => "eth_hashrate",
+        "eth_submitWork" => "eth_submitWork",
+        "eth_submitHashrate" => "eth_submitHashrate",
+        "eth_subscribe" => "eth_subscribe",
+        "eth_unsubscribe" => "eth_unsubscribe",
+        _ if method.starts_with("admin_") => "admin_*",
+        _ => "unknown",
+    }
+}
+
+pub(crate) fn record_auth_failure(transport: RpcTransport, error: &AuthError) {
+    PrivateRpcAuthMetrics::new_for(transport, auth_reason_label(error))
+        .failures_total
+        .increment(1);
+}
+
+fn auth_reason_label(error: &AuthError) -> &'static str {
+    match error {
+        AuthError::Missing => "missing",
+        AuthError::InvalidHex => "invalid_hex",
+        AuthError::TooShort => "too_short",
+        AuthError::UnsupportedVersion(_) => "unsupported_version",
+        AuthError::ZoneIdMismatch => "zone_id_mismatch",
+        AuthError::ChainIdMismatch => "chain_id_mismatch",
+        AuthError::ZonePortalMismatch => "zone_portal_mismatch",
+        AuthError::WindowTooLarge => "window_too_large",
+        AuthError::Expired => "expired",
+        AuthError::IssuedInFuture => "issued_in_future",
+        AuthError::InvalidSignature => "invalid_signature",
+        AuthError::UnsupportedSignatureType => "unsupported_signature_type",
+        AuthError::UnauthorizedKeychainKey => "unauthorized_keychain_key",
+        AuthError::RevokedKeychainKey => "revoked_keychain_key",
+        AuthError::ExpiredKeychainKey => "expired_keychain_key",
+        AuthError::KeychainSignatureTypeMismatch => "keychain_signature_type_mismatch",
+    }
+}

--- a/crates/rpc/src/provider.rs
+++ b/crates/rpc/src/provider.rs
@@ -16,7 +16,10 @@ use alloy_signer_local::PrivateKeySigner;
 use parking_lot::Mutex;
 use tempo_alloy::TempoNetwork;
 
-use crate::auth::{X_AUTHORIZATION_TOKEN, build_token_fields};
+use crate::{
+    auth::{X_AUTHORIZATION_TOKEN, build_token_fields},
+    metrics::ZoneProviderMetrics,
+};
 
 /// How many seconds before expiry to refresh the token.
 const REFRESH_BUFFER_SECS: u64 = 30;
@@ -47,6 +50,7 @@ pub struct ZoneProviderConfig {
 pub struct ZoneProvider {
     config: ZoneProviderConfig,
     state: Arc<Mutex<CachedState>>,
+    metrics: ZoneProviderMetrics,
 }
 
 struct CachedState {
@@ -66,6 +70,7 @@ impl ZoneProvider {
                 provider,
                 expires_at,
             })),
+            metrics: ZoneProviderMetrics::default(),
         })
     }
 
@@ -78,14 +83,27 @@ impl ZoneProvider {
         if now + REFRESH_BUFFER_SECS < state.expires_at {
             return state.provider.clone();
         }
-        // Refresh
-        match build_provider_with_token(&self.config) {
+        self.refresh_provider_with(&mut state, build_provider_with_token)
+    }
+
+    fn refresh_provider_with<F>(
+        &self,
+        state: &mut CachedState,
+        builder: F,
+    ) -> DynProvider<TempoNetwork>
+    where
+        F: FnOnce(&ZoneProviderConfig) -> eyre::Result<(DynProvider<TempoNetwork>, u64)>,
+    {
+        self.metrics.token_refresh_attempts_total.increment(1);
+
+        match builder(&self.config) {
             Ok((provider, expires_at)) => {
                 state.provider = provider;
                 state.expires_at = expires_at;
                 state.provider.clone()
             }
             Err(e) => {
+                self.metrics.token_refresh_failures_total.increment(1);
                 tracing::warn!(target: "zone::rpc", err = %e, "failed to refresh zone auth token, reusing stale");
                 state.provider.clone()
             }
@@ -142,4 +160,122 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("system clock before UNIX epoch")
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metrics_util::{
+        CompositeKey, MetricKind,
+        debugging::{DebugValue, DebuggingRecorder, Snapshotter},
+    };
+    use reth_metrics::metrics::{SharedString, Unit};
+    use std::{
+        collections::HashMap,
+        sync::{Mutex as StdMutex, OnceLock},
+    };
+
+    type SnapshotMap = HashMap<CompositeKey, (Option<Unit>, Option<SharedString>, DebugValue)>;
+
+    fn snapshotter() -> &'static Snapshotter {
+        static SNAPSHOTTER: OnceLock<Snapshotter> = OnceLock::new();
+
+        SNAPSHOTTER.get_or_init(|| {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            let _ = recorder.install();
+            snapshotter
+        })
+    }
+
+    fn metric_lock() -> &'static StdMutex<()> {
+        static LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| StdMutex::new(()))
+    }
+
+    fn with_metrics_snapshot<T>(action: impl FnOnce() -> T) -> (T, SnapshotMap) {
+        let _guard = metric_lock().lock().unwrap();
+        let _ = snapshotter().snapshot();
+        let result = action();
+        let snapshot = snapshotter().snapshot().into_hashmap();
+        (result, snapshot)
+    }
+
+    fn counter(snapshot: &SnapshotMap, name: &str) -> u64 {
+        snapshot
+            .iter()
+            .find(|(key, _)| key.kind() == MetricKind::Counter && key.key().name() == name)
+            .map(|(_, (_, _, value))| match value {
+                DebugValue::Counter(value) => *value,
+                other => panic!("expected counter for {name}, got {other:?}"),
+            })
+            .unwrap_or_else(|| panic!("metric {name} not found"))
+    }
+
+    fn test_config() -> ZoneProviderConfig {
+        ZoneProviderConfig {
+            signer: PrivateKeySigner::random(),
+            zone_id: 1,
+            chain_id: 42,
+            zone_portal: Address::ZERO,
+            token_ttl: Duration::from_secs(600),
+            rpc_url: "http://127.0.0.1:8545".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn refresh_success_increments_attempt_metric() {
+        let (_, snapshot) = with_metrics_snapshot(|| {
+            let provider = ZoneProvider::new(test_config()).unwrap();
+            let mut state = provider.state.lock();
+            state.expires_at = 0;
+            let _ = provider.refresh_provider_with(&mut state, build_provider_with_token);
+        });
+
+        assert_eq!(
+            counter(
+                &snapshot,
+                "zone_private_rpc.provider.token_refresh_attempts_total",
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "zone_private_rpc.provider.token_refresh_failures_total",
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn refresh_failure_reuses_stale_provider() {
+        let ((before, after, expires_at), snapshot) = with_metrics_snapshot(|| {
+            let provider = ZoneProvider::new(test_config()).unwrap();
+            let mut state = provider.state.lock();
+            state.expires_at = 0;
+            let before = state.provider.clone();
+            let after = provider
+                .refresh_provider_with(&mut state, |_| Err(eyre::eyre!("forced refresh failure")));
+            let expires_at = state.expires_at;
+            (before, after, expires_at)
+        });
+
+        assert!(std::ptr::eq(before.root(), after.root()));
+        assert_eq!(expires_at, 0);
+        assert_eq!(
+            counter(
+                &snapshot,
+                "zone_private_rpc.provider.token_refresh_attempts_total",
+            ),
+            1
+        );
+        assert_eq!(
+            counter(
+                &snapshot,
+                "zone_private_rpc.provider.token_refresh_failures_total",
+            ),
+            1
+        );
+    }
 }

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -6,11 +6,16 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use alloy_primitives::{Address, Bytes};
+use alloy_primitives::{Address, Bytes, hex};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, Log, state::StateOverride};
+use alloy_sol_types::SolCall;
 use serde::Deserialize;
 use serde_json::value::RawValue;
 use tempo_alloy::rpc::TempoTransactionRequest;
+use tempo_contracts::precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS,
+    account_keychain::IAccountKeychain::{self, KeyInfo, getKeyCall},
+};
 use tokio::sync::Mutex;
 
 use crate::{
@@ -18,7 +23,7 @@ use crate::{
     filter,
     handlers::ZoneRpcApi,
     policy,
-    types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
+    types::{BoxEyreFut, BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 
 /// Upstream JSON-RPC response envelope.
@@ -120,6 +125,33 @@ fn json_from(value: &serde_json::Value) -> Option<Address> {
 }
 
 impl ZoneRpcApi for ProxyZoneRpc {
+    fn get_keychain_key(&self, account: Address, key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
+        Box::pin(async move {
+            let call_data = getKeyCall {
+                account,
+                keyId: key_id,
+            }
+            .abi_encode();
+
+            let result = self
+                .forward(
+                    "eth_call",
+                    serde_json::json!([
+                        {
+                            "to": format!("{ACCOUNT_KEYCHAIN_ADDRESS:#x}"),
+                            "input": format!("0x{}", hex::encode(call_data)),
+                        },
+                        "latest"
+                    ]),
+                )
+                .await
+                .map_err(|err| eyre::eyre!(err.to_string()))?;
+            let output: Bytes = serde_json::from_str(result.get())?;
+
+            IAccountKeychain::getKeyCall::abi_decode_returns(output.as_ref()).map_err(Into::into)
+        })
+    }
+
     fn block_number(&self) -> BoxFut<'_> {
         Box::pin(async move { self.forward("eth_blockNumber", serde_json::json!([])).await })
     }

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -471,4 +471,29 @@ impl ZoneRpcApi for ProxyZoneRpc {
             Ok(result)
         })
     }
+
+    fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            to_raw(&serde_json::json!({
+                "account": auth.caller,
+                "expiresAt": alloy_primitives::U64::from(auth.expires_at),
+            }))
+        })
+    }
+
+    fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            Err(JsonRpcError::internal(
+                "zone-specific methods are not supported by the proxy backend",
+            ))
+        })
+    }
+
+    fn zone_get_deposit_status(&self, _tempo_block_number: u64, _auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            Err(JsonRpcError::internal(
+                "zone-specific methods are not supported by the proxy backend",
+            ))
+        })
+    }
 }

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -13,13 +13,22 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
-use std::sync::Arc;
-use tracing::{info, warn};
+use std::{
+    sync::{Arc, atomic::AtomicU64},
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
+use tempo_contracts::precompiles::account_keychain::IAccountKeychain::SignatureType as KeyInfoSignatureType;
+use tempo_primitives::transaction::{
+    SignatureType as TempoSignatureType,
+    tt_signature::{KeychainSignature, TempoSignature},
+};
+use tracing::{error, info, warn};
 
 use crate::{
-    auth::{self, AuthContext, AuthError, SignatureType},
+    auth::{self, AuthContext, AuthError},
     config::PrivateRpcConfig,
     handlers::{self, ZoneRpcApi},
+    metrics::{PrivateRpcCallMetrics, RpcTransport, record_auth_failure},
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse},
     ws::handle_ws_upgrade,
 };
@@ -34,6 +43,8 @@ pub struct RpcState {
     pub config: PrivateRpcConfig,
     /// Type-erased EthApi for handling RPC methods.
     pub api: Arc<dyn ZoneRpcApi>,
+    /// Number of currently active WebSocket sessions.
+    pub ws_sessions_active: Arc<AtomicU64>,
 }
 
 /// Start the private zone RPC server.
@@ -45,7 +56,11 @@ pub async fn start_private_rpc(
     api: Arc<dyn ZoneRpcApi>,
 ) -> eyre::Result<std::net::SocketAddr> {
     let listen_addr = config.listen_addr;
-    let state = Arc::new(RpcState { config, api });
+    let state = Arc::new(RpcState {
+        config,
+        api,
+        ws_sessions_active: Arc::new(AtomicU64::new(0)),
+    });
 
     let app = Router::new()
         .route("/", post(handle_rpc))
@@ -98,6 +113,7 @@ pub(crate) async fn process_rpc_text(
     text: &str,
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
+    transport: RpcTransport,
 ) -> RpcResult {
     let trimmed = text.trim_start();
 
@@ -119,7 +135,7 @@ pub(crate) async fn process_rpc_text(
             Ok(requests) => {
                 let mut responses = Vec::with_capacity(requests.len());
                 for req in &requests {
-                    responses.push(handlers::dispatch(req, auth, api).await);
+                    responses.push(dispatch_metered(req, auth, api, transport).await);
                 }
                 RpcResult::Batch(responses)
             }
@@ -130,7 +146,9 @@ pub(crate) async fn process_rpc_text(
         }
     } else {
         match serde_json::from_str::<JsonRpcRequest>(trimmed) {
-            Ok(request) => RpcResult::Single(handlers::dispatch(&request, auth, api).await),
+            Ok(request) => {
+                RpcResult::Single(dispatch_metered(&request, auth, api, transport).await)
+            }
             Err(e) => RpcResult::Single(JsonRpcResponse::error(
                 serde_json::Value::Null,
                 JsonRpcError::parse_error(format!("parse error: {e}")),
@@ -139,11 +157,62 @@ pub(crate) async fn process_rpc_text(
     }
 }
 
+async fn dispatch_metered(
+    req: &JsonRpcRequest,
+    auth: &AuthContext,
+    api: &dyn ZoneRpcApi,
+    transport: RpcTransport,
+) -> JsonRpcResponse {
+    let metrics = PrivateRpcCallMetrics::new_for(transport, &req.method);
+    let started_at = Instant::now();
+
+    metrics.started_total.increment(1);
+    let response = handlers::dispatch(req, auth, api).await;
+    metrics
+        .time_seconds
+        .record(started_at.elapsed().as_secs_f64());
+
+    if response.error.is_some() {
+        metrics.failed_total.increment(1);
+    } else {
+        metrics.successful_total.increment(1);
+    }
+
+    response
+}
+
 /// Map an [`AuthError`] to the appropriate HTTP status code.
-pub(crate) fn auth_error_status(err: &AuthError) -> StatusCode {
+pub(crate) fn auth_error_status(err: &AuthenticateError) -> StatusCode {
     match err {
-        AuthError::Missing => StatusCode::UNAUTHORIZED,
-        _ => StatusCode::FORBIDDEN,
+        AuthenticateError::Invalid(AuthError::Missing) => StatusCode::UNAUTHORIZED,
+        AuthenticateError::Invalid(_) => StatusCode::FORBIDDEN,
+        AuthenticateError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// Authentication failures split into invalid caller credentials vs server-side failures.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AuthenticateError {
+    #[error(transparent)]
+    Invalid(#[from] AuthError),
+    #[error(transparent)]
+    Internal(#[from] eyre::Report),
+}
+
+pub(crate) fn log_auth_error(err: &AuthenticateError, transport: &str) {
+    match err {
+        AuthenticateError::Invalid(cause) => {
+            warn!(target: "zone::rpc", %transport, err = %cause, "auth failed");
+        }
+        AuthenticateError::Internal(cause) => {
+            error!(target: "zone::rpc", %transport, err = %cause, "auth failed");
+        }
+    }
+}
+
+pub(crate) fn record_authenticate_error(err: &AuthenticateError, transport: RpcTransport) {
+    if let AuthenticateError::Invalid(cause) = err {
+        record_auth_failure(transport, cause);
     }
 }
 
@@ -153,10 +222,11 @@ async fn handle_rpc(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
-    let auth = match authenticate(&headers, &state.config) {
+    let auth = match authenticate(&headers, &state.config, state.api.as_ref()).await {
         Ok(auth) => auth,
         Err(e) => {
-            warn!(target: "zone::rpc", err = %e, "auth failed");
+            record_authenticate_error(&e, RpcTransport::Http);
+            log_auth_error(&e, "http");
             return (auth_error_status(&e), "").into_response();
         }
     };
@@ -168,38 +238,45 @@ async fn handle_rpc(
         }
     };
 
-    process_rpc_text(body_str, &auth, state.api.as_ref())
+    process_rpc_text(body_str, &auth, state.api.as_ref(), RpcTransport::Http)
         .await
         .into_response()
 }
 
 /// Authenticate the request using the `X-Authorization-Token` header.
-fn authenticate(headers: &HeaderMap, config: &PrivateRpcConfig) -> Result<AuthContext, AuthError> {
+async fn authenticate(
+    headers: &HeaderMap,
+    config: &PrivateRpcConfig,
+    api: &dyn ZoneRpcApi,
+) -> Result<AuthContext, AuthenticateError> {
     let header_value = headers
         .get(auth::X_AUTHORIZATION_TOKEN)
         .and_then(|v| v.to_str().ok())
         .ok_or(AuthError::Missing)?;
 
-    authenticate_token(header_value, config)
+    authenticate_token(header_value, config, api).await
 }
 
 /// Authenticate using a raw token string (shared by HTTP and WebSocket paths).
-pub(crate) fn authenticate_token(
+pub(crate) async fn authenticate_token(
     token_value: &str,
     config: &PrivateRpcConfig,
-) -> Result<AuthContext, AuthError> {
+    api: &dyn ZoneRpcApi,
+) -> Result<AuthContext, AuthenticateError> {
     let token = auth::parse_auth_header(token_value)?;
 
     // Validate token fields against server config
     token.validate(config.zone_id, config.chain_id, config.zone_portal)?;
 
-    // Verify the signature and recover the signer address
-    let sig_type = token.signature_type()?;
-    let caller = match sig_type {
-        SignatureType::Secp256k1 => auth::recover_secp256k1(&token.signature, &token.digest)?,
-        // P256 / WebAuthn / Keychain signature types are not yet supported
-        _ => return Err(AuthError::UnsupportedSignatureType),
-    };
+    let signature =
+        TempoSignature::from_bytes(&token.signature).map_err(|_| AuthError::InvalidSignature)?;
+    let caller = signature
+        .recover_signer(&token.digest)
+        .map_err(|_| AuthError::InvalidSignature)?;
+
+    if let TempoSignature::Keychain(keychain_signature) = &signature {
+        validate_keychain_signature(api, caller, keychain_signature, &token.digest).await?;
+    }
 
     let is_sequencer = caller == config.sequencer;
 
@@ -208,4 +285,45 @@ pub(crate) fn authenticate_token(
         is_sequencer,
         expires_at: token.expires_at,
     })
+}
+
+async fn validate_keychain_signature(
+    api: &dyn ZoneRpcApi,
+    caller: alloy_primitives::Address,
+    keychain_signature: &KeychainSignature,
+    digest: &alloy_primitives::B256,
+) -> Result<(), AuthenticateError> {
+    let key_id = keychain_signature
+        .key_id(digest)
+        .map_err(|_| AuthError::InvalidSignature)?;
+    let key_info = api.get_keychain_key(caller, key_id).await?;
+
+    if key_info.keyId.is_zero() {
+        return Err(AuthError::UnauthorizedKeychainKey.into());
+    }
+    if key_info.isRevoked {
+        return Err(AuthError::RevokedKeychainKey.into());
+    }
+    if key_info.expiry <= now_unix_seconds() {
+        return Err(AuthError::ExpiredKeychainKey.into());
+    }
+
+    let expected_signature_type = match keychain_signature.signature.signature_type() {
+        TempoSignatureType::Secp256k1 => KeyInfoSignatureType::Secp256k1,
+        TempoSignatureType::P256 => KeyInfoSignatureType::P256,
+        TempoSignatureType::WebAuthn => KeyInfoSignatureType::WebAuthn,
+    };
+
+    if key_info.signatureType != expected_signature_type {
+        return Err(AuthError::KeychainSignatureTypeMismatch.into());
+    }
+
+    Ok(())
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs()
 }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -14,6 +14,9 @@ use serde_json::{Value, value::RawValue};
 pub type BoxFut<'a> =
     Pin<Box<dyn Future<Output = Result<Box<RawValue>, JsonRpcError>> + Send + 'a>>;
 
+/// Shorthand for typed boxed futures returned by internal async helpers.
+pub type BoxEyreFut<'a, T> = Pin<Box<dyn Future<Output = eyre::Result<T>> + Send + 'a>>;
+
 /// A JSON-RPC 2.0 request.
 #[derive(Debug, Clone, Deserialize)]
 pub struct JsonRpcRequest {

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -189,7 +189,10 @@ pub fn classify_method(method: &str) -> Option<MethodTier> {
         | "net_version"
         | "net_listening"
         | "web3_clientVersion"
-        | "web3_sha3" => Some(MethodTier::Public),
+        | "web3_sha3"
+        | "zone_getAuthorizationTokenInfo"
+        | "zone_getZoneInfo"
+        | "zone_getDepositStatus" => Some(MethodTier::Public),
 
         // Fetch-then-check: public but redacted based on caller identity
         "eth_getTransactionByHash"

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -16,12 +16,18 @@ use axum::{
     response::IntoResponse,
 };
 use futures::stream::StreamExt;
-use std::sync::Arc;
+use std::sync::{Arc, atomic::Ordering};
 use tracing::warn;
 
 use crate::{
     auth::{self, AuthError},
-    server::{RpcState, auth_error_status, authenticate_token, process_rpc_text},
+    metrics::{
+        PrivateRpcWsDisconnectMetrics, PrivateRpcWsSessionMetrics, RpcTransport, WsDisconnectReason,
+    },
+    server::{
+        RpcState, auth_error_status, authenticate_token, log_auth_error, process_rpc_text,
+        record_authenticate_error,
+    },
 };
 
 /// Maximum WebSocket message size (1 MiB).
@@ -48,14 +54,15 @@ pub(crate) async fn handle_ws_upgrade(
         .or(query.token.as_deref());
 
     let auth = match token_str {
-        Some(token) => authenticate_token(token, &state.config),
-        None => Err(AuthError::Missing),
+        Some(token) => authenticate_token(token, &state.config, state.api.as_ref()).await,
+        None => Err(AuthError::Missing.into()),
     };
 
     let auth = match auth {
         Ok(auth) => auth,
         Err(e) => {
-            warn!(target: "zone::rpc", err = %e, "ws auth failed");
+            record_authenticate_error(&e, RpcTransport::Ws);
+            log_auth_error(&e, "ws");
             return (auth_error_status(&e), "").into_response();
         }
     };
@@ -72,29 +79,42 @@ async fn handle_ws_session(
     auth: crate::auth::AuthContext,
     state: Arc<RpcState>,
 ) {
-    while let Some(msg) = socket.next().await {
+    let ws_metrics = PrivateRpcWsSessionMetrics::default();
+    let active = state.ws_sessions_active.fetch_add(1, Ordering::Relaxed) + 1;
+    ws_metrics.sessions_active.set(active as f64);
+    ws_metrics.sessions_opened_total.increment(1);
+
+    let disconnect_reason = loop {
+        let Some(msg) = socket.next().await else {
+            break WsDisconnectReason::StreamEnded;
+        };
+
         let text = match msg {
             Ok(Message::Text(t)) => t,
             Ok(Message::Binary(b)) => match std::str::from_utf8(&b) {
                 Ok(s) => s.into(),
                 Err(_) => {
-                    let _ = socket
+                    if socket
                         .send(Message::Text(
                             r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"invalid UTF-8"},"id":null}"#.into(),
                         ))
-                        .await;
+                        .await
+                        .is_err()
+                    {
+                        break WsDisconnectReason::SendError;
+                    }
                     continue;
                 }
             },
-            Ok(Message::Close(_)) => break,
+            Ok(Message::Close(_)) => break WsDisconnectReason::ClientClose,
             Ok(_) => continue, // Ping/Pong handled by axum
             Err(e) => {
                 warn!(target: "zone::rpc", err = %e, "ws recv error");
-                break;
+                break WsDisconnectReason::RecvError;
             }
         };
 
-        let response_json = process_rpc_text(&text, &auth, state.api.as_ref())
+        let response_json = process_rpc_text(&text, &auth, state.api.as_ref(), RpcTransport::Ws)
             .await
             .into_json();
 
@@ -103,7 +123,13 @@ async fn handle_ws_session(
             .await
             .is_err()
         {
-            break;
+            break WsDisconnectReason::SendError;
         }
-    }
+    };
+
+    let active = state.ws_sessions_active.fetch_sub(1, Ordering::Relaxed) - 1;
+    ws_metrics.sessions_active.set(active as f64);
+    PrivateRpcWsDisconnectMetrics::new_for(disconnect_reason)
+        .disconnects_total
+        .increment(1);
 }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -58,6 +58,41 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
     stub!(new_block_filter, _c: zone_rpc::auth::AuthContext);
     stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
+
+    fn zone_get_authorization_token_info(&self, auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            zone_rpc::types::to_raw(&serde_json::json!({
+                "account": auth.caller,
+                "expiresAt": alloy_primitives::U64::from(auth.expires_at),
+            }))
+        })
+    }
+
+    fn zone_get_zone_info(&self, _auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            zone_rpc::types::to_raw(&serde_json::json!({
+                "zoneId": "0x1",
+                "zoneToken": format!("{:#x}", Address::repeat_byte(0x11)),
+                "sequencer": format!("{:#x}", Address::repeat_byte(0x22)),
+                "chainId": "0x2a",
+            }))
+        })
+    }
+
+    fn zone_get_deposit_status(
+        &self,
+        tempo_block_number: u64,
+        _auth: zone_rpc::auth::AuthContext,
+    ) -> BoxFut<'_> {
+        Box::pin(async move {
+            zone_rpc::types::to_raw(&serde_json::json!({
+                "tempoBlockNumber": alloy_primitives::U64::from(tempo_block_number),
+                "zoneProcessedThrough": alloy_primitives::U64::from(tempo_block_number),
+                "processed": true,
+                "deposits": [],
+            }))
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +298,30 @@ async fn ws_batch_request() {
     assert_eq!(arr[0]["result"], "0x42");
     assert_eq!(arr[1]["id"], 2);
     assert_eq!(arr[1]["result"], "0x1");
+}
+
+#[tokio::test]
+async fn ws_zone_method_roundtrip() {
+    let ctx = TestContext::start().await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"zone_getDepositStatus",
+            "params":["0x2a"],
+            "id":7
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    assert_eq!(resp["id"], 7);
+    assert_eq!(resp["result"]["tempoBlockNumber"], "0x2a");
+    assert_eq!(resp["result"]["processed"], true);
 }
 
 #[tokio::test]

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -1,24 +1,67 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, OnceLock},
+};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
+use base64::Engine as _;
 use futures::{SinkExt, StreamExt};
+use metrics_util::{
+    CompositeKey, MetricKind,
+    debugging::{DebugValue, DebuggingRecorder, Snapshotter},
+};
+use p256::{
+    EncodedPoint,
+    ecdsa::{SigningKey as P256SigningKey, signature::hazmat::PrehashSigner},
+};
+use parking_lot::Mutex;
+use rand::thread_rng;
+use reth_metrics::metrics::{Label, SharedString, Unit};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
+    KeyInfo, SignatureType as KeyInfoSignatureType,
+};
+use tempo_primitives::transaction::tt_signature::{
+    KeychainSignature, PrimitiveSignature, TempoSignature, WebAuthnSignature, normalize_p256_s,
+};
 use tokio_tungstenite::{connect_async, tungstenite};
 use zone_rpc::{
     PrivateRpcConfig,
     auth::build_token_fields,
     handlers::ZoneRpcApi,
     start_private_rpc,
-    types::{BoxFut, JsonRpcError},
+    types::{BoxEyreFut, BoxFut, JsonRpcError},
 };
 
 // ---------------------------------------------------------------------------
 // Mock API
 // ---------------------------------------------------------------------------
 
-struct MockZoneRpcApi;
+struct MockZoneRpcApi {
+    key_infos: Mutex<HashMap<(Address, Address), KeyInfo>>,
+}
+
+impl MockZoneRpcApi {
+    fn with_key(account: Address, key_id: Address, signature_type: KeyInfoSignatureType) -> Self {
+        let mut key_infos = HashMap::new();
+        key_infos.insert(
+            (account, key_id),
+            KeyInfo {
+                signatureType: signature_type,
+                keyId: key_id,
+                expiry: u64::MAX,
+                enforceLimits: false,
+                isRevoked: false,
+            },
+        );
+        Self {
+            key_infos: Mutex::new(key_infos),
+        }
+    }
+}
 
 macro_rules! stub {
     ($method:ident $(, $arg:ident : $ty:ty)*) => {
@@ -29,6 +72,22 @@ macro_rules! stub {
 }
 
 impl ZoneRpcApi for MockZoneRpcApi {
+    fn get_keychain_key(&self, account: Address, key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
+        let key_info = self
+            .key_infos
+            .lock()
+            .get(&(account, key_id))
+            .cloned()
+            .unwrap_or(KeyInfo {
+                signatureType: KeyInfoSignatureType::Secp256k1,
+                keyId: Address::ZERO,
+                expiry: 0,
+                enforceLimits: false,
+                isRevoked: false,
+            });
+        Box::pin(async move { Ok(key_info) })
+    }
+
     fn block_number(&self) -> BoxFut<'_> {
         Box::pin(async { zone_rpc::types::to_raw(&"0x42") })
     }
@@ -109,7 +168,7 @@ struct TestContext {
 }
 
 impl TestContext {
-    async fn start() -> Self {
+    async fn start(api: MockZoneRpcApi) -> Self {
         let signer = PrivateKeySigner::random();
         let config = PrivateRpcConfig {
             listen_addr: ([127, 0, 0, 1], 0).into(),
@@ -118,9 +177,7 @@ impl TestContext {
             zone_portal: PORTAL,
             sequencer: signer.address(),
         };
-        let addr = start_private_rpc(config, Arc::new(MockZoneRpcApi))
-            .await
-            .unwrap();
+        let addr = start_private_rpc(config, Arc::new(api)).await.unwrap();
         Self { addr, signer }
     }
 
@@ -145,6 +202,114 @@ impl TestContext {
     fn ws_url(&self) -> String {
         format!("ws://{}", self.addr)
     }
+
+    fn http_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+}
+
+fn default_api() -> MockZoneRpcApi {
+    MockZoneRpcApi {
+        key_infos: Mutex::new(HashMap::new()),
+    }
+}
+
+fn p256_public_key(signing_key: &P256SigningKey) -> (B256, B256) {
+    let encoded = EncodedPoint::from(signing_key.verifying_key());
+    let pub_key_x = B256::from_slice(encoded.x().expect("x coordinate present"));
+    let pub_key_y = B256::from_slice(encoded.y().expect("y coordinate present"));
+    (pub_key_x, pub_key_y)
+}
+
+fn sign_p256_token(digest: B256, signing_key: &P256SigningKey) -> eyre::Result<TempoSignature> {
+    let pre_hashed = Sha256::digest(digest);
+    let signature: p256::ecdsa::Signature = signing_key.sign_prehash(&pre_hashed)?;
+    let sig_bytes = signature.to_bytes();
+    let (pub_key_x, pub_key_y) = p256_public_key(signing_key);
+
+    Ok(TempoSignature::Primitive(PrimitiveSignature::P256(
+        tempo_primitives::transaction::tt_signature::P256SignatureWithPreHash {
+            r: B256::from_slice(&sig_bytes[0..32]),
+            s: normalize_p256_s(&sig_bytes[32..64]),
+            pub_key_x,
+            pub_key_y,
+            pre_hash: true,
+        },
+    )))
+}
+
+fn sign_webauthn_token(
+    signing_key: &P256SigningKey,
+    challenge: B256,
+) -> eyre::Result<TempoSignature> {
+    let mut authenticator_data = vec![0u8; 37];
+    authenticator_data[0..32].copy_from_slice(&[0xAA; 32]);
+    authenticator_data[32] = 0x01;
+    let challenge_b64url = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(challenge);
+    let client_data_json = format!(
+        r#"{{"type":"webauthn.get","challenge":"{challenge_b64url}","origin":"https://example.com","crossOrigin":false}}"#
+    );
+    let client_data_hash = Sha256::digest(client_data_json.as_bytes());
+    let mut final_hasher = Sha256::new();
+    final_hasher.update(&authenticator_data);
+    final_hasher.update(client_data_hash);
+    let message_hash = final_hasher.finalize();
+
+    let signature: p256::ecdsa::Signature = signing_key.sign_prehash(&message_hash)?;
+    let sig_bytes = signature.to_bytes();
+    let (pub_key_x, pub_key_y) = p256_public_key(signing_key);
+    let mut webauthn_data = authenticator_data;
+    webauthn_data.extend_from_slice(client_data_json.as_bytes());
+
+    Ok(TempoSignature::Primitive(PrimitiveSignature::WebAuthn(
+        WebAuthnSignature {
+            webauthn_data: Bytes::from(webauthn_data),
+            r: B256::from_slice(&sig_bytes[0..32]),
+            s: normalize_p256_s(&sig_bytes[32..64]),
+            pub_key_x,
+            pub_key_y,
+        },
+    )))
+}
+
+fn sign_keychain_token(
+    digest: B256,
+    access_signer: &P256SigningKey,
+    root_account: Address,
+    version: u8,
+) -> eyre::Result<(TempoSignature, Address)> {
+    let signing_hash = match version {
+        0x03 => digest,
+        0x04 => KeychainSignature::signing_hash(digest, root_account),
+        _ => eyre::bail!("unsupported keychain version"),
+    };
+    let primitive = match sign_p256_token(signing_hash, access_signer)? {
+        TempoSignature::Primitive(primitive) => primitive,
+        TempoSignature::Keychain(_) => unreachable!("primitive signature expected"),
+    };
+    let signature = if version == 0x03 {
+        TempoSignature::Keychain(KeychainSignature::new_v1(root_account, primitive))
+    } else {
+        TempoSignature::Keychain(KeychainSignature::new(root_account, primitive))
+    };
+    let key_id = signature
+        .recover_signer(&digest)
+        .expect("keychain signer recovery should succeed");
+    let access_key_id = match &signature {
+        TempoSignature::Keychain(keychain) => keychain
+            .key_id(&digest)
+            .expect("inner key recovery should succeed"),
+        TempoSignature::Primitive(_) => unreachable!("keychain signature expected"),
+    };
+    assert_eq!(key_id, root_account);
+    Ok((signature, access_key_id))
+}
+
+fn build_token_with_signature(signature: TempoSignature, fields: &[u8]) -> String {
+    let mut blob = Vec::with_capacity(signature.encoded_length() + fields.len());
+    blob.extend_from_slice(signature.to_bytes().as_ref());
+    blob.extend_from_slice(fields);
+    alloy_primitives::hex::encode(&blob)
 }
 
 /// Build a JSON-RPC request string.
@@ -157,22 +322,34 @@ async fn connect_with_header(
     ctx: &TestContext,
 ) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
     let token = ctx.build_token();
+    connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("ws connect failed")
+}
+
+async fn connect_with_token(
+    ws_url: &str,
+    addr: std::net::SocketAddr,
+    token: &str,
+) -> Result<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    tungstenite::Error,
+> {
     let req = tungstenite::http::Request::builder()
-        .uri(ctx.ws_url())
-        .header("x-authorization-token", &token)
+        .uri(ws_url)
+        .header("x-authorization-token", token)
         .header(
             "sec-websocket-key",
             tungstenite::handshake::client::generate_key(),
         )
-        .header("host", ctx.addr.to_string())
+        .header("host", addr.to_string())
         .header("upgrade", "websocket")
         .header("connection", "upgrade")
         .header("sec-websocket-version", "13")
         .body(())
         .unwrap();
 
-    let (ws, _) = connect_async(req).await.expect("ws connect failed");
-    ws
+    connect_async(req).await.map(|(ws, _)| ws)
 }
 
 /// Parse a JSON-RPC response from a WS text message.
@@ -183,13 +360,110 @@ fn parse_response(msg: tungstenite::Message) -> Value {
     }
 }
 
+type SnapshotMap = HashMap<CompositeKey, (Option<Unit>, Option<SharedString>, DebugValue)>;
+
+fn test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn snapshotter() -> &'static Snapshotter {
+    static SNAPSHOTTER: OnceLock<Snapshotter> = OnceLock::new();
+
+    SNAPSHOTTER.get_or_init(|| {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let _ = recorder.install();
+        snapshotter
+    })
+}
+
+fn snapshot_metrics() -> SnapshotMap {
+    snapshotter().snapshot().into_hashmap()
+}
+
+fn metric_value<'a>(
+    snapshot: &'a SnapshotMap,
+    kind: MetricKind,
+    name: &str,
+    labels: &[(&str, &str)],
+) -> &'a DebugValue {
+    snapshot
+        .iter()
+        .find(|(key, _)| {
+            key.kind() == kind
+                && key.key().name() == name
+                && labels_match(key.key().labels(), labels)
+        })
+        .map(|(_, (_, _, value))| value)
+        .unwrap_or_else(|| panic!("metric {name} with labels {labels:?} not found"))
+}
+
+fn labels_match<'a>(labels: impl Iterator<Item = &'a Label>, expected: &[(&str, &str)]) -> bool {
+    let mut actual: Vec<_> = labels.map(|label| (label.key(), label.value())).collect();
+    let mut expected = expected.to_vec();
+    actual.sort_unstable();
+    expected.sort_unstable();
+    actual == expected
+}
+
+fn counter(snapshot: &SnapshotMap, name: &str, labels: &[(&str, &str)]) -> u64 {
+    match metric_value(snapshot, MetricKind::Counter, name, labels) {
+        DebugValue::Counter(value) => *value,
+        other => panic!("expected counter for {name}, got {other:?}"),
+    }
+}
+
+fn gauge(snapshot: &SnapshotMap, name: &str, labels: &[(&str, &str)]) -> f64 {
+    match metric_value(snapshot, MetricKind::Gauge, name, labels) {
+        DebugValue::Gauge(value) => value.into_inner(),
+        other => panic!("expected gauge for {name}, got {other:?}"),
+    }
+}
+
+fn try_counter(snapshot: &SnapshotMap, name: &str, labels: &[(&str, &str)]) -> Option<u64> {
+    snapshot
+        .iter()
+        .find(|(key, _)| {
+            key.kind() == MetricKind::Counter
+                && key.key().name() == name
+                && labels_match(key.key().labels(), labels)
+        })
+        .map(|(_, (_, _, value))| match value {
+            DebugValue::Counter(value) => *value,
+            other => panic!("expected counter for {name}, got {other:?}"),
+        })
+}
+
+fn try_gauge(snapshot: &SnapshotMap, name: &str, labels: &[(&str, &str)]) -> Option<f64> {
+    snapshot
+        .iter()
+        .find(|(key, _)| {
+            key.kind() == MetricKind::Gauge
+                && key.key().name() == name
+                && labels_match(key.key().labels(), labels)
+        })
+        .map(|(_, (_, _, value))| match value {
+            DebugValue::Gauge(value) => value.into_inner(),
+            other => panic!("expected gauge for {name}, got {other:?}"),
+        })
+}
+
+fn histogram_len(snapshot: &SnapshotMap, name: &str, labels: &[(&str, &str)]) -> usize {
+    match metric_value(snapshot, MetricKind::Histogram, name, labels) {
+        DebugValue::Histogram(values) => values.len(),
+        other => panic!("expected histogram for {name}, got {other:?}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn ws_roundtrip_with_header_auth() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -205,7 +479,8 @@ async fn ws_roundtrip_with_header_auth() {
 
 #[tokio::test]
 async fn ws_roundtrip_with_query_auth() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let token = ctx.build_token();
     let url = format!("{}/?token={token}", ctx.ws_url());
 
@@ -224,7 +499,8 @@ async fn ws_roundtrip_with_query_auth() {
 
 #[tokio::test]
 async fn ws_reject_no_auth() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let result = connect_async(ctx.ws_url()).await;
     // Server should reject the upgrade — tungstenite surfaces this as an error
     // with the HTTP 401 status.
@@ -237,7 +513,8 @@ async fn ws_reject_no_auth() {
 
 #[tokio::test]
 async fn ws_reject_invalid_token() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let req = tungstenite::http::Request::builder()
         .uri(ctx.ws_url())
         .header("x-authorization-token", "deadbeef")
@@ -263,7 +540,8 @@ async fn ws_reject_invalid_token() {
 
 #[tokio::test]
 async fn ws_multiple_requests() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     for i in 1..=5 {
@@ -280,7 +558,8 @@ async fn ws_multiple_requests() {
 
 #[tokio::test]
 async fn ws_batch_request() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     let batch = serde_json::json!([
@@ -302,7 +581,8 @@ async fn ws_batch_request() {
 
 #[tokio::test]
 async fn ws_zone_method_roundtrip() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -326,7 +606,8 @@ async fn ws_zone_method_roundtrip() {
 
 #[tokio::test]
 async fn ws_invalid_json() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text("{broken".into()))
@@ -339,7 +620,8 @@ async fn ws_invalid_json() {
 
 #[tokio::test]
 async fn ws_unknown_method() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(jsonrpc("eth_foobar", 1).into()))
@@ -353,7 +635,8 @@ async fn ws_unknown_method() {
 
 #[tokio::test]
 async fn ws_disabled_method() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -369,7 +652,8 @@ async fn ws_disabled_method() {
 
 #[tokio::test]
 async fn ws_empty_batch() {
-    let ctx = TestContext::start().await;
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text("[]".into()))
@@ -378,4 +662,372 @@ async fn ws_empty_batch() {
     let resp = parse_response(ws.next().await.unwrap().unwrap());
 
     assert_eq!(resp["error"]["code"], -32700);
+}
+
+#[tokio::test]
+async fn ws_roundtrip_with_p256_auth() {
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
+    let signing_key = P256SigningKey::random(&mut thread_rng());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let token = build_token_with_signature(
+        sign_p256_token(digest, &signing_key).expect("p256 signing should succeed"),
+        &fields,
+    );
+    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("p256 ws connect failed");
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc("eth_blockNumber", 9).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 9);
+    assert_eq!(resp["result"], "0x42");
+}
+
+#[tokio::test]
+async fn ws_roundtrip_with_webauthn_auth() {
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
+    let signing_key = P256SigningKey::random(&mut thread_rng());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let token = build_token_with_signature(
+        sign_webauthn_token(&signing_key, digest).expect("webauthn signing should succeed"),
+        &fields,
+    );
+    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("webauthn ws connect failed");
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc("eth_chainId", 10).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 10);
+    assert_eq!(resp["result"], "0x1");
+}
+
+#[tokio::test]
+async fn ws_roundtrip_with_keychain_auth() {
+    let _guard = test_lock().lock().await;
+    let root_account = Address::repeat_byte(0x55);
+    let access_signer = P256SigningKey::random(&mut thread_rng());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let (signature, key_id) =
+        sign_keychain_token(digest, &access_signer, root_account, 0x04).unwrap();
+    let ctx = TestContext::start(MockZoneRpcApi::with_key(
+        root_account,
+        key_id,
+        KeyInfoSignatureType::P256,
+    ))
+    .await;
+    let token = build_token_with_signature(signature, &fields);
+    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("authorized keychain ws connect failed");
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc("eth_blockNumber", 11).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 11);
+    assert_eq!(resp["result"], "0x42");
+}
+
+#[tokio::test]
+async fn ws_reject_unauthorized_keychain_token() {
+    let _guard = test_lock().lock().await;
+    let root_account = Address::repeat_byte(0x44);
+    let access_signer = P256SigningKey::random(&mut thread_rng());
+    let ctx = TestContext::start(default_api()).await;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let (signature, _key_id) =
+        sign_keychain_token(digest, &access_signer, root_account, 0x04).unwrap();
+    let token = build_token_with_signature(signature, &fields);
+
+    let err = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect_err("missing keychain authorization should fail");
+    let tungstenite::Error::Http(response) = err else {
+        panic!("expected HTTP error, got {err:?}");
+    };
+    assert_eq!(response.status(), 403);
+}
+
+#[tokio::test]
+async fn http_auth_failure_records_metric() {
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
+    let _ = snapshotter().snapshot();
+
+    let response = reqwest::Client::new()
+        .post(ctx.http_url())
+        .body(jsonrpc("eth_blockNumber", 1))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let snapshot = snapshot_metrics();
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.auth.failures_total",
+            &[("transport", "http"), ("reason", "missing")],
+        ),
+        1
+    );
+}
+
+#[tokio::test]
+async fn ws_auth_failure_records_metric() {
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
+    let _ = snapshotter().snapshot();
+
+    let err = connect_async(ctx.ws_url())
+        .await
+        .expect_err("should fail without auth");
+    let tungstenite::Error::Http(response) = err else {
+        panic!("expected HTTP error, got {err:?}");
+    };
+    assert_eq!(response.status(), 401);
+
+    let snapshot = snapshot_metrics();
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.auth.failures_total",
+            &[("transport", "ws"), ("reason", "missing")],
+        ),
+        1
+    );
+}
+
+#[tokio::test]
+async fn http_call_metrics_record_success_and_unknown_method() {
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
+    let token = ctx.build_token();
+    let client = reqwest::Client::new();
+    let _ = snapshotter().snapshot();
+
+    let ok = client
+        .post(ctx.http_url())
+        .header("x-authorization-token", &token)
+        .body(jsonrpc("eth_blockNumber", 1))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), reqwest::StatusCode::OK);
+
+    let err = client
+        .post(ctx.http_url())
+        .header("x-authorization-token", &token)
+        .body(jsonrpc("eth_foobar", 2))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(err.status(), reqwest::StatusCode::OK);
+
+    let snapshot = snapshot_metrics();
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.calls.started_total",
+            &[("transport", "http"), ("method", "eth_blockNumber")],
+        ),
+        1
+    );
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.calls.successful_total",
+            &[("transport", "http"), ("method", "eth_blockNumber")],
+        ),
+        1
+    );
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.calls.failed_total",
+            &[("transport", "http"), ("method", "unknown")],
+        ),
+        1
+    );
+    assert_eq!(
+        histogram_len(
+            &snapshot,
+            "zone_private_rpc.calls.time_seconds",
+            &[("transport", "http"), ("method", "eth_blockNumber")],
+        ),
+        1
+    );
+    assert_eq!(
+        histogram_len(
+            &snapshot,
+            "zone_private_rpc.calls.time_seconds",
+            &[("transport", "http"), ("method", "unknown")],
+        ),
+        1
+    );
+}
+
+#[tokio::test]
+async fn ws_call_metrics_record_batch_items_and_admin_label() {
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
+    let mut ws = connect_with_header(&ctx).await;
+    let _ = snapshotter().snapshot();
+
+    let batch = serde_json::json!([
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},
+        {"jsonrpc":"2.0","method":"admin_peers","params":[],"id":2},
+    ]);
+
+    ws.send(tungstenite::Message::Text(batch.to_string().into()))
+        .await
+        .unwrap();
+
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let arr = resp.as_array().expect("expected batch response array");
+    assert_eq!(arr.len(), 2);
+    assert_eq!(arr[0]["result"], "0x42");
+    assert_eq!(arr[1]["error"]["code"], -32603);
+
+    let snapshot = snapshot_metrics();
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.calls.started_total",
+            &[("transport", "ws"), ("method", "eth_blockNumber")],
+        ),
+        1
+    );
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.calls.successful_total",
+            &[("transport", "ws"), ("method", "eth_blockNumber")],
+        ),
+        1
+    );
+    assert_eq!(
+        counter(
+            &snapshot,
+            "zone_private_rpc.calls.failed_total",
+            &[("transport", "ws"), ("method", "admin_*")],
+        ),
+        1
+    );
+    assert_eq!(
+        histogram_len(
+            &snapshot,
+            "zone_private_rpc.calls.time_seconds",
+            &[("transport", "ws"), ("method", "admin_*")],
+        ),
+        1
+    );
+}
+
+#[tokio::test]
+async fn ws_session_metrics_track_connect_and_disconnect() {
+    let _guard = test_lock().lock().await;
+    let ctx = TestContext::start(default_api()).await;
+    let _ = snapshotter().snapshot();
+
+    let mut ws = connect_with_header(&ctx).await;
+    let mut open_snapshot = None;
+    for _ in 0..50 {
+        tokio::task::yield_now().await;
+        let snapshot = snapshot_metrics();
+        if let Some(value) = try_gauge(&snapshot, "zone_private_rpc.ws.sessions_active", &[]) {
+            if value == 1.0
+                && try_counter(&snapshot, "zone_private_rpc.ws.sessions_opened_total", &[])
+                    == Some(1)
+            {
+                open_snapshot = Some(snapshot);
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    let open_snapshot = open_snapshot.expect(
+        "sessions_active gauge and sessions_opened_total counter should be recorded on open",
+    );
+    assert_eq!(
+        gauge(&open_snapshot, "zone_private_rpc.ws.sessions_active", &[]),
+        1.0
+    );
+    assert_eq!(
+        counter(
+            &open_snapshot,
+            "zone_private_rpc.ws.sessions_opened_total",
+            &[],
+        ),
+        1
+    );
+
+    ws.close(None).await.unwrap();
+    drop(ws);
+
+    let mut close_snapshot = None;
+    for _ in 0..50 {
+        tokio::task::yield_now().await;
+        let snapshot = snapshot_metrics();
+        if let Some(value) = try_gauge(&snapshot, "zone_private_rpc.ws.sessions_active", &[]) {
+            if value == 0.0
+                && try_counter(
+                    &snapshot,
+                    "zone_private_rpc.ws.disconnects_total",
+                    &[("reason", "client_close")],
+                ) == Some(1)
+            {
+                close_snapshot = Some(snapshot);
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    let close_snapshot =
+        close_snapshot.expect("sessions_active gauge and disconnect counter should be recorded");
+    assert_eq!(
+        gauge(&close_snapshot, "zone_private_rpc.ws.sessions_active", &[]),
+        0.0
+    );
+    assert_eq!(
+        counter(
+            &close_snapshot,
+            "zone_private_rpc.ws.disconnects_total",
+            &[("reason", "client_close")],
+        ),
+        1
+    );
 }

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -93,7 +93,11 @@ alloy-contract.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-sol-types.workspace = true
+base64.workspace = true
 const-hex.workspace = true
+metrics-util.workspace = true
+p256.workspace = true
+rand.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "test-utils"] }
 reth-node-builder.workspace = true
 reth-node-core.workspace = true

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -8,11 +8,13 @@ pub use zone_rpc::*;
 use std::{collections::HashMap, sync::Arc};
 
 use alloy_network::{ReceiptResponse, TransactionResponse};
-use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
+use alloy_primitives::{Address, B256, Bloom, Bytes, U64, U256};
+use alloy_provider::{DynProvider, Provider};
 use alloy_rpc_types_eth::{
     Block, BlockId, BlockNumberOrTag, BlockTransactions, Filter, FilterChanges, FilterId,
     state::{EvmOverrides, StateOverride},
 };
+use alloy_sol_types::{SolEvent, SolEventInterface};
 use reth_rpc::EthFilter;
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
@@ -26,12 +28,93 @@ use tempo_alloy::{
 use tempo_primitives::TempoTxEnvelope;
 use tokio::sync::Mutex;
 
+use crate::abi::{
+    TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZoneInbox, ZonePortal,
+};
 use zone_rpc::{
     auth::AuthContext,
     types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 
 type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthorizationTokenInfoResponse {
+    account: Address,
+    expires_at: U64,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ZoneInfoResponse {
+    zone_id: U64,
+    zone_token: Address,
+    sequencer: Address,
+    chain_id: U64,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DepositStatusResponse {
+    tempo_block_number: U64,
+    zone_processed_through: U64,
+    processed: bool,
+    deposits: Vec<DepositStatusEntry>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DepositStatusEntry {
+    deposit_hash: B256,
+    kind: DepositKind,
+    token: Address,
+    sender: Address,
+    recipient: Option<Address>,
+    amount: U256,
+    memo: Option<B256>,
+    status: DepositState,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DepositKind {
+    Regular,
+    Encrypted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DepositState {
+    Pending,
+    Processed,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+enum PortalDepositRecord {
+    Regular {
+        deposit_hash: B256,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        amount: u128,
+        memo: B256,
+    },
+    Encrypted {
+        deposit_hash: B256,
+        sender: Address,
+        token: Address,
+        amount: u128,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum TerminalDepositEvent {
+    RegularProcessed,
+    EncryptedProcessed { recipient: Address, memo: B256 },
+    EncryptedFailed,
+}
 
 /// [`ZoneRpcApi`] implementation backed by reth's [`EthHandlers`].
 ///
@@ -59,6 +142,11 @@ type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHe
 /// [`classify_method`]: zone_rpc::types::classify_method
 pub struct TempoZoneRpc<Api: EthApiTypes> {
     eth: EthHandlers<Api>,
+    config: zone_rpc::PrivateRpcConfig,
+    l1_provider: DynProvider<TempoNetwork>,
+    zone_provider: DynProvider<TempoNetwork>,
+    tempo_state:
+        crate::abi::TempoState::TempoStateInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     /// Maps filter IDs to the authenticated account that created them.
     /// Ensures filters can only be accessed by their creator.
     ///
@@ -70,9 +158,19 @@ pub struct TempoZoneRpc<Api: EthApiTypes> {
 
 impl<Api: EthApiTypes> TempoZoneRpc<Api> {
     /// Wrap reth's [`EthHandlers`] (api + filter + pubsub).
-    pub fn new(eth: EthHandlers<Api>) -> Self {
+    pub fn new(
+        eth: EthHandlers<Api>,
+        config: zone_rpc::PrivateRpcConfig,
+        l1_provider: DynProvider<TempoNetwork>,
+        zone_provider: DynProvider<TempoNetwork>,
+    ) -> Self {
+        let tempo_state = crate::abi::TempoState::new(TEMPO_STATE_ADDRESS, zone_provider.clone());
         Self {
             eth,
+            config,
+            l1_provider,
+            zone_provider,
+            tempo_state,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -101,6 +199,105 @@ impl<Api: EthApiTypes> TempoZoneRpc<Api> {
             Some(owner) if *owner == auth.caller => Ok(()),
             _ => Err(JsonRpcError::invalid_params("filter not found")),
         }
+    }
+
+    async fn portal_deposits_for_block(
+        &self,
+        tempo_block_number: u64,
+    ) -> Result<Vec<PortalDepositRecord>, JsonRpcError> {
+        if self.config.zone_portal.is_zero() {
+            return Err(JsonRpcError::internal("zone portal not configured"));
+        }
+
+        let filter = Filter::new()
+            .address(self.config.zone_portal)
+            .from_block(tempo_block_number)
+            .to_block(tempo_block_number)
+            .event_signature(vec![
+                ZonePortal::DepositMade::SIGNATURE_HASH,
+                ZonePortal::EncryptedDepositMade::SIGNATURE_HASH,
+            ]);
+
+        let logs = self.l1_provider.get_logs(&filter).await.map_err(internal)?;
+        let mut deposits = Vec::with_capacity(logs.len());
+
+        for log in logs {
+            match ZonePortal::ZonePortalEvents::decode_log(&log.inner)
+                .map_err(internal)?
+                .data
+            {
+                ZonePortal::ZonePortalEvents::DepositMade(event) => {
+                    deposits.push(PortalDepositRecord::Regular {
+                        deposit_hash: event.newCurrentDepositQueueHash,
+                        sender: event.sender,
+                        recipient: event.to,
+                        token: event.token,
+                        amount: event.netAmount,
+                        memo: event.memo,
+                    });
+                }
+                ZonePortal::ZonePortalEvents::EncryptedDepositMade(event) => {
+                    deposits.push(PortalDepositRecord::Encrypted {
+                        deposit_hash: event.newCurrentDepositQueueHash,
+                        sender: event.sender,
+                        token: event.token,
+                        amount: event.netAmount,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        Ok(deposits)
+    }
+
+    async fn terminal_event_for_deposit(
+        &self,
+        deposit_hash: B256,
+    ) -> Result<Option<TerminalDepositEvent>, JsonRpcError> {
+        let filter = Filter::new()
+            .address(ZONE_INBOX_ADDRESS)
+            .from_block(0)
+            .event_signature(vec![
+                ZoneInbox::DepositProcessed::SIGNATURE_HASH,
+                ZoneInbox::EncryptedDepositProcessed::SIGNATURE_HASH,
+                ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH,
+            ])
+            .topic1(deposit_hash);
+
+        let logs = self
+            .zone_provider
+            .get_logs(&filter)
+            .await
+            .map_err(internal)?;
+        let Some(log) = logs.last() else {
+            return Ok(None);
+        };
+
+        let Some(signature) = log.topics().first().copied() else {
+            return Ok(None);
+        };
+
+        if signature == ZoneInbox::DepositProcessed::SIGNATURE_HASH {
+            ZoneInbox::DepositProcessed::decode_log(&log.inner).map_err(internal)?;
+            return Ok(Some(TerminalDepositEvent::RegularProcessed));
+        }
+
+        if signature == ZoneInbox::EncryptedDepositProcessed::SIGNATURE_HASH {
+            let event =
+                ZoneInbox::EncryptedDepositProcessed::decode_log(&log.inner).map_err(internal)?;
+            return Ok(Some(TerminalDepositEvent::EncryptedProcessed {
+                recipient: event.to,
+                memo: event.memo,
+            }));
+        }
+
+        if signature == ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH {
+            ZoneInbox::EncryptedDepositFailed::decode_log(&log.inner).map_err(internal)?;
+            return Ok(Some(TerminalDepositEvent::EncryptedFailed));
+        }
+
+        Ok(None)
     }
 }
 
@@ -481,6 +678,137 @@ where
             }
 
             to_raw(&result)
+        })
+    }
+
+    fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            to_raw(&AuthorizationTokenInfoResponse {
+                account: auth.caller,
+                expires_at: U64::from(auth.expires_at),
+            })
+        })
+    }
+
+    fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            to_raw(&ZoneInfoResponse {
+                zone_id: U64::from(self.config.zone_id),
+                zone_token: ZONE_TOKEN_ADDRESS,
+                sequencer: self.config.sequencer,
+                chain_id: U64::from(self.config.chain_id),
+            })
+        })
+    }
+
+    fn zone_get_deposit_status(&self, tempo_block_number: u64, auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            let zone_processed_through = self
+                .tempo_state
+                .tempoBlockNumber()
+                .call()
+                .await
+                .map_err(internal)?;
+            let portal_deposits = self.portal_deposits_for_block(tempo_block_number).await?;
+
+            let mut deposits = Vec::new();
+            for deposit in portal_deposits {
+                match deposit {
+                    PortalDepositRecord::Regular {
+                        deposit_hash,
+                        sender,
+                        recipient,
+                        token,
+                        amount,
+                        memo,
+                    } => {
+                        if sender != auth.caller && recipient != auth.caller {
+                            continue;
+                        }
+
+                        let terminal = self.terminal_event_for_deposit(deposit_hash).await?;
+                        let status = if terminal.is_some() {
+                            DepositState::Processed
+                        } else {
+                            DepositState::Pending
+                        };
+
+                        deposits.push(DepositStatusEntry {
+                            deposit_hash,
+                            kind: DepositKind::Regular,
+                            token,
+                            sender,
+                            recipient: Some(recipient),
+                            amount: U256::from(amount),
+                            memo: Some(memo),
+                            status,
+                        });
+                    }
+                    PortalDepositRecord::Encrypted {
+                        deposit_hash,
+                        sender,
+                        token,
+                        amount,
+                    } => {
+                        let terminal = self.terminal_event_for_deposit(deposit_hash).await?;
+
+                        let include = match (&terminal, sender == auth.caller) {
+                            (_, true) => true,
+                            (
+                                Some(TerminalDepositEvent::EncryptedProcessed {
+                                    recipient, ..
+                                }),
+                                false,
+                            ) => *recipient == auth.caller,
+                            _ => false,
+                        };
+
+                        if !include {
+                            continue;
+                        }
+
+                        let (recipient, memo, status) = match terminal {
+                            Some(TerminalDepositEvent::EncryptedProcessed {
+                                recipient,
+                                memo,
+                                ..
+                            }) => (Some(recipient), Some(memo), DepositState::Processed),
+                            Some(TerminalDepositEvent::EncryptedFailed) => {
+                                (None, None, DepositState::Failed)
+                            }
+                            Some(TerminalDepositEvent::RegularProcessed) => {
+                                return Err(JsonRpcError::internal(
+                                    "regular deposit event matched encrypted deposit hash",
+                                ));
+                            }
+                            None => (None, None, DepositState::Pending),
+                        };
+
+                        deposits.push(DepositStatusEntry {
+                            deposit_hash,
+                            kind: DepositKind::Encrypted,
+                            token,
+                            sender,
+                            recipient,
+                            amount: U256::from(amount),
+                            memo,
+                            status,
+                        });
+                    }
+                }
+            }
+
+            let processed = zone_processed_through >= tempo_block_number
+                && deposits
+                    .iter()
+                    .all(|deposit| deposit.status != DepositState::Pending);
+
+            to_raw(&DepositStatusResponse {
+                tempo_block_number: U64::from(tempo_block_number),
+                zone_processed_through: U64::from(zone_processed_through),
+                processed,
+                deposits,
+            })
         })
     }
 }

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -25,6 +25,10 @@ use tempo_alloy::{
     TempoNetwork,
     rpc::{TempoHeaderResponse, TempoTransactionRequest},
 };
+use tempo_contracts::precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS,
+    account_keychain::IAccountKeychain::{IAccountKeychainInstance, KeyInfo},
+};
 use tempo_primitives::TempoTxEnvelope;
 use tokio::sync::Mutex;
 
@@ -33,7 +37,7 @@ use crate::abi::{
 };
 use zone_rpc::{
     auth::AuthContext,
-    types::{BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
+    types::{BoxEyreFut, BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 
 type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
@@ -305,6 +309,14 @@ impl<Api> zone_rpc::ZoneRpcApi for TempoZoneRpc<Api>
 where
     Api: FullEthApi + EthApiTypes<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
 {
+    fn get_keychain_key(&self, account: Address, key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
+        Box::pin(async move {
+            let keychain =
+                IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &self.zone_provider);
+            Ok(keychain.getKey(account, key_id).call().await?)
+        })
+    }
+
     fn block_number(&self) -> BoxFut<'_> {
         Box::pin(async move {
             let info = EthApiSpec::chain_info(&self.eth.api).map_err(internal)?;

--- a/crates/tempo-zone/tests/it/private_rpc.rs
+++ b/crates/tempo-zone/tests/it/private_rpc.rs
@@ -286,6 +286,9 @@ fn classify_public_methods() {
         "net_listening",
         "web3_clientVersion",
         "web3_sha3",
+        "zone_getAuthorizationTokenInfo",
+        "zone_getZoneInfo",
+        "zone_getDepositStatus",
     ] {
         assert_eq!(
             classify_method(method),

--- a/crates/tempo-zone/tests/it/private_rpc.rs
+++ b/crates/tempo-zone/tests/it/private_rpc.rs
@@ -1,6 +1,16 @@
 //! Tests for the private zone RPC module.
 
 use alloy_primitives::{Address, keccak256};
+use base64::Engine as _;
+use p256::{
+    EncodedPoint,
+    ecdsa::{SigningKey as P256SigningKey, signature::hazmat::PrehashSigner},
+};
+use rand::thread_rng;
+use sha2::{Digest, Sha256};
+use tempo_primitives::transaction::tt_signature::{
+    KeychainSignature, PrimitiveSignature, TempoSignature, WebAuthnSignature, normalize_p256_s,
+};
 use zone::rpc::{
     auth::{AuthorizationToken, SignatureType, build_token_fields},
     types::{MethodTier, classify_method},
@@ -46,6 +56,101 @@ fn make_test_token(
 ) -> AuthorizationToken {
     let blob = build_token_blob(version, zone_id, chain_id, portal, issued_at, expires_at);
     AuthorizationToken::parse(&blob).unwrap()
+}
+
+fn build_signed_token_blob(signature: TempoSignature, fields: &[u8]) -> Vec<u8> {
+    let mut blob = Vec::with_capacity(signature.encoded_length() + fields.len());
+    blob.extend_from_slice(signature.to_bytes().as_ref());
+    blob.extend_from_slice(fields);
+    blob
+}
+
+fn p256_public_key(
+    signing_key: &P256SigningKey,
+) -> (alloy_primitives::B256, alloy_primitives::B256) {
+    let encoded = EncodedPoint::from(signing_key.verifying_key());
+    (
+        alloy_primitives::B256::from_slice(encoded.x().expect("x coordinate present")),
+        alloy_primitives::B256::from_slice(encoded.y().expect("y coordinate present")),
+    )
+}
+
+fn sign_p256_signature(
+    digest: alloy_primitives::B256,
+    signing_key: &P256SigningKey,
+) -> TempoSignature {
+    let pre_hashed = Sha256::digest(digest);
+    let signature: p256::ecdsa::Signature = signing_key
+        .sign_prehash(&pre_hashed)
+        .expect("p256 signing should succeed");
+    let sig_bytes = signature.to_bytes();
+    let (pub_key_x, pub_key_y) = p256_public_key(signing_key);
+
+    TempoSignature::Primitive(PrimitiveSignature::P256(
+        tempo_primitives::transaction::tt_signature::P256SignatureWithPreHash {
+            r: alloy_primitives::B256::from_slice(&sig_bytes[0..32]),
+            s: normalize_p256_s(&sig_bytes[32..64]),
+            pub_key_x,
+            pub_key_y,
+            pre_hash: true,
+        },
+    ))
+}
+
+fn sign_webauthn_signature(
+    digest: alloy_primitives::B256,
+    signing_key: &P256SigningKey,
+) -> TempoSignature {
+    let mut authenticator_data = vec![0u8; 37];
+    authenticator_data[0..32].copy_from_slice(&[0xAA; 32]);
+    authenticator_data[32] = 0x01;
+    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+    let client_data_json = format!(
+        r#"{{"type":"webauthn.get","challenge":"{challenge}","origin":"https://example.com","crossOrigin":false}}"#
+    );
+    let client_data_hash = Sha256::digest(client_data_json.as_bytes());
+    let mut final_hasher = Sha256::new();
+    final_hasher.update(&authenticator_data);
+    final_hasher.update(client_data_hash);
+    let message_hash = final_hasher.finalize();
+    let signature: p256::ecdsa::Signature = signing_key
+        .sign_prehash(&message_hash)
+        .expect("webauthn signing should succeed");
+    let sig_bytes = signature.to_bytes();
+    let (pub_key_x, pub_key_y) = p256_public_key(signing_key);
+    let mut webauthn_data = authenticator_data;
+    webauthn_data.extend_from_slice(client_data_json.as_bytes());
+
+    TempoSignature::Primitive(PrimitiveSignature::WebAuthn(WebAuthnSignature {
+        webauthn_data: alloy_primitives::Bytes::from(webauthn_data),
+        r: alloy_primitives::B256::from_slice(&sig_bytes[0..32]),
+        s: normalize_p256_s(&sig_bytes[32..64]),
+        pub_key_x,
+        pub_key_y,
+    }))
+}
+
+fn sign_keychain_signature(
+    digest: alloy_primitives::B256,
+    signing_key: &P256SigningKey,
+    root_account: Address,
+    version: u8,
+) -> TempoSignature {
+    let keychain_digest = match version {
+        0x03 => digest,
+        0x04 => KeychainSignature::signing_hash(digest, root_account),
+        _ => panic!("unsupported keychain version"),
+    };
+    let primitive = match sign_p256_signature(keychain_digest, signing_key) {
+        TempoSignature::Primitive(primitive) => primitive,
+        TempoSignature::Keychain(_) => unreachable!("primitive signature expected"),
+    };
+
+    if version == 0x03 {
+        TempoSignature::Keychain(KeychainSignature::new_v1(root_account, primitive))
+    } else {
+        TempoSignature::Keychain(KeychainSignature::new(root_account, primitive))
+    }
 }
 
 // ============ Auth Token Parsing ============
@@ -118,6 +223,25 @@ fn parse_p256_signature_type() {
     let token = AuthorizationToken::parse(&blob).unwrap();
     assert_eq!(token.signature.len(), 130);
     assert_eq!(token.signature_type().unwrap(), SignatureType::P256);
+}
+
+#[test]
+fn parse_keychain_v2_signature_type() {
+    let now = now_secs();
+
+    let mut blob = vec![0x04];
+    blob.extend_from_slice(Address::repeat_byte(0x11).as_slice());
+    blob.push(0x01);
+    blob.extend_from_slice(&[0u8; 129]);
+    blob.push(0);
+    blob.extend_from_slice(&1u64.to_be_bytes());
+    blob.extend_from_slice(&1u64.to_be_bytes());
+    blob.extend_from_slice(&[0u8; 20]);
+    blob.extend_from_slice(&now.to_be_bytes());
+    blob.extend_from_slice(&(now + 600).to_be_bytes());
+
+    let token = AuthorizationToken::parse(&blob).unwrap();
+    assert_eq!(token.signature_type().unwrap(), SignatureType::Keychain);
 }
 
 #[test]
@@ -253,6 +377,91 @@ fn secp256k1_rejects_wrong_length() {
     assert!(recover_secp256k1(&[0u8; 64], &digest).is_err());
     assert!(recover_secp256k1(&[0u8; 66], &digest).is_err());
     assert!(recover_secp256k1(&[], &digest).is_err());
+}
+
+#[test]
+fn tempo_signature_roundtrip_p256_from_token_bytes() {
+    let signing_key = P256SigningKey::random(&mut thread_rng());
+    let now = now_secs();
+    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let expected = sign_p256_signature(digest, &signing_key)
+        .recover_signer(&digest)
+        .expect("p256 recovery should succeed");
+    let blob = build_signed_token_blob(sign_p256_signature(digest, &signing_key), &fields);
+    let token = AuthorizationToken::parse(&blob).unwrap();
+    let parsed = TempoSignature::from_bytes(&token.signature).unwrap();
+
+    assert_eq!(parsed.recover_signer(&token.digest).unwrap(), expected);
+}
+
+#[test]
+fn tempo_signature_roundtrip_webauthn_from_token_bytes() {
+    let signing_key = P256SigningKey::random(&mut thread_rng());
+    let now = now_secs();
+    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let signature = sign_webauthn_signature(digest, &signing_key);
+    let expected = signature
+        .recover_signer(&digest)
+        .expect("webauthn recovery should succeed");
+    let blob = build_signed_token_blob(signature, &fields);
+    let token = AuthorizationToken::parse(&blob).unwrap();
+    let parsed = TempoSignature::from_bytes(&token.signature).unwrap();
+
+    assert_eq!(parsed.recover_signer(&token.digest).unwrap(), expected);
+}
+
+#[test]
+fn tempo_signature_roundtrip_keychain_v1_from_token_bytes() {
+    let signing_key = P256SigningKey::random(&mut thread_rng());
+    let root_account = Address::repeat_byte(0x44);
+    let now = now_secs();
+    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let signature = sign_keychain_signature(digest, &signing_key, root_account, 0x03);
+    let expected_key_id = match &signature {
+        TempoSignature::Keychain(keychain) => keychain.key_id(&digest).unwrap(),
+        TempoSignature::Primitive(_) => unreachable!("keychain signature expected"),
+    };
+    let blob = build_signed_token_blob(signature, &fields);
+    let token = AuthorizationToken::parse(&blob).unwrap();
+    let parsed = TempoSignature::from_bytes(&token.signature).unwrap();
+
+    assert_eq!(parsed.recover_signer(&token.digest).unwrap(), root_account);
+    match parsed {
+        TempoSignature::Keychain(keychain) => {
+            assert_eq!(keychain.key_id(&token.digest).unwrap(), expected_key_id);
+        }
+        TempoSignature::Primitive(_) => panic!("expected keychain signature"),
+    }
+}
+
+#[test]
+fn tempo_signature_roundtrip_keychain_v2_from_token_bytes() {
+    let signing_key = P256SigningKey::random(&mut thread_rng());
+    let root_account = Address::repeat_byte(0x55);
+    let now = now_secs();
+    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let signature = sign_keychain_signature(digest, &signing_key, root_account, 0x04);
+    let expected_key_id = match &signature {
+        TempoSignature::Keychain(keychain) => keychain.key_id(&digest).unwrap(),
+        TempoSignature::Primitive(_) => unreachable!("keychain signature expected"),
+    };
+    let blob = build_signed_token_blob(signature, &fields);
+    let token = AuthorizationToken::parse(&blob).unwrap();
+    let parsed = TempoSignature::from_bytes(&token.signature).unwrap();
+
+    assert_eq!(parsed.recover_signer(&token.digest).unwrap(), root_account);
+    match parsed {
+        TempoSignature::Keychain(keychain) => {
+            assert_eq!(keychain.key_id(&token.digest).unwrap(), expected_key_id);
+        }
+        TempoSignature::Primitive(_) => panic!("expected keychain signature"),
+    }
+}
+
+#[test]
+fn tempo_signature_rejects_malformed_signature_bytes() {
+    let malformed = [0x04, 0x11, 0x22];
+    assert!(TempoSignature::from_bytes(&malformed).is_err());
 }
 
 // ============ Method Classification ============

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -8,12 +8,15 @@
 //! - Method tier enforcement (restricted/disabled/unknown methods)
 
 use alloy::{
-    primitives::{Address, address},
+    primitives::{Address, B256, address},
     signers::local::PrivateKeySigner,
 };
 use tempo_precompiles::PATH_USD_ADDRESS;
 
-use crate::utils::start_zone_with_private_rpc;
+use crate::utils::{
+    DEFAULT_TIMEOUT, ZoneAccount, start_zone_with_private_rpc, start_zone_with_private_rpc_l1,
+    start_zone_with_private_rpc_l1_with_encryption,
+};
 
 /// Auth enforcement: missing header → 401, garbage token → 401/403, wrong chain ID → 403.
 #[tokio::test(flavor = "multi_thread")]
@@ -266,6 +269,183 @@ async fn test_method_tiers() -> eyre::Result<()> {
         error["code"].as_i64().unwrap(),
         -32601,
         "unknown method should return -32601"
+    );
+
+    Ok(())
+}
+
+/// Zone-specific metadata methods return the authenticated account/token expiry
+/// and the configured zone metadata.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zone_metadata_methods() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1().await?;
+    let user_signer = PrivateKeySigner::random();
+
+    let auth_info = ctx
+        .call_as_user(
+            "zone_getAuthorizationTokenInfo",
+            serde_json::json!([]),
+            &user_signer,
+        )
+        .await?;
+    assert_eq!(
+        auth_info["result"]["account"].as_str().unwrap(),
+        format!("{:#x}", user_signer.address()),
+    );
+    assert!(
+        auth_info["result"]["expiresAt"].as_str().is_some(),
+        "expiresAt should be a quantity string",
+    );
+
+    let zone_info = ctx
+        .call_as_user("zone_getZoneInfo", serde_json::json!([]), &user_signer)
+        .await?;
+    assert_eq!(zone_info["result"]["zoneId"], "0x1");
+    assert_eq!(
+        zone_info["result"]["zoneToken"].as_str().unwrap(),
+        "0x20c0000000000000000000000000000000000000",
+    );
+    assert_eq!(
+        zone_info["result"]["sequencer"].as_str().unwrap(),
+        format!("{:#x}", ctx.config.sequencer),
+    );
+    assert_eq!(
+        zone_info["result"]["chainId"].as_str().unwrap(),
+        format!("0x{:x}", ctx.config.chain_id),
+    );
+
+    Ok(())
+}
+
+/// `zone_getDepositStatus` returns relevant regular deposits for both the sender
+/// and the plaintext recipient, and returns an empty list for unrelated callers.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zone_get_deposit_status_regular_and_empty() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1().await?;
+    let l1 = ctx.l1();
+    let portal_address = ctx.portal_address();
+
+    let depositor_signer = l1.user_signer();
+    let recipient_signer = l1.signer_at(2);
+    let recipient = recipient_signer.address();
+
+    let mut depositor =
+        ZoneAccount::with_signer(depositor_signer.clone(), l1, &ctx.zone, portal_address);
+    let deposit_amount: u128 = 1_000_000;
+    l1.fund_user(depositor.address(), deposit_amount).await?;
+
+    let (tempo_block_number, _) = depositor
+        .deposit_to_with_block(recipient, deposit_amount, DEFAULT_TIMEOUT, &ctx.zone)
+        .await?;
+
+    let sender_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &depositor_signer)
+        .await?;
+    let sender_deposits = sender_status["result"]["deposits"]
+        .as_array()
+        .expect("sender deposits should be an array");
+    assert_eq!(sender_status["result"]["processed"], true);
+    assert_eq!(sender_deposits.len(), 1);
+    assert_eq!(sender_deposits[0]["kind"], "regular");
+    assert_eq!(sender_deposits[0]["status"], "processed");
+    assert_eq!(
+        sender_deposits[0]["sender"].as_str().unwrap(),
+        format!("{:#x}", depositor.address()),
+    );
+    assert_eq!(
+        sender_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+    assert_eq!(sender_deposits[0]["amount"], "0xf4240");
+
+    let recipient_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &recipient_signer)
+        .await?;
+    let recipient_deposits = recipient_status["result"]["deposits"]
+        .as_array()
+        .expect("recipient deposits should be an array");
+    assert_eq!(recipient_status["result"]["processed"], true);
+    assert_eq!(recipient_deposits.len(), 1);
+    assert_eq!(
+        recipient_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+
+    let unrelated_signer = PrivateKeySigner::random();
+    let unrelated_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &unrelated_signer)
+        .await?;
+    let unrelated_deposits = unrelated_status["result"]["deposits"]
+        .as_array()
+        .expect("unrelated deposits should be an array");
+    assert_eq!(unrelated_status["result"]["processed"], true);
+    assert!(unrelated_deposits.is_empty());
+
+    Ok(())
+}
+
+/// `zone_getDepositStatus` reveals encrypted deposits to the sender immediately,
+/// and to the recipient once the L2 processed event has revealed the recipient.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zone_get_deposit_status_encrypted() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1_with_encryption().await?;
+    let l1 = ctx.l1();
+    let portal_address = ctx.portal_address();
+
+    let depositor_signer = l1.user_signer();
+    let recipient_signer = l1.signer_at(2);
+    let recipient = recipient_signer.address();
+
+    let mut depositor =
+        ZoneAccount::with_signer(depositor_signer.clone(), l1, &ctx.zone, portal_address);
+    let deposit_amount: u128 = 1_000_000;
+    let memo = B256::from([0x11; 32]);
+    l1.fund_user(depositor.address(), deposit_amount).await?;
+
+    let (tempo_block_number, _) = depositor
+        .deposit_encrypted_with_block(deposit_amount, recipient, memo, DEFAULT_TIMEOUT, &ctx.zone)
+        .await?;
+
+    let sender_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &depositor_signer)
+        .await?;
+    let sender_deposits = sender_status["result"]["deposits"]
+        .as_array()
+        .expect("sender deposits should be an array");
+    assert_eq!(sender_status["result"]["processed"], true);
+    assert_eq!(sender_deposits.len(), 1);
+    assert_eq!(sender_deposits[0]["kind"], "encrypted");
+    assert_eq!(sender_deposits[0]["status"], "processed");
+    assert_eq!(
+        sender_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+    assert_eq!(
+        sender_deposits[0]["memo"].as_str().unwrap(),
+        format!("{memo:#x}"),
+    );
+
+    let recipient_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &recipient_signer)
+        .await?;
+    let recipient_deposits = recipient_status["result"]["deposits"]
+        .as_array()
+        .expect("recipient deposits should be an array");
+    assert_eq!(recipient_status["result"]["processed"], true);
+    assert_eq!(recipient_deposits.len(), 1);
+    assert_eq!(
+        recipient_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+    assert_eq!(
+        recipient_deposits[0]["sender"].as_str().unwrap(),
+        format!("{:#x}", depositor.address()),
     );
 
     Ok(())

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -8,15 +8,39 @@
 //! - Method tier enforcement (restricted/disabled/unknown methods)
 
 use alloy::{
-    primitives::{Address, B256, address},
+    primitives::{Address, B256, U256, address, hex},
     signers::local::PrivateKeySigner,
 };
-use tempo_precompiles::PATH_USD_ADDRESS;
+use alloy_provider::ProviderBuilder;
+use alloy_sol_types::SolCall;
+use p256::ecdsa::SigningKey as P256SigningKey;
+use rand::thread_rng;
+use tempo_contracts::precompiles::{
+    ITIP20 as ContractTip20,
+    account_keychain::IAccountKeychain::SignatureType as KeyInfoSignatureType,
+};
+use tempo_precompiles::{PATH_USD_ADDRESS, tip20::ITIP20 as PrecompileTip20};
+use tokio::time::sleep;
+use zone::abi::ZONE_TOKEN_ADDRESS;
 
 use crate::utils::{
     DEFAULT_TIMEOUT, ZoneAccount, start_zone_with_private_rpc, start_zone_with_private_rpc_l1,
     start_zone_with_private_rpc_l1_with_encryption,
 };
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn corrupt_token_hex(token: &str) -> String {
+    let mut bytes = hex::decode(token).expect("token hex should decode");
+    let idx = usize::from(bytes.len() > 1);
+    bytes[idx] ^= 0x01;
+    hex::encode(bytes)
+}
 
 /// Auth enforcement: missing header → 401, garbage token → 401/403, wrong chain ID → 403.
 #[tokio::test(flavor = "multi_thread")]
@@ -51,6 +75,210 @@ async fn test_auth_rejection() -> eyre::Result<()> {
         .call_raw("eth_blockNumber", serde_json::json!([]), &bad_token)
         .await?;
     assert_eq!(status.as_u16(), 403, "wrong chain ID should return 403");
+
+    Ok(())
+}
+
+/// Real P256 and WebAuthn auth tokens are accepted by the private RPC.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_non_secp_auth_tokens() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc().await?;
+    let p256_signer = P256SigningKey::random(&mut thread_rng());
+    let webauthn_signer = P256SigningKey::random(&mut thread_rng());
+
+    for token in [
+        ctx.p256_token(&p256_signer),
+        ctx.webauthn_token(&webauthn_signer),
+    ] {
+        let resp = ctx
+            .call(
+                "zone_getAuthorizationTokenInfo",
+                serde_json::json!([]),
+                &token,
+            )
+            .await?;
+        assert!(
+            resp.get("error").is_none(),
+            "auth token should succeed: {resp}"
+        );
+        assert!(
+            resp["result"]["account"].as_str().is_some(),
+            "successful auth should include an account",
+        );
+    }
+
+    Ok(())
+}
+
+/// Invalid P256 signatures and WebAuthn challenge mismatches are rejected.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_non_secp_auth_tokens_are_rejected() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc().await?;
+    let p256_signer = P256SigningKey::random(&mut thread_rng());
+    let webauthn_signer = P256SigningKey::random(&mut thread_rng());
+
+    let bad_p256 = corrupt_token_hex(&ctx.p256_token(&p256_signer));
+    let (status, _) = ctx
+        .call_raw("eth_blockNumber", serde_json::json!([]), &bad_p256)
+        .await?;
+    assert_eq!(status.as_u16(), 403, "invalid P256 token should return 403");
+
+    let bad_webauthn = ctx.webauthn_token_with_challenge(&webauthn_signer, B256::repeat_byte(0x77));
+    let (status, _) = ctx
+        .call_raw("eth_blockNumber", serde_json::json!([]), &bad_webauthn)
+        .await?;
+    assert_eq!(
+        status.as_u16(),
+        403,
+        "WebAuthn token with wrong challenge should return 403",
+    );
+
+    Ok(())
+}
+
+/// Authorized P256 keychain tokens authenticate as the root account in both V1 and V2 encodings.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_keychain_auth_tokens_v1_and_v2() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut ctx = start_zone_with_private_rpc().await?;
+    let root_signer = PrivateKeySigner::random();
+    let access_signer = P256SigningKey::random(&mut thread_rng());
+
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        address!("0x0000000000000000000000000000000000001111"),
+        root_signer.address(),
+        1_000_000,
+    )
+    .await?;
+
+    let (_, key_id) = ctx.keychain_p256_token(root_signer.address(), &access_signer, 0x04);
+    ctx.authorize_keychain_key(
+        &root_signer,
+        key_id,
+        KeyInfoSignatureType::P256,
+        now_secs() + 300,
+    )
+    .await?;
+
+    for version in [0x03, 0x04] {
+        let (token, _) = ctx.keychain_p256_token(root_signer.address(), &access_signer, version);
+        let resp = ctx
+            .call(
+                "zone_getAuthorizationTokenInfo",
+                serde_json::json!([]),
+                &token,
+            )
+            .await?;
+        assert_eq!(
+            resp["result"]["account"].as_str().unwrap(),
+            format!("{:#x}", root_signer.address()),
+            "keychain auth should resolve to the root account",
+        );
+    }
+
+    Ok(())
+}
+
+/// Keychain auth rejects missing, revoked, expired, and signature-type-mismatched keys.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut ctx = start_zone_with_private_rpc().await?;
+
+    let missing_root = PrivateKeySigner::random();
+    let missing_access = P256SigningKey::random(&mut thread_rng());
+    let (missing_token, _) = ctx.keychain_p256_token(missing_root.address(), &missing_access, 0x04);
+    let (status, _) = ctx
+        .call_raw("eth_blockNumber", serde_json::json!([]), &missing_token)
+        .await?;
+    assert_eq!(
+        status.as_u16(),
+        403,
+        "missing keychain auth should return 403"
+    );
+
+    let revoked_root = PrivateKeySigner::random();
+    let revoked_access = P256SigningKey::random(&mut thread_rng());
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        address!("0x0000000000000000000000000000000000002222"),
+        revoked_root.address(),
+        1_000_000,
+    )
+    .await?;
+    let (revoked_token, revoked_key_id) =
+        ctx.keychain_p256_token(revoked_root.address(), &revoked_access, 0x04);
+    ctx.authorize_keychain_key(
+        &revoked_root,
+        revoked_key_id,
+        KeyInfoSignatureType::P256,
+        now_secs() + 300,
+    )
+    .await?;
+    ctx.revoke_keychain_key(&revoked_root, revoked_key_id)
+        .await?;
+    let (status, _) = ctx
+        .call_raw("eth_blockNumber", serde_json::json!([]), &revoked_token)
+        .await?;
+    assert_eq!(status.as_u16(), 403, "revoked key should return 403");
+
+    let expired_root = PrivateKeySigner::random();
+    let expired_access = P256SigningKey::random(&mut thread_rng());
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        address!("0x0000000000000000000000000000000000003333"),
+        expired_root.address(),
+        1_000_000,
+    )
+    .await?;
+    let (expired_token, expired_key_id) =
+        ctx.keychain_p256_token(expired_root.address(), &expired_access, 0x04);
+    ctx.authorize_keychain_key(
+        &expired_root,
+        expired_key_id,
+        KeyInfoSignatureType::P256,
+        now_secs() + 1,
+    )
+    .await?;
+    sleep(std::time::Duration::from_secs(2)).await;
+    let (status, _) = ctx
+        .call_raw("eth_blockNumber", serde_json::json!([]), &expired_token)
+        .await?;
+    assert_eq!(status.as_u16(), 403, "expired key should return 403");
+
+    let mismatch_root = PrivateKeySigner::random();
+    let mismatch_access = P256SigningKey::random(&mut thread_rng());
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        address!("0x0000000000000000000000000000000000004444"),
+        mismatch_root.address(),
+        1_000_000,
+    )
+    .await?;
+    let (mismatch_token, mismatch_key_id) =
+        ctx.keychain_p256_token(mismatch_root.address(), &mismatch_access, 0x04);
+    ctx.authorize_keychain_key(
+        &mismatch_root,
+        mismatch_key_id,
+        KeyInfoSignatureType::Secp256k1,
+        now_secs() + 300,
+    )
+    .await?;
+    let (status, _) = ctx
+        .call_raw("eth_blockNumber", serde_json::json!([]), &mismatch_token)
+        .await?;
+    assert_eq!(
+        status.as_u16(),
+        403,
+        "signature-type mismatch should return 403",
+    );
 
     Ok(())
 }
@@ -446,6 +674,135 @@ async fn test_zone_get_deposit_status_encrypted() -> eyre::Result<()> {
     assert_eq!(
         recipient_deposits[0]["sender"].as_str().unwrap(),
         format!("{:#x}", depositor.address()),
+    );
+
+    Ok(())
+}
+
+/// `eth_call` against the zone TIP-20 enforces read privacy for `balanceOf` and
+/// `allowance`, while the configured sequencer retains access.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip20_eth_call_privacy() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1().await?;
+    let l1 = ctx.l1();
+    let portal_address = ctx.portal_address();
+
+    let owner_signer = l1.user_signer();
+    let owner = owner_signer.address();
+    let spender_signer = l1.signer_at(2);
+    let spender = spender_signer.address();
+    let outsider_signer = PrivateKeySigner::random();
+
+    let deposit_amount: u128 = 1_000_000;
+    let allowance_amount: u128 = 333_333;
+
+    let mut owner_account =
+        ZoneAccount::with_signer(owner_signer.clone(), l1, &ctx.zone, portal_address);
+    l1.fund_user(owner, deposit_amount).await?;
+    owner_account
+        .deposit(deposit_amount, DEFAULT_TIMEOUT, &ctx.zone)
+        .await?;
+
+    let owner_provider = ProviderBuilder::new()
+        .wallet(owner_signer)
+        .connect_http(ctx.zone.http_url().clone());
+    let approve_receipt = ContractTip20::new(ZONE_TOKEN_ADDRESS, &owner_provider)
+        .approve(spender, U256::from(allowance_amount))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(approve_receipt.status(), "approve should succeed");
+
+    let balance_call = PrecompileTip20::balanceOfCall { account: owner };
+    let balance_data = format!("0x{}", hex::encode(balance_call.abi_encode()));
+    let allowance_call = PrecompileTip20::allowanceCall { owner, spender };
+    let allowance_data = format!("0x{}", hex::encode(allowance_call.abi_encode()));
+
+    let outsider_balance = ctx
+        .call_as_user(
+            "eth_call",
+            serde_json::json!([
+                {
+                    "to": format!("{ZONE_TOKEN_ADDRESS:#x}"),
+                    "data": balance_data,
+                },
+                "latest"
+            ]),
+            &outsider_signer,
+        )
+        .await?;
+    assert!(
+        outsider_balance.get("error").is_some(),
+        "non-owner balanceOf(other) should revert"
+    );
+
+    let outsider_allowance = ctx
+        .call_as_user(
+            "eth_call",
+            serde_json::json!([
+                {
+                    "to": format!("{ZONE_TOKEN_ADDRESS:#x}"),
+                    "data": allowance_data,
+                },
+                "latest"
+            ]),
+            &outsider_signer,
+        )
+        .await?;
+    assert!(
+        outsider_allowance.get("error").is_some(),
+        "unrelated caller allowance(owner, spender) should revert"
+    );
+
+    let sequencer_balance = ctx
+        .call_as_sequencer(
+            "eth_call",
+            serde_json::json!([
+                {
+                    "from": format!("{:#x}", ctx.config.sequencer),
+                    "to": format!("{ZONE_TOKEN_ADDRESS:#x}"),
+                    "data": format!("0x{}", hex::encode(balance_call.abi_encode())),
+                },
+                "latest"
+            ]),
+        )
+        .await?;
+    let sequencer_balance_bytes = hex::decode(
+        sequencer_balance["result"]
+            .as_str()
+            .expect("sequencer balanceOf should return hex")
+            .trim_start_matches("0x"),
+    )?;
+    assert_eq!(
+        PrecompileTip20::balanceOfCall::abi_decode_returns(&sequencer_balance_bytes)?,
+        U256::from(deposit_amount)
+    );
+
+    let sequencer_allowance = ctx
+        .call_as_sequencer(
+            "eth_call",
+            serde_json::json!([
+                {
+                    "from": format!("{:#x}", ctx.config.sequencer),
+                    "to": format!("{ZONE_TOKEN_ADDRESS:#x}"),
+                    "data": format!("0x{}", hex::encode(allowance_call.abi_encode())),
+                },
+                "latest"
+            ]),
+        )
+        .await?;
+    let sequencer_allowance_bytes = hex::decode(
+        sequencer_allowance["result"]
+            .as_str()
+            .expect("sequencer allowance should return hex")
+            .trim_start_matches("0x"),
+    )?;
+    assert_eq!(
+        PrecompileTip20::allowanceCall::abi_decode_returns(&sequencer_allowance_bytes)?,
+        U256::from(allowance_amount)
     );
 
     Ok(())

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -4,12 +4,18 @@ use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::Filter;
 use alloy_sol_types::{SolEvent, SolValue};
+use base64::Engine as _;
 use eyre::WrapErr;
+use p256::{
+    EncodedPoint,
+    ecdsa::{SigningKey as P256SigningKey, signature::hazmat::PrehashSigner},
+};
 use reth_ethereum::tasks::TaskManager;
 use reth_node_api::FullNodeComponents;
 use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle, rpc::RethRpcAddOns};
 use reth_node_core::args::RpcServerArgs;
 use reth_rpc_builder::RpcModuleSelection;
+use sha2::{Digest, Sha256};
 use std::{
     sync::{
         Arc,
@@ -18,7 +24,18 @@ use std::{
     time::Duration,
 };
 use tempo_chainspec::spec::TempoChainSpec;
-use tempo_primitives::TempoHeader;
+use tempo_contracts::precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS,
+    account_keychain::IAccountKeychain::{
+        IAccountKeychainInstance, SignatureType as KeyInfoSignatureType,
+    },
+};
+use tempo_primitives::{
+    TempoHeader,
+    transaction::tt_signature::{
+        KeychainSignature, PrimitiveSignature, TempoSignature, WebAuthnSignature, normalize_p256_s,
+    },
+};
 use zone::{
     Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1Deposit, L1PortalEvents,
     SharedL1StateCache, ZoneNode,
@@ -34,6 +51,15 @@ static NEXT_CHAIN_ID: AtomicU64 = AtomicU64::new(71_000);
 
 fn next_unique_chain_id() -> u64 {
     NEXT_CHAIN_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+fn test_dev_signer() -> alloy_signer_local::PrivateKeySigner {
+    MnemonicBuilder::<English>::default()
+        .phrase(TEST_MNEMONIC)
+        .index(0)
+        .expect("valid derivation index")
+        .build()
+        .expect("valid test mnemonic")
 }
 
 /// Default timeout for polling loops in e2e tests.
@@ -336,6 +362,7 @@ impl ZoneTestNode {
             Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
+            test_dev_signer().address(),
             throwaway_key,
         )
         .await
@@ -360,6 +387,7 @@ impl ZoneTestNode {
             Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
+            test_dev_signer().address(),
             sequencer_key,
         )
         .await
@@ -403,6 +431,7 @@ impl ZoneTestNode {
             genesis_tempo_block_number,
             chain_id,
             None,
+            Address::ZERO,
             throwaway_key,
         )
         .await
@@ -414,6 +443,7 @@ impl ZoneTestNode {
         genesis_tempo_block_number: Option<u64>,
         chain_id: u64,
         custom_genesis: Option<Genesis>,
+        sequencer: Address,
         sequencer_key: k256::SecretKey,
     ) -> eyre::Result<Self> {
         let tasks = TaskManager::current();
@@ -429,7 +459,7 @@ impl ZoneTestNode {
             l1_ws_url,
             portal_address,
             genesis_tempo_block_number,
-            Address::ZERO, // sequencer address (overridden by sequencer_key)
+            sequencer,
             sequencer_key,
             4,
             std::time::Duration::from_millis(100),
@@ -1938,6 +1968,170 @@ fn build_auth_token(
     alloy_primitives::hex::encode(&blob)
 }
 
+fn build_auth_token_with_signature(
+    signature: TempoSignature,
+    zone_id: u64,
+    chain_id: u64,
+    portal: Address,
+) -> String {
+    use zone::rpc::auth::build_token_fields;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expires_at = now + 600;
+
+    let (fields, _) = build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    let mut blob = Vec::with_capacity(signature.encoded_length() + fields.len());
+    blob.extend_from_slice(signature.to_bytes().as_ref());
+    blob.extend_from_slice(&fields);
+    alloy_primitives::hex::encode(&blob)
+}
+
+fn p256_public_key(signing_key: &P256SigningKey) -> (B256, B256) {
+    let encoded = EncodedPoint::from(signing_key.verifying_key());
+    (
+        B256::from_slice(encoded.x().expect("x coordinate present")),
+        B256::from_slice(encoded.y().expect("y coordinate present")),
+    )
+}
+
+fn sign_p256_auth_signature(digest: B256, signing_key: &P256SigningKey) -> TempoSignature {
+    let pre_hashed = Sha256::digest(digest);
+    let signature: p256::ecdsa::Signature = signing_key
+        .sign_prehash(&pre_hashed)
+        .expect("p256 signing failed");
+    let sig_bytes = signature.to_bytes();
+    let (pub_key_x, pub_key_y) = p256_public_key(signing_key);
+
+    TempoSignature::Primitive(PrimitiveSignature::P256(
+        tempo_primitives::transaction::tt_signature::P256SignatureWithPreHash {
+            r: B256::from_slice(&sig_bytes[0..32]),
+            s: normalize_p256_s(&sig_bytes[32..64]),
+            pub_key_x,
+            pub_key_y,
+            pre_hash: true,
+        },
+    ))
+}
+
+fn sign_webauthn_auth_signature(
+    signing_key: &P256SigningKey,
+    challenge_digest: B256,
+) -> TempoSignature {
+    let mut authenticator_data = vec![0u8; 37];
+    authenticator_data[0..32].copy_from_slice(&[0xAA; 32]);
+    authenticator_data[32] = 0x01;
+    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(challenge_digest);
+    let client_data_json = format!(
+        r#"{{"type":"webauthn.get","challenge":"{challenge}","origin":"https://example.com","crossOrigin":false}}"#
+    );
+    let client_data_hash = Sha256::digest(client_data_json.as_bytes());
+    let mut final_hasher = Sha256::new();
+    final_hasher.update(&authenticator_data);
+    final_hasher.update(client_data_hash);
+    let message_hash = final_hasher.finalize();
+    let signature: p256::ecdsa::Signature = signing_key
+        .sign_prehash(&message_hash)
+        .expect("webauthn signing failed");
+    let sig_bytes = signature.to_bytes();
+    let (pub_key_x, pub_key_y) = p256_public_key(signing_key);
+    let mut webauthn_data = authenticator_data;
+    webauthn_data.extend_from_slice(client_data_json.as_bytes());
+
+    TempoSignature::Primitive(PrimitiveSignature::WebAuthn(WebAuthnSignature {
+        webauthn_data: alloy_primitives::Bytes::from(webauthn_data),
+        r: B256::from_slice(&sig_bytes[0..32]),
+        s: normalize_p256_s(&sig_bytes[32..64]),
+        pub_key_x,
+        pub_key_y,
+    }))
+}
+
+fn build_p256_auth_token(
+    signing_key: &P256SigningKey,
+    zone_id: u64,
+    chain_id: u64,
+    portal: Address,
+) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expires_at = now + 600;
+    let (_, digest) =
+        zone::rpc::auth::build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    build_auth_token_with_signature(
+        sign_p256_auth_signature(digest, signing_key),
+        zone_id,
+        chain_id,
+        portal,
+    )
+}
+
+fn build_webauthn_auth_token(
+    signing_key: &P256SigningKey,
+    zone_id: u64,
+    chain_id: u64,
+    portal: Address,
+    challenge_digest: Option<B256>,
+) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expires_at = now + 600;
+    let (_, digest) =
+        zone::rpc::auth::build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    build_auth_token_with_signature(
+        sign_webauthn_auth_signature(signing_key, challenge_digest.unwrap_or(digest)),
+        zone_id,
+        chain_id,
+        portal,
+    )
+}
+
+fn build_keychain_auth_token(
+    signing_key: &P256SigningKey,
+    root_account: Address,
+    version: u8,
+    zone_id: u64,
+    chain_id: u64,
+    portal: Address,
+) -> (String, Address) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expires_at = now + 600;
+    let (_, digest) =
+        zone::rpc::auth::build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    let keychain_digest = match version {
+        0x03 => digest,
+        0x04 => KeychainSignature::signing_hash(digest, root_account),
+        _ => panic!("unsupported keychain version"),
+    };
+    let primitive = match sign_p256_auth_signature(keychain_digest, signing_key) {
+        TempoSignature::Primitive(primitive) => primitive,
+        TempoSignature::Keychain(_) => unreachable!("primitive signature expected"),
+    };
+    let signature = if version == 0x03 {
+        TempoSignature::Keychain(KeychainSignature::new_v1(root_account, primitive))
+    } else {
+        TempoSignature::Keychain(KeychainSignature::new(root_account, primitive))
+    };
+    let key_id = match &signature {
+        TempoSignature::Keychain(keychain) => keychain.key_id(&digest).unwrap(),
+        TempoSignature::Primitive(_) => unreachable!("keychain signature expected"),
+    };
+
+    (
+        build_auth_token_with_signature(signature, zone_id, chain_id, portal),
+        key_id,
+    )
+}
+
 /// Send a JSON-RPC request to the private zone RPC and return the parsed response.
 ///
 /// Returns the full JSON response body (including `jsonrpc`, `id`, `result`/`error`).
@@ -2059,6 +2253,59 @@ impl PrivateRpcTestCtx {
     pub(crate) fn user_token(&self, signer: &alloy_signer_local::PrivateKeySigner) -> String {
         build_auth_token(
             signer,
+            self.config.zone_id,
+            self.config.chain_id,
+            self.config.zone_portal,
+        )
+    }
+
+    /// Build a P256 auth token for a non-sequencer caller.
+    pub(crate) fn p256_token(&self, signing_key: &P256SigningKey) -> String {
+        build_p256_auth_token(
+            signing_key,
+            self.config.zone_id,
+            self.config.chain_id,
+            self.config.zone_portal,
+        )
+    }
+
+    /// Build a WebAuthn auth token for a non-sequencer caller.
+    pub(crate) fn webauthn_token(&self, signing_key: &P256SigningKey) -> String {
+        build_webauthn_auth_token(
+            signing_key,
+            self.config.zone_id,
+            self.config.chain_id,
+            self.config.zone_portal,
+            None,
+        )
+    }
+
+    /// Build a WebAuthn auth token with an overridden challenge digest.
+    pub(crate) fn webauthn_token_with_challenge(
+        &self,
+        signing_key: &P256SigningKey,
+        challenge_digest: B256,
+    ) -> String {
+        build_webauthn_auth_token(
+            signing_key,
+            self.config.zone_id,
+            self.config.chain_id,
+            self.config.zone_portal,
+            Some(challenge_digest),
+        )
+    }
+
+    /// Build a Keychain auth token signed by a P256 access key.
+    pub(crate) fn keychain_p256_token(
+        &self,
+        root_account: Address,
+        signing_key: &P256SigningKey,
+        version: u8,
+    ) -> (String, Address) {
+        build_keychain_auth_token(
+            signing_key,
+            root_account,
+            version,
             self.config.zone_id,
             self.config.chain_id,
             self.config.zone_portal,
@@ -2217,6 +2464,45 @@ impl PrivateRpcTestCtx {
     /// Returns the real portal address for tests that require one.
     pub(crate) fn portal_address(&self) -> Address {
         self.portal_address.expect("real portal address required")
+    }
+
+    /// Authorize an access key for a root account on the zone keychain precompile.
+    pub(crate) async fn authorize_keychain_key(
+        &mut self,
+        root_signer: &alloy_signer_local::PrivateKeySigner,
+        key_id: Address,
+        signature_type: KeyInfoSignatureType,
+        expiry: u64,
+    ) -> eyre::Result<()> {
+        let provider = ProviderBuilder::new()
+            .wallet(root_signer.clone())
+            .connect_http(self.zone.http_url().clone());
+        let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &provider);
+        let pending = keychain
+            .authorizeKey(key_id, signature_type, expiry, false, vec![])
+            .send()
+            .await?;
+        self.fixture.inject_empty_block(self.zone.deposit_queue());
+        let receipt = pending.get_receipt().await?;
+        eyre::ensure!(receipt.status(), "authorizeKey failed");
+        Ok(())
+    }
+
+    /// Revoke an access key from a root account on the zone keychain precompile.
+    pub(crate) async fn revoke_keychain_key(
+        &mut self,
+        root_signer: &alloy_signer_local::PrivateKeySigner,
+        key_id: Address,
+    ) -> eyre::Result<()> {
+        let provider = ProviderBuilder::new()
+            .wallet(root_signer.clone())
+            .connect_http(self.zone.http_url().clone());
+        let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &provider);
+        let pending = keychain.revokeKey(key_id).send().await?;
+        self.fixture.inject_empty_block(self.zone.deposit_queue());
+        let receipt = pending.get_receipt().await?;
+        eyre::ensure!(receipt.status(), "revokeKey failed");
+        Ok(())
     }
 }
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -133,7 +133,14 @@ pub(crate) struct ZoneTestNode {
     deposit_queue: DepositQueue,
     l1_state_cache: SharedL1StateCache,
     policy_cache: zone::SharedPolicyCache,
-    rpc_api: Arc<dyn zone::rpc::ZoneRpcApi>,
+    rpc_api_factory: Arc<
+        dyn Fn(
+                zone::rpc::PrivateRpcConfig,
+                alloy_provider::DynProvider<TempoNetwork>,
+            ) -> Arc<dyn zone::rpc::ZoneRpcApi>
+            + Send
+            + Sync,
+    >,
     node_handle: Box<dyn TestNodeHandle>,
     _tasks: TaskManager,
 }
@@ -166,9 +173,13 @@ impl ZoneTestNode {
         &self.policy_cache
     }
 
-    /// Returns the real private RPC API backed by the node's EthHandlers.
-    pub(crate) fn rpc_api(&self) -> Arc<dyn zone::rpc::ZoneRpcApi> {
-        self.rpc_api.clone()
+    /// Builds the real private RPC API backed by the node's EthHandlers.
+    pub(crate) fn rpc_api(
+        &self,
+        config: zone::rpc::PrivateRpcConfig,
+        l1_provider: alloy_provider::DynProvider<TempoNetwork>,
+    ) -> Arc<dyn zone::rpc::ZoneRpcApi> {
+        (self.rpc_api_factory)(config, l1_provider)
     }
 
     /// Subscribe to canonical state notifications.
@@ -451,7 +462,7 @@ impl ZoneTestNode {
             .launch_with_debug_capabilities()
             .await?;
 
-        let http_url = node_handle
+        let http_url: url::Url = node_handle
             .node
             .rpc_server_handle()
             .http_url()
@@ -462,15 +473,28 @@ impl ZoneTestNode {
         // Build the real private RPC API while the handle is still concrete,
         // before type-erasing it into Box<dyn TestNodeHandle>.
         let eth_handlers = node_handle.node.eth_handlers().clone();
-        let rpc_api: Arc<dyn zone::rpc::ZoneRpcApi> =
-            Arc::new(zone::rpc::TempoZoneRpc::new(eth_handlers));
+        let zone_http_url = http_url.clone();
+        let rpc_api_factory = Arc::new(
+            move |config: zone::rpc::PrivateRpcConfig,
+                  l1_provider: alloy_provider::DynProvider<TempoNetwork>| {
+                let zone_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+                    .connect_http(zone_http_url.clone())
+                    .erased();
+                Arc::new(zone::rpc::TempoZoneRpc::new(
+                    eth_handlers.clone(),
+                    config,
+                    l1_provider,
+                    zone_provider,
+                )) as Arc<dyn zone::rpc::ZoneRpcApi>
+            },
+        );
 
         Ok(Self {
             deposit_queue,
             http_url,
             l1_state_cache,
             policy_cache,
-            rpc_api,
+            rpc_api_factory,
             node_handle: Box::new(node_handle),
             _tasks: tasks,
         })
@@ -1542,6 +1566,34 @@ impl ZoneAccount {
         timeout: Duration,
         zone: &ZoneTestNode,
     ) -> eyre::Result<U256> {
+        self.deposit_to(self.address, amount, timeout, zone).await
+    }
+
+    /// Approve the ZonePortal to spend pathUSD on L1, then deposit to a specific recipient.
+    ///
+    /// Waits for the expected post-deposit balance on L2 and returns it.
+    pub(crate) async fn deposit_to(
+        &mut self,
+        recipient: Address,
+        amount: u128,
+        timeout: Duration,
+        zone: &ZoneTestNode,
+    ) -> eyre::Result<U256> {
+        Ok(self
+            .deposit_to_with_block(recipient, amount, timeout, zone)
+            .await?
+            .1)
+    }
+
+    /// Same as [`deposit_to`](Self::deposit_to), but also returns the L1 block number
+    /// that included the deposit transaction.
+    pub(crate) async fn deposit_to_with_block(
+        &mut self,
+        recipient: Address,
+        amount: u128,
+        timeout: Duration,
+        zone: &ZoneTestNode,
+    ) -> eyre::Result<(u64, U256)> {
         use tempo_contracts::precompiles::ITIP20;
         use tempo_precompiles::PATH_USD_ADDRESS;
         use zone::abi::{ZONE_TOKEN_ADDRESS, ZonePortal};
@@ -1557,24 +1609,31 @@ impl ZoneAccount {
         }
 
         // Snapshot balance before deposit so we wait for the expected increase
-        let balance_before = zone.balance_of(ZONE_TOKEN_ADDRESS, self.address).await?;
+        let balance_before = zone.balance_of(ZONE_TOKEN_ADDRESS, recipient).await?;
 
         let portal = ZonePortal::new(self.portal_address, &self.l1_provider);
         let receipt = portal
-            .deposit(PATH_USD_ADDRESS, self.address, amount, B256::ZERO)
+            .deposit(PATH_USD_ADDRESS, recipient, amount, B256::ZERO)
             .send()
             .await?
             .get_receipt()
             .await?;
         eyre::ensure!(receipt.status(), "L1 deposit tx failed");
 
-        zone.wait_for_balance(
-            ZONE_TOKEN_ADDRESS,
-            self.address,
-            balance_before + U256::from(amount),
-            timeout,
-        )
-        .await
+        let balance = zone
+            .wait_for_balance(
+                ZONE_TOKEN_ADDRESS,
+                recipient,
+                balance_before + U256::from(amount),
+                timeout,
+            )
+            .await?;
+
+        let block_number = receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("deposit receipt missing block number"))?;
+
+        Ok((block_number, balance))
     }
 
     /// Approve the ZonePortal to spend `amount` of a specific `token` on L1, then deposit.
@@ -1641,6 +1700,22 @@ impl ZoneAccount {
         timeout: Duration,
         zone: &ZoneTestNode,
     ) -> eyre::Result<U256> {
+        Ok(self
+            .deposit_encrypted_with_block(amount, recipient, memo, timeout, zone)
+            .await?
+            .1)
+    }
+
+    /// Same as [`deposit_encrypted`](Self::deposit_encrypted), but also returns the
+    /// L1 block number that included the encrypted deposit transaction.
+    pub(crate) async fn deposit_encrypted_with_block(
+        &mut self,
+        amount: u128,
+        recipient: Address,
+        memo: B256,
+        timeout: Duration,
+        zone: &ZoneTestNode,
+    ) -> eyre::Result<(u64, U256)> {
         use tempo_contracts::precompiles::ITIP20;
         use tempo_precompiles::PATH_USD_ADDRESS;
         use zone::{
@@ -1706,13 +1781,20 @@ impl ZoneAccount {
         eyre::ensure!(receipt.status(), "L1 depositEncrypted tx failed");
 
         // Wait for the zone to process the encrypted deposit and mint to recipient
-        zone.wait_for_balance(
-            ZONE_TOKEN_ADDRESS,
-            recipient,
-            balance_before + U256::from(amount),
-            timeout,
-        )
-        .await
+        let balance = zone
+            .wait_for_balance(
+                ZONE_TOKEN_ADDRESS,
+                recipient,
+                balance_before + U256::from(amount),
+                timeout,
+            )
+            .await?;
+
+        let block_number = receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("depositEncrypted receipt missing block number"))?;
+
+        Ok((block_number, balance))
     }
 
     /// Approve the ZoneOutbox, then request a withdrawal on L2.
@@ -1948,6 +2030,10 @@ async fn private_rpc_call_no_auth(
 pub(crate) struct PrivateRpcTestCtx {
     /// The underlying zone test node.
     pub zone: ZoneTestNode,
+    /// Optional real L1 test node for deposit-status integration tests.
+    pub l1: Option<L1TestNode>,
+    /// Optional real ZonePortal address on L1.
+    pub portal_address: Option<Address>,
     /// URL of the private RPC server (not the zone's direct HTTP endpoint).
     pub private_rpc_url: url::Url,
     /// The sequencer signer (gets full access on the private RPC).
@@ -2108,6 +2194,30 @@ impl PrivateRpcTestCtx {
         )
         .await
     }
+
+    /// Query `zone_getDepositStatus` via the private RPC as a specific user.
+    pub(crate) async fn get_deposit_status_as_user(
+        &self,
+        tempo_block_number: u64,
+        signer: &alloy_signer_local::PrivateKeySigner,
+    ) -> eyre::Result<serde_json::Value> {
+        self.call_as_user(
+            "zone_getDepositStatus",
+            serde_json::json!([format!("0x{tempo_block_number:x}")]),
+            signer,
+        )
+        .await
+    }
+
+    /// Returns the real L1 node for tests that require one.
+    pub(crate) fn l1(&self) -> &L1TestNode {
+        self.l1.as_ref().expect("real L1 context required")
+    }
+
+    /// Returns the real portal address for tests that require one.
+    pub(crate) fn portal_address(&self) -> Address {
+        self.portal_address.expect("real portal address required")
+    }
 }
 
 /// Start a zone node with a private RPC server for testing.
@@ -2141,15 +2251,99 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
         sequencer: sequencer_address,
     };
 
-    let local_addr = zone::rpc::start_private_rpc(config.clone(), zone.rpc_api()).await?;
+    let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_http(DUMMY_L1_URL.parse::<url::Url>()?)
+        .erased();
+    let local_addr =
+        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone(), l1_provider))
+            .await?;
     let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
 
     Ok(PrivateRpcTestCtx {
         zone,
+        l1: None,
+        portal_address: None,
         private_rpc_url,
         sequencer_signer,
         config,
         fixture,
+    })
+}
+
+/// Start a zone with a private RPC server backed by a real L1 + ZonePortal.
+pub(crate) async fn start_zone_with_private_rpc_l1() -> eyre::Result<PrivateRpcTestCtx> {
+    start_zone_with_private_rpc_l1_inner(None).await
+}
+
+/// Start a zone with a private RPC server backed by a real L1 and a portal
+/// with a registered encryption key.
+pub(crate) async fn start_zone_with_private_rpc_l1_with_encryption()
+-> eyre::Result<PrivateRpcTestCtx> {
+    use sha2::{Digest, Sha256};
+
+    let key_bytes: [u8; 32] =
+        Sha256::digest(b"private-rpc-zone-specific-methods-encryption-key").into();
+    let encryption_key = k256::SecretKey::from_slice(&key_bytes).expect("valid encryption key");
+    start_zone_with_private_rpc_l1_inner(Some(encryption_key)).await
+}
+
+async fn start_zone_with_private_rpc_l1_inner(
+    encryption_key: Option<k256::SecretKey>,
+) -> eyre::Result<PrivateRpcTestCtx> {
+    use alloy_provider::Provider;
+
+    let l1 = L1TestNode::start().await?;
+    let portal_address = l1.deploy_zone().await?;
+
+    let zone = if let Some(key) = encryption_key.clone() {
+        ZoneTestNode::start_from_l1_with_sequencer_key(
+            l1.http_url(),
+            l1.ws_url(),
+            portal_address,
+            key,
+        )
+        .await?
+    } else {
+        ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?
+    };
+
+    zone.wait_for_l2_tempo_finalized(0, DEFAULT_TIMEOUT).await?;
+
+    if let Some(key) = encryption_key.as_ref() {
+        l1.set_sequencer_encryption_key(portal_address, key).await?;
+    }
+
+    let chain_id: alloy_primitives::U64 = zone
+        .provider()
+        .raw_request("eth_chainId".into(), ())
+        .await?;
+    let chain_id = chain_id.to::<u64>();
+
+    let config = zone::rpc::PrivateRpcConfig {
+        listen_addr: ([127, 0, 0, 1], 0).into(),
+        zone_id: 1,
+        chain_id,
+        zone_portal: portal_address,
+        sequencer: l1.dev_address(),
+    };
+
+    let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_http(l1.http_url().clone())
+        .erased();
+    let local_addr =
+        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone(), l1_provider))
+            .await?;
+    let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
+    let sequencer_signer = l1.dev_signer();
+
+    Ok(PrivateRpcTestCtx {
+        zone,
+        l1: Some(l1),
+        portal_address: Some(portal_address),
+        private_rpc_url,
+        sequencer_signer,
+        config,
+        fixture: L1Fixture::new(),
     })
 }
 

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -346,6 +346,116 @@ In addition to the Ethereum JSON-RPC methods, the zone exposes zone-specific met
 | `zone_getZoneInfo` | Any authenticated | Returns zone metadata: `zoneId`, `zoneToken`, `sequencer` (address only, not private key), `chainId`. |
 | `zone_getDepositStatus(tempoBlockNumber)` | Scoped | Returns whether deposits from the given Tempo block have been processed on the zone. Only returns information about deposits where the sender or recipient is the authenticated account. |
 
+All integer fields in these responses use Ethereum JSON-RPC quantity encoding (hex strings such as `0x1`).
+
+### `zone_getAuthorizationTokenInfo`
+
+**Request**
+
+```json
+{
+  "method": "zone_getAuthorizationTokenInfo",
+  "params": []
+}
+```
+
+**Response**
+
+```json
+{
+  "account": "0x1234...",
+  "expiresAt": "0x67d2d7c0"
+}
+```
+
+- `account`: the authenticated account address recovered from the authorization token.
+- `expiresAt`: the token expiry timestamp (unix seconds).
+
+### `zone_getZoneInfo`
+
+**Request**
+
+```json
+{
+  "method": "zone_getZoneInfo",
+  "params": []
+}
+```
+
+**Response**
+
+```json
+{
+  "zoneId": "0x1",
+  "zoneToken": "0x20c0000000000000000000000000000000000000",
+  "sequencer": "0xabcd...",
+  "chainId": "0x2a"
+}
+```
+
+- `zoneId`: the configured zone identifier.
+- `zoneToken`: the zone's TIP-20 token address.
+- `sequencer`: the configured sequencer address.
+- `chainId`: the zone chain ID.
+
+### `zone_getDepositStatus(tempoBlockNumber)`
+
+**Request**
+
+```json
+{
+  "method": "zone_getDepositStatus",
+  "params": ["0x2a"]
+}
+```
+
+`tempoBlockNumber` MAY be supplied either as a JSON number or as a hex quantity string.
+
+**Response**
+
+```json
+{
+  "tempoBlockNumber": "0x2a",
+  "zoneProcessedThrough": "0x2a",
+  "processed": true,
+  "deposits": [
+    {
+      "depositHash": "0xfeed...",
+      "kind": "regular",
+      "token": "0x20c0000000000000000000000000000000000000",
+      "sender": "0xaaaa...",
+      "recipient": "0xbbbb...",
+      "amount": "0xf4240",
+      "memo": "0x1111...",
+      "status": "processed"
+    }
+  ]
+}
+```
+
+- `tempoBlockNumber`: the queried Tempo L1 block number.
+- `zoneProcessedThrough`: the latest Tempo block number the zone has processed on L2.
+- `processed`: `true` if the zone has advanced through `tempoBlockNumber` and every deposit visible to the authenticated caller from that block has reached a terminal status.
+- `deposits`: only deposits relevant to the authenticated caller.
+
+Each deposit entry has:
+
+- `depositHash`: the deposit queue hash (`newCurrentDepositQueueHash`) for that deposit.
+- `kind`: `"regular"` or `"encrypted"`.
+- `token`: the deposited token address.
+- `sender`: the L1 depositor address.
+- `recipient`: the plaintext recipient address when visible; otherwise `null`.
+- `amount`: the post-fee deposit amount.
+- `memo`: the deposit memo when visible; otherwise `null`.
+- `status`: `"pending"`, `"processed"`, or `"failed"`.
+
+Visibility rules:
+
+- Regular deposits are returned only when the authenticated account is the sender or the plaintext recipient.
+- Encrypted deposits are returned immediately to the sender.
+- Encrypted deposits are returned to a recipient-only caller only after the zone has emitted `EncryptedDepositProcessed` on L2, which reveals the recipient.
+- Pending encrypted deposits MUST keep `recipient` and `memo` as `null`; implementations MUST NOT decrypt or reveal hidden recipient data just to answer RPC.
+
 **Withdrawals**: To request a withdrawal, the caller MUST construct and sign a transaction calling `ZoneOutbox.requestWithdrawal(...)` and submit it via `eth_sendRawTransaction`. There is no server-side convenience method — authorization tokens are read-only credentials and MUST NOT be sufficient to authorize state-changing operations such as token transfers or withdrawals. Requiring a full transaction signature ensures that a stolen or replayed authorization token cannot be used to move funds.
 
 ## Error codes

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -18,7 +18,7 @@ This document specifies the RPC interface for Tempo privacy zones. The design st
 
 Every RPC request must include an authorization token in the `X-Authorization-Token` HTTP header (or as the first element of a JSON-RPC batch params wrapper — see [Transport](#transport)). The authorization token proves that the caller controls a Tempo account and scopes all responses to that account.
 
-Tempo accounts support multiple signature types (secp256k1, P256, and WebAuthn), so the authorization token scheme must support all of them. Additionally, accounts that have authorized Access Keys via the [AccountKeychain](/protocol/transactions/AccountKeychain) precompile can use those Access Keys to authenticate to the RPC on behalf of their root account.
+Tempo accounts support multiple signature types (secp256k1, P256, and WebAuthn), so the authorization token scheme must support all of them. Additionally, accounts that have authorized Access Keys via the [AccountKeychain](/protocol/transactions/AccountKeychain) precompile can use those Access Keys to authenticate to the RPC on behalf of their root account. The RPC server uses the same signature parser and recovery rules as Tempo transactions, so auth tokens accept the same wire formats as transaction signatures.
 
 ### Message
 
@@ -49,7 +49,7 @@ The authorization token signature follows the same format as [Tempo transaction 
 | **secp256k1** | Exactly 65 bytes, no type prefix | `address(uint160(uint256(keccak256(abi.encode(x, y)))))` — standard `ecrecover` |
 | **P256** | First byte `0x01`, 130 bytes total | `address(uint160(uint256(keccak256(abi.encodePacked(pubKeyX, pubKeyY)))))` — public key is embedded in the signature |
 | **WebAuthn** | First byte `0x02`, variable length (max 2KB) | Same as P256 (WebAuthn uses P256 keys) |
-| **Keychain** | First byte `0x03`, variable length | Authenticated account is the `user_address` field, not the signing key's address (see [Keychain Access Keys](#keychain-access-keys)) |
+| **Keychain** | First byte `0x03` (legacy V1) or `0x04` (V2), variable length | Authenticated account is the `user_address` field, not the signing key's address (see [Keychain Access Keys](#keychain-access-keys)) |
 
 #### secp256k1
 
@@ -85,18 +85,23 @@ The account address is derived from the public key in the signature, following t
 
 Accounts that have authorized Access Keys via the zone's `AccountKeychain` precompile can use those keys to authenticate to the RPC. The zone has its own independent `AccountKeychain` instance — it is **not** mirrored from Tempo L1. Users must register Keychain keys on the zone directly via transactions submitted to the zone's `AccountKeychain` precompile. This means a key registered on Tempo L1 does not automatically grant RPC access to the zone; the user must separately authorize it on the zone.
 
-A Keychain signature wraps an inner signature (secp256k1, P256, or WebAuthn) and includes the root account address:
+A Keychain signature wraps an inner signature (secp256k1, P256, or WebAuthn) and includes the root account address. The RPC server accepts both the legacy V1 and current V2 encodings supported by Tempo transaction signatures:
 
 ```
-keychain_signature = 0x03 || user_address (20 bytes) || inner_signature
+keychain_signature_v1 = 0x03 || user_address (20 bytes) || inner_signature
+keychain_signature_v2 = 0x04 || user_address (20 bytes) || inner_signature
 ```
+
+V2 is recommended. V2 binds `user_address` into the access-key signing hash, while V1 signs the raw authorization-token hash directly for backward compatibility.
 
 The server:
 
-1. Verifies the inner signature against `authorizationTokenHash`.
-2. Derives the signing key's address from the inner signature.
-3. Queries the zone's `AccountKeychain` precompile to verify that `user_address` has authorized the signing key (i.e., `getKey(user_address, keyId)` returns an active, non-expired, non-revoked key).
-4. Sets the authenticated account to `user_address` (the root account), not the Access Key's address.
+1. Parses the signature using the same rules as Tempo transactions.
+2. Verifies the inner signature against `authorizationTokenHash` for V1, or against `keccak256(0x04 || authorizationTokenHash || user_address)` for V2.
+3. Derives the signing key's address from the inner signature.
+4. Queries the zone's `AccountKeychain` precompile to verify that `user_address` has authorized the signing key (i.e., `getKey(user_address, keyId)` returns an active, non-expired, non-revoked key).
+5. Verifies that the stored `signatureType` matches the inner signature type (secp256k1, P256, or WebAuthn).
+6. Sets the authenticated account to `user_address` (the root account), not the Access Key's address.
 
 This allows session keys and scoped Access Keys to authenticate to the RPC with the same permissions as the root account. The AccountKeychain's spending limits and expiry are orthogonal to the RPC authorization token — the Keychain key must be active to authenticate, but its token-spending limits only apply to on-chain transactions, not RPC reads.
 
@@ -135,7 +140,7 @@ The `X-Authorization-Token` value is a single hex-encoded blob containing the co
 <signature bytes><version: 1 byte><zoneId: 8 bytes><chainId: 8 bytes><zonePortal: 20 bytes><issuedAt: 8 bytes><expiresAt: 8 bytes>
 ```
 
-The authorization token fields are always exactly 53 bytes (1 + 8 + 8 + 20 + 8 + 8). To parse the blob, the RPC server reads the **last 53 bytes** as the authorization token fields, and treats everything before them as the signature. The signature is then parsed using the same detection rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types) (secp256k1 is exactly 65 bytes; P256 starts with `0x01` and is 130 bytes; WebAuthn starts with `0x02` and is variable-length; Keychain starts with `0x03` and is variable-length). Parsing from the end avoids any ambiguity with variable-length signature types.
+The authorization token fields are always exactly 53 bytes (1 + 8 + 8 + 20 + 8 + 8). To parse the blob, the RPC server reads the **last 53 bytes** as the authorization token fields, and treats everything before them as the signature. The signature is then parsed using the same detection rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types) (secp256k1 is exactly 65 bytes; P256 starts with `0x01` and is 130 bytes; WebAuthn starts with `0x02` and is variable-length; Keychain starts with `0x03` for legacy V1 or `0x04` for V2 and is variable-length). Parsing from the end avoids any ambiguity with variable-length signature types.
 
 Requests without a valid authorization token receive a `401 Unauthorized` HTTP response. Requests with an expired or malformed token receive `403 Forbidden`.
 


### PR DESCRIPTION
## Summary
- add the spec'd `zone_getAuthorizationTokenInfo`, `zone_getZoneInfo`, and `zone_getDepositStatus` methods to the private RPC dispatcher and API surface
- implement zone-specific RPC handling in `TempoZoneRpc`, including L1 portal log lookup and L2 inbox event correlation for caller-scoped deposit status
- document the concrete request/response payloads and add unit, websocket, and e2e coverage for the new methods

## Testing
- cargo fmt
- cargo test -p zone-rpc --lib handlers::tests:: -- --nocapture
- cargo test -p zone-rpc --test it ws_zone_method_roundtrip -- --nocapture
- cargo test -p zone --test it classify_public_methods -- --nocapture
- cargo test -p zone --test it private_rpc_e2e:: -- --nocapture