### PR TITLE
chore(zone): redeploy moderato factory defaults

### DIFF
--- a/.codex/skills/zones-deploy-debug/SKILL.md
+++ b/.codex/skills/zones-deploy-debug/SKILL.md
@@ -19,20 +19,22 @@ Use this skill for repo-local zone deployment, smoke tests, and sync debugging.
 1. Build `tempo-zone` in release before judging sync speed.
 2. Deploy a fresh zone if you need a clean test surface.
 3. Start the zone node and confirm `http://localhost:8546` is answering.
-4. Deploy the router for that zone.
-5. Run the same-zone swap-and-deposit demo.
-6. If the demo stalls, compare the L1 block of the relevant tx with the latest `l1_block=` in the zone log before assuming the router flow is broken.
+4. For a direct bridge smoke test, run `just max-approve-portal`, `just send-deposit`, `just max-approve-outbox`, then `just send-withdrawal`.
+5. Deploy the router for that zone.
+6. Run the same-zone swap-and-deposit demo.
+7. If the demo stalls, compare the L1 block of the relevant tx with the latest `l1_block=` in the zone log before assuming the router flow is broken.
 
 ## What to inspect
 
 - `generated/<name>/zone.json`
 - `Justfile`
 - `docs/ZONES.md`
-- `/tmp/tempo-zone-<name>*/logs/immutable/reth.log`
+- `/tmp/tempo-zone-<name>*/logs/*/reth.log`
 
 ## Known sharp edges
 
 - Fresh `dev` nodes can look broken because they are still compiling and replaying L1; use `release` for meaningful validation.
+- Direct deposit/withdraw validation needs both approvals: `just max-approve-portal` before depositing and `just max-approve-outbox` before withdrawing.
 - The demo's first real wait point is token enablement on L2. If the zone is still replaying older L1 blocks, `demo-swap-and-deposit` can time out before the `TokenEnabled` event appears.
 - The current `just demo-swap-and-deposit` recipe takes optional overrides positionally, not as `amount=... tick=...`.
 - If a restarted zone crashes while seeding `transferPolicyId` for a temporary token, check `crates/tempo-zone/src/l1_state/tip403/cache.rs` and consider retesting with a fresh zone.

--- a/.codex/skills/zones-deploy-debug/references/commands.md
+++ b/.codex/skills/zones-deploy-debug/references/commands.md
@@ -37,6 +37,40 @@ Read deployment metadata:
 jq '{zoneId, portal, tempoAnchorBlock, zoneFactory, swapAndDepositRouter, sequencerAddress}' generated/my-zone/zone.json
 ```
 
+## Direct deposit + withdrawal validation
+
+Set the active portal first:
+
+```bash
+export L1_PORTAL_ADDRESS="$(jq -r '.portal' generated/my-zone/zone.json)"
+```
+
+Approve the L1 portal before depositing:
+
+```bash
+just max-approve-portal
+```
+
+Send a deposit to the zone:
+
+```bash
+just send-deposit 1000000
+```
+
+Approve the L2 outbox before withdrawing:
+
+```bash
+just max-approve-outbox
+```
+
+Request a withdrawal back to L1:
+
+```bash
+just send-withdrawal 400000
+```
+
+`just send-withdrawal` only waits for L1 finalization if both `L1_RPC_URL` and `L1_PORTAL_ADDRESS` are set.
+
 ## Router validation flow
 
 Deploy the router:
@@ -74,13 +108,13 @@ target/debug/tempo-xtask demo-swap-and-deposit \
 Tail the zone log:
 
 ```bash
-tail -f /tmp/tempo-zone-my-zone*/logs/immutable/reth.log
+tail -f /tmp/tempo-zone-my-zone*/logs/*/reth.log
 ```
 
 Useful patterns:
 
 ```bash
-rg -n "Prepared L1 block deposits|Including advanceTempo|TokenEnabled|DepositProcessed|WithdrawalProcessed" /tmp/tempo-zone-my-zone*/logs/immutable/reth.log
+rg -n "Prepared L1 block deposits|Including advanceTempo|TokenEnabled|DepositProcessed|WithdrawalProcessed" /tmp/tempo-zone-my-zone*/logs/*/reth.log
 ```
 
 When `demo-swap-and-deposit` stalls at token enablement:
@@ -94,7 +128,7 @@ cast receipt <tx-hash> --rpc-url "$HTTP_RPC"
 2. Compare it with the latest processed L1 block in the log:
 
 ```bash
-tail -n 200 /tmp/tempo-zone-my-zone*/logs/immutable/reth.log | rg "Prepared L1 block deposits|Including advanceTempo"
+tail -n 200 /tmp/tempo-zone-my-zone*/logs/*/reth.log | rg "Prepared L1 block deposits|Including advanceTempo"
 ```
 
 If the zone is still behind the tx block, wait longer or rerun the test with a `release` node.

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -447,7 +447,7 @@ graph TB
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0x4C64016B46A675F60B4E3f9606C3E2568746a2Fe` |
+| ZoneFactory (moderato) | `0x7Cc496Dc634b718289c192b59CF90262C5228545` |
 
 ### Zone Node CLI Options
 

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -17,7 +17,7 @@ use zone::abi::{ZoneInbox, ZonePortal};
 
 pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
 pub(crate) const MODERATO_ZONE_FACTORY: Address =
-    address!("0x4C64016B46A675F60B4E3f9606C3E2568746a2Fe");
+    address!("0x7Cc496Dc634b718289c192b59CF90262C5228545");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
     address!("0xDEc0000000000000000000000000000000000000");
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;


### PR DESCRIPTION
## Summary
- update the default moderato ZoneFactory address used by xtask and docs
- refresh the zones deploy/debug skill with the current direct smoke-test flow and log path

## Deployment
- ZoneFactory (moderato): `0x7Cc496Dc634b718289c192b59CF90262C5228545`
- Deployment tx: `0x87983ae734c3dfe86da5e3ce888c87c2c608bf213a75e1ef0ca6e7dd9df7f973`

## Verification
- `cargo build -p tempo-xtask`
- `just create-zone redeploy-smoke-20260327-110113`
- `just zone-up redeploy-smoke-20260327-110113 false release`
- direct deposit succeeded on L1 in `0xc313cddd7cebb6fb5119a1b01aa36b5c6e612432960ceb0e626937c9c7ac18fd` and was processed on L2
- direct withdrawal finalized on L1 in `0x2c9243d06c5bb89aa8ebc27b72c74cf66b566d8f407bdcf04ab002879a1dd18b`

Smoke zone metadata: `generated/redeploy-smoke-20260327-110113/zone.json`