### PR TITLE
feat: allow selecting the initial TIP-20 when deploying a zone

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -112,12 +112,25 @@ zone-info identifier:
     cargo run -p tempo-xtask -- zone-info {{identifier}}
 
 [group('zone')]
-[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars.')]
-create-zone name:
+[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars.')]
+create-zone name token="":
     #!/bin/bash
     set -euo pipefail
     PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
-    ZONE_TOKEN_L1="${ZONE_TOKEN:-0x20C0000000000000000000000000000000000000}"
+    ZONE_TOKEN_L1="{{token}}"
+    if [[ -z "$ZONE_TOKEN_L1" ]]; then
+        ZONE_TOKEN_L1="${ZONE_TOKEN:-0x20C0000000000000000000000000000000000000}"
+    fi
+    # Resolve well-known aliases (lowercased for case-insensitive matching)
+    ZONE_TOKEN_LOWER=$(echo "$ZONE_TOKEN_L1" | tr '[:upper:]' '[:lower:]')
+    case "$ZONE_TOKEN_LOWER" in
+        pathusd|path-usd|path_usd)
+            ZONE_TOKEN_L1="0x20C0000000000000000000000000000000000000" ;;
+        alphausd|alpha-usd|alpha_usd)
+            ZONE_TOKEN_L1="0x20c0000000000000000000000000000000000001" ;;
+        betausd|beta-usd|beta_usd)
+            ZONE_TOKEN_L1="0x20c0000000000000000000000000000000000002" ;;
+    esac
     SEQ_KEY="${SEQUENCER_KEY:?Set SEQUENCER_KEY env var}"
     L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
     HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
@@ -129,6 +142,7 @@ create-zone name:
     echo "Building xtask..."
     cargo build -p tempo-xtask
     echo "Creating zone '{{name}}' on L1 and generating genesis..."
+    echo "Initial portal token: $ZONE_TOKEN_L1"
     cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
@@ -606,17 +620,33 @@ check-balance-private name token="0x20C0000000000000000000000000000000000000" rp
     echo "Balance of $ACCOUNT: $BALANCE"
 
 [group('zone')]
-[doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Requires L1_RPC_URL env var.')]
-deploy-zone name:
+[doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL env var.')]
+deploy-zone name token="":
     #!/bin/bash
     set -euo pipefail
     L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
     HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
     OUTPUT="generated/{{name}}"
+    ZONE_TOKEN_L1="{{token}}"
+    if [[ -z "$ZONE_TOKEN_L1" ]]; then
+        ZONE_TOKEN_L1="${ZONE_TOKEN:-0x20C0000000000000000000000000000000000000}"
+    fi
+    # Resolve well-known aliases (lowercased for case-insensitive matching)
+    ZONE_TOKEN_LOWER=$(echo "$ZONE_TOKEN_L1" | tr '[:upper:]' '[:lower:]')
+    case "$ZONE_TOKEN_LOWER" in
+        pathusd|path-usd|path_usd)
+            ZONE_TOKEN_L1="0x20C0000000000000000000000000000000000000" ;;
+        alphausd|alpha-usd|alpha_usd)
+            ZONE_TOKEN_L1="0x20c0000000000000000000000000000000000001" ;;
+        betausd|beta-usd|beta_usd)
+            ZONE_TOKEN_L1="0x20c0000000000000000000000000000000000002" ;;
+    esac
 
     echo "============================================"
     echo "  Deploying Zone: {{name}}"
     echo "============================================"
+    echo ""
+    echo "  Initial portal token: $ZONE_TOKEN_L1"
     echo ""
 
     # Step 1: Generate a new sequencer keypair
@@ -644,6 +674,7 @@ deploy-zone name:
     cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
+        --initial-token "$ZONE_TOKEN_L1" \
         --sequencer "$SEQUENCER_ADDR" \
         --private-key "$SEQUENCER_KEY"
     echo ""
@@ -673,6 +704,7 @@ deploy-zone name:
     echo "  Zone ID:         $ZONE_ID"
     echo "  Zone Name:       {{name}}"
     echo "  Portal:          $PORTAL"
+    echo "  Initial Token:   $ZONE_TOKEN_L1"
     echo "  Sequencer:       $SEQUENCER_ADDR"
     echo "  Anchor Block:    $ANCHOR_BLOCK"
     echo ""

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -13,6 +13,12 @@ export L1_RPC_URL="wss://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
 just deploy-zone my-zone
 ```
 
+To choose a different initial TIP-20 on the portal at deploy time, pass it as the second positional argument:
+
+```bash
+just deploy-zone my-zone alphausd
+```
+
 This single command will:
 1. Generate a fresh sequencer keypair
 2. Fund the sequencer on L1 via `tempo_fundAddress`
@@ -118,15 +124,24 @@ export PRIVATE_KEY="$SEQUENCER_KEY"
 just create-zone my-zone
 ```
 
+To choose the initial TIP-20 enabled on the portal, pass it as the second positional argument:
+
+```bash
+just create-zone my-zone alphausd
+```
+
 This creates `generated/my-zone/` containing:
 - **`genesis.json`** — Zone L2 genesis state (system contracts, fee token, etc.)
 - **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block, `zoneFactory`, and optional router/sequencer metadata)
+
+This initial token controls the first L1 TIP-20 the portal accepts and mirrors onto the zone. The zone's fee token in genesis remains `pathUSD`.
 
 You can also run the xtask directly for more control:
 
 ```bash
 cargo run -p tempo-xtask -- create-zone \
   --output generated/my-zone \
+  --initial-token 0x20c0000000000000000000000000000000000001 \
   --sequencer "$SEQUENCER_ADDR" \
   --private-key "$SEQUENCER_KEY"
 ```
@@ -306,7 +321,7 @@ just set-supply-cap <token-address> 1000000000000
 
 ### Enable a Token on the Zone
 
-To deposit a custom token into the zone, it must be enabled on the ZonePortal. Currently the portal enables pathUSD by default. For custom tokens, the token must exist on L1 and the portal must recognise it. Only the sequencer can enable tokens.
+To deposit a custom token into the zone, it must be enabled on the ZonePortal. By default the portal starts with `pathUSD`, or whichever TIP-20 you selected with `just create-zone <name> <token>` or `just deploy-zone <name> <token>`. Additional tokens must exist on L1 and be enabled by the sequencer.
 
 ```bash
 # Enable a token by address (requires SEQUENCER_KEY, L1_RPC_URL, L1_PORTAL_ADDRESS)
@@ -458,13 +473,14 @@ graph TB
 | `SEQUENCER_KEY` | For sequencing | Sequencer private key |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
+| `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 
 ## Justfile Commands Reference
 
 | Command | Description |
 |---------|-------------|
-| `just deploy-zone <name>` | One-shot: keygen → fund → create → genesis → start node |
-| `just create-zone <name>` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`) |
+| `just deploy-zone <name> [<tip20>]` | One-shot: keygen → fund → create → genesis → start node |
+| `just create-zone <name> [<tip20>]` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`) |
 | `just deploy-router <name>` | Deploy `SwapAndDepositRouter` on L1 for the zone and save it to `zone.json` |
 | `just zone-up <name> [reset] [profile]` | Start the zone node. `reset=true` wipes datadir. `profile=release` for production. |
 | `just max-approve-portal` | Approve portal to spend tokens on L1 |


### PR DESCRIPTION
## Summary
- allow `just create-zone` and `just deploy-zone` to take an optional second positional token argument
- keep `pathUSD` as the default and continue supporting `ZONE_TOKEN` as an environment fallback
- document that this selects the portal's initial enabled TIP-20, while the zone fee token in genesis remains `pathUSD`
- fix the docs to use positional `just` arguments instead of misleading `token=...` examples

## Testing
- `just --dry-run create-zone demo alphausd`
- `just --dry-run deploy-zone demo alphausd`
- `just --show create-zone`
- `just --show deploy-zone`