### PR TITLE
chore: bump tempo to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10478,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10510,7 +10510,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10531,7 +10531,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10547,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10558,7 +10558,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10588,7 +10588,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -10639,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10691,7 +10691,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10750,7 +10750,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=698f7cb1b3d057cf67bbd81b21af53dfeb231610#698f7cb1b3d057cf67bbd81b21af53dfeb231610"
+source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,23 +78,23 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false, features = ["serde"] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false, features = ["serde"] }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
 
 # zones
 zone-precompiles = { path = "crates/precompiles", default-features = false }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 # tempo
-tempo-alloy = { workspace = true, features = ["tempo-compat"] }
+tempo-alloy.workspace = true
 tempo-contracts.workspace = true
 tempo-primitives.workspace = true
 

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -20,7 +20,7 @@ tempo-node.workspace = true
 tempo-payload-types.workspace = true
 tempo-primitives.workspace = true
 tempo-transaction-pool.workspace = true
-tempo-alloy = { workspace = true, features = ["tempo-compat"] }
+tempo-alloy.workspace = true
 tempo-contracts.workspace = true
 tempo-precompiles.workspace = true
 zone-precompiles = { workspace = true, features = ["std"] }


### PR DESCRIPTION
## Summary
- bump all workspace `tempo` git dependencies from `698f7cb1b3d057cf67bbd81b21af53dfeb231610` to current `tempo` `main` at `e331e2f488a368ea9ca76c422e12fedbfb6eb3b4`
- regenerate `Cargo.lock` for the new `tempo` source revision
- remove the local `tempo-alloy/tempo-compat` feature requests because upstream `tempo-alloy` no longer exposes that feature gate

## Why
This keeps `zones` in sync with the latest upstream `tempo` main. I also verified the corresponding upstream `reth` pin in `tempo` main before changing anything; it remains `7f4a9a0`, so no separate `reth` rev bump was needed here.

## Impact
The workspace now resolves and builds cleanly against the latest upstream `tempo` main commit.

## Validation
- `cargo check --workspace`
