### PR TITLE
test(ci): give restart e2e more recovery headroom

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,4 +7,4 @@ test-threads = "num-cpus"
 # resource contention and flaky timeouts on CI runners.
 [[profile.ci.overrides]]
 filter = "test(/^(e2e|l1_e2e|restart_e2e)::/) | test(advance_tempo)"
-threads-required = 4
+threads-required = 8

--- a/crates/tempo-zone/tests/it/restart_e2e.rs
+++ b/crates/tempo-zone/tests/it/restart_e2e.rs
@@ -15,7 +15,7 @@ use zone::abi::{ZONE_TOKEN_ADDRESS, ZonePortal};
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Timeout for waiting on withdrawals (includes batch submission + processing).
-const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
 /// Read the portal's `blockHash()` — the last submitted zone block hash.
 async fn portal_block_hash(


### PR DESCRIPTION
## Summary
- increase the restart e2e withdrawal wait from 60s to 120s
- raise the nextest `threads-required` weight for the node-heavy CI suites from 4 to 8
- keep this separate from #263 so the issue #262 PR stays focused on router coverage

## Testing
- forge build
- cargo nextest run -p zone --profile ci restart_e2e::
