### PR TITLE
fix(rpc): normalize pending block tag to latest

### DIFF
--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -368,6 +368,7 @@ async fn handle_get_block_by_number(
         Ok(v) => v,
         Err(resp) => return resp,
     };
+    let number = normalize_block_number(number);
 
     if full && !auth.is_sequencer {
         return JsonRpcResponse::error(id, JsonRpcError::sequencer_only());
@@ -752,6 +753,14 @@ async fn handle_zone_get_deposit_status(
         api.zone_get_deposit_status(tempo_block_number, auth.clone())
             .await,
     )
+}
+
+fn normalize_block_number(number: BlockNumberOrTag) -> BlockNumberOrTag {
+    if number.is_pending() {
+        BlockNumberOrTag::Latest
+    } else {
+        number
+    }
 }
 
 #[cfg(test)]

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -755,6 +755,7 @@ async fn handle_zone_get_deposit_status(
     )
 }
 
+/// Zones do not have a real pending block, so treat `pending` as `latest`.
 fn normalize_block_number(number: BlockNumberOrTag) -> BlockNumberOrTag {
     if number.is_pending() {
         BlockNumberOrTag::Latest


### PR DESCRIPTION
Resolves CHAIN-1024.

## Summary
- normalize `BlockNumberOrTag::Pending` to `Latest` in `eth_getBlockByNumber`
- keep the change local to the private RPC handler
- align zone RPC behavior with the fact that zones do not have a real pending block

## Testing
- cargo fmt --all
- tests not run