### PR TITLE
ci: add cyclops pr audit workflow

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,0 +1,15 @@
+name: Pull request audit
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  audit:
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main
+    with:
+      required-label: cyclops
+    secrets:
+      EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
+      EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
+      EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}


### PR DESCRIPTION
Adds the Cyclops security audit workflow so PRs labeled `cyclops` trigger an automated audit via the reusable workflow in `tempoxyz/gh-actions`.

**Note:** The repo secrets `EVENTS_KEY`, `EVENTS_CERT`, and `EVENTS_ARGS` need to be configured in the repo settings (Settings → Secrets → Actions) for this to work. These should match what's set on `tempoxyz/tempo`.

Also needs a `cyclops` label created in the repo.

Co-Authored-By: 0xKitsune <77890308+0xKitsune@users.noreply.github.com>

Prompted by: daniel