### PR TITLE
Implement zone-specific private RPC methods

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -9,7 +9,6 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
-use alloy_provider::ProviderBuilder;
 use clap::Parser;
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
@@ -167,31 +166,25 @@ fn main() {
 
             // Launch the private zone RPC server.
             let eth_handlers = handle.node.eth_handlers().clone();
-            let private_rpc_config = zone::rpc::PrivateRpcConfig {
-                listen_addr: ([0, 0, 0, 0], args.private_rpc_port).into(),
-                zone_id: args.zone_id,
-                chain_id: handle.node.chain_spec().chain().id(),
-                zone_portal: args.portal_address,
-                sequencer: sequencer_addr,
-            };
             let zone_rpc_url = handle
                 .node
                 .rpc_server_handle()
                 .http_url()
                 .expect("HTTP RPC server must be enabled for sequencer mode");
-            let l1_provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
-                .connect(&args.l1_rpc_url)
-                .await?
-                .erased();
-            let zone_provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
-                .connect_http(zone_rpc_url.clone())
-                .erased();
+            let private_rpc_config = zone::rpc::PrivateRpcConfig {
+                listen_addr: ([0, 0, 0, 0], args.private_rpc_port).into(),
+                l1_rpc_url: args.l1_rpc_url.clone(),
+                zone_rpc_url: zone_rpc_url.clone(),
+                zone_id: args.zone_id,
+                chain_id: handle.node.chain_spec().chain().id(),
+                zone_portal: args.portal_address,
+                sequencer: sequencer_addr,
+            };
             let api: Arc<dyn zone::rpc::ZoneRpcApi> = Arc::new(zone::rpc::TempoZoneRpc::new(
                 eth_handlers,
                 private_rpc_config.clone(),
-                l1_provider,
-                zone_provider,
-            ));
+            )
+            .await?);
             let local_addr = zone::rpc::start_private_rpc(private_rpc_config, api).await?;
             info!(target: "reth::cli", %local_addr, "Private zone RPC server started");
 

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -9,6 +9,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
+use alloy_provider::ProviderBuilder;
 use clap::Parser;
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
@@ -173,8 +174,24 @@ fn main() {
                 zone_portal: args.portal_address,
                 sequencer: sequencer_addr,
             };
-            let api: Arc<dyn zone::rpc::ZoneRpcApi> =
-                Arc::new(zone::rpc::TempoZoneRpc::new(eth_handlers));
+            let zone_rpc_url = handle
+                .node
+                .rpc_server_handle()
+                .http_url()
+                .expect("HTTP RPC server must be enabled for sequencer mode");
+            let l1_provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect(&args.l1_rpc_url)
+                .await?
+                .erased();
+            let zone_provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http(zone_rpc_url.clone())
+                .erased();
+            let api: Arc<dyn zone::rpc::ZoneRpcApi> = Arc::new(zone::rpc::TempoZoneRpc::new(
+                eth_handlers,
+                private_rpc_config.clone(),
+                l1_provider,
+                zone_provider,
+            ));
             let local_addr = zone::rpc::start_private_rpc(private_rpc_config, api).await?;
             info!(target: "reth::cli", %local_addr, "Private zone RPC server started");
 
@@ -184,12 +201,6 @@ fn main() {
                 %sequencer_addr,
                 "Starting sequencer background tasks"
             );
-
-            let zone_rpc_url = handle
-                .node
-                .rpc_server_handle()
-                .http_url()
-                .expect("HTTP RPC server must be enabled for sequencer mode");
 
             let sequencer_config = zone::ZoneSequencerConfig {
                 portal_address: args.portal_address,

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -8,6 +8,10 @@ use std::net::SocketAddr;
 pub struct PrivateRpcConfig {
     /// Address to listen on for the private RPC server.
     pub listen_addr: SocketAddr,
+    /// Tempo L1 RPC URL used by zone-specific RPC methods that inspect portal logs.
+    pub l1_rpc_url: String,
+    /// Zone L2 RPC URL used by zone-specific RPC methods that inspect L2 events.
+    pub zone_rpc_url: String,
     /// The zone's numeric identifier.
     pub zone_id: u64,
     /// The zone's chain ID.

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -3,7 +3,9 @@
 //! Each handler calls the underlying EthApi via the [`ZoneRpcApi`] trait,
 //! which performs typed privacy redactions internally before serialization.
 
-use alloy_primitives::{Address, B256, Bytes};
+use std::str::FromStr;
+
+use alloy_primitives::{Address, B256, Bytes, U64};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
 use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
@@ -187,38 +189,6 @@ struct CallParams(
     Option<BlockId>,
     Option<StateOverride>,
 );
-
-/// `u64` JSON-RPC param that accepts either a JSON number or a hex quantity.
-#[derive(Debug)]
-enum QuantityU64 {
-    Number(u64),
-    Quantity(alloy_primitives::U64),
-}
-
-impl QuantityU64 {
-    fn into_u64(self) -> u64 {
-        match self {
-            Self::Number(value) => value,
-            Self::Quantity(value) => value.to(),
-        }
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for QuantityU64 {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(serde::Deserialize)]
-        #[serde(untagged)]
-        enum Repr {
-            Number(u64),
-            Quantity(alloy_primitives::U64),
-        }
-
-        match Repr::deserialize(deserializer)? {
-            Repr::Number(value) => Ok(Self::Number(value)),
-            Repr::Quantity(value) => Ok(Self::Quantity(value)),
-        }
-    }
-}
 
 impl<'de> serde::Deserialize<'de> for CallParams {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -741,10 +711,19 @@ async fn handle_zone_get_deposit_status(
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
     let (tempo_block_number,) =
-        match parse_params::<(QuantityU64,)>(raw, &id, "expected [tempoBlockNumber]") {
-            Ok((tempo_block_number,)) => (tempo_block_number.into_u64(),),
+        match parse_params::<(String,)>(raw, &id, "expected [tempoBlockNumber]") {
+            Ok((tempo_block_number,)) => (tempo_block_number,),
             Err(resp) => return resp,
         };
+    let tempo_block_number = match U64::from_str(&tempo_block_number) {
+        Ok(tempo_block_number) => tempo_block_number.to(),
+        Err(_) => {
+            return JsonRpcResponse::error(
+                id,
+                JsonRpcError::invalid_params("expected [tempoBlockNumber]"),
+            );
+        }
+    };
 
     api_result(
         id,
@@ -902,21 +881,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dispatches_zone_get_deposit_status_for_hex_and_numeric_quantities() {
+    async fn dispatches_zone_get_deposit_status_for_hex_quantity() {
         let api = MockZoneRpcApi::default();
 
-        let hex_resp = dispatch(
+        let resp = dispatch(
             &request("zone_getDepositStatus", json!(["0x2a"])),
             &auth(),
             &api,
         )
         .await;
-        assert!(hex_resp.error.is_none());
+        assert!(resp.error.is_none());
         assert_eq!(api.last_tempo_block_number.load(Ordering::Relaxed), 42);
+    }
 
-        let numeric_resp =
-            dispatch(&request("zone_getDepositStatus", json!([7])), &auth(), &api).await;
-        assert!(numeric_resp.error.is_none());
-        assert_eq!(api.last_tempo_block_number.load(Ordering::Relaxed), 7);
+    #[tokio::test]
+    async fn rejects_numeric_zone_get_deposit_status_param() {
+        let api = MockZoneRpcApi::default();
+
+        let resp = dispatch(&request("zone_getDepositStatus", json!([7])), &auth(), &api).await;
+        assert!(resp.result.is_none());
+        assert_eq!(resp.error.as_ref().unwrap().code, -32602);
     }
 }

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -155,6 +155,17 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `eth_uninstallFilter(id)` — removes a filter.
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `zone_getAuthorizationTokenInfo()` — returns the authenticated account
+    /// and token expiry.
+    fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `zone_getZoneInfo()` — returns zone metadata.
+    fn zone_get_zone_info(&self, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `zone_getDepositStatus(tempoBlockNumber)` — returns per-caller deposit
+    /// processing state for a Tempo L1 block.
+    fn zone_get_deposit_status(&self, tempo_block_number: u64, auth: AuthContext) -> BoxFut<'_>;
 }
 
 /// Deserialize JSON-RPC params, returning an error response on failure.
@@ -176,6 +187,38 @@ struct CallParams(
     Option<BlockId>,
     Option<StateOverride>,
 );
+
+/// `u64` JSON-RPC param that accepts either a JSON number or a hex quantity.
+#[derive(Debug)]
+enum QuantityU64 {
+    Number(u64),
+    Quantity(alloy_primitives::U64),
+}
+
+impl QuantityU64 {
+    fn into_u64(self) -> u64 {
+        match self {
+            Self::Number(value) => value,
+            Self::Quantity(value) => value.to(),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for QuantityU64 {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Number(u64),
+            Quantity(alloy_primitives::U64),
+        }
+
+        match Repr::deserialize(deserializer)? {
+            Repr::Number(value) => Ok(Self::Number(value)),
+            Repr::Quantity(value) => Ok(Self::Quantity(value)),
+        }
+    }
+}
 
 impl<'de> serde::Deserialize<'de> for CallParams {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -298,6 +341,17 @@ pub async fn dispatch(
         "eth_getFilterChanges" => handle_get_filter_changes(id, raw, auth, api).await,
         "eth_newBlockFilter" => handle_new_block_filter(id, auth, api).await,
         "eth_uninstallFilter" => handle_uninstall_filter(id, raw, auth, api).await,
+        "zone_getAuthorizationTokenInfo" => api_result(
+            id,
+            "zone_getAuthorizationTokenInfo",
+            api.zone_get_authorization_token_info(auth.clone()).await,
+        ),
+        "zone_getZoneInfo" => api_result(
+            id,
+            "zone_getZoneInfo",
+            api.zone_get_zone_info(auth.clone()).await,
+        ),
+        "zone_getDepositStatus" => handle_zone_get_deposit_status(id, raw, auth, api).await,
         _ => {
             // Method is whitelisted but not yet implemented via direct API
             JsonRpcResponse::error(
@@ -677,4 +731,192 @@ async fn handle_uninstall_filter(
         "eth_uninstallFilter",
         api.uninstall_filter(filter_id, auth.clone()).await,
     )
+}
+
+/// Handle `zone_getDepositStatus(tempoBlockNumber)`.
+async fn handle_zone_get_deposit_status(
+    id: Value,
+    raw: &str,
+    auth: &AuthContext,
+    api: &dyn ZoneRpcApi,
+) -> JsonRpcResponse {
+    let (tempo_block_number,) =
+        match parse_params::<(QuantityU64,)>(raw, &id, "expected [tempoBlockNumber]") {
+            Ok((tempo_block_number,)) => (tempo_block_number.into_u64(),),
+            Err(resp) => return resp,
+        };
+
+    api_result(
+        id,
+        "zone_getDepositStatus",
+        api.zone_get_deposit_status(tempo_block_number, auth.clone())
+            .await,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use alloy_primitives::Address;
+    use serde_json::json;
+
+    use super::*;
+    use crate::types::to_raw;
+
+    struct MockZoneRpcApi {
+        last_tempo_block_number: AtomicU64,
+    }
+
+    impl Default for MockZoneRpcApi {
+        fn default() -> Self {
+            Self {
+                last_tempo_block_number: AtomicU64::new(0),
+            }
+        }
+    }
+
+    macro_rules! stub {
+        ($method:ident $(, $arg:ident : $ty:ty)*) => {
+            fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
+                Box::pin(async { Err(JsonRpcError::internal("not implemented")) })
+            }
+        };
+    }
+
+    impl ZoneRpcApi for MockZoneRpcApi {
+        fn get_keychain_key(&self, _account: Address, _key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
+            Box::pin(async { Err(eyre::eyre!("not implemented")) })
+        }
+
+        stub!(block_number);
+        stub!(chain_id);
+        stub!(net_version);
+        stub!(gas_price);
+        stub!(max_priority_fee_per_gas);
+        stub!(fee_history, _block_count: u64, _newest_block: BlockNumberOrTag, _reward_percentiles: Option<Vec<f64>>);
+        stub!(get_balance, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
+        stub!(get_transaction_count, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
+        stub!(block_by_number, _number: BlockNumberOrTag, _full: bool, _auth: AuthContext);
+        stub!(block_by_hash, _hash: B256, _full: bool, _auth: AuthContext);
+        stub!(transaction_by_hash, _hash: B256, _auth: AuthContext);
+        stub!(transaction_receipt, _hash: B256, _auth: AuthContext);
+        stub!(call, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
+        stub!(estimate_gas, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
+        stub!(send_raw_transaction, _data: Bytes, _auth: AuthContext);
+        stub!(send_raw_transaction_sync, _data: Bytes, _auth: AuthContext);
+        stub!(fill_transaction, _request: TempoTransactionRequest, _auth: AuthContext);
+        stub!(get_logs, _filter: Filter, _auth: AuthContext);
+        stub!(new_filter, _filter: Filter, _auth: AuthContext);
+        stub!(get_filter_logs, _id: FilterId, _auth: AuthContext);
+        stub!(get_filter_changes, _id: FilterId, _auth: AuthContext);
+        stub!(new_block_filter, _auth: AuthContext);
+        stub!(uninstall_filter, _id: FilterId, _auth: AuthContext);
+
+        fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
+            Box::pin(async move {
+                to_raw(&json!({
+                    "account": auth.caller,
+                    "expiresAt": alloy_primitives::U64::from(auth.expires_at),
+                }))
+            })
+        }
+
+        fn zone_get_zone_info(&self, auth: AuthContext) -> BoxFut<'_> {
+            Box::pin(async move {
+                to_raw(&json!({
+                    "zoneId": "0x1",
+                    "zoneToken": format!("{:#x}", Address::repeat_byte(0x11)),
+                    "sequencer": format!("{:#x}", auth.caller),
+                    "chainId": "0x2a",
+                }))
+            })
+        }
+
+        fn zone_get_deposit_status(
+            &self,
+            tempo_block_number: u64,
+            _auth: AuthContext,
+        ) -> BoxFut<'_> {
+            self.last_tempo_block_number
+                .store(tempo_block_number, Ordering::Relaxed);
+            Box::pin(async move {
+                to_raw(&json!({
+                    "tempoBlockNumber": alloy_primitives::U64::from(tempo_block_number),
+                    "zoneProcessedThrough": alloy_primitives::U64::from(tempo_block_number),
+                    "processed": true,
+                    "deposits": [],
+                }))
+            })
+        }
+    }
+
+    fn auth() -> AuthContext {
+        AuthContext {
+            caller: Address::repeat_byte(0xaa),
+            is_sequencer: false,
+            expires_at: 1_700_000_000,
+        }
+    }
+
+    fn request(method: &str, params: serde_json::Value) -> JsonRpcRequest {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1
+        }))
+        .expect("request should deserialize")
+    }
+
+    #[tokio::test]
+    async fn dispatches_zone_get_authorization_token_info() {
+        let api = MockZoneRpcApi::default();
+        let resp = dispatch(
+            &request("zone_getAuthorizationTokenInfo", json!([])),
+            &auth(),
+            &api,
+        )
+        .await;
+
+        assert!(resp.error.is_none());
+        let body: serde_json::Value =
+            serde_json::from_str(resp.result.as_ref().unwrap().get()).unwrap();
+        assert_eq!(
+            body["account"].as_str().unwrap(),
+            format!("{:#x}", Address::repeat_byte(0xaa)),
+        );
+        assert_eq!(body["expiresAt"], "0x6553f100");
+    }
+
+    #[tokio::test]
+    async fn dispatches_zone_get_zone_info() {
+        let api = MockZoneRpcApi::default();
+        let resp = dispatch(&request("zone_getZoneInfo", json!([])), &auth(), &api).await;
+
+        assert!(resp.error.is_none());
+        let body: serde_json::Value =
+            serde_json::from_str(resp.result.as_ref().unwrap().get()).unwrap();
+        assert_eq!(body["zoneId"], "0x1");
+        assert_eq!(body["chainId"], "0x2a");
+    }
+
+    #[tokio::test]
+    async fn dispatches_zone_get_deposit_status_for_hex_and_numeric_quantities() {
+        let api = MockZoneRpcApi::default();
+
+        let hex_resp = dispatch(
+            &request("zone_getDepositStatus", json!(["0x2a"])),
+            &auth(),
+            &api,
+        )
+        .await;
+        assert!(hex_resp.error.is_none());
+        assert_eq!(api.last_tempo_block_number.load(Ordering::Relaxed), 42);
+
+        let numeric_resp =
+            dispatch(&request("zone_getDepositStatus", json!([7])), &auth(), &api).await;
+        assert!(numeric_resp.error.is_none());
+        assert_eq!(api.last_tempo_block_number.load(Ordering::Relaxed), 7);
+    }
 }

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -519,6 +519,31 @@ impl ZoneRpcApi for ProxyZoneRpc {
             Ok(result)
         })
     }
+
+    fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            to_raw(&serde_json::json!({
+                "account": auth.caller,
+                "expiresAt": alloy_primitives::U64::from(auth.expires_at),
+            }))
+        })
+    }
+
+    fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            Err(JsonRpcError::internal(
+                "zone-specific methods are not supported by the proxy backend",
+            ))
+        })
+    }
+
+    fn zone_get_deposit_status(&self, _tempo_block_number: u64, _auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            Err(JsonRpcError::internal(
+                "zone-specific methods are not supported by the proxy backend",
+            ))
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -388,6 +388,9 @@ mod tests {
         stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
         stub!(new_block_filter, _c: crate::auth::AuthContext);
         stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
+        stub!(zone_get_authorization_token_info, _c: crate::auth::AuthContext);
+        stub!(zone_get_zone_info, _c: crate::auth::AuthContext);
+        stub!(zone_get_deposit_status, _a: u64, _c: crate::auth::AuthContext);
     }
 
     fn test_config() -> PrivateRpcConfig {

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -396,6 +396,8 @@ mod tests {
     fn test_config() -> PrivateRpcConfig {
         PrivateRpcConfig {
             listen_addr: ([127, 0, 0, 1], 0).into(),
+            l1_rpc_url: "http://127.0.0.1:1".to_string(),
+            zone_rpc_url: "http://127.0.0.1:1".to_string(),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
             zone_portal: PORTAL,

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -2,7 +2,7 @@
 
 use std::{future::Future, pin::Pin};
 
-use alloy_primitives::U256;
+use alloy_primitives::{Address, B256, U64, U256};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, value::RawValue};
 
@@ -157,6 +157,88 @@ impl JsonRpcError {
             data: None,
         }
     }
+}
+
+/// Response payload for `zone_getAuthorizationTokenInfo`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationTokenInfoResponse {
+    /// Authenticated account derived from the authorization token.
+    pub account: Address,
+    /// Expiration timestamp encoded as a JSON-RPC quantity.
+    pub expires_at: U64,
+}
+
+/// Response payload for `zone_getZoneInfo`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZoneInfoResponse {
+    /// The zone's numeric identifier.
+    pub zone_id: U64,
+    /// The fixed zone token contract address.
+    pub zone_token: Address,
+    /// The configured sequencer account.
+    pub sequencer: Address,
+    /// The zone chain ID.
+    pub chain_id: U64,
+}
+
+/// Response payload for `zone_getDepositStatus`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DepositStatusResponse {
+    /// The Tempo block number queried by the caller.
+    pub tempo_block_number: U64,
+    /// The latest Tempo block number processed on the zone.
+    pub zone_processed_through: U64,
+    /// Whether every relevant deposit for `tempo_block_number` has reached a terminal state.
+    pub processed: bool,
+    /// Deposits relevant to the authenticated caller.
+    pub deposits: Vec<DepositStatusEntry>,
+}
+
+/// Per-deposit status entry returned by `zone_getDepositStatus`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DepositStatusEntry {
+    /// The deposit queue hash used to correlate portal and inbox events.
+    pub deposit_hash: B256,
+    /// Whether the deposit is regular or encrypted.
+    pub kind: DepositKind,
+    /// The deposited token address.
+    pub token: Address,
+    /// The L1 sender who initiated the deposit.
+    pub sender: Address,
+    /// The revealed recipient, if visible to the caller.
+    pub recipient: Option<Address>,
+    /// The deposited amount.
+    pub amount: U256,
+    /// The revealed memo, if visible to the caller.
+    pub memo: Option<B256>,
+    /// The current terminal or pending state of the deposit.
+    pub status: DepositState,
+}
+
+/// Deposit kind returned by `zone_getDepositStatus`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DepositKind {
+    /// A plaintext deposit emitted by the portal.
+    Regular,
+    /// A deposit whose recipient and memo remain hidden until revealed on L2.
+    Encrypted,
+}
+
+/// Processing state returned by `zone_getDepositStatus`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DepositState {
+    /// The deposit has not yet reached a terminal L2 inbox event.
+    Pending,
+    /// The deposit was processed successfully on L2.
+    Processed,
+    /// The encrypted deposit reached an explicit failure event on L2.
+    Failed,
 }
 
 /// Method access tier.

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -192,7 +192,10 @@ pub fn classify_method(method: &str) -> Option<MethodTier> {
         | "net_version"
         | "net_listening"
         | "web3_clientVersion"
-        | "web3_sha3" => Some(MethodTier::Public),
+        | "web3_sha3"
+        | "zone_getAuthorizationTokenInfo"
+        | "zone_getZoneInfo"
+        | "zone_getDepositStatus" => Some(MethodTier::Public),
 
         // Fetch-then-check: public but redacted based on caller identity
         "eth_getTransactionByHash"

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -177,6 +177,8 @@ impl TestContext {
         let signer = PrivateKeySigner::random();
         let config = PrivateRpcConfig {
             listen_addr: ([127, 0, 0, 1], 0).into(),
+            l1_rpc_url: "http://127.0.0.1:1".to_string(),
+            zone_rpc_url: "http://127.0.0.1:1".to_string(),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
             zone_portal: PORTAL,

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -122,6 +122,41 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
     stub!(new_block_filter, _c: zone_rpc::auth::AuthContext);
     stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
+
+    fn zone_get_authorization_token_info(&self, auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            zone_rpc::types::to_raw(&serde_json::json!({
+                "account": auth.caller,
+                "expiresAt": alloy_primitives::U64::from(auth.expires_at),
+            }))
+        })
+    }
+
+    fn zone_get_zone_info(&self, _auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            zone_rpc::types::to_raw(&serde_json::json!({
+                "zoneId": "0x1",
+                "zoneToken": format!("{:#x}", Address::repeat_byte(0x11)),
+                "sequencer": format!("{:#x}", Address::repeat_byte(0x22)),
+                "chainId": "0x2a",
+            }))
+        })
+    }
+
+    fn zone_get_deposit_status(
+        &self,
+        tempo_block_number: u64,
+        _auth: zone_rpc::auth::AuthContext,
+    ) -> BoxFut<'_> {
+        Box::pin(async move {
+            zone_rpc::types::to_raw(&serde_json::json!({
+                "tempoBlockNumber": alloy_primitives::U64::from(tempo_block_number),
+                "zoneProcessedThrough": alloy_primitives::U64::from(tempo_block_number),
+                "processed": true,
+                "deposits": [],
+            }))
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -333,6 +368,30 @@ async fn ws_batch_request() {
     assert_eq!(arr[0]["result"], "0x42");
     assert_eq!(arr[1]["id"], 2);
     assert_eq!(arr[1]["result"], "0x1");
+}
+
+#[tokio::test]
+async fn ws_zone_method_roundtrip() {
+    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "method":"zone_getDepositStatus",
+            "params":["0x2a"],
+            "id":7
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    assert_eq!(resp["id"], 7);
+    assert_eq!(resp["result"]["tempoBlockNumber"], "0x2a");
+    assert_eq!(resp["result"]["processed"], true);
 }
 
 #[tokio::test]

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -8,13 +8,14 @@ pub use zone_rpc::*;
 use std::{collections::HashMap, sync::Arc};
 
 use alloy_network::{ReceiptResponse, TransactionResponse};
-use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
+use alloy_primitives::{Address, B256, Bloom, Bytes, U64, U256};
+use alloy_provider::{DynProvider, Provider};
 use alloy_rpc_types_eth::{
     Block, BlockId, BlockNumberOrTag, BlockTransactions, Filter, FilterChanges, FilterId,
     TransactionRequest,
     state::{EvmOverrides, StateOverride},
 };
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{SolCall, SolEvent, SolEventInterface};
 use eyre::WrapErr;
 use reth_rpc::EthFilter;
 use reth_rpc_builder::EthHandlers;
@@ -33,12 +34,93 @@ use tempo_contracts::precompiles::{
 use tempo_primitives::TempoTxEnvelope;
 use tokio::sync::Mutex;
 
+use crate::abi::{
+    TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZoneInbox, ZonePortal,
+};
 use zone_rpc::{
     auth::AuthContext,
     types::{BoxEyreFut, BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
 };
 
 type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuthorizationTokenInfoResponse {
+    account: Address,
+    expires_at: U64,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ZoneInfoResponse {
+    zone_id: U64,
+    zone_token: Address,
+    sequencer: Address,
+    chain_id: U64,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DepositStatusResponse {
+    tempo_block_number: U64,
+    zone_processed_through: U64,
+    processed: bool,
+    deposits: Vec<DepositStatusEntry>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DepositStatusEntry {
+    deposit_hash: B256,
+    kind: DepositKind,
+    token: Address,
+    sender: Address,
+    recipient: Option<Address>,
+    amount: U256,
+    memo: Option<B256>,
+    status: DepositState,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DepositKind {
+    Regular,
+    Encrypted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DepositState {
+    Pending,
+    Processed,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+enum PortalDepositRecord {
+    Regular {
+        deposit_hash: B256,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        amount: u128,
+        memo: B256,
+    },
+    Encrypted {
+        deposit_hash: B256,
+        sender: Address,
+        token: Address,
+        amount: u128,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum TerminalDepositEvent {
+    RegularProcessed,
+    EncryptedProcessed { recipient: Address, memo: B256 },
+    EncryptedFailed,
+}
 
 /// [`ZoneRpcApi`] implementation backed by reth's [`EthHandlers`].
 ///
@@ -66,6 +148,11 @@ type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHe
 /// [`classify_method`]: zone_rpc::types::classify_method
 pub struct TempoZoneRpc<Api: EthApiTypes> {
     eth: EthHandlers<Api>,
+    config: zone_rpc::PrivateRpcConfig,
+    l1_provider: DynProvider<TempoNetwork>,
+    zone_provider: DynProvider<TempoNetwork>,
+    tempo_state:
+        crate::abi::TempoState::TempoStateInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     /// Maps filter IDs to the authenticated account that created them.
     /// Ensures filters can only be accessed by their creator.
     ///
@@ -77,9 +164,19 @@ pub struct TempoZoneRpc<Api: EthApiTypes> {
 
 impl<Api: EthApiTypes> TempoZoneRpc<Api> {
     /// Wrap reth's [`EthHandlers`] (api + filter + pubsub).
-    pub fn new(eth: EthHandlers<Api>) -> Self {
+    pub fn new(
+        eth: EthHandlers<Api>,
+        config: zone_rpc::PrivateRpcConfig,
+        l1_provider: DynProvider<TempoNetwork>,
+        zone_provider: DynProvider<TempoNetwork>,
+    ) -> Self {
+        let tempo_state = crate::abi::TempoState::new(TEMPO_STATE_ADDRESS, zone_provider.clone());
         Self {
             eth,
+            config,
+            l1_provider,
+            zone_provider,
+            tempo_state,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -108,6 +205,105 @@ impl<Api: EthApiTypes> TempoZoneRpc<Api> {
             Some(owner) if *owner == auth.caller => Ok(()),
             _ => Err(JsonRpcError::invalid_params("filter not found")),
         }
+    }
+
+    async fn portal_deposits_for_block(
+        &self,
+        tempo_block_number: u64,
+    ) -> Result<Vec<PortalDepositRecord>, JsonRpcError> {
+        if self.config.zone_portal.is_zero() {
+            return Err(JsonRpcError::internal("zone portal not configured"));
+        }
+
+        let filter = Filter::new()
+            .address(self.config.zone_portal)
+            .from_block(tempo_block_number)
+            .to_block(tempo_block_number)
+            .event_signature(vec![
+                ZonePortal::DepositMade::SIGNATURE_HASH,
+                ZonePortal::EncryptedDepositMade::SIGNATURE_HASH,
+            ]);
+
+        let logs = self.l1_provider.get_logs(&filter).await.map_err(internal)?;
+        let mut deposits = Vec::with_capacity(logs.len());
+
+        for log in logs {
+            match ZonePortal::ZonePortalEvents::decode_log(&log.inner)
+                .map_err(internal)?
+                .data
+            {
+                ZonePortal::ZonePortalEvents::DepositMade(event) => {
+                    deposits.push(PortalDepositRecord::Regular {
+                        deposit_hash: event.newCurrentDepositQueueHash,
+                        sender: event.sender,
+                        recipient: event.to,
+                        token: event.token,
+                        amount: event.netAmount,
+                        memo: event.memo,
+                    });
+                }
+                ZonePortal::ZonePortalEvents::EncryptedDepositMade(event) => {
+                    deposits.push(PortalDepositRecord::Encrypted {
+                        deposit_hash: event.newCurrentDepositQueueHash,
+                        sender: event.sender,
+                        token: event.token,
+                        amount: event.netAmount,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        Ok(deposits)
+    }
+
+    async fn terminal_event_for_deposit(
+        &self,
+        deposit_hash: B256,
+    ) -> Result<Option<TerminalDepositEvent>, JsonRpcError> {
+        let filter = Filter::new()
+            .address(ZONE_INBOX_ADDRESS)
+            .from_block(0)
+            .event_signature(vec![
+                ZoneInbox::DepositProcessed::SIGNATURE_HASH,
+                ZoneInbox::EncryptedDepositProcessed::SIGNATURE_HASH,
+                ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH,
+            ])
+            .topic1(deposit_hash);
+
+        let logs = self
+            .zone_provider
+            .get_logs(&filter)
+            .await
+            .map_err(internal)?;
+        let Some(log) = logs.last() else {
+            return Ok(None);
+        };
+
+        let Some(signature) = log.topics().first().copied() else {
+            return Ok(None);
+        };
+
+        if signature == ZoneInbox::DepositProcessed::SIGNATURE_HASH {
+            ZoneInbox::DepositProcessed::decode_log(&log.inner).map_err(internal)?;
+            return Ok(Some(TerminalDepositEvent::RegularProcessed));
+        }
+
+        if signature == ZoneInbox::EncryptedDepositProcessed::SIGNATURE_HASH {
+            let event =
+                ZoneInbox::EncryptedDepositProcessed::decode_log(&log.inner).map_err(internal)?;
+            return Ok(Some(TerminalDepositEvent::EncryptedProcessed {
+                recipient: event.to,
+                memo: event.memo,
+            }));
+        }
+
+        if signature == ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH {
+            ZoneInbox::EncryptedDepositFailed::decode_log(&log.inner).map_err(internal)?;
+            return Ok(Some(TerminalDepositEvent::EncryptedFailed));
+        }
+
+        Ok(None)
     }
 }
 
@@ -521,6 +717,137 @@ where
             }
 
             to_raw(&result)
+        })
+    }
+
+    fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            to_raw(&AuthorizationTokenInfoResponse {
+                account: auth.caller,
+                expires_at: U64::from(auth.expires_at),
+            })
+        })
+    }
+
+    fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            to_raw(&ZoneInfoResponse {
+                zone_id: U64::from(self.config.zone_id),
+                zone_token: ZONE_TOKEN_ADDRESS,
+                sequencer: self.config.sequencer,
+                chain_id: U64::from(self.config.chain_id),
+            })
+        })
+    }
+
+    fn zone_get_deposit_status(&self, tempo_block_number: u64, auth: AuthContext) -> BoxFut<'_> {
+        Box::pin(async move {
+            let zone_processed_through = self
+                .tempo_state
+                .tempoBlockNumber()
+                .call()
+                .await
+                .map_err(internal)?;
+            let portal_deposits = self.portal_deposits_for_block(tempo_block_number).await?;
+
+            let mut deposits = Vec::new();
+            for deposit in portal_deposits {
+                match deposit {
+                    PortalDepositRecord::Regular {
+                        deposit_hash,
+                        sender,
+                        recipient,
+                        token,
+                        amount,
+                        memo,
+                    } => {
+                        if sender != auth.caller && recipient != auth.caller {
+                            continue;
+                        }
+
+                        let terminal = self.terminal_event_for_deposit(deposit_hash).await?;
+                        let status = if terminal.is_some() {
+                            DepositState::Processed
+                        } else {
+                            DepositState::Pending
+                        };
+
+                        deposits.push(DepositStatusEntry {
+                            deposit_hash,
+                            kind: DepositKind::Regular,
+                            token,
+                            sender,
+                            recipient: Some(recipient),
+                            amount: U256::from(amount),
+                            memo: Some(memo),
+                            status,
+                        });
+                    }
+                    PortalDepositRecord::Encrypted {
+                        deposit_hash,
+                        sender,
+                        token,
+                        amount,
+                    } => {
+                        let terminal = self.terminal_event_for_deposit(deposit_hash).await?;
+
+                        let include = match (&terminal, sender == auth.caller) {
+                            (_, true) => true,
+                            (
+                                Some(TerminalDepositEvent::EncryptedProcessed {
+                                    recipient, ..
+                                }),
+                                false,
+                            ) => *recipient == auth.caller,
+                            _ => false,
+                        };
+
+                        if !include {
+                            continue;
+                        }
+
+                        let (recipient, memo, status) = match terminal {
+                            Some(TerminalDepositEvent::EncryptedProcessed {
+                                recipient,
+                                memo,
+                                ..
+                            }) => (Some(recipient), Some(memo), DepositState::Processed),
+                            Some(TerminalDepositEvent::EncryptedFailed) => {
+                                (None, None, DepositState::Failed)
+                            }
+                            Some(TerminalDepositEvent::RegularProcessed) => {
+                                return Err(JsonRpcError::internal(
+                                    "regular deposit event matched encrypted deposit hash",
+                                ));
+                            }
+                            None => (None, None, DepositState::Pending),
+                        };
+
+                        deposits.push(DepositStatusEntry {
+                            deposit_hash,
+                            kind: DepositKind::Encrypted,
+                            token,
+                            sender,
+                            recipient,
+                            amount: U256::from(amount),
+                            memo,
+                            status,
+                        });
+                    }
+                }
+            }
+
+            let processed = zone_processed_through >= tempo_block_number
+                && deposits
+                    .iter()
+                    .all(|deposit| deposit.status != DepositState::Pending);
+
+            to_raw(&DepositStatusResponse {
+                tempo_block_number: U64::from(tempo_block_number),
+                zone_processed_through: U64::from(zone_processed_through),
+                processed,
+                deposits,
+            })
         })
     }
 }

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -48,31 +48,6 @@ use zone_rpc::{
 
 type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
 
-#[derive(Debug, Clone)]
-enum PortalDepositRecord {
-    Regular {
-        deposit_hash: B256,
-        sender: Address,
-        recipient: Address,
-        token: Address,
-        amount: u128,
-        memo: B256,
-    },
-    Encrypted {
-        deposit_hash: B256,
-        sender: Address,
-        token: Address,
-        amount: u128,
-    },
-}
-
-#[derive(Debug, Clone)]
-enum TerminalDepositEvent {
-    RegularProcessed,
-    EncryptedProcessed { recipient: Address, memo: B256 },
-    EncryptedFailed,
-}
-
 /// [`ZoneRpcApi`] implementation backed by reth's [`EthHandlers`].
 ///
 /// This is the privacy enforcement layer for the zone's JSON-RPC surface.
@@ -111,6 +86,31 @@ pub struct TempoZoneRpc<Api: EthApiTypes> {
     /// After bumping reth, use its `ActiveFilters` API to periodically sync this
     /// map and remove entries for filters that no longer exist on the reth side.
     filter_owners: Arc<Mutex<HashMap<FilterId, Address>>>,
+}
+
+#[derive(Debug, Clone)]
+enum PortalDepositRecord {
+    Regular {
+        deposit_hash: B256,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        amount: u128,
+        memo: B256,
+    },
+    Encrypted {
+        deposit_hash: B256,
+        sender: Address,
+        token: Address,
+        amount: u128,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum TerminalDepositEvent {
+    RegularProcessed,
+    EncryptedProcessed { recipient: Address, memo: B256 },
+    EncryptedFailed,
 }
 
 impl<Api: EthApiTypes> TempoZoneRpc<Api> {

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -702,11 +702,7 @@ where
                         }
 
                         let terminal = self.terminal_event_for_deposit(deposit_hash).await?;
-                        let status = if terminal.is_some() {
-                            DepositState::Processed
-                        } else {
-                            DepositState::Pending
-                        };
+                        let status = regular_deposit_status(terminal)?;
 
                         deposits.push(DepositStatusEntry {
                             deposit_hash,
@@ -742,22 +738,7 @@ where
                             continue;
                         }
 
-                        let (recipient, memo, status) = match terminal {
-                            Some(TerminalDepositEvent::EncryptedProcessed {
-                                recipient,
-                                memo,
-                                ..
-                            }) => (Some(recipient), Some(memo), DepositState::Processed),
-                            Some(TerminalDepositEvent::EncryptedFailed) => {
-                                (None, None, DepositState::Failed)
-                            }
-                            Some(TerminalDepositEvent::RegularProcessed) => {
-                                return Err(JsonRpcError::internal(
-                                    "regular deposit event matched encrypted deposit hash",
-                                ));
-                            }
-                            None => (None, None, DepositState::Pending),
-                        };
+                        let (recipient, memo, status) = encrypted_deposit_details(terminal)?;
 
                         deposits.push(DepositStatusEntry {
                             deposit_hash,
@@ -813,9 +794,95 @@ enum TerminalDepositEvent {
     EncryptedFailed,
 }
 
+fn regular_deposit_status(
+    terminal: Option<TerminalDepositEvent>,
+) -> Result<DepositState, JsonRpcError> {
+    match terminal {
+        Some(TerminalDepositEvent::RegularProcessed) => Ok(DepositState::Processed),
+        Some(TerminalDepositEvent::EncryptedProcessed { .. }) => Err(JsonRpcError::internal(
+            "encrypted deposit event matched regular deposit hash",
+        )),
+        Some(TerminalDepositEvent::EncryptedFailed) => Err(JsonRpcError::internal(
+            "encrypted deposit failure matched regular deposit hash",
+        )),
+        None => Ok(DepositState::Pending),
+    }
+}
+
+fn encrypted_deposit_details(
+    terminal: Option<TerminalDepositEvent>,
+) -> Result<(Option<Address>, Option<B256>, DepositState), JsonRpcError> {
+    match terminal {
+        Some(TerminalDepositEvent::EncryptedProcessed { recipient, memo }) => {
+            Ok((Some(recipient), Some(memo), DepositState::Processed))
+        }
+        Some(TerminalDepositEvent::EncryptedFailed) => Ok((None, None, DepositState::Failed)),
+        Some(TerminalDepositEvent::RegularProcessed) => Err(JsonRpcError::internal(
+            "regular deposit event matched encrypted deposit hash",
+        )),
+        None => Ok((None, None, DepositState::Pending)),
+    }
+}
+
 /// Strip privacy-sensitive fields from a block for non-sequencer callers.
 fn redact_block(block: &mut RpcBlock) {
     // header.inner = alloy Header, .inner = Sealed wrapper, .inner = TempoHeader (contains logs_bloom)
     block.header.inner.inner.inner.logs_bloom = Bloom::ZERO;
     block.transactions = BlockTransactions::Hashes(Vec::new());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regular_deposit_status_maps_terminal_events() {
+        assert_eq!(
+            regular_deposit_status(Some(TerminalDepositEvent::RegularProcessed)).unwrap(),
+            DepositState::Processed
+        );
+        assert_eq!(regular_deposit_status(None).unwrap(), DepositState::Pending);
+    }
+
+    #[test]
+    fn regular_deposit_status_rejects_encrypted_terminal_events() {
+        let err = regular_deposit_status(Some(TerminalDepositEvent::EncryptedFailed)).unwrap_err();
+        assert_eq!(
+            err.message,
+            "encrypted deposit failure matched regular deposit hash"
+        );
+    }
+
+    #[test]
+    fn encrypted_deposit_details_maps_terminal_events() {
+        let recipient = Address::repeat_byte(0x11);
+        let memo = B256::from([0x22; 32]);
+
+        assert_eq!(
+            encrypted_deposit_details(Some(TerminalDepositEvent::EncryptedProcessed {
+                recipient,
+                memo,
+            }))
+            .unwrap(),
+            (Some(recipient), Some(memo), DepositState::Processed)
+        );
+        assert_eq!(
+            encrypted_deposit_details(Some(TerminalDepositEvent::EncryptedFailed)).unwrap(),
+            (None, None, DepositState::Failed)
+        );
+        assert_eq!(
+            encrypted_deposit_details(None).unwrap(),
+            (None, None, DepositState::Pending)
+        );
+    }
+
+    #[test]
+    fn encrypted_deposit_details_rejects_regular_terminal_events() {
+        let err =
+            encrypted_deposit_details(Some(TerminalDepositEvent::RegularProcessed)).unwrap_err();
+        assert_eq!(
+            err.message,
+            "regular deposit event matched encrypted deposit hash"
+        );
+    }
 }

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -88,31 +88,6 @@ pub struct TempoZoneRpc<Api: EthApiTypes> {
     filter_owners: Arc<Mutex<HashMap<FilterId, Address>>>,
 }
 
-#[derive(Debug, Clone)]
-enum PortalDepositRecord {
-    Regular {
-        deposit_hash: B256,
-        sender: Address,
-        recipient: Address,
-        token: Address,
-        amount: u128,
-        memo: B256,
-    },
-    Encrypted {
-        deposit_hash: B256,
-        sender: Address,
-        token: Address,
-        amount: u128,
-    },
-}
-
-#[derive(Debug, Clone)]
-enum TerminalDepositEvent {
-    RegularProcessed,
-    EncryptedProcessed { recipient: Address, memo: B256 },
-    EncryptedFailed,
-}
-
 impl<Api: EthApiTypes> TempoZoneRpc<Api> {
     /// Wrap reth's [`EthHandlers`] (api + filter + pubsub).
     pub async fn new(
@@ -811,6 +786,31 @@ where
             })
         })
     }
+}
+
+#[derive(Debug, Clone)]
+enum PortalDepositRecord {
+    Regular {
+        deposit_hash: B256,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        amount: u128,
+        memo: B256,
+    },
+    Encrypted {
+        deposit_hash: B256,
+        sender: Address,
+        token: Address,
+        amount: u128,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum TerminalDepositEvent {
+    RegularProcessed,
+    EncryptedProcessed { recipient: Address, memo: B256 },
+    EncryptedFailed,
 }
 
 /// Strip privacy-sensitive fields from a block for non-sequencer callers.

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -9,7 +9,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use alloy_network::{ReceiptResponse, TransactionResponse};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U64, U256};
-use alloy_provider::{DynProvider, Provider};
+use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rpc_types_eth::{
     Block, BlockId, BlockNumberOrTag, BlockTransactions, Filter, FilterChanges, FilterId,
     TransactionRequest,
@@ -164,21 +164,31 @@ pub struct TempoZoneRpc<Api: EthApiTypes> {
 
 impl<Api: EthApiTypes> TempoZoneRpc<Api> {
     /// Wrap reth's [`EthHandlers`] (api + filter + pubsub).
-    pub fn new(
+    pub async fn new(
         eth: EthHandlers<Api>,
         config: zone_rpc::PrivateRpcConfig,
-        l1_provider: DynProvider<TempoNetwork>,
-        zone_provider: DynProvider<TempoNetwork>,
-    ) -> Self {
+    ) -> eyre::Result<Self> {
+        let l1_rpc_url = config.l1_rpc_url.clone();
+        let zone_rpc_url = config.zone_rpc_url.clone();
+        let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&l1_rpc_url)
+            .await
+            .wrap_err("failed to connect private RPC L1 provider")?
+            .erased();
+        let zone_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&zone_rpc_url)
+            .await
+            .wrap_err("failed to connect private RPC zone provider")?
+            .erased();
         let tempo_state = crate::abi::TempoState::new(TEMPO_STATE_ADDRESS, zone_provider.clone());
-        Self {
+        Ok(Self {
             eth,
             config,
             l1_provider,
             zone_provider,
             tempo_state,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
-        }
+        })
     }
 
     /// Returns a reference to the inner [`EthFilter`] handler.

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -39,63 +39,14 @@ use crate::abi::{
 };
 use zone_rpc::{
     auth::AuthContext,
-    types::{BoxEyreFut, BoxFut, JsonRpcError, internal, raw_null, raw_zero, to_raw},
+    types::{
+        AuthorizationTokenInfoResponse, BoxEyreFut, BoxFut, DepositKind, DepositState,
+        DepositStatusEntry, DepositStatusResponse, JsonRpcError, ZoneInfoResponse, internal,
+        raw_null, raw_zero, to_raw,
+    },
 };
 
 type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct AuthorizationTokenInfoResponse {
-    account: Address,
-    expires_at: U64,
-}
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ZoneInfoResponse {
-    zone_id: U64,
-    zone_token: Address,
-    sequencer: Address,
-    chain_id: U64,
-}
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct DepositStatusResponse {
-    tempo_block_number: U64,
-    zone_processed_through: U64,
-    processed: bool,
-    deposits: Vec<DepositStatusEntry>,
-}
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct DepositStatusEntry {
-    deposit_hash: B256,
-    kind: DepositKind,
-    token: Address,
-    sender: Address,
-    recipient: Option<Address>,
-    amount: U256,
-    memo: Option<B256>,
-    status: DepositState,
-}
-
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-#[serde(rename_all = "lowercase")]
-enum DepositKind {
-    Regular,
-    Encrypted,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "lowercase")]
-enum DepositState {
-    Pending,
-    Processed,
-    Failed,
-}
 
 #[derive(Debug, Clone)]
 enum PortalDepositRecord {

--- a/crates/tempo-zone/tests/it/private_rpc.rs
+++ b/crates/tempo-zone/tests/it/private_rpc.rs
@@ -328,6 +328,9 @@ fn classify_public_methods() {
         "net_listening",
         "web3_clientVersion",
         "web3_sha3",
+        "zone_getAuthorizationTokenInfo",
+        "zone_getZoneInfo",
+        "zone_getDepositStatus",
     ] {
         assert_eq!(
             classify_method(method),

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -7,7 +7,10 @@
 //! - Block redaction (logsBloom zeroed, transactions cleared for non-sequencers)
 //! - Method tier enforcement (restricted/disabled/unknown methods)
 
-use crate::utils::{now_secs, start_zone_with_private_rpc};
+use crate::utils::{
+    DEFAULT_TIMEOUT, ZoneAccount, now_secs, start_zone_with_private_rpc,
+    start_zone_with_private_rpc_l1, start_zone_with_private_rpc_l1_with_encryption,
+};
 use alloy::{
     primitives::{Address, B256, address, hex},
     signers::local::PrivateKeySigner,
@@ -483,6 +486,183 @@ async fn test_method_tiers() -> eyre::Result<()> {
         error["code"].as_i64().unwrap(),
         -32601,
         "unknown method should return -32601"
+    );
+
+    Ok(())
+}
+
+/// Zone-specific metadata methods return the authenticated account/token expiry
+/// and the configured zone metadata.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zone_metadata_methods() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1().await?;
+    let user_signer = PrivateKeySigner::random();
+
+    let auth_info = ctx
+        .call_as_user(
+            "zone_getAuthorizationTokenInfo",
+            serde_json::json!([]),
+            &user_signer,
+        )
+        .await?;
+    assert_eq!(
+        auth_info["result"]["account"].as_str().unwrap(),
+        format!("{:#x}", user_signer.address()),
+    );
+    assert!(
+        auth_info["result"]["expiresAt"].as_str().is_some(),
+        "expiresAt should be a quantity string",
+    );
+
+    let zone_info = ctx
+        .call_as_user("zone_getZoneInfo", serde_json::json!([]), &user_signer)
+        .await?;
+    assert_eq!(zone_info["result"]["zoneId"], "0x1");
+    assert_eq!(
+        zone_info["result"]["zoneToken"].as_str().unwrap(),
+        "0x20c0000000000000000000000000000000000000",
+    );
+    assert_eq!(
+        zone_info["result"]["sequencer"].as_str().unwrap(),
+        format!("{:#x}", ctx.config.sequencer),
+    );
+    assert_eq!(
+        zone_info["result"]["chainId"].as_str().unwrap(),
+        format!("0x{:x}", ctx.config.chain_id),
+    );
+
+    Ok(())
+}
+
+/// `zone_getDepositStatus` returns relevant regular deposits for both the sender
+/// and the plaintext recipient, and returns an empty list for unrelated callers.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zone_get_deposit_status_regular_and_empty() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1().await?;
+    let l1 = ctx.l1();
+    let portal_address = ctx.portal_address();
+
+    let depositor_signer = l1.user_signer();
+    let recipient_signer = l1.signer_at(2);
+    let recipient = recipient_signer.address();
+
+    let mut depositor =
+        ZoneAccount::with_signer(depositor_signer.clone(), l1, &ctx.zone, portal_address);
+    let deposit_amount: u128 = 1_000_000;
+    l1.fund_user(depositor.address(), deposit_amount).await?;
+
+    let (tempo_block_number, _) = depositor
+        .deposit_to_with_block(recipient, deposit_amount, DEFAULT_TIMEOUT, &ctx.zone)
+        .await?;
+
+    let sender_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &depositor_signer)
+        .await?;
+    let sender_deposits = sender_status["result"]["deposits"]
+        .as_array()
+        .expect("sender deposits should be an array");
+    assert_eq!(sender_status["result"]["processed"], true);
+    assert_eq!(sender_deposits.len(), 1);
+    assert_eq!(sender_deposits[0]["kind"], "regular");
+    assert_eq!(sender_deposits[0]["status"], "processed");
+    assert_eq!(
+        sender_deposits[0]["sender"].as_str().unwrap(),
+        format!("{:#x}", depositor.address()),
+    );
+    assert_eq!(
+        sender_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+    assert_eq!(sender_deposits[0]["amount"], "0xf4240");
+
+    let recipient_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &recipient_signer)
+        .await?;
+    let recipient_deposits = recipient_status["result"]["deposits"]
+        .as_array()
+        .expect("recipient deposits should be an array");
+    assert_eq!(recipient_status["result"]["processed"], true);
+    assert_eq!(recipient_deposits.len(), 1);
+    assert_eq!(
+        recipient_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+
+    let unrelated_signer = PrivateKeySigner::random();
+    let unrelated_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &unrelated_signer)
+        .await?;
+    let unrelated_deposits = unrelated_status["result"]["deposits"]
+        .as_array()
+        .expect("unrelated deposits should be an array");
+    assert_eq!(unrelated_status["result"]["processed"], true);
+    assert!(unrelated_deposits.is_empty());
+
+    Ok(())
+}
+
+/// `zone_getDepositStatus` reveals encrypted deposits to the sender immediately,
+/// and to the recipient once the L2 processed event has revealed the recipient.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zone_get_deposit_status_encrypted() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1_with_encryption().await?;
+    let l1 = ctx.l1();
+    let portal_address = ctx.portal_address();
+
+    let depositor_signer = l1.user_signer();
+    let recipient_signer = l1.signer_at(2);
+    let recipient = recipient_signer.address();
+
+    let mut depositor =
+        ZoneAccount::with_signer(depositor_signer.clone(), l1, &ctx.zone, portal_address);
+    let deposit_amount: u128 = 1_000_000;
+    let memo = B256::from([0x11; 32]);
+    l1.fund_user(depositor.address(), deposit_amount).await?;
+
+    let (tempo_block_number, _) = depositor
+        .deposit_encrypted_with_block(deposit_amount, recipient, memo, DEFAULT_TIMEOUT, &ctx.zone)
+        .await?;
+
+    let sender_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &depositor_signer)
+        .await?;
+    let sender_deposits = sender_status["result"]["deposits"]
+        .as_array()
+        .expect("sender deposits should be an array");
+    assert_eq!(sender_status["result"]["processed"], true);
+    assert_eq!(sender_deposits.len(), 1);
+    assert_eq!(sender_deposits[0]["kind"], "encrypted");
+    assert_eq!(sender_deposits[0]["status"], "processed");
+    assert_eq!(
+        sender_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+    assert_eq!(
+        sender_deposits[0]["memo"].as_str().unwrap(),
+        format!("{memo:#x}"),
+    );
+
+    let recipient_status = ctx
+        .get_deposit_status_as_user(tempo_block_number, &recipient_signer)
+        .await?;
+    let recipient_deposits = recipient_status["result"]["deposits"]
+        .as_array()
+        .expect("recipient deposits should be an array");
+    assert_eq!(recipient_status["result"]["processed"], true);
+    assert_eq!(recipient_deposits.len(), 1);
+    assert_eq!(
+        recipient_deposits[0]["recipient"].as_str().unwrap(),
+        format!("{:#x}", recipient),
+    );
+    assert_eq!(
+        recipient_deposits[0]["sender"].as_str().unwrap(),
+        format!("{:#x}", depositor.address()),
     );
 
     Ok(())

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -575,7 +575,7 @@ async fn test_zone_get_deposit_status_regular_and_empty() -> eyre::Result<()> {
     );
     assert_eq!(
         sender_deposits[0]["recipient"].as_str().unwrap(),
-        format!("{:#x}", recipient),
+        format!("{recipient:#x}"),
     );
     assert_eq!(sender_deposits[0]["amount"], "0xf4240");
 
@@ -589,7 +589,7 @@ async fn test_zone_get_deposit_status_regular_and_empty() -> eyre::Result<()> {
     assert_eq!(recipient_deposits.len(), 1);
     assert_eq!(
         recipient_deposits[0]["recipient"].as_str().unwrap(),
-        format!("{:#x}", recipient),
+        format!("{recipient:#x}"),
     );
 
     let unrelated_signer = PrivateKeySigner::random();
@@ -641,7 +641,7 @@ async fn test_zone_get_deposit_status_encrypted() -> eyre::Result<()> {
     assert_eq!(sender_deposits[0]["status"], "processed");
     assert_eq!(
         sender_deposits[0]["recipient"].as_str().unwrap(),
-        format!("{:#x}", recipient),
+        format!("{recipient:#x}"),
     );
     assert_eq!(
         sender_deposits[0]["memo"].as_str().unwrap(),
@@ -658,7 +658,7 @@ async fn test_zone_get_deposit_status_encrypted() -> eyre::Result<()> {
     assert_eq!(recipient_deposits.len(), 1);
     assert_eq!(
         recipient_deposits[0]["recipient"].as_str().unwrap(),
-        format!("{:#x}", recipient),
+        format!("{recipient:#x}"),
     );
     assert_eq!(
         recipient_deposits[0]["sender"].as_str().unwrap(),

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -497,7 +497,7 @@ async fn test_method_tiers() -> eyre::Result<()> {
 async fn test_zone_metadata_methods() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let ctx = start_zone_with_private_rpc_l1().await?;
+    let ctx = start_zone_with_private_rpc().await?;
     let user_signer = PrivateKeySigner::random();
 
     let auth_info = ctx
@@ -519,7 +519,10 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
     let zone_info = ctx
         .call_as_user("zone_getZoneInfo", serde_json::json!([]), &user_signer)
         .await?;
-    assert_eq!(zone_info["result"]["zoneId"], "0x1");
+    assert_eq!(
+        zone_info["result"]["zoneId"].as_str().unwrap(),
+        format!("0x{:x}", ctx.config.zone_id),
+    );
     assert_eq!(
         zone_info["result"]["zoneToken"].as_str().unwrap(),
         "0x20c0000000000000000000000000000000000000",

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -164,19 +164,15 @@ where
 /// - [`start_local_with_chain_id()`](Self::start_local_with_chain_id) — standalone with custom chain ID (multi-zone tests)
 /// - [`start_from_l1()`](Self::start_from_l1) — connected to a real [`L1TestNode`], genesis patched from L1 header
 /// - [`start()`](Self::start) — connected to an external L1 via WebSocket URL
+type RpcApiFuture = Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn zone::rpc::ZoneRpcApi>>>>>;
+type RpcApiFactory = dyn Fn(zone::rpc::PrivateRpcConfig) -> RpcApiFuture + Send + Sync;
+
 pub(crate) struct ZoneTestNode {
     http_url: url::Url,
     deposit_queue: DepositQueue,
     l1_state_cache: SharedL1StateCache,
     policy_cache: zone::SharedPolicyCache,
-    rpc_api_factory: Arc<
-        dyn Fn(
-                zone::rpc::PrivateRpcConfig,
-            )
-                -> Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn zone::rpc::ZoneRpcApi>>>>>
-            + Send
-            + Sync,
-    >,
+    rpc_api_factory: Arc<RpcApiFactory>,
     node_handle: Box<dyn TestNodeHandle>,
     _tasks: Runtime,
 }

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -12,6 +12,8 @@ use reth_node_core::args::RpcServerArgs;
 use reth_rpc_builder::RpcModuleSelection;
 use reth_tasks::Runtime;
 use std::{
+    future::Future,
+    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -170,8 +172,8 @@ pub(crate) struct ZoneTestNode {
     rpc_api_factory: Arc<
         dyn Fn(
                 zone::rpc::PrivateRpcConfig,
-                alloy_provider::DynProvider<TempoNetwork>,
-            ) -> Arc<dyn zone::rpc::ZoneRpcApi>
+            )
+                -> Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn zone::rpc::ZoneRpcApi>>>>>
             + Send
             + Sync,
     >,
@@ -208,12 +210,11 @@ impl ZoneTestNode {
     }
 
     /// Builds the real private RPC API backed by the node's EthHandlers.
-    pub(crate) fn rpc_api(
+    pub(crate) async fn rpc_api(
         &self,
         config: zone::rpc::PrivateRpcConfig,
-        l1_provider: alloy_provider::DynProvider<TempoNetwork>,
-    ) -> Arc<dyn zone::rpc::ZoneRpcApi> {
-        (self.rpc_api_factory)(config, l1_provider)
+    ) -> eyre::Result<Arc<dyn zone::rpc::ZoneRpcApi>> {
+        (self.rpc_api_factory)(config).await
     }
 
     /// Subscribe to canonical state notifications.
@@ -507,21 +508,16 @@ impl ZoneTestNode {
         // Build the real private RPC API while the handle is still concrete,
         // before type-erasing it into Box<dyn TestNodeHandle>.
         let eth_handlers = node_handle.node.eth_handlers().clone();
-        let zone_http_url = http_url.clone();
-        let rpc_api_factory = Arc::new(
-            move |config: zone::rpc::PrivateRpcConfig,
-                  l1_provider: alloy_provider::DynProvider<TempoNetwork>| {
-                let zone_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-                    .connect_http(zone_http_url.clone())
-                    .erased();
-                Arc::new(zone::rpc::TempoZoneRpc::new(
-                    eth_handlers.clone(),
-                    config,
-                    l1_provider,
-                    zone_provider,
-                )) as Arc<dyn zone::rpc::ZoneRpcApi>
-            },
-        );
+        let rpc_api_factory = Arc::new(move |config: zone::rpc::PrivateRpcConfig| {
+            let eth_handlers = eth_handlers.clone();
+            Box::pin(async move {
+                Ok(
+                    Arc::new(zone::rpc::TempoZoneRpc::new(eth_handlers, config).await?)
+                        as Arc<dyn zone::rpc::ZoneRpcApi>,
+                )
+            })
+                as Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn zone::rpc::ZoneRpcApi>>>>>
+        });
 
         Ok(Self {
             deposit_queue,
@@ -2691,18 +2687,16 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
 
     let config = zone::rpc::PrivateRpcConfig {
         listen_addr: ([127, 0, 0, 1], 0).into(),
+        l1_rpc_url: DUMMY_L1_URL.to_string(),
+        zone_rpc_url: zone.http_url().to_string(),
         zone_id: 0,
         chain_id,
         zone_portal: Address::ZERO,
         sequencer: sequencer_address,
     };
 
-    let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(DUMMY_L1_URL.parse::<url::Url>()?)
-        .erased();
     let local_addr =
-        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone(), l1_provider))
-            .await?;
+        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone()).await?).await?;
     let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
 
     Ok(PrivateRpcTestCtx {
@@ -2767,18 +2761,16 @@ async fn start_zone_with_private_rpc_l1_inner(
 
     let config = zone::rpc::PrivateRpcConfig {
         listen_addr: ([127, 0, 0, 1], 0).into(),
+        l1_rpc_url: l1.http_url().to_string(),
+        zone_rpc_url: zone.http_url().to_string(),
         zone_id: 1,
         chain_id,
         zone_portal: portal_address,
         sequencer: l1.dev_address(),
     };
 
-    let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(l1.http_url().clone())
-        .erased();
     let local_addr =
-        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone(), l1_provider))
-            .await?;
+        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone()).await?).await?;
     let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
     let sequencer_signer = l1.dev_signer();
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -167,7 +167,14 @@ pub(crate) struct ZoneTestNode {
     deposit_queue: DepositQueue,
     l1_state_cache: SharedL1StateCache,
     policy_cache: zone::SharedPolicyCache,
-    rpc_api: Arc<dyn zone::rpc::ZoneRpcApi>,
+    rpc_api_factory: Arc<
+        dyn Fn(
+                zone::rpc::PrivateRpcConfig,
+                alloy_provider::DynProvider<TempoNetwork>,
+            ) -> Arc<dyn zone::rpc::ZoneRpcApi>
+            + Send
+            + Sync,
+    >,
     node_handle: Box<dyn TestNodeHandle>,
     _tasks: Runtime,
 }
@@ -200,9 +207,13 @@ impl ZoneTestNode {
         &self.policy_cache
     }
 
-    /// Returns the real private RPC API backed by the node's EthHandlers.
-    pub(crate) fn rpc_api(&self) -> Arc<dyn zone::rpc::ZoneRpcApi> {
-        self.rpc_api.clone()
+    /// Builds the real private RPC API backed by the node's EthHandlers.
+    pub(crate) fn rpc_api(
+        &self,
+        config: zone::rpc::PrivateRpcConfig,
+        l1_provider: alloy_provider::DynProvider<TempoNetwork>,
+    ) -> Arc<dyn zone::rpc::ZoneRpcApi> {
+        (self.rpc_api_factory)(config, l1_provider)
     }
 
     /// Subscribe to canonical state notifications.
@@ -485,7 +496,7 @@ impl ZoneTestNode {
             .launch_with_debug_capabilities()
             .await?;
 
-        let http_url = node_handle
+        let http_url: url::Url = node_handle
             .node
             .rpc_server_handle()
             .http_url()
@@ -496,15 +507,28 @@ impl ZoneTestNode {
         // Build the real private RPC API while the handle is still concrete,
         // before type-erasing it into Box<dyn TestNodeHandle>.
         let eth_handlers = node_handle.node.eth_handlers().clone();
-        let rpc_api: Arc<dyn zone::rpc::ZoneRpcApi> =
-            Arc::new(zone::rpc::TempoZoneRpc::new(eth_handlers));
+        let zone_http_url = http_url.clone();
+        let rpc_api_factory = Arc::new(
+            move |config: zone::rpc::PrivateRpcConfig,
+                  l1_provider: alloy_provider::DynProvider<TempoNetwork>| {
+                let zone_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+                    .connect_http(zone_http_url.clone())
+                    .erased();
+                Arc::new(zone::rpc::TempoZoneRpc::new(
+                    eth_handlers.clone(),
+                    config,
+                    l1_provider,
+                    zone_provider,
+                )) as Arc<dyn zone::rpc::ZoneRpcApi>
+            },
+        );
 
         Ok(Self {
             deposit_queue,
             http_url,
             l1_state_cache,
             policy_cache,
-            rpc_api,
+            rpc_api_factory,
             node_handle: Box::new(node_handle),
             _tasks: tasks,
         })
@@ -1825,6 +1849,34 @@ impl ZoneAccount {
         timeout: Duration,
         zone: &ZoneTestNode,
     ) -> eyre::Result<U256> {
+        self.deposit_to(self.address, amount, timeout, zone).await
+    }
+
+    /// Approve the ZonePortal to spend pathUSD on L1, then deposit to a specific recipient.
+    ///
+    /// Waits for the expected post-deposit balance on L2 and returns it.
+    pub(crate) async fn deposit_to(
+        &mut self,
+        recipient: Address,
+        amount: u128,
+        timeout: Duration,
+        zone: &ZoneTestNode,
+    ) -> eyre::Result<U256> {
+        Ok(self
+            .deposit_to_with_block(recipient, amount, timeout, zone)
+            .await?
+            .1)
+    }
+
+    /// Same as [`deposit_to`](Self::deposit_to), but also returns the L1 block number
+    /// that included the deposit transaction.
+    pub(crate) async fn deposit_to_with_block(
+        &mut self,
+        recipient: Address,
+        amount: u128,
+        timeout: Duration,
+        zone: &ZoneTestNode,
+    ) -> eyre::Result<(u64, U256)> {
         use tempo_contracts::precompiles::ITIP20;
         use tempo_precompiles::PATH_USD_ADDRESS;
         use zone::abi::{ZONE_TOKEN_ADDRESS, ZonePortal};
@@ -1840,24 +1892,31 @@ impl ZoneAccount {
         }
 
         // Snapshot balance before deposit so we wait for the expected increase
-        let balance_before = zone.balance_of(ZONE_TOKEN_ADDRESS, self.address).await?;
+        let balance_before = zone.balance_of(ZONE_TOKEN_ADDRESS, recipient).await?;
 
         let portal = ZonePortal::new(self.portal_address, &self.l1_provider);
         let receipt = portal
-            .deposit(PATH_USD_ADDRESS, self.address, amount, B256::ZERO)
+            .deposit(PATH_USD_ADDRESS, recipient, amount, B256::ZERO)
             .send()
             .await?
             .get_receipt()
             .await?;
         eyre::ensure!(receipt.status(), "L1 deposit tx failed");
 
-        zone.wait_for_balance(
-            ZONE_TOKEN_ADDRESS,
-            self.address,
-            balance_before + U256::from(amount),
-            timeout,
-        )
-        .await
+        let balance = zone
+            .wait_for_balance(
+                ZONE_TOKEN_ADDRESS,
+                recipient,
+                balance_before + U256::from(amount),
+                timeout,
+            )
+            .await?;
+
+        let block_number = receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("deposit receipt missing block number"))?;
+
+        Ok((block_number, balance))
     }
 
     /// Approve the ZonePortal to spend `amount` of a specific `token` on L1, then deposit.
@@ -1924,6 +1983,22 @@ impl ZoneAccount {
         timeout: Duration,
         zone: &ZoneTestNode,
     ) -> eyre::Result<U256> {
+        Ok(self
+            .deposit_encrypted_with_block(amount, recipient, memo, timeout, zone)
+            .await?
+            .1)
+    }
+
+    /// Same as [`deposit_encrypted`](Self::deposit_encrypted), but also returns the
+    /// L1 block number that included the encrypted deposit transaction.
+    pub(crate) async fn deposit_encrypted_with_block(
+        &mut self,
+        amount: u128,
+        recipient: Address,
+        memo: B256,
+        timeout: Duration,
+        zone: &ZoneTestNode,
+    ) -> eyre::Result<(u64, U256)> {
         use tempo_contracts::precompiles::ITIP20;
         use tempo_precompiles::PATH_USD_ADDRESS;
         use zone::{
@@ -1989,13 +2064,20 @@ impl ZoneAccount {
         eyre::ensure!(receipt.status(), "L1 depositEncrypted tx failed");
 
         // Wait for the zone to process the encrypted deposit and mint to recipient
-        zone.wait_for_balance(
-            ZONE_TOKEN_ADDRESS,
-            recipient,
-            balance_before + U256::from(amount),
-            timeout,
-        )
-        .await
+        let balance = zone
+            .wait_for_balance(
+                ZONE_TOKEN_ADDRESS,
+                recipient,
+                balance_before + U256::from(amount),
+                timeout,
+            )
+            .await?;
+
+        let block_number = receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("depositEncrypted receipt missing block number"))?;
+
+        Ok((block_number, balance))
     }
 
     /// Approve the ZoneOutbox, then request a withdrawal on L2.
@@ -2302,6 +2384,10 @@ async fn private_rpc_call_no_auth(
 pub(crate) struct PrivateRpcTestCtx {
     /// The underlying zone test node.
     pub zone: ZoneTestNode,
+    /// Optional real L1 test node for deposit-status integration tests.
+    pub l1: Option<L1TestNode>,
+    /// Optional real ZonePortal address on L1.
+    pub portal_address: Option<Address>,
     /// URL of the private RPC server (not the zone's direct HTTP endpoint).
     pub private_rpc_url: url::Url,
     /// The sequencer signer (gets full access on the private RPC).
@@ -2554,6 +2640,30 @@ impl PrivateRpcTestCtx {
         eyre::ensure!(receipt.status(), "revokeKey failed");
         Ok(())
     }
+
+    /// Query `zone_getDepositStatus` via the private RPC as a specific user.
+    pub(crate) async fn get_deposit_status_as_user(
+        &self,
+        tempo_block_number: u64,
+        signer: &alloy_signer_local::PrivateKeySigner,
+    ) -> eyre::Result<serde_json::Value> {
+        self.call_as_user(
+            "zone_getDepositStatus",
+            serde_json::json!([format!("0x{tempo_block_number:x}")]),
+            signer,
+        )
+        .await
+    }
+
+    /// Returns the real L1 node for tests that require one.
+    pub(crate) fn l1(&self) -> &L1TestNode {
+        self.l1.as_ref().expect("real L1 context required")
+    }
+
+    /// Returns the real portal address for tests that require one.
+    pub(crate) fn portal_address(&self) -> Address {
+        self.portal_address.expect("real portal address required")
+    }
 }
 
 /// Start a zone node with a private RPC server for testing.
@@ -2587,15 +2697,99 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
         sequencer: sequencer_address,
     };
 
-    let local_addr = zone::rpc::start_private_rpc(config.clone(), zone.rpc_api()).await?;
+    let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_http(DUMMY_L1_URL.parse::<url::Url>()?)
+        .erased();
+    let local_addr =
+        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone(), l1_provider))
+            .await?;
     let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
 
     Ok(PrivateRpcTestCtx {
         zone,
+        l1: None,
+        portal_address: None,
         private_rpc_url,
         sequencer_signer,
         config,
         fixture,
+    })
+}
+
+/// Start a zone with a private RPC server backed by a real L1 + ZonePortal.
+pub(crate) async fn start_zone_with_private_rpc_l1() -> eyre::Result<PrivateRpcTestCtx> {
+    start_zone_with_private_rpc_l1_inner(None).await
+}
+
+/// Start a zone with a private RPC server backed by a real L1 and a portal
+/// with a registered encryption key.
+pub(crate) async fn start_zone_with_private_rpc_l1_with_encryption()
+-> eyre::Result<PrivateRpcTestCtx> {
+    use sha2::{Digest, Sha256};
+
+    let key_bytes: [u8; 32] =
+        Sha256::digest(b"private-rpc-zone-specific-methods-encryption-key").into();
+    let encryption_key = k256::SecretKey::from_slice(&key_bytes).expect("valid encryption key");
+    start_zone_with_private_rpc_l1_inner(Some(encryption_key)).await
+}
+
+async fn start_zone_with_private_rpc_l1_inner(
+    encryption_key: Option<k256::SecretKey>,
+) -> eyre::Result<PrivateRpcTestCtx> {
+    use alloy_provider::Provider;
+
+    let l1 = L1TestNode::start().await?;
+    let portal_address = l1.deploy_zone().await?;
+
+    let zone = if let Some(key) = encryption_key.clone() {
+        ZoneTestNode::start_from_l1_with_sequencer_key(
+            l1.http_url(),
+            l1.ws_url(),
+            portal_address,
+            key,
+        )
+        .await?
+    } else {
+        ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?
+    };
+
+    zone.wait_for_l2_tempo_finalized(0, DEFAULT_TIMEOUT).await?;
+
+    if let Some(key) = encryption_key.as_ref() {
+        l1.set_sequencer_encryption_key(portal_address, key).await?;
+    }
+
+    let chain_id: alloy_primitives::U64 = zone
+        .provider()
+        .raw_request("eth_chainId".into(), ())
+        .await?;
+    let chain_id = chain_id.to::<u64>();
+
+    let config = zone::rpc::PrivateRpcConfig {
+        listen_addr: ([127, 0, 0, 1], 0).into(),
+        zone_id: 1,
+        chain_id,
+        zone_portal: portal_address,
+        sequencer: l1.dev_address(),
+    };
+
+    let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_http(l1.http_url().clone())
+        .erased();
+    let local_addr =
+        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone(), l1_provider))
+            .await?;
+    let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
+    let sequencer_signer = l1.dev_signer();
+
+    Ok(PrivateRpcTestCtx {
+        zone,
+        l1: Some(l1),
+        portal_address: Some(portal_address),
+        private_rpc_url,
+        sequencer_signer,
+        config,
+        fixture: L1Fixture::new(),
     })
 }
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -13,6 +13,7 @@ use reth_rpc_builder::RpcModuleSelection;
 use reth_tasks::Runtime;
 use std::{
     future::Future,
+    ops::Deref,
     pin::Pin,
     sync::{
         Arc,
@@ -2376,10 +2377,6 @@ async fn private_rpc_call_no_auth(
 pub(crate) struct PrivateRpcTestCtx {
     /// The underlying zone test node.
     pub zone: ZoneTestNode,
-    /// Optional real L1 test node for deposit-status integration tests.
-    pub l1: Option<L1TestNode>,
-    /// Optional real ZonePortal address on L1.
-    pub portal_address: Option<Address>,
     /// URL of the private RPC server (not the zone's direct HTTP endpoint).
     pub private_rpc_url: url::Url,
     /// The sequencer signer (gets full access on the private RPC).
@@ -2388,6 +2385,33 @@ pub(crate) struct PrivateRpcTestCtx {
     pub config: zone::rpc::PrivateRpcConfig,
     /// L1 fixture for injecting deposits.
     pub fixture: L1Fixture,
+}
+
+/// Private RPC e2e context backed by a real L1 node and deployed ZonePortal.
+pub(crate) struct PrivateRpcL1TestCtx {
+    ctx: PrivateRpcTestCtx,
+    l1: L1TestNode,
+    portal_address: Address,
+}
+
+impl Deref for PrivateRpcL1TestCtx {
+    type Target = PrivateRpcTestCtx;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ctx
+    }
+}
+
+impl PrivateRpcL1TestCtx {
+    /// Returns the real L1 node for tests that require one.
+    pub(crate) fn l1(&self) -> &L1TestNode {
+        &self.l1
+    }
+
+    /// Returns the real portal address for tests that require one.
+    pub(crate) fn portal_address(&self) -> Address {
+        self.portal_address
+    }
 }
 
 impl PrivateRpcTestCtx {
@@ -2646,15 +2670,40 @@ impl PrivateRpcTestCtx {
         )
         .await
     }
+}
 
-    /// Returns the real L1 node for tests that require one.
-    pub(crate) fn l1(&self) -> &L1TestNode {
-        self.l1.as_ref().expect("real L1 context required")
-    }
+async fn zone_chain_id(zone: &ZoneTestNode) -> eyre::Result<u64> {
+    use alloy_provider::Provider;
 
-    /// Returns the real portal address for tests that require one.
-    pub(crate) fn portal_address(&self) -> Address {
-        self.portal_address.expect("real portal address required")
+    let chain_id: alloy_primitives::U64 = zone
+        .provider()
+        .raw_request("eth_chainId".into(), ())
+        .await?;
+    Ok(chain_id.to())
+}
+
+async fn start_private_rpc_url(
+    zone: &ZoneTestNode,
+    config: zone::rpc::PrivateRpcConfig,
+) -> eyre::Result<url::Url> {
+    let local_addr =
+        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config).await?).await?;
+    Ok(format!("http://{local_addr}").parse()?)
+}
+
+fn build_private_rpc_ctx(
+    zone: ZoneTestNode,
+    private_rpc_url: url::Url,
+    sequencer_signer: alloy_signer_local::PrivateKeySigner,
+    config: zone::rpc::PrivateRpcConfig,
+    fixture: L1Fixture,
+) -> PrivateRpcTestCtx {
+    PrivateRpcTestCtx {
+        zone,
+        private_rpc_url,
+        sequencer_signer,
+        config,
+        fixture,
     }
 }
 
@@ -2665,18 +2714,12 @@ impl PrivateRpcTestCtx {
 /// - A private RPC server on a random port
 /// - Sequencer credentials for testing access control
 pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTestCtx> {
-    use alloy_provider::Provider;
-
     let zone = ZoneTestNode::start_local().await?;
     let fixture = L1Fixture::new();
 
     fixture.seed_l1_cache(zone.l1_state_cache(), Address::ZERO, 20);
 
-    let chain_id: alloy_primitives::U64 = zone
-        .provider()
-        .raw_request("eth_chainId".into(), ())
-        .await?;
-    let chain_id = chain_id.to::<u64>();
+    let chain_id = zone_chain_id(&zone).await?;
 
     let sequencer_signer = alloy_signer_local::PrivateKeySigner::random();
     let sequencer_address = sequencer_signer.address();
@@ -2691,30 +2734,26 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
         sequencer: sequencer_address,
     };
 
-    let local_addr =
-        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone()).await?).await?;
-    let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
+    let private_rpc_url = start_private_rpc_url(&zone, config.clone()).await?;
 
-    Ok(PrivateRpcTestCtx {
+    Ok(build_private_rpc_ctx(
         zone,
-        l1: None,
-        portal_address: None,
         private_rpc_url,
         sequencer_signer,
         config,
         fixture,
-    })
+    ))
 }
 
 /// Start a zone with a private RPC server backed by a real L1 + ZonePortal.
-pub(crate) async fn start_zone_with_private_rpc_l1() -> eyre::Result<PrivateRpcTestCtx> {
+pub(crate) async fn start_zone_with_private_rpc_l1() -> eyre::Result<PrivateRpcL1TestCtx> {
     start_zone_with_private_rpc_l1_inner(None).await
 }
 
 /// Start a zone with a private RPC server backed by a real L1 and a portal
 /// with a registered encryption key.
 pub(crate) async fn start_zone_with_private_rpc_l1_with_encryption()
--> eyre::Result<PrivateRpcTestCtx> {
+-> eyre::Result<PrivateRpcL1TestCtx> {
     use sha2::{Digest, Sha256};
 
     let key_bytes: [u8; 32] =
@@ -2725,9 +2764,7 @@ pub(crate) async fn start_zone_with_private_rpc_l1_with_encryption()
 
 async fn start_zone_with_private_rpc_l1_inner(
     encryption_key: Option<k256::SecretKey>,
-) -> eyre::Result<PrivateRpcTestCtx> {
-    use alloy_provider::Provider;
-
+) -> eyre::Result<PrivateRpcL1TestCtx> {
     let l1 = L1TestNode::start().await?;
     let portal_address = l1.deploy_zone().await?;
 
@@ -2749,11 +2786,7 @@ async fn start_zone_with_private_rpc_l1_inner(
         l1.set_sequencer_encryption_key(portal_address, key).await?;
     }
 
-    let chain_id: alloy_primitives::U64 = zone
-        .provider()
-        .raw_request("eth_chainId".into(), ())
-        .await?;
-    let chain_id = chain_id.to::<u64>();
+    let chain_id = zone_chain_id(&zone).await?;
 
     let config = zone::rpc::PrivateRpcConfig {
         listen_addr: ([127, 0, 0, 1], 0).into(),
@@ -2765,19 +2798,19 @@ async fn start_zone_with_private_rpc_l1_inner(
         sequencer: l1.dev_address(),
     };
 
-    let local_addr =
-        zone::rpc::start_private_rpc(config.clone(), zone.rpc_api(config.clone()).await?).await?;
-    let private_rpc_url: url::Url = format!("http://{local_addr}").parse()?;
+    let private_rpc_url = start_private_rpc_url(&zone, config.clone()).await?;
     let sequencer_signer = l1.dev_signer();
 
-    Ok(PrivateRpcTestCtx {
-        zone,
-        l1: Some(l1),
-        portal_address: Some(portal_address),
-        private_rpc_url,
-        sequencer_signer,
-        config,
-        fixture: L1Fixture::new(),
+    Ok(PrivateRpcL1TestCtx {
+        ctx: build_private_rpc_ctx(
+            zone,
+            private_rpc_url,
+            sequencer_signer,
+            config,
+            L1Fixture::new(),
+        ),
+        l1,
+        portal_address,
     })
 }
 

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -351,6 +351,116 @@ In addition to the Ethereum JSON-RPC methods, the zone exposes zone-specific met
 | `zone_getZoneInfo` | Any authenticated | Returns zone metadata: `zoneId`, `zoneToken`, `sequencer` (address only, not private key), `chainId`. |
 | `zone_getDepositStatus(tempoBlockNumber)` | Scoped | Returns whether deposits from the given Tempo block have been processed on the zone. Only returns information about deposits where the sender or recipient is the authenticated account. |
 
+All integer fields in these responses use Ethereum JSON-RPC quantity encoding (hex strings such as `0x1`).
+
+### `zone_getAuthorizationTokenInfo`
+
+**Request**
+
+```json
+{
+  "method": "zone_getAuthorizationTokenInfo",
+  "params": []
+}
+```
+
+**Response**
+
+```json
+{
+  "account": "0x1234...",
+  "expiresAt": "0x67d2d7c0"
+}
+```
+
+- `account`: the authenticated account address recovered from the authorization token.
+- `expiresAt`: the token expiry timestamp (unix seconds).
+
+### `zone_getZoneInfo`
+
+**Request**
+
+```json
+{
+  "method": "zone_getZoneInfo",
+  "params": []
+}
+```
+
+**Response**
+
+```json
+{
+  "zoneId": "0x1",
+  "zoneToken": "0x20c0000000000000000000000000000000000000",
+  "sequencer": "0xabcd...",
+  "chainId": "0x2a"
+}
+```
+
+- `zoneId`: the configured zone identifier.
+- `zoneToken`: the zone's TIP-20 token address.
+- `sequencer`: the configured sequencer address.
+- `chainId`: the zone chain ID.
+
+### `zone_getDepositStatus(tempoBlockNumber)`
+
+**Request**
+
+```json
+{
+  "method": "zone_getDepositStatus",
+  "params": ["0x2a"]
+}
+```
+
+`tempoBlockNumber` MAY be supplied either as a JSON number or as a hex quantity string.
+
+**Response**
+
+```json
+{
+  "tempoBlockNumber": "0x2a",
+  "zoneProcessedThrough": "0x2a",
+  "processed": true,
+  "deposits": [
+    {
+      "depositHash": "0xfeed...",
+      "kind": "regular",
+      "token": "0x20c0000000000000000000000000000000000000",
+      "sender": "0xaaaa...",
+      "recipient": "0xbbbb...",
+      "amount": "0xf4240",
+      "memo": "0x1111...",
+      "status": "processed"
+    }
+  ]
+}
+```
+
+- `tempoBlockNumber`: the queried Tempo L1 block number.
+- `zoneProcessedThrough`: the latest Tempo block number the zone has processed on L2.
+- `processed`: `true` if the zone has advanced through `tempoBlockNumber` and every deposit visible to the authenticated caller from that block has reached a terminal status.
+- `deposits`: only deposits relevant to the authenticated caller.
+
+Each deposit entry has:
+
+- `depositHash`: the deposit queue hash (`newCurrentDepositQueueHash`) for that deposit.
+- `kind`: `"regular"` or `"encrypted"`.
+- `token`: the deposited token address.
+- `sender`: the L1 depositor address.
+- `recipient`: the plaintext recipient address when visible; otherwise `null`.
+- `amount`: the post-fee deposit amount.
+- `memo`: the deposit memo when visible; otherwise `null`.
+- `status`: `"pending"`, `"processed"`, or `"failed"`.
+
+Visibility rules:
+
+- Regular deposits are returned only when the authenticated account is the sender or the plaintext recipient.
+- Encrypted deposits are returned immediately to the sender.
+- Encrypted deposits are returned to a recipient-only caller only after the zone has emitted `EncryptedDepositProcessed` on L2, which reveals the recipient.
+- Pending encrypted deposits MUST keep `recipient` and `memo` as `null`; implementations MUST NOT decrypt or reveal hidden recipient data just to answer RPC.
+
 **Withdrawals**: To request a withdrawal, the caller MUST construct and sign a transaction calling `ZoneOutbox.requestWithdrawal(...)` and submit it via `eth_sendRawTransaction`. There is no server-side convenience method — authorization tokens are read-only credentials and MUST NOT be sufficient to authorize state-changing operations such as token transfers or withdrawals. Requiring a full transaction signature ensures that a stolen or replayed authorization token cannot be used to move funds.
 
 ## Error codes

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -414,7 +414,7 @@ All integer fields in these responses use Ethereum JSON-RPC quantity encoding (h
 }
 ```
 
-`tempoBlockNumber` MAY be supplied either as a JSON number or as a hex quantity string.
+`tempoBlockNumber` MUST be supplied as a JSON-RPC hex quantity string.
 
 **Response**
 


### PR DESCRIPTION
Supersedes #264.

This is a clean rebuild of the zone-specific private RPC work on top of current `main`, without the unrelated auth-token branch history that ended up in the earlier PR.

## Summary
- add the spec'd `zone_getAuthorizationTokenInfo`, `zone_getZoneInfo`, and `zone_getDepositStatus` methods to the private RPC dispatcher and API surface
- implement zone-specific RPC handling in `TempoZoneRpc`, including L1 portal log lookup and L2 inbox event correlation for caller-scoped deposit status
- document the concrete request/response payloads and add unit, websocket, and e2e coverage for the new methods

## Testing
- cargo fmt
- cargo test -p zone-rpc --lib handlers::tests:: -- --nocapture
- cargo test -p zone-rpc --test it ws_zone_method_roundtrip -- --nocapture
- cargo test -p zone --test it classify_public_methods -- --nocapture
- forge build
- cargo test -p zone --test it private_rpc_e2e:: -- --nocapture