### PR TITLE
fix(zone): stabilize restart recovery in ci

### DIFF
--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -47,6 +47,12 @@ const MAX_RETRIES: u32 = 3;
 /// Initial delay between retries (doubles on each attempt).
 const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(2);
 
+/// Startup replay can briefly race zone RPC log availability after a restart.
+/// Retry restoring pending withdrawals instead of panicking the monitor task on
+/// the first mismatch.
+const MAX_PENDING_WITHDRAWAL_RESTORE_RETRIES: u32 = 6;
+const INITIAL_PENDING_WITHDRAWAL_RESTORE_RETRY_DELAY: Duration = Duration::from_millis(500);
+
 /// Configuration for the [`ZoneMonitor`].
 #[derive(Debug, Clone)]
 pub struct ZoneMonitorConfig {
@@ -200,10 +206,29 @@ impl ZoneMonitor {
 
         // Restore pending withdrawal data from zone L2 events so the
         // withdrawal processor can pick up where it left off.
-        let pending = batch_submitter
-            .fetch_pending_withdrawals(&provider, config.outbox_address)
-            .await
-            .expect("failed to fetch pending withdrawals");
+        let mut restore_attempt = 0;
+        let mut restore_delay = INITIAL_PENDING_WITHDRAWAL_RESTORE_RETRY_DELAY;
+        let pending = loop {
+            match batch_submitter
+                .fetch_pending_withdrawals(&provider, config.outbox_address)
+                .await
+            {
+                Ok(pending) => break pending,
+                Err(err) if restore_attempt < MAX_PENDING_WITHDRAWAL_RESTORE_RETRIES => {
+                    restore_attempt += 1;
+                    warn!(
+                        attempt = restore_attempt,
+                        max_attempts = MAX_PENDING_WITHDRAWAL_RESTORE_RETRIES,
+                        retry_delay_ms = restore_delay.as_millis() as u64,
+                        error = %err,
+                        "Failed to restore pending withdrawals, retrying"
+                    );
+                    tokio::time::sleep(restore_delay).await;
+                    restore_delay = restore_delay.saturating_mul(2);
+                }
+                Err(err) => panic!("failed to fetch pending withdrawals: {err}"),
+            }
+        };
 
         if !pending.is_empty() {
             let mut store = withdrawal_store.lock();

--- a/crates/tempo-zone/tests/it/restart_e2e.rs
+++ b/crates/tempo-zone/tests/it/restart_e2e.rs
@@ -17,6 +17,11 @@ const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 /// Timeout for waiting on withdrawals (includes batch submission + processing).
 const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// Restart recovery can take longer on loaded CI runners because the new
+/// sequencer restores pending withdrawal data from historical L2 events before
+/// the processor can advance the portal head.
+const RESTART_RECOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Read the portal's `blockHash()` — the last submitted zone block hash.
 async fn portal_block_hash(
     l1: &L1TestNode,
@@ -155,7 +160,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
 
     // Wait for the batch to land on L1 (portal tail advances)
     crate::utils::poll_until(
-        WITHDRAWAL_TIMEOUT,
+        RESTART_RECOVERY_TIMEOUT,
         std::time::Duration::from_millis(200),
         "portal withdrawal queue tail > 0",
         || {
@@ -186,7 +191,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     // The OLD withdrawal from before the restart should be processed via
     // restored data (withdrawal processor was aborted before head advanced).
     crate::utils::poll_until(
-        WITHDRAWAL_TIMEOUT,
+        RESTART_RECOVERY_TIMEOUT,
         std::time::Duration::from_millis(200),
         "portal head advances past first withdrawal",
         || {


### PR DESCRIPTION
## Summary
- split the restart-related CI fixes out of #263 so issue #262 stays focused on router e2e coverage
- retry pending-withdrawal restoration during sequencer startup instead of failing the monitor task on a transient mismatch
- give the restart recovery test a longer timeout for the slowest CI runners

## Testing
- cargo nextest run -p zone --profile ci restart_e2e::test_sequencer_restart_with_pending_withdrawal_queue
- cargo nextest run -p zone --profile ci restart_e2e::