### PR TITLE
Handle L1 sequencer transfer portal events

### DIFF
--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -15,9 +15,9 @@ use alloy_primitives::{B256, keccak256};
 use alloy_sol_types::SolValue;
 
 pub use crate::constants::{
-    EMPTY_SENTINEL, TEMPO_BLOCK_HASH_SLOT, TEMPO_PACKED_SLOT, TEMPO_STATE_ADDRESS,
-    TEMPO_STATE_READER_ADDRESS, ZONE_CONFIG_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
-    ZONE_TOKEN_ADDRESS,
+    EMPTY_SENTINEL, PORTAL_PENDING_SEQUENCER_SLOT, PORTAL_SEQUENCER_SLOT, TEMPO_BLOCK_HASH_SLOT,
+    TEMPO_PACKED_SLOT, TEMPO_STATE_ADDRESS, TEMPO_STATE_READER_ADDRESS, ZONE_CONFIG_ADDRESS,
+    ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS,
 };
 
 /// Internal macro that emits the full `sol!` block, placing `$($rpc_attr)*`
@@ -155,6 +155,18 @@ macro_rules! define_abi {
                     address indexed fallbackRecipient,
                     address token,
                     uint128 amount
+                );
+
+                #[derive(Debug)]
+                event SequencerTransferStarted(
+                    address indexed currentSequencer,
+                    address indexed pendingSequencer
+                );
+
+                #[derive(Debug)]
+                event SequencerTransferred(
+                    address indexed previousSequencer,
+                    address indexed newSequencer
                 );
 
                 // -- Errors --

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -46,6 +46,16 @@ pub const ZONE_TIP20_FACTORY_ADDRESS: Address =
 /// Default zone token address (pathUSD TIP-20).
 pub const ZONE_TOKEN_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000000");
 
+/// ZonePortal storage slot 0: `sequencer` (address).
+pub const PORTAL_SEQUENCER_SLOT: B256 = B256::ZERO;
+
+/// ZonePortal storage slot 1: `pendingSequencer` (address).
+pub const PORTAL_PENDING_SEQUENCER_SLOT: B256 = {
+    let mut bytes = [0u8; 32];
+    bytes[31] = 1;
+    B256::new(bytes)
+};
+
 // ---------------------------------------------------------------------------
 //  Storage slot constants for the proof system
 // ---------------------------------------------------------------------------

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -24,12 +24,14 @@ use tracing::{debug, error, info, instrument, warn};
 use crate::{
     abi::{
         self, EncryptedDeposit as AbiEncryptedDeposit,
-        EncryptedDepositPayload as AbiEncryptedDepositPayload,
+        EncryptedDepositPayload as AbiEncryptedDepositPayload, PORTAL_PENDING_SEQUENCER_SLOT,
+        PORTAL_SEQUENCER_SLOT,
         ZonePortal::{
-            self, BounceBack, DepositMade, EncryptedDepositMade, TokenEnabled, ZonePortalEvents,
+            self, BounceBack, DepositMade, EncryptedDepositMade, SequencerTransferStarted,
+            SequencerTransferred, TokenEnabled, ZonePortalEvents,
         },
     },
-    l1_state::tip403::PolicyEvent,
+    l1_state::{cache::L1StateCache, tip403::PolicyEvent},
 };
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
@@ -424,6 +426,7 @@ impl L1Subscriber {
 
             let sealed = SealedHeader::seal_slow(header);
             self.update_l1_state_anchor(block_number, sealed.hash(), sealed.parent_hash());
+            self.apply_portal_state_events(block_number, &events);
             self.deposit_queue
                 .enqueue_sealed(sealed, events, policy_events);
             enqueued += 1;
@@ -515,6 +518,7 @@ impl L1Subscriber {
                     let tip_parent = tip_header.parent_hash();
                     self.apply_policy_events(tip_number, &tip_policy_events);
                     self.update_l1_state_anchor(tip_number, tip_hash, tip_parent);
+                    self.apply_portal_state_events(tip_number, &tip_events);
                     match self
                         .deposit_queue
                         .try_enqueue(tip_header, tip_events, tip_policy_events)
@@ -615,10 +619,18 @@ impl L1Subscriber {
     fn record_portal_event_metrics(&self, portal_events: &L1PortalEvents) {
         let mut regular = 0u64;
         let mut encrypted = 0u64;
+        let mut transfer_started = 0u64;
+        let mut transferred = 0u64;
         for deposit in &portal_events.deposits {
             match deposit {
                 L1Deposit::Regular(_) => regular += 1,
                 L1Deposit::Encrypted(_) => encrypted += 1,
+            }
+        }
+        for event in &portal_events.sequencer_events {
+            match event {
+                L1SequencerEvent::TransferStarted { .. } => transfer_started += 1,
+                L1SequencerEvent::Transferred { .. } => transferred += 1,
             }
         }
         if regular > 0 {
@@ -635,6 +647,16 @@ impl L1Subscriber {
             self.subscriber_metrics
                 .token_enabled_events_total
                 .increment(portal_events.enabled_tokens.len() as u64);
+        }
+        if transfer_started > 0 {
+            self.subscriber_metrics
+                .sequencer_transfer_started_events_total
+                .increment(transfer_started);
+        }
+        if transferred > 0 {
+            self.subscriber_metrics
+                .sequencer_transferred_events_total
+                .increment(transferred);
         }
     }
 
@@ -657,6 +679,22 @@ impl L1Subscriber {
             .set(cache.num_token_policies() as f64);
     }
 
+    /// Write decoded portal state changes into the shared L1 cache at the
+    /// confirmed block height.
+    fn apply_portal_state_events(&self, block_number: u64, portal_events: &L1PortalEvents) {
+        if portal_events.sequencer_events.is_empty() {
+            return;
+        }
+
+        let mut cache = self.config.l1_state_cache.write();
+        apply_sequencer_events_to_cache(
+            &mut cache,
+            self.config.portal_address,
+            block_number,
+            &portal_events.sequencer_events,
+        );
+    }
+
     /// Update the L1 state cache anchor. Detects reorgs by comparing
     /// `parent_hash` against the current anchor and clears the cache when they
     /// diverge.
@@ -675,6 +713,58 @@ impl L1Subscriber {
         }
         guard.update_anchor(NumHash { number, hash });
     }
+}
+
+fn apply_sequencer_events_to_cache(
+    cache: &mut L1StateCache,
+    portal_address: Address,
+    block_number: u64,
+    sequencer_events: &[L1SequencerEvent],
+) {
+    for event in sequencer_events {
+        match *event {
+            L1SequencerEvent::TransferStarted {
+                current_sequencer,
+                pending_sequencer,
+            } => {
+                cache.set(
+                    portal_address,
+                    PORTAL_SEQUENCER_SLOT,
+                    block_number,
+                    address_to_storage_value(current_sequencer),
+                );
+                cache.set(
+                    portal_address,
+                    PORTAL_PENDING_SEQUENCER_SLOT,
+                    block_number,
+                    address_to_storage_value(pending_sequencer),
+                );
+            }
+            L1SequencerEvent::Transferred {
+                previous_sequencer: _,
+                new_sequencer,
+            } => {
+                cache.set(
+                    portal_address,
+                    PORTAL_SEQUENCER_SLOT,
+                    block_number,
+                    address_to_storage_value(new_sequencer),
+                );
+                cache.set(
+                    portal_address,
+                    PORTAL_PENDING_SEQUENCER_SLOT,
+                    block_number,
+                    B256::ZERO,
+                );
+            }
+        }
+    }
+}
+
+fn address_to_storage_value(address: Address) -> B256 {
+    let mut bytes = [0u8; 32];
+    bytes[12..].copy_from_slice(address.as_slice());
+    B256::new(bytes)
 }
 
 /// A deposit extracted from L1.
@@ -814,6 +904,21 @@ impl L1Deposit {
     }
 }
 
+/// A sequencer-management event emitted by the L1 portal.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum L1SequencerEvent {
+    /// The current sequencer nominated a pending successor.
+    TransferStarted {
+        current_sequencer: Address,
+        pending_sequencer: Address,
+    },
+    /// The pending sequencer accepted and became the active sequencer.
+    Transferred {
+        previous_sequencer: Address,
+        new_sequencer: Address,
+    },
+}
+
 /// Result of attempting to enqueue an L1 block into the deposit queue.
 #[derive(Debug)]
 pub(crate) enum EnqueueOutcome {
@@ -837,6 +942,8 @@ pub struct L1PortalEvents {
     pub deposits: Vec<L1Deposit>,
     /// Tokens newly enabled for bridging in this block, with metadata.
     pub enabled_tokens: Vec<EnabledToken>,
+    /// Sequencer transfer events in the order they appeared in the block.
+    pub sequencer_events: Vec<L1SequencerEvent>,
 }
 
 /// A token newly enabled for bridging, with metadata for L2 creation.
@@ -866,11 +973,13 @@ impl EnabledToken {
 
 impl L1PortalEvents {
     /// Event signature hashes that this container knows how to decode.
-    const SIGNATURE_HASHES: [B256; 4] = [
+    const SIGNATURE_HASHES: [B256; 6] = [
         DepositMade::SIGNATURE_HASH,
         EncryptedDepositMade::SIGNATURE_HASH,
         BounceBack::SIGNATURE_HASH,
         TokenEnabled::SIGNATURE_HASH,
+        SequencerTransferStarted::SIGNATURE_HASH,
+        SequencerTransferred::SIGNATURE_HASH,
     ];
 
     /// Create portal events from deposits only.
@@ -946,6 +1055,31 @@ impl L1PortalEvents {
                     name: event.name,
                     symbol: event.symbol,
                     currency: event.currency,
+                });
+            }
+            ZonePortalEvents::SequencerTransferStarted(event) => {
+                info!(
+                    l1_block = block_number,
+                    current_sequencer = %event.currentSequencer,
+                    pending_sequencer = %event.pendingSequencer,
+                    "👤 Sequencer transfer started on L1"
+                );
+                self.sequencer_events
+                    .push(L1SequencerEvent::TransferStarted {
+                        current_sequencer: event.currentSequencer,
+                        pending_sequencer: event.pendingSequencer,
+                    });
+            }
+            ZonePortalEvents::SequencerTransferred(event) => {
+                info!(
+                    l1_block = block_number,
+                    previous_sequencer = %event.previousSequencer,
+                    new_sequencer = %event.newSequencer,
+                    "👤 Sequencer transferred on L1"
+                );
+                self.sequencer_events.push(L1SequencerEvent::Transferred {
+                    previous_sequencer: event.previousSequencer,
+                    new_sequencer: event.newSequencer,
                 });
             }
             _ => {}
@@ -1646,9 +1780,11 @@ impl Default for DepositQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::abi::DepositType;
+    use crate::abi::{DepositType, PORTAL_PENDING_SEQUENCER_SLOT, PORTAL_SEQUENCER_SLOT};
     use alloy_consensus::Header;
     use alloy_primitives::{FixedBytes, address};
+    use alloy_sol_types::SolEvent;
+    use std::collections::HashSet;
 
     fn make_test_header(number: u64) -> TempoHeader {
         TempoHeader {
@@ -1690,6 +1826,22 @@ mod tests {
     fn confirm_shared(queue: &DepositQueue) -> L1BlockDeposits {
         let num_hash = queue.peek().expect("queue is empty").header.num_hash();
         queue.confirm(num_hash).expect("confirm mismatch")
+    }
+
+    fn make_portal_log<E: SolEvent>(portal_address: Address, event: E) -> Log {
+        Log {
+            inner: alloy_primitives::Log {
+                address: portal_address,
+                data: event.encode_log_data(),
+            },
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        }
     }
 
     #[test]
@@ -1735,6 +1887,152 @@ mod tests {
             deposit.memo,
             B256::ZERO,
             "bounce-back deposits should clear memo"
+        );
+    }
+
+    #[test]
+    fn test_push_log_decodes_sequencer_transfer_started() {
+        let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+        let current_sequencer = address!("0x00000000000000000000000000000000000000A1");
+        let pending_sequencer = address!("0x00000000000000000000000000000000000000B2");
+        let event = SequencerTransferStarted {
+            currentSequencer: current_sequencer,
+            pendingSequencer: pending_sequencer,
+        };
+        let log = make_portal_log(portal_address, event);
+
+        let mut events = L1PortalEvents::default();
+        events
+            .push_log(&log, 123)
+            .expect("sequencer transfer start should decode");
+
+        assert_eq!(
+            events.sequencer_events,
+            vec![L1SequencerEvent::TransferStarted {
+                current_sequencer,
+                pending_sequencer,
+            }]
+        );
+        assert!(events.deposits.is_empty());
+        assert!(events.enabled_tokens.is_empty());
+    }
+
+    #[test]
+    fn test_push_log_decodes_sequencer_transferred() {
+        let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+        let previous_sequencer = address!("0x00000000000000000000000000000000000000A1");
+        let new_sequencer = address!("0x00000000000000000000000000000000000000B2");
+        let event = SequencerTransferred {
+            previousSequencer: previous_sequencer,
+            newSequencer: new_sequencer,
+        };
+        let log = make_portal_log(portal_address, event);
+
+        let mut events = L1PortalEvents::default();
+        events
+            .push_log(&log, 123)
+            .expect("sequencer transferred should decode");
+
+        assert_eq!(
+            events.sequencer_events,
+            vec![L1SequencerEvent::Transferred {
+                previous_sequencer,
+                new_sequencer,
+            }]
+        );
+        assert!(events.deposits.is_empty());
+        assert!(events.enabled_tokens.is_empty());
+    }
+
+    #[test]
+    fn test_apply_sequencer_events_to_cache_sets_pending_sequencer() {
+        let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+        let current_sequencer = address!("0x00000000000000000000000000000000000000A1");
+        let pending_sequencer = address!("0x00000000000000000000000000000000000000B2");
+        let mut cache = L1StateCache::new(HashSet::from([portal_address]));
+
+        apply_sequencer_events_to_cache(
+            &mut cache,
+            portal_address,
+            42,
+            &[L1SequencerEvent::TransferStarted {
+                current_sequencer,
+                pending_sequencer,
+            }],
+        );
+
+        assert_eq!(
+            cache.get(portal_address, PORTAL_SEQUENCER_SLOT, 42),
+            Some(address_to_storage_value(current_sequencer))
+        );
+        assert_eq!(
+            cache.get(portal_address, PORTAL_PENDING_SEQUENCER_SLOT, 42),
+            Some(address_to_storage_value(pending_sequencer))
+        );
+    }
+
+    #[test]
+    fn test_apply_sequencer_events_to_cache_accept_clears_pending_sequencer() {
+        let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+        let previous_sequencer = address!("0x00000000000000000000000000000000000000A1");
+        let new_sequencer = address!("0x00000000000000000000000000000000000000B2");
+        let mut cache = L1StateCache::new(HashSet::from([portal_address]));
+
+        apply_sequencer_events_to_cache(
+            &mut cache,
+            portal_address,
+            43,
+            &[L1SequencerEvent::Transferred {
+                previous_sequencer,
+                new_sequencer,
+            }],
+        );
+
+        assert_eq!(
+            cache.get(portal_address, PORTAL_SEQUENCER_SLOT, 43),
+            Some(address_to_storage_value(new_sequencer))
+        );
+        assert_eq!(
+            cache.get(portal_address, PORTAL_PENDING_SEQUENCER_SLOT, 43),
+            Some(B256::ZERO)
+        );
+    }
+
+    #[test]
+    fn test_apply_sequencer_events_to_cache_preserves_in_block_event_order() {
+        let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+        let sequencer_a = address!("0x00000000000000000000000000000000000000A1");
+        let sequencer_b = address!("0x00000000000000000000000000000000000000B2");
+        let sequencer_c = address!("0x00000000000000000000000000000000000000C3");
+        let mut cache = L1StateCache::new(HashSet::from([portal_address]));
+
+        apply_sequencer_events_to_cache(
+            &mut cache,
+            portal_address,
+            44,
+            &[
+                L1SequencerEvent::TransferStarted {
+                    current_sequencer: sequencer_a,
+                    pending_sequencer: sequencer_b,
+                },
+                L1SequencerEvent::Transferred {
+                    previous_sequencer: sequencer_a,
+                    new_sequencer: sequencer_b,
+                },
+                L1SequencerEvent::TransferStarted {
+                    current_sequencer: sequencer_b,
+                    pending_sequencer: sequencer_c,
+                },
+            ],
+        );
+
+        assert_eq!(
+            cache.get(portal_address, PORTAL_SEQUENCER_SLOT, 44),
+            Some(address_to_storage_value(sequencer_b))
+        );
+        assert_eq!(
+            cache.get(portal_address, PORTAL_PENDING_SEQUENCER_SLOT, 44),
+            Some(address_to_storage_value(sequencer_c))
         );
     }
 

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -28,7 +28,7 @@ pub use batch::{BatchData, BatchSubmitter};
 pub use engine::ZoneEngine;
 pub use l1::{
     Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1BlockDeposits, L1Deposit,
-    L1PortalEvents, L1Subscriber, L1SubscriberConfig,
+    L1PortalEvents, L1SequencerEvent, L1Subscriber, L1SubscriberConfig,
 };
 pub use l1_state::{PolicyProvider, SharedL1StateCache, SharedPolicyCache};
 pub use node::{ZoneExecutorBuilder, ZoneNode};

--- a/crates/tempo-zone/src/metrics.rs
+++ b/crates/tempo-zone/src/metrics.rs
@@ -68,6 +68,12 @@ pub(crate) struct L1SubscriberMetrics {
     /// Number of `TokenEnabled` events observed on L1.
     pub token_enabled_events_total: Counter,
 
+    /// Number of `SequencerTransferStarted` events observed on L1.
+    pub sequencer_transfer_started_events_total: Counter,
+
+    /// Number of `SequencerTransferred` events observed on L1.
+    pub sequencer_transferred_events_total: Counter,
+
     /// Number of reorgs detected by the subscriber.
     pub reorgs_detected_total: Counter,
 

--- a/crates/tempo-zone/tests/it/enable_token.rs
+++ b/crates/tempo-zone/tests/it/enable_token.rs
@@ -87,6 +87,7 @@ async fn test_enable_token_and_deposit_same_block() -> eyre::Result<()> {
     let events = L1PortalEvents {
         deposits: vec![L1Deposit::Regular(deposit)],
         enabled_tokens: vec![enabled],
+        ..Default::default()
     };
     fixture.enqueue_events(&block, zone.deposit_queue(), events);
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2961,6 +2961,7 @@ impl L1Fixture {
         let events = L1PortalEvents {
             deposits: vec![],
             enabled_tokens: tokens,
+            ..Default::default()
         };
         queue.enqueue(header, events, vec![]);
     }


### PR DESCRIPTION
## Summary
- add `SequencerTransferStarted` and `SequencerTransferred` to the Rust `ZonePortal` ABI and export portal sequencer slot constants
- decode sequencer transfer events into `L1PortalEvents`, preserve their in-block order, and replay them into the shared L1 state cache once blocks are confirmed
- add L1 subscriber metrics for sequencer transfer events and update integration helpers for the expanded `L1PortalEvents` shape

## Testing
- `cargo test -p zone --lib l1::tests::`
- `cargo test -p zone --test it --no-run`
- `cargo test -p zone --test it test_enable_token_and_deposit_same_block`

## Notes
- private RPC sequencer auth and `zone_get_zone_info` remain unchanged in this PR, per plan