### PR TITLE
feat(rpc): remove zonePortal from auth token, add unscoped tokens

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -574,7 +574,6 @@ zone-auth-token name:
         exit 1
     fi
     ZONE_ID=$(jq -r '.zoneId' "$ZONE_JSON")
-    PORTAL=$(jq -r '.portal' "$ZONE_JSON")
     GENESIS_JSON="generated/{{name}}/genesis.json"
     CHAIN_ID=$(jq -r '.config.chainId' "$GENESIS_JSON")
     NOW=$(date +%s)
@@ -583,10 +582,9 @@ zone-auth-token name:
     VERSION="00"
     ZONE_ID_HEX=$(printf '%08x' "$ZONE_ID")
     CHAIN_ID_HEX=$(printf '%016x' "$CHAIN_ID")
-    PORTAL_HEX=$(echo "$PORTAL" | sed 's/0x//' | tr '[:upper:]' '[:lower:]')
     ISSUED_HEX=$(printf '%016x' "$NOW")
     EXPIRES_HEX=$(printf '%016x' "$EXPIRES")
-    FIELDS="${VERSION}${ZONE_ID_HEX}${CHAIN_ID_HEX}${PORTAL_HEX}${ISSUED_HEX}${EXPIRES_HEX}"
+    FIELDS="${VERSION}${ZONE_ID_HEX}${CHAIN_ID_HEX}${ISSUED_HEX}${EXPIRES_HEX}"
     DIGEST=$(cast keccak "0x${MAGIC}${FIELDS}")
     SIG=$(cast wallet sign --no-hash "$DIGEST" --private-key "$PK")
     SIG_HEX=$(echo "$SIG" | sed 's/0x//')

--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -100,11 +100,7 @@ impl AuthorizationToken {
     /// Validate token fields against the server's zone configuration.
     ///
     /// A `zone_id` of `0` is unscoped and accepted for any zone.
-    pub fn validate(
-        &self,
-        expected_zone_id: u32,
-        expected_chain_id: u64,
-    ) -> Result<(), AuthError> {
+    pub fn validate(&self, expected_zone_id: u32, expected_chain_id: u64) -> Result<(), AuthError> {
         if self.version != 0 {
             return Err(AuthError::UnsupportedVersion(self.version));
         }

--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -15,9 +15,8 @@ const TEMPO_ZONE_RPC_MAGIC: [u8; 32] = {
     buf
 };
 
-/// Size of the fixed token fields (version + zoneId + chainId + zonePortal + issuedAt +
-/// expiresAt).
-const TOKEN_FIELDS_LEN: usize = 1 + 4 + 8 + 20 + 8 + 8; // 49 bytes
+/// Size of the fixed token fields (version + zoneId + chainId + issuedAt + expiresAt).
+const TOKEN_FIELDS_LEN: usize = 1 + 4 + 8 + 8 + 8; // 29 bytes
 
 /// HTTP header name for the authorization token.
 pub const X_AUTHORIZATION_TOKEN: &str = "x-authorization-token";
@@ -35,25 +34,23 @@ pub struct AuthContext {
 
 /// Parsed authorization token fields (before signature verification).
 ///
-/// The token is a hex-encoded blob: `<signature><version:1><zoneId:4><chainId:8><zonePortal:20><issuedAt:8><expiresAt:8>`.
-/// The last 49 bytes are always the fixed fields; everything before is the variable-length signature.
+/// The token is a hex-encoded blob: `<signature><version:1><zoneId:4><chainId:8><issuedAt:8><expiresAt:8>`.
+/// The last 29 bytes are always the fixed fields; everything before is the variable-length signature.
 ///
 /// See `docs/pages/protocol/privacy/rpc.md` — "Transport" and "Message" sections.
 #[derive(Debug, Clone)]
 pub struct AuthorizationToken {
     /// Spec version (must be 0).
     pub version: u8,
-    /// Zone ID.
+    /// Zone ID (0 = unscoped, valid for any zone).
     pub zone_id: u32,
     /// Chain ID.
     pub chain_id: u64,
-    /// ZonePortal address on Tempo L1.
-    pub zone_portal: Address,
     /// Issuance timestamp (unix seconds).
     pub issued_at: u64,
     /// Expiry timestamp (unix seconds).
     pub expires_at: u64,
-    /// The raw signature bytes (everything before the last 49 bytes).
+    /// The raw signature bytes (everything before the last 29 bytes).
     pub signature: Vec<u8>,
     /// The signing digest (keccak256 of the packed message).
     pub digest: B256,
@@ -76,9 +73,8 @@ impl AuthorizationToken {
         let version = fields[0];
         let zone_id = u32::from_be_bytes(fields[1..5].try_into().unwrap());
         let chain_id = u64::from_be_bytes(fields[5..13].try_into().unwrap());
-        let zone_portal = Address::from_slice(&fields[13..33]);
-        let issued_at = u64::from_be_bytes(fields[33..41].try_into().unwrap());
-        let expires_at = u64::from_be_bytes(fields[41..49].try_into().unwrap());
+        let issued_at = u64::from_be_bytes(fields[13..21].try_into().unwrap());
+        let expires_at = u64::from_be_bytes(fields[21..29].try_into().unwrap());
 
         // Build the signing digest
         let mut msg = Vec::with_capacity(32 + TOKEN_FIELDS_LEN);
@@ -86,7 +82,6 @@ impl AuthorizationToken {
         msg.push(version);
         msg.extend_from_slice(&zone_id.to_be_bytes());
         msg.extend_from_slice(&chain_id.to_be_bytes());
-        msg.extend_from_slice(zone_portal.as_slice());
         msg.extend_from_slice(&issued_at.to_be_bytes());
         msg.extend_from_slice(&expires_at.to_be_bytes());
         let digest = keccak256(&msg);
@@ -95,7 +90,6 @@ impl AuthorizationToken {
             version,
             zone_id,
             chain_id,
-            zone_portal,
             issued_at,
             expires_at,
             signature,
@@ -104,23 +98,21 @@ impl AuthorizationToken {
     }
 
     /// Validate token fields against the server's zone configuration.
+    ///
+    /// A `zone_id` of `0` is unscoped and accepted for any zone.
     pub fn validate(
         &self,
         expected_zone_id: u32,
         expected_chain_id: u64,
-        expected_portal: Address,
     ) -> Result<(), AuthError> {
         if self.version != 0 {
             return Err(AuthError::UnsupportedVersion(self.version));
         }
-        if self.zone_id != expected_zone_id {
+        if self.zone_id != 0 && self.zone_id != expected_zone_id {
             return Err(AuthError::ZoneIdMismatch);
         }
         if self.chain_id != expected_chain_id {
             return Err(AuthError::ChainIdMismatch);
-        }
-        if self.zone_portal != expected_portal {
-            return Err(AuthError::ZonePortalMismatch);
         }
         if self.expires_at.saturating_sub(self.issued_at) > 1800 {
             return Err(AuthError::WindowTooLarge);
@@ -144,12 +136,13 @@ impl AuthorizationToken {
 
 /// Build the unsigned token fields and their signing digest.
 ///
-/// Returns `(fields, digest)` where `fields` is the 49-byte suffix
+/// Returns `(fields, digest)` where `fields` is the 29-byte suffix
 /// and `digest` is the keccak256 hash to be signed.
+///
+/// Pass `zone_id = 0` for an unscoped token valid for any zone.
 pub fn build_token_fields(
     zone_id: u32,
     chain_id: u64,
-    zone_portal: Address,
     issued_at: u64,
     expires_at: u64,
 ) -> ([u8; TOKEN_FIELDS_LEN], B256) {
@@ -157,9 +150,8 @@ pub fn build_token_fields(
     fields[0] = 0; // version
     fields[1..5].copy_from_slice(&zone_id.to_be_bytes());
     fields[5..13].copy_from_slice(&chain_id.to_be_bytes());
-    fields[13..33].copy_from_slice(zone_portal.as_slice());
-    fields[33..41].copy_from_slice(&issued_at.to_be_bytes());
-    fields[41..49].copy_from_slice(&expires_at.to_be_bytes());
+    fields[13..21].copy_from_slice(&issued_at.to_be_bytes());
+    fields[21..29].copy_from_slice(&expires_at.to_be_bytes());
 
     let mut msg = Vec::with_capacity(32 + TOKEN_FIELDS_LEN);
     msg.extend_from_slice(&TEMPO_ZONE_RPC_MAGIC);

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -18,7 +18,7 @@ pub struct PrivateRpcConfig {
     pub zone_id: u32,
     /// The zone's chain ID.
     pub chain_id: u64,
-    /// The ZonePortal contract address on L1.
+    /// The ZonePortal contract address on L1 (used for querying deposits, not for auth tokens).
     pub zone_portal: Address,
     /// The sequencer address — callers matching this get unredacted responses.
     pub sequencer: Address,

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -16,8 +16,6 @@ pub enum AuthError {
     ZoneIdMismatch,
     #[error("chain ID mismatch")]
     ChainIdMismatch,
-    #[error("zone portal mismatch")]
-    ZonePortalMismatch,
     #[error("validity window too large (max 1800s)")]
     WindowTooLarge,
     #[error("authorization token expired")]

--- a/crates/rpc/src/provider.rs
+++ b/crates/rpc/src/provider.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use alloy_primitives::{Address, hex};
+use alloy_primitives::hex;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
@@ -33,8 +33,6 @@ pub struct ZoneProviderConfig {
     pub zone_id: u32,
     /// Chain identifier.
     pub chain_id: u64,
-    /// ZonePortal contract address on L1.
-    pub zone_portal: Address,
     /// How long each generated token is valid. Default: 600s, max: 1800s.
     pub token_ttl: Duration,
     /// The private zone RPC URL.
@@ -107,20 +105,14 @@ fn build_provider_with_token(
     let now = now_secs();
     let expires_at = now + config.token_ttl.as_secs();
 
-    let (fields, digest) = build_token_fields(
-        config.zone_id,
-        config.chain_id,
-        config.zone_portal,
-        now,
-        expires_at,
-    );
+    let (fields, digest) = build_token_fields(config.zone_id, config.chain_id, now, expires_at);
 
     let sig = config
         .signer
         .sign_hash_sync(&digest)
         .map_err(|e| eyre::eyre!("failed to sign zone auth token: {e}"))?;
 
-    // Build blob: <65-byte sig><49-byte fields>
+    // Build blob: <65-byte sig><29-byte fields>
     let mut blob = Vec::with_capacity(65 + fields.len());
     blob.extend_from_slice(&sig.r().to_be_bytes::<32>());
     blob.extend_from_slice(&sig.s().to_be_bytes::<32>());

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -219,7 +219,7 @@ pub(crate) async fn authenticate_token(
     let token = auth::parse_auth_header(token_value)?;
 
     // Validate token fields against server config
-    token.validate(config.zone_id, config.chain_id, config.zone_portal)?;
+    token.validate(config.zone_id, config.chain_id)?;
 
     let signature =
         TempoSignature::from_bytes(&token.signature).map_err(|_| AuthError::InvalidSignature)?;
@@ -400,7 +400,7 @@ mod tests {
         let root_account = Address::repeat_byte(0x55);
         let access_signer = P256SigningKey::random(&mut thread_rng());
         let now = now_secs();
-        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
         let (signature, key_id) =
             sign_keychain_signature(digest, &access_signer, root_account, 0x04)
                 .expect("keychain signing failed");

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -269,7 +269,6 @@ impl ZoneRpcApi for MockZoneRpcApi {
 
 const ZONE_ID: u32 = 1;
 const CHAIN_ID: u64 = 42;
-const PORTAL: Address = Address::ZERO;
 
 struct TestContext {
     addr: std::net::SocketAddr,
@@ -286,7 +285,7 @@ impl TestContext {
             retry_connection_interval: std::time::Duration::from_millis(100),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
-            zone_portal: PORTAL,
+            zone_portal: Address::ZERO,
             sequencer: signer.address(),
         };
         let addr = start_private_rpc(config, Arc::new(api)).await.unwrap();
@@ -295,7 +294,7 @@ impl TestContext {
 
     fn build_token(&self) -> String {
         let now = now_secs();
-        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
         let sig = self.signer.sign_hash_sync(&digest).expect("signing failed");
 
         let mut blob = Vec::with_capacity(65 + fields.len());
@@ -793,7 +792,7 @@ async fn ws_roundtrip_with_p256_auth() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
-    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let token = build_token_with_signature(
         sign_p256_signature(digest, &signing_key).expect("p256 signing should succeed"),
         &fields,
@@ -818,7 +817,7 @@ async fn ws_roundtrip_with_webauthn_auth() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
-    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let token = build_token_with_signature(
         sign_webauthn_signature(&signing_key, digest).expect("webauthn signing should succeed"),
         &fields,
@@ -843,7 +842,7 @@ async fn ws_roundtrip_with_keychain_auth() {
     let root_account = Address::repeat_byte(0x55);
     let access_signer = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
-    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let (signature, key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)
         .expect("keychain signing should succeed");
     let ctx = TestContext::start(MockZoneRpcApi::with_key(
@@ -874,7 +873,7 @@ async fn ws_reject_unauthorized_keychain_token() {
     let access_signer = P256SigningKey::random(&mut thread_rng());
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let now = now_secs();
-    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let (signature, _key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)
         .expect("keychain signing should succeed");
     let token = build_token_with_signature(signature, &fields);
@@ -894,7 +893,7 @@ async fn ws_keychain_lookup_failure_returns_500() {
     let access_signer = P256SigningKey::random(&mut thread_rng());
     let ctx = TestContext::start(MockZoneRpcApi::with_key_lookup_error("key lookup failed")).await;
     let now = now_secs();
-    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, PORTAL, now, now + 600);
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let (signature, _key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)
         .expect("keychain signing should succeed");
     let token = build_token_with_signature(signature, &fields);

--- a/crates/tempo-zone/tests/it/private_rpc.rs
+++ b/crates/tempo-zone/tests/it/private_rpc.rs
@@ -21,13 +21,10 @@ fn build_token_blob(
     version: u8,
     zone_id: u32,
     chain_id: u64,
-    portal: Address,
     issued_at: u64,
     expires_at: u64,
 ) -> Vec<u8> {
-    let (mut fields, _digest) =
-        build_token_fields(zone_id, chain_id, portal, issued_at, expires_at);
-    // build_token_fields always sets version=0; override for tests that need a different version.
+    let (mut fields, _digest) = build_token_fields(zone_id, chain_id, issued_at, expires_at);
     fields[0] = version;
     let mut blob = vec![0u8; 65]; // fake secp256k1 sig
     blob.extend_from_slice(&fields);
@@ -38,11 +35,10 @@ fn make_test_token(
     version: u8,
     zone_id: u32,
     chain_id: u64,
-    portal: Address,
     issued_at: u64,
     expires_at: u64,
 ) -> AuthorizationToken {
-    let blob = build_token_blob(version, zone_id, chain_id, portal, issued_at, expires_at);
+    let blob = build_token_blob(version, zone_id, chain_id, issued_at, expires_at);
     AuthorizationToken::parse(&blob).unwrap()
 }
 
@@ -51,14 +47,12 @@ fn make_test_token(
 #[test]
 fn parse_token_fields() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xAA);
 
-    let token = make_test_token(0, 42, 1337, portal, now, now + 600);
+    let token = make_test_token(0, 42, 1337, now, now + 600);
 
     assert_eq!(token.version, 0);
     assert_eq!(token.zone_id, 42);
     assert_eq!(token.chain_id, 1337);
-    assert_eq!(token.zone_portal, portal);
     assert_eq!(token.issued_at, now);
     assert_eq!(token.expires_at, now + 600);
     assert_eq!(token.signature.len(), 65);
@@ -66,8 +60,8 @@ fn parse_token_fields() {
 
 #[test]
 fn parse_token_too_short() {
-    // 49 bytes = exactly the message length, no room for a signature
-    let blob = vec![0u8; 49];
+    // 29 bytes = exactly the message length, no room for a signature
+    let blob = vec![0u8; 29];
     assert!(AuthorizationToken::parse(&blob).is_err());
 
     // Even shorter
@@ -78,11 +72,10 @@ fn parse_token_too_short() {
 fn parse_unknown_signature_length() {
     // 50-byte signature (not 65 or 130, and first byte is not 0x02/0x03) → should error
     let mut blob = vec![0u8; 50];
-    // 49 bytes of fields
+    // 29 bytes of fields
     blob.push(0);
     blob.extend_from_slice(&1u32.to_be_bytes());
     blob.extend_from_slice(&1u64.to_be_bytes());
-    blob.extend_from_slice(&[0u8; 20]);
     let now = now_secs();
     blob.extend_from_slice(&now.to_be_bytes());
     blob.extend_from_slice(&(now + 600).to_be_bytes());
@@ -93,17 +86,15 @@ fn parse_unknown_signature_length() {
 
 #[test]
 fn digest_is_deterministic() {
-    let portal = Address::repeat_byte(0xCC);
-    let t1 = make_test_token(0, 1, 2, portal, 1000, 1600);
-    let t2 = make_test_token(0, 1, 2, portal, 1000, 1600);
+    let t1 = make_test_token(0, 1, 2, 1000, 1600);
+    let t2 = make_test_token(0, 1, 2, 1000, 1600);
     assert_eq!(t1.digest, t2.digest);
 }
 
 #[test]
 fn digest_changes_with_params() {
-    let portal = Address::repeat_byte(0xCC);
-    let t1 = make_test_token(0, 1, 2, portal, 1000, 1600);
-    let t3 = make_test_token(0, 1, 3, portal, 1000, 1600);
+    let t1 = make_test_token(0, 1, 2, 1000, 1600);
+    let t3 = make_test_token(0, 1, 3, 1000, 1600);
     assert_ne!(t1.digest, t3.digest);
 }
 
@@ -112,69 +103,60 @@ fn digest_changes_with_params() {
 #[test]
 fn validate_accepts_valid_token() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
-    let token = make_test_token(0, 42, 1337, portal, now, now + 600);
-    assert!(token.validate(42, 1337, portal).is_ok());
+    let token = make_test_token(0, 42, 1337, now, now + 600);
+    assert!(token.validate(42, 1337).is_ok());
 }
 
 #[test]
 fn validate_rejects_wrong_version() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
-    let token = make_test_token(1, 42, 1337, portal, now, now + 600);
-    assert!(token.validate(42, 1337, portal).is_err());
+    let token = make_test_token(1, 42, 1337, now, now + 600);
+    assert!(token.validate(42, 1337).is_err());
 }
 
 #[test]
 fn validate_rejects_zone_id_mismatch() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
-    let token = make_test_token(0, 42, 1337, portal, now, now + 600);
-    assert!(token.validate(99, 1337, portal).is_err());
+    let token = make_test_token(0, 42, 1337, now, now + 600);
+    assert!(token.validate(99, 1337).is_err());
+}
+
+#[test]
+fn validate_accepts_unscoped_zone_id() {
+    let now = now_secs();
+    let token = make_test_token(0, 0, 1337, now, now + 600);
+    assert!(token.validate(42, 1337).is_ok());
+    assert!(token.validate(99, 1337).is_ok());
 }
 
 #[test]
 fn validate_rejects_chain_id_mismatch() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
-    let token = make_test_token(0, 42, 1337, portal, now, now + 600);
-    assert!(token.validate(42, 9999, portal).is_err());
-}
-
-#[test]
-fn validate_rejects_portal_mismatch() {
-    let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
-    let other = Address::repeat_byte(0xCC);
-    let token = make_test_token(0, 42, 1337, portal, now, now + 600);
-    assert!(token.validate(42, 1337, other).is_err());
+    let token = make_test_token(0, 42, 1337, now, now + 600);
+    assert!(token.validate(42, 9999).is_err());
 }
 
 #[test]
 fn validate_rejects_expired() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
-    // Token that expired 100s ago
-    let token = make_test_token(0, 42, 1337, portal, now - 700, now - 100);
-    assert!(token.validate(42, 1337, portal).is_err());
+    let token = make_test_token(0, 42, 1337, now - 700, now - 100);
+    assert!(token.validate(42, 1337).is_err());
 }
 
 #[test]
 fn validate_rejects_window_too_large() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
     // 2000s window > 1800s max
-    let token = make_test_token(0, 42, 1337, portal, now, now + 2000);
-    assert!(token.validate(42, 1337, portal).is_err());
+    let token = make_test_token(0, 42, 1337, now, now + 2000);
+    assert!(token.validate(42, 1337).is_err());
 }
 
 #[test]
 fn validate_rejects_issued_at_far_future() {
     let now = now_secs();
-    let portal = Address::repeat_byte(0xBB);
     // issuedAt is 200s in the future (> 60s max skew)
-    let token = make_test_token(0, 42, 1337, portal, now + 200, now + 800);
-    assert!(token.validate(42, 1337, portal).is_err());
+    let token = make_test_token(0, 42, 1337, now + 200, now + 800);
+    assert!(token.validate(42, 1337).is_err());
 }
 
 #[tokio::test]
@@ -183,7 +165,7 @@ async fn tempo_signature_roundtrip_secp256k1_from_token_bytes() {
 
     let signer = PrivateKeySigner::random();
     let now = now_secs();
-    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let (fields, digest) = build_token_fields(1, 2, now, now + 600);
     let sig = signer.sign_hash(&digest).await.unwrap();
 
     let mut sig_bytes = Vec::with_capacity(65);
@@ -215,7 +197,7 @@ fn tempo_signature_rejects_wrong_secp256k1_lengths() {
 fn tempo_signature_roundtrip_p256_from_token_bytes() {
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
-    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let (fields, digest) = build_token_fields(1, 2, now, now + 600);
     let expected = sign_p256_signature(digest, &signing_key)
         .expect("p256 signing should succeed")
         .recover_signer(&digest)
@@ -234,7 +216,7 @@ fn tempo_signature_roundtrip_p256_from_token_bytes() {
 fn tempo_signature_roundtrip_webauthn_from_token_bytes() {
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
-    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let (fields, digest) = build_token_fields(1, 2, now, now + 600);
     let signature =
         sign_webauthn_signature(&signing_key, digest).expect("webauthn signing should succeed");
     let expected = signature
@@ -252,7 +234,7 @@ fn tempo_signature_roundtrip_keychain_v1_from_token_bytes() {
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let root_account = Address::repeat_byte(0x44);
     let now = now_secs();
-    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let (fields, digest) = build_token_fields(1, 2, now, now + 600);
     let (signature, expected_key_id) =
         sign_keychain_signature(digest, &signing_key, root_account, 0x03)
             .expect("keychain signing should succeed");
@@ -274,7 +256,7 @@ fn tempo_signature_roundtrip_keychain_v2_from_token_bytes() {
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let root_account = Address::repeat_byte(0x55);
     let now = now_secs();
-    let (fields, digest) = build_token_fields(1, 2, Address::ZERO, now, now + 600);
+    let (fields, digest) = build_token_fields(1, 2, now, now + 600);
     let (signature, expected_key_id) =
         sign_keychain_signature(digest, &signing_key, root_account, 0x04)
             .expect("keychain signing should succeed");

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -174,9 +174,8 @@ async fn test_auth_rejection() -> eyre::Result<()> {
     // Valid signature but wrong chain ID → 403
     let bad_token = ctx.build_bad_token(
         &ctx.sequencer_signer,
-        0,
+        1,
         ctx.config.chain_id + 1,
-        Address::ZERO,
     );
     let (status, _) = ctx
         .call_raw("eth_blockNumber", serde_json::json!([]), &bad_token)

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -172,11 +172,7 @@ async fn test_auth_rejection() -> eyre::Result<()> {
     );
 
     // Valid signature but wrong chain ID → 403
-    let bad_token = ctx.build_bad_token(
-        &ctx.sequencer_signer,
-        1,
-        ctx.config.chain_id + 1,
-    );
+    let bad_token = ctx.build_bad_token(&ctx.sequencer_signer, 1, ctx.config.chain_id + 1);
     let (status, _) = ctx
         .call_raw("eth_blockNumber", serde_json::json!([]), &bad_token)
         .await?;

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2280,11 +2280,7 @@ fn build_auth_token_with_signature(
     auth_tokens::build_token_with_signature(signature, &fields)
 }
 
-fn build_p256_auth_token(
-    signing_key: &P256SigningKey,
-    zone_id: u32,
-    chain_id: u64,
-) -> String {
+fn build_p256_auth_token(signing_key: &P256SigningKey, zone_id: u32, chain_id: u64) -> String {
     let now = now_secs();
     let expires_at = now + 600;
     let (_, digest) = zone::rpc::auth::build_token_fields(zone_id, chain_id, now, expires_at);
@@ -2482,12 +2478,7 @@ impl PrivateRpcTestCtx {
 
     /// Build a WebAuthn auth token for a non-sequencer caller.
     pub(crate) fn webauthn_token(&self, signing_key: &P256SigningKey) -> String {
-        build_webauthn_auth_token(
-            signing_key,
-            self.config.zone_id,
-            self.config.chain_id,
-            None,
-        )
+        build_webauthn_auth_token(signing_key, self.config.zone_id, self.config.chain_id, None)
     }
 
     /// Build a WebAuthn auth token with an overridden challenge digest.

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2247,7 +2247,6 @@ fn build_auth_token(
     signer: &alloy_signer_local::PrivateKeySigner,
     zone_id: u32,
     chain_id: u64,
-    portal: Address,
 ) -> String {
     use alloy_signer::SignerSync;
     use zone::rpc::auth::build_token_fields;
@@ -2255,7 +2254,7 @@ fn build_auth_token(
     let now = now_secs();
     let expires_at = now + 600;
 
-    let (fields, digest) = build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    let (fields, digest) = build_token_fields(zone_id, chain_id, now, expires_at);
     let sig = signer.sign_hash_sync(&digest).expect("signing failed");
 
     let mut blob = Vec::with_capacity(65 + fields.len());
@@ -2271,14 +2270,13 @@ fn build_auth_token_with_signature(
     signature: TempoSignature,
     zone_id: u32,
     chain_id: u64,
-    portal: Address,
 ) -> String {
     use zone::rpc::auth::build_token_fields;
 
     let now = now_secs();
     let expires_at = now + 600;
 
-    let (fields, _) = build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    let (fields, _) = build_token_fields(zone_id, chain_id, now, expires_at);
     auth_tokens::build_token_with_signature(signature, &fields)
 }
 
@@ -2286,17 +2284,14 @@ fn build_p256_auth_token(
     signing_key: &P256SigningKey,
     zone_id: u32,
     chain_id: u64,
-    portal: Address,
 ) -> String {
     let now = now_secs();
     let expires_at = now + 600;
-    let (_, digest) =
-        zone::rpc::auth::build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    let (_, digest) = zone::rpc::auth::build_token_fields(zone_id, chain_id, now, expires_at);
     build_auth_token_with_signature(
         sign_p256_signature(digest, signing_key).expect("p256 signing failed"),
         zone_id,
         chain_id,
-        portal,
     )
 }
 
@@ -2304,19 +2299,16 @@ fn build_webauthn_auth_token(
     signing_key: &P256SigningKey,
     zone_id: u32,
     chain_id: u64,
-    portal: Address,
     challenge_digest: Option<B256>,
 ) -> String {
     let now = now_secs();
     let expires_at = now + 600;
-    let (_, digest) =
-        zone::rpc::auth::build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    let (_, digest) = zone::rpc::auth::build_token_fields(zone_id, chain_id, now, expires_at);
     build_auth_token_with_signature(
         sign_webauthn_signature(signing_key, challenge_digest.unwrap_or(digest))
             .expect("webauthn signing failed"),
         zone_id,
         chain_id,
-        portal,
     )
 }
 
@@ -2326,17 +2318,15 @@ fn build_keychain_auth_token(
     version: u8,
     zone_id: u32,
     chain_id: u64,
-    portal: Address,
 ) -> (String, Address) {
     let now = now_secs();
     let expires_at = now + 600;
-    let (_, digest) =
-        zone::rpc::auth::build_token_fields(zone_id, chain_id, portal, now, expires_at);
+    let (_, digest) = zone::rpc::auth::build_token_fields(zone_id, chain_id, now, expires_at);
     let (signature, key_id) = sign_keychain_signature(digest, signing_key, root_account, version)
         .expect("keychain signing failed");
 
     (
-        build_auth_token_with_signature(signature, zone_id, chain_id, portal),
+        build_auth_token_with_signature(signature, zone_id, chain_id),
         key_id,
     )
 }
@@ -2477,28 +2467,17 @@ impl PrivateRpcTestCtx {
             &self.sequencer_signer,
             self.config.zone_id,
             self.config.chain_id,
-            self.config.zone_portal,
         )
     }
 
     /// Build an auth token for a regular (non-sequencer) user.
     pub(crate) fn user_token(&self, signer: &alloy_signer_local::PrivateKeySigner) -> String {
-        build_auth_token(
-            signer,
-            self.config.zone_id,
-            self.config.chain_id,
-            self.config.zone_portal,
-        )
+        build_auth_token(signer, self.config.zone_id, self.config.chain_id)
     }
 
     /// Build a P256 auth token for a non-sequencer caller.
     pub(crate) fn p256_token(&self, signing_key: &P256SigningKey) -> String {
-        build_p256_auth_token(
-            signing_key,
-            self.config.zone_id,
-            self.config.chain_id,
-            self.config.zone_portal,
-        )
+        build_p256_auth_token(signing_key, self.config.zone_id, self.config.chain_id)
     }
 
     /// Build a WebAuthn auth token for a non-sequencer caller.
@@ -2507,7 +2486,6 @@ impl PrivateRpcTestCtx {
             signing_key,
             self.config.zone_id,
             self.config.chain_id,
-            self.config.zone_portal,
             None,
         )
     }
@@ -2522,7 +2500,6 @@ impl PrivateRpcTestCtx {
             signing_key,
             self.config.zone_id,
             self.config.chain_id,
-            self.config.zone_portal,
             Some(challenge_digest),
         )
     }
@@ -2540,7 +2517,6 @@ impl PrivateRpcTestCtx {
             version,
             self.config.zone_id,
             self.config.chain_id,
-            self.config.zone_portal,
         )
     }
 
@@ -2594,15 +2570,14 @@ impl PrivateRpcTestCtx {
         private_rpc_call_no_auth(&self.private_rpc_url, method, params).await
     }
 
-    /// Build an auth token with custom zone_id, chain_id, and portal (for negative testing).
+    /// Build an auth token with custom zone_id and chain_id (for negative testing).
     pub(crate) fn build_bad_token(
         &self,
         signer: &alloy_signer_local::PrivateKeySigner,
         zone_id: u32,
         chain_id: u64,
-        portal: Address,
     ) -> String {
-        build_auth_token(signer, zone_id, chain_id, portal)
+        build_auth_token(signer, zone_id, chain_id)
     }
 
     /// Inject an empty L1 block and wait for it to be processed.

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -28,9 +28,8 @@ The signed message is the `keccak256` hash of the following packed encoding:
 bytes32 authorizationTokenHash = keccak256(abi.encodePacked(
     bytes32(0x54656d706f5a6f6e65525043),  // "TempoZoneRPC" magic prefix
     uint8(version),                         // spec version (currently 0)
-    uint32(zoneId),                         // zone this key is valid for
+    uint32(zoneId),                         // zone this key is valid for (0 = unscoped)
     uint64(chainId),                        // zone chain ID (replay protection)
-    address(zonePortal),                    // ZonePortal address on Tempo
     uint64(issuedAt),                       // unix timestamp (seconds) of issuance
     uint64(expiresAt)                       // unix timestamp (seconds) of expiry
 ));
@@ -39,6 +38,14 @@ bytes32 authorizationTokenHash = keccak256(abi.encodePacked(
 The `version` field MUST be `0` for this version of the spec. The RPC server MUST reject authorization tokens with an unrecognized version. This allows future revisions to change authorization token semantics (e.g., adding scoped permissions) without ambiguity.
 
 This hash is the challenge that must be signed. Using a raw `keccak256` hash (rather than EIP-191 personal messages or EIP-712 typed data) allows all Tempo signature types to sign the same message consistently — P256 and WebAuthn signers cannot produce EIP-191 prefixed signatures. The `"TempoZoneRPC"` magic prefix provides domain separation, ensuring that authorization token hashes cannot collide with Tempo transaction hashes or other signing contexts.
+
+### Unscoped tokens
+
+A `zoneId` of `0` indicates an **unscoped** authorization token that is valid for any zone. Zone IDs are assigned by `ZoneFactory` starting at 1, so `0` is never a valid zone ID.
+
+When the RPC server receives a token with `zoneId == 0`, it MUST skip the zone ID check and accept the token for any zone. All other validation rules (version, chain ID, expiry, signature) still apply. The `chainId` field continues to provide cross-network replay protection.
+
+Unscoped tokens are useful for applications and SDKs that interact with multiple zones on the same network without managing separate tokens per zone. Since authorization tokens are read-only credentials (no RPC method authenticated solely by a token may modify state), the additional exposure is limited to read access across zones the user has accounts in.
 
 ### Signature types
 
@@ -109,9 +116,8 @@ This allows session keys and scoped Access Keys to authenticate to the RPC with 
 
 The RPC server MUST reject authorization tokens where:
 
-- `zoneId` does not equal the zone's configured `zoneId`.
+- `zoneId` does not equal the zone's configured `zoneId` **and** `zoneId` is not `0` (an unscoped token with `zoneId == 0` is valid for any zone — see [Unscoped tokens](#unscoped-tokens)).
 - `chainId` does not equal the zone's configured chain ID (`eth_chainId`).
-- `zonePortal` does not equal the zone's configured Tempo ZonePortal address.
 - `expiresAt - issuedAt > 1800` (maximum validity window is 30 minutes).
 - `expiresAt <= now` (key has expired).
 - `issuedAt > now + 60` (clock skew tolerance of 60 seconds into the future).
@@ -137,10 +143,10 @@ Content-Type: application/json
 The `X-Authorization-Token` value is a single hex-encoded blob containing the concatenation of the signature and the authorization token fields:
 
 ```
-<signature bytes><version: 1 byte><zoneId: 4 bytes><chainId: 8 bytes><zonePortal: 20 bytes><issuedAt: 8 bytes><expiresAt: 8 bytes>
+<signature bytes><version: 1 byte><zoneId: 4 bytes><chainId: 8 bytes><issuedAt: 8 bytes><expiresAt: 8 bytes>
 ```
 
-The authorization token fields are always exactly 49 bytes (1 + 4 + 8 + 20 + 8 + 8). To parse the blob, the RPC server reads the **last 49 bytes** as the authorization token fields, and treats everything before them as the signature. The signature is then parsed using the same detection rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types) (secp256k1 is exactly 65 bytes; P256 starts with `0x01` and is 130 bytes; WebAuthn starts with `0x02` and is variable-length; Keychain starts with `0x03` for legacy V1 or `0x04` for V2 and is variable-length). Parsing from the end avoids any ambiguity with variable-length signature types.
+The authorization token fields are always exactly 29 bytes (1 + 4 + 8 + 8 + 8). To parse the blob, the RPC server reads the **last 29 bytes** as the authorization token fields, and treats everything before them as the signature. The signature is then parsed using the same detection rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types) (secp256k1 is exactly 65 bytes; P256 starts with `0x01` and is 130 bytes; WebAuthn starts with `0x02` and is variable-length; Keychain starts with `0x03` for legacy V1 or `0x04` for V2 and is variable-length). Parsing from the end avoids any ambiguity with variable-length signature types.
 
 Requests without an authorization token receive a `401 Unauthorized` HTTP response. Requests with an expired, malformed, or unauthorized token receive `403 Forbidden`. If Keychain token verification fails because the server cannot read `AccountKeychain.getKey(...)`, the server returns `500 Internal Server Error`.
 
@@ -485,7 +491,7 @@ In addition to standard JSON-RPC error codes, the zone RPC uses:
 
 - **Side channels via timing**: Scoped methods that must fetch data before checking authorization are subject to a mandatory 100 ms response floor (see [Timing side channels and the 100 ms speed bump](#timing-side-channels-and-the-100-ms-speed-bump)). This ensures that `eth_getTransactionByHash` for a non-existent transaction and for another user's transaction have indistinguishable response times.
 - **Nonce privacy**: `eth_getTransactionCount` for non-authenticated accounts returns `0x0` rather than an error. This avoids revealing whether an account exists. The constant `0x0` response is indistinguishable from a genuinely new account.
-- **Authorization token replay**: Authorization tokens are scoped to a specific zone (`zoneId` and `chainId`) and a specific portal (`zonePortal`), with a maximum 30-minute window. Authorization tokens are strictly read-only credentials — no RPC method that is authenticated solely by an authorization token may modify state (see [Withdrawals](#zone-specific-rpc-methods)). The RPC server SHOULD implement nonce tracking or rate limiting to further reduce the window for abuse if a token is intercepted, but replay of a read-only token cannot move funds.
+- **Authorization token replay**: Authorization tokens are scoped to a specific zone (`zoneId`) and network (`chainId`), with a maximum 30-minute window. When `zoneId` is `0` (unscoped), the token is valid across all zones on that network. Authorization tokens are strictly read-only credentials — no RPC method that is authenticated solely by an authorization token may modify state (see [Withdrawals](#zone-specific-rpc-methods)). The RPC server SHOULD implement nonce tracking or rate limiting to further reduce the window for abuse if a token is intercepted, but replay of a read-only token cannot move funds.
 - **Simulation override extensions**: Some Ethereum clients support non-standard simulation extensions (state override sets and block override objects) on `eth_call`/`eth_estimateGas`. Privacy zones MUST reject these extensions for non-sequencer callers, because they can bypass or distort normal state access assumptions used by this spec's privacy model.
 - **Keychain key revocation and expiry**: When a root account revokes a Keychain key on-chain, the RPC server MUST stop accepting that key within 1 second of importing the block that contains the revocation. Cached Keychain verifications MUST also honor key expiry: a cache entry MUST expire no later than `min(authorizationToken.expiresAt, keyExpiry)` where `keyExpiry` is read from `AccountKeychain.getKey(...)`. In the current `AccountKeychain` implementation, inactive or revoked keys are surfaced as `keyId == 0` and `expiry == 0`, so those results MUST be treated as immediately invalid rather than "never expires." The recommended implementation is event-driven: the zone node watches for `KeyRevoked(account, publicKey)` events emitted by the AccountKeychain precompile during block execution and immediately evicts matching entries from the authorization token cache. This requires no cryptography — just a cache lookup and delete. As a fallback, implementations MAY poll the precompile via `getKey(user_address, keyId)`, but the 1-second deadline still applies.
 - **P256/WebAuthn key compromise**: Unlike secp256k1, P256 and WebAuthn keys include the public key in the signature. This means the public key is visible to the RPC server on every request. This is not a security concern (public keys are public), but implementations should be aware that the key material is transmitted in the clear over the connection.


### PR DESCRIPTION
## Summary

- Remove `zonePortal` from the authorization token signed message and wire format (49 → 29 bytes). The portal address was redundant — `zoneId` + `chainId` already uniquely identify a zone and prevent cross-network replay.
- Add unscoped authorization tokens: `zoneId = 0` (never a valid zone ID) signals the token is accepted by any zone on the same network. Useful for multi-zone SDKs and apps.
- Update the RPC spec (`rpc.md`), Rust implementation (`token.rs`, `server.rs`, `provider.rs`, `config.rs`, `error.rs`), and all tests.

Closes #331

## Test plan

- [x] `zone-rpc` tests pass (23/23)
- [x] `zone` integration tests pass (25/25 private_rpc unit tests, including new `validate_accepts_unscoped_zone_id`)
- [x] Full workspace builds cleanly
- [ ] CI


Made with [Cursor](https://cursor.com)