### PR TITLE
chore: bump tempo main to d65bf399

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6708,7 +6708,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6764,7 +6764,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6784,7 +6784,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6797,7 +6797,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6880,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6890,7 +6890,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6928,7 +6928,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6938,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6967,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6980,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7006,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7034,7 +7034,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7063,7 +7063,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7093,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7133,7 +7133,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7267,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7292,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7348,7 +7348,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7376,7 +7376,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7391,7 +7391,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7407,7 +7407,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7429,7 +7429,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "clap",
  "eyre",
@@ -7552,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7628,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7642,7 +7642,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7676,7 +7676,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7727,7 +7727,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "serde",
  "serde_json",
@@ -7789,7 +7789,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "bytes",
  "futures",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "bindgen",
  "cc",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "futures",
  "metrics",
@@ -7875,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7898,7 +7898,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7955,7 +7955,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7980,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8018,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8032,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8073,7 +8073,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8141,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8196,7 +8196,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8258,7 +8258,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8282,7 +8282,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "bytes",
  "eyre",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8318,7 +8318,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8339,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8351,7 +8351,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8374,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8384,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8419,10 +8419,11 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "eyre",
@@ -8464,7 +8465,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8493,7 +8494,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8509,7 +8510,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8522,7 +8523,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8600,7 +8601,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -8631,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8674,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8694,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8725,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8769,7 +8770,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8817,7 +8818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8831,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8847,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8899,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8926,7 +8927,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8940,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8960,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8975,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9016,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9037,7 +9038,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9053,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9063,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "clap",
  "eyre",
@@ -9080,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "clap",
  "eyre",
@@ -9097,7 +9098,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9141,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9167,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9194,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9214,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9238,7 +9239,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9260,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=72d0e04#72d0e04d856d1f8a62fb220e14e5898fde625d5b"
 dependencies = [
  "zstd",
 ]
@@ -10240,7 +10241,8 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slotmap"
 version = "1.1.1"
-source = "git+https://github.com/DaniPopes/slotmap.git?branch=dani%2Fshrink-methods#09fbd360968f9ecef19fc9559037cf869d33858b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
 ]
@@ -10494,7 +10496,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10527,7 +10529,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10535,6 +10537,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "eyre",
+ "once_cell",
  "paste",
  "reth-chainspec",
  "reth-cli",
@@ -10547,7 +10550,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10563,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10574,7 +10577,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10604,7 +10607,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -10656,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10690,7 +10693,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10709,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10728,7 +10731,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10739,7 +10742,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10768,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10791,7 +10794,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed25d8e4affee8c8ba71ed137c204e54b97ad69a#ed25d8e4affee8c8ba71ed137c204e54b97ad69a"
+source = "git+https://github.com/tempoxyz/tempo?rev=d65bf3995d23731e7fbce0300b04791bb6e1cd1a#d65bf3995d23731e7fbce0300b04791bb6e1cd1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11116,7 +11119,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.28.0",
 ]
 
@@ -11528,6 +11535,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,23 +78,23 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false, features = ["serde"] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false, features = ["serde"] }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "ed25d8e4affee8c8ba71ed137c204e54b97ad69a", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "d65bf3995d23731e7fbce0300b04791bb6e1cd1a", default-features = false }
 
 # zones
 zone-precompiles = { path = "crates/precompiles", default-features = false }
@@ -102,35 +102,35 @@ zone-primitives = { path = "crates/primitives", default-features = false }
 zone-rpc = { path = "crates/rpc" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50", features = [
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9060c50" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
 revm = { version = "36.0.0", features = ["optional_fee_charge"] }
 
 # alloy


### PR DESCRIPTION
## Summary
- bump the Tempo workspace git dependencies from `ed25d8e4affee8c8ba71ed137c204e54b97ad69a` to `d65bf3995d23731e7fbce0300b04791bb6e1cd1a` (Tempo `main` as of 2026-03-23)
- align the pinned `reth` revision to `72d0e04` to match upstream Tempo `main`
- refresh `Cargo.lock` for the new git revisions

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets` *(fails in this checkout because generated Foundry artifacts under `docs/specs/out/` are missing; `advance_tempo_repro` looks for `TempoState.sol/TempoState.json`)*
- `cargo test -p zone --test it private_rpc_e2e::test_zone_get_zone_info_returns_all_enabled_tokens -- --exact --nocapture` *(fails in this checkout with `ZoneFactory artifact not found – run forge build in docs/specs`)*