### PR TITLE
test(ci): serialize restart e2e with node-heavy suites

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,5 +6,5 @@ test-threads = "num-cpus"
 # Integration tests spin up full reth nodes — limit concurrency to avoid
 # resource contention and flaky timeouts on CI runners.
 [[profile.ci.overrides]]
-filter = "test(/^(e2e|l1_e2e)::/) | test(advance_tempo)"
+filter = "test(/^(e2e|l1_e2e|restart_e2e)::/) | test(advance_tempo)"
 threads-required = 4


### PR DESCRIPTION
## Summary
- extend the CI nextest concurrency override to include `restart_e2e`
- serialize restart tests with the existing node-heavy `e2e` and `l1_e2e` suites on GitHub runners
- keep this separate from #263 so the issue #262 PR stays focused on router coverage

## Testing
- forge build
- cargo nextest run -p zone --profile ci restart_e2e::
