### PR TITLE
fix: pin policy data and existence reads to engine block height

### DIFF
--- a/crates/tempo-zone/src/l1_state/tip403/cache.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/cache.rs
@@ -98,9 +98,11 @@ impl PolicyCache {
             .set(block_number, policy_id);
     }
 
-    /// Sets the policy type for a policy ID.
-    pub fn set_policy_type(&mut self, policy_id: u64, policy_type: PolicyType) {
-        self.get_policy_entry(policy_id).policy_type = Some(policy_type);
+    /// Sets the policy type for a policy ID at the given L1 block height.
+    pub fn set_policy_type(&mut self, policy_id: u64, block_number: u64, policy_type: PolicyType) {
+        let entry = self.get_policy_entry(policy_id);
+        entry.policy_type = Some(policy_type);
+        entry.created_at.get_or_insert(block_number);
     }
 
     /// Sets whether `user` is a member of the policy set at the given block.
@@ -111,9 +113,10 @@ impl PolicyCache {
     }
 
     /// Sets compound policy sub-policy IDs and marks the policy as compound.
-    pub fn set_compound(&mut self, policy_id: u64, compound: CompoundData) {
+    pub fn set_compound(&mut self, policy_id: u64, block_number: u64, compound: CompoundData) {
         let entry = self.get_policy_entry(policy_id);
         entry.policy_type = Some(PolicyType::COMPOUND);
+        entry.created_at.get_or_insert(block_number);
         entry.compound = Some(compound);
     }
 
@@ -289,7 +292,7 @@ impl PolicyCache {
                     policy_id,
                     policy_type,
                 } => {
-                    self.set_policy_type(*policy_id, *policy_type);
+                    self.set_policy_type(*policy_id, block_number, *policy_type);
                 }
                 PolicyEvent::CompoundPolicyCreated {
                     policy_id,
@@ -299,6 +302,7 @@ impl PolicyCache {
                 } => {
                     self.set_compound(
                         *policy_id,
+                        block_number,
                         CompoundData {
                             sender_policy_id: *sender_policy_id,
                             recipient_policy_id: *recipient_policy_id,
@@ -601,6 +605,9 @@ pub(super) use zone_primitives::policy::AuthRole;
 pub struct CachedPolicy {
     /// Policy type. `None` if the `PolicyCreated` event hasn't been observed yet.
     pub policy_type: Option<PolicyType>,
+    /// L1 block number at which this policy was first observed (created).
+    /// Used to avoid serving subscriber-ahead state during block building.
+    pub created_at: Option<u64>,
     /// Set membership for simple (non-compound) policies.
     pub members: MembershipSet,
     /// Compound sub-policy IDs. `None` for simple policies.
@@ -859,7 +866,7 @@ mod tests {
     fn whitelist_authorized_when_in_set() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
         cache.set_member(2, USER_B, 10, false);
 
@@ -877,7 +884,7 @@ mod tests {
     fn blacklist_authorized_when_not_in_set() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 3);
-        cache.set_policy_type(3, PolicyType::BLACKLIST);
+        cache.set_policy_type(3, 1, PolicyType::BLACKLIST);
         cache.set_member(3, USER_A, 10, true);
         cache.set_member(3, USER_B, 10, false);
 
@@ -895,7 +902,7 @@ mod tests {
     fn blacklist_unknown_user_returns_none() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 3);
-        cache.set_policy_type(3, PolicyType::BLACKLIST);
+        cache.set_policy_type(3, 1, PolicyType::BLACKLIST);
 
         // USER_A has no membership data — unknown, caller should fall back to RPC
         assert_eq!(
@@ -908,7 +915,7 @@ mod tests {
     fn whitelist_unknown_user_returns_none() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
 
         // USER_A has no membership data — unknown, caller should fall back to RPC
         assert_eq!(
@@ -941,7 +948,7 @@ mod tests {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 1);
         cache.set_token_policy(TOKEN, 20, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 20, true);
 
         // At block 15: policy_id=1 (always allow)
@@ -970,7 +977,7 @@ mod tests {
     fn block_versioned_membership_change() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, false);
         cache.set_member(2, USER_A, 20, true);
 
@@ -988,7 +995,7 @@ mod tests {
     fn clear_removes_all_data() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
 
         cache.clear();
@@ -1023,7 +1030,7 @@ mod tests {
         // Two tokens share policy 2
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_token_policy(token2, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
 
         // Both tokens see the same membership (per-policy, no fan-out needed)
@@ -1044,7 +1051,7 @@ mod tests {
 
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_token_policy(token2, 10, 2);
-        cache.set_policy_type(2, PolicyType::BLACKLIST);
+        cache.set_policy_type(2, 1, PolicyType::BLACKLIST);
         cache.set_member(2, USER_A, 10, true);
 
         // BLACKLIST: authorized when NOT in set
@@ -1074,8 +1081,8 @@ mod tests {
 
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_token_policy(token2, 10, 3);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
-        cache.set_policy_type(3, PolicyType::BLACKLIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
+        cache.set_policy_type(3, 1, PolicyType::BLACKLIST);
         cache.set_member(2, USER_A, 10, true);
         cache.set_member(3, USER_A, 10, true);
 
@@ -1095,7 +1102,7 @@ mod tests {
     fn advance_then_lookup() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::BLACKLIST);
+        cache.set_policy_type(2, 1, PolicyType::BLACKLIST);
         cache.set_member(2, USER_A, 10, true);
         cache.set_member(2, USER_A, 20, false);
 
@@ -1134,8 +1141,8 @@ mod tests {
         // Start with whitelist at block 10, switch to blacklist policy at block 20
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_token_policy(TOKEN, 20, 3);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
-        cache.set_policy_type(3, PolicyType::BLACKLIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
+        cache.set_policy_type(3, 1, PolicyType::BLACKLIST);
         cache.set_member(2, USER_A, 10, true);
         cache.set_member(3, USER_A, 10, true);
 
@@ -1157,14 +1164,15 @@ mod tests {
     fn compound_policy_sender_check() {
         let mut cache = PolicyCache::default();
         // Simple sub-policies
-        cache.set_policy_type(2, PolicyType::BLACKLIST); // sender policy
-        cache.set_policy_type(3, PolicyType::WHITELIST); // recipient policy
+        cache.set_policy_type(2, 1, PolicyType::BLACKLIST); // sender policy
+        cache.set_policy_type(3, 1, PolicyType::WHITELIST); // recipient policy
         cache.set_member(2, USER_A, 10, true); // USER_A blacklisted as sender
         cache.set_member(3, USER_A, 10, true); // USER_A whitelisted as recipient
 
         // Compound policy referencing sub-policies
         cache.set_compound(
             5,
+            1,
             CompoundData {
                 sender_policy_id: 2,
                 recipient_policy_id: 3,
@@ -1190,11 +1198,12 @@ mod tests {
     #[test]
     fn compound_policy_transfer_checks_both() {
         let mut cache = PolicyCache::default();
-        cache.set_policy_type(2, PolicyType::WHITELIST); // sender
-        cache.set_policy_type(3, PolicyType::WHITELIST); // recipient
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST); // sender
+        cache.set_policy_type(3, 1, PolicyType::WHITELIST); // recipient
 
         cache.set_compound(
             5,
+            1,
             CompoundData {
                 sender_policy_id: 2,
                 recipient_policy_id: 3,
@@ -1230,6 +1239,7 @@ mod tests {
         // Compound: sender=allow(1), recipient=reject(0), mint=allow(1)
         cache.set_compound(
             5,
+            1,
             CompoundData {
                 sender_policy_id: 1,
                 recipient_policy_id: 0,
@@ -1263,6 +1273,7 @@ mod tests {
         // Compound references sub-policy 99 which doesn't exist
         cache.set_compound(
             5,
+            1,
             CompoundData {
                 sender_policy_id: 99,
                 recipient_policy_id: 3,
@@ -1281,7 +1292,7 @@ mod tests {
     fn compound_returns_none_when_compound_data_missing() {
         let mut cache = PolicyCache::default();
         // Policy 5 has COMPOUND type but no compound data set
-        cache.set_policy_type(5, PolicyType::COMPOUND);
+        cache.set_policy_type(5, 1, PolicyType::COMPOUND);
         cache.set_token_policy(TOKEN, 10, 5);
 
         assert_eq!(
@@ -1328,7 +1339,7 @@ mod tests {
     fn observed_survives_advance() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
 
         // Before advance: known and authorized
@@ -1357,7 +1368,7 @@ mod tests {
     fn observed_survives_advance_for_removed_member() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
 
         // Add then remove USER_A
         cache.set_member(2, USER_A, 10, true);
@@ -1377,7 +1388,7 @@ mod tests {
     fn observed_survives_advance_blacklist() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::BLACKLIST);
+        cache.set_policy_type(2, 1, PolicyType::BLACKLIST);
         cache.set_member(2, USER_A, 10, true); // blacklisted
 
         cache.advance(20);
@@ -1399,7 +1410,7 @@ mod tests {
     fn clear_resets_observed() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 10, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
 
         assert_eq!(
@@ -1446,7 +1457,7 @@ mod tests {
     fn multiple_advances_preserve_observed() {
         let mut cache = PolicyCache::default();
         cache.set_token_policy(TOKEN, 5, 2);
-        cache.set_policy_type(2, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::WHITELIST);
 
         // Events at different blocks
         cache.set_member(2, USER_A, 10, true);
@@ -1479,8 +1490,8 @@ mod tests {
     fn apply_events_with_compound_policy() {
         let mut cache = PolicyCache::default();
         // Pre-populate simple sub-policies
-        cache.set_policy_type(2, PolicyType::BLACKLIST);
-        cache.set_policy_type(3, PolicyType::WHITELIST);
+        cache.set_policy_type(2, 1, PolicyType::BLACKLIST);
+        cache.set_policy_type(3, 1, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, false); // explicitly not blacklisted
         cache.set_member(3, USER_A, 10, true);
 

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -342,7 +342,7 @@ impl PolicyProvider {
 
         self.cache
             .write()
-            .set_policy_type(policy_id, result.policyType);
+            .set_policy_type(policy_id, block_number, result.policyType);
         info!(policy_id, policy_type = ?result.policyType, "Cached policy type from L1 RPC");
 
         Ok(result.policyType)
@@ -378,7 +378,7 @@ impl PolicyProvider {
             mint_recipient_policy_id: result.mintRecipientPolicyId,
         };
 
-        self.cache.write().set_compound(policy_id, compound);
+        self.cache.write().set_compound(policy_id, block_number, compound);
         info!(
             policy_id,
             sender = compound.sender_policy_id,
@@ -499,13 +499,15 @@ impl PolicyProvider {
     ///
     /// Panics if called from within an async context on the same tokio runtime.
     pub fn resolve_policy_type_sync(&self, policy_id: u64) -> Result<PolicyType> {
-        if let Some(policy) = self.cache.read().policies().get(&policy_id)
+        let cache = self.cache.read();
+        let block_number = cache.last_l1_block();
+        if let Some(policy) = cache.policies().get(&policy_id)
             && let Some(policy_type) = policy.policy_type
+            && policy.created_at.is_some_and(|b| b <= block_number)
         {
             return Ok(policy_type);
         }
-
-        let block_number = self.cache.read().last_l1_block();
+        drop(cache);
         debug!(
             policy_id,
             block_number, "Policy type cache miss, fetching from L1 RPC"
@@ -524,13 +526,15 @@ impl PolicyProvider {
     ///
     /// Panics if called from within an async context on the same tokio runtime.
     pub fn resolve_compound_data_sync(&self, policy_id: u64) -> Result<CompoundData> {
-        if let Some(policy) = self.cache.read().policies().get(&policy_id)
+        let cache = self.cache.read();
+        let block_number = cache.last_l1_block();
+        if let Some(policy) = cache.policies().get(&policy_id)
             && let Some(ref compound) = policy.compound
+            && policy.created_at.is_some_and(|b| b <= block_number)
         {
             return Ok(*compound);
         }
-
-        let block_number = self.cache.read().last_l1_block();
+        drop(cache);
         debug!(
             policy_id,
             block_number, "Compound data cache miss, fetching from L1 RPC"
@@ -554,14 +558,16 @@ impl PolicyProvider {
             return Ok(true);
         }
 
-        // Cache hit: if we have a policy record with a known type, it exists.
-        if let Some(policy) = self.cache.read().policies().get(&policy_id)
+        let cache = self.cache.read();
+        let block_number = cache.last_l1_block();
+        // Cache hit: if we have a policy record created at or before the engine's height, it exists.
+        if let Some(policy) = cache.policies().get(&policy_id)
             && policy.policy_type.is_some()
+            && policy.created_at.is_some_and(|b| b <= block_number)
         {
             return Ok(true);
         }
-
-        let block_number = self.cache.read().last_l1_block();
+        drop(cache);
         debug!(
             policy_id,
             block_number, "Policy exists cache miss, fetching from L1 RPC"

--- a/crates/tempo-zone/tests/it/l1_e2e.rs
+++ b/crates/tempo-zone/tests/it/l1_e2e.rs
@@ -1070,7 +1070,7 @@ async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
         let l1_block = l1.provider().get_block_number().await?;
         let mut cache = policy_cache.write();
         cache.set_token_policy(PATH_USD_ADDRESS, 0, policy_id);
-        cache.set_policy_type(policy_id, PolicyType::BLACKLIST);
+        cache.set_policy_type(policy_id, 1, PolicyType::BLACKLIST);
         cache.set_member(policy_id, blacklisted_recipient, 0, true);
         // Also seed for current and future blocks
         cache.set_token_policy(PATH_USD_ADDRESS, l1_block, policy_id);
@@ -1217,16 +1217,17 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
         let mut cache = zone.policy_cache().write();
         cache.set_token_policy(PATH_USD_ADDRESS, 0, compound_policy_id);
         cache.set_token_policy(PATH_USD_ADDRESS, l1_block, compound_policy_id);
-        cache.set_policy_type(compound_policy_id, PolicyType::COMPOUND);
+        cache.set_policy_type(compound_policy_id, 1, PolicyType::COMPOUND);
         cache.set_compound(
             compound_policy_id,
+            1,
             zone::l1_state::tip403::CompoundData {
                 sender_policy_id,
                 recipient_policy_id: 1,
                 mint_recipient_policy_id: 1,
             },
         );
-        cache.set_policy_type(sender_policy_id, PolicyType::BLACKLIST);
+        cache.set_policy_type(sender_policy_id, 1, PolicyType::BLACKLIST);
         cache.set_member(sender_policy_id, alice, 0, true);
         cache.set_member(sender_policy_id, alice, l1_block, true);
     }

--- a/crates/tempo-zone/tests/it/tip403_policy.rs
+++ b/crates/tempo-zone/tests/it/tip403_policy.rs
@@ -104,7 +104,7 @@ async fn test_policy_proxy_whitelist_authorization() -> eyre::Result<()> {
     {
         let cache = zone.policy_cache();
         let mut w = cache.write();
-        w.set_policy_type(5, ITIP403Registry::PolicyType::WHITELIST);
+        w.set_policy_type(5, 1, ITIP403Registry::PolicyType::WHITELIST);
         w.set_member(5, alice, 1, true);
         w.set_member(5, bob, 1, false);
     }
@@ -154,7 +154,7 @@ async fn test_policy_proxy_blacklist_authorization() -> eyre::Result<()> {
     {
         let cache = zone.policy_cache();
         let mut w = cache.write();
-        w.set_policy_type(5, ITIP403Registry::PolicyType::BLACKLIST);
+        w.set_policy_type(5, 1, ITIP403Registry::PolicyType::BLACKLIST);
         w.set_member(5, alice, 1, true);
         w.set_member(5, bob, 1, false);
     }
@@ -193,12 +193,13 @@ async fn test_policy_proxy_compound_policy() -> eyre::Result<()> {
     {
         let cache = zone.policy_cache();
         let mut w = cache.write();
-        w.set_policy_type(5, ITIP403Registry::PolicyType::WHITELIST);
+        w.set_policy_type(5, 1, ITIP403Registry::PolicyType::WHITELIST);
         w.set_member(5, alice, 1, true); // Alice whitelisted as sender
-        w.set_policy_type(6, ITIP403Registry::PolicyType::BLACKLIST);
+        w.set_policy_type(6, 1, ITIP403Registry::PolicyType::BLACKLIST);
         w.set_member(6, bob, 1, true); // Bob blacklisted as recipient
         w.set_compound(
             10,
+            1,
             CompoundData {
                 sender_policy_id: 5,
                 recipient_policy_id: 6,
@@ -313,14 +314,15 @@ async fn test_compound_policy_transfer_role_authorization() -> eyre::Result<()> 
     {
         let cache = zone.policy_cache();
         let mut w = cache.write();
-        w.set_policy_type(5, ITIP403Registry::PolicyType::WHITELIST);
+        w.set_policy_type(5, 1, ITIP403Registry::PolicyType::WHITELIST);
         w.set_member(5, alice, 1, true); // Alice whitelisted as sender
         w.set_member(5, bob, 1, false); // Bob not whitelisted as sender
-        w.set_policy_type(6, ITIP403Registry::PolicyType::BLACKLIST);
+        w.set_policy_type(6, 1, ITIP403Registry::PolicyType::BLACKLIST);
         w.set_member(6, alice, 1, false); // Alice not blacklisted as recipient
         w.set_member(6, bob, 1, true); // Bob blacklisted as recipient
         w.set_compound(
             10,
+            1,
             CompoundData {
                 sender_policy_id: 5,
                 recipient_policy_id: 6,


### PR DESCRIPTION
This PR adds a `created_at` block number to cached policy records so that `policyData`, `compoundPolicyData`, and `policyExists` queries only return cache hits for policies created at or before the engine's committed L1 height, preventing nodes with different L1 subscriber progress from producing divergent EVM results.