### PR TITLE
feat(zone): enable T2 deposit mint recipient checks

### DIFF
--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -447,7 +447,7 @@ graph TB
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0x8F3F0d21D01648d9373B3688CAc91b5253D3874C` |
+| ZoneFactory (moderato) | `0x4C64016B46A675F60B4E3f9606C3E2568746a2Fe` |
 
 ### Zone Node CLI Options
 

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -483,10 +483,9 @@ contract ZonePortal is IZonePortal {
         if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, to)) {
             revert DepositPolicyForbids();
         }
-        // TODO(T2): also check isAuthorizedMintRecipient for compound policies
-        // if (!TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, to)) {
-        //     revert DepositPolicyForbids();
-        // }
+        if (!TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, to)) {
+            revert DepositPolicyForbids();
+        }
 
         // Calculate deposit fee
         uint128 fee = calculateDepositFee();

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import { TIP20 } from "../../src/TIP20.sol";
-import { ITIP403Registry } from "../../src/interfaces/ITIP403Registry.sol";
 import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
+import { ITIP403Registry } from "../../src/interfaces/ITIP403Registry.sol";
 
 import { BLOCKHASH_HISTORY_WINDOW } from "../../src/zone/BlockHashHistory.sol";
 import {

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { TIP20 } from "../../src/TIP20.sol";
+import { ITIP403Registry } from "../../src/interfaces/ITIP403Registry.sol";
 import { ITIP20 } from "../../src/interfaces/ITIP20.sol";
 
 import { BLOCKHASH_HISTORY_WINDOW } from "../../src/zone/BlockHashHistory.sol";
@@ -282,6 +283,80 @@ contract ZonePortalTest is BaseTest {
         assertTrue(hash1 != hash2);
         assertTrue(hash2 != hash3);
         assertTrue(hash1 != hash3);
+    }
+
+    function test_deposit_revertsWhenCompoundPolicyBlocksMintRecipient() public {
+        uint128 depositAmount = 1000e6;
+
+        address[] memory senderAccounts = new address[](2);
+        senderAccounts[0] = alice;
+        senderAccounts[1] = address(portal);
+        uint64 senderPolicyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+        );
+
+        address[] memory recipientAccounts = new address[](3);
+        recipientAccounts[0] = alice;
+        recipientAccounts[1] = address(portal);
+        recipientAccounts[2] = bob;
+        uint64 recipientPolicyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+        );
+
+        address[] memory mintRecipientAccounts = new address[](1);
+        mintRecipientAccounts[0] = charlie;
+        uint64 mintRecipientPolicyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, mintRecipientAccounts
+        );
+
+        uint64 compoundPolicyId =
+            registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, mintRecipientPolicyId);
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(compoundPolicyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        vm.expectRevert(IZonePortal.DepositPolicyForbids.selector);
+        portal.deposit(address(pathUSD), bob, depositAmount, bytes32("memo"));
+        vm.stopPrank();
+    }
+
+    function test_deposit_allowsCompoundPolicyMintRecipient() public {
+        uint128 depositAmount = 1000e6;
+
+        address[] memory senderAccounts = new address[](2);
+        senderAccounts[0] = alice;
+        senderAccounts[1] = address(portal);
+        uint64 senderPolicyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+        );
+
+        address[] memory recipientAccounts = new address[](3);
+        recipientAccounts[0] = alice;
+        recipientAccounts[1] = address(portal);
+        recipientAccounts[2] = bob;
+        uint64 recipientPolicyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+        );
+
+        address[] memory mintRecipientAccounts = new address[](1);
+        mintRecipientAccounts[0] = bob;
+        uint64 mintRecipientPolicyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, mintRecipientAccounts
+        );
+
+        uint64 compoundPolicyId =
+            registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, mintRecipientPolicyId);
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(compoundPolicyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        bytes32 depositHash = portal.deposit(address(pathUSD), bob, depositAmount, bytes32("memo"));
+        vm.stopPrank();
+
+        assertEq(portal.currentDepositQueueHash(), depositHash);
+        assertEq(pathUSD.balanceOf(address(portal)), depositAmount);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -15,6 +15,8 @@ use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use zone_primitives::constants::zone_chain_id;
 
+use crate::zone_utils::MODERATO_ZONE_FACTORY;
+
 sol! {
     struct ZoneParams {
         bytes32 genesisBlockHash;
@@ -63,7 +65,7 @@ pub(crate) struct CreateZone {
 
     /// ZoneFactory contract address on Tempo L1.
     /// Default is the ZoneFactory deployed on moderato.
-    #[arg(long, default_value_t = address!("0xD8d977D60F61F8a5e5003a3A9dCF6ACae554BC8c"))]
+    #[arg(long, default_value_t = MODERATO_ZONE_FACTORY)]
     zone_factory: Address,
 
     /// Initial TIP-20 token address for the zone (additional tokens can be enabled later).

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -1,10 +1,12 @@
 use alloy::{
-    primitives::{Address, address},
+    primitives::Address,
     providers::ProviderBuilder,
 };
 use eyre::eyre;
 use tempo_alloy::TempoNetwork;
 use zone::abi::{ZoneFactory, ZonePortal};
+
+use crate::zone_utils::MODERATO_ZONE_FACTORY;
 
 #[derive(Debug, clap::Parser)]
 pub(crate) struct ZoneInfoCmd {
@@ -19,7 +21,7 @@ pub(crate) struct ZoneInfoCmd {
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.
-    #[arg(long, default_value_t = address!("0xD8d977D60F61F8a5e5003a3A9dCF6ACae554BC8c"))]
+    #[arg(long, default_value_t = MODERATO_ZONE_FACTORY)]
     zone_factory: Address,
 }
 

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -1,7 +1,4 @@
-use alloy::{
-    primitives::Address,
-    providers::ProviderBuilder,
-};
+use alloy::{primitives::Address, providers::ProviderBuilder};
 use eyre::eyre;
 use tempo_alloy::TempoNetwork;
 use zone::abi::{ZoneFactory, ZonePortal};

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -17,7 +17,7 @@ use zone::abi::{ZoneInbox, ZonePortal};
 
 pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
 pub(crate) const MODERATO_ZONE_FACTORY: Address =
-    address!("0xD8d977D60F61F8a5e5003a3A9dCF6ACae554BC8c");
+    address!("0x4C64016B46A675F60B4E3f9606C3E2568746a2Fe");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
     address!("0xDEc0000000000000000000000000000000000000");
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;


### PR DESCRIPTION
## Summary
- enable `isAuthorizedMintRecipient` checks for portal deposits
- add compound-policy allow/deny coverage in `ZonePortal.t.sol`
- update the moderato `ZoneFactory` default and docs to the freshly deployed instance `0x4C64016B46A675F60B4E3f9606C3E2568746a2Fe`

## Deployment
- new moderato `ZoneFactory`: `0x4C64016B46A675F60B4E3f9606C3E2568746a2Fe`
- deployment tx: `0xffe6720d265f618389a0196bfa55c3c7abf82f6ddf0ee8a4fd91b50830e0b357`

## Verification
- `forge test --match-path test/zone/ZonePortal.t.sol`
- `cargo build -p tempo-xtask`
- `just create-zone t2-zf-smoke-20260327`
- `RUST_LOG=warn just zone-up t2-zf-smoke-20260327 false release`
- `cast block-number --rpc-url http://localhost:8546` -> `170`
