### PR TITLE
fix(zone): configure explicit rpc reconnect policy

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -199,6 +199,9 @@ fn main() {
                 listen_addr: ([0, 0, 0, 0], args.private_rpc_port).into(),
                 l1_rpc_url: args.l1_rpc_url.clone(),
                 zone_rpc_url: zone_rpc_url.clone(),
+                retry_connection_interval: Duration::from_millis(
+                    args.l1_retry_connection_interval_ms,
+                ),
                 zone_id: args.zone_id,
                 chain_id: handle.node.chain_spec().chain().id(),
                 zone_portal: args.portal_address,
@@ -222,6 +225,9 @@ fn main() {
             let sequencer_config = zone::ZoneSequencerConfig {
                 portal_address: args.portal_address,
                 l1_rpc_url: args.l1_rpc_url,
+                retry_connection_interval: Duration::from_millis(
+                    args.l1_retry_connection_interval_ms,
+                ),
                 withdrawal_poll_interval: Duration::from_secs(
                     args.poll_interval_secs,
                 ),

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration for the private zone RPC server.
 
 use alloy_primitives::Address;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 /// Configuration for the private zone RPC server.
 #[derive(Debug, Clone)]
@@ -12,6 +12,8 @@ pub struct PrivateRpcConfig {
     pub l1_rpc_url: String,
     /// Zone L2 RPC URL used by zone-specific RPC methods that inspect L2 events.
     pub zone_rpc_url: String,
+    /// Interval between WebSocket reconnection attempts for long-lived RPC clients.
+    pub retry_connection_interval: Duration,
     /// The zone's numeric identifier.
     pub zone_id: u32,
     /// The zone's chain ID.

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -387,6 +387,7 @@ mod tests {
             listen_addr: ([127, 0, 0, 1], 0).into(),
             l1_rpc_url: "http://127.0.0.1:1".to_string(),
             zone_rpc_url: "http://127.0.0.1:1".to_string(),
+            retry_connection_interval: std::time::Duration::from_millis(100),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
             zone_portal: PORTAL,

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -283,6 +283,7 @@ impl TestContext {
             listen_addr: ([127, 0, 0, 1], 0).into(),
             l1_rpc_url: "http://127.0.0.1:1".to_string(),
             zone_rpc_url: "http://127.0.0.1:1".to_string(),
+            retry_connection_interval: std::time::Duration::from_millis(100),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
             zone_portal: PORTAL,

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -9,7 +9,7 @@ use alloy_consensus::BlockHeader as _;
 use alloy_eips::NumHash;
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
-use alloy_rpc_client::{ConnectionConfig, RpcClient};
+use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::{BlockId, Log};
 use alloy_sol_types::{SolEvent, SolEventInterface, SolValue};
 use alloy_transport::Authorization;
@@ -127,9 +127,7 @@ impl L1Subscriber {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
 
         let url: url::Url = self.config.l1_rpc_url.parse()?;
-        let mut conn_config = ConnectionConfig::new()
-            .with_max_retries(u32::MAX)
-            .with_retry_interval(self.config.retry_connection_interval);
+        let mut conn_config = crate::rpc_connection_config(self.config.retry_connection_interval);
 
         if !url.username().is_empty() {
             let auth = Authorization::basic(url.username(), url.password().unwrap_or_default());

--- a/crates/tempo-zone/src/l1_state/provider.rs
+++ b/crates/tempo-zone/src/l1_state/provider.rs
@@ -12,7 +12,7 @@
 
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
-use alloy_rpc_client::{ConnectionConfig, RpcClient};
+use alloy_rpc_client::RpcClient;
 use alloy_rpc_types_eth::BlockId;
 use alloy_transport::layers::RetryBackoffLayer;
 use eyre::Result;
@@ -98,9 +98,7 @@ impl L1StateProvider {
         let retry_layer =
             RetryBackoffLayer::new(config.max_retries, config.initial_backoff_ms, u64::MAX);
 
-        let conn_config = ConnectionConfig::new()
-            .with_max_retries(u32::MAX)
-            .with_retry_interval(config.retry_connection_interval);
+        let conn_config = crate::rpc_connection_config(config.retry_connection_interval);
 
         let client = RpcClient::builder()
             .layer(retry_layer)

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -40,6 +40,7 @@ use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
+use alloy_rpc_client::ConnectionConfig;
 use alloy_signer_local::PrivateKeySigner;
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 use tokio::sync::Notify;
@@ -49,8 +50,10 @@ use tokio::sync::Notify;
 pub struct ZoneSequencerConfig {
     /// ZonePortal contract address on Tempo L1.
     pub portal_address: Address,
-    /// Tempo L1 RPC URL (HTTP).
+    /// Tempo L1 RPC URL.
     pub l1_rpc_url: String,
+    /// Interval between WebSocket reconnection attempts for long-lived RPC clients.
+    pub retry_connection_interval: Duration,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: Duration,
     /// ZoneOutbox contract address on Zone L2.
@@ -59,7 +62,7 @@ pub struct ZoneSequencerConfig {
     pub inbox_address: Address,
     /// TempoState predeploy address on Zone L2.
     pub tempo_state_address: Address,
-    /// Zone L2 RPC URL (HTTP).
+    /// Zone L2 RPC URL.
     pub zone_rpc_url: String,
     /// How often the zone monitor polls for new L2 blocks.
     pub zone_poll_interval: Duration,
@@ -73,6 +76,12 @@ pub struct ZoneSequencerHandle {
     pub withdrawal_handle: tokio::task::JoinHandle<()>,
     /// Join handle for the zone monitor task (which also handles batch submission).
     pub monitor_handle: tokio::task::JoinHandle<()>,
+}
+
+pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> ConnectionConfig {
+    ConnectionConfig::new()
+        .with_max_retries(u32::MAX)
+        .with_retry_interval(retry_connection_interval)
 }
 
 /// Spawn all zone sequencer background tasks.
@@ -105,7 +114,10 @@ pub async fn spawn_zone_sequencer(
         ProviderBuilder::new_with_network::<TempoNetwork>()
             .with_nonce_key_filler()
             .wallet(wallet)
-            .connect(&config.l1_rpc_url)
+            .connect_with_config(
+                &config.l1_rpc_url,
+                rpc_connection_config(config.retry_connection_interval),
+            )
             .await
             .expect("valid L1 RPC URL")
             .erased();
@@ -124,6 +136,7 @@ pub async fn spawn_zone_sequencer(
         inbox_address: config.inbox_address,
         tempo_state_address: config.tempo_state_address,
         zone_rpc_url: config.zone_rpc_url,
+        retry_connection_interval: config.retry_connection_interval,
         poll_interval: config.zone_poll_interval,
         batch_interval: config.batch_interval,
         portal_address: config.portal_address,

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -114,7 +114,10 @@ pub async fn spawn_zone_sequencer(
         ProviderBuilder::new_with_network::<TempoNetwork>()
             .with_nonce_key_filler()
             .wallet(wallet)
-            .connect(&config.l1_rpc_url)
+            .connect_with_config(
+                &config.l1_rpc_url,
+                rpc_connection_config(config.retry_connection_interval),
+            )
             .await
             .expect("valid L1 RPC URL")
             .erased();

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -114,10 +114,7 @@ pub async fn spawn_zone_sequencer(
         ProviderBuilder::new_with_network::<TempoNetwork>()
             .with_nonce_key_filler()
             .wallet(wallet)
-            .connect_with_config(
-                &config.l1_rpc_url,
-                rpc_connection_config(config.retry_connection_interval),
-            )
+            .connect(&config.l1_rpc_url)
             .await
             .expect("valid L1 RPC URL")
             .erased();

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -336,7 +336,10 @@ where
 
         // Connect L1 provider upfront so startup failures are immediately visible.
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect(&l1_url)
+            .connect_with_config(
+                &l1_url,
+                crate::rpc_connection_config(self.l1_config.retry_connection_interval),
+            )
             .await?
             .erased();
 
@@ -571,7 +574,12 @@ where
 
         // Create PolicyProvider for the TIP-403 proxy precompile.
         let policy_l1 = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect(&self.l1_state_provider_config.l1_rpc_url)
+            .connect_with_config(
+                &self.l1_state_provider_config.l1_rpc_url,
+                crate::rpc_connection_config(
+                    self.l1_state_provider_config.retry_connection_interval,
+                ),
+            )
             .await?
             .erased();
 

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -155,12 +155,18 @@ impl<Api: EthApiTypes + 'static> TempoZoneRpc<Api> {
         let l1_rpc_url = config.l1_rpc_url.clone();
         let zone_rpc_url = config.zone_rpc_url.clone();
         let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect(&l1_rpc_url)
+            .connect_with_config(
+                &l1_rpc_url,
+                crate::rpc_connection_config(config.retry_connection_interval),
+            )
             .await
             .wrap_err("failed to connect private RPC L1 provider")?
             .erased();
         let zone_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect(&zone_rpc_url)
+            .connect_with_config(
+                &zone_rpc_url,
+                crate::rpc_connection_config(config.retry_connection_interval),
+            )
             .await
             .wrap_err("failed to connect private RPC zone provider")?
             .erased();

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -56,8 +56,10 @@ pub struct ZoneMonitorConfig {
     pub inbox_address: Address,
     /// TempoState predeploy address on Zone L2 (usually [`abi::TEMPO_STATE_ADDRESS`]).
     pub tempo_state_address: Address,
-    /// Zone L2 RPC URL (HTTP).
+    /// Zone L2 RPC URL.
     pub zone_rpc_url: String,
+    /// Interval between WebSocket reconnection attempts for the zone RPC client.
+    pub retry_connection_interval: Duration,
     /// How often to poll the zone L2 for new blocks (cheap RPC call).
     pub poll_interval: Duration,
     /// Maximum time to accumulate zone blocks before submitting a batch to L1.
@@ -130,7 +132,10 @@ impl ZoneMonitor {
     ) -> Self {
         let metrics = crate::metrics::ZoneMonitorMetrics::default();
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect(&config.zone_rpc_url)
+            .connect_with_config(
+                &config.zone_rpc_url,
+                crate::rpc_connection_config(config.retry_connection_interval),
+            )
             .await
             .expect("failed to connect to Zone RPC")
             .erased();
@@ -933,6 +938,7 @@ mod tests {
             inbox_address: Address::repeat_byte(0x33),
             tempo_state_address: Address::repeat_byte(0x44),
             zone_rpc_url: "http://unused.test".to_string(),
+            retry_connection_interval: Duration::from_millis(100),
             poll_interval: Duration::from_secs(1),
             batch_interval: Duration::from_secs(1),
             portal_address,

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2183,6 +2183,7 @@ pub(crate) async fn spawn_sequencer(
     let config = zone::ZoneSequencerConfig {
         portal_address,
         l1_rpc_url: l1.http_url().to_string(),
+        retry_connection_interval: Duration::from_millis(100),
         withdrawal_poll_interval: Duration::from_millis(500),
         outbox_address: ZONE_OUTBOX_ADDRESS,
         inbox_address: ZONE_INBOX_ADDRESS,
@@ -2776,6 +2777,7 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
         listen_addr: ([127, 0, 0, 1], 0).into(),
         l1_rpc_url: DUMMY_L1_URL.to_string(),
         zone_rpc_url: zone.http_url().to_string(),
+        retry_connection_interval: Duration::from_millis(100),
         zone_id: 0,
         chain_id,
         zone_portal: Address::ZERO,
@@ -2840,6 +2842,7 @@ async fn start_zone_with_private_rpc_l1_inner(
         listen_addr: ([127, 0, 0, 1], 0).into(),
         l1_rpc_url: l1.http_url().to_string(),
         zone_rpc_url: zone.http_url().to_string(),
+        retry_connection_interval: Duration::from_millis(100),
         zone_id: 1,
         chain_id,
         zone_portal: portal_address,


### PR DESCRIPTION
## Summary
- centralize the Zone RPC connection config so long-lived providers always set websocket reconnects to  with the configured retry interval
- switch the remaining direct  paths in the zone node, private RPC, and sequencer monitor over to 
- thread the retry interval through the sequencer and private RPC configs so all long-lived clients share the same reconnect behavior

## Verification
- cargo check -p tempo-zone -p zone-rpc