### PR TITLE
feat: contract read delegation, deployer whitelist, and multisig support

### DIFF
--- a/docs/pages/protocol/privacy/execution.md
+++ b/docs/pages/protocol/privacy/execution.md
@@ -118,7 +118,12 @@ function setWhitelistedDeployer(address deployer, bool allowed) external;
 
 **Bootstrapping a factory**: The sequencer whitelists their own EOA, deploys the factory contract via a direct deployment transaction, whitelists the factory address, and removes their own EOA. After this sequence only the factory can create new contracts.
 
-**Rationale**: Arbitrary contract deployment would allow users to deploy contracts that circumvent execution-level privacy protections — for example, a contract that calls `balanceOf` on behalf of a third party and emits the result as an event. The whitelist preserves this protection while allowing the sequencer to enable vetted factory contracts (e.g., a Safe proxy factory) whose deployed children have known, audited behavior.
+**Rationale**: While per-function access control (`balanceOf`, `allowance`) blocks direct balance reads by third-party contracts, arbitrary deployment still poses risks:
+
+1. **Gas side channels**: Standard EVM gas costs leak information. For example, a TIP-20 transfer to a new account (zero → non-zero storage) costs more than a transfer to an existing account. The zone's [fixed gas cost](#fixed-gas-constant-transfer-cost) mitigates this for the TIP-20 precompile, but user-deployed contracts with their own storage would reintroduce the same class of side channel — any storage write whose cost depends on the target's prior state reveals one bit of information per call.
+2. **No automatic privacy**: Contracts deployed on a privacy zone are not automatically private. Keeping user data confidential requires deliberate design — scoped view functions, fixed gas costs, and careful event filtering. Unrestricted deployment would create a false expectation that any contract inherits the zone's privacy properties, when in practice most contracts would leak information through public storage, events, or gas patterns.
+
+The whitelist ensures that only contracts with audited privacy behavior are deployed, and sets a clear expectation that each whitelisted contract has been reviewed for information leakage.
 
 ## Interaction with RPC
 

--- a/docs/pages/protocol/privacy/execution.md
+++ b/docs/pages/protocol/privacy/execution.md
@@ -93,11 +93,32 @@ Authorization is **operation-specific**: ZoneInbox access applies to `mint` only
 
 ## EVM restrictions
 
-### Contract creation disabled
+### Contract creation restricted
 
-Privacy zones disable the `CREATE` and `CREATE2` opcodes. The zone runs a fixed set of predeploys (system contracts and the zone token); user-deployed contracts are not supported. Any transaction or call that attempts contract creation reverts.
+Privacy zones restrict the `CREATE` and `CREATE2` opcodes to a set of **whitelisted deployer addresses**. Any `CREATE` or `CREATE2` executed by a non-whitelisted address reverts. By default the whitelist is empty — the zone launches with no user-deployable contracts, only the fixed predeploys.
 
-**Rationale**: Arbitrary contract deployment would allow users to deploy contracts that circumvent execution-level privacy protections — for example, a contract that calls `balanceOf` on behalf of a third party and emits the result as an event.
+**Whitelist management**: The sequencer manages the deployer whitelist via `ZoneConfig`:
+
+```solidity
+/// @notice Emitted when a deployer is added or removed.
+event DeployerWhitelistUpdated(address indexed deployer, bool allowed);
+
+/// @notice Returns true if the address is allowed to execute CREATE/CREATE2.
+function isWhitelistedDeployer(address deployer) external view returns (bool);
+
+/// @notice Add or remove a deployer. Callable only by the sequencer.
+function setWhitelistedDeployer(address deployer, bool allowed) external;
+```
+
+`setWhitelistedDeployer` is a sequencer-only system transaction — it reverts if `msg.sender != sequencer()`. The whitelist is stored in `ZoneConfig` contract state and checked by the EVM at opcode execution time.
+
+**EVM enforcement**: When the EVM encounters `CREATE` or `CREATE2`, it checks `ZoneConfig.isWhitelistedDeployer(executingAddress)` where `executingAddress` is the account whose code is running. If the check fails, the opcode reverts. For a direct deployment transaction (a tx with `to` = null), the executing address is the sender EOA. For a factory call, it is the factory contract. This means the same whitelist controls both EOA-initiated deployments and factory-initiated deployments.
+
+**Contracts deployed by whitelisted deployers are not themselves whitelisted** — they cannot deploy further contracts unless the sequencer explicitly adds them.
+
+**Bootstrapping a factory**: The sequencer whitelists their own EOA, deploys the factory contract via a direct deployment transaction, whitelists the factory address, and removes their own EOA. After this sequence only the factory can create new contracts.
+
+**Rationale**: Arbitrary contract deployment would allow users to deploy contracts that circumvent execution-level privacy protections — for example, a contract that calls `balanceOf` on behalf of a third party and emits the result as an event. The whitelist preserves this protection while allowing the sequencer to enable vetted factory contracts (e.g., a Safe proxy factory) whose deployed children have known, audited behavior.
 
 ## Interaction with RPC
 

--- a/docs/pages/protocol/privacy/multisig.md
+++ b/docs/pages/protocol/privacy/multisig.md
@@ -1,29 +1,46 @@
 # Deploying a Gnosis Safe on a Privacy Zone
 
-This document describes how to deploy and use a Gnosis Safe multisig wallet on a privacy zone. It covers the contracts involved, the sequencer setup steps, user-facing creation flow, and how the Safe interacts with the zone's privacy features.
+This document describes how to deploy and use a multisig wallet on a privacy zone. The zone uses a locked-down variant of Gnosis Safe ([`PrivateZoneSafe`](/specs/src/zone/PrivateZoneSafe.sol)) and a minimal factory ([`PrivateZoneSafeFactory`](/specs/src/zone/PrivateZoneSafeFactory.sol)) designed for the zone's privacy model.
 
 ## Prerequisites
 
 - The zone's [deployer whitelist](./execution#contract-creation-restricted) mechanism is active.
 - The sequencer has access to `ZoneConfig.setWhitelistedDeployer`.
-- The zone supports `DELEGATECALL` (required by Safe's minimal proxy pattern).
 - [Contract read delegation](./rpc#contract-read-delegation) is enabled on the RPC.
 
 ## Contracts
 
-A Gnosis Safe deployment requires three contracts:
+| Contract | Reference spec | Purpose | Whitelisted? |
+|----------|---------------|---------|--------------|
+| **PrivateZoneSafe** | [`PrivateZoneSafe.sol`](/specs/src/zone/PrivateZoneSafe.sol) | Singleton containing all Safe logic. Proxies delegate to it. | No |
+| **PrivateZoneSafeFactory** | [`PrivateZoneSafeFactory.sol`](/specs/src/zone/PrivateZoneSafeFactory.sol) | Deploys Safe proxies via `CREATE2` and calls `setup()`. | **Yes** |
+| **CompatibilityFallbackHandler** | (standard Gnosis Safe) | Fallback handler for EIP-1271 and other view functions. Set at factory construction. | No |
 
-| Contract | Purpose | Deploys children? |
-|----------|---------|-------------------|
-| **Safe singleton** | Master copy containing all Safe logic (`execTransaction`, `addOwnerWithThreshold`, etc.). Never called directly — used as a `DELEGATECALL` target. | No |
-| **SafeProxyFactory** | Creates new Safe instances via `CREATE2`. Each instance is a minimal proxy (EIP-1167) that delegates to the singleton. | Yes |
-| **CompatibilityFallbackHandler** | Default fallback handler for view functions (`isValidSignature`, `getMessageHash`, etc.). Set during Safe initialization. | No |
+Only the factory needs to be whitelisted as a deployer.
 
-Only the **SafeProxyFactory** needs to be whitelisted as a deployer, because it is the only contract that executes `CREATE2`. The singleton and fallback handler are passive — they are deployed once and referenced by address.
+### Differences from standard Gnosis Safe
+
+The `PrivateZoneSafe` singleton removes features that are unnecessary or dangerous on a privacy zone:
+
+| Feature | Standard Safe | PrivateZoneSafe | Reason |
+|---------|--------------|-----------------|--------|
+| Modules | `enableModule`, `execTransactionFromModule`, etc. | Removed | Modules bypass the multisig threshold and could exfiltrate data autonomously |
+| Guards | `setGuard` | Removed | Guards add arbitrary pre/post hooks that could interact with external state |
+| DELEGATECALL | `operation = 0` or `1` | `operation = 0` only | DELEGATECALL runs arbitrary code in the Safe's storage context |
+| `getStorageAt` | Reads arbitrary storage slots | Removed | Reduces on-chain attack surface for cross-contract probing |
+| `setFallbackHandler` | Changeable post-setup | Removed | Prevents post-initialization handler changes that could leak information |
+| Gas refunds | `gasPrice`, `gasToken`, `refundReceiver` | Removed | Refund logic uses variable gas; zone's fixed-fee model makes refunds unnecessary |
+| `execTransaction` | 10 parameters | 4 parameters (`to`, `value`, `data`, `signatures`) | Simplified — no operation, no refund fields |
+
+The factory is also simplified: `PrivateZoneSafeFactory` bakes in the singleton and fallback handler at construction, so `createProxy` takes only `owners`, `threshold`, and `userSalt`. A `computeAddress` view function lets users derive their Safe's address before deployment.
+
+### Public view functions
+
+The Safe's view functions (`getOwners`, `isOwner`, `getThreshold`, `nonce`) are public — any authenticated user can call them via `eth_call`. This is an accepted trade-off: `getOwners()` must be public for the RPC's [contract read delegation](./rpc#contract-read-delegation) mechanism to work, and the remaining views expose no information beyond what `getOwners()` already reveals.
 
 ## Sequencer setup
 
-The sequencer performs these steps as system transactions. Each step is a separate transaction.
+The sequencer performs these steps as system transactions.
 
 ### 1. Whitelist the sequencer EOA
 
@@ -31,13 +48,13 @@ The sequencer performs these steps as system transactions. Each step is a separa
 ZoneConfig.setWhitelistedDeployer(sequencer, true)
 ```
 
-### 2. Deploy the Safe contracts
+### 2. Deploy the contracts
 
 Three direct deployment transactions (tx with `to` = null):
 
-1. **Safe singleton** — deploy the `Safe` master copy. Record the deployed address `SINGLETON`.
-2. **CompatibilityFallbackHandler** — deploy the fallback handler. Record the address `FALLBACK_HANDLER`.
-3. **SafeProxyFactory** — deploy the proxy factory. Record the address `FACTORY`.
+1. **PrivateZoneSafe** singleton — record the deployed address `SINGLETON`.
+2. **CompatibilityFallbackHandler** — record the address `FALLBACK_HANDLER`.
+3. **PrivateZoneSafeFactory** — constructed with `(SINGLETON, FALLBACK_HANDLER)`. Record the address `FACTORY`.
 
 The sequencer can use `CREATE2` with fixed salts to make these addresses deterministic and reproducible across zones.
 
@@ -53,59 +70,42 @@ ZoneConfig.setWhitelistedDeployer(FACTORY, true)
 ZoneConfig.setWhitelistedDeployer(sequencer, false)
 ```
 
-After this step, only the factory can create new contracts. The sequencer can no longer deploy arbitrary code.
+After this step, only the factory can create new contracts.
 
 ### 5. Publish the addresses
 
-The sequencer publishes `SINGLETON`, `FACTORY`, and `FALLBACK_HANDLER` as part of the zone's public configuration so that users can construct Safe creation transactions.
+The sequencer publishes `FACTORY` as part of the zone's public configuration. The singleton and fallback handler addresses are readable from the factory (`factory.singleton()`, `factory.fallbackHandler()`).
 
 ## User flow: creating a Safe
 
-A user creates a new Safe by sending a transaction to the SafeProxyFactory. No deployer whitelist entry is needed for the user — the factory is whitelisted, and it executes the `CREATE2`.
+A user creates a new Safe by calling the factory. No deployer whitelist entry is needed for the user — the factory is whitelisted, and it executes the `CREATE2`.
 
-### 1. Prepare the initializer
+### 1. Compute the Safe address (optional)
 
-The initializer is an ABI-encoded call to `Safe.setup()`:
-
-```solidity
-bytes memory initializer = abi.encodeCall(Safe.setup, (
-    owners,           // address[] — initial owner addresses
-    threshold,        // uint256 — required signatures (k of n)
-    address(0),       // address — optional delegate call target (none)
-    "",               // bytes — optional delegate call data (none)
-    FALLBACK_HANDLER, // address — fallback handler
-    address(0),       // address — payment token (none)
-    0,                // uint256 — payment amount (none)
-    payable(address(0)) // address — payment receiver (none)
-));
-```
-
-### 2. Compute the Safe address
-
-The user can deterministically compute their Safe address before deployment:
-
-```
-address safe = keccak256(
-    0xff,
-    FACTORY,
-    salt,
-    keccak256(proxyCreationCode ++ SINGLETON)
-)
-```
-
-where `salt` is `keccak256(keccak256(initializer) ++ userSalt)` per the SafeProxyFactory implementation. The user picks `userSalt` (typically a nonce).
-
-### 3. Send the creation transaction
+The factory provides a view function for deterministic address computation:
 
 ```solidity
-SafeProxyFactory(FACTORY).createProxyWithNonce(SINGLETON, initializer, userSalt)
+address safe = factory.computeAddress(owners, threshold, userSalt);
 ```
 
-The factory calls `CREATE2` to deploy a minimal proxy pointing to `SINGLETON`, then calls `setup()` on the new proxy with the provided initializer. The Safe is now live.
+The user can fund this address before deployment if desired.
 
-### 4. Fund the Safe
+### 2. Deploy the Safe
 
-Transfer zone tokens to the computed Safe address. Since the address is deterministic, the user can fund it before or after deployment.
+```solidity
+address safe = factory.createProxy(owners, threshold, userSalt);
+```
+
+The factory:
+1. Encodes `PrivateZoneSafe.setup(owners, threshold, fallbackHandler)` as the initializer.
+2. Computes `salt = keccak256(abi.encode(keccak256(initializer), userSalt))`.
+3. Deploys a `PrivateZoneSafeProxy` via `CREATE2`.
+4. Calls `setup()` on the new proxy.
+5. Emits `ProxyCreation(proxy, singleton)`.
+
+### 3. Fund the Safe
+
+Transfer zone tokens to the Safe address.
 
 ## Using the Safe
 
@@ -121,17 +121,38 @@ Non-owners see dummy values for the Safe address, same as any other account they
 
 ### Executing transactions
 
-Safe transactions require k-of-n owner signatures. The flow is:
+The `PrivateZoneSafe` has a simplified `execTransaction` with four parameters:
 
-1. **Propose** — one owner constructs the `execTransaction` payload (target, value, data, operation, signatures).
-2. **Collect signatures** — owners sign the Safe transaction hash off-chain. Coordination happens outside the zone (e.g., via a Safe transaction service or direct messaging).
-3. **Submit** — any owner submits the fully-signed `execTransaction` call via `eth_sendRawTransaction`. The Safe contract verifies the signatures on-chain and executes the inner transaction.
+```solidity
+function execTransaction(
+    address to,
+    uint256 value,
+    bytes calldata data,
+    bytes calldata signatures
+) external returns (bool success);
+```
 
-The zone RPC does not enforce the multisig threshold — that is the Safe contract's responsibility. The RPC only controls _read_ access.
+The flow:
+
+1. **Propose** — one owner constructs the transaction payload and computes the Safe transaction hash using `getTransactionHash(to, value, data, nonce)`.
+2. **Collect signatures** — owners sign the EIP-712 hash off-chain. Signatures must be sorted by signer address in ascending order. Coordination happens outside the zone (e.g., via encrypted messaging).
+3. **Submit** — any owner submits the fully-signed `execTransaction` call via `eth_sendRawTransaction`.
+
+The contract verifies the signatures, increments the nonce, and executes the inner call. Only `CALL` operations are supported — `DELEGATECALL` is disabled.
+
+### Approving hashes on-chain
+
+As an alternative to off-chain ECDSA signatures, owners can pre-approve a transaction hash on-chain:
+
+```solidity
+safe.approveHash(txHash);
+```
+
+When constructing the signatures array, a pre-approved hash is encoded with `v = 1` and `r = ownerAddress`. This is useful when an owner cannot produce an off-chain signature (e.g., a hardware wallet integration that prefers on-chain approval).
 
 ### Owner management
 
-Owners are managed through Safe's standard functions, all executed via `execTransaction` with the required signatures:
+Owners are managed through the Safe's own functions, executed via `execTransaction` (self-call):
 
 - `addOwnerWithThreshold(address owner, uint256 threshold)`
 - `removeOwner(address prevOwner, address owner, uint256 threshold)`
@@ -140,15 +161,66 @@ Owners are managed through Safe's standard functions, all executed via `execTran
 
 When owners change, the RPC server's [cached `getOwners()` result](./rpc#contract-read-delegation) is invalidated on the next block import. Removed owners lose read access promptly.
 
-## Privacy considerations
+## Privacy analysis
 
-- **Owner set visibility**: The Safe's `getOwners()` is a view function callable by anyone through `eth_call`. However, the zone's [RPC scoping](./rpc) restricts `eth_call` — only authenticated owners (via read delegation) can call view functions on the Safe. External observers cannot enumerate the owner set.
-- **Transaction privacy**: Safe `execTransaction` calls are submitted as regular zone transactions. The zone's privacy model applies: transaction contents are visible only to the sender (the submitting owner) and the sequencer. Other owners see the _effects_ (balance changes, event logs) through their delegated read access, but not the raw transaction.
-- **Signature coordination**: Owners must exchange signatures off-chain before submission. This coordination channel is outside the zone's scope. Owners should use an encrypted channel to avoid leaking transaction intent.
-- **`ProxyCreation` events**: The SafeProxyFactory emits a `ProxyCreation(proxy, singleton)` event on deployment. The zone's [event filtering](./rpc#event-filtering) scopes events to accounts the caller is associated with. Since the Safe hasn't been set up yet when the event fires, the event is visible to the transaction sender. After setup, owners gain event access via read delegation.
+### What the RPC protects
 
-## Limitations
+- **Balance and nonce**: `eth_getBalance` and `eth_getTransactionCount` for the Safe address return real values only for owners (via read delegation). Non-owners get `0x0`.
+- **Events** (`SafeSetup`, `AddedOwner`, `RemovedOwner`, `ChangedThreshold`, `ExecutionSuccess`, `ExecutionFailure`): Scoped by the RPC's [event filtering](./rpc#event-filtering) to the Safe's owners. Non-owners do not see Safe events.
+- **Transaction receipts**: Only the submitting owner can retrieve the `execTransaction` receipt via `eth_getTransactionReceipt`.
+- **`ProxyCreation` events**: Emitted by the factory during deployment, before the Safe is initialized. Visible to the creation transaction sender. After `setup()`, owners gain event access via delegation.
 
-- **No modules or guards**: The zone does not restrict Safe modules or guards at the protocol level, but enabling them requires careful review — a module could bypass privacy protections if it interacts with external contracts. Sequencers SHOULD document which Safe configurations are supported.
-- **No contract-to-contract Safe creation**: The factory is whitelisted, but a contract calling the factory would need the factory to be reachable via a regular call. This works — the restriction is on who executes `CREATE2`, which is always the factory.
-- **Single factory**: The zone supports one SafeProxyFactory instance. If a new Safe version is released, the sequencer deploys a new singleton and factory, whitelists the new factory, and optionally removes the old one.
+### Public view functions
+
+Any authenticated user can call the Safe's view functions via `eth_call`:
+
+| Function | What it reveals |
+|----------|----------------|
+| `getOwners()` | Full owner address list |
+| `isOwner(address)` | Whether a specific address is an owner |
+| `getThreshold()` | Required number of signatures |
+| `nonce()` | Number of executed transactions |
+| `domainSeparator()` | EIP-712 domain (derived from chain ID and Safe address — no private data) |
+| `getTransactionHash(...)` | Transaction hash for given parameters (pure computation — no private data) |
+| `approvedHashes(owner, hash)` | Whether a specific owner pre-approved a specific hash |
+
+This is an accepted trade-off. `getOwners()` must be public for the RPC's contract read delegation to work. The other functions expose no information beyond what `getOwners()` reveals, with two exceptions:
+
+- **`nonce()`** reveals the Safe's total transaction count — a measure of activity. This is minor; the same information could be inferred by watching `ExecutionSuccess` events (which are RPC-scoped), but `nonce()` makes it available directly.
+- **`approvedHashes(owner, hash)`** reveals whether a specific owner pre-approved a specific hash. An attacker would need to know both the owner address (available via `getOwners()`) and the exact transaction hash (which requires knowing the transaction parameters). This is acceptable because knowing the transaction parameters already implies access to the transaction details.
+
+### What the sequencer sees
+
+The sequencer processes all transactions and has full state access:
+
+- **Owner addresses**: Via `SafeSetup`, `AddedOwner`, and `RemovedOwner` events.
+- **Signer identities**: The `signatures` field in `execTransaction` contains ECDSA signatures from which signer addresses can be recovered. The sequencer learns which specific owners signed each transaction.
+- **Transaction contents**: The inner `to`, `value`, and `data` of every Safe transaction are visible in the `execTransaction` calldata.
+
+This is consistent with the zone's general trust model — the sequencer is trusted with transaction contents.
+
+### On-chain cross-contract probing
+
+One Safe's `execTransaction` could call another Safe's view functions. The information leakage from this is limited:
+
+- `execTransaction` discards the inner call's return data. The caller observes only success/failure.
+- View functions return values without reverting, so the success signal is constant regardless of the return value.
+- No helper contracts can be deployed to relay return data (deployer whitelist prevents this).
+
+**Residual risk**: Gas measurement of the inner call could serve as a side channel (e.g., `isOwner` iterates the owner linked list, and gas cost varies by list position). This requires a coordinated multisig action and the signal is noisy. Mitigation via constant-gas view functions is possible but not required for initial deployment.
+
+### Signature coordination
+
+Owners must exchange signatures off-chain before submission. This coordination channel is outside the zone's scope. Owners SHOULD use an end-to-end encrypted channel to avoid leaking transaction intent and signer identities to third parties.
+
+## Upgrading
+
+If a new `PrivateZoneSafe` version is needed (e.g., after a protocol upgrade), the sequencer:
+
+1. Whitelists their EOA.
+2. Deploys a new singleton and factory.
+3. Whitelists the new factory.
+4. Removes their EOA from the whitelist.
+5. Optionally removes the old factory from the whitelist (existing Safes continue to work — they delegate to the old singleton, which remains deployed).
+
+Existing Safes are not affected. New Safes are created against the new singleton.

--- a/docs/pages/protocol/privacy/multisig.md
+++ b/docs/pages/protocol/privacy/multisig.md
@@ -1,0 +1,154 @@
+# Deploying a Gnosis Safe on a Privacy Zone
+
+This document describes how to deploy and use a Gnosis Safe multisig wallet on a privacy zone. It covers the contracts involved, the sequencer setup steps, user-facing creation flow, and how the Safe interacts with the zone's privacy features.
+
+## Prerequisites
+
+- The zone's [deployer whitelist](./execution#contract-creation-restricted) mechanism is active.
+- The sequencer has access to `ZoneConfig.setWhitelistedDeployer`.
+- The zone supports `DELEGATECALL` (required by Safe's minimal proxy pattern).
+- [Contract read delegation](./rpc#contract-read-delegation) is enabled on the RPC.
+
+## Contracts
+
+A Gnosis Safe deployment requires three contracts:
+
+| Contract | Purpose | Deploys children? |
+|----------|---------|-------------------|
+| **Safe singleton** | Master copy containing all Safe logic (`execTransaction`, `addOwnerWithThreshold`, etc.). Never called directly — used as a `DELEGATECALL` target. | No |
+| **SafeProxyFactory** | Creates new Safe instances via `CREATE2`. Each instance is a minimal proxy (EIP-1167) that delegates to the singleton. | Yes |
+| **CompatibilityFallbackHandler** | Default fallback handler for view functions (`isValidSignature`, `getMessageHash`, etc.). Set during Safe initialization. | No |
+
+Only the **SafeProxyFactory** needs to be whitelisted as a deployer, because it is the only contract that executes `CREATE2`. The singleton and fallback handler are passive — they are deployed once and referenced by address.
+
+## Sequencer setup
+
+The sequencer performs these steps as system transactions. Each step is a separate transaction.
+
+### 1. Whitelist the sequencer EOA
+
+```
+ZoneConfig.setWhitelistedDeployer(sequencer, true)
+```
+
+### 2. Deploy the Safe contracts
+
+Three direct deployment transactions (tx with `to` = null):
+
+1. **Safe singleton** — deploy the `Safe` master copy. Record the deployed address `SINGLETON`.
+2. **CompatibilityFallbackHandler** — deploy the fallback handler. Record the address `FALLBACK_HANDLER`.
+3. **SafeProxyFactory** — deploy the proxy factory. Record the address `FACTORY`.
+
+The sequencer can use `CREATE2` with fixed salts to make these addresses deterministic and reproducible across zones.
+
+### 3. Whitelist the factory
+
+```
+ZoneConfig.setWhitelistedDeployer(FACTORY, true)
+```
+
+### 4. Remove the sequencer EOA from the whitelist
+
+```
+ZoneConfig.setWhitelistedDeployer(sequencer, false)
+```
+
+After this step, only the factory can create new contracts. The sequencer can no longer deploy arbitrary code.
+
+### 5. Publish the addresses
+
+The sequencer publishes `SINGLETON`, `FACTORY`, and `FALLBACK_HANDLER` as part of the zone's public configuration so that users can construct Safe creation transactions.
+
+## User flow: creating a Safe
+
+A user creates a new Safe by sending a transaction to the SafeProxyFactory. No deployer whitelist entry is needed for the user — the factory is whitelisted, and it executes the `CREATE2`.
+
+### 1. Prepare the initializer
+
+The initializer is an ABI-encoded call to `Safe.setup()`:
+
+```solidity
+bytes memory initializer = abi.encodeCall(Safe.setup, (
+    owners,           // address[] — initial owner addresses
+    threshold,        // uint256 — required signatures (k of n)
+    address(0),       // address — optional delegate call target (none)
+    "",               // bytes — optional delegate call data (none)
+    FALLBACK_HANDLER, // address — fallback handler
+    address(0),       // address — payment token (none)
+    0,                // uint256 — payment amount (none)
+    payable(address(0)) // address — payment receiver (none)
+));
+```
+
+### 2. Compute the Safe address
+
+The user can deterministically compute their Safe address before deployment:
+
+```
+address safe = keccak256(
+    0xff,
+    FACTORY,
+    salt,
+    keccak256(proxyCreationCode ++ SINGLETON)
+)
+```
+
+where `salt` is `keccak256(keccak256(initializer) ++ userSalt)` per the SafeProxyFactory implementation. The user picks `userSalt` (typically a nonce).
+
+### 3. Send the creation transaction
+
+```solidity
+SafeProxyFactory(FACTORY).createProxyWithNonce(SINGLETON, initializer, userSalt)
+```
+
+The factory calls `CREATE2` to deploy a minimal proxy pointing to `SINGLETON`, then calls `setup()` on the new proxy with the provided initializer. The Safe is now live.
+
+### 4. Fund the Safe
+
+Transfer zone tokens to the computed Safe address. Since the address is deterministic, the user can fund it before or after deployment.
+
+## Using the Safe
+
+### Reading Safe state (RPC)
+
+Each Safe owner authenticates to the zone RPC with their own key. The RPC server calls `getOwners()` on the Safe (via [contract read delegation](./rpc#contract-read-delegation)) and grants read access if the caller is in the owner list. This allows owners to:
+
+- Query the Safe's token balance via `eth_getBalance`.
+- Call view functions (`getOwners()`, `getThreshold()`, `nonce()`) via `eth_call`.
+- Retrieve Safe-related events via `eth_getLogs`.
+
+Non-owners see dummy values for the Safe address, same as any other account they don't control.
+
+### Executing transactions
+
+Safe transactions require k-of-n owner signatures. The flow is:
+
+1. **Propose** — one owner constructs the `execTransaction` payload (target, value, data, operation, signatures).
+2. **Collect signatures** — owners sign the Safe transaction hash off-chain. Coordination happens outside the zone (e.g., via a Safe transaction service or direct messaging).
+3. **Submit** — any owner submits the fully-signed `execTransaction` call via `eth_sendRawTransaction`. The Safe contract verifies the signatures on-chain and executes the inner transaction.
+
+The zone RPC does not enforce the multisig threshold — that is the Safe contract's responsibility. The RPC only controls _read_ access.
+
+### Owner management
+
+Owners are managed through Safe's standard functions, all executed via `execTransaction` with the required signatures:
+
+- `addOwnerWithThreshold(address owner, uint256 threshold)`
+- `removeOwner(address prevOwner, address owner, uint256 threshold)`
+- `swapOwner(address prevOwner, address oldOwner, address newOwner)`
+- `changeThreshold(uint256 threshold)`
+
+When owners change, the RPC server's [cached `getOwners()` result](./rpc#contract-read-delegation) is invalidated on the next block import. Removed owners lose read access promptly.
+
+## Privacy considerations
+
+- **Owner set visibility**: The Safe's `getOwners()` is a view function callable by anyone through `eth_call`. However, the zone's [RPC scoping](./rpc) restricts `eth_call` — only authenticated owners (via read delegation) can call view functions on the Safe. External observers cannot enumerate the owner set.
+- **Transaction privacy**: Safe `execTransaction` calls are submitted as regular zone transactions. The zone's privacy model applies: transaction contents are visible only to the sender (the submitting owner) and the sequencer. Other owners see the _effects_ (balance changes, event logs) through their delegated read access, but not the raw transaction.
+- **Signature coordination**: Owners must exchange signatures off-chain before submission. This coordination channel is outside the zone's scope. Owners should use an encrypted channel to avoid leaking transaction intent.
+- **`ProxyCreation` events**: The SafeProxyFactory emits a `ProxyCreation(proxy, singleton)` event on deployment. The zone's [event filtering](./rpc#event-filtering) scopes events to accounts the caller is associated with. Since the Safe hasn't been set up yet when the event fires, the event is visible to the transaction sender. After setup, owners gain event access via read delegation.
+
+## Limitations
+
+- **No modules or guards**: The zone does not restrict Safe modules or guards at the protocol level, but enabling them requires careful review — a module could bypass privacy protections if it interacts with external contracts. Sequencers SHOULD document which Safe configurations are supported.
+- **No contract-to-contract Safe creation**: The factory is whitelisted, but a contract calling the factory would need the factory to be reachable via a regular call. This works — the restriction is on who executes `CREATE2`, which is always the factory.
+- **Single factory**: The zone supports one SafeProxyFactory instance. If a new Safe version is released, the sequencer deploys a new singleton and factory, whitelists the new factory, and optionally removes the old one.

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -748,6 +748,15 @@ interface IZoneConfig {
 
     /// @notice Check if a token is enabled by reading from L1 ZonePortal
     function isEnabledToken(address token) external view returns (bool);
+
+    /// @notice Emitted when a deployer is added or removed.
+    event DeployerWhitelistUpdated(address indexed deployer, bool allowed);
+
+    /// @notice Returns true if the address is allowed to execute CREATE/CREATE2.
+    function isWhitelistedDeployer(address deployer) external view returns (bool);
+
+    /// @notice Add or remove a deployer. Callable only by the sequencer.
+    function setWhitelistedDeployer(address deployer, bool allowed) external;
 }
 ```
 

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -174,10 +174,37 @@ These methods are available to any authenticated caller but filter results to on
 
 | Method | Scoping rule |
 |--------|-------------|
-| `eth_getBalance` | Returns the native balance for the authenticated account only. Queries for other accounts return `0x0`. |
-| `eth_getTransactionCount` | Returns the nonce for the authenticated account only. Queries for other accounts return `0x0`. |
-| `eth_call` | Executes the call with `from` set to the authenticated account. The [execution environment](./execution) enforces `balanceOf` access control at the EVM level, so callers can only query their own balance. Calls that attempt to read other accounts' state will revert. |
+| `eth_getBalance` | Returns the native balance for the authenticated account only, or for a [delegated contract](#contract-read-delegation). Queries for other accounts return `0x0`. |
+| `eth_getTransactionCount` | Returns the nonce for the authenticated account only, or for a [delegated contract](#contract-read-delegation). Queries for other accounts return `0x0`. |
+| `eth_call` | Executes the call with `from` set to the authenticated account. The [execution environment](./execution) enforces `balanceOf` access control at the EVM level, so callers can only query their own balance. Calls targeting a [delegated contract](#contract-read-delegation) bypass this restriction — the execution environment allows the call to read the contract's state. |
 | `eth_estimateGas` | Only allowed when `from` equals the authenticated account. TIP-20 transfers always return the [fixed 100,000 gas](./execution#fixed-gas-constant-transfer-cost). |
+
+#### Contract read delegation
+
+Contracts that implement `getOwners()` (returning `address[]`) can grant read access to their owners through the RPC. When the authenticated account is an owner of a contract, the RPC server treats that contract as an associated account for scoping purposes.
+
+**Resolution**: When a scoped method targets an address with code, the RPC server calls `getOwners()` on that address. If the call succeeds and the authenticated account is in the returned list, the caller is granted read access to the contract's state. If the call reverts or the account is not in the list, normal scoping applies (the request is denied or returns a dummy value).
+
+**Scope of access**: A delegated read grants the caller the same visibility they would have if the contract were their own account:
+
+- `eth_getBalance` for the contract address returns the contract's real balance.
+- `eth_getTransactionCount` for the contract address returns the contract's real nonce.
+- `eth_call` with `to` set to the contract address is allowed — the caller can invoke view functions on the contract (e.g., `getOwners()`, `nonce()`, `getThreshold()`).
+- `eth_getLogs` returns events where the contract address is a relevant party, following the same [event filtering rules](#event-filtering-rules) applied to the authenticated account.
+
+Delegated read access is strictly read-only. It does not allow the caller to send transactions from the contract or bypass the contract's own execution logic (e.g., multisig threshold).
+
+**Caching**: The RPC server SHOULD cache `getOwners()` results per contract address and invalidate the cache when the contract's state changes (detected via block import). The cache TTL SHOULD NOT exceed the authorization token validity window. This avoids calling `getOwners()` on every request while ensuring removed owners lose access promptly.
+
+**Use case — multisig wallets**: A Gnosis Safe deployed on the zone stores its owners in contract state and exposes them via `getOwners()`. Each Safe owner authenticates to the RPC with their own key, and the RPC server grants them read access to the Safe's balances, nonce, and configuration. To execute transactions, owners collect the required k-of-n signatures off-chain and submit a Safe `execTransaction` call via `eth_sendRawTransaction`. The multisig threshold is enforced by the Safe contract, not the RPC layer.
+
+**Interface requirement**: The contract MUST implement the following view function for read delegation to apply:
+
+```solidity
+function getOwners() external view returns (address[] memory);
+```
+
+Contracts without this function, or where the call reverts, are not eligible for read delegation. The RPC server MUST NOT attempt other ownership-checking methods as a fallback — a single standard interface avoids ambiguity and prevents probing attacks where the server tries multiple selectors on unknown contracts.
 
 #### Transaction access
 
@@ -213,8 +240,8 @@ To close this side channel, the RPC server MUST enforce a **minimum response tim
 **Implementation**: The server records the wall-clock time at the start of request processing. After computing the response, if less than 100 ms have elapsed, the server sleeps for the remainder before sending the response. This applies regardless of whether the response is populated or empty. The 100 ms floor is chosen to be comfortably above the worst-case database lookup time while remaining imperceptible to interactive users.
 
 Methods that do **not** need the speed bump include those where authorization can be checked before any data fetch:
-- `eth_getBalance` / `eth_getTransactionCount`: The server checks if the queried address matches the caller *before* reading state. Non-matching addresses return `0x0` without a lookup.
-- `eth_call` / `eth_estimateGas`: The `from` field is validated against the authenticated account before execution begins.
+- `eth_getBalance` / `eth_getTransactionCount`: The server checks if the queried address matches the caller *before* reading state. Non-matching addresses return `0x0` without a lookup. **Exception**: when the target is a contract address, the server must call `getOwners()` to check [contract read delegation](#contract-read-delegation) before it can decide — this path MUST apply the 100 ms speed bump.
+- `eth_call` / `eth_estimateGas`: The `from` field is validated against the authenticated account before execution begins. When the `to` address is a delegated contract, the `getOwners()` check adds a data-dependent path — the 100 ms speed bump MUST apply.
 - `eth_sendRawTransaction`: Sender verification happens during transaction decoding, before any state access.
 
 #### Event filtering
@@ -374,6 +401,8 @@ In addition to standard JSON-RPC error codes, the zone RPC uses:
 - **Metadata leakage**: Even with content-level privacy, connection-level metadata (IP addresses, request timing, request frequency) can leak information. Deployments SHOULD use TLS and MAY require additional transport-level privacy measures.
 - **Fixed gas and transfer receipts**: The [fixed 100,000 gas cost](./execution#fixed-gas-constant-transfer-cost) on TIP-20 transfers ensures that `gasUsed` in transaction receipts is identical for all transfers. Without this, an observer who obtains a receipt (e.g., the sender) could infer whether the recipient was a new or existing account.
 - **Block header sanitization**: Block headers returned to non-sequencer callers have `logsBloom` zeroed (see [Block responses](#block-responses)). The Bloom filter would otherwise allow probing whether a specific address had activity in a given block, defeating per-account event scoping. This applies to all code paths that return block headers: `eth_getBlockByNumber`, `eth_getBlockByHash`, and `eth_subscribe("newHeads")`. Aggregate fields like `gasUsed` are intentionally public — the zone does not hide overall activity volume, only per-account details.
+- **Contract read delegation and owner removal**: When an owner is removed from a contract (e.g., via a Safe `removeOwner` call), the cached `getOwners()` result becomes stale. The RPC server MUST invalidate the cache within one block of the state change. Until invalidation, the removed owner retains read access. Implementations SHOULD watch for state changes to known delegated contracts during block import and eagerly evict stale entries. The 100 ms speed bump applies to delegated reads to prevent probing whether a given address is an owner of a contract.
+- **Contract read delegation and malicious contracts**: A contract could implement `getOwners()` to return arbitrary addresses, granting them read access to the contract's state. This is not a privacy concern for other accounts — delegated access only reveals the contract's own state, not the state of the returned addresses. The risk is limited to the contract author granting unintended read access to their own contract.
 
 ## Implementation notes
 

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -12,7 +12,7 @@ This document specifies the RPC interface for Tempo privacy zones. The design st
 ## Non-goals
 
 - Public block explorers or permissionless indexing. The zone is a private validium; only authenticated participants and the sequencer can observe state.
-- Support for arbitrary smart contract deployment. Zones run a fixed set of predeploys; contract creation is disabled.
+- Support for arbitrary smart contract deployment. Contract creation is restricted to [whitelisted deployer addresses](./execution#contract-creation-restricted) managed by the sequencer.
 
 ## Authorization tokens
 

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -183,7 +183,7 @@ These methods are available to any authenticated caller but filter results to on
 
 Contracts that implement `getOwners()` (returning `address[]`) can grant read access to their owners through the RPC. When the authenticated account is an owner of a contract, the RPC server treats that contract as an associated account for scoping purposes.
 
-**Resolution**: When a scoped method targets an address with code, the RPC server calls `getOwners()` on that address. If the call succeeds and the authenticated account is in the returned list, the caller is granted read access to the contract's state. If the call reverts or the account is not in the list, normal scoping applies (the request is denied or returns a dummy value).
+**Resolution**: When a scoped method targets an address with code, the RPC server calls `getOwners()` on that address with a gas limit of **100,000 gas**. If the call succeeds within this budget and the authenticated account is in the returned list, the caller is granted read access to the contract's state. If the call reverts, exceeds the gas limit, or the account is not in the list, normal scoping applies (the request is denied or returns a dummy value). The gas cap prevents malicious contracts from consuming unbounded RPC resources via expensive `getOwners()` implementations.
 
 **Scope of access**: A delegated read grants the caller the same visibility they would have if the contract were their own account:
 
@@ -204,7 +204,7 @@ Delegated read access is strictly read-only. It does not allow the caller to sen
 function getOwners() external view returns (address[] memory);
 ```
 
-Contracts without this function, or where the call reverts, are not eligible for read delegation. The RPC server MUST NOT attempt other ownership-checking methods as a fallback — a single standard interface avoids ambiguity and prevents probing attacks where the server tries multiple selectors on unknown contracts.
+Contracts without this function, or where the call reverts or exceeds 100,000 gas, are not eligible for read delegation. The gas cap is sufficient for Safes with up to ~50 owners; contracts that exceed it are silently treated as non-delegated. The RPC server MUST NOT attempt other ownership-checking methods as a fallback — a single standard interface avoids ambiguity and prevents probing attacks where the server tries multiple selectors on unknown contracts.
 
 #### Transaction access
 

--- a/docs/specs/src/zone/PrivateZoneSafe.sol
+++ b/docs/specs/src/zone/PrivateZoneSafe.sol
@@ -44,7 +44,9 @@ contract PrivateZoneSafe {
                                 EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address fallbackHandler);
+    event SafeSetup(
+        address indexed initiator, address[] owners, uint256 threshold, address fallbackHandler
+    );
     event ExecutionSuccess(bytes32 indexed txHash);
     event ExecutionFailure(bytes32 indexed txHash);
     event AddedOwner(address indexed owner);
@@ -101,14 +103,22 @@ contract PrivateZoneSafe {
     /// @param _owners Initial owner addresses. Must be non-zero, non-sentinel, and unique.
     /// @param _threshold Number of required confirmations. Must be >= 1 and <= owners.length.
     /// @param _fallbackHandler Address of the fallback handler for view function delegation.
-    function setup(address[] calldata _owners, uint256 _threshold, address _fallbackHandler) external {
+    function setup(
+        address[] calldata _owners,
+        uint256 _threshold,
+        address _fallbackHandler
+    )
+        external
+    {
         if (initialized) revert AlreadyInitialized();
         if (_threshold == 0 || _threshold > _owners.length) revert InvalidThreshold();
 
         address current = SENTINEL;
         for (uint256 i = _owners.length; i > 0; i--) {
             address owner = _owners[i - 1];
-            if (owner == address(0) || owner == SENTINEL || owner == address(this)) revert InvalidOwner();
+            if (owner == address(0) || owner == SENTINEL || owner == address(this)) {
+                revert InvalidOwner();
+            }
             if (owners[owner] != address(0)) revert DuplicateOwner();
             owners[owner] = current;
             current = owner;
@@ -139,12 +149,15 @@ contract PrivateZoneSafe {
         uint256 value,
         bytes calldata data,
         bytes calldata signatures
-    ) external returns (bool success) {
+    )
+        external
+        returns (bool success)
+    {
         bytes32 txHash = getTransactionHash(to, value, data, nonce);
         _checkSignatures(txHash, signatures);
         nonce++;
 
-        (success,) = to.call{value: value}(data);
+        (success,) = to.call{ value: value }(data);
 
         if (success) {
             emit ExecutionSuccess(txHash);
@@ -192,7 +205,10 @@ contract PrivateZoneSafe {
         }
     }
 
-    function _splitSignature(bytes calldata signatures, uint256 index)
+    function _splitSignature(
+        bytes calldata signatures,
+        uint256 index
+    )
         internal
         pure
         returns (uint8 v, bytes32 r, bytes32 s)
@@ -211,7 +227,9 @@ contract PrivateZoneSafe {
     /// @dev Must be called via execTransaction (self-call).
     function addOwnerWithThreshold(address owner, uint256 _threshold) external {
         _requireSelfCall();
-        if (owner == address(0) || owner == SENTINEL || owner == address(this)) revert InvalidOwner();
+        if (owner == address(0) || owner == SENTINEL || owner == address(this)) {
+            revert InvalidOwner();
+        }
         if (owners[owner] != address(0)) revert DuplicateOwner();
 
         owners[owner] = owners[SENTINEL];
@@ -246,7 +264,9 @@ contract PrivateZoneSafe {
     /// @dev Must be called via execTransaction (self-call).
     function swapOwner(address prevOwner, address oldOwner, address newOwner) external {
         _requireSelfCall();
-        if (newOwner == address(0) || newOwner == SENTINEL || newOwner == address(this)) revert InvalidOwner();
+        if (newOwner == address(0) || newOwner == SENTINEL || newOwner == address(this)) {
+            revert InvalidOwner();
+        }
         if (owners[newOwner] != address(0)) revert DuplicateOwner();
         if (owners[prevOwner] != oldOwner) revert InvalidOwner();
         if (oldOwner == SENTINEL) revert InvalidOwner();
@@ -298,7 +318,12 @@ contract PrivateZoneSafe {
     }
 
     /// @notice Compute the EIP-712 transaction hash for signing.
-    function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 _nonce)
+    function getTransactionHash(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint256 _nonce
+    )
         public
         view
         returns (bytes32)
@@ -334,5 +359,6 @@ contract PrivateZoneSafe {
         }
     }
 
-    receive() external payable {}
+    receive() external payable { }
+
 }

--- a/docs/specs/src/zone/PrivateZoneSafe.sol
+++ b/docs/specs/src/zone/PrivateZoneSafe.sol
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/**
+ * @title PrivateZoneSafe
+ * @notice Locked-down Gnosis Safe singleton for privacy zones.
+ *
+ * @dev This is a reference specification, not a production implementation. It documents the
+ * subset of Gnosis Safe functionality that is safe to deploy on a privacy zone.
+ *
+ * Removed from standard Safe:
+ *
+ *   - **Modules**: enableModule, disableModule, execTransactionFromModule, getModules,
+ *     isModuleEnabled. Modules can bypass the multisig threshold and execute transactions
+ *     autonomously, which expands the attack surface on a privacy zone.
+ *
+ *   - **Guards**: setGuard. Transaction guards add arbitrary pre/post-execution hooks that
+ *     could interact with external state in ways that leak information.
+ *
+ *   - **DELEGATECALL operation**: execTransaction only supports operation=0 (CALL).
+ *     DELEGATECALL runs arbitrary code in the Safe's storage context, which on a privacy
+ *     zone could be used to read state that should be scoped to the Safe's owners.
+ *
+ *   - **getStorageAt**: The standard Safe exposes a function to read arbitrary storage slots.
+ *     This is removed to reduce the on-chain attack surface. Owners can still read Safe state
+ *     via the dedicated view functions.
+ *
+ *   - **setFallbackHandler**: The fallback handler is set once during setup and cannot be
+ *     changed. This prevents post-initialization changes that could introduce view functions
+ *     with unintended information leakage.
+ *
+ *   - **Refund mechanism**: execTransaction's gas refund parameters (gasPrice, gasToken,
+ *     refundReceiver) are removed. Refund logic uses variable gas that could create side
+ *     channels, and the zone's fixed-fee model makes refunds unnecessary.
+ *
+ * View functions (getOwners, isOwner, getThreshold, nonce) remain public. On a privacy zone
+ * any authenticated user can call these via eth_call. This is an accepted trade-off:
+ * getOwners() must be public for the RPC's contract read delegation to work, and the other
+ * views expose no information beyond what getOwners() already reveals.
+ */
+contract PrivateZoneSafe {
+
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address fallbackHandler);
+    event ExecutionSuccess(bytes32 indexed txHash);
+    event ExecutionFailure(bytes32 indexed txHash);
+    event AddedOwner(address indexed owner);
+    event RemovedOwner(address indexed owner);
+    event ChangedThreshold(uint256 threshold);
+
+    /*//////////////////////////////////////////////////////////////
+                                ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error AlreadyInitialized();
+    error InvalidThreshold();
+    error InvalidOwner();
+    error DuplicateOwner();
+    error OwnerCountBelowThreshold();
+    error InvalidSignature();
+    error NotEnoughSignatures();
+    error HashAlreadyApproved();
+    error NotOwner();
+    error CallFailed();
+
+    /*//////////////////////////////////////////////////////////////
+                               CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    address internal constant SENTINEL = address(0x1);
+    bytes32 internal constant DOMAIN_SEPARATOR_TYPEHASH =
+        keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
+    bytes32 internal constant SAFE_TX_TYPEHASH =
+        keccak256("SafeTx(address to,uint256 value,bytes data,uint256 nonce)");
+
+    /*//////////////////////////////////////////////////////////////
+                                STATE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Linked list of owners: mapping(current => next). SENTINEL is the head.
+    mapping(address => address) internal owners;
+    uint256 public ownerCount;
+    uint256 public threshold;
+    uint256 public nonce;
+
+    /// @dev Pre-approved hashes per owner: mapping(owner => mapping(hash => approved)).
+    mapping(address => mapping(bytes32 => bool)) public approvedHashes;
+
+    address public fallbackHandler;
+    bool internal initialized;
+
+    /*//////////////////////////////////////////////////////////////
+                             INITIALIZATION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Initialize the Safe with owners, threshold, and fallback handler.
+    /// @dev Can only be called once. The proxy factory calls this immediately after CREATE2.
+    /// @param _owners Initial owner addresses. Must be non-zero, non-sentinel, and unique.
+    /// @param _threshold Number of required confirmations. Must be >= 1 and <= owners.length.
+    /// @param _fallbackHandler Address of the fallback handler for view function delegation.
+    function setup(address[] calldata _owners, uint256 _threshold, address _fallbackHandler) external {
+        if (initialized) revert AlreadyInitialized();
+        if (_threshold == 0 || _threshold > _owners.length) revert InvalidThreshold();
+
+        address current = SENTINEL;
+        for (uint256 i = _owners.length; i > 0; i--) {
+            address owner = _owners[i - 1];
+            if (owner == address(0) || owner == SENTINEL || owner == address(this)) revert InvalidOwner();
+            if (owners[owner] != address(0)) revert DuplicateOwner();
+            owners[owner] = current;
+            current = owner;
+        }
+        owners[SENTINEL] = current;
+
+        ownerCount = _owners.length;
+        threshold = _threshold;
+        fallbackHandler = _fallbackHandler;
+        initialized = true;
+
+        emit SafeSetup(msg.sender, _owners, _threshold, _fallbackHandler);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          TRANSACTION EXECUTION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Execute a transaction confirmed by the required number of owners.
+    /// @dev Only CALL operations are supported. DELEGATECALL is disabled on privacy zones.
+    /// @param to Destination address.
+    /// @param value Ether value to send.
+    /// @param data Calldata for the inner transaction.
+    /// @param signatures Concatenated ECDSA signatures (65 bytes each) or pre-approved hash markers.
+    /// @return success True if the inner call succeeded.
+    function execTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        bytes calldata signatures
+    ) external returns (bool success) {
+        bytes32 txHash = getTransactionHash(to, value, data, nonce);
+        _checkSignatures(txHash, signatures);
+        nonce++;
+
+        (success,) = to.call{value: value}(data);
+
+        if (success) {
+            emit ExecutionSuccess(txHash);
+        } else {
+            emit ExecutionFailure(txHash);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         SIGNATURE VERIFICATION
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Pre-approve a transaction hash. Used for on-chain confirmations.
+    /// @param hashToApprove The Safe transaction hash to approve.
+    function approveHash(bytes32 hashToApprove) external {
+        if (!isOwner(msg.sender)) revert NotOwner();
+        if (approvedHashes[msg.sender][hashToApprove]) revert HashAlreadyApproved();
+        approvedHashes[msg.sender][hashToApprove] = true;
+    }
+
+    /// @dev Verify that the required number of owners have signed the transaction hash.
+    ///      Supports two signature types per the standard Safe encoding:
+    ///        - ECDSA (v ∈ {27, 28}): recover signer from (r, s, v).
+    ///        - Pre-approved hash (v == 1): r is the owner address, verified against approvedHashes.
+    ///      Signers must be provided in ascending address order (prevents duplicates).
+    function _checkSignatures(bytes32 txHash, bytes calldata signatures) internal view {
+        uint256 requiredSignatures = threshold;
+        if (signatures.length < requiredSignatures * 65) revert NotEnoughSignatures();
+
+        address lastOwner = address(0);
+        for (uint256 i = 0; i < requiredSignatures; i++) {
+            (uint8 v, bytes32 r, bytes32 s) = _splitSignature(signatures, i);
+
+            address signer;
+            if (v == 1) {
+                signer = address(uint160(uint256(r)));
+                if (!approvedHashes[signer][txHash]) revert InvalidSignature();
+            } else {
+                signer = ecrecover(txHash, v, r, s);
+            }
+
+            if (signer == address(0) || !isOwner(signer)) revert InvalidSignature();
+            if (signer <= lastOwner) revert InvalidSignature();
+            lastOwner = signer;
+        }
+    }
+
+    function _splitSignature(bytes calldata signatures, uint256 index)
+        internal
+        pure
+        returns (uint8 v, bytes32 r, bytes32 s)
+    {
+        uint256 offset = index * 65;
+        r = bytes32(signatures[offset:offset + 32]);
+        s = bytes32(signatures[offset + 32:offset + 64]);
+        v = uint8(signatures[offset + 64]);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          OWNER MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Add a new owner and update the threshold.
+    /// @dev Must be called via execTransaction (self-call).
+    function addOwnerWithThreshold(address owner, uint256 _threshold) external {
+        _requireSelfCall();
+        if (owner == address(0) || owner == SENTINEL || owner == address(this)) revert InvalidOwner();
+        if (owners[owner] != address(0)) revert DuplicateOwner();
+
+        owners[owner] = owners[SENTINEL];
+        owners[SENTINEL] = owner;
+        ownerCount++;
+
+        emit AddedOwner(owner);
+
+        if (threshold != _threshold) _changeThreshold(_threshold);
+    }
+
+    /// @notice Remove an owner and update the threshold.
+    /// @dev Must be called via execTransaction (self-call).
+    /// @param prevOwner The owner that points to the owner to be removed in the linked list.
+    /// @param owner The owner to remove.
+    /// @param _threshold New threshold after removal.
+    function removeOwner(address prevOwner, address owner, uint256 _threshold) external {
+        _requireSelfCall();
+        if (owners[prevOwner] != owner) revert InvalidOwner();
+        if (owner == SENTINEL) revert InvalidOwner();
+
+        owners[prevOwner] = owners[owner];
+        owners[owner] = address(0);
+        ownerCount--;
+
+        emit RemovedOwner(owner);
+
+        if (threshold != _threshold) _changeThreshold(_threshold);
+    }
+
+    /// @notice Replace an owner with a new address.
+    /// @dev Must be called via execTransaction (self-call).
+    function swapOwner(address prevOwner, address oldOwner, address newOwner) external {
+        _requireSelfCall();
+        if (newOwner == address(0) || newOwner == SENTINEL || newOwner == address(this)) revert InvalidOwner();
+        if (owners[newOwner] != address(0)) revert DuplicateOwner();
+        if (owners[prevOwner] != oldOwner) revert InvalidOwner();
+        if (oldOwner == SENTINEL) revert InvalidOwner();
+
+        owners[newOwner] = owners[oldOwner];
+        owners[prevOwner] = newOwner;
+        owners[oldOwner] = address(0);
+
+        emit RemovedOwner(oldOwner);
+        emit AddedOwner(newOwner);
+    }
+
+    /// @notice Change the required number of confirmations.
+    /// @dev Must be called via execTransaction (self-call).
+    function changeThreshold(uint256 _threshold) external {
+        _requireSelfCall();
+        _changeThreshold(_threshold);
+    }
+
+    function _changeThreshold(uint256 _threshold) internal {
+        if (_threshold == 0 || _threshold > ownerCount) revert InvalidThreshold();
+        threshold = _threshold;
+        emit ChangedThreshold(_threshold);
+    }
+
+    function _requireSelfCall() internal view {
+        if (msg.sender != address(this)) revert CallFailed();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Returns the list of Safe owners.
+    /// @dev Public — required by the zone RPC's contract read delegation mechanism.
+    function getOwners() external view returns (address[] memory) {
+        address[] memory result = new address[](ownerCount);
+        address current = owners[SENTINEL];
+        for (uint256 i = 0; i < ownerCount; i++) {
+            result[i] = current;
+            current = owners[current];
+        }
+        return result;
+    }
+
+    /// @notice Check if an address is a Safe owner.
+    function isOwner(address owner) public view returns (bool) {
+        return owner != SENTINEL && owners[owner] != address(0);
+    }
+
+    /// @notice Compute the EIP-712 transaction hash for signing.
+    function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 _nonce)
+        public
+        view
+        returns (bytes32)
+    {
+        bytes32 domain =
+            keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, block.chainid, address(this)));
+        bytes32 safeTxHash =
+            keccak256(abi.encode(SAFE_TX_TYPEHASH, to, value, keccak256(data), _nonce));
+        return keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), domain, safeTxHash));
+    }
+
+    /// @notice Returns the EIP-712 domain separator for this Safe.
+    function domainSeparator() external view returns (bytes32) {
+        return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, block.chainid, address(this)));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           FALLBACK / RECEIVE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Delegates view function calls to the fallback handler (e.g., EIP-1271 support).
+    fallback() external payable {
+        address handler = fallbackHandler;
+        if (handler == address(0)) return;
+
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := staticcall(gas(), handler, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    receive() external payable {}
+}

--- a/docs/specs/src/zone/PrivateZoneSafeFactory.sol
+++ b/docs/specs/src/zone/PrivateZoneSafeFactory.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { PrivateZoneSafe } from "./PrivateZoneSafe.sol";
+
+/**
+ * @title PrivateZoneSafeProxy
+ * @notice Minimal proxy (EIP-1167) that delegates all calls to the PrivateZoneSafe singleton.
+ * @dev Created by PrivateZoneSafeFactory via CREATE2. The singleton address is immutable
+ *      and encoded into the proxy bytecode at deployment time.
+ */
+contract PrivateZoneSafeProxy {
+    address internal immutable singleton;
+
+    constructor(address _singleton) {
+        singleton = _singleton;
+    }
+
+    fallback() external payable {
+        address impl = singleton;
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), impl, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    receive() external payable {}
+}
+
+/**
+ * @title PrivateZoneSafeFactory
+ * @notice Factory for deploying PrivateZoneSafe proxies via CREATE2.
+ *
+ * @dev This factory is deployed by the sequencer and whitelisted in ZoneConfig as an
+ * authorized deployer. It is the only non-system contract allowed to execute CREATE2 on
+ * the zone.
+ *
+ * The factory is intentionally minimal:
+ *   - One function: createProxy (deploys a proxy and calls setup).
+ *   - Deterministic addresses via CREATE2 with a user-chosen salt.
+ *   - No ownership, no upgrades, no admin functions.
+ *
+ * The singleton address is set at construction and cannot be changed. To deploy Safes
+ * against a new singleton (e.g., after a protocol upgrade), the sequencer deploys a new
+ * factory instance and whitelists it.
+ */
+contract PrivateZoneSafeFactory {
+
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Emitted when a new Safe proxy is created.
+    /// @param proxy Address of the newly deployed proxy.
+    /// @param singleton Address of the singleton the proxy delegates to.
+    event ProxyCreation(address indexed proxy, address indexed singleton);
+
+    /*//////////////////////////////////////////////////////////////
+                                ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error ProxyCreationFailed();
+    error SetupFailed();
+
+    /*//////////////////////////////////////////////////////////////
+                               IMMUTABLES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice The PrivateZoneSafe singleton all proxies delegate to.
+    address public immutable singleton;
+
+    /// @notice The fallback handler set during Safe setup.
+    address public immutable fallbackHandler;
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    /// @param _singleton Address of the deployed PrivateZoneSafe master copy.
+    /// @param _fallbackHandler Address of the compatibility fallback handler.
+    constructor(address _singleton, address _fallbackHandler) {
+        singleton = _singleton;
+        fallbackHandler = _fallbackHandler;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           PROXY DEPLOYMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Deploy a new Safe proxy and initialize it.
+    /// @dev The proxy address is deterministic: it depends on the singleton address,
+    ///      the initializer (derived from owners + threshold), and the salt.
+    ///
+    ///      Users can compute the address before deployment:
+    ///        salt = keccak256(abi.encode(keccak256(initializer), userSalt))
+    ///        address = CREATE2(factory, salt, keccak256(creationCode))
+    ///
+    /// @param owners Initial owner addresses for the Safe.
+    /// @param _threshold Number of required signatures.
+    /// @param userSalt User-chosen salt for address derivation.
+    /// @return proxy Address of the deployed Safe proxy.
+    function createProxy(address[] calldata owners, uint256 _threshold, bytes32 userSalt)
+        external
+        returns (address proxy)
+    {
+        bytes memory initializer =
+            abi.encodeCall(PrivateZoneSafe.setup, (owners, _threshold, fallbackHandler));
+
+        bytes32 salt = keccak256(abi.encode(keccak256(initializer), userSalt));
+        bytes memory creationCode = abi.encodePacked(type(PrivateZoneSafeProxy).creationCode, abi.encode(singleton));
+
+        assembly {
+            proxy := create2(0, add(creationCode, 0x20), mload(creationCode), salt)
+        }
+        if (proxy == address(0)) revert ProxyCreationFailed();
+
+        emit ProxyCreation(proxy, singleton);
+
+        (bool success,) = proxy.call(initializer);
+        if (!success) revert SetupFailed();
+    }
+
+    /// @notice Compute the deterministic address of a proxy before deployment.
+    /// @param owners Initial owner addresses.
+    /// @param _threshold Number of required signatures.
+    /// @param userSalt User-chosen salt.
+    /// @return predicted The address the proxy would be deployed to.
+    function computeAddress(address[] calldata owners, uint256 _threshold, bytes32 userSalt)
+        external
+        view
+        returns (address predicted)
+    {
+        bytes memory initializer =
+            abi.encodeCall(PrivateZoneSafe.setup, (owners, _threshold, fallbackHandler));
+
+        bytes32 salt = keccak256(abi.encode(keccak256(initializer), userSalt));
+        bytes32 creationCodeHash =
+            keccak256(abi.encodePacked(type(PrivateZoneSafeProxy).creationCode, abi.encode(singleton)));
+
+        predicted = address(
+            uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, creationCodeHash))))
+        );
+    }
+}

--- a/docs/specs/src/zone/PrivateZoneSafeFactory.sol
+++ b/docs/specs/src/zone/PrivateZoneSafeFactory.sol
@@ -10,6 +10,7 @@ import { PrivateZoneSafe } from "./PrivateZoneSafe.sol";
  *      and encoded into the proxy bytecode at deployment time.
  */
 contract PrivateZoneSafeProxy {
+
     address internal immutable singleton;
 
     constructor(address _singleton) {
@@ -28,7 +29,8 @@ contract PrivateZoneSafeProxy {
         }
     }
 
-    receive() external payable {}
+    receive() external payable { }
+
 }
 
 /**
@@ -103,7 +105,11 @@ contract PrivateZoneSafeFactory {
     /// @param _threshold Number of required signatures.
     /// @param userSalt User-chosen salt for address derivation.
     /// @return proxy Address of the deployed Safe proxy.
-    function createProxy(address[] calldata owners, uint256 _threshold, bytes32 userSalt)
+    function createProxy(
+        address[] calldata owners,
+        uint256 _threshold,
+        bytes32 userSalt
+    )
         external
         returns (address proxy)
     {
@@ -111,7 +117,8 @@ contract PrivateZoneSafeFactory {
             abi.encodeCall(PrivateZoneSafe.setup, (owners, _threshold, fallbackHandler));
 
         bytes32 salt = keccak256(abi.encode(keccak256(initializer), userSalt));
-        bytes memory creationCode = abi.encodePacked(type(PrivateZoneSafeProxy).creationCode, abi.encode(singleton));
+        bytes memory creationCode =
+            abi.encodePacked(type(PrivateZoneSafeProxy).creationCode, abi.encode(singleton));
 
         assembly {
             proxy := create2(0, add(creationCode, 0x20), mload(creationCode), salt)
@@ -129,7 +136,11 @@ contract PrivateZoneSafeFactory {
     /// @param _threshold Number of required signatures.
     /// @param userSalt User-chosen salt.
     /// @return predicted The address the proxy would be deployed to.
-    function computeAddress(address[] calldata owners, uint256 _threshold, bytes32 userSalt)
+    function computeAddress(
+        address[] calldata owners,
+        uint256 _threshold,
+        bytes32 userSalt
+    )
         external
         view
         returns (address predicted)
@@ -138,11 +149,17 @@ contract PrivateZoneSafeFactory {
             abi.encodeCall(PrivateZoneSafe.setup, (owners, _threshold, fallbackHandler));
 
         bytes32 salt = keccak256(abi.encode(keccak256(initializer), userSalt));
-        bytes32 creationCodeHash =
-            keccak256(abi.encodePacked(type(PrivateZoneSafeProxy).creationCode, abi.encode(singleton)));
+        bytes32 creationCodeHash = keccak256(
+            abi.encodePacked(type(PrivateZoneSafeProxy).creationCode, abi.encode(singleton))
+        );
 
         predicted = address(
-            uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, creationCodeHash))))
+            uint160(
+                uint256(
+                    keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, creationCodeHash))
+                )
+            )
         );
     }
+
 }

--- a/docs/specs/test/zone/PrivateZoneSafe.t.sol
+++ b/docs/specs/test/zone/PrivateZoneSafe.t.sol
@@ -1,0 +1,757 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { PrivateZoneSafe } from "../../src/zone/PrivateZoneSafe.sol";
+import {
+    PrivateZoneSafeFactory,
+    PrivateZoneSafeProxy
+} from "../../src/zone/PrivateZoneSafeFactory.sol";
+import { Test } from "forge-std/Test.sol";
+
+/// @title PrivateZoneSafeTest
+/// @notice Tests for the locked-down Safe singleton and factory for privacy zones
+contract PrivateZoneSafeTest is Test {
+
+    PrivateZoneSafe public singleton;
+    PrivateZoneSafeFactory public factory;
+    address public fallbackHandler;
+
+    uint256 internal ownerKey1 = 0xa1;
+    uint256 internal ownerKey2 = 0xb2;
+    uint256 internal ownerKey3 = 0xc3;
+    address internal owner1;
+    address internal owner2;
+    address internal owner3;
+    address internal nonOwner = address(0xdead);
+
+    function setUp() public {
+        owner1 = vm.addr(ownerKey1);
+        owner2 = vm.addr(ownerKey2);
+        owner3 = vm.addr(ownerKey3);
+
+        singleton = new PrivateZoneSafe();
+        fallbackHandler = address(new MockFallbackHandler());
+        factory = new PrivateZoneSafeFactory(address(singleton), fallbackHandler);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function _sortedOwners2() internal view returns (address[] memory) {
+        address[] memory owners = new address[](2);
+        if (owner1 < owner2) {
+            owners[0] = owner1;
+            owners[1] = owner2;
+        } else {
+            owners[0] = owner2;
+            owners[1] = owner1;
+        }
+        return owners;
+    }
+
+    function _sortedOwners3() internal view returns (address[] memory) {
+        address[] memory addrs = new address[](3);
+        addrs[0] = owner1;
+        addrs[1] = owner2;
+        addrs[2] = owner3;
+        // Simple sort for 3 elements
+        for (uint256 i = 0; i < 3; i++) {
+            for (uint256 j = i + 1; j < 3; j++) {
+                if (addrs[i] > addrs[j]) {
+                    (addrs[i], addrs[j]) = (addrs[j], addrs[i]);
+                }
+            }
+        }
+        return addrs;
+    }
+
+    function _deploySafe(address[] memory owners, uint256 threshold)
+        internal
+        returns (PrivateZoneSafe)
+    {
+        address proxy = factory.createProxy(owners, threshold, bytes32(0));
+        return PrivateZoneSafe(payable(proxy));
+    }
+
+    function _signTransaction(
+        PrivateZoneSafe safe,
+        uint256[] memory keys,
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal view returns (bytes memory) {
+        bytes32 txHash = safe.getTransactionHash(to, value, data, safe.nonce());
+
+        // Sort keys by derived address (ascending) for Safe signature ordering
+        for (uint256 i = 0; i < keys.length; i++) {
+            for (uint256 j = i + 1; j < keys.length; j++) {
+                if (vm.addr(keys[i]) > vm.addr(keys[j])) {
+                    (keys[i], keys[j]) = (keys[j], keys[i]);
+                }
+            }
+        }
+
+        bytes memory signatures;
+        for (uint256 i = 0; i < keys.length; i++) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(keys[i], txHash);
+            signatures = abi.encodePacked(signatures, r, s, v);
+        }
+        return signatures;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         FACTORY: DEPLOYMENT
+    //////////////////////////////////////////////////////////////*/
+
+    function test_factory_createProxy_success() public {
+        address[] memory owners = _sortedOwners2();
+        address proxy = factory.createProxy(owners, 1, bytes32(0));
+
+        assertTrue(proxy != address(0));
+        PrivateZoneSafe safe = PrivateZoneSafe(payable(proxy));
+        assertEq(safe.ownerCount(), 2);
+        assertEq(safe.threshold(), 1);
+        assertTrue(safe.isOwner(owner1));
+        assertTrue(safe.isOwner(owner2));
+    }
+
+    function test_factory_createProxy_emitsEvent() public {
+        address[] memory owners = _sortedOwners2();
+
+        vm.expectEmit(false, true, false, false);
+        emit PrivateZoneSafeFactory.ProxyCreation(address(0), address(singleton));
+        factory.createProxy(owners, 1, bytes32(0));
+    }
+
+    function test_factory_createProxy_differentSalts() public {
+        address[] memory owners = _sortedOwners2();
+        address proxy1 = factory.createProxy(owners, 1, bytes32(uint256(1)));
+        address proxy2 = factory.createProxy(owners, 1, bytes32(uint256(2)));
+
+        assertTrue(proxy1 != proxy2);
+    }
+
+    function test_factory_createProxy_sameSaltReverts() public {
+        address[] memory owners = _sortedOwners2();
+        factory.createProxy(owners, 1, bytes32(0));
+
+        vm.expectRevert(PrivateZoneSafeFactory.ProxyCreationFailed.selector);
+        factory.createProxy(owners, 1, bytes32(0));
+    }
+
+    function test_factory_computeAddress_matchesDeployment() public {
+        address[] memory owners = _sortedOwners2();
+        bytes32 salt = bytes32(uint256(42));
+
+        address predicted = factory.computeAddress(owners, 1, salt);
+        address actual = factory.createProxy(owners, 1, salt);
+
+        assertEq(predicted, actual);
+    }
+
+    function test_factory_immutables() public view {
+        assertEq(factory.singleton(), address(singleton));
+        assertEq(factory.fallbackHandler(), fallbackHandler);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         SETUP: INITIALIZATION
+    //////////////////////////////////////////////////////////////*/
+
+    function test_setup_setsOwnersAndThreshold() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 2);
+
+        assertEq(safe.ownerCount(), 3);
+        assertEq(safe.threshold(), 2);
+
+        address[] memory retrieved = safe.getOwners();
+        assertEq(retrieved.length, 3);
+
+        for (uint256 i = 0; i < owners.length; i++) {
+            assertTrue(safe.isOwner(owners[i]));
+        }
+    }
+
+    function test_setup_setsFallbackHandler() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        assertEq(safe.fallbackHandler(), fallbackHandler);
+    }
+
+    function test_setup_cannotCallTwice() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        vm.expectRevert(PrivateZoneSafe.AlreadyInitialized.selector);
+        safe.setup(owners, 1, fallbackHandler);
+    }
+
+    function test_setup_revertsZeroThreshold() public {
+        address[] memory owners = _sortedOwners2();
+
+        vm.expectRevert(PrivateZoneSafeFactory.SetupFailed.selector);
+        factory.createProxy(owners, 0, bytes32(0));
+    }
+
+    function test_setup_revertsThresholdTooHigh() public {
+        address[] memory owners = _sortedOwners2();
+
+        vm.expectRevert(PrivateZoneSafeFactory.SetupFailed.selector);
+        factory.createProxy(owners, 3, bytes32(0));
+    }
+
+    function test_setup_revertsZeroAddressOwner() public {
+        address[] memory owners = new address[](2);
+        owners[0] = address(0);
+        owners[1] = owner1;
+
+        vm.expectRevert(PrivateZoneSafeFactory.SetupFailed.selector);
+        factory.createProxy(owners, 1, bytes32(0));
+    }
+
+    function test_setup_revertsSentinelOwner() public {
+        address[] memory owners = new address[](1);
+        owners[0] = address(0x1); // SENTINEL
+
+        vm.expectRevert(PrivateZoneSafeFactory.SetupFailed.selector);
+        factory.createProxy(owners, 1, bytes32(0));
+    }
+
+    function test_setup_revertsDuplicateOwner() public {
+        address[] memory owners = new address[](2);
+        owners[0] = owner1;
+        owners[1] = owner1;
+
+        // Duplicate owners cause setup to fail inside the proxy.
+        // The factory catches this and reverts with SetupFailed.
+        // However, since owner1 appears twice, the linked list check
+        // (owners[owner] != address(0)) triggers on the second insertion
+        // only after the first has been written. Use a fresh proxy to test directly.
+        address proxy = address(new PrivateZoneSafeProxy(address(singleton)));
+        vm.expectRevert(PrivateZoneSafe.DuplicateOwner.selector);
+        PrivateZoneSafe(payable(proxy)).setup(owners, 1, fallbackHandler);
+    }
+
+    function test_setup_emitsEvent() public {
+        address[] memory owners = _sortedOwners2();
+        bytes32 salt = bytes32(uint256(99));
+        address predicted = factory.computeAddress(owners, 1, salt);
+
+        vm.expectEmit(true, false, false, true, predicted);
+        emit PrivateZoneSafe.SafeSetup(address(factory), owners, 1, fallbackHandler);
+        factory.createProxy(owners, 1, salt);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      EXEC TRANSACTION: BASIC
+    //////////////////////////////////////////////////////////////*/
+
+    function test_execTransaction_success() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+        vm.deal(address(safe), 1 ether);
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+
+        bytes memory sig = _signTransaction(safe, keys, nonOwner, 0.5 ether, "");
+        bool success = safe.execTransaction(nonOwner, 0.5 ether, "", sig);
+
+        assertTrue(success);
+        assertEq(nonOwner.balance, 0.5 ether);
+        assertEq(safe.nonce(), 1);
+    }
+
+    function test_execTransaction_incrementsNonce() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        assertEq(safe.nonce(), 0);
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+
+        bytes memory sig = _signTransaction(safe, keys, address(0), 0, "");
+        safe.execTransaction(address(0), 0, "", sig);
+
+        assertEq(safe.nonce(), 1);
+    }
+
+    function test_execTransaction_emitsSuccess() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+
+        bytes32 txHash = safe.getTransactionHash(address(0), 0, "", safe.nonce());
+        bytes memory sig = _signTransaction(safe, keys, address(0), 0, "");
+
+        vm.expectEmit(true, false, false, false);
+        emit PrivateZoneSafe.ExecutionSuccess(txHash);
+        safe.execTransaction(address(0), 0, "", sig);
+    }
+
+    function test_execTransaction_emitsFailure() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        MockReverter reverter = new MockReverter();
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+
+        bytes32 txHash =
+            safe.getTransactionHash(address(reverter), 0, abi.encodeCall(reverter.fail, ()), safe.nonce());
+        bytes memory sig =
+            _signTransaction(safe, keys, address(reverter), 0, abi.encodeCall(reverter.fail, ()));
+
+        vm.expectEmit(true, false, false, false);
+        emit PrivateZoneSafe.ExecutionFailure(txHash);
+        bool success = safe.execTransaction(
+            address(reverter), 0, abi.encodeCall(reverter.fail, ()), sig
+        );
+
+        assertFalse(success);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                   EXEC TRANSACTION: MULTISIG THRESHOLD
+    //////////////////////////////////////////////////////////////*/
+
+    function test_execTransaction_2of3() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 2);
+        vm.deal(address(safe), 1 ether);
+
+        uint256[] memory keys = new uint256[](2);
+        keys[0] = ownerKey1;
+        keys[1] = ownerKey2;
+
+        bytes memory sig = _signTransaction(safe, keys, nonOwner, 0.1 ether, "");
+        bool success = safe.execTransaction(nonOwner, 0.1 ether, "", sig);
+
+        assertTrue(success);
+        assertEq(nonOwner.balance, 0.1 ether);
+    }
+
+    function test_execTransaction_revertsWithTooFewSignatures() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 2);
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+
+        bytes memory sig = _signTransaction(safe, keys, address(0), 0, "");
+
+        vm.expectRevert(PrivateZoneSafe.NotEnoughSignatures.selector);
+        safe.execTransaction(address(0), 0, "", sig);
+    }
+
+    function test_execTransaction_revertsWithNonOwnerSignature() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        uint256 fakeKey = 0xdead;
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = fakeKey;
+
+        bytes memory sig = _signTransaction(safe, keys, address(0), 0, "");
+
+        vm.expectRevert(PrivateZoneSafe.InvalidSignature.selector);
+        safe.execTransaction(address(0), 0, "", sig);
+    }
+
+    function test_execTransaction_revertsDuplicateSignatures() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 2);
+
+        bytes32 txHash = safe.getTransactionHash(address(0), 0, "", safe.nonce());
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(ownerKey1, txHash);
+
+        // Duplicate signature
+        bytes memory sig = abi.encodePacked(r1, s1, v1, r1, s1, v1);
+
+        vm.expectRevert(PrivateZoneSafe.InvalidSignature.selector);
+        safe.execTransaction(address(0), 0, "", sig);
+    }
+
+    function test_execTransaction_revertsUnsortedSignatures() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 2);
+
+        bytes32 txHash = safe.getTransactionHash(address(0), 0, "", safe.nonce());
+
+        // Sign with two keys
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(ownerKey1, txHash);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(ownerKey2, txHash);
+
+        address signer1 = vm.addr(ownerKey1);
+        address signer2 = vm.addr(ownerKey2);
+
+        // Reverse order (descending instead of ascending)
+        bytes memory sig;
+        if (signer1 < signer2) {
+            sig = abi.encodePacked(r2, s2, v2, r1, s1, v1);
+        } else {
+            sig = abi.encodePacked(r1, s1, v1, r2, s2, v2);
+        }
+
+        vm.expectRevert(PrivateZoneSafe.InvalidSignature.selector);
+        safe.execTransaction(address(0), 0, "", sig);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                     EXEC TRANSACTION: APPROVE HASH
+    //////////////////////////////////////////////////////////////*/
+
+    function test_approveHash_allowsExecution() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes32 txHash = safe.getTransactionHash(address(0), 0, "", safe.nonce());
+
+        // owner1 approves the hash on-chain
+        vm.prank(owner1);
+        safe.approveHash(txHash);
+        assertTrue(safe.approvedHashes(owner1, txHash));
+
+        // Use v=1, r=ownerAddress encoding
+        bytes memory sig = abi.encodePacked(bytes32(uint256(uint160(owner1))), bytes32(0), uint8(1));
+
+        safe.execTransaction(address(0), 0, "", sig);
+        assertEq(safe.nonce(), 1);
+    }
+
+    function test_approveHash_revertsForNonOwner() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes32 txHash = safe.getTransactionHash(address(0), 0, "", safe.nonce());
+
+        vm.prank(nonOwner);
+        vm.expectRevert(PrivateZoneSafe.NotOwner.selector);
+        safe.approveHash(txHash);
+    }
+
+    function test_approveHash_revertsIfAlreadyApproved() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes32 txHash = safe.getTransactionHash(address(0), 0, "", safe.nonce());
+
+        vm.startPrank(owner1);
+        safe.approveHash(txHash);
+        vm.expectRevert(PrivateZoneSafe.HashAlreadyApproved.selector);
+        safe.approveHash(txHash);
+        vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        OWNER MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    function test_addOwner() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes memory addCall =
+            abi.encodeCall(safe.addOwnerWithThreshold, (owner3, 1));
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+        bytes memory sig = _signTransaction(safe, keys, address(safe), 0, addCall);
+
+        safe.execTransaction(address(safe), 0, addCall, sig);
+
+        assertTrue(safe.isOwner(owner3));
+        assertEq(safe.ownerCount(), 3);
+    }
+
+    function test_addOwner_emitsEvent() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes memory addCall =
+            abi.encodeCall(safe.addOwnerWithThreshold, (owner3, 1));
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+        bytes memory sig = _signTransaction(safe, keys, address(safe), 0, addCall);
+
+        vm.expectEmit(true, false, false, false, address(safe));
+        emit PrivateZoneSafe.AddedOwner(owner3);
+        safe.execTransaction(address(safe), 0, addCall, sig);
+    }
+
+    function test_removeOwner() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        // The linked list is: SENTINEL -> last inserted -> ... -> first inserted -> SENTINEL
+        // getOwners() traverses from SENTINEL, so getOwners()[0] is the last inserted.
+        // To remove getOwners()[0], prevOwner is SENTINEL (0x1).
+        address[] memory currentOwners = safe.getOwners();
+        address toRemove = currentOwners[0];
+
+        bytes memory removeCall =
+            abi.encodeCall(safe.removeOwner, (address(0x1), toRemove, 1));
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+        // Make sure we sign with a key that isn't being removed
+        if (vm.addr(ownerKey1) == toRemove) {
+            keys[0] = ownerKey2;
+        }
+        bytes memory sig = _signTransaction(safe, keys, address(safe), 0, removeCall);
+
+        safe.execTransaction(address(safe), 0, removeCall, sig);
+
+        assertEq(safe.ownerCount(), 2);
+        assertFalse(safe.isOwner(toRemove));
+    }
+
+    function test_swapOwner() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        address[] memory currentOwners = safe.getOwners();
+        // Swap last owner for owner3
+        address toSwap = currentOwners[currentOwners.length - 1];
+
+        bytes memory swapCall;
+        if (currentOwners.length == 1) {
+            swapCall = abi.encodeCall(safe.swapOwner, (address(0x1), toSwap, owner3));
+        } else {
+            swapCall = abi.encodeCall(
+                safe.swapOwner, (currentOwners[currentOwners.length - 2], toSwap, owner3)
+            );
+        }
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+        bytes memory sig = _signTransaction(safe, keys, address(safe), 0, swapCall);
+
+        safe.execTransaction(address(safe), 0, swapCall, sig);
+
+        assertTrue(safe.isOwner(owner3));
+        assertFalse(safe.isOwner(toSwap));
+        assertEq(safe.ownerCount(), 2);
+    }
+
+    function test_changeThreshold() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes memory call_ =
+            abi.encodeCall(safe.changeThreshold, (2));
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+        bytes memory sig = _signTransaction(safe, keys, address(safe), 0, call_);
+
+        safe.execTransaction(address(safe), 0, call_, sig);
+
+        assertEq(safe.threshold(), 2);
+    }
+
+    function test_changeThreshold_revertsIfTooHigh() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes memory call_ = abi.encodeCall(safe.changeThreshold, (3));
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+        bytes memory sig = _signTransaction(safe, keys, address(safe), 0, call_);
+
+        // Inner call fails, execTransaction returns false
+        bool success = safe.execTransaction(address(safe), 0, call_, sig);
+        assertFalse(success);
+        assertEq(safe.threshold(), 1);
+    }
+
+    function test_ownerManagement_revertsIfNotSelfCall() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        vm.prank(owner1);
+        vm.expectRevert(PrivateZoneSafe.CallFailed.selector);
+        safe.addOwnerWithThreshold(owner3, 1);
+
+        vm.prank(owner1);
+        vm.expectRevert(PrivateZoneSafe.CallFailed.selector);
+        safe.removeOwner(address(0x1), owner2, 1);
+
+        vm.prank(owner1);
+        vm.expectRevert(PrivateZoneSafe.CallFailed.selector);
+        safe.changeThreshold(2);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_getOwners_returnsAllOwners() public {
+        address[] memory owners = _sortedOwners3();
+        PrivateZoneSafe safe = _deploySafe(owners, 2);
+
+        address[] memory retrieved = safe.getOwners();
+        assertEq(retrieved.length, 3);
+
+        // All owners should be present (order may differ due to linked list)
+        for (uint256 i = 0; i < owners.length; i++) {
+            bool found = false;
+            for (uint256 j = 0; j < retrieved.length; j++) {
+                if (owners[i] == retrieved[j]) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found);
+        }
+    }
+
+    function test_isOwner_returnsTrueForOwner() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        assertTrue(safe.isOwner(owner1));
+        assertTrue(safe.isOwner(owner2));
+    }
+
+    function test_isOwner_returnsFalseForNonOwner() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        assertFalse(safe.isOwner(nonOwner));
+        assertFalse(safe.isOwner(address(0)));
+        assertFalse(safe.isOwner(address(0x1))); // SENTINEL
+    }
+
+    function test_getTransactionHash_isDeterministic() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes32 hash1 = safe.getTransactionHash(nonOwner, 1 ether, "", 0);
+        bytes32 hash2 = safe.getTransactionHash(nonOwner, 1 ether, "", 0);
+        assertEq(hash1, hash2);
+
+        // Different params produce different hashes
+        bytes32 hash3 = safe.getTransactionHash(nonOwner, 2 ether, "", 0);
+        assertTrue(hash1 != hash3);
+    }
+
+    function test_domainSeparator() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        bytes32 expected = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"),
+                block.chainid,
+                address(safe)
+            )
+        );
+        assertEq(safe.domainSeparator(), expected);
+    }
+
+    function test_viewFunctions_callableByAnyone() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        vm.startPrank(nonOwner);
+        safe.getOwners();
+        safe.isOwner(owner1);
+        safe.threshold();
+        safe.nonce();
+        safe.ownerCount();
+        safe.domainSeparator();
+        safe.getTransactionHash(address(0), 0, "", 0);
+        vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          RECEIVE ETHER
+    //////////////////////////////////////////////////////////////*/
+
+    function test_receiveEther() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        vm.deal(address(this), 1 ether);
+        (bool sent,) = address(safe).call{ value: 1 ether }("");
+        assertTrue(sent);
+        assertEq(address(safe).balance, 1 ether);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      REPLAY PROTECTION
+    //////////////////////////////////////////////////////////////*/
+
+    function test_replayProtection_nonceIncrements() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe = _deploySafe(owners, 1);
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+
+        bytes memory sig1 = _signTransaction(safe, keys, address(0), 0, "");
+        safe.execTransaction(address(0), 0, "", sig1);
+
+        // Same signature won't work again because nonce changed
+        vm.expectRevert(PrivateZoneSafe.InvalidSignature.selector);
+        safe.execTransaction(address(0), 0, "", sig1);
+    }
+
+    function test_replayProtection_crossSafe() public {
+        address[] memory owners = _sortedOwners2();
+        PrivateZoneSafe safe1 = _deploySafe(owners, 1);
+
+        owners = _sortedOwners2();
+        PrivateZoneSafe safe2 =
+            PrivateZoneSafe(payable(factory.createProxy(owners, 1, bytes32(uint256(1)))));
+
+        uint256[] memory keys = new uint256[](1);
+        keys[0] = ownerKey1;
+
+        bytes memory sig = _signTransaction(safe1, keys, address(0), 0, "");
+        safe1.execTransaction(address(0), 0, "", sig);
+
+        // Signature from safe1 cannot be replayed on safe2 (different domain separator)
+        bytes memory sig2 = _signTransaction(safe1, keys, address(0), 0, "");
+        vm.expectRevert(PrivateZoneSafe.InvalidSignature.selector);
+        safe2.execTransaction(address(0), 0, "", sig2);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                   SINGLETON: DIRECT CALL PREVENTION
+    //////////////////////////////////////////////////////////////*/
+
+    function test_singleton_cannotBeUsedDirectly() public {
+        address[] memory owners = _sortedOwners2();
+        singleton.setup(owners, 1, fallbackHandler);
+
+        // Second setup reverts
+        vm.expectRevert(PrivateZoneSafe.AlreadyInitialized.selector);
+        singleton.setup(owners, 1, fallbackHandler);
+    }
+}
+
+/*//////////////////////////////////////////////////////////////
+                         TEST HELPERS
+//////////////////////////////////////////////////////////////*/
+
+contract MockFallbackHandler {
+    function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
+        return 0x1626ba7e;
+    }
+}
+
+contract MockReverter {
+    function fail() external pure {
+        revert("always fails");
+    }
+}

--- a/docs/specs/test/zone/PrivateZoneSafe.t.sol
+++ b/docs/specs/test/zone/PrivateZoneSafe.t.sol
@@ -66,7 +66,10 @@ contract PrivateZoneSafeTest is Test {
         return addrs;
     }
 
-    function _deploySafe(address[] memory owners, uint256 threshold)
+    function _deploySafe(
+        address[] memory owners,
+        uint256 threshold
+    )
         internal
         returns (PrivateZoneSafe)
     {
@@ -80,7 +83,11 @@ contract PrivateZoneSafeTest is Test {
         address to,
         uint256 value,
         bytes memory data
-    ) internal view returns (bytes memory) {
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
         bytes32 txHash = safe.getTransactionHash(to, value, data, safe.nonce());
 
         // Sort keys by derived address (ascending) for Safe signature ordering
@@ -303,16 +310,16 @@ contract PrivateZoneSafeTest is Test {
         uint256[] memory keys = new uint256[](1);
         keys[0] = ownerKey1;
 
-        bytes32 txHash =
-            safe.getTransactionHash(address(reverter), 0, abi.encodeCall(reverter.fail, ()), safe.nonce());
+        bytes32 txHash = safe.getTransactionHash(
+            address(reverter), 0, abi.encodeCall(reverter.fail, ()), safe.nonce()
+        );
         bytes memory sig =
             _signTransaction(safe, keys, address(reverter), 0, abi.encodeCall(reverter.fail, ()));
 
         vm.expectEmit(true, false, false, false);
         emit PrivateZoneSafe.ExecutionFailure(txHash);
-        bool success = safe.execTransaction(
-            address(reverter), 0, abi.encodeCall(reverter.fail, ()), sig
-        );
+        bool success =
+            safe.execTransaction(address(reverter), 0, abi.encodeCall(reverter.fail, ()), sig);
 
         assertFalse(success);
     }
@@ -457,8 +464,7 @@ contract PrivateZoneSafeTest is Test {
         address[] memory owners = _sortedOwners2();
         PrivateZoneSafe safe = _deploySafe(owners, 1);
 
-        bytes memory addCall =
-            abi.encodeCall(safe.addOwnerWithThreshold, (owner3, 1));
+        bytes memory addCall = abi.encodeCall(safe.addOwnerWithThreshold, (owner3, 1));
 
         uint256[] memory keys = new uint256[](1);
         keys[0] = ownerKey1;
@@ -474,8 +480,7 @@ contract PrivateZoneSafeTest is Test {
         address[] memory owners = _sortedOwners2();
         PrivateZoneSafe safe = _deploySafe(owners, 1);
 
-        bytes memory addCall =
-            abi.encodeCall(safe.addOwnerWithThreshold, (owner3, 1));
+        bytes memory addCall = abi.encodeCall(safe.addOwnerWithThreshold, (owner3, 1));
 
         uint256[] memory keys = new uint256[](1);
         keys[0] = ownerKey1;
@@ -496,8 +501,7 @@ contract PrivateZoneSafeTest is Test {
         address[] memory currentOwners = safe.getOwners();
         address toRemove = currentOwners[0];
 
-        bytes memory removeCall =
-            abi.encodeCall(safe.removeOwner, (address(0x1), toRemove, 1));
+        bytes memory removeCall = abi.encodeCall(safe.removeOwner, (address(0x1), toRemove, 1));
 
         uint256[] memory keys = new uint256[](1);
         keys[0] = ownerKey1;
@@ -545,8 +549,7 @@ contract PrivateZoneSafeTest is Test {
         address[] memory owners = _sortedOwners3();
         PrivateZoneSafe safe = _deploySafe(owners, 1);
 
-        bytes memory call_ =
-            abi.encodeCall(safe.changeThreshold, (2));
+        bytes memory call_ = abi.encodeCall(safe.changeThreshold, (2));
 
         uint256[] memory keys = new uint256[](1);
         keys[0] = ownerKey1;
@@ -738,6 +741,7 @@ contract PrivateZoneSafeTest is Test {
         vm.expectRevert(PrivateZoneSafe.AlreadyInitialized.selector);
         singleton.setup(owners, 1, fallbackHandler);
     }
+
 }
 
 /*//////////////////////////////////////////////////////////////
@@ -745,13 +749,17 @@ contract PrivateZoneSafeTest is Test {
 //////////////////////////////////////////////////////////////*/
 
 contract MockFallbackHandler {
+
     function isValidSignature(bytes32, bytes calldata) external pure returns (bytes4) {
         return 0x1626ba7e;
     }
+
 }
 
 contract MockReverter {
+
     function fail() external pure {
         revert("always fails");
     }
+
 }


### PR DESCRIPTION
## Summary

Adds three interconnected features that enable multisig wallets (Gnosis Safe) on privacy zones:

- **Contract read delegation** (RPC): When the authenticated account is in a contract's `getOwners()` list, the RPC grants read access to that contract's balance, nonce, view functions, and events. Capped at 100k gas to prevent DoS.
- **Deployer whitelist** (execution): Replaces the blanket `CREATE`/`CREATE2` disable with a sequencer-managed whitelist in `ZoneConfig`. Includes bootstrap flow for deploying factories.
- **PrivateZoneSafe** (contracts + docs): Locked-down Safe singleton that removes modules, guards, DELEGATECALL, `getStorageAt`, `setFallbackHandler`, and gas refunds. Minimal factory with deterministic `CREATE2` deployment. 44 Foundry tests.
- **Multisig guide** (docs): End-to-end documentation covering sequencer setup, user creation flow, transaction execution, and privacy analysis of the Safe's view functions, events, and signature exposure.

### Files changed

| Area | Files |
|------|-------|
| RPC spec | `docs/pages/protocol/privacy/rpc.md` |
| Execution spec | `docs/pages/protocol/privacy/execution.md` |
| Zone config interface | `docs/pages/protocol/privacy/overview.md` |
| Multisig guide | `docs/pages/protocol/privacy/multisig.md` |
| Safe singleton | `docs/specs/src/zone/PrivateZoneSafe.sol` |
| Safe factory + proxy | `docs/specs/src/zone/PrivateZoneSafeFactory.sol` |
| Tests (44) | `docs/specs/test/zone/PrivateZoneSafe.t.sol` |

## Test plan

- [x] All 44 Foundry tests pass (`forge test --match-contract PrivateZoneSafeTest`)
- [ ] Review `getOwners()` gas cap (100k) for Safe compatibility with large owner sets
- [ ] Review deployer whitelist enforcement at EVM level
- [ ] Review privacy analysis: public view functions are an accepted trade-off
- [ ] Review that removed Safe features (modules, guards, DELEGATECALL) don't break expected user flows
- [ ] Verify 100ms timing speed bump covers delegated read paths