### PR TITLE
fix(zone): correct withdrawal queue hash encoding

### DIFF
--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -594,7 +594,7 @@ impl Withdrawal {
 
         let mut hash = EMPTY_SENTINEL;
         for w in withdrawals.iter().rev() {
-            hash = keccak256((w.clone(), hash).abi_encode());
+            hash = keccak256((w.clone(), hash).abi_encode_params());
         }
         hash
     }

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -424,7 +424,7 @@ mod tests {
         let w = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 1000);
         let hash = abi::Withdrawal::queue_hash(std::slice::from_ref(&w));
 
-        let expected = keccak256((w, EMPTY_SENTINEL).abi_encode());
+        let expected = keccak256((w, EMPTY_SENTINEL).abi_encode_params());
         assert_eq!(hash, expected);
     }
 
@@ -435,9 +435,38 @@ mod tests {
 
         let hash = abi::Withdrawal::queue_hash(&[w0.clone(), w1.clone()]);
 
-        let inner = keccak256((w1, EMPTY_SENTINEL).abi_encode());
-        let expected = keccak256((w0, inner).abi_encode());
+        let inner = keccak256((w1, EMPTY_SENTINEL).abi_encode_params());
+        let expected = keccak256((w0, inner).abi_encode_params());
         assert_eq!(hash, expected);
+    }
+
+    #[test]
+    fn withdrawal_hash_requires_param_encoding() {
+        let w = abi::Withdrawal {
+            token: address!("0x20c0000000000000000000000000000000000000"),
+            sender: address!("0x70997970c51812dc3a010c7d01b50e0d17dc79c8"),
+            to: address!("0x70997970c51812dc3a010c7d01b50e0d17dc79c8"),
+            amount: 500_000,
+            fee: 0,
+            memo: B256::ZERO,
+            gasLimit: 0,
+            fallbackRecipient: address!("0x70997970c51812dc3a010c7d01b50e0d17dc79c8"),
+            callbackData: Default::default(),
+        };
+
+        let tuple_value_hash = keccak256((w.clone(), EMPTY_SENTINEL).abi_encode());
+        let param_hash = keccak256((w, EMPTY_SENTINEL).abi_encode_params());
+
+        assert_ne!(
+            tuple_value_hash, param_hash,
+            "tuple-value encoding must differ from Solidity abi.encode(args...) here"
+        );
+        assert_eq!(
+            param_hash,
+            alloy_primitives::b256!(
+                "b48c451d87f74a89050368265aab8eeebe85b871f9239f60f53f5eec2b68e509"
+            )
+        );
     }
 
     #[test]

--- a/crates/tempo-zone/tests/it/restart_e2e.rs
+++ b/crates/tempo-zone/tests/it/restart_e2e.rs
@@ -9,7 +9,7 @@
 
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
 use alloy::primitives::{Address, U256};
-use zone::abi::{ZONE_TOKEN_ADDRESS, ZonePortal};
+use zone::abi::{ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZoneOutbox, ZonePortal};
 
 /// Longer timeout for real L1 tests.
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -39,6 +39,45 @@ async fn batch_submitted_count(l1: &L1TestNode, portal_address: Address) -> eyre
     let portal = ZonePortal::new(portal_address, l1.provider());
     let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
     Ok(events.len())
+}
+
+async fn wait_for_withdrawal_requested(
+    zone: &ZoneTestNode,
+    sender: Address,
+    amount: u128,
+) -> eyre::Result<()> {
+    let outbox = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, zone.provider());
+    let expected_amount = U256::from(amount);
+
+    crate::utils::poll_until(
+        WITHDRAWAL_TIMEOUT,
+        std::time::Duration::from_millis(200),
+        "WithdrawalRequested visible on zone L2",
+        || {
+            let outbox = &outbox;
+            async move {
+                let events = outbox
+                    .WithdrawalRequested_filter()
+                    .from_block(0)
+                    .query()
+                    .await?;
+                if events
+                    .iter()
+                    .any(|(event, _)| event.sender == sender && expected_amount == event.amount)
+                {
+                    Ok(Some(()))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    )
+    .await
+}
+
+async fn abort_task(handle: tokio::task::JoinHandle<()>) {
+    handle.abort();
+    let _ = handle.await;
 }
 
 /// Sequencer restart after a successful batch + withdrawal cycle.
@@ -147,11 +186,19 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     l1.fund_user(account.address(), deposit_amount).await?;
     account.deposit(deposit_amount, L1_TIMEOUT, &zone).await?;
 
-    let seq_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    let zone::ZoneSequencerHandle {
+        withdrawal_handle,
+        monitor_handle,
+    } = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+
+    // Keep batch submission running, but stop L1 processing so the portal queue
+    // is guaranteed to remain pending until after the restart.
+    abort_task(withdrawal_handle).await;
 
     // Request withdrawal — wait for the batch to be submitted to L1
     let withdrawal_amount: u128 = 500_000;
     account.withdraw(withdrawal_amount).await?;
+    wait_for_withdrawal_requested(&zone, account.address(), withdrawal_amount).await?;
 
     // Wait for the batch to land on L1 (portal tail advances)
     crate::utils::poll_until(
@@ -175,13 +222,10 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     );
 
     // --- Abort sequencer BEFORE the withdrawal is processed ---
-    // Abort withdrawal processor first so it can't race to process the pending slot.
-    seq_handle.withdrawal_handle.abort();
-    seq_handle.monitor_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    abort_task(monitor_handle).await;
 
     // --- Respawn sequencer (fetch_pending_withdrawals runs during init) ---
-    let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    let seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
     // The OLD withdrawal from before the restart should be processed via
     // restored data (withdrawal processor was aborted before head advanced).
@@ -191,7 +235,16 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
         "portal head advances past first withdrawal",
         || {
             let l1 = &l1;
+            let seq_handle2 = &seq_handle2;
             async move {
+                if seq_handle2.monitor_handle.is_finished() {
+                    eyre::bail!("restarted monitor task exited before restoring the pending withdrawal");
+                }
+                if seq_handle2.withdrawal_handle.is_finished() {
+                    eyre::bail!(
+                        "restarted withdrawal processor exited before processing the pending withdrawal"
+                    );
+                }
                 let (head, _) = portal_queue_state(l1, portal_address).await?;
                 if head >= tail_before {
                     Ok(Some(head))


### PR DESCRIPTION
## Summary
- hash withdrawal queue entries with ABI parameter encoding so Rust matches Solidity `abi.encode(withdrawal, prevHash)`
- add a regression test showing why tuple-value encoding produces the wrong hash for withdrawals
- harden the restart e2e so it always leaves a real pending portal slot and fails fast if restore crashes

## Testing
- forge build
- cargo test -p zone withdrawal_ -- --nocapture
- RUST_LOG=zone::batch=info,zone::zonemonitor=info,zone::withdrawals=info,reth_tasks=error cargo nextest run --profile ci test_sequencer_restart_with_pending_withdrawal_queue --failure-output immediate-final --success-output never --retries 0