### PR TITLE
chore: unify tempo zone metrics scopes

### DIFF
--- a/crates/rpc/src/metrics.rs
+++ b/crates/rpc/src/metrics.rs
@@ -11,7 +11,7 @@ use reth_metrics::{
 use crate::types::classify_method;
 
 #[derive(Metrics, Clone)]
-#[metrics(scope = "zone_private_rpc.calls")]
+#[metrics(scope = "tempo_zone_private_rpc.calls")]
 pub(crate) struct PrivateRpcCallMetrics {
     /// Number of private RPC calls that started.
     pub(crate) started_total: Counter,
@@ -30,14 +30,14 @@ impl PrivateRpcCallMetrics {
 }
 
 #[derive(Metrics, Clone)]
-#[metrics(scope = "zone_private_rpc")]
+#[metrics(scope = "tempo_zone_private_rpc")]
 pub(crate) struct PrivateRpcAuthMetrics {
     /// Number of authentication failures.
     pub(crate) auth_failures_total: Counter,
 }
 
 #[derive(Metrics, Clone)]
-#[metrics(scope = "zone_private_rpc.provider")]
+#[metrics(scope = "tempo_zone_private_rpc.provider")]
 pub(crate) struct ZoneProviderMetrics {
     /// Number of private RPC provider token refresh attempts.
     pub(crate) token_refresh_attempts_total: Counter,

--- a/crates/rpc/src/metrics.rs
+++ b/crates/rpc/src/metrics.rs
@@ -11,7 +11,7 @@ use reth_metrics::{
 use crate::types::classify_method;
 
 #[derive(Metrics, Clone)]
-#[metrics(scope = "tempo_zone_private_rpc.calls")]
+#[metrics(scope = "tempo_zone_private_rpc_calls")]
 pub(crate) struct PrivateRpcCallMetrics {
     /// Number of private RPC calls that started.
     pub(crate) started_total: Counter,
@@ -37,7 +37,7 @@ pub(crate) struct PrivateRpcAuthMetrics {
 }
 
 #[derive(Metrics, Clone)]
-#[metrics(scope = "tempo_zone_private_rpc.provider")]
+#[metrics(scope = "tempo_zone_private_rpc_provider")]
 pub(crate) struct ZoneProviderMetrics {
     /// Number of private RPC provider token refresh attempts.
     pub(crate) token_refresh_attempts_total: Counter,

--- a/crates/tempo-zone/src/l1_state/tip403/metrics.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/metrics.rs
@@ -7,7 +7,7 @@ use reth_metrics::{
 
 /// Metrics for the TIP-403 policy cache, provider, and resolution task.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "tip403")]
+#[metrics(scope = "tempo_zone_tip403")]
 pub struct Tip403Metrics {
     /// Total authorization checks performed (cache + RPC).
     pub authorization_checks_total: Counter,

--- a/crates/tempo-zone/src/metrics.rs
+++ b/crates/tempo-zone/src/metrics.rs
@@ -7,7 +7,7 @@ use reth_metrics::{
 
 /// Metrics emitted by the withdrawal processor.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "zone_withdrawal_processor")]
+#[metrics(scope = "tempo_zone_withdrawal_processor")]
 pub(crate) struct WithdrawalProcessorMetrics {
     /// Current portal withdrawal queue head slot.
     pub(crate) portal_queue_head: Gauge,
@@ -36,7 +36,7 @@ pub(crate) struct WithdrawalProcessorMetrics {
 
 /// Metrics emitted by the L1 subscriber / deposit ingestion pipeline.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "zone_l1_subscriber")]
+#[metrics(scope = "tempo_zone_l1_subscriber")]
 pub(crate) struct L1SubscriberMetrics {
     /// Whether a backfill is currently running (1) or idle (0).
     pub backfill_in_progress: Gauge,
@@ -89,7 +89,7 @@ pub(crate) struct L1SubscriberMetrics {
 
 /// Metrics emitted by the zone monitor and batch submitter.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "zone_monitor")]
+#[metrics(scope = "tempo_zone_monitor")]
 pub(crate) struct ZoneMonitorMetrics {
     /// Most recent zone block observed on L2.
     pub latest_zone_block_observed: Gauge,


### PR DESCRIPTION
## Summary
- prefix all metrics scopes so they start with `tempo_zone_`
- keep the existing per-component suffixes for the private RPC, zone monitor, L1 subscriber, withdrawal processor, and TIP-403 metrics
- normalize the TIP-403 scope from `tip403` to `tempo_zone_tip403`

## Testing
- cargo check -p zone -p zone-rpc