### PR TITLE
fix(batch): return error when batch submission exhausts retries

### DIFF
--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -750,7 +750,9 @@ impl ZoneMonitor {
         // All retries exhausted — resync from portal.
         self.resync_from_portal().await;
 
-        Ok(())
+        Err(eyre::eyre!(
+            "batch submission failed after {MAX_RETRIES} retries for zone block {last_zone_block}"
+        ))
     }
 
     /// Resync the local submission anchor from portal-confirmed on-chain state.


### PR DESCRIPTION
This PR makes `submit_batch_with_retry` return Err after exhausting retries instead of `Ok(())`, so the stepping loop breaks early instead of continuing with subsequent sub-batches that are expected to fail.