### PR TITLE
chore(xtask): update encrypted swap-and-deposit demo flow

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -174,7 +174,7 @@ deploy-router name dex="0xDEc0000000000000000000000000000000000000":
         --stablecoin-dex "{{dex}}"
 
 [group('zone')]
-[doc('Runs a same-zone router demo: creates temporary tokens + DEX liquidity, withdraws token A from the zone, swaps on L1, and deposits token B back into the same zone. Requires L1_RPC_URL and PRIVATE_KEY env vars.')]
+[doc('Runs a same-zone router demo: creates temporary tokens + DEX liquidity, withdraws token A from the zone, swaps on L1, and deposits token B back into the same zone via an encrypted deposit. Requires L1_RPC_URL and PRIVATE_KEY env vars.')]
 demo-swap-and-deposit name amount="100000000" tick="0" rpc=zone_rpc:
     #!/bin/bash
     set -euo pipefail

--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -11,7 +11,8 @@
 // The `sol!` macro generates functions whose arity we don't control.
 #![allow(clippy::too_many_arguments)]
 
-use alloy_primitives::{B256, keccak256};
+use alloc::vec::Vec;
+use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_sol_types::SolValue;
 
 pub use crate::constants::{
@@ -508,6 +509,7 @@ macro_rules! define_abi {
             contract SwapAndDepositRouter {
                 function onWithdrawalReceived(
                     address sender,
+                    address tokenIn,
                     uint128 amount,
                     bytes calldata data
                 ) external returns (bytes4);
@@ -532,6 +534,77 @@ impl ZonePortal::sequencerEncryptionKeyReturn {
             0 | 1 => Some(0x02 + self.yParity),
             _ => None,
         }
+    }
+}
+
+/// Plaintext callback payload for `SwapAndDepositRouter.onWithdrawalReceived`.
+///
+/// This payload tells the router to optionally swap the withdrawn token on L1
+/// and then perform a regular `ZonePortal.deposit(...)`.
+#[derive(Debug, Clone)]
+pub struct SwapAndDepositRouterPlaintextCallback {
+    /// Token that should be deposited after the optional L1 swap.
+    pub token_out: Address,
+    /// Target zone portal that receives the downstream deposit.
+    pub target_portal: Address,
+    /// Zone recipient for the downstream plaintext deposit.
+    pub recipient: Address,
+    /// Memo recorded on the downstream plaintext deposit.
+    pub memo: B256,
+    /// Minimum acceptable output from the optional swap.
+    ///
+    /// Ignored when `tokenIn == token_out` and the router can deposit directly.
+    pub min_amount_out: u128,
+}
+
+impl SwapAndDepositRouterPlaintextCallback {
+    /// ABI-encode the router callback data expected by the Solidity router.
+    pub fn abi_encode(&self) -> Vec<u8> {
+        (
+            false,
+            self.token_out,
+            self.target_portal,
+            self.recipient,
+            self.memo,
+            self.min_amount_out,
+        )
+            .abi_encode_params()
+    }
+}
+
+/// Encrypted callback payload for `SwapAndDepositRouter.onWithdrawalReceived`.
+///
+/// This payload tells the router to optionally swap the withdrawn token on L1
+/// and then call `ZonePortal.depositEncrypted(...)` with an ECIES-encrypted
+/// `(recipient, memo)` payload.
+#[derive(Debug, Clone)]
+pub struct SwapAndDepositRouterEncryptedCallback {
+    /// Token that should be deposited after the optional L1 swap.
+    pub token_out: Address,
+    /// Target zone portal that receives the downstream encrypted deposit.
+    pub target_portal: Address,
+    /// Portal encryption key index used to build [`Self::encrypted`].
+    pub key_index: U256,
+    /// ECIES-encrypted `(recipient, memo)` payload for `depositEncrypted`.
+    pub encrypted: EncryptedDepositPayload,
+    /// Minimum acceptable output from the optional swap.
+    ///
+    /// Ignored when `tokenIn == token_out` and the router can deposit directly.
+    pub min_amount_out: u128,
+}
+
+impl SwapAndDepositRouterEncryptedCallback {
+    /// ABI-encode the router callback data expected by the Solidity router.
+    pub fn abi_encode(&self) -> Vec<u8> {
+        (
+            true,
+            self.token_out,
+            self.target_portal,
+            self.key_index,
+            self.encrypted.clone(),
+            self.min_amount_out,
+        )
+            .abi_encode_params()
     }
 }
 
@@ -721,5 +794,58 @@ mod tests {
 
         assert_eq!(solidity_encoding, rust_encoding, "ABI encodings must match");
         assert_eq!(solidity_hash, rust_hash, "Deposit hash chains must match");
+    }
+
+    #[test]
+    fn test_router_plaintext_callback_encoding_matches_tuple() {
+        let callback = SwapAndDepositRouterPlaintextCallback {
+            token_out: address!("0x0000000000000000000000000000000000001001"),
+            target_portal: address!("0x0000000000000000000000000000000000002001"),
+            recipient: address!("0x0000000000000000000000000000000000003001"),
+            memo: B256::from([0x11; 32]),
+            min_amount_out: 1234,
+        };
+
+        let tuple_encoding = (
+            false,
+            callback.token_out,
+            callback.target_portal,
+            callback.recipient,
+            callback.memo,
+            callback.min_amount_out,
+        )
+            .abi_encode_params();
+
+        assert_eq!(callback.abi_encode(), tuple_encoding);
+    }
+
+    #[test]
+    fn test_router_encrypted_callback_encoding_matches_tuple() {
+        let encrypted = EncryptedDepositPayload {
+            ephemeralPubkeyX: B256::from([0x22; 32]),
+            ephemeralPubkeyYParity: 0x02,
+            ciphertext: Bytes::from(vec![0xaa, 0xbb, 0xcc, 0xdd]),
+            nonce: [0x33; 12].into(),
+            tag: [0x44; 16].into(),
+        };
+        let callback = SwapAndDepositRouterEncryptedCallback {
+            token_out: address!("0x0000000000000000000000000000000000001002"),
+            target_portal: address!("0x0000000000000000000000000000000000002002"),
+            key_index: U256::from(7),
+            encrypted: encrypted.clone(),
+            min_amount_out: 5678,
+        };
+
+        let tuple_encoding = (
+            true,
+            callback.token_out,
+            callback.target_portal,
+            callback.key_index,
+            encrypted,
+            callback.min_amount_out,
+        )
+            .abi_encode_params();
+
+        assert_eq!(callback.abi_encode(), tuple_encoding);
     }
 }

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -1683,19 +1683,16 @@ impl WithdrawalArgs {
         memo: B256,
         min_amount_out: u128,
     ) -> Self {
-        use alloy_sol_types::SolValue;
+        use zone::abi::SwapAndDepositRouterPlaintextCallback;
 
-        // SwapAndDepositRouter plaintext callback format:
-        // (bool isEncrypted, address tokenOut, address targetPortal, address recipient, bytes32 memo, uint128 minAmountOut)
-        let callback_data = (
-            false,
+        let callback_data = SwapAndDepositRouterPlaintextCallback {
             token_out,
             target_portal,
             recipient,
             memo,
             min_amount_out,
-        )
-            .abi_encode();
+        }
+        .abi_encode();
 
         Self {
             amount,
@@ -1717,19 +1714,14 @@ impl WithdrawalArgs {
         encrypted: zone::abi::EncryptedDepositPayload,
         min_amount_out: u128,
     ) -> Self {
-        use alloy_sol_types::SolValue;
-
-        // SwapAndDepositRouter encrypted callback format:
-        // (bool isEncrypted, address tokenOut, address targetPortal, uint256 keyIndex, EncryptedDepositPayload encrypted, uint128 minAmountOut)
-        let callback_data = (
-            true,
+        let callback_data = zone::abi::SwapAndDepositRouterEncryptedCallback {
             token_out,
             target_portal,
             key_index,
             encrypted,
             min_amount_out,
-        )
-            .abi_encode();
+        }
+        .abi_encode();
 
         Self {
             amount,

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -236,7 +236,7 @@ The sequencer includes the withdrawal in the next batch submission to L1 and pro
 
 #### Router Swap + Deposit Demo (Same Zone)
 
-This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone.
+This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone via an encrypted deposit. If the portal does not already have the current sequencer encryption key registered, the demo registers it automatically before building the routed callback payload.
 
 Prerequisites:
 - A running zone with an active sequencer

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -334,7 +334,7 @@ impl DemoSwapAndDeposit {
                 B256::ZERO,
                 ROUTER_CALLBACK_GAS_LIMIT,
                 operator,
-                Bytes::from(callback_data),
+                callback_data,
             )
             .gas(WITHDRAWAL_TX_GAS)
             .send()

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -1,19 +1,26 @@
 use alloy::{
     network::EthereumWallet,
-    primitives::{Address, B256, Bytes, U256},
+    primitives::{Address, B256, Bytes, U256, keccak256},
     providers::{Provider, ProviderBuilder},
-    signers::local::PrivateKeySigner,
+    signers::{Signer, local::PrivateKeySigner},
     sol,
     sol_types::SolValue,
 };
 use eyre::{WrapErr as _, eyre};
+use k256::{AffinePoint, ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
 use std::{path::PathBuf, time::Duration};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::{
     IRolesAuth, ITIP20 as TIP20Token, ITIP20Factory as TIP20Factory,
 };
 use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS, tip20::ISSUER_ROLE};
-use zone::abi::{ZONE_OUTBOX_ADDRESS, ZoneOutbox, ZonePortal};
+use zone::{
+    abi::{
+        EncryptedDepositPayload, SwapAndDepositRouterEncryptedCallback, ZONE_OUTBOX_ADDRESS,
+        ZoneOutbox, ZonePortal,
+    },
+    precompiles::ecies::encrypt_deposit,
+};
 
 use crate::zone_utils::{
     ROUTER_CALLBACK_GAS_LIMIT, STABLECOIN_DEX_ADDRESS, ZoneMetadata, check, fund_l1_wallet,
@@ -25,6 +32,7 @@ const DEMO_PATHUSD_GAS_NET: u128 = 5_000_000;
 const DEX_LIQUIDITY_MULTIPLIER: u128 = 3;
 const NONCE_CONFLICT_RETRIES: u32 = 5;
 const PATHUSD_HEADROOM: u128 = 10_000_000;
+const WITHDRAWAL_TX_GAS: u64 = 1_000_000;
 
 sol! {
     #[sol(rpc)]
@@ -57,7 +65,8 @@ pub(crate) struct DemoSwapAndDeposit {
     #[arg(long, env = "PRIVATE_KEY")]
     private_key: String,
 
-    /// Sequencer private key (hex). Needed to enable tokens on the portal.
+    /// Sequencer private key (hex). Needed to enable tokens on the portal and
+    /// to encrypt the routed deposit payload.
     #[arg(long, env = "SEQUENCER_KEY")]
     sequencer_key: Option<String>,
 
@@ -137,13 +146,19 @@ impl DemoSwapAndDeposit {
             .call()
             .await
             .wrap_err("failed to fetch portal deposit fee")?;
+        let withdrawal_fee = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &l2)
+            .calculateWithdrawalFee(ROUTER_CALLBACK_GAS_LIMIT)
+            .call()
+            .await
+            .wrap_err("failed to fetch outbox withdrawal fee")?;
         let dex_liquidity = self
             .amount
             .checked_mul(DEX_LIQUIDITY_MULTIPLIER)
             .ok_or_else(|| eyre!("dex liquidity amount overflow"))?;
         let alpha_gross_deposit = self
             .amount
-            .checked_add(deposit_fee)
+            .checked_add(withdrawal_fee)
+            .and_then(|value| value.checked_add(deposit_fee))
             .ok_or_else(|| eyre!("alpha deposit amount overflow"))?;
         let pathusd_gross_deposit = DEMO_PATHUSD_GAS_NET
             .checked_add(deposit_fee)
@@ -162,6 +177,7 @@ impl DemoSwapAndDeposit {
         println!("  Swap amount:      {}", self.amount);
         println!("  DEX tick:         {}", self.tick);
         println!("  Deposit fee:      {deposit_fee}");
+        println!("  Withdrawal fee:   {withdrawal_fee}");
         println!();
 
         println!("Step 1: Fund the operator with pathUSD on L1");
@@ -217,6 +233,11 @@ impl DemoSwapAndDeposit {
             .call()
             .await
             .wrap_err("failed to quote DEX swap")?;
+        let expected_beta_net = expected_beta.checked_sub(deposit_fee).ok_or_else(|| {
+            eyre!(
+                "quoted swap output {expected_beta} does not cover the portal deposit fee {deposit_fee}"
+            )
+        })?;
         println!(
             "  Seeded liquidity: {dex_liquidity} units at tick {}",
             self.tick
@@ -225,6 +246,7 @@ impl DemoSwapAndDeposit {
             "  Quoted swap output for {} AlphaUSD: {expected_beta} BetaUSD",
             self.amount
         );
+        println!("  Expected L2 BetaUSD after portal fee: {expected_beta_net}");
         println!();
 
         println!("Step 6: Deposit pathUSD for L2 gas and AlphaUSD for the swap");
@@ -264,25 +286,45 @@ impl DemoSwapAndDeposit {
         check(&receipt, "deposit AlphaUSD")?;
         wait_for_deposit_processed(&l2, l2_from_block, operator, operator, alpha).await?;
 
-        let alpha_before = token_balance(&l2, alpha, operator)
+        let alpha_before = token_balance(&l2_operator, alpha, operator)
             .await
             .unwrap_or_default();
-        let beta_before = token_balance(&l2, beta, operator).await.unwrap_or_default();
+        let beta_before = token_balance(&l2_operator, beta, operator)
+            .await
+            .unwrap_or_default();
         println!("  L2 AlphaUSD balance: {alpha_before}");
         println!("  L2 BetaUSD balance:  {beta_before}");
         println!();
 
         println!(
-            "Step 7: Withdraw AlphaUSD to the router and let it swap+deposit back into the zone"
+            "Step 7: Withdraw AlphaUSD to the router, swap on L1, and deposit BetaUSD back into the zone using an encrypted deposit"
         );
-        TIP20Token::new(alpha, &l2_operator)
+        let receipt = TIP20Token::new(alpha, &l2_operator)
             .approve(ZONE_OUTBOX_ADDRESS, U256::MAX)
             .gas(150_000)
-            .send_sync()
+            .send()
+            .await
+            .wrap_err("failed to submit AlphaUSD approval for the outbox")?
+            .get_receipt()
             .await
             .wrap_err("failed to approve AlphaUSD for the outbox")?;
+        check(&receipt, "approve AlphaUSD for outbox")?;
+        println!(
+            "  Outbox approved for AlphaUSD on L2  [tx: {}]",
+            receipt.transaction_hash
+        );
 
-        let callback_data = (false, beta, portal, operator, B256::ZERO, expected_beta).abi_encode();
+        let portal_contract_seq = ZonePortal::new(portal, &l1_seq);
+        let callback_data = build_encrypted_router_callback(
+            &portal_contract_seq,
+            portal,
+            beta,
+            operator,
+            B256::ZERO,
+            expected_beta,
+            &sequencer_key,
+        )
+        .await?;
         let l1_from_block = l1.get_block_number().await.unwrap_or(0);
         let receipt = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &l2_operator)
             .requestWithdrawal(
@@ -294,8 +336,11 @@ impl DemoSwapAndDeposit {
                 operator,
                 Bytes::from(callback_data),
             )
-            .gas(500_000)
-            .send_sync()
+            .gas(WITHDRAWAL_TX_GAS)
+            .send()
+            .await
+            .wrap_err("failed to submit routed withdrawal request on the zone")?
+            .get_receipt()
             .await
             .wrap_err("failed to request routed withdrawal on the zone")?;
         check(&receipt, "request routed withdrawal")?;
@@ -304,7 +349,7 @@ impl DemoSwapAndDeposit {
             receipt.transaction_hash
         );
 
-        let l2_alpha_after_request = token_balance(&l2, alpha, operator)
+        let l2_alpha_after_request = token_balance(&l2_operator, alpha, operator)
             .await
             .unwrap_or_default();
         println!("  AlphaUSD balance immediately after request: {l2_alpha_after_request}");
@@ -321,10 +366,16 @@ impl DemoSwapAndDeposit {
         .await?;
         println!("  Router callback processed on L1 (block {l1_block})");
 
-        let expected_beta_balance = beta_before + U256::from(expected_beta);
-        let final_beta =
-            wait_for_balance(&l2, beta, operator, expected_beta_balance, "BetaUSD").await?;
-        let final_alpha = token_balance(&l2, alpha, operator)
+        let expected_beta_balance = beta_before + U256::from(expected_beta_net);
+        let final_beta = wait_for_balance(
+            &l2_operator,
+            beta,
+            operator,
+            expected_beta_balance,
+            "BetaUSD",
+        )
+        .await?;
+        let final_alpha = token_balance(&l2_operator, alpha, operator)
             .await
             .unwrap_or_default();
         println!("  Final L2 AlphaUSD balance: {final_alpha}");
@@ -502,4 +553,134 @@ fn parse_private_key(private_key: &str) -> eyre::Result<PrivateKeySigner> {
         .unwrap_or(private_key)
         .parse()
         .wrap_err("invalid private key")
+}
+
+async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+    portal_address: Address,
+    token_out: Address,
+    recipient: Address,
+    memo: B256,
+    min_amount_out: u128,
+    sequencer_private_key: &str,
+) -> eyre::Result<Bytes> {
+    let (key, key_index) =
+        ensure_sequencer_encryption_key(portal, portal_address, sequencer_private_key).await?;
+    let y_parity = key.normalized_y_parity().ok_or_else(|| {
+        eyre!(
+            "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
+            key.yParity
+        )
+    })?;
+
+    let encrypted =
+        encrypt_deposit(&key.x, y_parity, recipient, memo, portal_address, key_index)
+            .ok_or_else(|| eyre!("ECIES encryption failed — invalid sequencer public key?"))?;
+
+    let callback = SwapAndDepositRouterEncryptedCallback {
+        token_out,
+        target_portal: portal_address,
+        key_index,
+        encrypted: EncryptedDepositPayload {
+            ephemeralPubkeyX: encrypted.eph_pub_x,
+            ephemeralPubkeyYParity: encrypted.eph_pub_y_parity,
+            ciphertext: Bytes::from(encrypted.ciphertext),
+            nonce: encrypted.nonce.into(),
+            tag: encrypted.tag.into(),
+        },
+        min_amount_out,
+    };
+
+    Ok(Bytes::from(callback.abi_encode()))
+}
+
+async fn ensure_sequencer_encryption_key<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+    portal_address: Address,
+    sequencer_private_key: &str,
+) -> eyre::Result<(ZonePortal::sequencerEncryptionKeyReturn, U256)> {
+    let (expected_x, expected_y_parity) = derive_encryption_public_key(sequencer_private_key)
+        .wrap_err("failed to derive the sequencer encryption public key from SEQUENCER_KEY")?;
+    let key_count = portal
+        .encryptionKeyCount()
+        .call()
+        .await
+        .wrap_err("failed to read portal encryption key count")?;
+
+    let needs_registration = if key_count == U256::ZERO {
+        println!("  Registering the sequencer encryption key on the portal");
+        true
+    } else {
+        let current_key = portal
+            .sequencerEncryptionKey()
+            .call()
+            .await
+            .wrap_err("failed to read the active sequencer encryption key")?;
+        let current_y_parity = current_key.normalized_y_parity().ok_or_else(|| {
+            eyre!(
+                "unexpected portal yParity {:#x}, expected 0/1 or 0x02/0x03",
+                current_key.yParity
+            )
+        })?;
+        if current_key.x == expected_x && current_y_parity == expected_y_parity {
+            false
+        } else {
+            println!(
+                "  Portal encryption key does not match SEQUENCER_KEY; registering the current sequencer key"
+            );
+            true
+        }
+    };
+
+    if needs_registration {
+        register_sequencer_encryption_key(portal, portal_address, sequencer_private_key).await?;
+    }
+
+    portal
+        .encryption_key()
+        .await
+        .wrap_err("failed to fetch the active sequencer encryption key")
+}
+
+async fn register_sequencer_encryption_key<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+    portal_address: Address,
+    sequencer_private_key: &str,
+) -> eyre::Result<()> {
+    let (x, y_parity) = derive_encryption_public_key(sequencer_private_key)
+        .wrap_err("failed to derive the sequencer encryption public key")?;
+    let signer = parse_private_key(sequencer_private_key)?;
+    let message = keccak256((portal_address, x, U256::from(y_parity)).abi_encode());
+    let sig = signer
+        .sign_hash(&message)
+        .await
+        .wrap_err("failed to sign the encryption key proof-of-possession")?;
+    let pop_v = sig.v() as u8 + 27;
+    let pop_r = B256::from(sig.r().to_be_bytes::<32>());
+    let pop_s = B256::from(sig.s().to_be_bytes::<32>());
+
+    let receipt = portal
+        .setSequencerEncryptionKey(x, y_parity, pop_v, pop_r, pop_s)
+        .send_sync()
+        .await
+        .wrap_err("failed to send setSequencerEncryptionKey")?;
+    check(&receipt, "setSequencerEncryptionKey")?;
+    println!(
+        "  Sequencer encryption key registered on L1  [tx: {}]",
+        receipt.transaction_hash
+    );
+    Ok(())
+}
+
+fn derive_encryption_public_key(sequencer_private_key: &str) -> eyre::Result<(B256, u8)> {
+    let key_str = sequencer_private_key
+        .strip_prefix("0x")
+        .unwrap_or(sequencer_private_key);
+    let enc_key = k256::SecretKey::from_slice(&const_hex::decode(key_str)?)?;
+    let scalar: Scalar = *enc_key.to_nonzero_scalar();
+    let pub_point = AffinePoint::from(ProjectivePoint::GENERATOR * scalar);
+    let encoded = pub_point.to_encoded_point(true);
+    let x = B256::from_slice(encoded.x().unwrap().as_slice());
+    let y_parity = encoded.as_bytes()[0];
+    Ok((x, y_parity))
 }


### PR DESCRIPTION
## Summary
- update the Rust-side swap-and-deposit demo to use the encrypted deposit path end to end
- align the Rust router callback helper encoding with the Solidity parameter encoding used by the demo and test helpers
- refresh the related docs and helper usage

## Scope
- Rust/demo/helper changes only
- no Solidity contract changes
- no protocol behavior changes

## Testing
- cargo test -p zone-primitives
- cargo check -p tempo-xtask
- just demo-swap-and-deposit smoke-router-20260325-214618 100000000 0 http://localhost:9546