### PR TITLE
feat: limit zone IDs to uint32 and require 15M gas for zone creation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -560,7 +560,7 @@ zone-auth-token name:
     EXPIRES=$((NOW + 600))
     MAGIC="54656d706f5a6f6e655250430000000000000000000000000000000000000000"
     VERSION="00"
-    ZONE_ID_HEX=$(printf '%016x' "$ZONE_ID")
+    ZONE_ID_HEX=$(printf '%08x' "$ZONE_ID")
     CHAIN_ID_HEX=$(printf '%016x' "$CHAIN_ID")
     PORTAL_HEX=$(echo "$PORTAL" | sed 's/0x//' | tr '[:upper:]' '[:lower:]')
     ISSUED_HEX=$(printf '%016x' "$NOW")

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -104,7 +104,7 @@ struct ZoneArgs {
     /// Zone ID for the private RPC auth token validation.
     /// Must match the zone's on-chain ID from ZoneFactory.
     #[arg(long = "zone.id", env = "ZONE_ID", default_value_t = 0)]
-    pub zone_id: u64,
+    pub zone_id: u32,
 
     /// Port for the private zone RPC server (0 for OS-assigned).
     #[arg(

--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -170,7 +170,7 @@ macro_rules! define_abi {
 
                 // -- View functions --
 
-                function zoneId() external view returns (uint64);
+                function zoneId() external view returns (uint32);
                 function sequencer() external view returns (address);
                 function verifier() external view returns (address);
                 function sequencerPubkey() external view returns (bytes32);
@@ -369,7 +369,7 @@ macro_rules! define_abi {
 
             #[derive(Debug)]
             struct ZoneInfo {
-                uint64 zoneId;
+                uint32 zoneId;
                 address portal;
                 address messenger;
                 address initialToken;
@@ -395,7 +395,7 @@ macro_rules! define_abi {
                 }
                 #[derive(Debug)]
                 event ZoneCreated(
-                    uint64 indexed zoneId,
+                    uint32 indexed zoneId,
                     address indexed portal,
                     address indexed messenger,
                     address token,
@@ -405,10 +405,10 @@ macro_rules! define_abi {
                     bytes32 genesisTempoBlockHash,
                     uint64 genesisTempoBlockNumber
                 );
-                function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
+                function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
                 function verifier() external view returns (address);
-                function zones(uint64 zoneId) external view returns (ZoneInfo memory);
-                function zoneCount() external view returns (uint64);
+                function zones(uint32 zoneId) external view returns (ZoneInfo memory);
+                function zoneCount() external view returns (uint32);
                 function isZonePortal(address portal) external view returns (bool);
                 function isZoneMessenger(address messenger) external view returns (bool);
             }

--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -17,7 +17,7 @@ const TEMPO_ZONE_RPC_MAGIC: [u8; 32] = {
 
 /// Size of the fixed token fields (version + zoneId + chainId + zonePortal + issuedAt +
 /// expiresAt).
-const TOKEN_FIELDS_LEN: usize = 1 + 8 + 8 + 20 + 8 + 8; // 53 bytes
+const TOKEN_FIELDS_LEN: usize = 1 + 4 + 8 + 20 + 8 + 8; // 49 bytes
 
 /// HTTP header name for the authorization token.
 pub const X_AUTHORIZATION_TOKEN: &str = "x-authorization-token";
@@ -35,8 +35,8 @@ pub struct AuthContext {
 
 /// Parsed authorization token fields (before signature verification).
 ///
-/// The token is a hex-encoded blob: `<signature><version:1><zoneId:8><chainId:8><zonePortal:20><issuedAt:8><expiresAt:8>`.
-/// The last 53 bytes are always the fixed fields; everything before is the variable-length signature.
+/// The token is a hex-encoded blob: `<signature><version:1><zoneId:4><chainId:8><zonePortal:20><issuedAt:8><expiresAt:8>`.
+/// The last 49 bytes are always the fixed fields; everything before is the variable-length signature.
 ///
 /// See `docs/pages/protocol/privacy/rpc.md` — "Transport" and "Message" sections.
 #[derive(Debug, Clone)]
@@ -44,7 +44,7 @@ pub struct AuthorizationToken {
     /// Spec version (must be 0).
     pub version: u8,
     /// Zone ID.
-    pub zone_id: u64,
+    pub zone_id: u32,
     /// Chain ID.
     pub chain_id: u64,
     /// ZonePortal address on Tempo L1.
@@ -53,7 +53,7 @@ pub struct AuthorizationToken {
     pub issued_at: u64,
     /// Expiry timestamp (unix seconds).
     pub expires_at: u64,
-    /// The raw signature bytes (everything before the last 53 bytes).
+    /// The raw signature bytes (everything before the last 49 bytes).
     pub signature: Vec<u8>,
     /// The signing digest (keccak256 of the packed message).
     pub digest: B256,
@@ -74,11 +74,11 @@ impl AuthorizationToken {
         let signature = blob[..fields_start].to_vec();
 
         let version = fields[0];
-        let zone_id = u64::from_be_bytes(fields[1..9].try_into().unwrap());
-        let chain_id = u64::from_be_bytes(fields[9..17].try_into().unwrap());
-        let zone_portal = Address::from_slice(&fields[17..37]);
-        let issued_at = u64::from_be_bytes(fields[37..45].try_into().unwrap());
-        let expires_at = u64::from_be_bytes(fields[45..53].try_into().unwrap());
+        let zone_id = u32::from_be_bytes(fields[1..5].try_into().unwrap());
+        let chain_id = u64::from_be_bytes(fields[5..13].try_into().unwrap());
+        let zone_portal = Address::from_slice(&fields[13..33]);
+        let issued_at = u64::from_be_bytes(fields[33..41].try_into().unwrap());
+        let expires_at = u64::from_be_bytes(fields[41..49].try_into().unwrap());
 
         // Build the signing digest
         let mut msg = Vec::with_capacity(32 + TOKEN_FIELDS_LEN);
@@ -106,7 +106,7 @@ impl AuthorizationToken {
     /// Validate token fields against the server's zone configuration.
     pub fn validate(
         &self,
-        expected_zone_id: u64,
+        expected_zone_id: u32,
         expected_chain_id: u64,
         expected_portal: Address,
     ) -> Result<(), AuthError> {
@@ -144,10 +144,10 @@ impl AuthorizationToken {
 
 /// Build the unsigned token fields and their signing digest.
 ///
-/// Returns `(fields, digest)` where `fields` is the 53-byte suffix
+/// Returns `(fields, digest)` where `fields` is the 49-byte suffix
 /// and `digest` is the keccak256 hash to be signed.
 pub fn build_token_fields(
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     zone_portal: Address,
     issued_at: u64,
@@ -155,11 +155,11 @@ pub fn build_token_fields(
 ) -> ([u8; TOKEN_FIELDS_LEN], B256) {
     let mut fields = [0u8; TOKEN_FIELDS_LEN];
     fields[0] = 0; // version
-    fields[1..9].copy_from_slice(&zone_id.to_be_bytes());
-    fields[9..17].copy_from_slice(&chain_id.to_be_bytes());
-    fields[17..37].copy_from_slice(zone_portal.as_slice());
-    fields[37..45].copy_from_slice(&issued_at.to_be_bytes());
-    fields[45..53].copy_from_slice(&expires_at.to_be_bytes());
+    fields[1..5].copy_from_slice(&zone_id.to_be_bytes());
+    fields[5..13].copy_from_slice(&chain_id.to_be_bytes());
+    fields[13..33].copy_from_slice(zone_portal.as_slice());
+    fields[33..41].copy_from_slice(&issued_at.to_be_bytes());
+    fields[41..49].copy_from_slice(&expires_at.to_be_bytes());
 
     let mut msg = Vec::with_capacity(32 + TOKEN_FIELDS_LEN);
     msg.extend_from_slice(&TEMPO_ZONE_RPC_MAGIC);

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -13,7 +13,7 @@ pub struct PrivateRpcConfig {
     /// Zone L2 RPC URL used by zone-specific RPC methods that inspect L2 events.
     pub zone_rpc_url: String,
     /// The zone's numeric identifier.
-    pub zone_id: u64,
+    pub zone_id: u32,
     /// The zone's chain ID.
     pub chain_id: u64,
     /// The ZonePortal contract address on L1.

--- a/crates/rpc/src/provider.rs
+++ b/crates/rpc/src/provider.rs
@@ -30,7 +30,7 @@ pub struct ZoneProviderConfig {
     /// Signer for generating authorization tokens.
     pub signer: PrivateKeySigner,
     /// Zone identifier.
-    pub zone_id: u64,
+    pub zone_id: u32,
     /// Chain identifier.
     pub chain_id: u64,
     /// ZonePortal contract address on L1.
@@ -120,7 +120,7 @@ fn build_provider_with_token(
         .sign_hash_sync(&digest)
         .map_err(|e| eyre::eyre!("failed to sign zone auth token: {e}"))?;
 
-    // Build blob: <65-byte sig><53-byte fields>
+    // Build blob: <65-byte sig><49-byte fields>
     let mut blob = Vec::with_capacity(65 + fields.len());
     blob.extend_from_slice(&sig.r().to_be_bytes::<32>());
     blob.extend_from_slice(&sig.s().to_be_bytes::<32>());

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -322,7 +322,7 @@ mod tests {
 
     use auth_tokens::{build_token_with_signature, now_secs, sign_keychain_signature};
 
-    const ZONE_ID: u64 = 7;
+    const ZONE_ID: u32 = 7;
     const CHAIN_ID: u64 = 99;
     const PORTAL: Address = Address::repeat_byte(0x22);
 

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -163,7 +163,7 @@ impl ZoneRpcApi for MockZoneRpcApi {
 // Test context
 // ---------------------------------------------------------------------------
 
-const ZONE_ID: u64 = 1;
+const ZONE_ID: u32 = 1;
 const CHAIN_ID: u64 = 42;
 const PORTAL: Address = Address::ZERO;
 

--- a/crates/tempo-zone/tests/it/private_rpc.rs
+++ b/crates/tempo-zone/tests/it/private_rpc.rs
@@ -66,8 +66,8 @@ fn parse_token_fields() {
 
 #[test]
 fn parse_token_too_short() {
-    // 53 bytes = exactly the message length, no room for a signature
-    let blob = vec![0u8; 53];
+    // 49 bytes = exactly the message length, no room for a signature
+    let blob = vec![0u8; 49];
     assert!(AuthorizationToken::parse(&blob).is_err());
 
     // Even shorter

--- a/crates/tempo-zone/tests/it/private_rpc.rs
+++ b/crates/tempo-zone/tests/it/private_rpc.rs
@@ -19,7 +19,7 @@ use zone::rpc::{
 /// version byte when a non-zero version is requested (for negative tests).
 fn build_token_blob(
     version: u8,
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     portal: Address,
     issued_at: u64,
@@ -36,7 +36,7 @@ fn build_token_blob(
 
 fn make_test_token(
     version: u8,
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     portal: Address,
     issued_at: u64,
@@ -78,9 +78,9 @@ fn parse_token_too_short() {
 fn parse_unknown_signature_length() {
     // 50-byte signature (not 65 or 130, and first byte is not 0x02/0x03) → should error
     let mut blob = vec![0u8; 50];
-    // 53 bytes of fields
+    // 49 bytes of fields
     blob.push(0);
-    blob.extend_from_slice(&1u64.to_be_bytes());
+    blob.extend_from_slice(&1u32.to_be_bytes());
     blob.extend_from_slice(&1u64.to_be_bytes());
     blob.extend_from_slice(&[0u8; 20]);
     let now = now_secs();

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2189,7 +2189,7 @@ pub(crate) fn seed_fixture_for_zone(fixture: &L1Fixture, zone: &ZoneTestNode, se
 /// suitable for the `X-Authorization-Token` header.
 fn build_auth_token(
     signer: &alloy_signer_local::PrivateKeySigner,
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     portal: Address,
 ) -> String {
@@ -2213,7 +2213,7 @@ fn build_auth_token(
 
 fn build_auth_token_with_signature(
     signature: TempoSignature,
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     portal: Address,
 ) -> String {
@@ -2228,7 +2228,7 @@ fn build_auth_token_with_signature(
 
 fn build_p256_auth_token(
     signing_key: &P256SigningKey,
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     portal: Address,
 ) -> String {
@@ -2246,7 +2246,7 @@ fn build_p256_auth_token(
 
 fn build_webauthn_auth_token(
     signing_key: &P256SigningKey,
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     portal: Address,
     challenge_digest: Option<B256>,
@@ -2268,7 +2268,7 @@ fn build_keychain_auth_token(
     signing_key: &P256SigningKey,
     root_account: Address,
     version: u8,
-    zone_id: u64,
+    zone_id: u32,
     chain_id: u64,
     portal: Address,
 ) -> (String, Address) {
@@ -2542,7 +2542,7 @@ impl PrivateRpcTestCtx {
     pub(crate) fn build_bad_token(
         &self,
         signer: &alloy_signer_local::PrivateKeySigner,
-        zone_id: u64,
+        zone_id: u32,
         chain_id: u64,
         portal: Address,
     ) -> String {

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -328,7 +328,7 @@ interface IZoneToken {
 }
 
 struct ZoneInfo {
-    uint64 zoneId;
+    uint32 zoneId;
     address portal;
     address messenger;
     address initialToken;       // first TIP-20 enabled at creation
@@ -471,7 +471,7 @@ interface IZoneFactory {
     }
 
     event ZoneCreated(
-        uint64 indexed zoneId,
+        uint32 indexed zoneId,
         address indexed portal,
         address indexed messenger,
         address initialToken,
@@ -482,9 +482,9 @@ interface IZoneFactory {
         uint64 genesisTempoBlockNumber
     );
 
-    function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
+    function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
     function zoneCount() external view returns (uint64);
-    function zones(uint64 zoneId) external view returns (ZoneInfo memory);
+    function zones(uint32 zoneId) external view returns (ZoneInfo memory);
     function isZonePortal(address portal) external view returns (bool);
 }
 ```

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -483,7 +483,7 @@ interface IZoneFactory {
     );
 
     function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
-    function zoneCount() external view returns (uint64);
+    function zoneCount() external view returns (uint32);
     function zones(uint32 zoneId) external view returns (ZoneInfo memory);
     function isZonePortal(address portal) external view returns (bool);
 }

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -28,7 +28,7 @@ The signed message is the `keccak256` hash of the following packed encoding:
 bytes32 authorizationTokenHash = keccak256(abi.encodePacked(
     bytes32(0x54656d706f5a6f6e65525043),  // "TempoZoneRPC" magic prefix
     uint8(version),                         // spec version (currently 0)
-    uint64(zoneId),                         // zone this key is valid for
+    uint32(zoneId),                         // zone this key is valid for
     uint64(chainId),                        // zone chain ID (replay protection)
     address(zonePortal),                    // ZonePortal address on Tempo
     uint64(issuedAt),                       // unix timestamp (seconds) of issuance
@@ -137,10 +137,10 @@ Content-Type: application/json
 The `X-Authorization-Token` value is a single hex-encoded blob containing the concatenation of the signature and the authorization token fields:
 
 ```
-<signature bytes><version: 1 byte><zoneId: 8 bytes><chainId: 8 bytes><zonePortal: 20 bytes><issuedAt: 8 bytes><expiresAt: 8 bytes>
+<signature bytes><version: 1 byte><zoneId: 4 bytes><chainId: 8 bytes><zonePortal: 20 bytes><issuedAt: 8 bytes><expiresAt: 8 bytes>
 ```
 
-The authorization token fields are always exactly 53 bytes (1 + 8 + 8 + 20 + 8 + 8). To parse the blob, the RPC server reads the **last 53 bytes** as the authorization token fields, and treats everything before them as the signature. The signature is then parsed using the same detection rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types) (secp256k1 is exactly 65 bytes; P256 starts with `0x01` and is 130 bytes; WebAuthn starts with `0x02` and is variable-length; Keychain starts with `0x03` for legacy V1 or `0x04` for V2 and is variable-length). Parsing from the end avoids any ambiguity with variable-length signature types.
+The authorization token fields are always exactly 49 bytes (1 + 4 + 8 + 20 + 8 + 8). To parse the blob, the RPC server reads the **last 49 bytes** as the authorization token fields, and treats everything before them as the signature. The signature is then parsed using the same detection rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types) (secp256k1 is exactly 65 bytes; P256 starts with `0x01` and is 130 bytes; WebAuthn starts with `0x02` and is variable-length; Keychain starts with `0x03` for legacy V1 or `0x04` for V2 and is variable-length). Parsing from the end avoids any ambiguity with variable-length signature types.
 
 Requests without an authorization token receive a `401 Unauthorized` HTTP response. Requests with an expired, malformed, or unauthorized token receive `403 Forbidden`. If Keychain token verification fails because the server cannot read `AccountKeychain.getKey(...)`, the server returns `500 Internal Server Error`.
 

--- a/docs/pages/protocol/tips/tip-xxxx.mdx
+++ b/docs/pages/protocol/tips/tip-xxxx.mdx
@@ -78,7 +78,6 @@ For zone addresses (HRP `tempoz`), the zone ID is encoded in the data using Bitc
 | 0-252 | Direct value | 1 |
 | 253-65,535 | `0xFD` + 2 bytes LE | 3 |
 | 65,536-4,294,967,295 | `0xFE` + 4 bytes LE | 5 |
-| > 4,294,967,295 | `0xFF` + 8 bytes LE | 9 |
 
 For mainnet addresses (HRP `tempo`), the zone ID is omitted (0 bytes).
 

--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -15,7 +15,7 @@ interface IZoneToken {
 
 /// @notice Common types for the Zone protocol
 struct ZoneInfo {
-    uint64 zoneId;
+    uint32 zoneId;
     address portal;
     address messenger;
     address initialToken; // first TIP-20 enabled at zone creation (additional tokens enabled via enableToken)
@@ -398,7 +398,7 @@ interface IZoneFactory {
     }
 
     event ZoneCreated(
-        uint64 indexed zoneId,
+        uint32 indexed zoneId,
         address indexed portal,
         address indexed messenger,
         address initialToken,
@@ -412,13 +412,15 @@ interface IZoneFactory {
     error InvalidToken();
     error InvalidSequencer();
     error InvalidVerifier();
+    error InsufficientGas();
+    error ZoneIdOverflow();
 
     function isValidVerifier(address verifier) external view returns (bool);
     function createZone(CreateZoneParams calldata params)
         external
-        returns (uint64 zoneId, address portal);
-    function zoneCount() external view returns (uint64);
-    function zones(uint64 zoneId) external view returns (ZoneInfo memory);
+        returns (uint32 zoneId, address portal);
+    function zoneCount() external view returns (uint32);
+    function zones(uint32 zoneId) external view returns (ZoneInfo memory);
     function isZonePortal(address portal) external view returns (bool);
     function isZoneMessenger(address messenger) external view returns (bool);
 
@@ -528,7 +530,7 @@ interface IZonePortal {
     /// @notice Maximum allowed gas fee rate (1e18)
     function MAX_GAS_FEE_RATE() external view returns (uint128);
 
-    function zoneId() external view returns (uint64);
+    function zoneId() external view returns (uint32);
     function messenger() external view returns (address);
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);

--- a/docs/specs/src/zone/ZoneFactory.sol
+++ b/docs/specs/src/zone/ZoneFactory.sol
@@ -15,11 +15,15 @@ contract ZoneFactory is IZoneFactory {
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Minimum gas required for zone creation.
+    /// @dev Prevents low-cost zone spam. The caller must supply at least this much gas.
+    uint256 public constant ZONE_CREATION_GAS = 15_000_000;
+
     /// @notice Next zone ID to be assigned
     /// @dev Starts at 1, reserving zone ID 0 for potential future use (e.g., mainnet as zone 0)
-    uint64 internal _nextZoneId = 1;
+    uint32 internal _nextZoneId = 1;
 
-    mapping(uint64 => ZoneInfo) internal _zones;
+    mapping(uint32 => ZoneInfo) internal _zones;
     mapping(address => bool) internal _isZonePortal;
     mapping(address => bool) internal _isZoneMessenger;
     mapping(address => bool) internal _validVerifiers;
@@ -46,14 +50,17 @@ contract ZoneFactory is IZoneFactory {
 
     function createZone(CreateZoneParams calldata params)
         external
-        returns (uint64 zoneId, address portal)
+        returns (uint32 zoneId, address portal)
     {
         // Validate initial token is a TIP-20
         if (!TempoUtilities.isTIP20(params.initialToken)) revert InvalidToken();
         if (params.sequencer == address(0)) revert InvalidSequencer();
         if (!_validVerifiers[params.verifier]) revert InvalidVerifier();
+        if (gasleft() < ZONE_CREATION_GAS) revert InsufficientGas();
 
-        zoneId = _nextZoneId++;
+        zoneId = _nextZoneId;
+        if (zoneId == type(uint32).max) revert ZoneIdOverflow();
+        _nextZoneId = zoneId + 1;
 
         // We deploy messenger first, then portal.
         // Messenger needs portal's address at construction (immutable).
@@ -153,11 +160,11 @@ contract ZoneFactory is IZoneFactory {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Returns the number of zones created (not including reserved zone 0)
-    function zoneCount() external view returns (uint64) {
+    function zoneCount() external view returns (uint32) {
         return _nextZoneId - 1;
     }
 
-    function zones(uint64 zoneId) external view returns (ZoneInfo memory) {
+    function zones(uint32 zoneId) external view returns (ZoneInfo memory) {
         return _zones[zoneId];
     }
 

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -53,7 +53,7 @@ contract ZonePortal is IZonePortal {
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    uint64 public immutable zoneId;
+    uint32 public immutable zoneId;
     address public immutable messenger;
     address public immutable verifier;
     uint64 public immutable genesisTempoBlockNumber;
@@ -98,7 +98,7 @@ contract ZonePortal is IZonePortal {
     //////////////////////////////////////////////////////////////*/
 
     constructor(
-        uint64 _zoneId,
+        uint32 _zoneId,
         address _initialToken,
         address _messenger,
         address _sequencer,

--- a/docs/specs/test/zone/ZoneBridge.t.sol
+++ b/docs/specs/test/zone/ZoneBridge.t.sol
@@ -97,7 +97,7 @@ contract ZoneBridgeTest is BaseTest {
     //////////////////////////////////////////////////////////////*/
 
     MockWithdrawalReceiver public withdrawalReceiver;
-    uint64 public zoneId;
+    uint32 public zoneId;
 
     bytes32 constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");

--- a/docs/specs/test/zone/ZoneFactory.t.sol
+++ b/docs/specs/test/zone/ZoneFactory.t.sol
@@ -39,7 +39,7 @@ contract ZoneFactoryTest is BaseTest {
             })
         });
 
-        (uint64 zoneId, address portal) = zoneFactory.createZone(params);
+        (uint32 zoneId, address portal) = zoneFactory.createZone(params);
 
         assertEq(zoneId, 1);
         assertTrue(portal != address(0));
@@ -69,7 +69,7 @@ contract ZoneFactoryTest is BaseTest {
             })
         });
 
-        (uint64 zoneId, address portal) = zoneFactory.createZone(params);
+        (uint32 zoneId, address portal) = zoneFactory.createZone(params);
 
         ZoneInfo memory info = zoneFactory.zones(zoneId);
         address messengerAddr = info.messenger;
@@ -95,7 +95,7 @@ contract ZoneFactoryTest is BaseTest {
             })
         });
 
-        (uint64 zoneId1, address portal1) = zoneFactory.createZone(params1);
+        (uint32 zoneId1, address portal1) = zoneFactory.createZone(params1);
 
         IZoneFactory.CreateZoneParams memory params2 = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
@@ -108,7 +108,7 @@ contract ZoneFactoryTest is BaseTest {
             })
         });
 
-        (uint64 zoneId2, address portal2) = zoneFactory.createZone(params2);
+        (uint32 zoneId2, address portal2) = zoneFactory.createZone(params2);
 
         assertEq(zoneId1, 1);
         assertEq(zoneId2, 2);
@@ -137,17 +137,16 @@ contract ZoneFactoryTest is BaseTest {
 
         // Record logs and verify ZoneCreated event was emitted
         vm.recordLogs();
-        (uint64 zoneId, address portal) = zoneFactory.createZone(params);
+        (uint32 zoneId, address portal) = zoneFactory.createZone(params);
 
         // Verify logs contain ZoneCreated event with correct data
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool found = false;
         for (uint256 i = 0; i < logs.length; i++) {
-            // New event signature includes messenger: ZoneCreated(uint64,address,address,address,address,address,bytes32,bytes32,uint64)
             if (
                 logs[i].topics[0]
                     == keccak256(
-                        "ZoneCreated(uint64,address,address,address,address,address,bytes32,bytes32,uint64)"
+                        "ZoneCreated(uint32,address,address,address,address,address,bytes32,bytes32,uint64)"
                     )
             ) {
                 found = true;

--- a/docs/specs/test/zone/ZoneIntegration.t.sol
+++ b/docs/specs/test/zone/ZoneIntegration.t.sol
@@ -68,7 +68,7 @@ contract ZoneIntegrationTest is BaseTest {
 
     // Helpers
     TrackingReceiver public receiver;
-    uint64 public zoneId;
+    uint32 public zoneId;
 
     bytes32 constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -134,7 +134,7 @@ contract ZonePortalTest is BaseTest {
     GasConsumingReceiver public gasConsumingReceiver;
     SuccessfulReceiver public successfulReceiver;
 
-    uint64 public testZoneId;
+    uint32 public testZoneId;
     bytes32 public constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 public constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
     uint64 public genesisTempoBlockNumber;

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -31,7 +31,7 @@ sol! {
     #[sol(rpc)]
     contract ZoneFactory {
         event ZoneCreated(
-            uint64 indexed zoneId,
+            uint32 indexed zoneId,
             address indexed portal,
             address indexed messenger,
             address initialToken,
@@ -43,7 +43,7 @@ sol! {
         );
 
         function verifier() external view returns (address);
-        function createZone(CreateZoneParams calldata params) external returns (uint64 zoneId, address portal);
+        function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
     }
 }
 

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -47,7 +47,7 @@ impl ZoneInfoCmd {
             found.ok_or_else(|| eyre!("no zone found with portal address {portal}"))?
         } else {
             self.identifier
-                .parse::<u64>()
+                .parse::<u32>()
                 .map_err(|_| eyre!("expected a zone ID (integer) or portal address (0x...)"))?
         };
 


### PR DESCRIPTION
## Summary

- **Zone ID narrowed from `uint64` to `uint32`**: 4 billion zones is more than sufficient, and the smaller type halves storage and calldata cost for zone ID fields. Updated across Solidity contracts (`IZone`, `ZoneFactory`, `ZonePortal`), Rust ABI bindings (`abi.rs`), xtask tooling (`create_zone.rs`, `zone_info.rs`), documentation (`overview.md`), and all test files.
- **Zone creation gas floor of 15M**: `ZoneFactory.createZone` now reverts with `InsufficientGas()` if `gasleft() < 15_000_000`. This prevents low-cost zone spam by requiring callers to supply substantial gas, making bulk zone creation economically prohibitive.
- **Overflow protection**: `ZoneIdOverflow()` error added for the `uint32` boundary check.

### Files changed

| Area | Files |
|------|-------|
| Interfaces | `docs/specs/src/zone/IZone.sol` |
| Factory | `docs/specs/src/zone/ZoneFactory.sol` |
| Portal | `docs/specs/src/zone/ZonePortal.sol` |
| Rust ABI | `crates/primitives/src/abi.rs` |
| Tooling | `xtask/src/create_zone.rs`, `xtask/src/zone_info.rs` |
| Docs | `docs/pages/protocol/privacy/overview.md` |
| Tests | `docs/specs/test/zone/ZoneFactory.t.sol`, `ZonePortal.t.sol`, `ZoneIntegration.t.sol`, `ZoneBridge.t.sol` |

## Test plan

- [x] All 231 zone Solidity tests pass (`forge test --match-path "test/zone/*"`)
- [x] Rust workspace compiles clean (`cargo check`)
- [ ] Verify no downstream consumers rely on zone ID being 64 bits
- [ ] Confirm 15M gas threshold is appropriate for mainnet gas prices