### PR TITLE
feat: derive zone chain ID deterministically from zone ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10852,6 +10852,7 @@ dependencies = [
  "tempo-revm",
  "tokio",
  "zone",
+ "zone-primitives",
 ]
 
 [[package]]
@@ -10862,6 +10863,7 @@ dependencies = [
  "alloy-signer-local",
  "clap",
  "const-hex",
+ "eyre",
  "k256",
  "reth-cli-util",
  "reth-consensus",
@@ -10872,6 +10874,7 @@ dependencies = [
  "tokio",
  "tracing",
  "zone",
+ "zone-primitives",
 ]
 
 [[package]]

--- a/bin/tempo-zone/Cargo.toml
+++ b/bin/tempo-zone/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 # tempo
 zone = { path = "../../crates/tempo-zone" }
+zone-primitives.workspace = true
 tempo-chainspec = { workspace = true, features = ["cli"] }
 
 # reth
@@ -32,6 +33,7 @@ rustls = { version = "0.23", features = ["aws-lc-rs"] }
 
 # misc
 clap.workspace = true
+eyre.workspace = true
 const-hex.workspace = true
 k256.workspace = true
 tokio.workspace = true

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -17,6 +17,7 @@ use reth_ethereum::chainspec::EthChainSpec;
 use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 use zone::{ZoneNode, evm::ZoneEvmConfig};
+use zone_primitives::constants::zone_chain_id;
 
 type ZoneCli = Cli<TempoChainSpecParser, ZoneArgs>;
 
@@ -187,6 +188,21 @@ fn main() {
 
             let handle = builder.node(node).launch_with_debug_capabilities().await?;
             info!(target: "reth::cli", "Tempo Zone node started");
+
+            // Verify the chain ID matches the deterministic derivation from the zone ID.
+            // Skip when zone_id is 0 (local testing default).
+            if args.zone_id != 0 {
+                let expected_chain_id = zone_chain_id(args.zone_id);
+                let actual_chain_id = handle.node.chain_spec().chain().id();
+                if actual_chain_id != expected_chain_id {
+                    eyre::bail!(
+                        "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
+                        args.zone_id,
+                        expected_chain_id,
+                        actual_chain_id,
+                    );
+                }
+            }
 
             // Launch the private zone RPC server.
             let eth_handlers = handle.node.eth_handlers().clone();

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -79,3 +79,15 @@ pub const ZONE_OUTBOX_LAST_BATCH_INDEX_SLOT: U256 = {
     le[0] = 2;
     U256::from_le_bytes(le)
 };
+
+/// Base offset for deriving zone chain IDs: `4217000000 + zone_id`.
+///
+/// Each zone gets a unique EIP-155 chain ID derived from its on-chain zone ID
+/// assigned by the `ZoneFactory` contract. The prefix `4217` comes from the
+/// Tempo L1 chain ID.
+pub const ZONE_CHAIN_ID_BASE: u64 = 4_217_000_000;
+
+/// Derives the EIP-155 chain ID for a zone from its on-chain zone ID.
+pub const fn zone_chain_id(zone_id: u32) -> u64 {
+    ZONE_CHAIN_ID_BASE + zone_id as u64
+}

--- a/crates/tempo-zone/tests/advance_tempo.rs
+++ b/crates/tempo-zone/tests/advance_tempo.rs
@@ -11,9 +11,9 @@ use revm::{
     state::AccountInfo,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
-use zone_primitives::constants::zone_chain_id;
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
 use tempo_revm::TempoBlockEnv;
+use zone_primitives::constants::zone_chain_id;
 
 const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
 const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");

--- a/crates/tempo-zone/tests/advance_tempo.rs
+++ b/crates/tempo-zone/tests/advance_tempo.rs
@@ -11,6 +11,7 @@ use revm::{
     state::AccountInfo,
 };
 use tempo_chainspec::hardfork::TempoHardfork;
+use zone_primitives::constants::zone_chain_id;
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
 use tempo_revm::TempoBlockEnv;
 
@@ -127,7 +128,7 @@ fn deploy_contract(
 
 /// Build an EVM with the zone contracts deployed in-memory (same as xtask generate_zone_genesis).
 fn setup_zone_evm_with_contracts() -> TempoEvm<CacheDB<EmptyDB>> {
-    let chain_id = 13371u64;
+    let chain_id = zone_chain_id(1);
     let gas_limit = 30_000_000u64;
 
     let db = CacheDB::default();

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -456,7 +456,7 @@ graph TB
 | `--l1.rpc-url` | (required) | L1 WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
 | `--l1.genesis-block-number` | (from zone.json) | L1 block when the zone was created |
-| `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth) |
+| `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `4217000000 + zone_id`. |
 | `--sequencer-key` | (optional) | Sequencer private key for block production |
 | `--block.interval-ms` | 250 | Block building interval |
 | `--zone.batch-interval-secs` | 60 | Max seconds to accumulate zone blocks before submitting a batch to L1 |

--- a/docs/pages/protocol/privacy/overview.md
+++ b/docs/pages/protocol/privacy/overview.md
@@ -57,6 +57,16 @@ A zone is created via `ZoneFactory.createZone(...)` with:
 
 The factory deploys a `ZonePortal` that escrows enabled tokens on Tempo and a `ZoneMessenger` for withdrawal callbacks. The initial token is automatically enabled at deployment.
 
+### Chain ID
+
+Each zone has a unique EIP-155 chain ID derived deterministically from its on-chain zone ID:
+
+```
+chain_id = 4217000000 + zone_id
+```
+
+The prefix `4217` corresponds to the Tempo L1 chain ID. This ensures replay protection between zones — a transaction signed for one zone cannot be replayed on another. The chain ID is set in the zone's genesis configuration during creation and validated by the zone node at startup.
+
 ### Token management
 
 The sequencer manages which tokens are available for bridging:

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,6 +18,7 @@ tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives.workspace = true
+zone-primitives.workspace = true
 tempo-revm.workspace = true
 
 alloy = { workspace = true, features = [

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -13,6 +13,7 @@ use eyre::{WrapErr as _, eyre};
 use std::path::PathBuf;
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
+use zone_primitives::constants::zone_chain_id;
 
 sol! {
     struct ZoneParams {
@@ -77,10 +78,6 @@ pub(crate) struct CreateZone {
     /// Private key (hex) for signing the createZone transaction on L1.
     #[arg(long)]
     private_key: String,
-
-    /// Zone L2 chain ID.
-    #[arg(long, default_value_t = 13371)]
-    chain_id: u64,
 
     /// Base fee per gas for the zone L2.
     #[arg(long, default_value_t = TEMPO_T0_BASE_FEE.into())]
@@ -159,6 +156,7 @@ impl CreateZone {
 
         let zone_id = event.zoneId;
         let portal = event.portal;
+        let chain_id = zone_chain_id(zone_id);
 
         // Re-fetch the header from the block that included the `createZone` tx.
         // The portal (and its sequencer storage slot) only exists from this block onward,
@@ -185,7 +183,7 @@ impl CreateZone {
 
         let genesis_cmd = crate::generate_zone_genesis::GenerateZoneGenesis {
             output: self.output.clone(),
-            chain_id: self.chain_id,
+            chain_id,
             base_fee_per_gas: self.base_fee_per_gas,
             gas_limit: self.gas_limit,
             tempo_portal: portal,
@@ -201,6 +199,7 @@ impl CreateZone {
         // Write zone.json with deployment metadata for downstream tooling (e.g. `just zone-up`).
         let zone_json = serde_json::json!({
             "zoneId": zone_id,
+            "chainId": chain_id,
             "portal": format!("{portal}"),
             "initialToken": format!("{}", self.initial_token),
             "sequencer": format!("{}", self.sequencer),
@@ -216,6 +215,7 @@ impl CreateZone {
 
         println!("Zone created successfully!");
         println!("  Zone ID: {zone_id}");
+        println!("  Chain ID: {chain_id}");
         println!("  Portal: {portal}");
         println!("  Initial Token: {}", self.initial_token);
         println!("  Sequencer: {}", self.sequencer);

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -58,7 +58,7 @@ pub(crate) struct GenerateZoneGenesis {
     #[arg(short, long)]
     pub(crate) output: PathBuf,
 
-    #[arg(long, default_value_t = 13371)]
+    #[arg(long)]
     pub(crate) chain_id: u64,
 
     #[arg(long, default_value_t = TEMPO_T0_BASE_FEE.into())]

--- a/zone-genesis/genesis.json
+++ b/zone-genesis/genesis.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "chainId": 13371,
+    "chainId": 4217000001,
     "homesteadBlock": 0,
     "daoForkSupport": false,
     "eip150Block": 0,


### PR DESCRIPTION
All zones previously defaulted to chain ID `13371`, meaning signed transactions on one zone could be replayed on any other zone. Zone chain IDs are now derived as `4217000000 + zone_id`, giving each zone a unique EIP-155 chain ID anchored to the Tempo L1 chain ID prefix.

## Changes

- Added `ZONE_CHAIN_ID_BASE` constant and `zone_chain_id()` helper in `zone-primitives`
- `create-zone` xtask no longer accepts `--chain-id`; derives it from the zone ID returned by `ZoneFactory.createZone()`
- `generate-zone-genesis` now requires `--chain-id` explicitly (no default) when run standalone
- `zone.json` now includes the derived `chainId`
- Zone node validates `chain_id == 4217000000 + zone_id` on startup (skipped when `zone_id=0` for local testing)
- Added Chain ID section to the zone protocol spec (`docs/pages/protocol/privacy/overview.md`)
- Updated stale `13371` references in `zone-genesis/genesis.json` and tests

Prompted by: dan