### PR TITLE
feat(xtask): add router deploy and same-zone swap demo commands

### DIFF
--- a/.codex/skills/zones-deploy-debug/SKILL.md
+++ b/.codex/skills/zones-deploy-debug/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: zones-deploy-debug
+description: Deploy Tempo Zones, start zone nodes, validate router swap-and-deposit flows, and debug zone sync, portal ingestion, withdrawal, sequencer key, and generated zone artifact issues in this repository. Use when working with just deploy-zone, zone-up, deploy-router, demo-swap-and-deposit, or generated/<name>/zone.json.
+---
+
+# Zones Deploy Debug
+
+Use this skill for repo-local zone deployment, smoke tests, and sync debugging.
+
+## Start here
+
+1. If the zone already exists, read `generated/<name>/zone.json` first.
+2. For real smoke tests, prefer `release` for `tempo-zone`.
+3. Use the `Justfile` and `docs/ZONES.md` as the source of truth for user-facing commands.
+4. Read `references/commands.md` for concrete command patterns and troubleshooting checks.
+
+## Preferred workflow
+
+1. Build `tempo-zone` in release before judging sync speed.
+2. Deploy a fresh zone if you need a clean test surface.
+3. Start the zone node and confirm `http://localhost:8546` is answering.
+4. Deploy the router for that zone.
+5. Run the same-zone swap-and-deposit demo.
+6. If the demo stalls, compare the L1 block of the relevant tx with the latest `l1_block=` in the zone log before assuming the router flow is broken.
+
+## What to inspect
+
+- `generated/<name>/zone.json`
+- `Justfile`
+- `docs/ZONES.md`
+- `/tmp/tempo-zone-<name>*/logs/immutable/reth.log`
+
+## Known sharp edges
+
+- Fresh `dev` nodes can look broken because they are still compiling and replaying L1; use `release` for meaningful validation.
+- The demo's first real wait point is token enablement on L2. If the zone is still replaying older L1 blocks, `demo-swap-and-deposit` can time out before the `TokenEnabled` event appears.
+- The current `just demo-swap-and-deposit` recipe takes optional overrides positionally, not as `amount=... tick=...`.
+- If a restarted zone crashes while seeding `transferPolicyId` for a temporary token, check `crates/tempo-zone/src/l1_state/tip403/cache.rs` and consider retesting with a fresh zone.

--- a/.codex/skills/zones-deploy-debug/agents/openai.yaml
+++ b/.codex/skills/zones-deploy-debug/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Zones Deploy Debug"
+  short_description: "Deploy Tempo Zones and debug sync issues"
+  default_prompt: "Use $zones-deploy-debug to deploy a zone, validate router flows, or debug zone sync and portal issues."

--- a/.codex/skills/zones-deploy-debug/references/commands.md
+++ b/.codex/skills/zones-deploy-debug/references/commands.md
@@ -1,0 +1,107 @@
+# Zone Commands
+
+## Release-first smoke test
+
+```bash
+cargo build --bin tempo-zone --release
+```
+
+Create a fresh zone when you need a clean router test:
+
+```bash
+just deploy-zone my-zone
+```
+
+That recipe creates the zone, stores `sequencerKey` in `generated/my-zone/zone.json`, and starts the node immediately. If you need tighter control, run:
+
+```bash
+target/debug/tempo-xtask create-zone --output generated/my-zone --l1-rpc-url "$HTTP_RPC" --sequencer "$SEQUENCER_ADDR" --private-key "$SEQUENCER_KEY"
+target/debug/tempo-xtask set-encryption-key --l1-rpc-url "$HTTP_RPC" --portal "$PORTAL" --private-key "$SEQUENCER_KEY"
+```
+
+## Start a zone in release
+
+```bash
+RUST_LOG=warn just zone-up my-zone false release
+```
+
+Health check:
+
+```bash
+cast block-number --rpc-url http://localhost:8546
+```
+
+Read deployment metadata:
+
+```bash
+jq '{zoneId, portal, tempoAnchorBlock, zoneFactory, swapAndDepositRouter, sequencerAddress}' generated/my-zone/zone.json
+```
+
+## Router validation flow
+
+Deploy the router:
+
+```bash
+just deploy-router my-zone
+```
+
+Run the demo with defaults:
+
+```bash
+just demo-swap-and-deposit my-zone
+```
+
+If you need overrides, pass them positionally because the current recipe treats them as positional args:
+
+```bash
+just demo-swap-and-deposit my-zone 100000000 0 http://localhost:8546
+```
+
+Direct xtask equivalent:
+
+```bash
+target/debug/tempo-xtask demo-swap-and-deposit \
+  --zone-dir generated/my-zone \
+  --l1-rpc-url "$HTTP_RPC" \
+  --zone-rpc-url http://localhost:8546 \
+  --private-key "$PRIVATE_KEY" \
+  --amount 100000000 \
+  --tick 0
+```
+
+## Sync debugging
+
+Tail the zone log:
+
+```bash
+tail -f /tmp/tempo-zone-my-zone*/logs/immutable/reth.log
+```
+
+Useful patterns:
+
+```bash
+rg -n "Prepared L1 block deposits|Including advanceTempo|TokenEnabled|DepositProcessed|WithdrawalProcessed" /tmp/tempo-zone-my-zone*/logs/immutable/reth.log
+```
+
+When `demo-swap-and-deposit` stalls at token enablement:
+
+1. Get the L1 tx block for the `enableToken` tx:
+
+```bash
+cast receipt <tx-hash> --rpc-url "$HTTP_RPC"
+```
+
+2. Compare it with the latest processed L1 block in the log:
+
+```bash
+tail -n 200 /tmp/tempo-zone-my-zone*/logs/immutable/reth.log | rg "Prepared L1 block deposits|Including advanceTempo"
+```
+
+If the zone is still behind the tx block, wait longer or rerun the test with a `release` node.
+
+## Known failure modes
+
+- `swapAndDepositRouter not found`: run `just deploy-router <name>` or pass `--router`.
+- Missing sequencer key: read `sequencerKey` from `generated/<name>/zone.json` or set `SEQUENCER_KEY`.
+- Timeout waiting for `TokenEnabled`: the zone is usually still catching up.
+- Restart crash with `failed to seed transferPolicyId ... Uninitialized`: inspect `crates/tempo-zone/src/l1_state/tip403/cache.rs` and prefer a fresh zone for smoke tests involving temporary tokens.

--- a/Justfile
+++ b/Justfile
@@ -138,6 +138,50 @@ create-zone name:
     echo "Zone '{{name}}' created. Artifacts in $OUTPUT/"
 
 [group('zone')]
+[doc('Deploys SwapAndDepositRouter on L1 for an existing zone and saves it to generated/<name>/zone.json. Requires L1_RPC_URL and PRIVATE_KEY env vars.')]
+deploy-router name dex="0xDEc0000000000000000000000000000000000000":
+    #!/bin/bash
+    set -euo pipefail
+    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
+    L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
+    HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
+    ZONE_DIR="generated/{{name}}"
+    ZONE_JSON="$ZONE_DIR/zone.json"
+    if [[ ! -f "$ZONE_JSON" ]]; then
+        echo "Error: $ZONE_JSON not found. Run 'just create-zone {{name}}' first." >&2
+        exit 1
+    fi
+    echo "Building Solidity specs..."
+    (cd docs/specs && forge build --skip test) || true
+    cargo run -p tempo-xtask -- deploy-router \
+        --zone-dir "$ZONE_DIR" \
+        --l1-rpc-url "$HTTP_RPC" \
+        --private-key "$PK" \
+        --stablecoin-dex "{{dex}}"
+
+[group('zone')]
+[doc('Runs a same-zone router demo: creates temporary tokens + DEX liquidity, withdraws token A from the zone, swaps on L1, and deposits token B back into the same zone. Requires L1_RPC_URL and PRIVATE_KEY env vars.')]
+demo-swap-and-deposit name amount="100000000" tick="0" rpc=zone_rpc:
+    #!/bin/bash
+    set -euo pipefail
+    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
+    L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
+    HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
+    ZONE_DIR="generated/{{name}}"
+    ZONE_JSON="$ZONE_DIR/zone.json"
+    if [[ ! -f "$ZONE_JSON" ]]; then
+        echo "Error: $ZONE_JSON not found. Run 'just create-zone {{name}}' first." >&2
+        exit 1
+    fi
+    cargo run -p tempo-xtask -- demo-swap-and-deposit \
+        --zone-dir "$ZONE_DIR" \
+        --l1-rpc-url "$HTTP_RPC" \
+        --zone-rpc-url "{{rpc}}" \
+        --private-key "$PK" \
+        --amount "{{amount}}" \
+        --tick "{{tick}}"
+
+[group('zone')]
 [doc('Starts a Tempo Zone L2 node, subscribing to L1 deposits. Pass the zone name used in create-zone. Use profile=release for production.')]
 zone-up name reset="false" profile="dev" args="":
     #!/bin/bash

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -22,6 +22,7 @@ This single command will:
 6. Build and start the zone node
 
 > The sequencer key is saved in `generated/<name>/zone.json` — `zone-up` reads it automatically.
+> `zone.json` now also stores `zoneFactory`, and `just deploy-router` appends `swapAndDepositRouter`.
 
 Once running, generate a user wallet and deposit some tokens:
 
@@ -119,7 +120,7 @@ just create-zone my-zone
 
 This creates `generated/my-zone/` containing:
 - **`genesis.json`** — Zone L2 genesis state (system contracts, fee token, etc.)
-- **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block)
+- **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block, `zoneFactory`, and optional router/sequencer metadata)
 
 You can also run the xtask directly for more control:
 
@@ -217,6 +218,38 @@ just send-withdrawal 1000000 <recipient-address>   # withdraw to a specific addr
 ```
 
 The sequencer includes the withdrawal in the next batch submission to L1 and processes it automatically.
+
+#### Router Swap + Deposit Demo (Same Zone)
+
+This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone.
+
+Prerequisites:
+- A running zone with an active sequencer
+- `L1_RPC_URL` and `PRIVATE_KEY` set
+- `generated/<name>/zone.json` present
+- `SEQUENCER_KEY` set if `zone.json` does not already contain `sequencerKey`
+
+Deploy the router once for the zone:
+
+```bash
+just deploy-router my-zone
+```
+
+That command saves the router address to `generated/my-zone/zone.json` as `swapAndDepositRouter`.
+
+Run the demo:
+
+```bash
+just demo-swap-and-deposit my-zone
+```
+
+Optional parameters:
+
+```bash
+just demo-swap-and-deposit my-zone amount=100000000 tick=0
+```
+
+This is a same-zone demo only. The command creates its own temporary tokens and DEX liquidity automatically, so you do not need to pre-create assets or seed the order book yourself.
 
 #### Check balance via Private RPC
 
@@ -432,6 +465,7 @@ graph TB
 |---------|-------------|
 | `just deploy-zone <name>` | One-shot: keygen → fund → create → genesis → start node |
 | `just create-zone <name>` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`) |
+| `just deploy-router <name>` | Deploy `SwapAndDepositRouter` on L1 for the zone and save it to `zone.json` |
 | `just zone-up <name> [reset] [profile]` | Start the zone node. `reset=true` wipes datadir. `profile=release` for production. |
 | `just max-approve-portal` | Approve portal to spend tokens on L1 |
 | `just send-deposit [to]` | Deposit tokens from L1 to zone (defaults to sender) |
@@ -439,6 +473,7 @@ graph TB
 | `just enable-token <token>` | Enable a TIP-20 token on the portal for bridging (sequencer only) |
 | `just max-approve-outbox` | Approve outbox to spend tokens on zone |
 | `just send-withdrawal [to]` | Withdraw tokens from zone to L1 (defaults to sender) |
+| `just demo-swap-and-deposit <name>` | Self-contained same-zone router demo: create tokens, seed DEX liquidity, swap on L1, deposit output back into the zone |
 | `just check-balance <addr>` | Check token balance on the zone |
 | `just zone-auth-token <name>` | Generate a signed private RPC auth token (10 min TTL) |
 | `just check-balance-private <name>` | Check balance via the private RPC (auto-generates auth token) |

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -205,6 +205,7 @@ impl CreateZone {
             "initialToken": format!("{}", self.initial_token),
             "sequencer": format!("{}", self.sequencer),
             "tempoAnchorBlock": confirm_header.inner.number,
+            "zoneFactory": format!("{}", self.zone_factory),
         });
         let zone_json_path = self.output.join("zone.json");
         std::fs::write(
@@ -218,6 +219,7 @@ impl CreateZone {
         println!("  Portal: {portal}");
         println!("  Initial Token: {}", self.initial_token);
         println!("  Sequencer: {}", self.sequencer);
+        println!("  ZoneFactory: {}", self.zone_factory);
         println!("  Tempo anchor block: {}", confirm_header.inner.number);
         println!(
             "  Genesis written to: {}",

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -1,0 +1,505 @@
+use alloy::{
+    network::EthereumWallet,
+    primitives::{Address, B256, Bytes, U256},
+    providers::{Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+    sol,
+    sol_types::SolValue,
+};
+use eyre::{WrapErr as _, eyre};
+use std::{path::PathBuf, time::Duration};
+use tempo_alloy::TempoNetwork;
+use tempo_contracts::precompiles::{
+    IRolesAuth, ITIP20 as TIP20Token, ITIP20Factory as TIP20Factory,
+};
+use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS, tip20::ISSUER_ROLE};
+use zone::abi::{ZONE_OUTBOX_ADDRESS, ZoneOutbox, ZonePortal};
+
+use crate::zone_utils::{
+    ROUTER_CALLBACK_GAS_LIMIT, STABLECOIN_DEX_ADDRESS, ZoneMetadata, check, fund_l1_wallet,
+    normalize_http_rpc, token_balance, wait_for_balance, wait_for_deposit_processed,
+    wait_for_token_enabled, wait_for_withdrawal_processed,
+};
+
+const DEMO_PATHUSD_GAS_NET: u128 = 5_000_000;
+const DEX_LIQUIDITY_MULTIPLIER: u128 = 3;
+const NONCE_CONFLICT_RETRIES: u32 = 5;
+const PATHUSD_HEADROOM: u128 = 10_000_000;
+
+sol! {
+    #[sol(rpc)]
+    contract StablecoinDEX {
+        function createPair(address base) external returns (bytes32 key);
+        function place(address token, uint128 amount, bool isBid, int16 tick) external returns (uint128 orderId);
+        function quoteSwapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn) external view returns (uint128 amountOut);
+    }
+}
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct DemoSwapAndDeposit {
+    /// Path to the zone directory containing zone.json.
+    #[arg(long)]
+    zone_dir: PathBuf,
+
+    /// Tempo L1 RPC URL.
+    #[arg(
+        long,
+        env = "L1_RPC_URL",
+        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+    )]
+    l1_rpc_url: String,
+
+    /// Zone L2 RPC URL.
+    #[arg(long, env = "ZONE_RPC_URL", default_value = "http://localhost:8546")]
+    zone_rpc_url: String,
+
+    /// Private key (hex) for the operator / demo wallet.
+    #[arg(long, env = "PRIVATE_KEY")]
+    private_key: String,
+
+    /// Sequencer private key (hex). Needed to enable tokens on the portal.
+    #[arg(long, env = "SEQUENCER_KEY")]
+    sequencer_key: Option<String>,
+
+    /// SwapAndDepositRouter address. Falls back to zone.json.
+    #[arg(long)]
+    router: Option<Address>,
+
+    /// Demo swap amount in token base units (6 decimals for the demo tokens).
+    #[arg(long, default_value_t = 100_000_000)]
+    amount: u128,
+
+    /// Tick used for the seeded DEX liquidity.
+    #[arg(long, default_value_t = 0)]
+    tick: i16,
+}
+
+impl DemoSwapAndDeposit {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let zone_metadata = ZoneMetadata::load(&self.zone_dir)?;
+        let portal = zone_metadata.get_required_address("portal")?;
+        let router = self
+            .router
+            .or(zone_metadata.get_optional_address("swapAndDepositRouter")?)
+            .ok_or_else(|| {
+                eyre!(
+                    "swapAndDepositRouter not found in {}. Run `just deploy-router <name>` or pass --router.",
+                    self.zone_dir.join("zone.json").display()
+                )
+            })?;
+        let sequencer_key = self
+            .sequencer_key
+            .or_else(|| zone_metadata.get_optional_string("sequencerKey"))
+            .ok_or_else(|| {
+                eyre!(
+                    "sequencer key missing. Set SEQUENCER_KEY or store sequencerKey in {}.",
+                    self.zone_dir.join("zone.json").display()
+                )
+            })?;
+
+        let operator_signer = parse_private_key(&self.private_key)?;
+        let operator = operator_signer.address();
+        let sequencer_signer = parse_private_key(&sequencer_key)?;
+        let sequencer = sequencer_signer.address();
+
+        let http_rpc = normalize_http_rpc(&self.l1_rpc_url);
+
+        let faucet_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&http_rpc)
+            .await?;
+        let operator_wallet = EthereumWallet::from(operator_signer);
+        let l1 = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(operator_wallet)
+            .connect(&http_rpc)
+            .await?;
+        l1.client()
+            .set_poll_interval(std::time::Duration::from_secs(1));
+
+        let sequencer_wallet = EthereumWallet::from(sequencer_signer);
+        let l1_seq = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(sequencer_wallet)
+            .connect(&http_rpc)
+            .await?;
+        l1_seq
+            .client()
+            .set_poll_interval(std::time::Duration::from_secs(1));
+
+        let l2 = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&self.zone_rpc_url)
+            .await?;
+        let l2_operator = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(EthereumWallet::from(parse_private_key(&self.private_key)?))
+            .connect(&self.zone_rpc_url)
+            .await?;
+
+        let deposit_fee = ZonePortal::new(portal, &l1)
+            .calculateDepositFee()
+            .call()
+            .await
+            .wrap_err("failed to fetch portal deposit fee")?;
+        let dex_liquidity = self
+            .amount
+            .checked_mul(DEX_LIQUIDITY_MULTIPLIER)
+            .ok_or_else(|| eyre!("dex liquidity amount overflow"))?;
+        let alpha_gross_deposit = self
+            .amount
+            .checked_add(deposit_fee)
+            .ok_or_else(|| eyre!("alpha deposit amount overflow"))?;
+        let pathusd_gross_deposit = DEMO_PATHUSD_GAS_NET
+            .checked_add(deposit_fee)
+            .ok_or_else(|| eyre!("pathUSD deposit amount overflow"))?;
+
+        println!("╔══════════════════════════════════════════════════════════════╗");
+        println!("║       Same-Zone Router Swap + Deposit Demo                  ║");
+        println!("╚══════════════════════════════════════════════════════════════╝");
+        println!();
+        println!("  Operator:         {operator}");
+        println!("  Sequencer:        {sequencer}");
+        println!("  Portal:           {portal}");
+        println!("  Router:           {router}");
+        println!("  L1 RPC:           {http_rpc}");
+        println!("  Zone RPC:         {}", self.zone_rpc_url);
+        println!("  Swap amount:      {}", self.amount);
+        println!("  DEX tick:         {}", self.tick);
+        println!("  Deposit fee:      {deposit_fee}");
+        println!();
+
+        println!("Step 1: Fund the operator with pathUSD on L1");
+        fund_l1_wallet(&faucet_provider, operator).await?;
+        let required_pathusd = dex_liquidity
+            .checked_add(pathusd_gross_deposit)
+            .and_then(|value| value.checked_add(PATHUSD_HEADROOM))
+            .ok_or_else(|| eyre!("required pathUSD amount overflow"))?;
+        let l1_balance = wait_for_balance(
+            &l1,
+            PATH_USD_ADDRESS,
+            operator,
+            U256::from(required_pathusd),
+            "L1 pathUSD",
+        )
+        .await
+        .wrap_err(
+            "operator pathUSD balance did not reach the minimum needed for the demo after tempo_fundAddress",
+        )?;
+        println!("  L1 pathUSD balance after faucet request: {l1_balance}");
+        println!();
+
+        println!("Step 2: Create fresh AlphaUSD and BetaUSD demo tokens");
+        let alpha = create_demo_token(&l1, operator, "AlphaUSD", "aUSD", B256::random()).await?;
+        let beta = create_demo_token(&l1, operator, "BetaUSD", "bUSD", B256::random()).await?;
+        println!("  AlphaUSD: {alpha}");
+        println!("  BetaUSD:  {beta}");
+        println!();
+
+        println!("Step 3: Configure and mint the demo tokens");
+        let mint_amount = dex_liquidity
+            .checked_add(self.amount)
+            .ok_or_else(|| eyre!("mint amount overflow"))?;
+        configure_and_mint_demo_token(&l1, operator, alpha, mint_amount).await?;
+        configure_and_mint_demo_token(&l1, operator, beta, mint_amount).await?;
+        println!("  Minted {mint_amount} units of each token to the operator");
+        println!();
+
+        println!("Step 4: Enable both tokens on the zone portal");
+        let zone_inbox_from_block = l2.get_block_number().await.unwrap_or(0);
+        enable_token_with_retry(&ZonePortal::new(portal, &l1_seq), alpha).await?;
+        wait_for_token_enabled(&l2, zone_inbox_from_block, alpha).await?;
+        let zone_inbox_from_block = l2.get_block_number().await.unwrap_or(0);
+        enable_token_with_retry(&ZonePortal::new(portal, &l1_seq), beta).await?;
+        wait_for_token_enabled(&l2, zone_inbox_from_block, beta).await?;
+        println!("  Both demo tokens are now available on the zone");
+        println!();
+
+        println!("Step 5: Seed StablecoinDEX liquidity for AlphaUSD/BetaUSD swaps");
+        seed_dex_liquidity(&l1, alpha, beta, dex_liquidity, self.tick).await?;
+        let expected_beta = StablecoinDEX::new(STABLECOIN_DEX_ADDRESS, &l1)
+            .quoteSwapExactAmountIn(alpha, beta, self.amount)
+            .call()
+            .await
+            .wrap_err("failed to quote DEX swap")?;
+        println!(
+            "  Seeded liquidity: {dex_liquidity} units at tick {}",
+            self.tick
+        );
+        println!(
+            "  Quoted swap output for {} AlphaUSD: {expected_beta} BetaUSD",
+            self.amount
+        );
+        println!();
+
+        println!("Step 6: Deposit pathUSD for L2 gas and AlphaUSD for the swap");
+        let portal_contract = ZonePortal::new(portal, &l1);
+
+        let l2_from_block = l2.get_block_number().await.unwrap_or(0);
+        TIP20Token::new(PATH_USD_ADDRESS, &l1)
+            .approve(portal, U256::MAX)
+            .send_sync()
+            .await
+            .wrap_err("failed to approve pathUSD for portal")?;
+        let receipt = portal_contract
+            .deposit(
+                PATH_USD_ADDRESS,
+                operator,
+                pathusd_gross_deposit,
+                B256::ZERO,
+            )
+            .send_sync()
+            .await
+            .wrap_err("failed to deposit pathUSD to the zone")?;
+        check(&receipt, "deposit pathUSD")?;
+        wait_for_deposit_processed(&l2, l2_from_block, operator, operator, PATH_USD_ADDRESS)
+            .await?;
+
+        let l2_from_block = l2.get_block_number().await.unwrap_or(0);
+        TIP20Token::new(alpha, &l1)
+            .approve(portal, U256::MAX)
+            .send_sync()
+            .await
+            .wrap_err("failed to approve AlphaUSD for portal")?;
+        let receipt = portal_contract
+            .deposit(alpha, operator, alpha_gross_deposit, B256::ZERO)
+            .send_sync()
+            .await
+            .wrap_err("failed to deposit AlphaUSD to the zone")?;
+        check(&receipt, "deposit AlphaUSD")?;
+        wait_for_deposit_processed(&l2, l2_from_block, operator, operator, alpha).await?;
+
+        let alpha_before = token_balance(&l2, alpha, operator)
+            .await
+            .unwrap_or_default();
+        let beta_before = token_balance(&l2, beta, operator).await.unwrap_or_default();
+        println!("  L2 AlphaUSD balance: {alpha_before}");
+        println!("  L2 BetaUSD balance:  {beta_before}");
+        println!();
+
+        println!(
+            "Step 7: Withdraw AlphaUSD to the router and let it swap+deposit back into the zone"
+        );
+        TIP20Token::new(alpha, &l2_operator)
+            .approve(ZONE_OUTBOX_ADDRESS, U256::MAX)
+            .gas(100_000)
+            .send_sync()
+            .await
+            .wrap_err("failed to approve AlphaUSD for the outbox")?;
+
+        let callback_data = (false, beta, portal, operator, B256::ZERO, expected_beta).abi_encode();
+        let l1_from_block = l1.get_block_number().await.unwrap_or(0);
+        let receipt = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &l2_operator)
+            .requestWithdrawal(
+                alpha,
+                router,
+                self.amount,
+                B256::ZERO,
+                ROUTER_CALLBACK_GAS_LIMIT,
+                operator,
+                Bytes::from(callback_data),
+            )
+            .gas(500_000)
+            .send_sync()
+            .await
+            .wrap_err("failed to request routed withdrawal on the zone")?;
+        check(&receipt, "request routed withdrawal")?;
+        println!(
+            "  Routed withdrawal requested on L2  [tx: {}]",
+            receipt.transaction_hash
+        );
+
+        let l2_alpha_after_request = token_balance(&l2, alpha, operator)
+            .await
+            .unwrap_or_default();
+        println!("  AlphaUSD balance immediately after request: {l2_alpha_after_request}");
+
+        let l1_block = wait_for_withdrawal_processed(
+            &l1,
+            l1_from_block,
+            portal,
+            router,
+            alpha,
+            self.amount,
+            true,
+        )
+        .await?;
+        println!("  Router callback processed on L1 (block {l1_block})");
+
+        let expected_beta_balance = beta_before + U256::from(expected_beta);
+        let final_beta =
+            wait_for_balance(&l2, beta, operator, expected_beta_balance, "BetaUSD").await?;
+        let final_alpha = token_balance(&l2, alpha, operator)
+            .await
+            .unwrap_or_default();
+        println!("  Final L2 AlphaUSD balance: {final_alpha}");
+        println!("  Final L2 BetaUSD balance:  {final_beta}");
+        println!();
+
+        println!("Demo complete!");
+        println!("  AlphaUSD:       {alpha}");
+        println!("  BetaUSD:        {beta}");
+        println!("  Router:         {router}");
+        println!("  Portal:         {portal}");
+        println!("  L2 withdrawal request tx: {}", receipt.transaction_hash);
+        println!("  Beta received:  {}", final_beta - beta_before);
+
+        Ok(())
+    }
+}
+
+async fn create_demo_token<P: Provider<TempoNetwork>>(
+    l1: &P,
+    admin: Address,
+    name: &str,
+    symbol: &str,
+    salt: B256,
+) -> eyre::Result<Address> {
+    let factory = TIP20Factory::new(TIP20_FACTORY_ADDRESS, l1);
+    let token = factory
+        .getTokenAddress(admin, salt)
+        .call()
+        .await
+        .wrap_err("failed to compute token address")?;
+    let receipt = factory
+        .createToken(
+            name.to_string(),
+            symbol.to_string(),
+            "USD".to_string(),
+            PATH_USD_ADDRESS,
+            admin,
+            salt,
+        )
+        .send_sync()
+        .await
+        .wrap_err("createToken failed")?;
+    check(&receipt, "createToken")?;
+    Ok(token)
+}
+
+async fn configure_and_mint_demo_token<P: Provider<TempoNetwork>>(
+    l1: &P,
+    admin: Address,
+    token: Address,
+    mint_amount: u128,
+) -> eyre::Result<()> {
+    let token_contract = TIP20Token::new(token, l1);
+    let receipt = token_contract
+        .setSupplyCap(U256::from(u128::MAX))
+        .send_sync()
+        .await
+        .wrap_err("setSupplyCap failed")?;
+    check(&receipt, "setSupplyCap")?;
+
+    let receipt = IRolesAuth::new(token, l1)
+        .grantRole(*ISSUER_ROLE, admin)
+        .send_sync()
+        .await
+        .wrap_err("grantRole failed")?;
+    check(&receipt, "grantRole")?;
+
+    let receipt = token_contract
+        .mint(admin, U256::from(mint_amount))
+        .send_sync()
+        .await
+        .wrap_err("mint failed")?;
+    check(&receipt, "mint")?;
+    Ok(())
+}
+
+async fn seed_dex_liquidity<P: Provider<TempoNetwork>>(
+    l1: &P,
+    alpha: Address,
+    beta: Address,
+    amount: u128,
+    tick: i16,
+) -> eyre::Result<()> {
+    let dex = StablecoinDEX::new(STABLECOIN_DEX_ADDRESS, l1);
+
+    let receipt = dex
+        .createPair(alpha)
+        .send_sync()
+        .await
+        .wrap_err("createPair(alpha) failed")?;
+    check(&receipt, "createPair(alpha)")?;
+
+    let receipt = dex
+        .createPair(beta)
+        .send_sync()
+        .await
+        .wrap_err("createPair(beta) failed")?;
+    check(&receipt, "createPair(beta)")?;
+
+    let receipt = TIP20Token::new(PATH_USD_ADDRESS, l1)
+        .approve(STABLECOIN_DEX_ADDRESS, U256::MAX)
+        .send_sync()
+        .await
+        .wrap_err("approve pathUSD for DEX failed")?;
+    check(&receipt, "approve pathUSD for DEX")?;
+
+    let receipt = dex
+        .place(alpha, amount, true, tick)
+        .send_sync()
+        .await
+        .wrap_err("place AlphaUSD bid failed")?;
+    check(&receipt, "place AlphaUSD bid")?;
+
+    let receipt = TIP20Token::new(beta, l1)
+        .approve(STABLECOIN_DEX_ADDRESS, U256::MAX)
+        .send_sync()
+        .await
+        .wrap_err("approve BetaUSD for DEX failed")?;
+    check(&receipt, "approve BetaUSD for DEX")?;
+
+    let receipt = dex
+        .place(beta, amount, false, tick)
+        .send_sync()
+        .await
+        .wrap_err("place BetaUSD ask failed")?;
+    check(&receipt, "place BetaUSD ask")?;
+
+    Ok(())
+}
+
+async fn enable_token_with_retry<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+    token: Address,
+) -> eyre::Result<()> {
+    let mut last_err = None;
+
+    for attempt in 0..NONCE_CONFLICT_RETRIES {
+        match portal.enableToken(token).send().await {
+            Ok(pending) => {
+                let receipt = pending.get_receipt().await?;
+                check(&receipt, "enableToken")?;
+                println!(
+                    "  Enabled token {token} on L1  [tx: {}]",
+                    receipt.transaction_hash
+                );
+                return Ok(());
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                if msg.contains("underpriced") || msg.contains("nonce") {
+                    println!(
+                        "  Retry {}/{} for enableToken due to nonce conflict...",
+                        attempt + 1,
+                        NONCE_CONFLICT_RETRIES
+                    );
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    last_err = Some(err);
+                    continue;
+                }
+                return Err(err)
+                    .wrap_err("enableToken failed — check SEQUENCER_KEY and zone state");
+            }
+        }
+    }
+
+    Err(last_err
+        .map(|err| eyre!(err))
+        .unwrap_or_else(|| eyre!("enableToken failed after retries")))
+}
+
+fn parse_private_key(private_key: &str) -> eyre::Result<PrivateKeySigner> {
+    private_key
+        .strip_prefix("0x")
+        .unwrap_or(private_key)
+        .parse()
+        .wrap_err("invalid private key")
+}

--- a/xtask/src/deploy_router.rs
+++ b/xtask/src/deploy_router.rs
@@ -1,0 +1,126 @@
+use alloy::{
+    network::{EthereumWallet, TransactionBuilder},
+    primitives::{Address, Bytes, TxKind},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    signers::local::PrivateKeySigner,
+    sol_types::SolValue,
+};
+use eyre::{WrapErr as _, eyre};
+use std::path::PathBuf;
+use tempo_alloy::TempoNetwork;
+
+use crate::zone_utils::{
+    L1_EXPLORER, MODERATO_ZONE_FACTORY, STABLECOIN_DEX_ADDRESS, ZoneMetadata, check,
+    normalize_http_rpc,
+};
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct DeployRouter {
+    /// Path to the zone directory containing zone.json.
+    #[arg(long)]
+    zone_dir: PathBuf,
+
+    /// Tempo L1 RPC URL.
+    #[arg(
+        long,
+        env = "L1_RPC_URL",
+        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+    )]
+    l1_rpc_url: String,
+
+    /// Private key (hex) for signing the deployment transaction.
+    #[arg(long, env = "PRIVATE_KEY")]
+    private_key: String,
+
+    /// ZoneFactory contract address. Falls back to zone.json, then the moderato default.
+    #[arg(long)]
+    zone_factory: Option<Address>,
+
+    /// StablecoinDEX address passed to the router constructor.
+    #[arg(long, default_value_t = STABLECOIN_DEX_ADDRESS)]
+    stablecoin_dex: Address,
+
+    /// Path to the Foundry compiled output directory containing contract artifacts.
+    #[arg(long, default_value = "docs/specs/out")]
+    specs_out: PathBuf,
+}
+
+impl DeployRouter {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let mut zone_metadata = ZoneMetadata::load(&self.zone_dir)?;
+        let zone_factory = self
+            .zone_factory
+            .or(zone_metadata.get_optional_address("zoneFactory")?)
+            .unwrap_or(MODERATO_ZONE_FACTORY);
+
+        let key_str = self
+            .private_key
+            .strip_prefix("0x")
+            .unwrap_or(&self.private_key);
+        let signer: PrivateKeySigner = key_str.parse()?;
+        let deployer = signer.address();
+        let wallet = EthereumWallet::from(signer);
+        let http_rpc = normalize_http_rpc(&self.l1_rpc_url);
+
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(wallet)
+            .connect(&http_rpc)
+            .await?;
+        provider
+            .client()
+            .set_poll_interval(std::time::Duration::from_secs(1));
+
+        let mut deploy_bytes = load_forge_bytecode(&self.specs_out, "SwapAndDepositRouter")?;
+        deploy_bytes.extend_from_slice(&(self.stablecoin_dex, zone_factory).abi_encode());
+
+        println!("Deploying SwapAndDepositRouter...");
+        println!("  Deployer:       {deployer}");
+        println!("  ZoneFactory:    {zone_factory}");
+        println!("  StablecoinDEX:  {}", self.stablecoin_dex);
+
+        let tx = TransactionRequest::default()
+            .with_kind(TxKind::Create)
+            .input(Bytes::from(deploy_bytes).into());
+        let receipt = provider
+            .send_transaction(tx.into())
+            .await?
+            .get_receipt()
+            .await
+            .wrap_err("failed to fetch router deployment receipt")?;
+        check(&receipt, "deploy-router")?;
+
+        let router = receipt
+            .contract_address
+            .ok_or_else(|| eyre!("router deployment receipt missing contract address"))?;
+
+        zone_metadata.set_address("zoneFactory", zone_factory);
+        zone_metadata.set_address("swapAndDepositRouter", router);
+        zone_metadata.save()?;
+
+        println!("SwapAndDepositRouter deployed successfully!");
+        println!("  Address:   {router}");
+        println!("  L1 tx:     {L1_EXPLORER}/{}", receipt.transaction_hash);
+        println!("  Updated:   {}", self.zone_dir.join("zone.json").display());
+
+        Ok(())
+    }
+}
+
+fn load_forge_bytecode(specs_out: &std::path::Path, contract: &str) -> eyre::Result<Vec<u8>> {
+    let artifact_path = specs_out.join(format!("{contract}.sol/{contract}.json"));
+    let artifact = std::fs::read_to_string(&artifact_path).wrap_err_with(|| {
+        format!(
+            "{contract} artifact not found at {}",
+            artifact_path.display()
+        )
+    })?;
+    let artifact_json: serde_json::Value = serde_json::from_str(&artifact)
+        .wrap_err_with(|| format!("failed parsing {}", artifact_path.display()))?;
+    let hex_str = artifact_json["bytecode"]["object"]
+        .as_str()
+        .ok_or_else(|| eyre!("missing bytecode in {}", artifact_path.display()))?;
+
+    alloy::primitives::hex::decode(hex_str)
+        .wrap_err_with(|| format!("invalid bytecode in {}", artifact_path.display()))
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,19 +1,23 @@
 //! xtask is a Swiss army knife of tools that help with running and testing tempo.
 use crate::{
-    create_zone::CreateZone, demo_blacklist::DemoBlacklist, encrypted_deposit::EncryptedDeposit,
-    generate_zone_genesis::GenerateZoneGenesis, set_encryption_key::SetEncryptionKey,
-    spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
+    create_zone::CreateZone, demo_blacklist::DemoBlacklist,
+    demo_swap_and_deposit::DemoSwapAndDeposit, deploy_router::DeployRouter,
+    encrypted_deposit::EncryptedDeposit, generate_zone_genesis::GenerateZoneGenesis,
+    set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;
 
 mod create_zone;
 mod demo_blacklist;
+mod demo_swap_and_deposit;
+mod deploy_router;
 mod encrypted_deposit;
 mod generate_zone_genesis;
 mod set_encryption_key;
 mod spam_deposits;
 mod zone_info;
+mod zone_utils;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -25,6 +29,11 @@ async fn main() -> eyre::Result<()> {
     match args.action {
         Action::CreateZone(args) => args.run().await.wrap_err("failed to create zone"),
         Action::DemoBlacklist(args) => args.run().await.wrap_err("failed to run blacklist demo"),
+        Action::DemoSwapAndDeposit(args) => args
+            .run()
+            .await
+            .wrap_err("failed to run swap-and-deposit demo"),
+        Action::DeployRouter(args) => args.run().await.wrap_err("failed to deploy router"),
         Action::EncryptedDeposit(args) => args
             .run()
             .await
@@ -52,6 +61,8 @@ struct Args {
 enum Action {
     CreateZone(CreateZone),
     DemoBlacklist(DemoBlacklist),
+    DemoSwapAndDeposit(DemoSwapAndDeposit),
+    DeployRouter(DeployRouter),
     EncryptedDeposit(EncryptedDeposit),
     GenerateZoneGenesis(GenerateZoneGenesis),
     SetEncryptionKey(SetEncryptionKey),

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -1,0 +1,241 @@
+use alloy::{
+    network::primitives::ReceiptResponse,
+    primitives::{Address, U256, address},
+    providers::Provider,
+    rpc::types::Filter,
+    sol_types::SolEvent,
+};
+use eyre::{WrapErr as _, eyre};
+use serde_json::Value;
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tempo_alloy::TempoNetwork;
+use tempo_contracts::precompiles::ITIP20 as TIP20Token;
+use zone::abi::{ZoneInbox, ZonePortal};
+
+pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
+pub(crate) const MODERATO_ZONE_FACTORY: Address =
+    address!("0x7F4528b1a555D704bC20f8328557240BED29488D");
+pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
+    address!("0xDEc0000000000000000000000000000000000000");
+pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;
+const DEFAULT_WAIT_ATTEMPTS: usize = 120;
+const DEFAULT_WAIT_POLL: Duration = Duration::from_millis(500);
+
+pub(crate) struct ZoneMetadata {
+    path: PathBuf,
+    value: Value,
+}
+
+impl ZoneMetadata {
+    pub(crate) fn load(zone_dir: &Path) -> eyre::Result<Self> {
+        let path = zone_dir.join("zone.json");
+        let contents = std::fs::read_to_string(&path)
+            .wrap_err_with(|| format!("failed reading {}", path.display()))?;
+        let value: Value = serde_json::from_str(&contents)
+            .wrap_err_with(|| format!("failed parsing {}", path.display()))?;
+        if !value.is_object() {
+            return Err(eyre!(
+                "expected {} to contain a JSON object",
+                path.display()
+            ));
+        }
+        Ok(Self { path, value })
+    }
+
+    pub(crate) fn save(&self) -> eyre::Result<()> {
+        std::fs::write(
+            &self.path,
+            serde_json::to_string_pretty(&self.value).wrap_err("failed encoding zone.json")?,
+        )
+        .wrap_err_with(|| format!("failed writing {}", self.path.display()))
+    }
+
+    pub(crate) fn get_required_address(&self, key: &str) -> eyre::Result<Address> {
+        let value = self
+            .value
+            .get(key)
+            .and_then(Value::as_str)
+            .ok_or_else(|| eyre!("{key} not found in {}", self.path.display()))?;
+        value
+            .parse()
+            .wrap_err_with(|| format!("invalid {key} address in {}", self.path.display()))
+    }
+
+    pub(crate) fn get_optional_address(&self, key: &str) -> eyre::Result<Option<Address>> {
+        self.value
+            .get(key)
+            .and_then(Value::as_str)
+            .map(|value| {
+                value
+                    .parse()
+                    .wrap_err_with(|| format!("invalid {key} address in {}", self.path.display()))
+            })
+            .transpose()
+    }
+
+    pub(crate) fn get_optional_string(&self, key: &str) -> Option<String> {
+        self.value
+            .get(key)
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+    }
+
+    pub(crate) fn set_address(&mut self, key: &str, value: Address) {
+        self.set_string(key, value.to_string());
+    }
+
+    pub(crate) fn set_string(&mut self, key: &str, value: impl Into<String>) {
+        if let Some(obj) = self.value.as_object_mut() {
+            obj.insert(key.to_string(), Value::String(value.into()));
+        }
+    }
+}
+
+pub(crate) fn normalize_http_rpc(rpc_url: &str) -> String {
+    rpc_url
+        .replace("wss://", "https://")
+        .replace("ws://", "http://")
+}
+
+pub(crate) fn check(receipt: &impl ReceiptResponse, label: &str) -> eyre::Result<()> {
+    if !receipt.status() {
+        return Err(eyre!("{label} reverted"));
+    }
+    Ok(())
+}
+
+pub(crate) async fn fund_l1_wallet<P: Provider<TempoNetwork>>(
+    provider: &P,
+    address: Address,
+) -> eyre::Result<()> {
+    let _: Vec<alloy::primitives::B256> = provider
+        .raw_request("tempo_fundAddress".into(), (address,))
+        .await
+        .wrap_err("tempo_fundAddress RPC request failed")?;
+    Ok(())
+}
+
+pub(crate) async fn token_balance<P: Provider<TempoNetwork>>(
+    provider: &P,
+    token: Address,
+    account: Address,
+) -> eyre::Result<U256> {
+    TIP20Token::new(token, provider)
+        .balanceOf(account)
+        .call()
+        .await
+        .wrap_err("balanceOf failed")
+}
+
+pub(crate) async fn wait_for_token_enabled<P: Provider<TempoNetwork>>(
+    l2: &P,
+    from_block: u64,
+    token: Address,
+) -> eyre::Result<u64> {
+    let filter = Filter::new()
+        .address(zone::abi::ZONE_INBOX_ADDRESS)
+        .event_signature(ZoneInbox::TokenEnabled::SIGNATURE_HASH)
+        .from_block(from_block);
+
+    for _ in 0..DEFAULT_WAIT_ATTEMPTS {
+        let logs = l2.get_logs(&filter).await.unwrap_or_default();
+        for log in &logs {
+            if let Ok(event) = ZoneInbox::TokenEnabled::decode_log(&log.inner)
+                && event.data.token == token
+            {
+                return Ok(log.block_number.unwrap_or(0));
+            }
+        }
+        tokio::time::sleep(DEFAULT_WAIT_POLL).await;
+    }
+
+    Err(eyre!("timeout waiting for TokenEnabled event on L2"))
+}
+
+pub(crate) async fn wait_for_deposit_processed<P: Provider<TempoNetwork>>(
+    l2: &P,
+    from_block: u64,
+    sender: Address,
+    to: Address,
+    token: Address,
+) -> eyre::Result<u64> {
+    let filter = Filter::new()
+        .address(zone::abi::ZONE_INBOX_ADDRESS)
+        .event_signature(ZoneInbox::DepositProcessed::SIGNATURE_HASH)
+        .from_block(from_block);
+
+    for _ in 0..DEFAULT_WAIT_ATTEMPTS {
+        let logs = l2.get_logs(&filter).await.unwrap_or_default();
+        for log in &logs {
+            if let Ok(event) = ZoneInbox::DepositProcessed::decode_log(&log.inner)
+                && event.data.sender == sender
+                && event.data.to == to
+                && event.data.token == token
+            {
+                return Ok(log.block_number.unwrap_or(0));
+            }
+        }
+        tokio::time::sleep(DEFAULT_WAIT_POLL).await;
+    }
+
+    Err(eyre!("timeout waiting for DepositProcessed"))
+}
+
+pub(crate) async fn wait_for_balance<P: Provider<TempoNetwork>>(
+    provider: &P,
+    token: Address,
+    account: Address,
+    expected_balance: U256,
+    label: &str,
+) -> eyre::Result<U256> {
+    for _ in 0..DEFAULT_WAIT_ATTEMPTS {
+        let balance = token_balance(provider, token, account)
+            .await
+            .unwrap_or_default();
+        if balance >= expected_balance {
+            return Ok(balance);
+        }
+        tokio::time::sleep(DEFAULT_WAIT_POLL).await;
+    }
+
+    Err(eyre!(
+        "timeout waiting for {label} balance to reach {expected_balance}"
+    ))
+}
+
+pub(crate) async fn wait_for_withdrawal_processed<P: Provider<TempoNetwork>>(
+    l1: &P,
+    from_block: u64,
+    portal: Address,
+    to: Address,
+    token: Address,
+    amount: u128,
+    callback_success: bool,
+) -> eyre::Result<u64> {
+    let filter = Filter::new()
+        .address(portal)
+        .event_signature(ZonePortal::WithdrawalProcessed::SIGNATURE_HASH)
+        .from_block(from_block);
+
+    for _ in 0..(DEFAULT_WAIT_ATTEMPTS * 2) {
+        let logs = l1.get_logs(&filter).await.unwrap_or_default();
+        for log in &logs {
+            if let Ok(event) = ZonePortal::WithdrawalProcessed::decode_log(&log.inner)
+                && event.data.to == to
+                && event.data.token == token
+                && event.data.amount == amount
+                && event.data.callbackSuccess == callback_success
+            {
+                return Ok(log.block_number.unwrap_or(0));
+            }
+        }
+        tokio::time::sleep(DEFAULT_WAIT_POLL).await;
+    }
+
+    Err(eyre!(
+        "timeout waiting for WithdrawalProcessed(to={to}, token={token}, amount={amount}, callbackSuccess={callback_success})"
+    ))
+}


### PR DESCRIPTION
## Summary
- add `tempo-xtask deploy-router` to deploy `SwapAndDepositRouter` and persist it in `generated/<name>/zone.json`
- add `tempo-xtask demo-swap-and-deposit` for the same-zone swap + deposit flow used in the PR 263 test
- add `just deploy-router` and `just demo-swap-and-deposit` wrappers
- document the new router workflow in `docs/ZONES.md`

## Testing
- cargo build -p tempo-xtask
- cargo run -p tempo-xtask -- deploy-router --help
- cargo run -p tempo-xtask -- demo-swap-and-deposit --help
- verified actionable failures for missing `zone.json`, missing router metadata, and missing sequencer key
