### PR TITLE
Return enabled tokens from zone_getZoneInfo

### DIFF
--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -805,7 +805,7 @@ mod tests {
             Box::pin(async move {
                 to_raw(&json!({
                     "zoneId": "0x1",
-                    "zoneToken": format!("{:#x}", Address::repeat_byte(0x11)),
+                    "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
                     "sequencer": format!("{:#x}", auth.caller),
                     "chainId": "0x2a",
                 }))
@@ -877,6 +877,10 @@ mod tests {
         let body: serde_json::Value =
             serde_json::from_str(resp.result.as_ref().unwrap().get()).unwrap();
         assert_eq!(body["zoneId"], "0x1");
+        assert_eq!(
+            body["zoneTokens"][0],
+            format!("{:#x}", Address::repeat_byte(0x11))
+        );
         assert_eq!(body["chainId"], "0x2a");
     }
 

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -175,8 +175,8 @@ pub struct AuthorizationTokenInfoResponse {
 pub struct ZoneInfoResponse {
     /// The zone's numeric identifier.
     pub zone_id: U64,
-    /// The fixed zone token contract address.
-    pub zone_token: Address,
+    /// The enabled zone token contract addresses.
+    pub zone_tokens: Vec<Address>,
     /// The configured sequencer account.
     pub sequencer: Address,
     /// The zone chain ID.

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -136,7 +136,7 @@ impl ZoneRpcApi for MockZoneRpcApi {
         Box::pin(async move {
             zone_rpc::types::to_raw(&serde_json::json!({
                 "zoneId": "0x1",
-                "zoneToken": format!("{:#x}", Address::repeat_byte(0x11)),
+                "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
                 "sequencer": format!("{:#x}", Address::repeat_byte(0x22)),
                 "chainId": "0x2a",
             }))

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -193,6 +193,17 @@ impl<Api: EthApiTypes> TempoZoneRpc<Api> {
         Ok(deposits)
     }
 
+    async fn zone_tokens(&self) -> Result<Vec<Address>, JsonRpcError> {
+        if self.config.zone_portal.is_zero() {
+            return Ok(vec![ZONE_TOKEN_ADDRESS]);
+        }
+
+        ZonePortal::new(self.config.zone_portal, &self.l1_provider)
+            .enabled_tokens()
+            .await
+            .map_err(internal)
+    }
+
     async fn terminal_event_for_deposit(
         &self,
         deposit_hash: B256,
@@ -667,9 +678,10 @@ where
 
     fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
+            let zone_tokens = self.zone_tokens().await?;
             to_raw(&ZoneInfoResponse {
                 zone_id: U64::from(self.config.zone_id),
-                zone_token: ZONE_TOKEN_ADDRESS,
+                zone_tokens,
                 sequencer: self.config.sequencer,
                 chain_id: U64::from(self.config.chain_id),
             })

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -574,8 +574,8 @@ async fn test_zone_get_zone_info_returns_all_enabled_tokens() -> eyre::Result<()
     assert_eq!(
         zone_tokens,
         vec![
-            format!("{:#x}", PATH_USD_ADDRESS),
-            format!("{:#x}", alpha_token)
+            format!("{PATH_USD_ADDRESS:#x}"),
+            format!("{alpha_token:#x}")
         ],
     );
 

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -524,8 +524,13 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
         format!("0x{:x}", ctx.config.zone_id),
     );
     assert_eq!(
-        zone_info["result"]["zoneToken"].as_str().unwrap(),
-        "0x20c0000000000000000000000000000000000000",
+        zone_info["result"]["zoneTokens"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|token| token.as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["0x20c0000000000000000000000000000000000000"],
     );
     assert_eq!(
         zone_info["result"]["sequencer"].as_str().unwrap(),
@@ -534,6 +539,44 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
     assert_eq!(
         zone_info["result"]["chainId"].as_str().unwrap(),
         format!("0x{:x}", ctx.config.chain_id),
+    );
+
+    Ok(())
+}
+
+/// `zone_getZoneInfo` returns every token currently enabled on the portal.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zone_get_zone_info_returns_all_enabled_tokens() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_private_rpc_l1().await?;
+    let user_signer = PrivateKeySigner::random();
+    let alpha_salt = B256::with_last_byte(0x44);
+    let alpha_token = ctx
+        .l1()
+        .create_tip20("AlphaUSD", "aUSD", alpha_salt)
+        .await?;
+
+    ctx.l1()
+        .enable_token_on_portal(ctx.portal_address(), alpha_token)
+        .await?;
+
+    let zone_info = ctx
+        .call_as_user("zone_getZoneInfo", serde_json::json!([]), &user_signer)
+        .await?;
+    let zone_tokens = zone_info["result"]["zoneTokens"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|token| token.as_str().unwrap().to_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        zone_tokens,
+        vec![
+            format!("{:#x}", PATH_USD_ADDRESS),
+            format!("{:#x}", alpha_token)
+        ],
     );
 
     Ok(())

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -348,7 +348,7 @@ In addition to the Ethereum JSON-RPC methods, the zone exposes zone-specific met
 | Method | Access | Description |
 |--------|--------|-------------|
 | `zone_getAuthorizationTokenInfo` | Any authenticated | Returns the authenticated account address and token expiry. Useful for verifying the authorization token is valid. |
-| `zone_getZoneInfo` | Any authenticated | Returns zone metadata: `zoneId`, `zoneToken`, `sequencer` (address only, not private key), `chainId`. |
+| `zone_getZoneInfo` | Any authenticated | Returns zone metadata: `zoneId`, `zoneTokens`, `sequencer` (address only, not private key), `chainId`. |
 | `zone_getDepositStatus(tempoBlockNumber)` | Scoped | Returns whether deposits from the given Tempo block have been processed on the zone. Only returns information about deposits where the sender or recipient is the authenticated account. |
 
 All integer fields in these responses use Ethereum JSON-RPC quantity encoding (hex strings such as `0x1`).
@@ -392,14 +392,17 @@ All integer fields in these responses use Ethereum JSON-RPC quantity encoding (h
 ```json
 {
   "zoneId": "0x1",
-  "zoneToken": "0x20c0000000000000000000000000000000000000",
+  "zoneTokens": [
+    "0x20c0000000000000000000000000000000000000",
+    "0x20c0000000000000000000000000000000aa0001"
+  ],
   "sequencer": "0xabcd...",
   "chainId": "0x2a"
 }
 ```
 
 - `zoneId`: the configured zone identifier.
-- `zoneToken`: the zone's TIP-20 token address.
+- `zoneTokens`: the zone's currently enabled TIP-20 token addresses.
 - `sequencer`: the configured sequencer address.
 - `chainId`: the zone chain ID.
 


### PR DESCRIPTION
## Summary
- change `zone_getZoneInfo` to return `zoneTokens` as a vector of enabled token addresses
- read enabled tokens from the portal when configured, while preserving the standalone fallback to the default zone token
- update private RPC tests, handler mocks, and docs to match the plural response shape

## Testing
- cargo test -p zone-rpc dispatches_zone_get_zone_info
- cargo test -p zone test_zone_metadata_methods
- cargo test -p zone test_zone_get_zone_info