### PR TITLE
chore: bump tempo to main and align reth deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
  "alloy-rlp",
  "num_enum",
  "serde",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
@@ -299,8 +299,8 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive 0.9.1",
  "serde",
  "serde_with",
  "sha2 0.10.9",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
+checksum = "3cb6ba2dafd6327f78f2b59ae539bd5c39c57a01dc76763e92942619d934a7bb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -326,6 +326,7 @@ dependencies = [
  "op-revm",
  "revm",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -482,7 +483,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap 6.1.0",
+ "dashmap",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -631,8 +632,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive 0.9.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -665,12 +666,12 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive 0.9.1",
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
@@ -1609,24 +1610,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1832,12 +1815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1885,15 +1872,6 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
@@ -1904,36 +1882,17 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform 0.1.9",
- "semver 1.0.27",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform 0.3.2",
+ "cargo-platform",
  "semver 1.0.27",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cast"
@@ -2204,9 +2163,9 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2279,7 +2238,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -2371,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -2623,31 +2582,19 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.0",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
+ "derive_more",
  "document-features",
+ "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -2854,29 +2801,18 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
+ "arbitrary",
  "cfg-if",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -3057,15 +2993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,25 +3003,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.6",
+ "redox_users",
  "winapi",
 ]
 
@@ -3340,15 +3255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "ethereum_hashing"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3388,12 +3294,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_ssz"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.14.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
 name = "ethereum_ssz_derive"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
 dependencies = [
  "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd596f91cff004fc8d02be44c21c0f9b93140a04b66027ae052f5f8e05b48eba"
+dependencies = [
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3479,6 +3412,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-cache"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41c7aa69c00ebccf06c3fa7ffe2a6cf26a58b5fe4deabfe646285ff48136a8f"
+dependencies = [
+ "equivalent",
+ "rapidhash",
+ "typeid",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -3808,7 +3752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
- "dashmap 6.1.0",
+ "dashmap",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -4799,6 +4743,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4908,7 +4863,7 @@ version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "errno",
  "libc",
 ]
@@ -4926,6 +4881,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "tikv-jemalloc-sys",
+ "zstd-sys",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4935,6 +4906,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4952,12 +4932,6 @@ dependencies = [
  "linked-hash-map",
  "serde_core",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5038,9 +5012,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 
 [[package]]
 name = "mach2"
@@ -5155,7 +5129,7 @@ dependencies = [
  "mach2 0.6.0",
  "metrics",
  "once_cell",
- "procfs 0.18.0",
+ "procfs",
  "rlimit",
  "windows 0.62.2",
 ]
@@ -5193,21 +5167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mini-moka"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-utils",
- "dashmap 5.5.3",
- "skeptic",
- "smallvec",
- "tagptr",
- "triomphe",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5237,9 +5196,9 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+checksum = "2956e537fc68236d2aa048f55704f231cc93f1c4de42fe1ecb5bd7938061fc4a"
 dependencies = [
  "modular-bitfield-impl",
  "static_assertions",
@@ -5247,13 +5206,13 @@ dependencies = [
 
 [[package]]
 name = "modular-bitfield-impl"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5560,9 +5519,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
+checksum = "a95dd0974d5e60ffe9342a70cc0033d299244fab01cb16a958eb7352ddba1fa7"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -5573,9 +5532,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
+checksum = "fadcb964b0aa645d12e952d470c7585d23286d8bcf1ac41589410b6724216b68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5593,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
+checksum = "c8ea44162d493219cc678aaca1253d46c3aa73aa361326dfa9d406f086dfa135"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -5609,9 +5568,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6753d90efbaa8ea8bcb89c1737408ca85fa60d7adb875049d3f382c063666f86"
+checksum = "83aa8dc34bdf077c8e6d48ff75beff4ac14b428d982c9722483ccd7473c0e114"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5624,9 +5583,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
+checksum = "be9d16ec9f7810e0623a37edc293d1c05fe9c58a5647f6973fdd93e0b4795015"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5643,9 +5602,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
+checksum = "2c0ac5c5ddcbffadcd097d278c717d34849bcc629f6e4f8514eb000ec862def8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5654,8 +5613,8 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-serde",
  "derive_more",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "ethereum_ssz 0.9.1",
+ "ethereum_ssz_derive 0.9.1",
  "op-alloy-consensus",
  "serde",
  "sha2 0.10.9",
@@ -5665,9 +5624,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+checksum = "57a98f3a512a7e02a1dcf1242b57302d83657b265a665d50ad98d0b158efaf2c"
 dependencies = [
  "auto_impl",
  "revm",
@@ -5767,12 +5726,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p256"
@@ -6145,7 +6098,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6181,38 +6134,15 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
-dependencies = [
- "bitflags 2.11.0",
- "chrono",
- "flate2",
- "hex",
- "procfs-core 0.17.0",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "procfs"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.11.0",
- "procfs-core 0.18.0",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
-dependencies = [
- "bitflags 2.11.0",
  "chrono",
- "hex",
+ "flate2",
+ "procfs-core",
+ "rustix",
 ]
 
 [[package]]
@@ -6222,6 +6152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags 2.11.0",
+ "chrono",
  "hex",
 ]
 
@@ -6309,17 +6240,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.11.0",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -6527,23 +6447,65 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.11.0",
- "cassowary",
  "compact_str",
- "crossterm 0.28.1",
+ "hashbrown 0.16.1",
  "indoc",
- "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.16.3",
+ "strum",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -6608,17 +6570,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6756,8 +6707,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6780,8 +6731,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6793,6 +6744,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
+ "rayon",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -6811,8 +6763,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6831,8 +6783,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6840,13 +6792,12 @@ dependencies = [
  "reth-cli-runner",
  "reth-db",
  "serde_json",
- "shellexpand",
 ]
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6854,9 +6805,10 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "backon",
+ "blake3",
  "clap",
  "comfy-table",
- "crossterm 0.28.1",
+ "crossterm",
  "eyre",
  "fdlimit",
  "futures",
@@ -6865,7 +6817,9 @@ dependencies = [
  "itertools 0.14.0",
  "lz4",
  "metrics",
+ "parking_lot",
  "ratatui",
+ "rayon",
  "reqwest 0.12.28",
  "reth-chainspec",
  "reth-cli",
@@ -6901,13 +6855,15 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune",
+ "reth-prune-types",
  "reth-revm",
  "reth-stages",
+ "reth-stages-types",
  "reth-static-file",
  "reth-static-file-types",
+ "reth-storage-api",
  "reth-tasks",
  "reth-trie",
- "reth-trie-common",
  "reth-trie-db",
  "secp256k1 0.30.0",
  "serde",
@@ -6915,7 +6871,7 @@ dependencies = [
  "tar",
  "tokio",
  "tokio-stream",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "url",
  "zstd",
@@ -6923,8 +6879,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6933,8 +6889,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6951,8 +6907,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6971,8 +6927,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6981,8 +6937,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6991,14 +6947,14 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file-types",
  "serde",
- "toml 0.8.23",
+ "toml",
  "url",
 ]
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7010,11 +6966,12 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
  "reth-primitives-traits",
@@ -7022,8 +6979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7048,8 +7005,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7057,6 +7014,7 @@ dependencies = [
  "metrics",
  "page_size",
  "parking_lot",
+ "quanta",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
@@ -7066,31 +7024,33 @@ dependencies = [
  "reth-storage-errors",
  "reth-tracing",
  "rustc-hash",
- "strum 0.27.2",
- "sysinfo 0.33.1",
+ "strum",
+ "sysinfo 0.38.4",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
  "arbitrary",
+ "arrayvec",
  "bytes",
  "derive_more",
  "metrics",
  "modular-bitfield",
+ "op-alloy-consensus",
  "parity-scale-codec",
  "proptest",
  "reth-codecs",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-stages-types",
@@ -7102,8 +7062,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7132,8 +7092,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7147,8 +7107,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7172,8 +7132,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7196,15 +7156,15 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
+ "dashmap",
  "data-encoding",
  "enr",
  "hickory-resolver",
  "linked_hash_set",
- "parking_lot",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-tokio-util",
@@ -7220,8 +7180,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7255,8 +7215,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7283,8 +7243,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7306,8 +7266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7330,31 +7290,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-engine-service"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
-dependencies = [
- "futures",
- "pin-project",
- "reth-chainspec",
- "reth-consensus",
- "reth-engine-primitives",
- "reth-engine-tree",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-network-p2p",
- "reth-node-types",
- "reth-payload-builder",
- "reth-provider",
- "reth-prune",
- "reth-stages-api",
- "reth-tasks",
-]
-
-[[package]]
 name = "reth-engine-tree"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7364,11 +7302,10 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "crossbeam-channel",
- "dashmap 6.1.0",
  "derive_more",
+ "fixed-cache",
  "futures",
  "metrics",
- "mini-moka",
  "moka",
  "parking_lot",
  "rayon",
@@ -7396,13 +7333,13 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
- "reth-trie-sparse-parallel",
  "revm",
  "revm-primitives",
  "schnellru",
- "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7410,8 +7347,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7438,23 +7375,23 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "ethereum_ssz 0.10.1",
+ "ethereum_ssz_derive 0.10.1",
  "snap",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7469,8 +7406,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7491,8 +7428,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7502,8 +7439,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7530,8 +7467,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7551,8 +7488,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -7591,8 +7528,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "clap",
  "eyre",
@@ -7607,14 +7544,15 @@ dependencies = [
  "reth-node-ethereum",
  "reth-node-metrics",
  "reth-rpc-server-types",
+ "reth-tasks",
  "reth-tracing",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7629,8 +7567,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7647,8 +7585,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7660,8 +7598,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7689,28 +7627,22 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
- "arbitrary",
- "modular-bitfield",
  "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
- "serde_with",
 ]
 
 [[package]]
 name = "reth-etl"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7719,8 +7651,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7743,16 +7675,14 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
- "parking_lot",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -7765,8 +7695,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7778,8 +7708,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7796,8 +7726,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7834,8 +7764,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7848,8 +7778,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "serde",
  "serde_json",
@@ -7858,8 +7788,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7886,8 +7816,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "bytes",
  "futures",
@@ -7906,12 +7836,13 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
- "dashmap 6.1.0",
+ "crossbeam-queue",
+ "dashmap",
  "derive_more",
  "parking_lot",
  "reth-mdbx-sys",
@@ -7922,17 +7853,17 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cc",
 ]
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "futures",
  "metrics",
@@ -7943,8 +7874,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -7952,8 +7883,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7966,8 +7897,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8023,8 +7954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8048,8 +7979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8071,8 +8002,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8086,8 +8017,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8100,8 +8031,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8117,8 +8048,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8141,8 +8072,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8169,7 +8100,6 @@ dependencies = [
  "reth-downloaders",
  "reth-engine-local",
  "reth-engine-primitives",
- "reth-engine-service",
  "reth-engine-tree",
  "reth-engine-util",
  "reth-evm",
@@ -8200,6 +8130,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -8209,8 +8140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8240,7 +8171,6 @@ dependencies = [
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
- "reth-provider",
  "reth-prune-types",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -8248,15 +8178,15 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-tracing",
  "reth-tracing-otlp",
  "reth-transaction-pool",
  "secp256k1 0.30.0",
  "serde",
- "shellexpand",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.18",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "url",
  "vergen",
@@ -8265,8 +8195,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8303,8 +8233,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8320,15 +8250,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8351,8 +8281,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "bytes",
  "eyre",
@@ -8363,7 +8293,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
- "procfs 0.17.0",
+ "procfs",
  "reqwest 0.12.28",
  "reth-metrics",
  "reth-tasks",
@@ -8375,8 +8305,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8386,24 +8316,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-optimism-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "op-alloy-consensus",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
 name = "reth-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8423,8 +8338,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8435,8 +8350,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8458,8 +8373,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8468,8 +8383,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8482,12 +8397,14 @@ dependencies = [
  "auto_impl",
  "byteorder",
  "bytes",
+ "dashmap",
  "derive_more",
  "modular-bitfield",
  "once_cell",
  "op-alloy-consensus",
  "proptest",
  "proptest-arbitrary-interop",
+ "quanta",
  "rayon",
  "reth-codecs",
  "revm-bytecode",
@@ -8501,14 +8418,13 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "dashmap 6.1.0",
  "eyre",
  "itertools 0.14.0",
  "metrics",
@@ -8524,6 +8440,7 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
+ "reth-fs-util",
  "reth-metrics",
  "reth-nippy-jar",
  "reth-node-types",
@@ -8533,19 +8450,21 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-trie",
  "reth-trie-db",
  "revm-database",
  "revm-state",
- "strum 0.27.2",
+ "rocksdb",
+ "strum",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-prune"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8563,6 +8482,7 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "reth-static-file-types",
+ "reth-storage-api",
  "reth-tokio-util",
  "rustc-hash",
  "thiserror 2.0.18",
@@ -8572,8 +8492,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8581,14 +8501,15 @@ dependencies = [
  "modular-bitfield",
  "reth-codecs",
  "serde",
- "strum 0.27.2",
+ "strum",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-revm"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8600,8 +8521,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8629,13 +8550,9 @@ dependencies = [
  "derive_more",
  "dyn-clone",
  "futures",
- "http",
- "http-body",
- "hyper",
  "itertools 0.14.0",
  "jsonrpsee",
  "jsonrpsee-types",
- "jsonwebtoken",
  "parking_lot",
  "pin-project",
  "reth-chain-state",
@@ -8664,6 +8581,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
+ "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-common",
  "revm",
@@ -8675,15 +8593,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower",
  "tracing",
  "tracing-futures",
 ]
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -8713,8 +8630,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8732,9 +8649,11 @@ dependencies = [
  "reth-metrics",
  "reth-network-api",
  "reth-node-core",
+ "reth-payload-primitives",
  "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
+ "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-layer",
@@ -8754,8 +8673,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8767,7 +8686,6 @@ dependencies = [
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
  "thiserror 2.0.18",
@@ -8775,11 +8693,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "async-trait",
  "jsonrpsee-core",
@@ -8805,8 +8724,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8849,8 +8768,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,8 +8816,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8911,8 +8830,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8922,13 +8841,13 @@ dependencies = [
  "reth-errors",
  "reth-network-api",
  "serde",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
 name = "reth-stages"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8938,6 +8857,7 @@ dependencies = [
  "futures-util",
  "itertools 0.14.0",
  "num-traits",
+ "page_size",
  "rayon",
  "reqwest 0.12.28",
  "reth-chainspec",
@@ -8955,6 +8875,7 @@ dependencies = [
  "reth-execution-types",
  "reth-exex",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-network-p2p",
  "reth-primitives-traits",
  "reth-provider",
@@ -8965,6 +8886,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-testing-utils",
  "reth-trie",
  "reth-trie-db",
@@ -8976,8 +8898,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9003,8 +8925,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9017,8 +8939,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9037,21 +8959,23 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "clap",
  "derive_more",
  "fixed-map",
+ "reth-stages-types",
  "serde",
- "strum 0.27.2",
+ "strum",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9074,8 +8998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9091,17 +9015,20 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
- "auto_impl",
- "dyn-clone",
+ "crossbeam-utils",
+ "dashmap",
  "futures-util",
+ "libc",
  "metrics",
+ "parking_lot",
  "pin-project",
  "rayon",
  "reth-metrics",
  "thiserror 2.0.18",
+ "thread-priority",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -9109,8 +9036,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9125,8 +9052,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9135,8 +9062,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "clap",
  "eyre",
@@ -9152,8 +9079,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "clap",
  "eyre",
@@ -9169,8 +9096,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9213,8 +9140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9239,8 +9166,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9266,48 +9193,52 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
+ "metrics",
+ "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
+ "reth-metrics",
  "reth-primitives-traits",
+ "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-common",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
- "dashmap 6.1.0",
  "derive_more",
  "itertools 0.14.0",
  "metrics",
  "rayon",
  "reth-execution-errors",
  "reth-metrics",
+ "reth-primitives-traits",
  "reth-provider",
  "reth-storage-errors",
+ "reth-tasks",
  "reth-trie",
- "reth-trie-common",
  "reth-trie-sparse",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9319,41 +9250,26 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-trie-common",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie-sparse-parallel"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "metrics",
- "rayon",
- "reth-execution-errors",
- "reth-metrics",
- "reth-trie-common",
- "reth-trie-sparse",
+ "serde",
+ "serde_json",
+ "slotmap",
  "smallvec",
  "tracing",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.10.2#f9788d50e1394f5ee34e790e3ac2bc7fd34c7cca"
+version = "1.11.3"
+source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "34.0.0"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -9370,9 +9286,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
 dependencies = [
  "bitvec",
  "phf",
@@ -9382,9 +9298,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "13.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9399,9 +9315,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "14.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -9415,9 +9331,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "10.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -9429,9 +9345,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
 dependencies = [
  "auto_impl",
  "either",
@@ -9443,9 +9359,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -9462,9 +9378,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "15.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
 dependencies = [
  "auto_impl",
  "either",
@@ -9480,9 +9396,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.34.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e435414e9de50a1b930da602067c76365fea2fea11e80ceb50783c94ddd127f"
+checksum = "9487362b728f80dd2033ef5f4d0688453435bbe7caa721fa7e3b8fa25d89242b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -9498,9 +9414,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "32.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -9547,9 +9463,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
@@ -9584,9 +9500,9 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+checksum = "57b0b88a509053cbfd535726dcaaceee631313cef981266119527a1d110f6d2b"
 
 [[package]]
 name = "ripemd"
@@ -9637,12 +9553,22 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -9730,19 +9656,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -9750,7 +9663,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -10117,15 +10030,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -10251,15 +10155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shellexpand"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
-dependencies = [
- "dirs",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10331,21 +10226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata 0.14.2",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
-
-[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10356,6 +10236,14 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "git+https://github.com/DaniPopes/slotmap.git?branch=dani%2Fshrink-methods#09fbd360968f9ecef19fc9559037cf869d33858b"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -10454,33 +10342,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -10563,19 +10429,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "windows 0.57.0",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
@@ -10586,6 +10439,20 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.61.3",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -10620,14 +10487,14 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10640,7 +10507,8 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
- "dashmap 6.1.0",
+ "async-trait",
+ "dashmap",
  "derive_more",
  "futures",
  "reth-evm",
@@ -10658,8 +10526,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10678,8 +10546,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10694,18 +10562,19 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-sol-types",
+ "serde",
 ]
 
 [[package]]
 name = "tempo-evm"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10734,8 +10603,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -10786,8 +10655,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10820,8 +10689,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10839,8 +10708,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10858,8 +10727,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10869,8 +10738,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10893,12 +10762,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempo-contracts",
 ]
 
 [[package]]
 name = "tempo-revm"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10920,8 +10790,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.4.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.4.1#1401f1ae6d28625dc6debfddbee6b571732991c5"
+version = "1.4.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11039,6 +10909,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread-priority"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -11217,7 +11101,6 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -11254,38 +11137,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -11308,20 +11170,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
@@ -11340,12 +11188,6 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -11532,9 +11374,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a250055a3518b5efba928a18ffac8d32d42ea607a9affff4532144cd5b2e378e"
+checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
  "time",
  "tracing",
@@ -11622,7 +11464,7 @@ checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "ethereum_ssz",
+ "ethereum_ssz 0.9.1",
  "smallvec",
  "typenum",
 ]
@@ -11648,12 +11490,6 @@ dependencies = [
  "hash-db",
  "rlp",
 ]
-
-[[package]]
-name = "triomphe"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
 name = "try-lock"
@@ -11696,6 +11532,12 @@ dependencies = [
  "thiserror 2.0.18",
  "utf-8",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -11759,20 +11601,14 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -11875,7 +11711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.23.1",
+ "cargo_metadata",
  "derive_builder",
  "regex",
  "rustversion",
@@ -12193,16 +12029,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -12246,24 +12072,12 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -12275,8 +12089,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -12306,31 +12120,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12378,15 +12170,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12900,7 +12683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -13083,6 +12866,7 @@ dependencies = [
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-storage-api",
+ "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
  "revm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,23 +78,23 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.4.1", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
 
 # zones
 zone-precompiles = { path = "crates/precompiles", default-features = false }
@@ -102,44 +102,45 @@ zone-primitives = { path = "crates/primitives", default-features = false }
 zone-rpc = { path = "crates/rpc" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2", features = [
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "tempo/v1.10.2" }
-revm = { version = "34.0.0", features = ["optional_fee_charge"] }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+revm = { version = "36.0.0", features = ["optional_fee_charge"] }
 
 # alloy
 alloy = { version = "1.6.1", default-features = false }
 alloy-consensus = { version = "1.6.1", default-features = false }
 alloy-contract = { version = "1.6.1", default-features = false }
 alloy-eips = { version = "1.6.1", default-features = false }
-alloy-evm = "0.27.3"
+alloy-evm = "0.29.2"
 alloy-network = { version = "1.6.1", default-features = false }
-alloy-primitives = { version = "1.5.4", default-features = false }
+alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-provider = { version = "1.6.1", default-features = false }
 alloy-rlp = { version = "0.3.13", default-features = false }
 alloy-rpc-client = "1.6.1"

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -213,7 +213,7 @@ fn main() {
             );
 
             // Spawn as critical tasks — node shuts down if either exits.
-            handle.node.task_executor.spawn_critical("zone-monitor", async move {
+            handle.node.task_executor.spawn_critical_task("zone-monitor", async move {
                 tokio::select! {
                     res = seq_handle.withdrawal_handle => {
                         tracing::error!(target: "reth::cli", ?res, "Withdrawal processor task exited");

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -22,12 +22,12 @@ tempo-precompiles-macros.workspace = true
 
 # alloy (direct versions for no_std — workspace versions have default-features = true)
 alloy = { version = "1.6.1", default-features = false }
-alloy-evm = { version = "0.27.3", default-features = false }
-alloy-primitives = { version = "1.5.4", default-features = false }
+alloy-evm = { version = "0.29.2", default-features = false }
+alloy-primitives = { version = "1.5.7", default-features = false }
 alloy-sol-types = { version = "1.5.7", default-features = false }
 
 # revm
-revm = { version = "34.0.0", default-features = false }
+revm = { version = "36.0.0", default-features = false }
 
 # crypto
 aes-gcm = { version = "0.10.3", default-features = false, features = ["aes", "alloc"] }

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -32,7 +32,6 @@ reth-basic-payload-builder.workspace = true
 reth-chainspec.workspace = true
 reth-errors.workspace = true
 reth-eth-wire-types.workspace = true
-reth-ethereum.workspace = true
 reth-evm.workspace = true
 reth-metrics.workspace = true
 reth-node-api.workspace = true
@@ -46,6 +45,7 @@ reth-rpc.workspace = true
 reth-rpc-builder.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-storage-api.workspace = true
+reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
 
 # alloy

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -22,7 +22,7 @@ use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_errors::ProviderError;
 use reth_evm::{
     ConfigureEvm, Database, NextBlockEnvAttributes,
-    execute::{BlockBuilder, BlockBuilderOutcome, ExecutionOutcome},
+    execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionOutput},
 };
 use reth_node_api::FullNodeTypes;
 use reth_node_builder::{BuilderContext, components::PayloadBuilderBuilder};
@@ -387,16 +387,14 @@ where
         let eth_payload =
             EthBuiltPayload::new(attributes.payload_id(), sealed_block, total_fees, requests);
 
-        let execution_outcome = ExecutionOutcome::new(
-            db.take_bundle(),
-            vec![execution_result.receipts],
-            block.number(),
-            vec![execution_result.requests],
-        );
+        let execution_output = BlockExecutionOutput {
+            result: execution_result,
+            state: db.take_bundle(),
+        };
 
         let executed_block = BuiltPayloadExecutedBlock {
             recovered_block: Arc::new(block),
-            execution_output: Arc::new(execution_outcome),
+            execution_output: Arc::new(execution_output),
             hashed_state: Either::Left(Arc::new(hashed_state)),
             trie_updates: Either::Left(Arc::new(trie_updates)),
         };

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -10,11 +10,12 @@ use alloy_evm::{
     Database, Evm, EvmEnv, EvmFactory,
     block::{BlockExecutorFactory, BlockExecutorFor},
     precompiles::PrecompilesMap,
-    revm::{Inspector, database::State, inspector::NoOpInspector},
+    revm::{Inspector, inspector::NoOpInspector},
 };
 use alloy_provider::{Provider, ProviderBuilder};
 use reth_evm::{
     ConfigureEngineEvm, ConfigureEvm, EvmEnvFor, ExecutableTxIterator, ExecutionCtxFor,
+    block::StateDB,
     execute::{BlockAssembler, BlockAssemblerInput},
 };
 use reth_primitives_traits::{SealedBlock, SealedHeader};
@@ -276,12 +277,12 @@ impl BlockExecutorFactory for ZoneEvmConfig {
 
     fn create_executor<'a, DB, I>(
         &'a self,
-        evm: TempoEvm<&'a mut State<DB>, I>,
+        evm: TempoEvm<DB, I>,
         ctx: Self::ExecutionCtx<'a>,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
-        DB: Database + 'a,
-        I: Inspector<TempoCtx<&'a mut State<DB>>> + 'a,
+        DB: StateDB + 'a,
+        I: Inspector<TempoCtx<DB>> + 'a,
     {
         ZoneBlockExecutor::new(evm, ctx, self.chain_spec())
     }
@@ -327,7 +328,11 @@ impl ConfigureEvm for ZoneEvmConfig {
                 parent_hash: block.header().parent_hash(),
                 parent_beacon_block_root: block.header().parent_beacon_block_root(),
                 ommers: &[],
-                withdrawals: block.body().withdrawals.as_ref().map(Cow::Borrowed),
+                withdrawals: block
+                    .body()
+                    .withdrawals
+                    .as_ref()
+                    .map(|withdrawals| Cow::Borrowed(withdrawals.as_slice())),
                 extra_data: block.header().extra_data().clone(),
                 tx_count_hint: Some(block.body().transactions.len()),
             },

--- a/crates/tempo-zone/src/executor.rs
+++ b/crates/tempo-zone/src/executor.rs
@@ -9,7 +9,8 @@ use alloy_evm::{
     block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, OnStateHook},
     eth::{EthBlockExecutor, EthTxResult},
 };
-use reth_revm::{Inspector, State};
+use reth_evm::block::StateDB;
+use reth_revm::Inspector;
 use tempo_chainspec::TempoChainSpec;
 use tempo_evm::{TempoBlockExecutionCtx, TempoReceiptBuilder, evm::TempoEvm};
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
@@ -20,21 +21,16 @@ use tempo_revm::evm::TempoContext;
 /// Wraps [`EthBlockExecutor`] without any subblock validation, gas-section tracking,
 /// or end-of-block metadata system transaction requirements.
 pub(crate) struct ZoneBlockExecutor<'a, DB: Database, I> {
-    inner: EthBlockExecutor<
-        'a,
-        TempoEvm<&'a mut State<DB>, I>,
-        &'a TempoChainSpec,
-        TempoReceiptBuilder,
-    >,
+    inner: EthBlockExecutor<'a, TempoEvm<DB, I>, &'a TempoChainSpec, TempoReceiptBuilder>,
 }
 
 impl<'a, DB, I> ZoneBlockExecutor<'a, DB, I>
 where
-    DB: Database,
-    I: Inspector<TempoContext<&'a mut State<DB>>>,
+    DB: StateDB,
+    I: Inspector<TempoContext<DB>>,
 {
     pub(crate) fn new(
-        evm: TempoEvm<&'a mut State<DB>, I>,
+        evm: TempoEvm<DB, I>,
         ctx: TempoBlockExecutionCtx<'a>,
         chain_spec: &'a TempoChainSpec,
     ) -> Self {
@@ -51,12 +47,12 @@ where
 
 impl<'a, DB, I> BlockExecutor for ZoneBlockExecutor<'a, DB, I>
 where
-    DB: Database,
-    I: Inspector<TempoContext<&'a mut State<DB>>>,
+    DB: StateDB,
+    I: Inspector<TempoContext<DB>>,
 {
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
-    type Evm = TempoEvm<&'a mut State<DB>, I>;
+    type Evm = TempoEvm<DB, I>;
     type Result = EthTxResult<<Self::Evm as Evm>::HaltReason, TempoTxType>;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -87,7 +87,7 @@ impl L1Subscriber {
     pub fn spawn(
         config: L1SubscriberConfig,
         deposit_queue: DepositQueue,
-        task_executor: impl reth_ethereum::tasks::TaskSpawner,
+        task_executor: reth_tasks::Runtime,
     ) {
         let tracked_tokens = config.policy_cache.read().tracked_tokens();
         let subscriber = Self {
@@ -98,7 +98,7 @@ impl L1Subscriber {
             subscriber_metrics: Default::default(),
         };
 
-        task_executor.spawn_critical(
+        task_executor.spawn_critical_task(
             "l1-deposit-subscriber",
             Box::pin(async move {
                 loop {

--- a/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
@@ -39,11 +39,11 @@ use super::{AuthRole, task::PolicyTaskHandle};
 pub fn spawn_pool_prefetch_task<Pool>(
     pool: Pool,
     handle: PolicyTaskHandle,
-    task_executor: impl reth_ethereum::tasks::TaskSpawner,
+    task_executor: reth_tasks::Runtime,
 ) where
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + 'static,
 {
-    task_executor.spawn(Box::pin(async move {
+    task_executor.spawn_task(Box::pin(async move {
         run_pool_prefetch(pool, handle).await;
     }));
 }

--- a/crates/tempo-zone/src/l1_state/tip403/task.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/task.rs
@@ -172,12 +172,12 @@ pub fn spawn_policy_resolution_task(
     l1_provider: DynProvider<TempoNetwork>,
     max_concurrent: usize,
     channel_capacity: usize,
-    task_executor: impl reth_ethereum::tasks::TaskSpawner,
+    task_executor: reth_tasks::Runtime,
 ) -> PolicyTaskHandle {
     let (tx, rx) = mpsc::channel(channel_capacity);
     let handle = PolicyTaskHandle::new(tx);
 
-    task_executor.spawn_critical(
+    task_executor.spawn_critical_task(
         "l1-policy-resolution",
         Box::pin(async move {
             let task = PolicyResolutionTask {

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -403,7 +403,7 @@ where
         );
         ctx.node
             .task_executor()
-            .spawn_critical("zone-engine", engine.run());
+            .spawn_critical_task("zone-engine", engine.run());
         info!(target: "reth::cli", "ZoneEngine spawned — L1-driven block production active");
 
         self.inner.launch_add_ons(ctx).await
@@ -687,7 +687,7 @@ where
 
         // Spawn unified Tempo pool maintenance task
         // This consolidates: expired AA txs, 2D nonce updates, AMM cache, and keychain revocations
-        ctx.task_executor().spawn_critical(
+        ctx.task_executor().spawn_critical_task(
             "txpool maintenance - tempo pool",
             tempo_transaction_pool::maintain::maintain_tempo_pool(transaction_pool.clone()),
         );

--- a/crates/tempo-zone/tests/advance_tempo.rs
+++ b/crates/tempo-zone/tests/advance_tempo.rs
@@ -256,23 +256,18 @@ fn advance_tempo_repro() {
     match &config_result {
         Ok(result) => {
             println!("config() result: {:?}", result.result);
+            let gas_used = result.result.gas_used();
             match &result.result {
-                ExecutionResult::Success {
-                    output, gas_used, ..
-                } => {
+                ExecutionResult::Success { output, .. } => {
                     if let Output::Call(data) = output {
                         println!("config() returned: {data}");
                     }
                     println!("config() gas_used: {gas_used}");
                 }
-                ExecutionResult::Revert {
-                    output, gas_used, ..
-                } => {
+                ExecutionResult::Revert { output, .. } => {
                     println!("config() REVERTED: {output}, gas_used: {gas_used}");
                 }
-                ExecutionResult::Halt {
-                    reason, gas_used, ..
-                } => {
+                ExecutionResult::Halt { reason, .. } => {
                     println!("config() HALTED: {reason:?}, gas_used: {gas_used}");
                 }
             }
@@ -288,22 +283,21 @@ fn advance_tempo_repro() {
     let hash_result =
         evm.transact_system_call(sequencer, TEMPO_STATE_ADDRESS, Bytes::from(hash_calldata));
     match &hash_result {
-        Ok(result) => match &result.result {
-            ExecutionResult::Success {
-                output, gas_used, ..
-            } => {
-                if let Output::Call(data) = output {
-                    println!("tempoBlockHash() returned: {data}");
+        Ok(result) => {
+            let gas_used = result.result.gas_used();
+            match &result.result {
+                ExecutionResult::Success { output, .. } => {
+                    if let Output::Call(data) = output {
+                        println!("tempoBlockHash() returned: {data}");
+                    }
+                    println!("tempoBlockHash() gas_used: {gas_used}");
                 }
-                println!("tempoBlockHash() gas_used: {gas_used}");
+                ExecutionResult::Revert { output, .. } => {
+                    println!("tempoBlockHash() REVERTED: {output}, gas_used: {gas_used}");
+                }
+                other => println!("tempoBlockHash() other: {other:?}"),
             }
-            ExecutionResult::Revert {
-                output, gas_used, ..
-            } => {
-                println!("tempoBlockHash() REVERTED: {output}, gas_used: {gas_used}");
-            }
-            other => println!("tempoBlockHash() other: {other:?}"),
-        },
+        }
         Err(e) => println!("tempoBlockHash() ERROR: {e:?}"),
     }
 
@@ -390,38 +384,35 @@ fn advance_tempo_repro() {
     let advance_result =
         evm.transact_system_call(sequencer, ZONE_INBOX_ADDRESS, Bytes::from(advance_calldata));
     match &advance_result {
-        Ok(result) => match &result.result {
-            ExecutionResult::Success {
-                output, gas_used, ..
-            } => {
-                if let Output::Call(data) = output {
-                    println!("advanceTempo() SUCCESS, output: {data}");
+        Ok(result) => {
+            let gas_used = result.result.gas_used();
+            match &result.result {
+                ExecutionResult::Success { output, .. } => {
+                    if let Output::Call(data) = output {
+                        println!("advanceTempo() SUCCESS, output: {data}");
+                    }
+                    println!("advanceTempo() gas_used: {gas_used}");
                 }
-                println!("advanceTempo() gas_used: {gas_used}");
-            }
-            ExecutionResult::Revert {
-                output, gas_used, ..
-            } => {
-                println!("advanceTempo() REVERTED: {output}");
-                println!("advanceTempo() gas_used: {gas_used}");
-                if output.len() >= 4 {
-                    let sel = &output[..4];
-                    println!("  error selector: 0x{}", const_hex::encode(sel));
-                    if sel == [0x08, 0xc3, 0x79, 0xa0]
-                        && output.len() > 4
-                        && let Ok(msg) = <alloy_sol_types::sol_data::String as alloy_sol_types::SolType>::abi_decode(&output[4..])
-                    {
-                        println!("  Error message: {msg}");
+                ExecutionResult::Revert { output, .. } => {
+                    println!("advanceTempo() REVERTED: {output}");
+                    println!("advanceTempo() gas_used: {gas_used}");
+                    if output.len() >= 4 {
+                        let sel = &output[..4];
+                        println!("  error selector: 0x{}", const_hex::encode(sel));
+                        if sel == [0x08, 0xc3, 0x79, 0xa0]
+                            && output.len() > 4
+                            && let Ok(msg) = <alloy_sol_types::sol_data::String as alloy_sol_types::SolType>::abi_decode(&output[4..])
+                        {
+                            println!("  Error message: {msg}");
+                        }
                     }
                 }
+                ExecutionResult::Halt { reason, .. } => {
+                    println!("advanceTempo() HALTED: {reason:?}");
+                    println!("advanceTempo() gas_used: {gas_used}");
+                }
             }
-            ExecutionResult::Halt {
-                reason, gas_used, ..
-            } => {
-                println!("advanceTempo() HALTED: {reason:?}");
-                println!("advanceTempo() gas_used: {gas_used}");
-            }
-        },
+        }
         Err(e) => println!("advanceTempo() ERROR: {e:?}"),
     }
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -6,11 +6,11 @@ use alloy_rpc_types_eth::Filter;
 use alloy_sol_types::{SolEvent, SolValue};
 use eyre::WrapErr;
 use p256::ecdsa::SigningKey as P256SigningKey;
-use reth_ethereum::tasks::TaskManager;
 use reth_node_api::FullNodeComponents;
 use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle, rpc::RethRpcAddOns};
 use reth_node_core::args::RpcServerArgs;
 use reth_rpc_builder::RpcModuleSelection;
+use reth_tasks::Runtime;
 use std::{
     sync::{
         Arc,
@@ -169,7 +169,7 @@ pub(crate) struct ZoneTestNode {
     policy_cache: zone::SharedPolicyCache,
     rpc_api: Arc<dyn zone::rpc::ZoneRpcApi>,
     node_handle: Box<dyn TestNodeHandle>,
-    _tasks: TaskManager,
+    _tasks: Runtime,
 }
 
 impl ZoneTestNode {
@@ -439,7 +439,7 @@ impl ZoneTestNode {
         custom_genesis: Option<Genesis>,
         sequencer_key: k256::SecretKey,
     ) -> eyre::Result<Self> {
-        let tasks = TaskManager::current();
+        let tasks = Runtime::test();
 
         let mut genesis = custom_genesis.unwrap_or_else(|| {
             serde_json::from_str(include_str!("../assets/zone-test-genesis.json"))
@@ -480,7 +480,7 @@ impl ZoneTestNode {
         let policy_cache = zone_node.policy_cache();
 
         let node_handle = NodeBuilder::new(node_config)
-            .testing_node(tasks.executor())
+            .testing_node(tasks.clone())
             .node(zone_node)
             .launch_with_debug_capabilities()
             .await?;
@@ -527,7 +527,7 @@ pub(crate) struct L1TestNode {
     http_url: url::Url,
     ws_url: url::Url,
     _node_handle: Box<dyn TestNodeHandle>,
-    _tasks: TaskManager,
+    _tasks: Runtime,
 }
 
 impl L1TestNode {
@@ -1403,7 +1403,7 @@ impl L1TestNode {
     pub(crate) async fn start_with(
         f: impl FnOnce(&mut NodeConfig<TempoChainSpec>),
     ) -> eyre::Result<Self> {
-        let tasks = TaskManager::current();
+        let tasks = Runtime::test();
 
         let genesis: serde_json::Value =
             serde_json::from_str(include_str!("../assets/test-genesis.json"))?;
@@ -1428,7 +1428,7 @@ impl L1TestNode {
         f(&mut node_config);
 
         let node_handle = NodeBuilder::new(node_config)
-            .testing_node(tasks.executor())
+            .testing_node(tasks.clone())
             .node(tempo_node::node::TempoNode::default())
             .launch_with_debug_capabilities()
             .await?;


### PR DESCRIPTION
## Summary
- bump the workspace tempo crates to `ed25d8e4affee8c8ba71ed137c204e54b97ad69a` from `main`
- align reth to the matching upstream revision `9060c50` and update local alloy/revm pins to stay type-compatible
- fix the resulting task runtime, payload execution output, EVM executor, and test API breakages across the zone node and CLI

## Verification
- `cargo check --workspace --all-targets`
- `cargo fmt --check`
- `cargo test -p zone-primitives`
- `cargo test -p zone --test advance_tempo -- --nocapture` *(fails in this checkout because `docs/specs/out/TempoState.sol/TempoState.json` is missing)*