### PR TITLE
feat: Add native private RPC websocket subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12895,6 +12895,7 @@ dependencies = [
  "tempo-transaction-pool",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
  "zone-precompiles",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12874,6 +12874,7 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-builder",
  "reth-rpc-eth-api",
+ "reth-rpc-eth-types",
  "reth-storage-api",
  "reth-tasks",
  "reth-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04", feat
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
 reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
 reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }
 reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "72d0e04" }

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -76,12 +76,14 @@ pub fn is_caller_eligible(log: &Log, caller: &Address) -> bool {
 ///
 /// TODO: once the enabled-token registry is plumbed through, also filter
 /// by emitting contract address (only logs from enabled TIP-20 tokens).
+pub fn is_log_visible(log: &Log, caller: &Address) -> bool {
+    log.topic0().is_some_and(|t| WHITELISTED_TOPICS.contains(t)) && is_caller_eligible(log, caller)
+}
+
+/// Filters logs to only those the caller is allowed to see.
 pub fn filter_logs(logs: Vec<Log>, caller: &Address) -> Vec<Log> {
     logs.into_iter()
-        .filter(|log| {
-            log.topic0().is_some_and(|t| WHITELISTED_TOPICS.contains(t))
-                && is_caller_eligible(log, caller)
-        })
+        .filter(|log| is_log_visible(log, caller))
         .collect()
 }
 

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -14,6 +14,7 @@ use tracing::warn;
 
 use crate::{
     auth::AuthContext,
+    subscription::BoxWsSubscriptionFut,
     types::{
         BoxEyreFut, BoxFut, JsonRpcError, JsonRpcRequest, JsonRpcResponse, MethodTier,
         classify_method,
@@ -157,6 +158,26 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `eth_uninstallFilter(id)` — removes a filter.
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_>;
+
+    /// `eth_subscribe("newHeads")` — opens a stream of new block headers.
+    fn ws_subscribe_new_heads(&self, _auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async { Err(JsonRpcError::method_disabled()) })
+    }
+
+    /// `eth_subscribe("logs", filter)` — opens a stream of matching logs.
+    fn ws_subscribe_logs(&self, _filter: Filter, _auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async { Err(JsonRpcError::method_disabled()) })
+    }
+
+    /// `eth_subscribe("newPendingTransactions", full?)` — opens a stream of
+    /// pending transactions, returning either hashes or full transaction objects.
+    fn ws_subscribe_pending_transactions(
+        &self,
+        _full: bool,
+        _auth: AuthContext,
+    ) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async { Err(JsonRpcError::method_disabled()) })
+    }
 
     /// `zone_getAuthorizationTokenInfo()` — returns the authenticated account
     /// and token expiry.

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -25,4 +25,4 @@ pub use handlers::ZoneRpcApi;
 pub use provider::{ZoneProvider, ZoneProviderConfig};
 pub use proxy::ProxyZoneRpc;
 pub use server::start_private_rpc;
-pub use subscription::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream};
+pub use subscription::{BoxWsSubscriptionFut, WsSubscriptionStream};

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -16,6 +16,7 @@ pub mod policy;
 pub mod provider;
 pub mod proxy;
 pub mod server;
+pub mod subscription;
 pub mod types;
 mod ws;
 
@@ -24,3 +25,4 @@ pub use handlers::ZoneRpcApi;
 pub use provider::{ZoneProvider, ZoneProviderConfig};
 pub use proxy::ProxyZoneRpc;
 pub use server::start_private_rpc;
+pub use subscription::{BoxWsSubscriptionFut, WsSubscription, WsSubscriptionStream};

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 /// Maximum number of requests in a single JSON-RPC batch.
-const MAX_BATCH_SIZE: usize = 100;
+pub(crate) const MAX_BATCH_SIZE: usize = 100;
 
 /// Shared state for the private RPC server.
 #[derive(Clone)]
@@ -86,17 +86,6 @@ pub async fn start_private_rpc(
 pub(crate) enum RpcResult {
     Single(JsonRpcResponse),
     Batch(Vec<JsonRpcResponse>),
-}
-
-impl RpcResult {
-    /// Serialize to a JSON string for the WebSocket transport.
-    pub(crate) fn into_json(self) -> String {
-        match self {
-            Self::Single(resp) => serde_json::to_string(&resp),
-            Self::Batch(resps) => serde_json::to_string(&resps),
-        }
-        .expect("JsonRpcResponse serialization is infallible")
-    }
 }
 
 impl IntoResponse for RpcResult {
@@ -155,7 +144,7 @@ pub(crate) async fn process_rpc_text(
     }
 }
 
-async fn dispatch_request(
+pub(crate) async fn dispatch_request(
     req: &JsonRpcRequest,
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,

--- a/crates/rpc/src/subscription.rs
+++ b/crates/rpc/src/subscription.rs
@@ -1,0 +1,51 @@
+//! Shared websocket subscription types for the private zone RPC.
+
+use std::{future::Future, pin::Pin};
+
+use futures::Stream;
+use serde_json::value::RawValue;
+use tokio::task::JoinHandle;
+
+use crate::types::JsonRpcError;
+
+/// A boxed stream of serialized websocket subscription items.
+pub type WsSubscriptionStream =
+    Pin<Box<dyn Stream<Item = Result<Box<RawValue>, JsonRpcError>> + Send + 'static>>;
+
+/// A boxed future that resolves to a websocket subscription.
+pub type BoxWsSubscriptionFut<'a> =
+    Pin<Box<dyn Future<Output = Result<WsSubscription, JsonRpcError>> + Send + 'a>>;
+
+/// A transport-agnostic websocket subscription returned by the RPC API.
+pub struct WsSubscription {
+    /// Stream of serialized `eth_subscription` payloads.
+    pub(crate) stream: WsSubscriptionStream,
+    cleanup_task: Option<JoinHandle<()>>,
+}
+
+impl WsSubscription {
+    /// Create a subscription backed by a direct event stream.
+    pub fn new(stream: WsSubscriptionStream) -> Self {
+        Self {
+            stream,
+            cleanup_task: None,
+        }
+    }
+
+    /// Create a subscription with a cleanup task that should be aborted when
+    /// the subscription is dropped.
+    pub fn with_cleanup(stream: WsSubscriptionStream, cleanup_task: JoinHandle<()>) -> Self {
+        Self {
+            stream,
+            cleanup_task: Some(cleanup_task),
+        }
+    }
+}
+
+impl Drop for WsSubscription {
+    fn drop(&mut self) {
+        if let Some(task) = self.cleanup_task.take() {
+            task.abort();
+        }
+    }
+}

--- a/crates/rpc/src/subscription.rs
+++ b/crates/rpc/src/subscription.rs
@@ -11,19 +11,6 @@ use crate::types::JsonRpcError;
 pub type WsSubscriptionStream =
     Pin<Box<dyn Stream<Item = Result<Box<RawValue>, JsonRpcError>> + Send + 'static>>;
 
-/// A boxed future that resolves to a websocket subscription.
+/// A boxed future that resolves to a websocket subscription stream.
 pub type BoxWsSubscriptionFut<'a> =
-    Pin<Box<dyn Future<Output = Result<WsSubscription, JsonRpcError>> + Send + 'a>>;
-
-/// A transport-agnostic websocket subscription returned by the RPC API.
-pub struct WsSubscription {
-    /// Stream of serialized `eth_subscription` payloads.
-    pub(crate) stream: WsSubscriptionStream,
-}
-
-impl WsSubscription {
-    /// Create a subscription backed by a direct event stream.
-    pub fn new(stream: WsSubscriptionStream) -> Self {
-        Self { stream }
-    }
-}
+    Pin<Box<dyn Future<Output = Result<WsSubscriptionStream, JsonRpcError>> + Send + 'a>>;

--- a/crates/rpc/src/subscription.rs
+++ b/crates/rpc/src/subscription.rs
@@ -4,7 +4,6 @@ use std::{future::Future, pin::Pin};
 
 use futures::Stream;
 use serde_json::value::RawValue;
-use tokio::task::JoinHandle;
 
 use crate::types::JsonRpcError;
 
@@ -20,32 +19,11 @@ pub type BoxWsSubscriptionFut<'a> =
 pub struct WsSubscription {
     /// Stream of serialized `eth_subscription` payloads.
     pub(crate) stream: WsSubscriptionStream,
-    cleanup_task: Option<JoinHandle<()>>,
 }
 
 impl WsSubscription {
     /// Create a subscription backed by a direct event stream.
     pub fn new(stream: WsSubscriptionStream) -> Self {
-        Self {
-            stream,
-            cleanup_task: None,
-        }
-    }
-
-    /// Create a subscription with a cleanup task that should be aborted when
-    /// the subscription is dropped.
-    pub fn with_cleanup(stream: WsSubscriptionStream, cleanup_task: JoinHandle<()>) -> Self {
-        Self {
-            stream,
-            cleanup_task: Some(cleanup_task),
-        }
-    }
-}
-
-impl Drop for WsSubscription {
-    fn drop(&mut self) {
-        if let Some(task) = self.cleanup_task.take() {
-            task.abort();
-        }
+        Self { stream }
     }
 }

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -7,6 +7,10 @@
 //! Auth is validated once during the HTTP upgrade handshake — individual
 //! messages are not re-authenticated since WS frames don't carry auth headers.
 
+use alloy_rpc_types_eth::{
+    Filter, FilterId,
+    pubsub::{Params as SubscriptionParams, SubscriptionKind},
+};
 use axum::{
     extract::{
         Query, State,
@@ -15,23 +19,306 @@ use axum::{
     http::HeaderMap,
     response::IntoResponse,
 };
-use futures::stream::StreamExt;
-use std::sync::Arc;
+use futures::{SinkExt, stream::StreamExt};
+use serde::de::DeserializeOwned;
+use serde_json::{Value, value::RawValue};
+use std::{collections::HashMap, sync::Arc};
+use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::warn;
 
 use crate::{
-    auth::{self, AuthError},
-    server::{RpcState, authenticate_token, process_rpc_text},
+    auth::{self, AuthContext, AuthError},
+    server::{MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request},
+    subscription::WsSubscription,
+    types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
 };
 
 /// Maximum WebSocket message size (1 MiB).
 const MAX_WS_MESSAGE_SIZE: usize = 1 << 20;
+
+type NotificationTx = mpsc::UnboundedSender<String>;
 
 /// Query parameters for the WebSocket upgrade endpoint.
 #[derive(serde::Deserialize, Default)]
 pub(crate) struct WsQuery {
     /// Auth token passed as query param (fallback when headers are unavailable).
     token: Option<String>,
+}
+
+struct ActiveSubscription {
+    task: JoinHandle<()>,
+}
+
+struct WsSession {
+    next_subscription_id: u64,
+    subscriptions: HashMap<FilterId, ActiveSubscription>,
+}
+
+impl Default for WsSession {
+    fn default() -> Self {
+        Self {
+            next_subscription_id: 1,
+            subscriptions: HashMap::new(),
+        }
+    }
+}
+
+impl WsSession {
+    fn next_subscription_id(&mut self) -> FilterId {
+        let id = FilterId::from(format!("0x{:x}", self.next_subscription_id));
+        self.next_subscription_id += 1;
+        id
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct SubscribeParams(
+    SubscriptionKind,
+    #[serde(default)] Option<SubscriptionParams>,
+);
+
+fn success_response<T: serde::Serialize>(id: Value, result: &T) -> JsonRpcResponse {
+    match to_raw(result) {
+        Ok(raw) => JsonRpcResponse::success(id, raw),
+        Err(err) => JsonRpcResponse::error(id, err),
+    }
+}
+
+fn parse_ws_params<T: DeserializeOwned>(
+    req: &JsonRpcRequest,
+    message: &'static str,
+) -> Result<T, JsonRpcResponse> {
+    let raw = req
+        .params
+        .as_deref()
+        .map(|params| params.get())
+        .unwrap_or("[]");
+    serde_json::from_str(raw)
+        .map_err(|_| JsonRpcResponse::error(req.id.clone(), JsonRpcError::invalid_params(message)))
+}
+
+#[derive(serde::Serialize)]
+struct SubscriptionNotification<'a> {
+    jsonrpc: &'static str,
+    method: &'static str,
+    params: SubscriptionNotificationParams<'a>,
+}
+
+#[derive(serde::Serialize)]
+struct SubscriptionNotificationParams<'a> {
+    subscription: &'a FilterId,
+    result: &'a RawValue,
+}
+
+fn subscription_notification_raw(subscription_id: &FilterId, result: &RawValue) -> String {
+    serde_json::to_string(&SubscriptionNotification {
+        jsonrpc: "2.0",
+        method: "eth_subscription",
+        params: SubscriptionNotificationParams {
+            subscription: subscription_id,
+            result,
+        },
+    })
+    .expect("subscription notification serialization is infallible")
+}
+
+fn spawn_subscription(
+    subscription_id: FilterId,
+    mut subscription: WsSubscription,
+    notifications: NotificationTx,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        // Let the subscribe response get enqueued before the first notification.
+        tokio::task::yield_now().await;
+
+        while let Some(item) = subscription.stream.next().await {
+            let result = match item {
+                Ok(result) => result,
+                Err(err) => {
+                    warn!(
+                        target: "zone::rpc",
+                        subscription = ?subscription_id,
+                        err = %err,
+                        "ws subscription stream failed"
+                    );
+                    break;
+                }
+            };
+
+            if notifications
+                .send(subscription_notification_raw(
+                    &subscription_id,
+                    result.as_ref(),
+                ))
+                .is_err()
+            {
+                return;
+            }
+        }
+    })
+}
+
+async fn handle_subscribe(
+    req: &JsonRpcRequest,
+    auth: &AuthContext,
+    state: &Arc<RpcState>,
+    notifications: &NotificationTx,
+    session: &mut WsSession,
+) -> JsonRpcResponse {
+    let SubscribeParams(kind, params) =
+        match parse_ws_params(req, "expected [subscription, params?]") {
+            Ok(params) => params,
+            Err(resp) => return resp,
+        };
+
+    let subscription = match kind {
+        SubscriptionKind::NewHeads => {
+            if !matches!(params, None | Some(SubscriptionParams::None)) {
+                return JsonRpcResponse::error(
+                    req.id.clone(),
+                    JsonRpcError::invalid_params("eth_subscribe(newHeads) does not accept params"),
+                );
+            }
+
+            match state.api.ws_subscribe_new_heads(auth.clone()).await {
+                Ok(subscription) => subscription,
+                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+            }
+        }
+        SubscriptionKind::Logs => {
+            let filter = match params.unwrap_or_default() {
+                SubscriptionParams::None => Filter::default(),
+                SubscriptionParams::Logs(filter) => *filter,
+                SubscriptionParams::Bool(_) => {
+                    return JsonRpcResponse::error(
+                        req.id.clone(),
+                        JsonRpcError::invalid_params("eth_subscribe(logs) expects a filter object"),
+                    );
+                }
+            };
+
+            match state.api.ws_subscribe_logs(filter, auth.clone()).await {
+                Ok(subscription) => subscription,
+                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+            }
+        }
+        SubscriptionKind::NewPendingTransactions => {
+            let full = match params.unwrap_or(SubscriptionParams::None) {
+                SubscriptionParams::None | SubscriptionParams::Bool(false) => false,
+                SubscriptionParams::Bool(true) => true,
+                SubscriptionParams::Logs(_) => {
+                    return JsonRpcResponse::error(
+                        req.id.clone(),
+                        JsonRpcError::invalid_params(
+                            "eth_subscribe(newPendingTransactions) expects an optional boolean",
+                        ),
+                    );
+                }
+            };
+
+            match state
+                .api
+                .ws_subscribe_pending_transactions(full, auth.clone())
+                .await
+            {
+                Ok(subscription) => subscription,
+                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+            }
+        }
+        SubscriptionKind::Syncing => {
+            return JsonRpcResponse::error(req.id.clone(), JsonRpcError::method_disabled());
+        }
+    };
+
+    let subscription_id = session.next_subscription_id();
+    let task = spawn_subscription(subscription_id.clone(), subscription, notifications.clone());
+    session
+        .subscriptions
+        .insert(subscription_id.clone(), ActiveSubscription { task });
+    success_response(req.id.clone(), &subscription_id)
+}
+
+async fn handle_unsubscribe(req: &JsonRpcRequest, session: &mut WsSession) -> JsonRpcResponse {
+    let (subscription_id,) = match parse_ws_params::<(FilterId,)>(req, "expected [subscriptionId]")
+    {
+        Ok(params) => params,
+        Err(resp) => return resp,
+    };
+
+    let Some(active) = session.subscriptions.remove(&subscription_id) else {
+        return success_response(req.id.clone(), &false);
+    };
+
+    active.task.abort();
+    success_response(req.id.clone(), &true)
+}
+
+async fn dispatch_ws_request(
+    req: &JsonRpcRequest,
+    auth: &AuthContext,
+    state: &Arc<RpcState>,
+    notifications: &NotificationTx,
+    session: &mut WsSession,
+) -> JsonRpcResponse {
+    match req.method.as_str() {
+        "eth_subscribe" => handle_subscribe(req, auth, state, notifications, session).await,
+        "eth_unsubscribe" => handle_unsubscribe(req, session).await,
+        _ => dispatch_request(req, auth, state.api.as_ref()).await,
+    }
+}
+
+async fn process_ws_text(
+    text: &str,
+    auth: &AuthContext,
+    state: &Arc<RpcState>,
+    notifications: &NotificationTx,
+    session: &mut WsSession,
+) -> String {
+    let trimmed = text.trim_start();
+
+    let response = if trimmed.starts_with('[') {
+        match serde_json::from_str::<Vec<JsonRpcRequest>>(trimmed) {
+            Ok(requests) if requests.is_empty() => {
+                JsonRpcResponse::error(Value::Null, JsonRpcError::parse_error("empty batch"))
+            }
+            Ok(requests) if requests.len() > MAX_BATCH_SIZE => JsonRpcResponse::error(
+                Value::Null,
+                JsonRpcError::invalid_params(format!(
+                    "batch too large ({} > {MAX_BATCH_SIZE})",
+                    requests.len()
+                )),
+            ),
+            Ok(requests) => {
+                let mut responses = Vec::with_capacity(requests.len());
+                for req in &requests {
+                    responses
+                        .push(dispatch_ws_request(req, auth, state, notifications, session).await);
+                }
+                return serde_json::to_string(&responses)
+                    .expect("JsonRpcResponse serialization is infallible");
+            }
+            Err(err) => JsonRpcResponse::error(
+                Value::Null,
+                JsonRpcError::parse_error(format!("parse error: {err}")),
+            ),
+        }
+    } else {
+        match serde_json::from_str::<JsonRpcRequest>(trimmed) {
+            Ok(request) => dispatch_ws_request(&request, auth, state, notifications, session).await,
+            Err(err) => JsonRpcResponse::error(
+                Value::Null,
+                JsonRpcError::parse_error(format!("parse error: {err}")),
+            ),
+        }
+    };
+
+    serde_json::to_string(&response).expect("JsonRpcResponse serialization is infallible")
+}
+
+fn cleanup_ws_session(session: WsSession) {
+    for (_, active) in session.subscriptions {
+        active.task.abort();
+    }
 }
 
 /// WebSocket upgrade handler — authenticates via header or `?token=` query param.
@@ -68,25 +355,35 @@ pub(crate) async fn handle_ws_upgrade(
 /// Run a single authenticated WebSocket session, dispatching JSON-RPC
 /// messages through the same pipeline as HTTP.
 async fn handle_ws_session(
-    mut socket: WebSocket,
+    socket: WebSocket,
     auth: crate::auth::AuthContext,
     state: Arc<RpcState>,
 ) {
-    while let Some(msg) = socket.next().await {
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+    let (notifications, mut outbound) = mpsc::unbounded_channel::<String>();
+    let writer = tokio::spawn(async move {
+        while let Some(message) = outbound.recv().await {
+            if ws_sender.send(Message::Text(message.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut session = WsSession::default();
+
+    while let Some(msg) = ws_receiver.next().await {
         let text = match msg {
             Ok(Message::Text(t)) => t,
             Ok(Message::Binary(b)) => match std::str::from_utf8(&b) {
                 Ok(s) => s.into(),
                 Err(_) => {
-                    if socket
-                        .send(Message::Text(
-                            r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"invalid UTF-8"},"id":null}"#.into(),
+                    let _ = notifications.send(
+                        serde_json::to_string(&JsonRpcResponse::error(
+                            Value::Null,
+                            JsonRpcError::parse_error("invalid UTF-8"),
                         ))
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
+                        .expect("JsonRpcResponse serialization is infallible"),
+                    );
                     continue;
                 }
             },
@@ -98,16 +395,15 @@ async fn handle_ws_session(
             }
         };
 
-        let response_json = process_rpc_text(&text, &auth, state.api.as_ref())
-            .await
-            .into_json();
+        let response_json =
+            process_ws_text(&text, &auth, &state, &notifications, &mut session).await;
 
-        if socket
-            .send(Message::Text(response_json.into()))
-            .await
-            .is_err()
-        {
+        if notifications.send(response_json).is_err() {
             break;
         }
     }
+
+    cleanup_ws_session(session);
+    drop(notifications);
+    let _ = writer.await;
 }

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -512,12 +512,7 @@ async fn handle_ws_session(
 
     loop {
         let msg = tokio::select! {
-            changed = close_session_rx.changed() => {
-                if changed.is_ok() && *close_session_rx.borrow() {
-                    break;
-                }
-                break;
-            }
+            _ = close_session_rx.changed() => break,
             msg = ws_receiver.next() => match msg {
                 Some(msg) => msg,
                 None => break,

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -23,7 +23,10 @@ use futures::{SinkExt, stream::StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, value::RawValue};
 use std::{collections::HashMap, sync::Arc};
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
 use tracing::warn;
 
 use crate::{
@@ -35,8 +38,13 @@ use crate::{
 
 /// Maximum WebSocket message size (1 MiB).
 const MAX_WS_MESSAGE_SIZE: usize = 1 << 20;
+/// Maximum number of queued outbound messages before the session is dropped.
+const MAX_WS_OUTBOUND_QUEUE: usize = 1024;
+/// Maximum number of active or pending subscriptions per WebSocket session.
+const MAX_WS_SUBSCRIPTIONS: usize = 32;
 
-type NotificationTx = mpsc::UnboundedSender<String>;
+type NotificationTx = mpsc::Sender<String>;
+type CloseSessionTx = watch::Sender<bool>;
 
 /// Query parameters for the WebSocket upgrade endpoint.
 #[derive(serde::Deserialize, Default)]
@@ -56,6 +64,7 @@ struct PendingSubscription {
 
 struct WsSession {
     next_subscription_id: u64,
+    pending_subscription_count: usize,
     subscriptions: HashMap<FilterId, ActiveSubscription>,
 }
 
@@ -63,16 +72,38 @@ impl Default for WsSession {
     fn default() -> Self {
         Self {
             next_subscription_id: 1,
+            pending_subscription_count: 0,
             subscriptions: HashMap::new(),
         }
     }
 }
 
 impl WsSession {
+    fn total_subscription_count(&self) -> usize {
+        self.pending_subscription_count + self.subscriptions.len()
+    }
+
     fn next_subscription_id(&mut self) -> FilterId {
         let id = FilterId::from(format!("0x{:x}", self.next_subscription_id));
         self.next_subscription_id += 1;
         id
+    }
+
+    fn reserve_subscription_id(&mut self) -> Result<FilterId, JsonRpcError> {
+        if self.total_subscription_count() >= MAX_WS_SUBSCRIPTIONS {
+            return Err(JsonRpcError::invalid_params(format!(
+                "too many active subscriptions ({MAX_WS_SUBSCRIPTIONS} max)"
+            )));
+        }
+
+        self.pending_subscription_count += 1;
+        Ok(self.next_subscription_id())
+    }
+
+    fn activate_subscription(&mut self, subscription_id: FilterId, task: JoinHandle<()>) {
+        self.pending_subscription_count = self.pending_subscription_count.saturating_sub(1);
+        self.subscriptions
+            .insert(subscription_id, ActiveSubscription { task });
     }
 
     fn cleanup(self) {
@@ -137,6 +168,7 @@ fn spawn_subscription(
     subscription_id: FilterId,
     mut subscription: WsSubscriptionStream,
     notifications: NotificationTx,
+    close_session: CloseSessionTx,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(item) = subscription.next().await {
@@ -153,17 +185,39 @@ fn spawn_subscription(
                 }
             };
 
-            if notifications
-                .send(subscription_notification_raw(
-                    &subscription_id,
-                    result.as_ref(),
-                ))
-                .is_err()
-            {
+            if !try_queue_notification(
+                &notifications,
+                &close_session,
+                subscription_notification_raw(&subscription_id, result.as_ref()),
+            ) {
                 return;
             }
         }
     })
+}
+
+fn request_session_close(close_session: &CloseSessionTx) {
+    let _ = close_session.send(true);
+}
+
+fn try_queue_notification(
+    notifications: &NotificationTx,
+    close_session: &CloseSessionTx,
+    message: String,
+) -> bool {
+    match notifications.try_send(message) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            warn!(
+                target: "zone::rpc",
+                max_queue = MAX_WS_OUTBOUND_QUEUE,
+                "ws outbound queue full, closing session"
+            );
+            request_session_close(close_session);
+            false
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => false,
+    }
 }
 
 struct WsDispatchResult {
@@ -269,7 +323,12 @@ async fn handle_subscribe(
         }
     };
 
-    let subscription_id = session.next_subscription_id();
+    let subscription_id = match session.reserve_subscription_id() {
+        Ok(subscription_id) => subscription_id,
+        Err(err) => {
+            return WsDispatchResult::response_only(JsonRpcResponse::error(req.id.clone(), err));
+        }
+    };
     WsDispatchResult {
         response: success_response(req.id.clone(), &subscription_id),
         pending_subscriptions: vec![PendingSubscription {
@@ -386,13 +445,17 @@ async fn process_ws_text(
 fn activate_pending_subscriptions(
     pending_subscriptions: Vec<PendingSubscription>,
     notifications: &NotificationTx,
+    close_session: &CloseSessionTx,
     session: &mut WsSession,
 ) {
     for pending in pending_subscriptions {
-        let task = spawn_subscription(pending.id.clone(), pending.stream, notifications.clone());
-        session
-            .subscriptions
-            .insert(pending.id, ActiveSubscription { task });
+        let task = spawn_subscription(
+            pending.id.clone(),
+            pending.stream,
+            notifications.clone(),
+            close_session.clone(),
+        );
+        session.activate_subscription(pending.id, task);
     }
 }
 
@@ -435,7 +498,8 @@ async fn handle_ws_session(
     state: Arc<RpcState>,
 ) {
     let (mut ws_sender, mut ws_receiver) = socket.split();
-    let (notifications, mut outbound) = mpsc::unbounded_channel::<String>();
+    let (notifications, mut outbound) = mpsc::channel::<String>(MAX_WS_OUTBOUND_QUEUE);
+    let (close_session, mut close_session_rx) = watch::channel(false);
     let writer = tokio::spawn(async move {
         while let Some(message) = outbound.recv().await {
             if ws_sender.send(Message::Text(message.into())).await.is_err() {
@@ -446,19 +510,36 @@ async fn handle_ws_session(
 
     let mut session = WsSession::default();
 
-    while let Some(msg) = ws_receiver.next().await {
+    loop {
+        let msg = tokio::select! {
+            changed = close_session_rx.changed() => {
+                if changed.is_ok() && *close_session_rx.borrow() {
+                    break;
+                }
+                break;
+            }
+            msg = ws_receiver.next() => match msg {
+                Some(msg) => msg,
+                None => break,
+            },
+        };
+
         let text = match msg {
             Ok(Message::Text(t)) => t,
             Ok(Message::Binary(b)) => match std::str::from_utf8(&b) {
                 Ok(s) => s.into(),
                 Err(_) => {
-                    let _ = notifications.send(
+                    if !try_queue_notification(
+                        &notifications,
+                        &close_session,
                         serde_json::to_string(&JsonRpcResponse::error(
                             Value::Null,
                             JsonRpcError::parse_error("invalid UTF-8"),
                         ))
                         .expect("JsonRpcResponse serialization is infallible"),
-                    );
+                    ) {
+                        break;
+                    }
                     continue;
                 }
             },
@@ -473,11 +554,16 @@ async fn handle_ws_session(
         let (response_json, pending_subscriptions) =
             process_ws_text(&text, &auth, &state, &mut session).await;
 
-        if notifications.send(response_json).is_err() {
+        if !try_queue_notification(&notifications, &close_session, response_json) {
             break;
         }
 
-        activate_pending_subscriptions(pending_subscriptions, &notifications, &mut session);
+        activate_pending_subscriptions(
+            pending_subscriptions,
+            &notifications,
+            &close_session,
+            &mut session,
+        );
     }
 
     session.cleanup();

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -74,6 +74,12 @@ impl WsSession {
         self.next_subscription_id += 1;
         id
     }
+
+    fn cleanup(self) {
+        for (_, active) in self.subscriptions {
+            active.task.abort();
+        }
+    }
 }
 
 #[derive(serde::Deserialize)]
@@ -377,12 +383,6 @@ async fn process_ws_text(
     }
 }
 
-fn cleanup_ws_session(session: WsSession) {
-    for (_, active) in session.subscriptions {
-        active.task.abort();
-    }
-}
-
 fn activate_pending_subscriptions(
     pending_subscriptions: Vec<PendingSubscription>,
     notifications: &NotificationTx,
@@ -480,7 +480,7 @@ async fn handle_ws_session(
         activate_pending_subscriptions(pending_subscriptions, &notifications, &mut session);
     }
 
-    cleanup_ws_session(session);
+    session.cleanup();
     drop(notifications);
     let _ = writer.await;
 }

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -129,14 +129,13 @@ fn success_response<T: serde::Serialize>(id: Value, result: &T) -> JsonRpcRespon
 fn parse_ws_params<T: DeserializeOwned>(
     req: &JsonRpcRequest,
     message: &'static str,
-) -> Result<T, JsonRpcResponse> {
+) -> Result<T, JsonRpcError> {
     let raw = req
         .params
         .as_deref()
         .map(|params| params.get())
         .unwrap_or("[]");
-    serde_json::from_str(raw)
-        .map_err(|_| JsonRpcResponse::error(req.id.clone(), JsonRpcError::invalid_params(message)))
+    serde_json::from_str(raw).map_err(|_| JsonRpcError::invalid_params(message))
 }
 
 #[derive(serde::Serialize)]
@@ -243,7 +242,9 @@ async fn handle_subscribe(
     let SubscribeParams(kind, params) =
         match parse_ws_params(req, "expected [subscription, params?]") {
             Ok(params) => params,
-            Err(resp) => return WsDispatchResult::response_only(resp),
+            Err(err) => {
+                return WsDispatchResult::response_only(JsonRpcResponse::error(req.id.clone(), err));
+            }
         };
 
     let subscription = match kind {
@@ -342,7 +343,7 @@ async fn handle_unsubscribe(req: &JsonRpcRequest, session: &mut WsSession) -> Js
     let (subscription_id,) = match parse_ws_params::<(FilterId,)>(req, "expected [subscriptionId]")
     {
         Ok(params) => params,
-        Err(resp) => return resp,
+        Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
     };
 
     let Some(active) = session.subscriptions.remove(&subscription_id) else {
@@ -405,11 +406,11 @@ async fn process_ws_text(
                     responses.push(result.response);
                     pending_subscriptions.extend(result.pending_subscriptions);
                 }
-                return (
+                (
                     serde_json::to_string(&responses)
                         .expect("JsonRpcResponse serialization is infallible"),
                     pending_subscriptions,
-                );
+                )
             }
             Err(err) => (
                 serde_json::to_string(&JsonRpcResponse::error(

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -29,7 +29,7 @@ use tracing::warn;
 use crate::{
     auth::{self, AuthContext, AuthError},
     server::{MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request},
-    subscription::WsSubscription,
+    subscription::WsSubscriptionStream,
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
 };
 
@@ -47,6 +47,11 @@ pub(crate) struct WsQuery {
 
 struct ActiveSubscription {
     task: JoinHandle<()>,
+}
+
+struct PendingSubscription {
+    id: FilterId,
+    stream: WsSubscriptionStream,
 }
 
 struct WsSession {
@@ -124,14 +129,11 @@ fn subscription_notification_raw(subscription_id: &FilterId, result: &RawValue) 
 
 fn spawn_subscription(
     subscription_id: FilterId,
-    mut subscription: WsSubscription,
+    mut subscription: WsSubscriptionStream,
     notifications: NotificationTx,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        // Let the subscribe response get enqueued before the first notification.
-        tokio::task::yield_now().await;
-
-        while let Some(item) = subscription.stream.next().await {
+        while let Some(item) = subscription.next().await {
             let result = match item {
                 Ok(result) => result,
                 Err(err) => {
@@ -158,31 +160,49 @@ fn spawn_subscription(
     })
 }
 
+struct WsDispatchResult {
+    response: JsonRpcResponse,
+    pending_subscriptions: Vec<PendingSubscription>,
+}
+
+impl WsDispatchResult {
+    fn response_only(response: JsonRpcResponse) -> Self {
+        Self {
+            response,
+            pending_subscriptions: Vec::new(),
+        }
+    }
+}
+
 async fn handle_subscribe(
     req: &JsonRpcRequest,
     auth: &AuthContext,
     state: &Arc<RpcState>,
-    notifications: &NotificationTx,
     session: &mut WsSession,
-) -> JsonRpcResponse {
+) -> WsDispatchResult {
     let SubscribeParams(kind, params) =
         match parse_ws_params(req, "expected [subscription, params?]") {
             Ok(params) => params,
-            Err(resp) => return resp,
+            Err(resp) => return WsDispatchResult::response_only(resp),
         };
 
     let subscription = match kind {
         SubscriptionKind::NewHeads => {
             if !matches!(params, None | Some(SubscriptionParams::None)) {
-                return JsonRpcResponse::error(
+                return WsDispatchResult::response_only(JsonRpcResponse::error(
                     req.id.clone(),
                     JsonRpcError::invalid_params("eth_subscribe(newHeads) does not accept params"),
-                );
+                ));
             }
 
             match state.api.ws_subscribe_new_heads(auth.clone()).await {
                 Ok(subscription) => subscription,
-                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+                Err(err) => {
+                    return WsDispatchResult::response_only(JsonRpcResponse::error(
+                        req.id.clone(),
+                        err,
+                    ));
+                }
             }
         }
         SubscriptionKind::Logs => {
@@ -190,16 +210,21 @@ async fn handle_subscribe(
                 SubscriptionParams::None => Filter::default(),
                 SubscriptionParams::Logs(filter) => *filter,
                 SubscriptionParams::Bool(_) => {
-                    return JsonRpcResponse::error(
+                    return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
                         JsonRpcError::invalid_params("eth_subscribe(logs) expects a filter object"),
-                    );
+                    ));
                 }
             };
 
             match state.api.ws_subscribe_logs(filter, auth.clone()).await {
                 Ok(subscription) => subscription,
-                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+                Err(err) => {
+                    return WsDispatchResult::response_only(JsonRpcResponse::error(
+                        req.id.clone(),
+                        err,
+                    ));
+                }
             }
         }
         SubscriptionKind::NewPendingTransactions => {
@@ -207,12 +232,12 @@ async fn handle_subscribe(
                 SubscriptionParams::None | SubscriptionParams::Bool(false) => false,
                 SubscriptionParams::Bool(true) => true,
                 SubscriptionParams::Logs(_) => {
-                    return JsonRpcResponse::error(
+                    return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
                         JsonRpcError::invalid_params(
                             "eth_subscribe(newPendingTransactions) expects an optional boolean",
                         ),
-                    );
+                    ));
                 }
             };
 
@@ -222,20 +247,30 @@ async fn handle_subscribe(
                 .await
             {
                 Ok(subscription) => subscription,
-                Err(err) => return JsonRpcResponse::error(req.id.clone(), err),
+                Err(err) => {
+                    return WsDispatchResult::response_only(JsonRpcResponse::error(
+                        req.id.clone(),
+                        err,
+                    ));
+                }
             }
         }
         SubscriptionKind::Syncing => {
-            return JsonRpcResponse::error(req.id.clone(), JsonRpcError::method_disabled());
+            return WsDispatchResult::response_only(JsonRpcResponse::error(
+                req.id.clone(),
+                JsonRpcError::method_disabled(),
+            ));
         }
     };
 
     let subscription_id = session.next_subscription_id();
-    let task = spawn_subscription(subscription_id.clone(), subscription, notifications.clone());
-    session
-        .subscriptions
-        .insert(subscription_id.clone(), ActiveSubscription { task });
-    success_response(req.id.clone(), &subscription_id)
+    WsDispatchResult {
+        response: success_response(req.id.clone(), &subscription_id),
+        pending_subscriptions: vec![PendingSubscription {
+            id: subscription_id,
+            stream: subscription,
+        }],
+    }
 }
 
 async fn handle_unsubscribe(req: &JsonRpcRequest, session: &mut WsSession) -> JsonRpcResponse {
@@ -257,13 +292,14 @@ async fn dispatch_ws_request(
     req: &JsonRpcRequest,
     auth: &AuthContext,
     state: &Arc<RpcState>,
-    notifications: &NotificationTx,
     session: &mut WsSession,
-) -> JsonRpcResponse {
+) -> WsDispatchResult {
     match req.method.as_str() {
-        "eth_subscribe" => handle_subscribe(req, auth, state, notifications, session).await,
-        "eth_unsubscribe" => handle_unsubscribe(req, session).await,
-        _ => dispatch_request(req, auth, state.api.as_ref()).await,
+        "eth_subscribe" => handle_subscribe(req, auth, state, session).await,
+        "eth_unsubscribe" => {
+            WsDispatchResult::response_only(handle_unsubscribe(req, session).await)
+        }
+        _ => WsDispatchResult::response_only(dispatch_request(req, auth, state.api.as_ref()).await),
     }
 }
 
@@ -271,53 +307,92 @@ async fn process_ws_text(
     text: &str,
     auth: &AuthContext,
     state: &Arc<RpcState>,
-    notifications: &NotificationTx,
     session: &mut WsSession,
-) -> String {
+) -> (String, Vec<PendingSubscription>) {
     let trimmed = text.trim_start();
 
-    let response = if trimmed.starts_with('[') {
+    if trimmed.starts_with('[') {
         match serde_json::from_str::<Vec<JsonRpcRequest>>(trimmed) {
-            Ok(requests) if requests.is_empty() => {
-                JsonRpcResponse::error(Value::Null, JsonRpcError::parse_error("empty batch"))
-            }
-            Ok(requests) if requests.len() > MAX_BATCH_SIZE => JsonRpcResponse::error(
-                Value::Null,
-                JsonRpcError::invalid_params(format!(
-                    "batch too large ({} > {MAX_BATCH_SIZE})",
-                    requests.len()
-                )),
+            Ok(requests) if requests.is_empty() => (
+                serde_json::to_string(&JsonRpcResponse::error(
+                    Value::Null,
+                    JsonRpcError::parse_error("empty batch"),
+                ))
+                .expect("JsonRpcResponse serialization is infallible"),
+                Vec::new(),
+            ),
+            Ok(requests) if requests.len() > MAX_BATCH_SIZE => (
+                serde_json::to_string(&JsonRpcResponse::error(
+                    Value::Null,
+                    JsonRpcError::invalid_params(format!(
+                        "batch too large ({} > {MAX_BATCH_SIZE})",
+                        requests.len()
+                    )),
+                ))
+                .expect("JsonRpcResponse serialization is infallible"),
+                Vec::new(),
             ),
             Ok(requests) => {
                 let mut responses = Vec::with_capacity(requests.len());
+                let mut pending_subscriptions = Vec::new();
                 for req in &requests {
-                    responses
-                        .push(dispatch_ws_request(req, auth, state, notifications, session).await);
+                    let result = dispatch_ws_request(req, auth, state, session).await;
+                    responses.push(result.response);
+                    pending_subscriptions.extend(result.pending_subscriptions);
                 }
-                return serde_json::to_string(&responses)
-                    .expect("JsonRpcResponse serialization is infallible");
+                return (
+                    serde_json::to_string(&responses)
+                        .expect("JsonRpcResponse serialization is infallible"),
+                    pending_subscriptions,
+                );
             }
-            Err(err) => JsonRpcResponse::error(
-                Value::Null,
-                JsonRpcError::parse_error(format!("parse error: {err}")),
+            Err(err) => (
+                serde_json::to_string(&JsonRpcResponse::error(
+                    Value::Null,
+                    JsonRpcError::parse_error(format!("parse error: {err}")),
+                ))
+                .expect("JsonRpcResponse serialization is infallible"),
+                Vec::new(),
             ),
         }
     } else {
         match serde_json::from_str::<JsonRpcRequest>(trimmed) {
-            Ok(request) => dispatch_ws_request(&request, auth, state, notifications, session).await,
-            Err(err) => JsonRpcResponse::error(
-                Value::Null,
-                JsonRpcError::parse_error(format!("parse error: {err}")),
+            Ok(request) => {
+                let result = dispatch_ws_request(&request, auth, state, session).await;
+                (
+                    serde_json::to_string(&result.response)
+                        .expect("JsonRpcResponse serialization is infallible"),
+                    result.pending_subscriptions,
+                )
+            }
+            Err(err) => (
+                serde_json::to_string(&JsonRpcResponse::error(
+                    Value::Null,
+                    JsonRpcError::parse_error(format!("parse error: {err}")),
+                ))
+                .expect("JsonRpcResponse serialization is infallible"),
+                Vec::new(),
             ),
         }
-    };
-
-    serde_json::to_string(&response).expect("JsonRpcResponse serialization is infallible")
+    }
 }
 
 fn cleanup_ws_session(session: WsSession) {
     for (_, active) in session.subscriptions {
         active.task.abort();
+    }
+}
+
+fn activate_pending_subscriptions(
+    pending_subscriptions: Vec<PendingSubscription>,
+    notifications: &NotificationTx,
+    session: &mut WsSession,
+) {
+    for pending in pending_subscriptions {
+        let task = spawn_subscription(pending.id.clone(), pending.stream, notifications.clone());
+        session
+            .subscriptions
+            .insert(pending.id, ActiveSubscription { task });
     }
 }
 
@@ -395,12 +470,14 @@ async fn handle_ws_session(
             }
         };
 
-        let response_json =
-            process_ws_text(&text, &auth, &state, &notifications, &mut session).await;
+        let (response_json, pending_subscriptions) =
+            process_ws_text(&text, &auth, &state, &mut session).await;
 
         if notifications.send(response_json).is_err() {
             break;
         }
+
+        activate_pending_subscriptions(pending_subscriptions, &notifications, &mut session);
     }
 
     cleanup_ws_session(session);

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -243,7 +243,10 @@ async fn handle_subscribe(
         match parse_ws_params(req, "expected [subscription, params?]") {
             Ok(params) => params,
             Err(err) => {
-                return WsDispatchResult::response_only(JsonRpcResponse::error(req.id.clone(), err));
+                return WsDispatchResult::response_only(JsonRpcResponse::error(
+                    req.id.clone(),
+                    err,
+                ));
             }
         };
 

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -17,7 +17,7 @@ use zone_rpc::{
     auth::build_token_fields,
     handlers::ZoneRpcApi,
     start_private_rpc,
-    subscription::{BoxWsSubscriptionFut, WsSubscription},
+    subscription::{BoxWsSubscriptionFut, WsSubscriptionStream},
     types::{BoxEyreFut, BoxFut, JsonRpcError},
 };
 
@@ -154,7 +154,8 @@ impl ZoneRpcApi for MockZoneRpcApi {
                 "parentHash": format!("{:#x}", alloy_primitives::B256::ZERO),
                 "logsBloom": format!("0x{}", "0".repeat(512)),
             }))]);
-            Ok(WsSubscription::new(Box::pin(stream)))
+            let stream: WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
         })
     }
 
@@ -189,7 +190,8 @@ impl ZoneRpcApi for MockZoneRpcApi {
                 "logIndex": "0x0",
                 "removed": false
             }))]);
-            Ok(WsSubscription::new(Box::pin(stream)))
+            let stream: WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
         })
     }
 
@@ -220,7 +222,8 @@ impl ZoneRpcApi for MockZoneRpcApi {
                     b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
                 ))])
             };
-            Ok(WsSubscription::new(Box::pin(stream)))
+            let stream: WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
         })
     }
 

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -731,6 +731,50 @@ async fn ws_subscribe_rejects_invalid_param_shapes() {
 }
 
 #[tokio::test]
+async fn ws_subscribe_rejects_too_many_active_subscriptions() {
+    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    for id in 1..=32 {
+        ws.send(tungstenite::Message::Text(
+            jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), id).into(),
+        ))
+        .await
+        .unwrap();
+
+        let resp = loop {
+            let message = parse_response(ws.next().await.unwrap().unwrap());
+            if message["id"] == id {
+                break message;
+            }
+        };
+
+        assert!(resp["result"].as_str().is_some());
+    }
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 33).into(),
+    ))
+    .await
+    .unwrap();
+
+    let resp = loop {
+        let message = parse_response(ws.next().await.unwrap().unwrap());
+        if message["id"] == 33 {
+            break message;
+        }
+    };
+
+    assert_eq!(resp["error"]["code"], -32602);
+    assert!(
+        resp["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("too many active subscriptions")
+    );
+}
+
+#[tokio::test]
 async fn ws_empty_batch() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let mut ws = connect_with_header(&ctx).await;

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -1,13 +1,13 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, b256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use futures::{SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt, stream};
 use p256::ecdsa::SigningKey as P256SigningKey;
 use parking_lot::Mutex;
 use rand::thread_rng;
-use serde_json::Value;
+use serde_json::{Value, json};
 use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
     KeyInfo, SignatureType as KeyInfoSignatureType,
 };
@@ -17,6 +17,7 @@ use zone_rpc::{
     auth::build_token_fields,
     handlers::ZoneRpcApi,
     start_private_rpc,
+    subscription::{BoxWsSubscriptionFut, WsSubscription},
     types::{BoxEyreFut, BoxFut, JsonRpcError},
 };
 
@@ -36,6 +37,7 @@ use auth_tokens::{
 struct MockZoneRpcApi {
     key_infos: Mutex<HashMap<(Address, Address), KeyInfo>>,
     key_lookup_error: Option<&'static str>,
+    ws_subscriptions_enabled: bool,
 }
 
 impl MockZoneRpcApi {
@@ -54,6 +56,7 @@ impl MockZoneRpcApi {
         Self {
             key_infos: Mutex::new(key_infos),
             key_lookup_error: None,
+            ws_subscriptions_enabled: false,
         }
     }
 
@@ -61,6 +64,15 @@ impl MockZoneRpcApi {
         Self {
             key_infos: Mutex::new(HashMap::new()),
             key_lookup_error: Some(message),
+            ws_subscriptions_enabled: false,
+        }
+    }
+
+    fn with_ws_subscriptions() -> Self {
+        Self {
+            key_infos: Mutex::new(HashMap::new()),
+            key_lookup_error: None,
+            ws_subscriptions_enabled: true,
         }
     }
 }
@@ -122,6 +134,95 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
     stub!(new_block_filter, _c: zone_rpc::auth::AuthContext);
     stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
+
+    fn ws_subscribe_new_heads(
+        &self,
+        _auth: zone_rpc::auth::AuthContext,
+    ) -> BoxWsSubscriptionFut<'_> {
+        let enabled = self.ws_subscriptions_enabled;
+        Box::pin(async move {
+            if !enabled {
+                return Err(JsonRpcError::method_disabled());
+            }
+
+            let stream = stream::iter(vec![zone_rpc::types::to_raw(&json!({
+                "hash": format!(
+                    "{:#x}",
+                    b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
+                ),
+                "number": "0x42",
+                "parentHash": format!("{:#x}", alloy_primitives::B256::ZERO),
+                "logsBloom": format!("0x{}", "0".repeat(512)),
+            }))]);
+            Ok(WsSubscription::new(Box::pin(stream)))
+        })
+    }
+
+    fn ws_subscribe_logs(
+        &self,
+        _filter: alloy_rpc_types_eth::Filter,
+        _auth: zone_rpc::auth::AuthContext,
+    ) -> BoxWsSubscriptionFut<'_> {
+        let enabled = self.ws_subscriptions_enabled;
+        Box::pin(async move {
+            if !enabled {
+                return Err(JsonRpcError::method_disabled());
+            }
+
+            let stream = stream::iter(vec![zone_rpc::types::to_raw(&json!({
+                "address": format!("{:#x}", Address::ZERO),
+                "topics": [format!(
+                    "{:#x}",
+                    b256!("0x1111111111111111111111111111111111111111111111111111111111111111")
+                )],
+                "data": "0x",
+                "blockHash": format!(
+                    "{:#x}",
+                    b256!("0x2222222222222222222222222222222222222222222222222222222222222222")
+                ),
+                "blockNumber": "0x42",
+                "transactionHash": format!(
+                    "{:#x}",
+                    b256!("0x3333333333333333333333333333333333333333333333333333333333333333")
+                ),
+                "transactionIndex": "0x0",
+                "logIndex": "0x0",
+                "removed": false
+            }))]);
+            Ok(WsSubscription::new(Box::pin(stream)))
+        })
+    }
+
+    fn ws_subscribe_pending_transactions(
+        &self,
+        full: bool,
+        _auth: zone_rpc::auth::AuthContext,
+    ) -> BoxWsSubscriptionFut<'_> {
+        let enabled = self.ws_subscriptions_enabled;
+        Box::pin(async move {
+            if !enabled {
+                return Err(JsonRpcError::method_disabled());
+            }
+
+            let stream = if full {
+                stream::iter(vec![zone_rpc::types::to_raw(&json!({
+                    "hash": format!(
+                        "{:#x}",
+                        b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
+                    ),
+                    "from": format!("{:#x}", Address::repeat_byte(0x11)),
+                    "to": format!("{:#x}", Address::repeat_byte(0x22)),
+                    "nonce": "0x7"
+                }))])
+            } else {
+                stream::iter(vec![zone_rpc::types::to_raw(&format!(
+                    "{:#x}",
+                    b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
+                ))])
+            };
+            Ok(WsSubscription::new(Box::pin(stream)))
+        })
+    }
 
     fn zone_get_authorization_token_info(&self, auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
@@ -210,6 +311,10 @@ impl TestContext {
 /// Build a JSON-RPC request string.
 fn jsonrpc(method: &str, id: u64) -> String {
     serde_json::json!({"jsonrpc":"2.0","method":method,"params":[],"id":id}).to_string()
+}
+
+fn jsonrpc_with_params(method: &str, params: Value, id: u64) -> String {
+    serde_json::json!({"jsonrpc":"2.0","method":method,"params":params,"id":id}).to_string()
 }
 
 /// Connect to the WS endpoint using the X-Authorization-Token header.
@@ -424,12 +529,12 @@ async fn ws_unknown_method() {
 }
 
 #[tokio::test]
-async fn ws_disabled_method() {
+async fn ws_disabled_subscription_method() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_subscribe", 1).into(),
+        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 1).into(),
     ))
     .await
     .unwrap();
@@ -437,6 +542,189 @@ async fn ws_disabled_method() {
 
     assert_eq!(resp["id"], 1);
     assert_eq!(resp["error"]["code"], -32006);
+}
+
+#[tokio::test]
+async fn ws_subscribe_new_heads_emits_redacted_headers() {
+    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 1);
+    let subscription_id = resp["result"].as_str().expect("subscription id");
+
+    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("timed out waiting for newHeads notification")
+        .unwrap()
+        .unwrap();
+    let notification = parse_response(notification);
+
+    assert_eq!(notification["method"], "eth_subscription");
+    assert_eq!(notification["params"]["subscription"], subscription_id);
+    assert_eq!(
+        notification["params"]["result"]["hash"],
+        format!(
+            "{:#x}",
+            b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
+        )
+    );
+    assert_eq!(
+        notification["params"]["result"]["logsBloom"],
+        format!("0x{}", "0".repeat(512))
+    );
+    assert!(
+        notification["params"]["result"]
+            .get("transactions")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn ws_subscribe_logs_emits_notifications() {
+    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["logs", {}]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 1);
+    let subscription_id = resp["result"].as_str().expect("subscription id");
+
+    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("timed out waiting for log notification")
+        .unwrap()
+        .unwrap();
+    let notification = parse_response(notification);
+
+    assert_eq!(notification["method"], "eth_subscription");
+    assert_eq!(notification["params"]["subscription"], subscription_id);
+    assert_eq!(notification["params"]["result"]["blockNumber"], "0x42");
+}
+
+#[tokio::test]
+async fn ws_subscribe_pending_transactions_hashes_emits_notifications() {
+    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions"]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 1);
+    let subscription_id = resp["result"].as_str().expect("subscription id");
+
+    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("timed out waiting for pending tx hash notification")
+        .unwrap()
+        .unwrap();
+    let notification = parse_response(notification);
+
+    assert_eq!(notification["method"], "eth_subscription");
+    assert_eq!(notification["params"]["subscription"], subscription_id);
+    assert_eq!(
+        notification["params"]["result"],
+        format!(
+            "{:#x}",
+            b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
+        )
+    );
+}
+
+#[tokio::test]
+async fn ws_subscribe_pending_transactions_full_emits_notifications() {
+    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions", true]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 1);
+    let subscription_id = resp["result"].as_str().expect("subscription id");
+
+    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+        .await
+        .expect("timed out waiting for full pending tx notification")
+        .unwrap()
+        .unwrap();
+    let notification = parse_response(notification);
+
+    assert_eq!(notification["method"], "eth_subscription");
+    assert_eq!(notification["params"]["subscription"], subscription_id);
+    assert_eq!(notification["params"]["result"]["nonce"], "0x7");
+    assert_eq!(
+        notification["params"]["result"]["from"],
+        format!("{:#x}", Address::repeat_byte(0x11))
+    );
+}
+
+#[tokio::test]
+async fn ws_unsubscribe_removes_subscription() {
+    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["logs", {}]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let subscription_id = resp["result"].clone();
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_unsubscribe", json!([subscription_id]), 2).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = loop {
+        let message = parse_response(ws.next().await.unwrap().unwrap());
+        if message["id"] == 2 {
+            break message;
+        }
+    };
+
+    assert_eq!(resp["id"], 2);
+    assert_eq!(resp["result"], true);
+}
+
+#[tokio::test]
+async fn ws_subscribe_rejects_invalid_param_shapes() {
+    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    for (id, params) in [
+        (1, json!(["newHeads", false])),
+        (2, json!(["logs", false])),
+        (3, json!(["newPendingTransactions", {}])),
+    ] {
+        ws.send(tungstenite::Message::Text(
+            jsonrpc_with_params("eth_subscribe", params, id).into(),
+        ))
+        .await
+        .unwrap();
+        let resp = parse_response(ws.next().await.unwrap().unwrap());
+        assert_eq!(resp["id"], id);
+        assert_eq!(resp["error"]["code"], -32602);
+    }
 }
 
 #[tokio::test]

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -75,7 +75,6 @@ derive_more = { workspace = true, features = ["deref", "deref_mut"] }
 either.workspace = true
 eyre.workspace = true
 serde = { workspace = true, features = ["derive"] }
-serde_json.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
 tokio.workspace = true

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -74,6 +74,7 @@ derive_more = { workspace = true, features = ["deref", "deref_mut"] }
 either.workspace = true
 eyre.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
 tokio.workspace = true
@@ -113,6 +114,7 @@ tempo-payload-types.workspace = true
 sha2.workspace = true
 tempo-precompiles = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tokio-tungstenite.workspace = true
 
 [features]
 default = []

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -44,6 +44,7 @@ reth-revm.workspace = true
 reth-rpc.workspace = true
 reth-rpc-builder.workspace = true
 reth-rpc-eth-api.workspace = true
+reth-rpc-eth-types.workspace = true
 reth-storage-api.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -31,7 +31,6 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::logs_utils;
 use reth_transaction_pool::TransactionPool;
-use serde_json::value::RawValue;
 use tempo_alloy::{
     TempoNetwork,
     rpc::{TempoHeaderResponse, TempoTransactionRequest},
@@ -40,7 +39,7 @@ use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     account_keychain::IAccountKeychain::{self, KeyInfo, getKeyCall},
 };
-use tempo_primitives::TempoTxEnvelope;
+use tempo_primitives::{TempoHeader, TempoTxEnvelope};
 use tokio::{
     sync::Mutex,
     time::{MissedTickBehavior, interval},
@@ -800,8 +799,14 @@ where
                         .collect::<Vec<_>>();
                     futures::stream::iter(headers)
                 })
-                .map(move |header| serialize_ws_header(&header, redact_logs_bloom));
-            Ok(WsSubscription::new(Box::pin(stream)))
+                .map(move |mut header| {
+                    if redact_logs_bloom {
+                        redact_ws_header(&mut header);
+                    }
+                    to_raw(&header)
+                });
+            let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
         })
     }
 
@@ -833,7 +838,8 @@ where
 
             if auth.is_sequencer {
                 let stream = stream.map(|log| to_raw(&log));
-                return Ok(WsSubscription::new(Box::pin(stream)));
+                let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
+                return Ok(stream);
             }
 
             let stream = stream.filter_map(move |log| {
@@ -841,7 +847,8 @@ where
                     zone_rpc::filter::is_log_visible(&log, &caller).then(|| to_raw(&log)),
                 )
             });
-            Ok(WsSubscription::new(Box::pin(stream)))
+            let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
         })
     }
 
@@ -859,7 +866,8 @@ where
                         |mut rx| async move { rx.recv().await.map(|hash| (hash, rx)) },
                     )
                     .map(|hash| to_raw(&hash));
-                    return Ok(WsSubscription::new(Box::pin(stream)));
+                    let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
+                    return Ok(stream);
                 }
 
                 let api = self.eth.api.clone();
@@ -872,7 +880,8 @@ where
                             .map_err(internal)
                             .and_then(|tx| to_raw(&tx))
                     });
-                return Ok(WsSubscription::new(Box::pin(stream)));
+                let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
+                return Ok(stream);
             }
 
             let caller = auth.caller;
@@ -887,7 +896,8 @@ where
                                     .then(|| to_raw(&*pending_tx.transaction.hash())),
                             )
                         });
-                return Ok(WsSubscription::new(Box::pin(stream)));
+                let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
+                return Ok(stream);
             }
 
             let api = self.eth.api.clone();
@@ -901,7 +911,8 @@ where
                                 .and_then(|tx| to_raw(&tx))
                         }))
                     });
-            Ok(WsSubscription::new(Box::pin(stream)))
+            let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
         })
     }
 
@@ -1074,30 +1085,18 @@ fn encrypted_deposit_details(
     }
 }
 
-/// Strip privacy-sensitive fields from a block for non-sequencer callers.
-fn redact_block(block: &mut RpcBlock) {
-    // header.inner = alloy Header, .inner = Sealed wrapper, .inner = TempoHeader (contains logs_bloom)
-    block.header.inner.inner.inner.logs_bloom = Bloom::ZERO;
-    block.transactions = BlockTransactions::Hashes(Vec::new());
+fn redact_tempo_header(header: &mut TempoHeader) {
+    header.inner.logs_bloom = Bloom::ZERO;
 }
 
-/// Serialize a `newHeads` item, optionally redacting `logsBloom`.
-fn serialize_ws_header<T: serde::Serialize>(
-    header: &T,
-    redact_logs_bloom: bool,
-) -> Result<Box<RawValue>, JsonRpcError> {
-    if !redact_logs_bloom {
-        return to_raw(header);
-    }
+fn redact_ws_header(header: &mut TempoHeaderResponse) {
+    redact_tempo_header(&mut header.inner.inner);
+}
 
-    let mut value = serde_json::to_value(header).map_err(internal)?;
-    if let Some(obj) = value.as_object_mut() {
-        obj.insert(
-            "logsBloom".to_string(),
-            serde_json::Value::String(format!("0x{}", "0".repeat(512))),
-        );
-    }
-    to_raw(&value)
+/// Strip privacy-sensitive fields from a block for non-sequencer callers.
+fn redact_block(block: &mut RpcBlock) {
+    redact_tempo_header(&mut block.header.inner);
+    block.transactions = BlockTransactions::Hashes(Vec::new());
 }
 
 #[cfg(test)]

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -895,7 +895,7 @@ where
                         .filter_map(move |pending_tx| {
                             std::future::ready(
                                 (pending_tx.transaction.sender() == caller)
-                                    .then(|| to_raw(&*pending_tx.transaction.hash())),
+                                    .then(|| to_raw(pending_tx.transaction.hash())),
                             )
                         });
                 let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -21,12 +21,14 @@ use alloy_rpc_types_eth::{
 };
 use alloy_sol_types::{SolCall, SolEvent, SolEventInterface};
 use eyre::WrapErr;
+use futures::StreamExt;
 use reth_rpc::{EthFilter, eth::filter::EthFilterError};
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
-    EthApiTypes, EthFilterApiServer,
+    EthApiTypes, EthFilterApiServer, RpcConvert,
     helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
 };
+use serde_json::value::RawValue;
 use tempo_alloy::{
     TempoNetwork,
     rpc::{TempoHeaderResponse, TempoTransactionRequest},
@@ -37,7 +39,7 @@ use tempo_contracts::precompiles::{
 };
 use tempo_primitives::TempoTxEnvelope;
 use tokio::{
-    sync::Mutex,
+    sync::{Mutex, mpsc},
     time::{MissedTickBehavior, interval},
 };
 
@@ -764,6 +766,165 @@ where
         })
     }
 
+    fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let redact_logs_bloom = !auth.is_sequencer;
+            let pubsub = self.eth.pubsub.clone();
+            let (tx, rx) = mpsc::unbounded_channel();
+            let task = tokio::spawn(async move {
+                let mut stream = Box::pin(pubsub.new_headers_stream());
+                while let Some(header) = stream.next().await {
+                    if tx
+                        .send(serialize_ws_header(&header, redact_logs_bloom))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            });
+            Ok(WsSubscription::with_cleanup(
+                ws_stream_from_receiver(rx),
+                task,
+            ))
+        })
+    }
+
+    fn ws_subscribe_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let pubsub = self.eth.pubsub.clone();
+
+            if auth.is_sequencer {
+                let (tx, rx) = mpsc::unbounded_channel();
+                let task = tokio::spawn(async move {
+                    let mut stream = Box::pin(pubsub.log_stream(filter));
+                    while let Some(log) = stream.next().await {
+                        if tx.send(to_raw(&log)).is_err() {
+                            break;
+                        }
+                    }
+                });
+                return Ok(WsSubscription::with_cleanup(
+                    ws_stream_from_receiver(rx),
+                    task,
+                ));
+            }
+
+            zone_rpc::filter::scope_filter(&mut filter);
+            let caller = auth.caller;
+            let (tx, rx) = mpsc::unbounded_channel();
+            let task = tokio::spawn(async move {
+                let mut stream = Box::pin(pubsub.log_stream(filter));
+                while let Some(log) = stream.next().await {
+                    if !zone_rpc::filter::is_log_visible(&log, &caller) {
+                        continue;
+                    }
+
+                    if tx.send(to_raw(&log)).is_err() {
+                        break;
+                    }
+                }
+            });
+            Ok(WsSubscription::with_cleanup(
+                ws_stream_from_receiver(rx),
+                task,
+            ))
+        })
+    }
+
+    fn ws_subscribe_pending_transactions(
+        &self,
+        full: bool,
+        auth: AuthContext,
+    ) -> BoxWsSubscriptionFut<'_> {
+        Box::pin(async move {
+            let pubsub = self.eth.pubsub.clone();
+
+            if auth.is_sequencer {
+                if !full {
+                    let (tx, rx) = mpsc::unbounded_channel();
+                    let task = tokio::spawn(async move {
+                        let mut stream = Box::pin(pubsub.pending_transaction_hashes_stream());
+                        while let Some(hash) = stream.next().await {
+                            if tx.send(to_raw(&hash)).is_err() {
+                                break;
+                            }
+                        }
+                    });
+                    return Ok(WsSubscription::with_cleanup(
+                        ws_stream_from_receiver(rx),
+                        task,
+                    ));
+                }
+
+                let api = self.eth.api.clone();
+                let (tx, rx) = mpsc::unbounded_channel();
+                let task = tokio::spawn(async move {
+                    let mut stream = Box::pin(pubsub.full_pending_transaction_stream());
+                    while let Some(pending_tx) = stream.next().await {
+                        let item = api
+                            .converter()
+                            .fill_pending(pending_tx.transaction.to_consensus())
+                            .map_err(internal)
+                            .and_then(|tx| to_raw(&tx));
+                        if tx.send(item).is_err() {
+                            break;
+                        }
+                    }
+                });
+                return Ok(WsSubscription::with_cleanup(
+                    ws_stream_from_receiver(rx),
+                    task,
+                ));
+            }
+
+            let caller = auth.caller;
+
+            if !full {
+                let (tx, rx) = mpsc::unbounded_channel();
+                let task = tokio::spawn(async move {
+                    let mut stream = Box::pin(pubsub.full_pending_transaction_stream());
+                    while let Some(pending_tx) = stream.next().await {
+                        if pending_tx.transaction.sender() != caller {
+                            continue;
+                        }
+
+                        if tx.send(to_raw(&*pending_tx.transaction.hash())).is_err() {
+                            break;
+                        }
+                    }
+                });
+                return Ok(WsSubscription::with_cleanup(
+                    ws_stream_from_receiver(rx),
+                    task,
+                ));
+            }
+
+            let api = self.eth.api.clone();
+            let (tx, rx) = mpsc::unbounded_channel();
+            let task = tokio::spawn(async move {
+                let mut stream = Box::pin(pubsub.full_pending_transaction_stream());
+                while let Some(pending_tx) = stream.next().await {
+                    if pending_tx.transaction.sender() != caller {
+                        continue;
+                    }
+
+                    let item = api
+                        .converter()
+                        .fill_pending(pending_tx.transaction.to_consensus())
+                        .map_err(internal)
+                        .and_then(|tx| to_raw(&tx));
+                    if tx.send(item).is_err() {
+                        break;
+                    }
+                }
+            });
+            Ok(WsSubscription::with_cleanup(
+                ws_stream_from_receiver(rx),
+                task,
+            ))
+        })
+    }
+
     fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             to_raw(&AuthorizationTokenInfoResponse {
@@ -938,6 +1099,33 @@ fn redact_block(block: &mut RpcBlock) {
     // header.inner = alloy Header, .inner = Sealed wrapper, .inner = TempoHeader (contains logs_bloom)
     block.header.inner.inner.inner.logs_bloom = Bloom::ZERO;
     block.transactions = BlockTransactions::Hashes(Vec::new());
+}
+
+/// Serialize a `newHeads` item, optionally redacting `logsBloom`.
+fn serialize_ws_header<T: serde::Serialize>(
+    header: &T,
+    redact_logs_bloom: bool,
+) -> Result<Box<RawValue>, JsonRpcError> {
+    if !redact_logs_bloom {
+        return to_raw(header);
+    }
+
+    let mut value = serde_json::to_value(header).map_err(internal)?;
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "logsBloom".to_string(),
+            serde_json::Value::String(format!("0x{}", "0".repeat(512))),
+        );
+    }
+    to_raw(&value)
+}
+
+fn ws_stream_from_receiver(
+    rx: mpsc::UnboundedReceiver<Result<Box<RawValue>, JsonRpcError>>,
+) -> WsSubscriptionStream {
+    Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+        rx.recv().await.map(|item| (item, rx))
+    }))
 }
 
 #[cfg(test)]

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -861,6 +861,8 @@ where
             if auth.is_sequencer {
                 if !full {
                     let pool = self.eth.api.pool().clone();
+                    // Sequencers can use the direct hash listener because no sender scoping is
+                    // required; non-sequencers must source full tx events to filter by sender.
                     let stream = futures::stream::unfold(
                         pool.pending_transactions_listener(),
                         |mut rx| async move { rx.recv().await.map(|hash| (hash, rx)) },

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -22,12 +22,15 @@ use alloy_rpc_types_eth::{
 use alloy_sol_types::{SolCall, SolEvent, SolEventInterface};
 use eyre::WrapErr;
 use futures::StreamExt;
+use reth_provider::CanonStateSubscriptions;
 use reth_rpc::{EthFilter, eth::filter::EthFilterError};
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, RpcConvert,
     helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
 };
+use reth_rpc_eth_types::logs_utils;
+use reth_transaction_pool::TransactionPool;
 use serde_json::value::RawValue;
 use tempo_alloy::{
     TempoNetwork,
@@ -39,7 +42,7 @@ use tempo_contracts::precompiles::{
 };
 use tempo_primitives::TempoTxEnvelope;
 use tokio::{
-    sync::{Mutex, mpsc},
+    sync::Mutex,
     time::{MissedTickBehavior, interval},
 };
 
@@ -769,65 +772,76 @@ where
     fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
         Box::pin(async move {
             let redact_logs_bloom = !auth.is_sequencer;
-            let pubsub = self.eth.pubsub.clone();
-            let (tx, rx) = mpsc::unbounded_channel();
-            let task = tokio::spawn(async move {
-                let mut stream = Box::pin(pubsub.new_headers_stream());
-                while let Some(header) = stream.next().await {
-                    if tx
-                        .send(serialize_ws_header(&header, redact_logs_bloom))
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-            });
-            Ok(WsSubscription::with_cleanup(
-                ws_stream_from_receiver(rx),
-                task,
-            ))
+            let api = self.eth.api.clone();
+            let provider = self.eth.api.provider().clone();
+            let stream = provider
+                .canonical_state_stream()
+                .flat_map(move |new_chain| {
+                    let api = api.clone();
+                    let headers = new_chain
+                        .committed()
+                        .blocks_iter()
+                        .filter_map(move |block| {
+                            match api
+                                .converter()
+                                .convert_header(block.clone_sealed_header(), block.rlp_length())
+                            {
+                                Ok(header) => Some(header),
+                                Err(err) => {
+                                    tracing::error!(
+                                        target: "rpc",
+                                        %err,
+                                        "Failed to convert header"
+                                    );
+                                    None
+                                }
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    futures::stream::iter(headers)
+                })
+                .map(move |header| serialize_ws_header(&header, redact_logs_bloom));
+            Ok(WsSubscription::new(Box::pin(stream)))
         })
     }
 
     fn ws_subscribe_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
         Box::pin(async move {
-            let pubsub = self.eth.pubsub.clone();
+            let provider = self.eth.api.provider().clone();
+            let caller = auth.caller;
 
-            if auth.is_sequencer {
-                let (tx, rx) = mpsc::unbounded_channel();
-                let task = tokio::spawn(async move {
-                    let mut stream = Box::pin(pubsub.log_stream(filter));
-                    while let Some(log) = stream.next().await {
-                        if tx.send(to_raw(&log)).is_err() {
-                            break;
-                        }
-                    }
-                });
-                return Ok(WsSubscription::with_cleanup(
-                    ws_stream_from_receiver(rx),
-                    task,
-                ));
+            if !auth.is_sequencer {
+                zone_rpc::filter::scope_filter(&mut filter);
             }
 
-            zone_rpc::filter::scope_filter(&mut filter);
-            let caller = auth.caller;
-            let (tx, rx) = mpsc::unbounded_channel();
-            let task = tokio::spawn(async move {
-                let mut stream = Box::pin(pubsub.log_stream(filter));
-                while let Some(log) = stream.next().await {
-                    if !zone_rpc::filter::is_log_visible(&log, &caller) {
-                        continue;
-                    }
+            let stream = provider
+                .canonical_state_stream()
+                .flat_map(|canon_state| futures::stream::iter(canon_state.block_receipts()))
+                .flat_map(move |(block_receipts, removed)| {
+                    let all_logs = logs_utils::matching_block_logs_with_tx_hashes(
+                        &filter,
+                        block_receipts.block,
+                        block_receipts.timestamp,
+                        block_receipts
+                            .tx_receipts
+                            .iter()
+                            .map(|(tx, receipt)| (*tx, receipt)),
+                        removed,
+                    );
+                    futures::stream::iter(all_logs)
+                });
 
-                    if tx.send(to_raw(&log)).is_err() {
-                        break;
-                    }
-                }
+            if auth.is_sequencer {
+                let stream = stream.map(|log| to_raw(&log));
+                return Ok(WsSubscription::new(Box::pin(stream)));
+            }
+
+            let stream = stream.filter_map(move |log| {
+                std::future::ready(
+                    zone_rpc::filter::is_log_visible(&log, &caller).then(|| to_raw(&log)),
+                )
             });
-            Ok(WsSubscription::with_cleanup(
-                ws_stream_from_receiver(rx),
-                task,
-            ))
+            Ok(WsSubscription::new(Box::pin(stream)))
         })
     }
 
@@ -837,91 +851,57 @@ where
         auth: AuthContext,
     ) -> BoxWsSubscriptionFut<'_> {
         Box::pin(async move {
-            let pubsub = self.eth.pubsub.clone();
-
             if auth.is_sequencer {
                 if !full {
-                    let (tx, rx) = mpsc::unbounded_channel();
-                    let task = tokio::spawn(async move {
-                        let mut stream = Box::pin(pubsub.pending_transaction_hashes_stream());
-                        while let Some(hash) = stream.next().await {
-                            if tx.send(to_raw(&hash)).is_err() {
-                                break;
-                            }
-                        }
-                    });
-                    return Ok(WsSubscription::with_cleanup(
-                        ws_stream_from_receiver(rx),
-                        task,
-                    ));
+                    let pool = self.eth.api.pool().clone();
+                    let stream = futures::stream::unfold(
+                        pool.pending_transactions_listener(),
+                        |mut rx| async move { rx.recv().await.map(|hash| (hash, rx)) },
+                    )
+                    .map(|hash| to_raw(&hash));
+                    return Ok(WsSubscription::new(Box::pin(stream)));
                 }
 
                 let api = self.eth.api.clone();
-                let (tx, rx) = mpsc::unbounded_channel();
-                let task = tokio::spawn(async move {
-                    let mut stream = Box::pin(pubsub.full_pending_transaction_stream());
-                    while let Some(pending_tx) = stream.next().await {
-                        let item = api
-                            .converter()
+                let pool = self.eth.api.pool().clone();
+                let stream = pool
+                    .new_pending_pool_transactions_listener()
+                    .map(move |pending_tx| {
+                        api.converter()
                             .fill_pending(pending_tx.transaction.to_consensus())
                             .map_err(internal)
-                            .and_then(|tx| to_raw(&tx));
-                        if tx.send(item).is_err() {
-                            break;
-                        }
-                    }
-                });
-                return Ok(WsSubscription::with_cleanup(
-                    ws_stream_from_receiver(rx),
-                    task,
-                ));
+                            .and_then(|tx| to_raw(&tx))
+                    });
+                return Ok(WsSubscription::new(Box::pin(stream)));
             }
 
             let caller = auth.caller;
+            let pool = self.eth.api.pool().clone();
 
             if !full {
-                let (tx, rx) = mpsc::unbounded_channel();
-                let task = tokio::spawn(async move {
-                    let mut stream = Box::pin(pubsub.full_pending_transaction_stream());
-                    while let Some(pending_tx) = stream.next().await {
-                        if pending_tx.transaction.sender() != caller {
-                            continue;
-                        }
-
-                        if tx.send(to_raw(&*pending_tx.transaction.hash())).is_err() {
-                            break;
-                        }
-                    }
-                });
-                return Ok(WsSubscription::with_cleanup(
-                    ws_stream_from_receiver(rx),
-                    task,
-                ));
+                let stream =
+                    pool.new_pending_pool_transactions_listener()
+                        .filter_map(move |pending_tx| {
+                            std::future::ready(
+                                (pending_tx.transaction.sender() == caller)
+                                    .then(|| to_raw(&*pending_tx.transaction.hash())),
+                            )
+                        });
+                return Ok(WsSubscription::new(Box::pin(stream)));
             }
 
             let api = self.eth.api.clone();
-            let (tx, rx) = mpsc::unbounded_channel();
-            let task = tokio::spawn(async move {
-                let mut stream = Box::pin(pubsub.full_pending_transaction_stream());
-                while let Some(pending_tx) = stream.next().await {
-                    if pending_tx.transaction.sender() != caller {
-                        continue;
-                    }
-
-                    let item = api
-                        .converter()
-                        .fill_pending(pending_tx.transaction.to_consensus())
-                        .map_err(internal)
-                        .and_then(|tx| to_raw(&tx));
-                    if tx.send(item).is_err() {
-                        break;
-                    }
-                }
-            });
-            Ok(WsSubscription::with_cleanup(
-                ws_stream_from_receiver(rx),
-                task,
-            ))
+            let stream =
+                pool.new_pending_pool_transactions_listener()
+                    .filter_map(move |pending_tx| {
+                        std::future::ready((pending_tx.transaction.sender() == caller).then(|| {
+                            api.converter()
+                                .fill_pending(pending_tx.transaction.to_consensus())
+                                .map_err(internal)
+                                .and_then(|tx| to_raw(&tx))
+                        }))
+                    });
+            Ok(WsSubscription::new(Box::pin(stream)))
         })
     }
 
@@ -1118,14 +1098,6 @@ fn serialize_ws_header<T: serde::Serialize>(
         );
     }
     to_raw(&value)
-}
-
-fn ws_stream_from_receiver(
-    rx: mpsc::UnboundedReceiver<Result<Box<RawValue>, JsonRpcError>>,
-) -> WsSubscriptionStream {
-    Box::pin(futures::stream::unfold(rx, |mut rx| async move {
-        rx.recv().await.map(|item| (item, rx))
-    }))
 }
 
 #[cfg(test)]

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -18,8 +18,14 @@ use alloy::{
 use alloy_provider::ProviderBuilder;
 use alloy_signer_local::{MnemonicBuilder, coins_bip39::English};
 use alloy_sol_types::SolCall;
+use futures::{SinkExt, StreamExt};
 use p256::ecdsa::SigningKey as P256SigningKey;
 use rand::thread_rng;
+use serde_json::{Value, json};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::{
     ITIP20 as ContractTip20,
@@ -27,6 +33,10 @@ use tempo_contracts::precompiles::{
 };
 use tempo_precompiles::{PATH_USD_ADDRESS, tip20::ITIP20 as PrecompileTip20};
 use tokio::time::sleep;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{Message, client::IntoClientRequest},
+};
 
 fn corrupt_token_hex(token: &str) -> String {
     let mut bytes = hex::decode(token).expect("token hex should decode");
@@ -49,6 +59,94 @@ fn assert_filter_not_found_error(response: &serde_json::Value) {
         "filter not found",
         "filter-not-found message should be stable",
     );
+}
+
+type PrivateRpcWs =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+fn private_rpc_ws_url(http_url: &url::Url) -> eyre::Result<url::Url> {
+    let mut ws_url = http_url.clone();
+    let target_scheme = if ws_url.scheme() == "https" {
+        "wss"
+    } else {
+        "ws"
+    };
+    ws_url
+        .set_scheme(target_scheme)
+        .map_err(|_| eyre::eyre!("failed to derive websocket URL"))?;
+    Ok(ws_url)
+}
+
+fn jsonrpc_with_params(method: &str, params: Value, id: u64) -> String {
+    json!({"jsonrpc":"2.0","method":method,"params":params,"id":id}).to_string()
+}
+
+async fn connect_private_rpc_ws(url: &url::Url, auth_token: &str) -> eyre::Result<PrivateRpcWs> {
+    let ws_url = private_rpc_ws_url(url)?;
+    let mut req = ws_url.as_str().into_client_request()?;
+    req.headers_mut().insert(
+        "x-authorization-token",
+        auth_token
+            .parse()
+            .expect("auth token header should be valid"),
+    );
+    let (ws, _) = connect_async(req).await?;
+    Ok(ws)
+}
+
+async fn ws_next_json(ws: &mut PrivateRpcWs) -> eyre::Result<Value> {
+    let Some(msg) = tokio::time::timeout(DEFAULT_TIMEOUT, ws.next())
+        .await
+        .map_err(|_| eyre::eyre!("timed out waiting for websocket message"))?
+    else {
+        eyre::bail!("websocket closed unexpectedly");
+    };
+
+    match msg? {
+        Message::Text(text) => Ok(serde_json::from_str(&text)?),
+        other => eyre::bail!("expected text websocket message, got {other:?}"),
+    }
+}
+
+async fn ws_subscribe(ws: &mut PrivateRpcWs, params: Value) -> eyre::Result<String> {
+    ws.send(Message::Text(
+        jsonrpc_with_params("eth_subscribe", params, 1).into(),
+    ))
+    .await?;
+    let response = ws_next_json(ws).await?;
+    Ok(response["result"]
+        .as_str()
+        .expect("subscription response should include an id")
+        .to_owned())
+}
+
+async fn ws_expect_no_message(ws: &mut PrivateRpcWs, duration: Duration) -> eyre::Result<()> {
+    match tokio::time::timeout(duration, ws.next()).await {
+        Err(_) => Ok(()),
+        Ok(Some(Ok(Message::Close(_)))) | Ok(None) => Ok(()),
+        Ok(Some(Ok(Message::Text(text)))) => {
+            eyre::bail!("unexpected websocket message: {text}")
+        }
+        Ok(Some(Ok(other))) => eyre::bail!("unexpected websocket frame: {other:?}"),
+        Ok(Some(Err(err))) => Err(err.into()),
+    }
+}
+
+async fn ws_collect_messages_until_quiet(
+    ws: &mut PrivateRpcWs,
+    duration: Duration,
+) -> eyre::Result<Vec<Value>> {
+    let mut messages = Vec::new();
+
+    loop {
+        match tokio::time::timeout(duration, ws.next()).await {
+            Err(_) => return Ok(messages),
+            Ok(Some(Ok(Message::Close(_)))) | Ok(None) => return Ok(messages),
+            Ok(Some(Ok(Message::Text(text)))) => messages.push(serde_json::from_str(&text)?),
+            Ok(Some(Ok(other))) => eyre::bail!("unexpected websocket frame: {other:?}"),
+            Ok(Some(Err(err))) => return Err(err.into()),
+        }
+    }
 }
 
 /// Auth enforcement: missing header → 401, garbage token → 401/403, wrong chain ID → 403.
@@ -709,6 +807,232 @@ async fn test_method_tiers() -> eyre::Result<()> {
         -32601,
         "unknown method should return -32601"
     );
+
+    Ok(())
+}
+
+/// WebSocket log subscriptions apply the same caller-scoped filtering as
+/// polling log APIs, while the sequencer sees the full stream.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ws_logs_subscription_scopes_non_sequencer_and_allows_sequencer() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut ctx = start_zone_with_private_rpc().await?;
+    let owner_signer = MnemonicBuilder::<English>::default()
+        .phrase(TEST_MNEMONIC)
+        .build()?;
+    let outsider_signer = PrivateKeySigner::random();
+    let spender = PrivateKeySigner::random().address();
+
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        owner_signer.address(),
+        owner_signer.address(),
+        1_000_000,
+    )
+    .await?;
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        outsider_signer.address(),
+        outsider_signer.address(),
+        1_000_000,
+    )
+    .await?;
+
+    let owner_token = ctx.user_token(&owner_signer);
+    let sequencer_token = ctx.sequencer_token();
+    let mut owner_ws = connect_private_rpc_ws(&ctx.private_rpc_url, &owner_token).await?;
+    let mut sequencer_ws = connect_private_rpc_ws(&ctx.private_rpc_url, &sequencer_token).await?;
+
+    let owner_subscription = ws_subscribe(
+        &mut owner_ws,
+        json!(["logs", {"address": format!("{PATH_USD_ADDRESS:#x}")}]),
+    )
+    .await?;
+    let sequencer_subscription = ws_subscribe(
+        &mut sequencer_ws,
+        json!(["logs", {"address": format!("{PATH_USD_ADDRESS:#x}")}]),
+    )
+    .await?;
+
+    let owner_provider = ProviderBuilder::new()
+        .wallet(owner_signer.clone())
+        .connect_http(ctx.zone.http_url().clone());
+    let outsider_provider = ProviderBuilder::new()
+        .wallet(outsider_signer.clone())
+        .connect_http(ctx.zone.http_url().clone());
+
+    let owner_pending = ContractTip20::new(PATH_USD_ADDRESS, &owner_provider)
+        .approve(spender, U256::from(111u64))
+        .gas_price(TEMPO_T0_BASE_FEE as u128)
+        .gas(150_000)
+        .send()
+        .await?;
+    let outsider_pending = ContractTip20::new(PATH_USD_ADDRESS, &outsider_provider)
+        .approve(spender, U256::from(222u64))
+        .gas_price(TEMPO_T0_BASE_FEE as u128)
+        .gas(150_000)
+        .send()
+        .await?;
+
+    let owner_hash = *owner_pending.tx_hash();
+    let outsider_hash = *outsider_pending.tx_hash();
+
+    ctx.fixture.inject_empty_block(ctx.zone.deposit_queue());
+
+    let owner_receipt = owner_pending.get_receipt().await?;
+    let outsider_receipt = outsider_pending.get_receipt().await?;
+    assert!(owner_receipt.status(), "owner approve should succeed");
+    assert!(outsider_receipt.status(), "outsider approve should succeed");
+
+    let mut owner_notifications = vec![ws_next_json(&mut owner_ws).await?];
+    owner_notifications
+        .extend(ws_collect_messages_until_quiet(&mut owner_ws, Duration::from_millis(500)).await?);
+    let owner_hashes = owner_notifications
+        .into_iter()
+        .map(|notification| {
+            assert_eq!(
+                notification["params"]["subscription"].as_str().unwrap(),
+                owner_subscription
+            );
+            notification["params"]["result"]["transactionHash"]
+                .as_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect::<HashSet<_>>();
+    assert_eq!(owner_hashes, HashSet::from([format!("{owner_hash:#x}")]));
+
+    let mut sequencer_notifications = vec![ws_next_json(&mut sequencer_ws).await?];
+    sequencer_notifications.extend(
+        ws_collect_messages_until_quiet(&mut sequencer_ws, Duration::from_millis(500)).await?,
+    );
+    let sequencer_hashes = sequencer_notifications
+        .into_iter()
+        .map(|notification| {
+            assert_eq!(
+                notification["params"]["subscription"].as_str().unwrap(),
+                sequencer_subscription
+            );
+            notification["params"]["result"]["transactionHash"]
+                .as_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect::<HashSet<_>>();
+    assert!(sequencer_hashes.contains(&format!("{owner_hash:#x}")));
+    assert!(sequencer_hashes.contains(&format!("{outsider_hash:#x}")));
+
+    Ok(())
+}
+
+/// Pending transaction subscriptions are sender-scoped for non-sequencers,
+/// while the sequencer sees the unfiltered full transaction stream.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ws_pending_transactions_are_sender_scoped_for_users() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut ctx = start_zone_with_private_rpc().await?;
+    let owner_signer = MnemonicBuilder::<English>::default()
+        .phrase(TEST_MNEMONIC)
+        .build()?;
+    let outsider_signer = PrivateKeySigner::random();
+    let spender = PrivateKeySigner::random().address();
+
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        owner_signer.address(),
+        owner_signer.address(),
+        1_000_000,
+    )
+    .await?;
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        outsider_signer.address(),
+        outsider_signer.address(),
+        1_000_000,
+    )
+    .await?;
+
+    let owner_token = ctx.user_token(&owner_signer);
+    let sequencer_token = ctx.sequencer_token();
+    let mut owner_ws = connect_private_rpc_ws(&ctx.private_rpc_url, &owner_token).await?;
+    let mut sequencer_ws = connect_private_rpc_ws(&ctx.private_rpc_url, &sequencer_token).await?;
+
+    let owner_subscription = ws_subscribe(&mut owner_ws, json!(["newPendingTransactions"])).await?;
+    let sequencer_subscription =
+        ws_subscribe(&mut sequencer_ws, json!(["newPendingTransactions", true])).await?;
+
+    let owner_provider = ProviderBuilder::new()
+        .wallet(owner_signer.clone())
+        .connect_http(ctx.zone.http_url().clone());
+    let outsider_provider = ProviderBuilder::new()
+        .wallet(outsider_signer.clone())
+        .connect_http(ctx.zone.http_url().clone());
+
+    let owner_pending = ContractTip20::new(PATH_USD_ADDRESS, &owner_provider)
+        .approve(spender, U256::from(333u64))
+        .gas_price(TEMPO_T0_BASE_FEE as u128)
+        .gas(150_000)
+        .send()
+        .await?;
+    let outsider_pending = ContractTip20::new(PATH_USD_ADDRESS, &outsider_provider)
+        .approve(spender, U256::from(444u64))
+        .gas_price(TEMPO_T0_BASE_FEE as u128)
+        .gas(150_000)
+        .send()
+        .await?;
+
+    let owner_hash = *owner_pending.tx_hash();
+    let outsider_hash = *outsider_pending.tx_hash();
+
+    let owner_notification = ws_next_json(&mut owner_ws).await?;
+    assert_eq!(
+        owner_notification["params"]["subscription"]
+            .as_str()
+            .unwrap(),
+        owner_subscription
+    );
+    assert_eq!(
+        owner_notification["params"]["result"].as_str().unwrap(),
+        format!("{owner_hash:#x}")
+    );
+    ws_expect_no_message(&mut owner_ws, Duration::from_millis(500)).await?;
+
+    let mut sequencer_pending = HashMap::new();
+    for _ in 0..2 {
+        let notification = ws_next_json(&mut sequencer_ws).await?;
+        assert_eq!(
+            notification["params"]["subscription"].as_str().unwrap(),
+            sequencer_subscription
+        );
+        let tx = notification["params"]["result"]
+            .as_object()
+            .expect("sequencer should receive full pending tx objects");
+        sequencer_pending.insert(
+            tx["hash"].as_str().unwrap().to_owned(),
+            tx["from"].as_str().unwrap().to_owned(),
+        );
+    }
+    assert_eq!(
+        sequencer_pending,
+        HashMap::from([
+            (
+                format!("{owner_hash:#x}"),
+                format!("{:#x}", owner_signer.address()),
+            ),
+            (
+                format!("{outsider_hash:#x}"),
+                format!("{:#x}", outsider_signer.address()),
+            ),
+        ])
+    );
+
+    ctx.fixture.inject_empty_block(ctx.zone.deposit_queue());
+    let owner_receipt = owner_pending.get_receipt().await?;
+    let outsider_receipt = outsider_pending.get_receipt().await?;
+    assert!(owner_receipt.status(), "owner approve should succeed");
+    assert!(outsider_receipt.status(), "outsider approve should succeed");
 
     Ok(())
 }

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -144,8 +144,6 @@ The authorization token fields are always exactly 49 bytes (1 + 4 + 8 + 20 + 8 +
 
 Requests without an authorization token receive a `401 Unauthorized` HTTP response. Requests with an expired, malformed, or unauthorized token receive `403 Forbidden`. If Keychain token verification fails because the server cannot read `AccountKeychain.getKey(...)`, the server returns `500 Internal Server Error`.
 
-The same endpoint also accepts WebSocket upgrades. For WebSocket clients, the authorization token is supplied during the upgrade handshake via the `X-Authorization-Token` header or a `?token=0x...` query parameter. `eth_subscribe` and `eth_unsubscribe` are **WebSocket-only**; calling them over HTTP returns `-32006` (method disabled).
-
 ## RPC method access control
 
 The zone RPC starts from the standard Ethereum JSON-RPC method set and applies per-method restrictions. Each method falls into one of four categories: **allowed** (unrestricted), **scoped** (filtered to the authenticated account), **restricted** (sequencer-only), or **disabled** (not available).
@@ -165,7 +163,7 @@ These methods return public zone information and are available to any authentica
 | `eth_feeHistory` | Fee history is public |
 | `eth_getBlockByNumber` | Returns block headers **without transaction details** (see [Block responses](#block-responses)) |
 | `eth_getBlockByHash` | Returns block headers **without transaction details** |
-| `eth_subscribe("newHeads")` | **WebSocket-only.** Pushes block headers on new blocks. The `logsBloom` field is zeroed for non-sequencers (see [Block responses](#block-responses)). |
+| `eth_subscribe("newHeads")` | Pushes block headers on new blocks. The `logsBloom` field is zeroed (see [Block responses](#block-responses)). |
 | `eth_syncing` | Returns sync status. Low risk — reveals node state, not account data. |
 | `eth_coinbase` | Returns the sequencer address (already public via `zone_getZoneInfo`). |
 | `net_version` | Network ID |
@@ -193,7 +191,6 @@ These methods are available to any authenticated caller but filter results to on
 | `eth_getTransactionByHash` | Returns the transaction only if the authenticated account is the `from` (sender) of the transaction. Returns `null` for transactions sent by other accounts. |
 | `eth_getTransactionReceipt` | Returns the receipt only if the authenticated account is the sender. Returns `null` otherwise. Logs within the receipt are filtered (see [Event filtering](#event-filtering)). |
 | `eth_sendRawTransaction` | Accepts and broadcasts the transaction. The zone validates that the transaction sender matches the authenticated account. Transactions from mismatched accounts are rejected with error code `-32003` (transaction rejected). |
-| `eth_subscribe("newPendingTransactions")` | **WebSocket-only.** Default mode returns transaction hashes. Passing `true` returns full pending transaction objects. Non-sequencers only receive pending transactions where `from == authenticated account`; the sequencer receives the full pending stream. |
 
 #### Transaction simulation
 
@@ -233,7 +230,7 @@ Methods that do **not** need the speed bump include those where authorization ca
 | `eth_getFilterLogs` | Same filtering as `eth_getLogs`. |
 | `eth_getFilterChanges` | Same filtering. Only returns new events matching the filter since last poll. |
 | `eth_newFilter` | Creates a filter. The filter is implicitly scoped to the authenticated account. |
-| `eth_subscribe("logs")` | **WebSocket-only.** Uses the native log pubsub stream, then applies the same scoping and post-filtering rules as `eth_getLogs` / `eth_getFilterChanges`. |
+| `eth_subscribe("logs")` | WebSocket equivalent of `eth_newFilter` + `eth_getFilterChanges`. The subscription is implicitly scoped to the authenticated account using the same [event filtering rules](#event-filtering-rules). |
 | `eth_newBlockFilter` | Allowed. Returns new block hashes. |
 | `eth_uninstallFilter` | Allowed. Removes a previously created filter. |
 
@@ -274,7 +271,8 @@ These methods are not supported on privacy zones.
 | `eth_submitHashrate` | Zones have no mining |
 | `eth_getProof` | Merkle proofs include sibling hashes that reveal state trie structure (number of accounts, address prefix distribution, slot occupancy), leaking information beyond the queried account |
 | `eth_getFilterLogs` (unscoped) | All log access goes through the scoped path |
-| `eth_newPendingTransactionFilter` | Polling equivalent of `eth_subscribe("newPendingTransactions")` is not exposed; pending-tx observation is WebSocket-only |
+| `eth_newPendingTransactionFilter` | Polling equivalent of `eth_subscribe("newPendingTransactions")` — mempool observation |
+| `eth_subscribe("newPendingTransactions")` | Mempool observation reveals all pending activity. Other subscription types (`newHeads`, `logs`) are classified above. |
 
 Disabled methods return error code `-32601` (method not found).
 
@@ -501,4 +499,4 @@ In addition to standard JSON-RPC error codes, the zone RPC uses:
 - Filter state (from `eth_newFilter`) is stored per-authenticated-account. Filters created by one authorization token are accessible by subsequent authorization tokens for the same account.
 - The zone node SHOULD cache authorization token verification results for the duration of token validity to avoid repeated signature recovery. For Keychain Access Keys, cache entries MUST have a TTL bounded by the earlier of authorization-token expiry and the active key's `expiry`, and MUST be invalidated within 1 second of importing a block that revokes the key (see [Keychain key revocation and expiry](#security-considerations)). The recommended approach is to hook into block import and evict cache entries when `KeyRevoked` events are observed.
 - P256 and WebAuthn signature verification is more expensive than secp256k1. The RPC server SHOULD aggressively cache verified authorization tokens to amortize the verification cost. A verified authorization token can be cached by its hash for the remaining duration of its validity.
-- WebSocket connections (`eth_subscribe`) follow the same authorization-token model. The authorization token is provided during the WebSocket handshake and scopes all subscriptions for that connection. The current implementation authenticates only at handshake time: it does **not** proactively terminate an already-open WebSocket when the authorization token later expires or when a Keychain key is later revoked. Fresh auth state is picked up on the next connection or reconnect.
+- WebSocket connections (`eth_subscribe`) follow the same authorization-token model. The authorization token is provided during the WebSocket handshake and scopes all subscriptions for that connection. The connection is terminated when the authorization token expires; clients must reconnect with a fresh token. For Keychain-authenticated WebSocket connections, the server MUST also terminate the connection within 1 second of importing a block that revokes the Keychain key, following the same deadline as [Keychain key revocation](#security-considerations).

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -144,6 +144,8 @@ The authorization token fields are always exactly 49 bytes (1 + 4 + 8 + 20 + 8 +
 
 Requests without an authorization token receive a `401 Unauthorized` HTTP response. Requests with an expired, malformed, or unauthorized token receive `403 Forbidden`. If Keychain token verification fails because the server cannot read `AccountKeychain.getKey(...)`, the server returns `500 Internal Server Error`.
 
+The same endpoint also accepts WebSocket upgrades. For WebSocket clients, the authorization token is supplied during the upgrade handshake via the `X-Authorization-Token` header or a `?token=0x...` query parameter. `eth_subscribe` and `eth_unsubscribe` are **WebSocket-only**; calling them over HTTP returns `-32006` (method disabled).
+
 ## RPC method access control
 
 The zone RPC starts from the standard Ethereum JSON-RPC method set and applies per-method restrictions. Each method falls into one of four categories: **allowed** (unrestricted), **scoped** (filtered to the authenticated account), **restricted** (sequencer-only), or **disabled** (not available).
@@ -163,7 +165,7 @@ These methods return public zone information and are available to any authentica
 | `eth_feeHistory` | Fee history is public |
 | `eth_getBlockByNumber` | Returns block headers **without transaction details** (see [Block responses](#block-responses)) |
 | `eth_getBlockByHash` | Returns block headers **without transaction details** |
-| `eth_subscribe("newHeads")` | Pushes block headers on new blocks. The `logsBloom` field is zeroed (see [Block responses](#block-responses)). |
+| `eth_subscribe("newHeads")` | **WebSocket-only.** Pushes block headers on new blocks. The `logsBloom` field is zeroed for non-sequencers (see [Block responses](#block-responses)). |
 | `eth_syncing` | Returns sync status. Low risk — reveals node state, not account data. |
 | `eth_coinbase` | Returns the sequencer address (already public via `zone_getZoneInfo`). |
 | `net_version` | Network ID |
@@ -191,6 +193,7 @@ These methods are available to any authenticated caller but filter results to on
 | `eth_getTransactionByHash` | Returns the transaction only if the authenticated account is the `from` (sender) of the transaction. Returns `null` for transactions sent by other accounts. |
 | `eth_getTransactionReceipt` | Returns the receipt only if the authenticated account is the sender. Returns `null` otherwise. Logs within the receipt are filtered (see [Event filtering](#event-filtering)). |
 | `eth_sendRawTransaction` | Accepts and broadcasts the transaction. The zone validates that the transaction sender matches the authenticated account. Transactions from mismatched accounts are rejected with error code `-32003` (transaction rejected). |
+| `eth_subscribe("newPendingTransactions")` | **WebSocket-only.** Default mode returns transaction hashes. Passing `true` returns full pending transaction objects. Non-sequencers only receive pending transactions where `from == authenticated account`; the sequencer receives the full pending stream. |
 
 #### Transaction simulation
 
@@ -230,7 +233,7 @@ Methods that do **not** need the speed bump include those where authorization ca
 | `eth_getFilterLogs` | Same filtering as `eth_getLogs`. |
 | `eth_getFilterChanges` | Same filtering. Only returns new events matching the filter since last poll. |
 | `eth_newFilter` | Creates a filter. The filter is implicitly scoped to the authenticated account. |
-| `eth_subscribe("logs")` | WebSocket equivalent of `eth_newFilter` + `eth_getFilterChanges`. The subscription is implicitly scoped to the authenticated account using the same [event filtering rules](#event-filtering-rules). |
+| `eth_subscribe("logs")` | **WebSocket-only.** Uses the native log pubsub stream, then applies the same scoping and post-filtering rules as `eth_getLogs` / `eth_getFilterChanges`. |
 | `eth_newBlockFilter` | Allowed. Returns new block hashes. |
 | `eth_uninstallFilter` | Allowed. Removes a previously created filter. |
 
@@ -271,8 +274,7 @@ These methods are not supported on privacy zones.
 | `eth_submitHashrate` | Zones have no mining |
 | `eth_getProof` | Merkle proofs include sibling hashes that reveal state trie structure (number of accounts, address prefix distribution, slot occupancy), leaking information beyond the queried account |
 | `eth_getFilterLogs` (unscoped) | All log access goes through the scoped path |
-| `eth_newPendingTransactionFilter` | Polling equivalent of `eth_subscribe("newPendingTransactions")` — mempool observation |
-| `eth_subscribe("newPendingTransactions")` | Mempool observation reveals all pending activity. Other subscription types (`newHeads`, `logs`) are classified above. |
+| `eth_newPendingTransactionFilter` | Polling equivalent of `eth_subscribe("newPendingTransactions")` is not exposed; pending-tx observation is WebSocket-only |
 
 Disabled methods return error code `-32601` (method not found).
 
@@ -499,4 +501,4 @@ In addition to standard JSON-RPC error codes, the zone RPC uses:
 - Filter state (from `eth_newFilter`) is stored per-authenticated-account. Filters created by one authorization token are accessible by subsequent authorization tokens for the same account.
 - The zone node SHOULD cache authorization token verification results for the duration of token validity to avoid repeated signature recovery. For Keychain Access Keys, cache entries MUST have a TTL bounded by the earlier of authorization-token expiry and the active key's `expiry`, and MUST be invalidated within 1 second of importing a block that revokes the key (see [Keychain key revocation and expiry](#security-considerations)). The recommended approach is to hook into block import and evict cache entries when `KeyRevoked` events are observed.
 - P256 and WebAuthn signature verification is more expensive than secp256k1. The RPC server SHOULD aggressively cache verified authorization tokens to amortize the verification cost. A verified authorization token can be cached by its hash for the remaining duration of its validity.
-- WebSocket connections (`eth_subscribe`) follow the same authorization-token model. The authorization token is provided during the WebSocket handshake and scopes all subscriptions for that connection. The connection is terminated when the authorization token expires; clients must reconnect with a fresh token. For Keychain-authenticated WebSocket connections, the server MUST also terminate the connection within 1 second of importing a block that revokes the Keychain key, following the same deadline as [Keychain key revocation](#security-considerations).
+- WebSocket connections (`eth_subscribe`) follow the same authorization-token model. The authorization token is provided during the WebSocket handshake and scopes all subscriptions for that connection. The current implementation authenticates only at handshake time: it does **not** proactively terminate an already-open WebSocket when the authorization token later expires or when a Keychain key is later revoked. Fresh auth state is picked up on the next connection or reconnect.


### PR DESCRIPTION
## Summary
- add websocket-only private RPC subscription handling with connection-local IDs and unsubscribe cleanup
- implement native pubsub-backed `newHeads`, `logs`, and `newPendingTransactions` subscriptions with the correct private filtering/redaction behavior
- add WS integration coverage and zone-level WS e2e coverage for the new subscription paths

## Testing
- cargo test -p zone-rpc --test it ws::
- cargo test -p zone --test it private_rpc_e2e::test_ws_
- cargo test -p zone --test it private_rpc_e2e::test_method_tiers

## Notes
- `cargo test -p zone --test it private_rpc_e2e::` still depends on Foundry artifacts under `docs/specs/out`; in this workspace it fails in pre-existing artifact-gated tests with `ZoneFactory artifact not found - run forge build in docs/specs`.