### PR TITLE
fix(rpc): remove filter ownership entry unconditionally on uninstall

### DIFF
--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -517,10 +517,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
                 .forward("eth_uninstallFilter", serde_json::json!([id]))
                 .await?;
 
-            let removed: bool = serde_json::from_str(result.get()).unwrap_or(false);
-            if removed {
-                self.filter_owners.lock().await.remove(&id);
-            }
+            self.filter_owners.lock().await.remove(&id);
 
             Ok(result)
         })


### PR DESCRIPTION
This PR removes the filter ownership map entry regardless of the upstream uninstall result, fixing a slow memory leak when filters expire upstream before uninstall.