### PR TITLE
feat: add witness pipeline and proof generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e33f6a175ec6a9e0aca777567f9ff7c3deefc255660df887e7fa3585e9801d8"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -120,7 +140,7 @@ checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "num_enum",
+ "num_enum 0.7.6",
  "serde",
  "strum",
 ]
@@ -141,7 +161,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "k256",
  "once_cell",
@@ -215,11 +235,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "derive_more",
+ "derive_more 2.1.1",
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -298,7 +318,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",
@@ -321,7 +341,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "op-alloy",
  "op-revm",
  "revm",
@@ -378,7 +398,7 @@ checksum = "ae95062f48461967424eecb1e1ab703e493b6a7aca7f9c327cc1c06758eb6ec2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -404,7 +424,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -435,7 +455,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 2.1.1",
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
@@ -449,7 +469,7 @@ dependencies = [
  "rand 0.9.2",
  "rapidhash",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
 ]
@@ -517,7 +537,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "wasmtimer",
 ]
@@ -564,7 +584,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -631,7 +651,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.1.1",
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",
  "serde",
@@ -649,7 +669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d9d9a32059dff4809fe4db016db13ba1a20babf767c4cd26e97c93ee9efe4c"
 dependencies = [
  "alloy-primitives",
- "derive_more",
+ "derive_more 2.1.1",
  "serde",
  "serde_with",
 ]
@@ -665,7 +685,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",
  "jsonwebtoken",
@@ -765,6 +785,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer-aws"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7298e489d69d290e1407e491669979da38f3f28e4cdc530c9b492aef65db93"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "k256",
+ "spki",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-signer-local"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,7 +880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -865,7 +904,7 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64 0.22.1",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
@@ -873,7 +912,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
@@ -890,7 +929,7 @@ dependencies = [
  "itertools 0.14.0",
  "reqwest 0.13.2",
  "serde_json",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -924,8 +963,8 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http",
- "rustls",
+ "http 1.4.0",
+ "rustls 0.23.37",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
@@ -944,7 +983,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "derive_arbitrary",
- "derive_more",
+ "derive_more 2.1.1",
  "nybbles",
  "proptest",
  "proptest-derive",
@@ -980,6 +1019,15 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "anstream"
@@ -1099,7 +1147,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -1116,7 +1164,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -1136,7 +1184,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -1157,7 +1205,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "zeroize",
@@ -1199,7 +1247,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1211,7 +1259,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1224,7 +1272,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1257,7 +1305,7 @@ dependencies = [
  "ark-relations",
  "ark-std 0.5.0",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "tracing",
@@ -1293,7 +1341,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1306,7 +1354,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1385,6 +1433,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-scoped"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4042078ea593edffc452eef14e99fdb2b120caa4ad9618bcdeabc4a023b98740"
+dependencies = [
+ "futures",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1488,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,6 +1530,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,23 +1595,382 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "1.104.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41ae6a33da941457e89075ef8ca5b4870c8009fe4dceeba82fce2f30f313ac6"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.10.9",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version 0.4.1",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1514,7 +1983,28 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1528,8 +2018,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1540,6 +2030,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +2051,22 @@ checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
  "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "serde",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1584,6 +2104,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +2142,26 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1623,7 +2173,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1688,6 +2238,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,7 +2278,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1717,7 +2287,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1726,7 +2296,20 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
+dependencies = [
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1758,7 +2341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1821,6 +2404,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -1835,6 +2432,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
 ]
 
 [[package]]
@@ -1874,6 +2481,15 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
@@ -1884,12 +2500,26 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.9",
+ "semver 1.0.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.2",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2135,7 +2765,7 @@ dependencies = [
  "bs58",
  "const-hex",
  "digest 0.10.7",
- "generic-array",
+ "generic-array 0.14.7",
  "ripemd",
  "serde",
  "sha2 0.10.9",
@@ -2236,7 +2866,7 @@ version = "2026.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19c4e1e7a838cff536ffbe38f441c555eee99322d755aed3e06af9407c127fd3"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2274,7 +2904,7 @@ version = "2026.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06938675df074ca7749a6d531c4706bcc339e842105e73b03a76d45bd860b349"
 dependencies = [
- "axum",
+ "axum 0.8.8",
  "bytes",
  "cfg-if",
  "commonware-codec",
@@ -2288,7 +2918,7 @@ dependencies = [
  "getrandom 0.2.17",
  "governor",
  "libc",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pin-project",
@@ -2318,7 +2948,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "hashbrown 0.16.1",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-rational",
  "num-traits",
@@ -2371,6 +3001,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d72c1252426a83be2092dd5884a5f6e3b8e7180f6891b6263d2c21b92ec8816"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2488,7 +3131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2538,6 +3181,19 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -2590,7 +3246,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
@@ -2621,7 +3277,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2633,7 +3289,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2783,6 +3439,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashu"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b3e5ac1e23ff1995ef05b912e2b012a8784506987a2651552db2c73fb3d7e0"
+dependencies = [
+ "dashu-base",
+ "dashu-float",
+ "dashu-int",
+ "dashu-macros",
+ "dashu-ratio",
+ "rustversion",
+]
+
+[[package]]
+name = "dashu-base"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b80bf6b85aa68c58ffea2ddb040109943049ce3fbdf4385d0380aef08ef289"
+
+[[package]]
+name = "dashu-float"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85078445a8dbd2e1bd21f04a816f352db8d333643f0c9b78ca7c3d1df71063e7"
+dependencies = [
+ "dashu-base",
+ "dashu-int",
+ "num-modular",
+ "num-order",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
+name = "dashu-int"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee99d08031ca34a4d044efbbb21dff9b8c54bb9d8c82a189187c0651ffdb9fbf"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "num-order",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
+name = "dashu-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93381c3ef6366766f6e9ed9cf09e4ef9dec69499baf04f0c60e70d653cf0ab10"
+dependencies = [
+ "dashu-base",
+ "dashu-float",
+ "dashu-int",
+ "dashu-ratio",
+ "paste",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+]
+
+[[package]]
+name = "dashu-ratio"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e33b04dd7ce1ccf8a02a69d3419e354f2bbfdf4eb911a0b7465487248764c9"
+dependencies = [
+ "dashu-base",
+ "dashu-float",
+ "dashu-int",
+ "num-modular",
+ "num-order",
+ "rustversion",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +3549,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
+name = "deepsize2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b5184084af9beed35eecbf4c36baf6e26b9dc47b61b74e02f930c72a58e71b"
+dependencies = [
+ "deepsize_derive2",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "deepsize_derive2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f8817865cacf3b93b943ca06b0fc5fd8e99eabfdb7ea5d296efcbc4afc4f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "delay_map"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,6 +3587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -2911,11 +3667,31 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2944,7 +3720,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -2960,6 +3736,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,6 +3752,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3040,6 +3837,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "downloader"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3873,33 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "dynasm"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7d4c414c94bc830797115b8e5f434d58e7e80cb42ba88508c14bc6ea270625"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602f7458a3859195fb840e6e0cce5f4330dd9dfbfece0edaf31fe427af346f55"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
+]
 
 [[package]]
 name = "ecdsa"
@@ -3133,6 +3977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "elf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,10 +3991,11 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
+ "ff 0.13.1",
+ "generic-array 0.14.7",
+ "group 0.13.0",
  "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -3152,6 +4003,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enr"
@@ -3180,6 +4037,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3300,6 +4178,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,12 +4238,41 @@ dependencies = [
 
 [[package]]
 name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "bitvec",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
+ "byteorder",
+ "ff_derive",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
+dependencies = [
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3423,6 +4341,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -3587,6 +4511,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
+name = "gen_ops"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304de19db7028420975a296ab0fcbbc8e69438c4ed254a1e41e2a7f37d5f0e0a"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,6 +4531,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96512db27971c2c3eece70a1e106fbe6c87760234e31e8f7e5634912fe52794a"
+dependencies = [
+ "serde",
+ "typenum",
 ]
 
 [[package]]
@@ -3648,6 +4594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "git2"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3676,7 +4628,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 1.4.0",
  "js-sys",
  "pin-project",
  "serde",
@@ -3737,13 +4689,44 @@ dependencies = [
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "memuse",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -3757,7 +4740,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -3774,6 +4757,29 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "halo2"
+version = "0.1.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
+dependencies = [
+ "halo2_proofs",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pasta_curves 0.4.1",
+ "rand_core 0.6.4",
+ "rayon",
 ]
 
 [[package]]
@@ -3801,6 +4807,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -3941,6 +4949,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -3951,12 +4970,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -3967,8 +4997,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4014,6 +5044,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -4022,9 +5076,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4037,19 +5091,36 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4058,7 +5129,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4075,9 +5146,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4306,6 +5377,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4341,7 +5425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -4355,6 +5439,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4411,6 +5504,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -4533,16 +5635,16 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http",
+ "http 1.4.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier 0.5.3",
  "soketto",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tracing",
  "url",
@@ -4558,20 +5660,20 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -4583,19 +5685,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
 dependencies = [
  "base64 0.22.1",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls",
+ "rustls 0.23.37",
  "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -4606,7 +5708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
 dependencies = [
  "heck",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4619,10 +5721,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
 dependencies = [
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4635,7 +5737,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -4645,7 +5747,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
- "http",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4660,7 +5762,7 @@ dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -4669,11 +5771,11 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
- "http",
+ "http 1.4.0",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "tower",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -4690,6 +5792,20 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "jubjub"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
+dependencies = [
+ "bitvec",
+ "bls12_381",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4762,6 +5878,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -4828,7 +5947,7 @@ version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a54ad7278b8bc5301d5ffd2a94251c004feb971feba96c971ea4063645990757"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "errno",
  "libc",
 ]
@@ -4851,7 +5970,7 @@ version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "bzip2-sys",
  "cc",
  "libc",
@@ -5029,15 +6148,40 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "memmap2"
@@ -5047,6 +6191,12 @@ checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memuse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "metrics"
@@ -5204,6 +6354,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
+name = "mti"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9563a7d5556636e74bbd8773241fbcbc5c89b9f6bfdc97b29b56e740c2c74b9"
+dependencies = [
+ "typeid_prefix",
+ "typeid_suffix",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,6 +6403,12 @@ dependencies = [
  "core2",
  "unsigned-varint",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nom"
@@ -5311,11 +6477,22 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -5365,12 +6542,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -5397,12 +6589,33 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.7.6",
  "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5411,7 +6624,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5425,6 +6638,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nybbles"
@@ -5458,6 +6677,15 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5508,7 +6736,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -5557,7 +6785,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "op-alloy-consensus",
  "serde",
  "serde_json",
@@ -5576,7 +6804,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-serde",
- "derive_more",
+ "derive_more 2.1.1",
  "ethereum_ssz 0.9.1",
  "ethereum_ssz_derive 0.9.1",
  "op-alloy-consensus",
@@ -5611,6 +6839,20 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -5631,8 +6873,8 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
- "opentelemetry",
+ "http 1.4.0",
+ "opentelemetry 0.31.0",
  "reqwest 0.12.28",
 ]
 
@@ -5642,16 +6884,16 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
- "http",
- "opentelemetry",
+ "http 1.4.0",
+ "opentelemetry 0.31.0",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.5",
  "tracing",
 ]
 
@@ -5661,10 +6903,10 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.5",
  "tonic-prost",
 ]
 
@@ -5683,13 +6925,25 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -5705,6 +6959,270 @@ dependencies = [
 ]
 
 [[package]]
+name = "p3-air"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d275c27bb81483d669709d7244ce333b51f9743af2474cdc09ba1509f5c290db"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "serde",
+]
+
+[[package]]
+name = "p3-baby-bear"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a083928c9055f2171e3cb0bb4767969e4955473e71ba61affe46d7a3c98a89"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-bn254-fr"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abf208fbfe540d6e2a6caaa2a9a345b1c8cb23ffdcdfcc6987244525d4fc821"
+dependencies = [
+ "ff 0.13.1",
+ "num-bigint 0.4.6",
+ "p3-field",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b725b453bbb35117a1abf0ddfd900b0676063d6e4231e0fa6bb0d76018d8ad"
+dependencies = [
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518695b56f450f9223bdd8994dda87916b97ebf1d1c03c956807e78522fdb333"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a1f81101bff744b7ebba7f4497e917a2c6716d6e62736e4a56e555a2d98cb7"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36459d4acb03d08097d713f336c7393990bb489ab19920d4f68658c7a5c10968"
+dependencies = [
+ "itertools 0.12.1",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "p3-util",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-fri"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2529a174a04189cfe705d756fb0e33d3c8fb06b167b521ddb877c78407f12a"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-interpolation",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-interpolation"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662049877c802155cdb4863db59899469fc3565d22d9047e1bd22d6b71f28e5"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+]
+
+[[package]]
+name = "p3-keccak-air"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169c96f8f0aaa9042872fdb6bbae0477fd1363b87c23877dbb2ec7fb46f8fcfa"
+dependencies = [
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-koala-bear"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1f52bcb6be38bdc8fa6b38b3434d4eedd511f361d4249fd798c6a5ef817b40"
+dependencies = [
+ "num-bigint 0.4.6",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e9cd136a4095a25c41a9edfdcce2dfae58ef01639317813bdbbd5b55c583"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand 0.8.5",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e524d47a49fb4265611303339c4ef970d892817b006cc330dad18afb91e411b1"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6cb8edcb276033d43769a3725570c340d2ed6f35c3cca4cddeee07718fa376"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "p3-merkle-tree"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e8bc3c224fc70d22f9556393e1482b52539e11c7b82ac6933c436fd82738f4"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-commit",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-symmetric",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a26197df2097b98ab7038d59a01e1fe1a0f545e7e04aa9436b2454b1836654f"
+dependencies = [
+ "gcd",
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "rand 0.8.5",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1d3b5202096bca57cde912fbbb9cbaedaf5ac7c42a924c7166b98709d64d21"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
+name = "p3-uni-stark"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef1cdb8285a7adb78df991852d3b66d3b25cf6ffc34f528505d1aee49bdb968"
+dependencies = [
+ "itertools 0.12.1",
+ "p3-air",
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.3.2-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5f0388aa6d935ca3a17444086120f393f0b2f0816010b5ff95998c1c4095e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,6 +7230,15 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group 0.12.1",
 ]
 
 [[package]]
@@ -5737,7 +7264,7 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5767,6 +7294,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pasta_curves"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.13.1",
+ "group 0.13.0",
+ "lazy_static",
+ "rand 0.8.5",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5793,6 +7350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5806,6 +7372,16 @@ checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -6057,11 +7633,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -6184,12 +7770,55 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6203,6 +7832,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -6246,8 +7884,8 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
- "rustls",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -6267,8 +7905,8 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
- "rustls",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6399,6 +8037,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-set-blaze"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8421b5d459262eabbe49048d362897ff3e3830b44eac6cfe341d6acb2f0f13d2"
+dependencies = [
+ "gen_ops",
+ "itertools 0.12.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6501,6 +8151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon-scan"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f87cc11a0140b4b0da0ffc889885760c61b13672d80a908920b2c0df078fa14"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6579,6 +8238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6595,27 +8260,35 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6629,18 +8302,18 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier 0.6.2",
  "serde",
@@ -6648,16 +8321,31 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.0",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -6701,7 +8389,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "derive_more",
+ "derive_more 2.1.1",
  "metrics",
  "parking_lot",
  "pin-project",
@@ -6736,7 +8424,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-ethereum-forks",
  "reth-network-peers",
  "reth-primitives-traits",
@@ -6955,7 +8643,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-transport",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "eyre",
  "futures",
  "reqwest 0.13.2",
@@ -6974,7 +8662,7 @@ version = "1.11.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
 dependencies = [
  "alloy-primitives",
- "derive_more",
+ "derive_more 2.1.1",
  "eyre",
  "metrics",
  "page_size",
@@ -6988,7 +8676,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "strum",
  "sysinfo 0.38.4",
  "tempfile",
@@ -7006,7 +8694,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "metrics",
  "modular-bitfield",
  "proptest",
@@ -7099,7 +8787,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.1.1",
  "discv5",
  "enr",
  "futures",
@@ -7264,7 +8952,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "crossbeam-channel",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "metrics",
  "moka",
@@ -7408,7 +9096,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "pin-project",
  "reth-codecs",
@@ -7439,7 +9127,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-chainspec",
  "reth-codecs-derive",
  "reth-ethereum-primitives",
@@ -7553,7 +9241,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -7619,7 +9307,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-util",
  "metrics",
  "rayon",
@@ -7694,7 +9382,7 @@ dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
@@ -7809,7 +9497,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -7822,7 +9510,7 @@ dependencies = [
  "byteorder",
  "crossbeam-queue",
  "dashmap",
- "derive_more",
+ "derive_more 2.1.1",
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
@@ -7835,7 +9523,7 @@ name = "reth-mdbx-sys"
 version = "1.11.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "cc",
 ]
 
@@ -7885,7 +9573,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "discv5",
  "enr",
  "futures",
@@ -7919,7 +9607,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -7941,7 +9629,7 @@ dependencies = [
  "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "enr",
  "futures",
  "reth-eth-wire-types",
@@ -7965,7 +9653,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "parking_lot",
  "reth-consensus",
@@ -8015,7 +9703,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f
 dependencies = [
  "anyhow",
  "bincode",
- "derive_more",
+ "derive_more 2.1.1",
  "lz4_flex",
  "memmap2",
  "reth-fs-util",
@@ -8127,7 +9815,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
- "derive_more",
+ "derive_more 2.1.1",
  "dirs-next",
  "eyre",
  "futures",
@@ -8243,7 +9931,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "humantime",
  "pin-project",
@@ -8265,7 +9953,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f
 dependencies = [
  "bytes",
  "eyre",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "jsonrpsee-server",
  "metrics",
@@ -8278,7 +9966,7 @@ dependencies = [
  "reth-tasks",
  "tikv-jemalloc-ctl",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -8379,7 +10067,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "dashmap",
- "derive_more",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
  "proptest",
@@ -8464,7 +10152,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-tokio-util",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8477,7 +10165,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f
 dependencies = [
  "alloy-primitives",
  "arbitrary",
- "derive_more",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "reth-codecs",
  "serde",
@@ -8527,7 +10215,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
- "derive_more",
+ "derive_more 2.1.1",
  "dyn-clone",
  "futures",
  "itertools 0.14.0",
@@ -8616,7 +10304,7 @@ dependencies = [
  "alloy-network",
  "alloy-provider",
  "dyn-clone",
- "http",
+ "http 1.4.0",
  "jsonrpsee",
  "metrics",
  "pin-project",
@@ -8646,7 +10334,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -8760,7 +10448,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "itertools 0.14.0",
  "jsonrpsee-core",
@@ -8800,10 +10488,10 @@ version = "1.11.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
 dependencies = [
  "alloy-rpc-types-engine",
- "http",
+ "http 1.4.0",
  "jsonrpsee-http-client",
  "pin-project",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -8945,7 +10633,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f
 dependencies = [
  "alloy-primitives",
  "clap",
- "derive_more",
+ "derive_more 2.1.1",
  "fixed-map",
  "reth-stages-types",
  "serde",
@@ -8985,7 +10673,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-codecs",
  "reth-primitives-traits",
  "reth-prune-types",
@@ -9066,7 +10754,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f
 dependencies = [
  "clap",
  "eyre",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -9109,7 +10797,7 @@ dependencies = [
  "revm",
  "revm-interpreter",
  "revm-primitives",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "schnellru",
  "serde",
  "serde_json",
@@ -9160,7 +10848,7 @@ dependencies = [
  "arbitrary",
  "arrayvec",
  "bytes",
- "derive_more",
+ "derive_more 2.1.1",
  "hash-db",
  "itertools 0.14.0",
  "nybbles",
@@ -9201,7 +10889,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
- "derive_more",
+ "derive_more 2.1.1",
  "itertools 0.14.0",
  "metrics",
  "rayon",
@@ -9439,7 +11127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
- "num_enum",
+ "num_enum 0.7.6",
  "once_cell",
  "serde",
 ]
@@ -9570,6 +11258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
+name = "rrs-succinct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd079cd303257a4cb4e5aadfa79a7fe23f3c8301aa4740ccc3a99673485a352"
+dependencies = [
+ "downcast-rs",
+ "num_enum 0.5.11",
+ "paste",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9583,7 +11282,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -9603,6 +11302,18 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -9652,6 +11363,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -9661,7 +11384,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -9676,6 +11399,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -9699,10 +11431,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -9720,10 +11452,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
@@ -9735,6 +11467,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -9779,6 +11521,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "cfg-if",
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
 ]
 
 [[package]]
@@ -9838,6 +11613,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9845,7 +11636,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "serdect",
  "subtle",
@@ -9967,6 +11758,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_arrays"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10074,6 +11874,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10083,6 +11909,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -10196,7 +12028,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "thiserror 2.0.18",
  "time",
@@ -10219,6 +12051,442 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slop-air"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "242539aba9e5424923d7bd629775570c7d10ec28584e96ea599575a51bedcde8"
+dependencies = [
+ "p3-air",
+]
+
+[[package]]
+name = "slop-algebra"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+dependencies = [
+ "itertools 0.14.0",
+ "p3-field",
+ "serde",
+]
+
+[[package]]
+name = "slop-alloc"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58b7800cba9b31377f9353174d13fd8e39608b6f1d1531f0e92b8ce4af49ae0"
+dependencies = [
+ "serde",
+ "slop-algebra",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-baby-bear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949e3c822532a87b4ad04f7280283c256621b0a83aee1b40cbd721df29df641d"
+dependencies = [
+ "lazy_static",
+ "p3-baby-bear",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-basefold"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58984f92091a668a006b6895487079d99209e599b02d636f061fe4ae26977fb5"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-primitives",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-basefold-prover"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86eb8581b52f97860242fe5e8d6b49d2a37e1b38d4a647adf24acaa2965ee7d"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-fri",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-bn254"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+dependencies = [
+ "ff 0.13.1",
+ "p3-bn254-fr",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-challenger"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+dependencies = [
+ "futures",
+ "p3-challenger",
+ "serde",
+ "slop-algebra",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-commit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584339690d20fb6b34b0dc957cbd267221ba2ab7b0c1292c118378f3498979c4"
+dependencies = [
+ "p3-commit",
+ "serde",
+ "slop-alloc",
+]
+
+[[package]]
+name = "slop-dft"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148281e1611ca570d016a733aac2f3ec9867241cc800a96d15bc6ecfd010daf7"
+dependencies = [
+ "p3-dft",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-fri"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0857a346ea28496ee56b1dcad192db8c7ff0455a18bfd67ce6513323b594b746"
+dependencies = [
+ "p3-fri",
+]
+
+[[package]]
+name = "slop-futures"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbfea5447d243572da7aae8d5e57856229a97fb8bc6a42439d4c5f4de951ee0"
+dependencies = [
+ "crossbeam",
+ "futures",
+ "pin-project",
+ "rayon",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "slop-jagged"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc420430b93d38e9aae903bc4bc11c342f8d49d015cca26eeb36a6ea3f7a0f1f"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "slop-keccak-air"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288abf40d9901f79e221ece87f11324826289bf5d694fde07dd785bdb4afda38"
+dependencies = [
+ "p3-keccak-air",
+]
+
+[[package]]
+name = "slop-koala-bear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+dependencies = [
+ "lazy_static",
+ "p3-koala-bear",
+ "serde",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-poseidon2",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "slop-matrix"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1117c395388bd172826115ac4f9a7e09bf9c937ceafa82194132a058e27c0d"
+dependencies = [
+ "p3-matrix",
+]
+
+[[package]]
+name = "slop-maybe-rayon"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81316cfe721c3f47cd0af63002a8b6557c951ff9588fa7db0f4f3b99af091486"
+dependencies = [
+ "p3-maybe-rayon",
+]
+
+[[package]]
+name = "slop-merkle-tree"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e700652778c15320f6269362103b87a3787a7c9d70fb05d9742dbce66c46f764"
+dependencies = [
+ "derive-where",
+ "ff 0.13.1",
+ "itertools 0.14.0",
+ "p3-merkle-tree",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "slop-tensor",
+ "thiserror 1.0.69",
+ "zkhash",
+]
+
+[[package]]
+name = "slop-multilinear"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6151db452ace0d960314f46c61a2b8d45e1fa4dfd5830447c67fc1e1e1e823b5"
+dependencies = [
+ "derive-where",
+ "futures",
+ "num_cpus",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-matrix",
+ "slop-tensor",
+]
+
+[[package]]
+name = "slop-poseidon2"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+dependencies = [
+ "p3-poseidon2",
+]
+
+[[package]]
+name = "slop-primitives"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+dependencies = [
+ "slop-algebra",
+]
+
+[[package]]
+name = "slop-stacked"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c9fb9c908a2d10037934e2c299d30f98a2146f6ded87a7b529b05ddbfda27"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-tensor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-sumcheck"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c691f34c05e933777059a10804e00f77834b927abc2701f5f394e9c2b49c1c"
+dependencies = [
+ "futures",
+ "itertools 0.14.0",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-challenger",
+ "slop-multilinear",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "slop-symmetric"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+dependencies = [
+ "p3-symmetric",
+]
+
+[[package]]
+name = "slop-tensor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1796e5ff7dcdcd2c15f423a27550a4688e25009bd5ca648d9593d66f243950d6"
+dependencies = [
+ "arrayvec",
+ "derive-where",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-futures",
+ "slop-matrix",
+ "thiserror 1.0.69",
+ "transpose",
+]
+
+[[package]]
+name = "slop-uni-stark"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504f32330985e48a6aa9c9e0985641a4dc084d3843ff59075591b24b818f2a67"
+dependencies = [
+ "p3-uni-stark",
+]
+
+[[package]]
+name = "slop-utils"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba510663661800990c1207ddbf3a1e67a551f05d882a60197adbb19c6824754f"
+dependencies = [
+ "p3-util",
+ "tracing-forest",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "slop-whir"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71f6a16450fc701450831121810da91c6ee3ac50e4705327dcd4957b046015a"
+dependencies = [
+ "derive-where",
+ "futures",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-baby-bear",
+ "slop-basefold",
+ "slop-challenger",
+ "slop-commit",
+ "slop-dft",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-tensor",
+ "slop-utils",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "slotmap"
@@ -10244,6 +12512,16 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snowbridge-amcl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460a9ed63cdf03c1b9847e8a12a5f5ba19c4efd5869e4a737e05be25d7c427e5"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
 
 [[package]]
 name = "socket2"
@@ -10274,12 +12552,566 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
  "sha1",
 ]
+
+[[package]]
+name = "sp1-build"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fe5854ea3054c20b34fe85b08437583174e8cd71e612fcfef67ea841daea14"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.18.1",
+ "chrono",
+ "clap",
+ "dirs",
+ "sp1-primitives",
+]
+
+[[package]]
+name = "sp1-core-executor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc9268de48a534ccb82287a517c0a07ee594136bc9fce6c7eb438c69e7917be"
+dependencies = [
+ "bincode",
+ "bytemuck",
+ "cfg-if",
+ "clap",
+ "deepsize2",
+ "elf",
+ "enum-map",
+ "eyre",
+ "hashbrown 0.14.5",
+ "hex",
+ "itertools 0.14.0",
+ "memmap2",
+ "num",
+ "rrs-succinct",
+ "serde",
+ "serde_arrays",
+ "serde_json",
+ "slop-air",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-symmetric",
+ "sp1-curves",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives",
+ "strum",
+ "subenum",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tracing",
+ "typenum",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-core-machine"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d436300d3052341854e58c88a9b5444a6f45689ee8933f9bec047ac367693182"
+dependencies = [
+ "bincode",
+ "cfg-if",
+ "enum-map",
+ "futures",
+ "generic-array 1.1.0",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "num",
+ "num_cpus",
+ "rayon",
+ "rayon-scan",
+ "rrs-succinct",
+ "serde",
+ "serde_json",
+ "slop-air",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-futures",
+ "slop-keccak-air",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-uni-stark",
+ "snowbridge-amcl",
+ "sp1-core-executor",
+ "sp1-curves",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives",
+ "static_assertions",
+ "strum",
+ "sysinfo 0.30.13",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-forest",
+ "tracing-subscriber 0.3.23",
+ "typenum",
+]
+
+[[package]]
+name = "sp1-cuda"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a03bb846daaabe6e94af5e5199aa110b42c68482d6380b7e765d9d6b65119d52"
+dependencies = [
+ "bincode",
+ "bytes",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-primitives",
+ "sp1-prover",
+ "sp1-prover-types",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-curves"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3ad4fc0f5ea7286fbe5c788d97125dc0cb40eb81f15becb432a65f350cd2f9"
+dependencies = [
+ "cfg-if",
+ "dashu",
+ "elliptic-curve",
+ "generic-array 1.1.0",
+ "itertools 0.14.0",
+ "k256",
+ "num",
+ "p256",
+ "serde",
+ "slop-algebra",
+ "snowbridge-amcl",
+ "sp1-primitives",
+ "typenum",
+]
+
+[[package]]
+name = "sp1-derive"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f111a90749619066fbd7ba102b22375bc6c824abb66804c3184ba0f650d017a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sp1-hypercube"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff340db83b2c38b01f022624b8b792c38f201417581d6855dbe9a445d2485f"
+dependencies = [
+ "arrayref",
+ "deepsize2",
+ "derive-where",
+ "futures",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "rayon-scan",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-futures",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-poseidon2",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-uni-stark",
+ "slop-whir",
+ "sp1-derive",
+ "sp1-primitives",
+ "strum",
+ "thiserror 1.0.69",
+ "thousands",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-jit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcadaa9206d36ae953c1b4390373879281ef1423115aa180e7ef0e82259d92aa"
+dependencies = [
+ "dynasmrt",
+ "hashbrown 0.14.5",
+ "memfd",
+ "memmap2",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-primitives"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
+dependencies = [
+ "bincode",
+ "blake3",
+ "elf",
+ "hex",
+ "itertools 0.14.0",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "serde",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-koala-bear",
+ "slop-poseidon2",
+ "slop-primitives",
+ "slop-symmetric",
+]
+
+[[package]]
+name = "sp1-prover"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64545387a6b5ee58155d75183223a8f19961e23d76a13a49c16514896e52ff7"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "clap",
+ "dirs",
+ "downloader",
+ "either",
+ "enum-map",
+ "eyre",
+ "futures",
+ "hashbrown 0.14.5",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "lru 0.12.5",
+ "mti",
+ "num-bigint 0.4.6",
+ "opentelemetry 0.23.0",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha2 0.10.9",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-futures",
+ "slop-jagged",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-symmetric",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-jit",
+ "sp1-primitives",
+ "sp1-prover-types",
+ "sp1-recursion-circuit",
+ "sp1-recursion-compiler",
+ "sp1-recursion-executor",
+ "sp1-recursion-gnark-ffi",
+ "sp1-recursion-machine",
+ "sp1-verifier",
+ "static_assertions",
+ "sysinfo 0.30.13",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic 0.12.3",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "sp1-prover-types"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834512266314b8dd35fd52b921d62abb113c3c35b27358acdbc178b3a17ec72e"
+dependencies = [
+ "anyhow",
+ "async-scoped",
+ "bincode",
+ "chrono",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "mti",
+ "prost 0.13.5",
+ "serde",
+ "tokio",
+ "tonic 0.12.3",
+ "tonic-build",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-circuit"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "105531a782d66030eab608832e0829e4699053a6d41cd3c2c7931def9c9540fb"
+dependencies = [
+ "bincode",
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "rayon",
+ "serde",
+ "slop-air",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-basefold-prover",
+ "slop-bn254",
+ "slop-challenger",
+ "slop-commit",
+ "slop-jagged",
+ "slop-koala-bear",
+ "slop-matrix",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-symmetric",
+ "slop-tensor",
+ "slop-whir",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-compiler",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-compiler"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab98d241444285539b0d4203288fbe9887707c355e346cfb176b461524c58d"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "itertools 0.14.0",
+ "serde",
+ "slop-algebra",
+ "slop-bn254",
+ "slop-symmetric",
+ "sp1-core-machine",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "tracing",
+ "vec_map",
+]
+
+[[package]]
+name = "sp1-recursion-executor"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc69767dce218874edbef09515ccc5fb32d5e6b857a95a99944a66f6f405f5b1"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "range-set-blaze",
+ "serde",
+ "slop-algebra",
+ "slop-maybe-rayon",
+ "slop-poseidon2",
+ "slop-symmetric",
+ "smallvec",
+ "sp1-derive",
+ "sp1-hypercube",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-gnark-ffi"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f526cb636baa1ad67f1410884e7a5580b7068beee3ee88609fb39f906bab27b3"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bindgen 0.70.1",
+ "cfg-if",
+ "hex",
+ "num-bigint 0.4.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-compiler",
+ "sp1-verifier",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
+name = "sp1-recursion-machine"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ec6719240b0933289332d730be328d3a3e4f9e6ff9ee2e20ec2b4a99aeed9"
+dependencies = [
+ "itertools 0.14.0",
+ "rand 0.8.5",
+ "slop-air",
+ "slop-algebra",
+ "slop-basefold",
+ "slop-matrix",
+ "slop-maybe-rayon",
+ "slop-symmetric",
+ "sp1-derive",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "strum",
+ "tracing",
+ "zkhash",
+]
+
+[[package]]
+name = "sp1-sdk"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-aws",
+ "alloy-signer-local",
+ "anyhow",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "backoff",
+ "bincode",
+ "cfg-if",
+ "dirs",
+ "eventsource-stream",
+ "futures",
+ "hex",
+ "indicatif",
+ "itertools 0.14.0",
+ "k256",
+ "num-bigint 0.4.6",
+ "prost 0.13.5",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "rustls 0.23.37",
+ "serde",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-alloc",
+ "slop-basefold",
+ "slop-commit",
+ "slop-jagged",
+ "slop-merkle-tree",
+ "slop-multilinear",
+ "slop-stacked",
+ "slop-sumcheck",
+ "slop-tensor",
+ "sp1-build",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-cuda",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-prover",
+ "sp1-prover-types",
+ "sp1-recursion-executor",
+ "sp1-recursion-gnark-ffi",
+ "sp1-verifier",
+ "strum",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic 0.12.3",
+ "tracing",
+ "twirp-rs",
+ "zstd",
+]
+
+[[package]]
+name = "sp1-verifier"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11dd15bf0dc2325ced1f3bb58bfed84efc5228a09127ab6787ee5103514f09e"
+dependencies = [
+ "bincode",
+ "blake3",
+ "cfg-if",
+ "dirs",
+ "hex",
+ "lazy_static",
+ "serde",
+ "sha2 0.10.9",
+ "slop-algebra",
+ "slop-challenger",
+ "slop-primitives",
+ "slop-symmetric",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-recursion-executor",
+ "sp1-recursion-machine",
+ "strum",
+ "substrate-bn-succinct-rs",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spin"
@@ -10319,6 +13151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10343,6 +13181,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "subenum"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3d08fe7078c57309d5c3d938e50eba95ba1d33b9c3a101a8465fc6861a5416"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "substrate-bn-succinct-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a241fd7c1016fb8ad30fcf5a20986c0c4538e8f15a1b41a1761516299e377ec1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -10409,6 +13275,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -10492,7 +13373,7 @@ dependencies = [
  "alloy-transport",
  "async-trait",
  "dashmap",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "reth-evm",
  "reth-primitives-traits",
@@ -10566,7 +13447,7 @@ dependencies = [
  "alloy-rlp",
  "commonware-codec",
  "commonware-cryptography",
- "derive_more",
+ "derive_more 2.1.1",
  "rayon",
  "reth-chainspec",
  "reth-consensus",
@@ -10679,7 +13560,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-ethereum-engine-primitives",
  "reth-node-api",
  "reth-payload-primitives",
@@ -10697,7 +13578,7 @@ dependencies = [
  "alloy-evm",
  "commonware-codec",
  "commonware-cryptography",
- "derive_more",
+ "derive_more 2.1.1",
  "revm",
  "scoped-tls",
  "tempo-chainspec",
@@ -10731,7 +13612,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "base64 0.22.1",
- "derive_more",
+ "derive_more 2.1.1",
  "modular-bitfield",
  "once_cell",
  "p256",
@@ -10757,7 +13638,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
- "derive_more",
+ "derive_more 2.1.1",
  "reth-evm",
  "reth-rpc-eth-types",
  "reth-storage-api",
@@ -10819,7 +13700,7 @@ dependencies = [
  "k256",
  "rand 0.8.5",
  "reth-evm",
- "rustls",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "tempo-alloy",
@@ -10839,6 +13720,7 @@ name = "tempo-zone"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-provider",
  "alloy-signer-local",
  "clap",
  "const-hex",
@@ -10848,7 +13730,8 @@ dependencies = [
  "reth-consensus",
  "reth-ethereum",
  "reth-tracing",
- "rustls",
+ "rustls 0.23.37",
+ "tempo-alloy",
  "tempo-chainspec",
  "tokio",
  "tracing",
@@ -10895,6 +13778,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread-priority"
@@ -10993,6 +13882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11057,11 +13955,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -11085,11 +13993,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -11121,8 +14029,14 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -11144,6 +14058,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
@@ -11151,7 +14076,7 @@ dependencies = [
  "indexmap 2.13.0",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -11160,7 +14085,7 @@ version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -11171,6 +14096,40 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
@@ -11178,10 +14137,10 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -11189,10 +14148,24 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11202,8 +14175,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.5",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -11238,8 +14231,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -11250,7 +14243,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -11315,6 +14308,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-forest"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
+dependencies = [
+ "ansi_term",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11365,7 +14371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -11431,6 +14437,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "tree_hash"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11479,11 +14495,11 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -11491,10 +14507,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "twirp-rs"
+version = "0.13.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27dfcc06b8d9262bc2d4b8d1847c56af9971a52dd8a0076876de9db763227d0d"
+dependencies = [
+ "async-trait",
+ "axum 0.7.9",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "prost 0.13.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower 0.5.3",
+ "url",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typeid_prefix"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9da1387307fdee46aa441e4f08a1b491e659fcac1aca9cd71f2c624a0de5d1b"
+
+[[package]]
+name = "typeid_suffix"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b55e96f110c6db5d1a2f24072552537f0091dc90cebeaa679540bac93e7405"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "typenum"
@@ -11621,6 +14674,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11644,8 +14703,11 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "md-5",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -11662,13 +14724,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "vergen"
 version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
@@ -11718,6 +14789,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -11854,6 +14931,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -11986,6 +15076,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -12025,6 +15125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12482,6 +15591,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
@@ -12644,6 +15762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12767,6 +15891,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "zkhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+ "bitvec",
+ "blake2",
+ "bls12_381",
+ "byteorder",
+ "cfg-if",
+ "group 0.12.1",
+ "group 0.13.0",
+ "halo2",
+ "hex",
+ "jubjub",
+ "lazy_static",
+ "pasta_curves 0.5.1",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "sha3",
+ "subtle",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12792,9 +15943,11 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "alloy-transport",
+ "alloy-trie",
+ "async-trait",
  "base64 0.22.1",
  "const-hex",
- "derive_more",
+ "derive_more 2.1.1",
  "either",
  "eyre",
  "futures",
@@ -12827,10 +15980,12 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-common",
  "revm",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sp1-sdk",
  "tempo-alloy",
  "tempo-chainspec",
  "tempo-consensus",
@@ -12850,6 +16005,8 @@ dependencies = [
  "zone-precompiles",
  "zone-primitives",
  "zone-rpc",
+ "zone-stf",
+ "zone-test-utils",
 ]
 
 [[package]]
@@ -12903,7 +16060,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
- "axum",
+ "axum 0.8.8",
  "base64 0.22.1",
  "eyre",
  "futures",
@@ -12948,6 +16105,27 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "zone-stf",
+ "zone-test-utils",
+]
+
+[[package]]
+name = "zone-test-utils"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+ "const-hex",
+ "revm",
+ "serde",
+ "serde_json",
+ "tempo-chainspec",
+ "tempo-evm",
+ "tempo-primitives",
+ "tempo-revm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/tempo-zone",
   "crates/rpc",
   "crates/zone-stf",
+  "crates/zone-test-utils",
   "xtask",
 ]
 
@@ -102,6 +103,7 @@ zone-precompiles = { path = "crates/precompiles", default-features = false }
 zone-primitives = { path = "crates/primitives", default-features = false }
 zone-stf = { path = "crates/zone-stf" }
 zone-rpc = { path = "crates/rpc" }
+zone-test-utils = { path = "crates/zone-test-utils" }
 
 # reth
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
@@ -164,6 +166,7 @@ commonware-utils = "2026.2.0"
 
 # misc
 aes-gcm = "0.10.3"
+async-trait = "0.1.89"
 base64 = "0.22.1"
 clap = { version = "4.5.45", features = ["derive"] }
 const-hex = { version = "1.15.0" }

--- a/bin/tempo-zone/Cargo.toml
+++ b/bin/tempo-zone/Cargo.toml
@@ -26,8 +26,11 @@ reth-tracing.workspace = true
 
 # alloy
 alloy-primitives.workspace = true
+alloy-provider.workspace = true
 alloy-signer-local.workspace = true
 
+# tempo (networking)
+tempo-alloy = { workspace = true }
 # tls
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 
@@ -47,3 +50,4 @@ path = "src/main.rs"
 default = ["jemalloc"]
 
 jemalloc = ["reth-cli-util/jemalloc", "reth-ethereum/jemalloc"]
+succinct-prover = ["zone/succinct-prover"]

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -8,15 +8,18 @@
 
 use std::{sync::Arc, time::Duration};
 
+use alloy_provider::Provider;
+
 use alloy_primitives::Address;
 use clap::Parser;
+use eyre as _;
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
 
 use reth_ethereum::chainspec::EthChainSpec;
 use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
-use zone::{ZoneNode, evm::ZoneEvmConfig};
+use zone::{ProofGenerator, ZoneNode, evm::ZoneEvmConfig};
 use zone_primitives::constants::zone_chain_id;
 
 type ZoneCli = Cli<TempoChainSpecParser, ZoneArgs>;
@@ -114,6 +117,30 @@ struct ZoneArgs {
         default_value_t = 8544
     )]
     pub private_rpc_port: u16,
+
+    /// Batch proof backend implementation.
+    #[arg(
+        long = "prover.backend",
+        env = "ZONE_PROVER_BACKEND",
+        value_enum,
+        default_value_t = ProverBackend::Soft
+    )]
+    pub prover_backend: ProverBackend,
+
+    /// Skip local SP1 simulation before dispatching to the Succinct prover network.
+    #[arg(
+        long = "prover.succinct.skip-simulation",
+        env = "ZONE_PROVER_SUCCINCT_SKIP_SIMULATION",
+        default_value_t = false
+    )]
+    pub prover_succinct_skip_simulation: bool,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum, Default)]
+enum ProverBackend {
+    #[default]
+    Soft,
+    Succinct,
 }
 
 fn prepend_log_filter(filter: &mut String, directives: &str) {
@@ -175,7 +202,6 @@ fn main() {
                     .expect("invalid sequencer key hex");
                 k256::SecretKey::from_slice(&bytes).expect("invalid secp256k1 secret key")
             };
-
             let node = ZoneNode::new(
                 args.l1_rpc_url.clone(),
                 args.portal_address,
@@ -185,6 +211,7 @@ fn main() {
                 args.l1_fetch_concurrency,
                 Duration::from_millis(args.l1_retry_connection_interval_ms),
             );
+            let witness_store = node.witness_store();
 
             let handle = builder.node(node).launch_with_debug_capabilities().await?;
             info!(target: "reth::cli", "Tempo Zone node started");
@@ -238,6 +265,51 @@ fn main() {
                 "Starting sequencer background tasks"
             );
 
+            // Create a read-only L1 provider for the proof generator
+            // (separate from the walletted provider used for batch submission).
+            let l1_proof_provider = alloy_provider::ProviderBuilder::new_with_network::<
+                tempo_alloy::TempoNetwork,
+            >()
+            .connect(&args.l1_rpc_url)
+            .await
+            .expect("valid L1 RPC URL for proof generator")
+            .erased();
+
+            let proof_generator: Arc<dyn zone::BatchProofGenerator> = match args.prover_backend {
+                ProverBackend::Soft => Arc::new(ProofGenerator::new(
+                    handle.node.provider().clone(),
+                    witness_store.clone(),
+                    l1_proof_provider,
+                    sequencer_addr,
+                )),
+                ProverBackend::Succinct => {
+                    #[cfg(feature = "succinct-prover")]
+                    {
+                        info!(
+                            target: "reth::cli",
+                            "Using Succinct (SP1 prover network) batch proof backend"
+                        );
+                        Arc::new(zone::proof::SuccinctBatchProofGenerator::new(
+                            handle.node.provider().clone(),
+                            witness_store.clone(),
+                            l1_proof_provider,
+                            sequencer_addr,
+                            zone::proof::SuccinctNetworkProverConfig {
+                                skip_simulation: args.prover_succinct_skip_simulation,
+                            },
+                        ).await?)
+                    }
+                    #[cfg(not(feature = "succinct-prover"))]
+                    {
+                        return Err(eyre::eyre!(
+                            "prover backend 'succinct' requested, but this binary was built \
+                             without the 'succinct-prover' feature"
+                        ));
+                    }
+                }
+            };
+
+
             let sequencer_config = zone::ZoneSequencerConfig {
                 portal_address: args.portal_address,
                 l1_rpc_url: args.l1_rpc_url,
@@ -255,7 +327,9 @@ fn main() {
                 batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
             };
 
-            let seq_handle = zone::spawn_zone_sequencer(sequencer_config, sequencer_signer).await;
+            let seq_handle =
+                zone::spawn_zone_sequencer(sequencer_config, sequencer_signer, proof_generator)
+                    .await;
 
             info!(
                 target: "reth::cli",

--- a/crates/tempo-zone/ARCHITECTURE.md
+++ b/crates/tempo-zone/ARCHITECTURE.md
@@ -1,0 +1,127 @@
+# Tempo Zone Node Architecture
+
+## Overview
+
+The zone node is a lightweight L2 built on reth that executes zone blocks driven by Tempo L1 events. It bridges deposits from L1, executes user transactions, and submits batch proofs back to L1.
+
+## Data Flow
+
+```
+                            Tempo L1
+                   ┌─────────────────────────┐
+                   │       ZonePortal         │
+                   │  deposit() submitBatch() │
+                   │  processWithdrawal()     │
+                   └──┬──────────┬────────┬───┘
+                      │          │        │
+              WS subscribe   submitBatch  processWithdrawal
+              + getLogs      (sequencer)  (sequencer)
+                      │          ▲        ▲
+                      ▼          │        │
+               ┌──────────┐     │   ┌────────────────────┐
+               │L1Subscriber│    │   │WithdrawalProcessor │
+               │(critical) │    │   │(sequencer only)    │
+               └─────┬─────┘    │   └──────────▲─────────┘
+                     │          │              │ notify
+                     ▼          │              │
+              ┌────────────┐    │    ┌─────────┴──────────┐
+              │DepositQueue│    │    │  SharedWithdrawal   │
+              │(Arc<Mutex>)│    │    │  Store              │
+              └─────┬──────┘    │    └──────────▲──────────┘
+                    │ notify    │               │
+                    ▼           │               │
+              ┌──────────┐     │     ┌─────────┴──────────┐
+              │ZoneEngine│     │     │   ZoneMonitor       │
+              │(critical)│     │     │  - poll Zone L2     │
+              └────┬─────┘     │     │  - collect events   │
+                   │ FCU       │     │  - build BatchData  │
+                   ▼           │     └──────────▲──────────┘
+         ┌──────────────────┐  │                │
+         │ZonePayloadBuilder│  │     ┌──────────┴──────────┐
+         │ - advanceTempo   │  │     │  ProofGenerator      │
+         │ - pool txs       │  │     │  - merge accesses    │
+         │ - finalizeWdBatch│  │     │  - local MPT proofs  │
+         │ - RecordingDB    │  │     │  - L1 eth_getProof   │
+         └───────┬──────────┘  │     │  - assemble witness  │
+                 │             │     │  - prove_zone_batch() │
+                 ▼             │     └──────────▲──────────┘
+         ┌──────────────────┐  │                │
+         │SharedWitnessStore│──┼────────────────┘
+         │(Arc<Mutex>)      │  │     take_range + prune
+         └──────────────────┘  │
+                               │
+                     ┌─────────┴─────────┐
+                     │  BatchSubmitter    │
+                     │  ZonePortal.      │
+                     │  submitBatch()    │
+                     └───────────────────┘
+```
+
+## Task Boundaries
+
+| Task | Type | Description |
+|---|---|---|
+| `l1-deposit-subscriber` | `spawn_critical` | WS subscription to L1, populates DepositQueue |
+| `zone-engine` | `spawn_critical` | Drives block production via FCU |
+| `l1-state-listener` | `spawn_critical` | Caches L1 state for TempoStateReader precompile |
+| zone monitor | `tokio::spawn` | Polls L2, generates proofs, submits batches (sequencer only) |
+| withdrawal processor | `tokio::spawn` | Processes withdrawals on L1 (sequencer only) |
+
+## Witness Generation Pipeline
+
+The pipeline bridges the builder (which executes blocks) and the prover (which re-executes from proofs).
+
+### Phase 1: Recording (builder, per block)
+
+```
+ZonePayloadBuilder::try_build()
+  └─ wraps DB in RecordingDatabase
+  └─ wraps L1 provider in RecordingL1StateProvider
+  └─ executes advanceTempo + pool txs + finalizeWithdrawalBatch
+  └─ snapshots RecordedAccesses → AccessSnapshot { accounts, storage }
+  └─ snapshots RecordedL1Reads → Vec<RecordedL1Read>
+  └─ stores BuiltBlockWitness in SharedWitnessStore
+```
+
+### Phase 2: Proof Generation (ProofGenerator, per batch)
+
+```
+ProofGenerator::generate_batch_proof(from, to)
+  └─ prune_below(from) + take_range(from, to) from WitnessStore
+  └─ merge all AccessSnapshots into union
+  └─ state_by_block_hash(S₀) → StateProvider
+  └─ generate_zone_state_witness() — local trie walk, MPT proofs against S₀
+  └─ fetch_l1_proofs() — eth_getProof over RPC for Tempo L1 reads
+  └─ generate_tempo_state_proof() — deduplicate MPT nodes into pool
+  └─ assemble_witness() → BatchWitness
+  └─ prove_zone_batch() → BatchOutput
+  └─ encode_batch_output() → 192-byte soft proof
+```
+
+### Why Proofs Are Generated Against S₀
+
+The prover bootstraps a single `WitnessDatabase` from the initial zone state (S₀ — the state before any block in the batch). All blocks in the batch execute against this database. Therefore, all MPT proofs must be valid against S₀'s state root, not intermediate state roots. The builder records raw access sets (not proofs), and the `ProofGenerator` merges them into a union before generating proofs against S₀.
+
+## Sequencer vs Validator
+
+- **Sequencer** (`--sequencer.key` present): All components active — builder records witnesses, ProofGenerator proves, monitor submits batches, withdrawal processor runs.
+- **Validator** (no key): Core node only — builder still records (always-on via `ZoneEvmConfig::new_with_recording`), but no monitor/prover/submitter. WitnessStore accumulates but is never consumed.
+
+## Current Limitations (POC)
+
+1. **Single-block-per-batch**: The builder always produces exactly one block per batch. Every block includes both `advanceTempo` and `finalizeWithdrawalBatch` system transactions, and `zone_block_index` is hardcoded to 0. Multi-block batching would require: re-indexing `zone_block_index` across blocks, making `finalizeWithdrawalBatch` conditional on final-block status, and fixing user tx extraction to handle varying system tx positions.
+
+2. **Soft proof (no authentication)**: The proof is ABI-packed `BatchOutput` with no ZK or TEE attestation. The L1 verifier must accept any proof bytes.
+
+3. **Unbounded WitnessStore on validators**: Recording is always-on. On non-sequencer nodes the store grows indefinitely since no `ProofGenerator` consumes entries.
+
+4. **Sequential L1 proof fetching**: `eth_getProof` calls in `ProofGenerator` are sequential; could be parallelized.
+
+5. **No batch size cap**: The monitor processes arbitrarily large block ranges, risking memory pressure on catch-up after outages.
+
+## Error Handling
+
+- **ProofGenerator**: Returns `(empty, empty)` on any failure — batch still submitted with empty proof (POC mode).
+- **BatchSubmitter**: Retries 3x with exponential backoff (2s/4s/8s). On exhaustion, resyncs `prev_block_hash` from portal.
+- **L1Subscriber/L1StateListener**: Auto-reconnect after 5s on failure.
+- **ZoneEngine**: 100ms pause on build failure, retries on next loop iteration.

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -20,11 +20,12 @@ tempo-node.workspace = true
 tempo-payload-types.workspace = true
 tempo-primitives.workspace = true
 tempo-transaction-pool.workspace = true
-tempo-alloy.workspace = true
+tempo-alloy = { workspace = true }
 tempo-contracts.workspace = true
 tempo-precompiles.workspace = true
 zone-precompiles = { workspace = true, features = ["std"] }
 zone-primitives = { workspace = true, features = ["std", "serde", "rpc"] }
+zone-stf = { workspace = true, features = ["serde"] }
 zone-rpc.workspace = true
 
 # reth
@@ -48,6 +49,7 @@ reth-rpc-eth-types.workspace = true
 reth-storage-api.workspace = true
 reth-tasks.workspace = true
 reth-transaction-pool.workspace = true
+reth-trie-common.workspace = true
 
 # alloy
 alloy-consensus.workspace = true
@@ -68,6 +70,7 @@ alloy-transport.workspace = true
 revm.workspace = true
 
 # misc
+async-trait.workspace = true
 metrics.workspace = true
 k256.workspace = true
 url = "2"
@@ -79,6 +82,7 @@ futures.workspace = true
 parking_lot.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+sp1-sdk = { version = "6.0.1", optional = true, features = ["network"] }
 
 [dev-dependencies]
 alloy = { workspace = true, features = [
@@ -94,11 +98,13 @@ alloy-contract.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-sol-types.workspace = true
+alloy-trie = "0.9"
 base64.workspace = true
 const-hex.workspace = true
 p256.workspace = true
 rand.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "test-utils"] }
+zone-stf = { workspace = true, features = ["test-utils"] }
 reth-node-builder.workspace = true
 reth-node-core.workspace = true
 reth-rpc-builder.workspace = true
@@ -115,9 +121,11 @@ sha2.workspace = true
 tempo-precompiles = { workspace = true, features = ["test-utils"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-tungstenite.workspace = true
+zone-test-utils.workspace = true
 
 [features]
 default = []
+succinct-prover = ["dep:sp1-sdk"]
 test-utils = [
 	"reth-chainspec/test-utils",
 	"reth-ethereum/test-utils",

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -74,6 +74,10 @@ pub struct BatchData {
     pub next_processed_deposit_hash: B256,
     /// Withdrawal queue hash for this batch (`B256::ZERO` if no withdrawals).
     pub withdrawal_queue_hash: B256,
+    /// Verifier configuration bytes (empty for POC, populated when prover is active).
+    pub verifier_config: Bytes,
+    /// Proof bytes (empty for POC, populated by `zone_stf::prove_zone_batch`).
+    pub proof: Bytes,
 }
 
 /// Submits zone batches to the ZonePortal contract on Tempo L1.
@@ -130,15 +134,17 @@ impl BatchSubmitter {
     /// [`EIP2935_HISTORY_WINDOW`] — use [`classify_anchor_gap`](Self::classify_anchor_gap)
     /// first and split via stepping if the gap is too large.
     ///
-    /// `verifierConfig` and `proof` are set to empty bytes — the verifier
-    /// contract must be configured to accept empty proofs.
-    // TODO: pass real proof bytes once proof generation is implemented.
+    /// Uses the `verifier_config` and `proof` bytes from [`BatchData`].
+    /// When proof generation is enabled, these are populated by
+    /// `zone_stf::prove_zone_batch`. When disabled (POC mode), they default
+    /// to empty bytes and the verifier contract must accept empty proofs.
     #[instrument(skip_all, fields(
         portal = %self.portal_address,
         tempo_block = batch.tempo_block_number,
         prev_block_hash = %batch.prev_block_hash,
         next_block_hash = %batch.next_block_hash,
         withdrawal_queue_hash = %batch.withdrawal_queue_hash,
+        has_proof = !batch.proof.is_empty(),
     ))]
     pub async fn submit_batch(&self, batch: &BatchData) -> Result<B256> {
         if batch.tempo_block_number < self.genesis_tempo_block_number {
@@ -200,8 +206,8 @@ impl BatchSubmitter {
                 block_transition,
                 deposit_transition,
                 batch.withdrawal_queue_hash,
-                Bytes::new(),
-                Bytes::new(),
+                batch.verifier_config.clone(),
+                batch.proof.clone(),
             )
             .nonce_key(SUBMIT_BATCH_NONCE_KEY)
             .send()
@@ -452,6 +458,12 @@ impl BatchSubmitter {
     pub async fn read_portal_block_hash(&self) -> Result<B256> {
         let hash = self.portal.blockHash().call().await?;
         Ok(hash)
+    }
+
+    /// Read the current `withdrawalBatchIndex` from the ZonePortal on L1.
+    pub async fn read_portal_withdrawal_batch_index(&self) -> Result<u64> {
+        let index = self.portal.withdrawalBatchIndex().call().await?;
+        Ok(index)
     }
 
     /// Read the current withdrawal queue tail from the ZonePortal on L1.

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -46,7 +46,7 @@ use tempo_primitives::{
     transaction::envelope::{TEMPO_SYSTEM_TX_SENDER, TEMPO_SYSTEM_TX_SIGNATURE},
 };
 use tempo_transaction_pool::TempoTransactionPool;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::node::ZoneNode;
 
@@ -59,9 +59,17 @@ struct RequestedWithdrawalContext {
 }
 
 /// Factory for constructing the zone payload builder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct ZonePayloadFactory;
+pub struct ZonePayloadFactory {
+    witness_store: crate::witness::SharedWitnessStore,
+}
+
+impl ZonePayloadFactory {
+    pub fn new(witness_store: crate::witness::SharedWitnessStore) -> Self {
+        Self { witness_store }
+    }
+}
 
 impl<Node> PayloadBuilderBuilder<Node, TempoTransactionPool<Node::Provider>, ZoneEvmConfig>
     for ZonePayloadFactory
@@ -80,6 +88,7 @@ where
             pool,
             provider: ctx.provider().clone(),
             evm_config,
+            witness_store: self.witness_store,
         })
     }
 }
@@ -93,6 +102,140 @@ pub struct ZonePayloadBuilder<Provider> {
     provider: Provider,
     /// Zone-specific EVM configuration (precompiles, hardfork spec, gas params).
     evm_config: ZoneEvmConfig,
+    witness_store: crate::witness::SharedWitnessStore,
+}
+
+impl<Provider> ZonePayloadBuilder<Provider>
+where
+    Provider: StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + Clone,
+{
+    /// Snapshot recorded state accesses and store them for the zone monitor.
+    ///
+    /// The builder does NOT generate MPT proofs — that is deferred to the
+    /// monitor, which merges accesses from all blocks in the batch and
+    /// generates proofs against S₀ (the initial state root) in one shot.
+    ///
+    /// `prepared` contains the already-processed deposits and decryptions.
+    /// `header_rlp` is the RLP-encoded Tempo header used in `advanceTempo`.
+    fn store_block_witness(
+        &self,
+        parent_header: &reth_primitives_traits::SealedHeader<TempoHeader>,
+        sealed_block: &Arc<reth_primitives_traits::SealedBlock<tempo_primitives::Block>>,
+        recorded_accesses: &crate::witness::RecordedAccesses,
+        l1_reads: Vec<crate::witness::RecordedL1Read>,
+        prepared: &PreparedL1Block,
+        header_rlp: Vec<u8>,
+        finalize_withdrawal_batch_count: U256,
+    ) {
+        use alloy_consensus::BlockHeader;
+        use zone_stf::types::{
+            ChaumPedersenProof, DecryptionData, DepositType, QueuedDeposit, ZoneBlock, ZoneHeader,
+        };
+
+        let block_number = sealed_block.number();
+
+        let access_snapshot = crate::witness::AccessSnapshot {
+            accounts: recorded_accesses.accessed_accounts(),
+            storage: recorded_accesses.accessed_storage(),
+        };
+
+        // Extract user transactions by stripping system txs.
+        // Layout: [advanceTempo, ...user_txs..., finalizeWdBatch]
+        let all_txs: Vec<_> = sealed_block.body().transactions().collect();
+        let skip_front = 1; // advanceTempo is always first
+        let skip_back = 1; // finalizeWithdrawalBatch is always last
+        let user_tx_bytes: Vec<Vec<u8>> = if all_txs.len() > skip_front + skip_back {
+            all_txs[skip_front..all_txs.len() - skip_back]
+                .iter()
+                .map(|tx| alloy_rlp::encode(*tx))
+                .collect()
+        } else {
+            vec![]
+        };
+
+        let deposits: Vec<QueuedDeposit> = prepared
+            .queued_deposits
+            .iter()
+            .map(|qd| {
+                let deposit_type = match qd.depositType {
+                    abi::DepositType::Regular => DepositType::Regular,
+                    abi::DepositType::Encrypted => DepositType::Encrypted,
+                    _ => DepositType::Regular,
+                };
+                QueuedDeposit {
+                    deposit_type,
+                    deposit_data: qd.depositData.clone(),
+                }
+            })
+            .collect();
+
+        let decryptions: Vec<DecryptionData> = prepared
+            .decryptions
+            .iter()
+            .map(|d| DecryptionData {
+                shared_secret: d.sharedSecret,
+                shared_secret_y_parity: d.sharedSecretYParity,
+                to: d.to,
+                memo: d.memo,
+                cp_proof: ChaumPedersenProof {
+                    s: d.cpProof.s,
+                    c: d.cpProof.c,
+                },
+            })
+            .collect();
+
+        let zone_block = ZoneBlock {
+            number: block_number,
+            parent_hash: parent_header.hash(),
+            timestamp: sealed_block.timestamp(),
+            beneficiary: sealed_block.beneficiary(),
+            gas_limit: sealed_block.gas_limit(),
+            base_fee_per_gas: sealed_block.base_fee_per_gas().unwrap_or_default(),
+            expected_state_root: sealed_block.state_root(),
+            tempo_header_rlp: Some(header_rlp.clone()),
+            deposits,
+            decryptions,
+            finalize_withdrawal_batch_count: Some(finalize_withdrawal_batch_count),
+            transactions: user_tx_bytes,
+        };
+
+        let state_root = parent_header.state_root();
+        let prev_block_header = ZoneHeader {
+            parent_hash: parent_header.parent_hash(),
+            beneficiary: parent_header.beneficiary(),
+            state_root,
+            transactions_root: parent_header.transactions_root(),
+            receipts_root: parent_header.receipts_root(),
+            number: parent_header.number(),
+            timestamp: parent_header.timestamp(),
+        };
+
+        let chain_id = {
+            use reth_chainspec::EthChainSpec;
+            self.provider.chain_spec().chain().id()
+        };
+
+        let witness = crate::witness::BuiltBlockWitness {
+            zone_block,
+            access_snapshot: access_snapshot.clone(),
+            prev_block_header,
+            parent_block_hash: parent_header.hash(),
+            l1_reads,
+            chain_id,
+            tempo_header_rlp: Some(header_rlp),
+        };
+
+        let mut store = self.witness_store.lock().expect("witness store poisoned");
+        store.insert(block_number, witness);
+
+        info!(
+            target: "zone::witness",
+            block_number,
+            accounts = access_snapshot.accounts.len(),
+            storage_accounts = access_snapshot.storage.len(),
+            "Stored block witness data (accesses only, proof generation deferred)"
+        );
+    }
 }
 
 impl<Provider> PayloadBuilder for ZonePayloadBuilder<Provider>
@@ -187,10 +330,17 @@ where
         let state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
         let state_provider: Box<dyn StateProvider> = state_provider;
         let state = StateProviderDatabase::new(&state_provider);
+
+        // Wrap the database in a RecordingDatabase to capture all state accesses
+        // for witness generation. The `accesses` handle is cloned so we can
+        // retrieve recorded data after the State is consumed.
+        let recorded_accesses = crate::witness::RecordedAccesses::new();
+        let recording_db = crate::witness::RecordingDatabase::new(
+            Box::new(cached_reads.as_db_mut(state)) as Box<dyn Database<Error = ProviderError>>,
+            recorded_accesses.clone(),
+        );
         let mut db = State::builder()
-            .with_database(
-                Box::new(cached_reads.as_db_mut(state)) as Box<dyn Database<Error = ProviderError>>
-            )
+            .with_database(recording_db)
             .with_bundle_update()
             .build();
 
@@ -232,8 +382,26 @@ where
             PayloadBuilderError::Internal(err.into())
         })?;
 
+        // Set the L1 recording block index for this zone block.
+        // Block index is 0-based within a batch; for single-block-per-build this is always 0.
+        // TODO(multi-block): Re-index zone_block_index in ProofGenerator when
+        // merging L1 reads across blocks. Currently always 0 because the builder
+        // produces one block at a time.
+        self.evm_config.set_l1_recording_block_index(0);
+
         // Execute advanceTempo system transaction — exactly one per zone block.
+        let header_rlp = alloy_rlp::encode(&*prepared.header);
         {
+            // Log header details for debugging chain continuity
+            info!(
+                target: "zone::payload",
+                l1_block_number = prepared.header.number(),
+                l1_parent_hash = %prepared.header.parent_hash(),
+                l1_block_hash = %prepared.header.hash(),
+                header_rlp_len = header_rlp.len(),
+                "advanceTempo header details"
+            );
+
             let advance_tx = build_advance_tempo_tx(prepared);
             let mut reverted = false;
             match builder.execute_transaction_with_result_closure(advance_tx, |result| {
@@ -371,8 +539,9 @@ where
                 }
             })
             .collect::<Result<Vec<_>, _>>()?;
+        let finalize_withdrawal_count = U256::from(requested_withdrawals.len());
         let finalize_tx = build_finalize_withdrawal_batch_tx(
-            U256::from(requested_withdrawals.len()),
+            finalize_withdrawal_count,
             block_number,
             encrypted_senders,
         );
@@ -416,6 +585,17 @@ where
         let sealed_block = Arc::new(block.sealed_block().clone());
         let elapsed = start.elapsed();
 
+        // Collect recorded L1 reads from the precompile wrapper.
+        let l1_reads = self.evm_config.take_l1_reads().unwrap_or_default();
+
+        debug!(
+            target: "zone::payload",
+            accounts = recorded_accesses.accessed_accounts().len(),
+            storage_accounts = recorded_accesses.accessed_storage().len(),
+            l1_reads = l1_reads.len(),
+            "Recorded state accesses for witness generation"
+        );
+
         info!(
             number = sealed_block.number(),
             l1_block = prepared.header.number(),
@@ -426,6 +606,17 @@ where
             tx_count = sealed_block.body().transactions.len(),
             ?elapsed,
             "Built zone payload"
+        );
+
+        // Store recorded accesses for the monitor to generate proofs later.
+        self.store_block_witness(
+            &parent_header,
+            &sealed_block,
+            &recorded_accesses,
+            l1_reads,
+            prepared,
+            header_rlp,
+            finalize_withdrawal_count,
         );
 
         let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests);

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -33,29 +33,62 @@ use crate::executor::ZoneBlockExecutor;
 
 use crate::{
     abi::{TEMPO_STATE_READER_ADDRESS, ZONE_TX_CONTEXT_ADDRESS},
-    l1_state::{L1StateProvider, PolicyProvider, SharedL1StateCache, TempoStateReader},
+    l1_state::{
+        L1StateProvider, L1StorageReader, PolicyProvider, SharedL1StateCache, TempoStateReader,
+    },
     precompiles::{
         AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
         ZONE_TIP20_FACTORY_ADDRESS, ZONE_TIP403_PROXY_ADDRESS, ZoneTip20Token,
         ZoneTip403ProxyRegistry, ZoneTokenFactory,
     },
     tx_context::ZoneTxContext,
+    witness::{RecordingL1StateProvider, SharedRecordedReads},
 };
 
 type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
 
 /// Zone EVM factory — wraps [`TempoEvmFactory`] and registers the
 /// [`TempoStateReader`] precompile for reading Tempo L1 storage from zone contracts.
-#[derive(Debug, Clone)]
+///
+/// The L1 storage reader is stored as `Arc<dyn L1StorageReader>` to allow swapping
+/// in a [`RecordingL1StateProvider`](crate::witness::RecordingL1StateProvider) during
+/// witness generation without changing the factory's type.
+#[derive(Clone)]
 pub struct ZoneEvmFactory {
+    l1_reader: Arc<dyn L1StorageReader>,
     l1_provider: L1StateProvider,
     policy_provider: Option<PolicyProvider>,
 }
 
+impl std::fmt::Debug for ZoneEvmFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ZoneEvmFactory").finish()
+    }
+}
+
 impl ZoneEvmFactory {
     /// Create a new factory with the given L1 state provider.
+    ///
+    /// The `L1StateProvider` is used both as the default [`L1StorageReader`]
+    /// (for the TempoStateReader precompile) and for sequencer lookups.
     pub fn new(l1_provider: L1StateProvider) -> Self {
         Self {
+            l1_reader: Arc::new(l1_provider.clone()),
+            l1_provider,
+            policy_provider: None,
+        }
+    }
+
+    /// Create a new factory with a custom [`L1StorageReader`].
+    ///
+    /// Used when wrapping the provider in a [`RecordingL1StateProvider`] for
+    /// witness generation.
+    pub fn new_with_reader(
+        l1_reader: Arc<dyn L1StorageReader>,
+        l1_provider: L1StateProvider,
+    ) -> Self {
+        Self {
+            l1_reader,
             l1_provider,
             policy_provider: None,
         }
@@ -74,7 +107,7 @@ impl ZoneEvmFactory {
         let cfg = evm.ctx().cfg.clone();
         let (_, _, precompiles) = evm.components_mut();
         precompiles.apply_precompile(&TEMPO_STATE_READER_ADDRESS, |_| {
-            Some(TempoStateReader::create(self.l1_provider.clone()))
+            Some(TempoStateReader::create(self.l1_reader.clone()))
         });
         precompiles.apply_precompile(&ZONE_TX_CONTEXT_ADDRESS, |_| Some(ZoneTxContext::create()));
         precompiles.apply_precompile(&CHAUM_PEDERSEN_VERIFY_ADDRESS, |_| {
@@ -230,10 +263,18 @@ pub struct ZoneEvmConfig {
     inner: TempoEvmConfig,
     zone_factory: ZoneEvmFactory,
     block_assembler: ZoneBlockAssembler,
+    /// Shared handle for L1 read recordings. Present when the L1 reader is
+    /// wrapped in a [`RecordingL1StateProvider`] (normal sequencer operation).
+    /// `None` for CLI subcommands that don't produce proofs.
+    #[allow(dead_code)]
+    recorded_l1_reads: Option<SharedRecordedReads>,
+    /// Handle to the recording provider for setting `zone_block_index`.
+    /// Stored as `Arc` so the builder can call `set_zone_block_index`.
+    recording_l1_provider: Option<Arc<RecordingL1StateProvider>>,
 }
 
 impl ZoneEvmConfig {
-    /// Create a new zone EVM config with the given chain spec, L1 state
+    /// Create a new zone EVM config with the given chain spec and L1 state
     /// provider.
     pub fn new(chain_spec: Arc<TempoChainSpec>, l1_provider: L1StateProvider) -> Self {
         let zone_factory = ZoneEvmFactory::new(l1_provider);
@@ -243,6 +284,50 @@ impl ZoneEvmConfig {
             inner,
             zone_factory,
             block_assembler,
+            recorded_l1_reads: None,
+            recording_l1_provider: None,
+        }
+    }
+
+    /// Create a new zone EVM config with recording enabled.
+    ///
+    /// Wraps the given L1 provider in a [`RecordingL1StateProvider`] so all
+    /// `TempoStateReader` precompile reads are captured for witness generation.
+    pub fn new_with_recording(
+        chain_spec: Arc<TempoChainSpec>,
+        l1_provider: L1StateProvider,
+    ) -> Self {
+        let recording = Arc::new(RecordingL1StateProvider::new(Arc::new(l1_provider.clone())));
+        let recorded_reads = recording.recorded_reads();
+        let zone_factory = ZoneEvmFactory::new_with_reader(
+            recording.clone() as Arc<dyn L1StorageReader>,
+            l1_provider,
+        );
+        let inner = TempoEvmConfig::new(chain_spec.clone());
+        let block_assembler = ZoneBlockAssembler::new(chain_spec);
+        Self {
+            inner,
+            zone_factory,
+            block_assembler,
+            recorded_l1_reads: Some(recorded_reads),
+            recording_l1_provider: Some(recording),
+        }
+    }
+
+    /// Take all recorded L1 reads since the last call, clearing the buffer.
+    ///
+    /// Returns `None` if recording is not enabled (CLI subcommands).
+    pub fn take_l1_reads(&self) -> Option<Vec<crate::witness::RecordedL1Read>> {
+        self.recording_l1_provider.as_ref().map(|p| p.take_reads())
+    }
+
+    /// Set the zone block index for subsequent L1 read recordings.
+    ///
+    /// Must be called before each zone block execution so reads are
+    /// tagged with the correct block index in the batch.
+    pub fn set_l1_recording_block_index(&self, index: u64) {
+        if let Some(p) = &self.recording_l1_provider {
+            p.set_zone_block_index(index);
         }
     }
 

--- a/crates/tempo-zone/src/l1_state/mod.rs
+++ b/crates/tempo-zone/src/l1_state/mod.rs
@@ -5,7 +5,11 @@
 //! - [`L1StateCache`] — an in-memory cache of L1 contract storage slots, anchored by block hash.
 //! - [`L1StateProvider`] — a cache-first, RPC-fallback reader for `eth_getStorageAt`.
 //! - [`TempoStateReader`] — a standalone `DynPrecompile` that handles `readStorageAt` calls.
+//! - [`L1StorageReader`] — trait abstracting synchronous L1 storage reads.
 //! - [`tip403`] — TIP-403 policy cache and provider.
+
+use alloy_primitives::{Address, B256};
+use eyre::Result;
 
 pub mod cache;
 pub mod precompile;
@@ -20,3 +24,15 @@ pub use tip403::{
     AuthRole, PolicyCache, PolicyEvent, PolicyProvider, PolicyTaskHandle, PolicyTaskMessage,
     SharedPolicyCache, Tip403Metrics, spawn_policy_resolution_task, spawn_pool_prefetch_task,
 };
+
+/// Trait abstracting synchronous L1 storage reads.
+///
+/// Implemented by [`L1StateProvider`] (cache + RPC) and
+/// [`RecordingL1StateProvider`](crate::witness::RecordingL1StateProvider) (recording wrapper).
+///
+/// Used by [`TempoStateReader`] and [`ZoneEvmFactory`](crate::evm::ZoneEvmFactory) to decouple
+/// the precompile from the concrete provider implementation.
+pub trait L1StorageReader: Send + Sync + 'static {
+    /// Read a storage slot from Tempo L1 at a specific block height.
+    fn get_storage(&self, address: Address, slot: B256, block_number: u64) -> Result<B256>;
+}

--- a/crates/tempo-zone/src/l1_state/precompile.rs
+++ b/crates/tempo-zone/src/l1_state/precompile.rs
@@ -24,13 +24,15 @@
 //!
 //! [`L1StateProvider`]: super::provider::L1StateProvider
 
+use std::sync::Arc;
+
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolError};
 use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, error, warn};
 
-use super::provider::L1StateProvider;
+use super::L1StorageReader;
 
 alloy_sol_types::sol! {
     /// Read a single storage slot from a Tempo L1 contract at a specific block height.
@@ -69,12 +71,12 @@ pub struct TempoStateReader;
 
 impl TempoStateReader {
     /// Create a [`DynPrecompile`] that dispatches `readStorageAt` and
-    /// `readStorageBatchAt` calls to the given [`L1StateProvider`].
+    /// `readStorageBatchAt` calls to the given [`L1StorageReader`].
     ///
-    /// The returned precompile captures `provider` by move and can be registered in a
+    /// The returned precompile captures `provider` by `Arc` and can be registered in a
     /// [`PrecompilesMap`](alloy_evm::precompiles::PrecompilesMap) at the TempoStateReader
     /// predeploy address.
-    pub fn create(provider: L1StateProvider) -> DynPrecompile {
+    pub fn create(provider: Arc<dyn L1StorageReader>) -> DynPrecompile {
         DynPrecompile::new_stateful(
             PrecompileId::Custom("TempoStateReader".into()),
             move |input| {
@@ -96,10 +98,10 @@ impl TempoStateReader {
 
                 let result = if selector == readStorageAtCall::SELECTOR {
                     debug!(target: "zone::precompile", "TempoStateReader: readStorageAt");
-                    Self::handle_single_slot(&provider, data)
+                    Self::handle_single_slot(provider.as_ref(), data)
                 } else if selector == readStorageBatchAtCall::SELECTOR {
                     debug!(target: "zone::precompile", "TempoStateReader: readStorageBatchAt");
-                    Self::handle_multi_slot(&provider, data)
+                    Self::handle_multi_slot(provider.as_ref(), data)
                 } else {
                     warn!(target: "zone::precompile", selector = ?selector, "TempoStateReader: unknown selector");
                     Ok(PrecompileOutput::new_reverted(0, Bytes::new()))
@@ -125,7 +127,7 @@ impl TempoStateReader {
     /// Decodes the ABI calldata, performs a synchronous lookup via the provider at the specified
     /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32`
     /// value. Returns a hard [`PrecompileError`] if both the cache and RPC fallback fail.
-    fn handle_single_slot(provider: &L1StateProvider, data: &[u8]) -> PrecompileResult {
+    fn handle_single_slot(provider: &dyn L1StorageReader, data: &[u8]) -> PrecompileResult {
         let call = readStorageAtCall::abi_decode(data)
             .map_err(|_| PrecompileError::other("ABI decode failed"))?;
 
@@ -150,7 +152,7 @@ impl TempoStateReader {
     /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32[]`
     /// result. If **any** slot fails both cache and RPC lookup, the entire call fails with a
     /// hard [`PrecompileError`].
-    fn handle_multi_slot(provider: &L1StateProvider, data: &[u8]) -> PrecompileResult {
+    fn handle_multi_slot(provider: &dyn L1StorageReader, data: &[u8]) -> PrecompileResult {
         let call = readStorageBatchAtCall::abi_decode(data)
             .map_err(|_| PrecompileError::other("ABI decode failed"))?;
 

--- a/crates/tempo-zone/src/l1_state/provider.rs
+++ b/crates/tempo-zone/src/l1_state/provider.rs
@@ -263,6 +263,12 @@ impl L1StateProvider {
     }
 }
 
+impl super::L1StorageReader for L1StateProvider {
+    fn get_storage(&self, address: Address, slot: B256, block_number: u64) -> Result<B256> {
+        self.get_storage(address, slot, block_number)
+    }
+}
+
 impl SequencerExt for L1StateProvider {
     fn latest_sequencer(&self) -> Option<Address> {
         self.get_latest_sequencer().ok()

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -20,9 +20,11 @@ mod node;
 pub mod nonce_keys;
 pub mod payload;
 pub mod precompiles;
+pub mod proof;
 pub mod rpc;
 mod tx_context;
 pub mod withdrawals;
+pub mod witness;
 pub mod zonemonitor;
 
 pub use batch::{BatchData, BatchSubmitter};
@@ -34,7 +36,9 @@ pub use l1::{
 pub use l1_state::{PolicyProvider, SharedL1StateCache, SharedPolicyCache};
 pub use node::{ZoneExecutorBuilder, ZoneNode};
 pub use payload::{ZonePayloadAttributes, ZonePayloadTypes};
+pub use proof::{BatchProofGenerator, ProofGenerator};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};
+pub use witness::{SharedWitnessStore, WitnessStore};
 pub use zonemonitor::{ZoneMonitorConfig, spawn_zone_monitor};
 
 use std::{sync::Arc, time::Duration};
@@ -89,9 +93,8 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
 ///
 /// This is the top-level POC entrypoint that starts:
 /// - **Zone monitor** — polls the Zone L2 for new blocks, extracts withdrawal events into the
-///   shared store, builds [`BatchData`], and submits each batch **synchronously** to the
-///   ZonePortal on Tempo L1 (with empty proof bytes). Local state only advances on
-///   successful submission.
+///   shared store, builds [`BatchData`], and submits each batch to the ZonePortal on Tempo L1.
+///   Proof generation is delegated to the `proof_generator`.
 /// - **Withdrawal processor** — polls the ZonePortal withdrawal queue on Tempo L1 and calls
 ///   `processWithdrawal` for each pending withdrawal.
 ///
@@ -102,6 +105,7 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
 pub async fn spawn_zone_sequencer(
     config: ZoneSequencerConfig,
     signer: PrivateKeySigner,
+    proof_generator: Arc<dyn BatchProofGenerator>,
 ) -> ZoneSequencerHandle {
     // Build a single shared L1 provider with the sequencer wallet.
     // Both the batch submitter (inside the zone monitor) and the withdrawal
@@ -151,6 +155,7 @@ pub async fn spawn_zone_sequencer(
         l1_provider,
         withdrawal_store,
         withdrawal_notify,
+        proof_generator,
     );
 
     ZoneSequencerHandle {

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -87,6 +87,8 @@ pub struct ZoneNode {
     sequencer_key: k256::SecretKey,
     /// Address of the L1 deposit portal contract.
     portal_address: alloy_primitives::Address,
+    /// Shared witness store for builder → monitor communication.
+    witness_store: crate::witness::SharedWitnessStore,
     /// Optional pre-configured list of enabled token addresses. When set, the
     /// startup L1 RPC query for `enabledTokenCount`/`enabledTokens` is skipped.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
@@ -133,6 +135,8 @@ impl ZoneNode {
             ..Default::default()
         };
 
+        let witness_store: crate::witness::SharedWitnessStore = Default::default();
+
         Self {
             deposit_queue,
             l1_config,
@@ -142,8 +146,14 @@ impl ZoneNode {
             sequencer,
             sequencer_key,
             portal_address,
+            witness_store,
             initial_tokens: None,
         }
+    }
+
+    /// Get a clone of the shared witness store handle.
+    pub fn witness_store(&self) -> crate::witness::SharedWitnessStore {
+        self.witness_store.clone()
     }
 
     /// Set the initial list of enabled token addresses.
@@ -175,6 +185,10 @@ impl ZoneNode {
     /// Returns a [`ComponentsBuilder`] configured for a Zone node.
     pub fn components<N>(
         executor_builder: ZoneExecutorBuilder,
+        _sequencer: alloy_primitives::Address,
+        _sequencer_key: k256::SecretKey,
+        _portal_address: alloy_primitives::Address,
+        witness_store: crate::witness::SharedWitnessStore,
     ) -> ComponentsBuilder<
         N,
         ZonePoolBuilder,
@@ -190,7 +204,9 @@ impl ZoneNode {
             .node_types::<N>()
             .pool(ZonePoolBuilder)
             .executor(executor_builder)
-            .payload(BasicPayloadServiceBuilder::new(ZonePayloadFactory))
+            .payload(BasicPayloadServiceBuilder::new(ZonePayloadFactory::new(
+                witness_store,
+            )))
             .network(NoopNetworkBuilder::<ZoneNetworkPrimitives>::default())
             .noop_consensus()
     }
@@ -467,7 +483,13 @@ where
             self.l1_state_cache.clone(),
             self.policy_cache.clone(),
         );
-        Self::components(executor_builder)
+        Self::components(
+            executor_builder,
+            self.sequencer,
+            self.sequencer_key.clone(),
+            self.portal_address,
+            self.witness_store.clone(),
+        )
     }
 
     fn add_ons(&self) -> Self::AddOns {
@@ -569,7 +591,7 @@ where
         )
         .await?;
 
-        let mut evm_config = ZoneEvmConfig::new(ctx.chain_spec(), l1_provider);
+        let mut evm_config = ZoneEvmConfig::new_with_recording(ctx.chain_spec(), l1_provider);
 
         // Create PolicyProvider for the TIP-403 proxy precompile.
         let policy_l1 = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -585,7 +607,7 @@ where
         let policy_provider =
             crate::l1_state::PolicyProvider::new(self.policy_cache, policy_l1, runtime_handle);
         evm_config = evm_config.with_policy_provider(policy_provider);
-        info!(target: "reth::cli", "Zone EVM initialized with TempoStateReader + TIP-403 proxy precompiles");
+        info!(target: "reth::cli", "Zone EVM initialized with TempoStateReader + TIP-403 proxy precompiles (recording enabled)");
 
         Ok(evm_config)
     }

--- a/crates/tempo-zone/src/proof.rs
+++ b/crates/tempo-zone/src/proof.rs
@@ -1,0 +1,538 @@
+//! Batch proof generation service.
+//!
+//! The [`ProofGenerator`] owns the full proof pipeline: taking per-block
+//! witness data from the [`WitnessStore`], generating zone state MPT proofs
+//! via the node's [`StateProviderFactory`], fetching L1 proofs over RPC,
+//! assembling the [`BatchWitness`], and running the prover.
+//!
+//! The zone monitor calls [`ProofGenerator::generate_batch_proof`] once per
+//! batch instead of performing these steps itself.
+
+use alloy_primitives::{B256, Bytes};
+use alloy_provider::{DynProvider, Provider};
+use alloy_rpc_types_eth::BlockNumberOrTag;
+use eyre::Result;
+use reth_provider::StateProviderFactory;
+use tempo_alloy::TempoNetwork;
+use tracing::{debug, info};
+
+#[cfg(feature = "succinct-prover")]
+use sp1_sdk::{
+    HashableKey, NetworkProver, ProveRequest, Prover, ProverClient, ProvingKey, SP1Stdin,
+};
+#[cfg(feature = "succinct-prover")]
+use tokio::sync::Mutex as AsyncMutex;
+#[cfg(feature = "succinct-prover")]
+use zone_sp1_program::ELF as ZONE_PROVER_SP1_ELF;
+
+use crate::witness::{
+    AccessSnapshot, FetchedL1Proof, RecordedL1Read, SharedWitnessStore, WitnessGenerator,
+    WitnessGeneratorConfig, group_l1_reads_for_proof_fetch,
+};
+
+/// Node-internal proof generation service.
+///
+/// Holds a direct handle to the node's state database (via `StateProviderFactory`)
+/// so it can generate zone state MPT proofs without going through RPC. L1 proofs
+/// are still fetched over RPC since the L1 chain is external.
+pub struct ProofGenerator<Provider> {
+    provider: Provider,
+    witness_store: SharedWitnessStore,
+    witness_generator: WitnessGenerator,
+    l1_provider: DynProvider<TempoNetwork>,
+}
+
+impl<P> ProofGenerator<P>
+where
+    P: StateProviderFactory,
+{
+    /// Create a new proof generator.
+    ///
+    /// - `provider` — the node's `StateProviderFactory` for direct trie access
+    /// - `witness_store` — shared with the builder, which writes per-block data
+    /// - `l1_provider` — Tempo L1 RPC provider for `eth_getProof` calls
+    /// - `sequencer` — the sequencer address for public inputs
+    pub fn new(
+        provider: P,
+        witness_store: SharedWitnessStore,
+        l1_provider: DynProvider<TempoNetwork>,
+        sequencer: alloy_primitives::Address,
+    ) -> Self {
+        let witness_generator = WitnessGenerator::new(WitnessGeneratorConfig { sequencer });
+        Self {
+            provider,
+            witness_store,
+            witness_generator,
+            l1_provider,
+        }
+    }
+
+    /// Generate a proof for the given zone block range.
+    ///
+    /// 1. Takes per-block data from the [`WitnessStore`].
+    /// 2. Merges all [`AccessSnapshot`]s into a single union.
+    /// 3. Generates zone state MPT proofs against S₀ using
+    ///    [`StateProviderFactory::state_by_block_hash`] — a direct local trie
+    ///    walk, no RPC.
+    /// 4. Fetches L1 `eth_getProof` responses for recorded Tempo state reads.
+    /// 5. Assembles the [`BatchWitness`] and runs the prover.
+    ///
+    /// Returns `(verifier_config, proof)` on success, or an error if witness
+    /// data is missing or proof generation fails.
+    pub async fn generate_batch_proof(
+        &self,
+        from: u64,
+        to: u64,
+        tempo_block_number: u64,
+        prev_block_hash: B256,
+        expected_withdrawal_batch_index: u64,
+    ) -> Result<(Bytes, Bytes)> {
+        // TODO(production): Replace soft proof (ABI-packed BatchOutput) with a
+        // real ZK proof (SP1) or TEE attestation (SGX/TDX).
+
+        let batch_witness = self
+            .build_batch_witness(
+                from,
+                to,
+                tempo_block_number,
+                prev_block_hash,
+                expected_withdrawal_batch_index,
+            )
+            .await?;
+
+        // Run the prover.
+        let output = zone_stf::prove_zone_batch(batch_witness)
+            .map_err(|e| eyre::eyre!("prove_zone_batch failed: {e}"))?;
+
+        info!(
+            from,
+            to,
+            next_block_hash = %output.block_transition.next_block_hash,
+            withdrawal_queue_hash = %output.withdrawal_queue_hash,
+            "Proof generated successfully"
+        );
+
+        let proof_bytes = encode_batch_output(&output);
+        Ok((Bytes::new(), proof_bytes.into()))
+    }
+
+    /// Assemble a complete [`zone_stf::types::BatchWitness`] from the local
+    /// witness store, local zone state trie, and Tempo L1 account/storage proofs.
+    async fn build_batch_witness(
+        &self,
+        from: u64,
+        to: u64,
+        tempo_block_number: u64,
+        prev_block_hash: B256,
+        expected_withdrawal_batch_index: u64,
+    ) -> Result<zone_stf::types::BatchWitness> {
+        // Take witness data from the store for the block range, and prune
+        // any stale entries below `from` (e.g., leftover from resyncs).
+        let block_witnesses = {
+            let mut store = self.witness_store.lock().expect("witness store poisoned");
+            let before = store.len();
+            store.prune_below(from);
+            let pruned = before - store.len();
+            if pruned > 0 {
+                debug!(
+                    pruned,
+                    from, "Pruned stale witness entries below batch start"
+                );
+            }
+            store.take_range(from, to).map_err(|missing_block| {
+                eyre::eyre!(
+                    "missing witness data for block {missing_block} in range [{from}, {to}]"
+                )
+            })?
+        };
+
+        let first = &block_witnesses[0].1;
+        let chain_id = first.chain_id;
+        let prev_block_header = first.prev_block_header.clone();
+        let s0_parent_hash = first.parent_block_hash;
+
+        // Merge access snapshots from ALL blocks into a single union.
+        let mut merged_accesses = AccessSnapshot::default();
+        let mut all_l1_reads = Vec::new();
+        let mut zone_blocks = Vec::new();
+        // Ancestry headers are only used in ancestry mode (anchor != tempo).
+        // For now we always use direct mode, so this stays empty.
+        let tempo_ancestry_headers: Vec<Vec<u8>> = vec![];
+
+        for (_, bw) in &block_witnesses {
+            merged_accesses.merge(&bw.access_snapshot);
+            all_l1_reads.extend(bw.l1_reads.iter().cloned());
+            zone_blocks.push(bw.zone_block.clone());
+        }
+
+        info!(
+            from,
+            to,
+            accounts = merged_accesses.accounts.len(),
+            storage_accounts = merged_accesses.storage.len(),
+            "Merged access snapshots, generating zone state witness via local trie"
+        );
+
+        // Open a state provider for S₀ (parent of the first block in the batch).
+        let state_provider = self
+            .provider
+            .state_by_block_hash(s0_parent_hash)
+            .map_err(|e| {
+                eyre::eyre!("failed to open state provider for S₀ ({s0_parent_hash}): {e}")
+            })?;
+
+        let s0_state_root = prev_block_header.state_root;
+
+        // Generate zone state witness via direct trie walk — no RPC.
+        let initial_zone_state = self.witness_generator.generate_zone_state_witness(
+            &*state_provider,
+            s0_state_root,
+            &merged_accesses.accounts,
+            &merged_accesses.storage,
+        )?;
+
+        // Fetch L1 eth_getProof responses for recorded reads.
+        let l1_proofs = self.fetch_l1_proofs(&all_l1_reads).await?;
+
+        // Generate the Tempo state proof from recorded reads + fetched proofs.
+        let tempo_state_proofs = self
+            .witness_generator
+            .generate_tempo_state_proof(&all_l1_reads, &l1_proofs)?;
+
+        // In direct mode (anchor == tempo), the anchor block hash is the hash
+        // of the Tempo header processed by the last advanceTempo in the batch.
+        // If no block in the batch advanced Tempo, the binding carries over from
+        // the previous batch and we read the hash from the zone state witness.
+        let anchor_block_hash = block_witnesses
+            .iter()
+            .rev()
+            .find_map(|(_, bw)| bw.tempo_header_rlp.as_ref())
+            .map(alloy_primitives::keccak256)
+            .unwrap_or_else(|| {
+                // No advanceTempo in this batch — read from the zone state witness.
+                // The initial_zone_state already includes TempoState slot 0 because
+                // the WitnessGenerator unconditionally adds it.
+                initial_zone_state
+                    .accounts
+                    .get(&zone_stf::execute::TEMPO_STATE_ADDRESS)
+                    .and_then(|acct| {
+                        acct.storage
+                            .get(&zone_stf::execute::storage::TEMPO_STATE_BLOCK_HASH_SLOT)
+                    })
+                    .map(|v| B256::from(v.to_be_bytes()))
+                    .unwrap_or(B256::ZERO)
+            });
+
+        let public_inputs = zone_stf::types::PublicInputs {
+            prev_block_hash,
+            tempo_block_number,
+            anchor_block_number: tempo_block_number,
+            anchor_block_hash,
+            expected_withdrawal_batch_index,
+            sequencer: self.witness_generator.sequencer(),
+        };
+
+        // Assemble the complete batch witness.
+        let batch_witness = self.witness_generator.assemble_witness(
+            public_inputs,
+            chain_id,
+            prev_block_header,
+            zone_blocks,
+            initial_zone_state,
+            tempo_state_proofs,
+            tempo_ancestry_headers,
+        );
+        Ok(batch_witness)
+    }
+
+    /// Fetch `eth_getProof` responses from the Tempo L1 chain for all
+    /// recorded L1 reads.
+    ///
+    /// Groups reads by `(tempo_block_number, account)` and issues one
+    /// `eth_getProof` RPC call per group.
+    async fn fetch_l1_proofs(&self, l1_reads: &[RecordedL1Read]) -> Result<Vec<FetchedL1Proof>> {
+        use alloy_rpc_types_eth::EIP1186AccountProofResponse;
+
+        if l1_reads.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let groups = group_l1_reads_for_proof_fetch(l1_reads);
+        let mut proofs = Vec::with_capacity(groups.len());
+
+        // TODO(perf): Fetch L1 proofs concurrently with futures::join_all and a
+        // concurrency limiter instead of sequential await.
+        for ((tempo_block_number, account), slots) in &groups {
+            debug!(
+                tempo_block_number,
+                %account,
+                slot_count = slots.len(),
+                "Fetching eth_getProof from Tempo L1"
+            );
+
+            let storage_keys: Vec<alloy_primitives::StorageKey> = slots.to_vec();
+
+            let proof_response: EIP1186AccountProofResponse = self
+                .l1_provider
+                .get_proof(*account, storage_keys)
+                .block_id(BlockNumberOrTag::Number(*tempo_block_number).into())
+                .await?;
+
+            proofs.push(FetchedL1Proof {
+                tempo_block_number: *tempo_block_number,
+                proof: proof_response,
+            });
+        }
+
+        info!(
+            proof_count = proofs.len(),
+            read_count = l1_reads.len(),
+            "Fetched L1 proofs for Tempo state reads"
+        );
+
+        Ok(proofs)
+    }
+}
+
+/// Shared, type-erased proof generator handle.
+///
+/// The `ProofGenerator` is generic over `Provider`, but the monitor doesn't
+/// need to know the concrete provider type. This trait object wrapper allows
+/// the monitor to hold a simple `Arc<dyn BatchProofGenerator>`.
+#[async_trait::async_trait]
+pub trait BatchProofGenerator: Send + Sync {
+    async fn generate_batch_proof(
+        &self,
+        from: u64,
+        to: u64,
+        tempo_block_number: u64,
+        prev_block_hash: B256,
+        expected_withdrawal_batch_index: u64,
+    ) -> Result<(Bytes, Bytes)>;
+}
+
+#[async_trait::async_trait]
+impl<P> BatchProofGenerator for ProofGenerator<P>
+where
+    P: StateProviderFactory + Send + Sync,
+{
+    async fn generate_batch_proof(
+        &self,
+        from: u64,
+        to: u64,
+        tempo_block_number: u64,
+        prev_block_hash: B256,
+        expected_withdrawal_batch_index: u64,
+    ) -> Result<(Bytes, Bytes)> {
+        Self::generate_batch_proof(
+            self,
+            from,
+            to,
+            tempo_block_number,
+            prev_block_hash,
+            expected_withdrawal_batch_index,
+        )
+        .await
+    }
+}
+
+#[cfg(feature = "succinct-prover")]
+const SUCCINCT_VERIFIER_CONFIG_V1: u8 = 1;
+#[cfg(feature = "succinct-prover")]
+const SUCCINCT_PROOF_SYSTEM_SP1_PLONK: u8 = 1;
+#[cfg(feature = "succinct-prover")]
+const SP1_PUBLIC_VALUES_LEN_BATCH_OUTPUT: usize = 192;
+
+/// Configuration for the Succinct (SP1 prover network) proof backend.
+///
+/// The SDK reads credentials (private key, RPC endpoint) from the environment.
+/// See the SP1/Succinct SDK docs for the exact variables expected by
+/// `sp1_sdk::NetworkProver::new()`.
+#[cfg(feature = "succinct-prover")]
+#[derive(Debug, Clone)]
+pub struct SuccinctNetworkProverConfig {
+    /// Skip local simulation before dispatching the request to the prover
+    /// network. Useful when the caller already trusts witness generation.
+    pub skip_simulation: bool,
+}
+
+#[cfg(feature = "succinct-prover")]
+impl Default for SuccinctNetworkProverConfig {
+    fn default() -> Self {
+        Self {
+            skip_simulation: false,
+        }
+    }
+}
+
+#[cfg(feature = "succinct-prover")]
+struct SuccinctNetworkProverState {
+    prover: NetworkProver,
+    pk: sp1_sdk::SP1ProvingKey,
+    vk: sp1_sdk::SP1VerifyingKey,
+}
+
+/// Batch proof generator backed by Succinct's SP1 prover network.
+///
+/// This reuses the same witness assembly pipeline as [`ProofGenerator`], but
+/// sends the witness to an SP1 guest program that runs `zone_stf::prove_zone_batch`
+/// and commits the 192-byte batch-output encoding as public values.
+#[cfg(feature = "succinct-prover")]
+pub struct SuccinctBatchProofGenerator<Provider> {
+    inner: ProofGenerator<Provider>,
+    config: SuccinctNetworkProverConfig,
+    prover_state: AsyncMutex<SuccinctNetworkProverState>,
+}
+
+#[cfg(feature = "succinct-prover")]
+impl<P> SuccinctBatchProofGenerator<P>
+where
+    P: StateProviderFactory,
+{
+    /// Create a new Succinct-backed proof generator.
+    pub async fn new(
+        provider: P,
+        witness_store: SharedWitnessStore,
+        l1_provider: DynProvider<TempoNetwork>,
+        sequencer: alloy_primitives::Address,
+        config: SuccinctNetworkProverConfig,
+    ) -> Result<Self> {
+        let inner = ProofGenerator::new(provider, witness_store, l1_provider, sequencer);
+
+        let prover = ProverClient::builder().network().build().await;
+        let pk = prover
+            .setup(ZONE_PROVER_SP1_ELF)
+            .await
+            .map_err(|e| eyre::eyre!("SP1 network prover setup failed: {e}"))?;
+        let vk = pk.verifying_key().clone();
+
+        Ok(Self {
+            inner,
+            config,
+            prover_state: AsyncMutex::new(SuccinctNetworkProverState { prover, pk, vk }),
+        })
+    }
+}
+
+#[cfg(feature = "succinct-prover")]
+#[async_trait::async_trait]
+impl<P> BatchProofGenerator for SuccinctBatchProofGenerator<P>
+where
+    P: StateProviderFactory + Send + Sync,
+{
+    async fn generate_batch_proof(
+        &self,
+        from: u64,
+        to: u64,
+        tempo_block_number: u64,
+        prev_block_hash: B256,
+        expected_withdrawal_batch_index: u64,
+    ) -> Result<(Bytes, Bytes)> {
+        let batch_witness = self
+            .inner
+            .build_batch_witness(
+                from,
+                to,
+                tempo_block_number,
+                prev_block_hash,
+                expected_withdrawal_batch_index,
+            )
+            .await?;
+
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&batch_witness);
+
+        info!(
+            from,
+            to, "Dispatching batch proof to Succinct prover network"
+        );
+
+        let state = self.prover_state.lock().await;
+        let proof = state
+            .prover
+            .prove(&state.pk, stdin)
+            .plonk()
+            .skip_simulation(self.config.skip_simulation)
+            .await
+            .map_err(|e| eyre::eyre!("SP1 network proof failed: {e}"))?;
+
+        let public_values = proof.public_values.to_vec();
+        if public_values.len() != SP1_PUBLIC_VALUES_LEN_BATCH_OUTPUT {
+            return Err(eyre::eyre!(
+                "unexpected SP1 public values length: got {}, expected {}",
+                public_values.len(),
+                SP1_PUBLIC_VALUES_LEN_BATCH_OUTPUT
+            ));
+        }
+
+        let vk_hash = B256::from(state.vk.bytes32_raw());
+        let verifier_config = encode_succinct_verifier_config(vk_hash, &public_values)?;
+        let proof_bytes: Bytes = proof.bytes().into();
+
+        info!(
+            from,
+            to,
+            proof_len = proof_bytes.len(),
+            public_values_len = public_values.len(),
+            vk_hash = %vk_hash,
+            "Succinct proof generated successfully"
+        );
+
+        Ok((verifier_config, proof_bytes))
+    }
+}
+
+#[cfg(feature = "succinct-prover")]
+fn encode_succinct_verifier_config(vk_hash: B256, public_values: &[u8]) -> Result<Bytes> {
+    let public_values_len = u32::try_from(public_values.len())
+        .map_err(|_| eyre::eyre!("SP1 public values too long: {}", public_values.len()))?;
+
+    // Binary encoding (v1):
+    // [0]      version (=1)
+    // [1]      proof system (=1 for SP1 Plonk)
+    // [2..34]  vk hash (bytes32)
+    // [34..38] public values len (u32, big-endian)
+    // [38..]   public values bytes
+    let mut buf = Vec::with_capacity(38 + public_values.len());
+    buf.push(SUCCINCT_VERIFIER_CONFIG_V1);
+    buf.push(SUCCINCT_PROOF_SYSTEM_SP1_PLONK);
+    buf.extend_from_slice(vk_hash.as_slice());
+    buf.extend_from_slice(&public_values_len.to_be_bytes());
+    buf.extend_from_slice(public_values);
+    Ok(buf.into())
+}
+
+/// Encode a [`BatchOutput`] into proof bytes.
+///
+/// Soft-proof format: ABI-packed concatenation of the output commitment fields.
+/// The L1 verifier can decode this to validate the batch transition without a ZK proof.
+///
+/// Layout (192 bytes):
+/// - `[0..32]`   prev_block_hash
+/// - `[32..64]`  next_block_hash
+/// - `[64..96]`  prev_processed_deposit_hash
+/// - `[96..128]` next_processed_deposit_hash
+/// - `[128..160]` withdrawal_queue_hash
+/// - `[160..192]` withdrawal_batch_index (left-padded u64)
+fn encode_batch_output(output: &zone_stf::types::BatchOutput) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(192);
+    buf.extend_from_slice(output.block_transition.prev_block_hash.as_slice());
+    buf.extend_from_slice(output.block_transition.next_block_hash.as_slice());
+    buf.extend_from_slice(
+        output
+            .deposit_queue_transition
+            .prev_processed_hash
+            .as_slice(),
+    );
+    buf.extend_from_slice(
+        output
+            .deposit_queue_transition
+            .next_processed_hash
+            .as_slice(),
+    );
+    buf.extend_from_slice(output.withdrawal_queue_hash.as_slice());
+    buf.extend_from_slice(
+        &alloy_primitives::U256::from(output.last_batch.withdrawal_batch_index).to_be_bytes::<32>(),
+    );
+    buf
+}

--- a/crates/tempo-zone/src/witness/generator.rs
+++ b/crates/tempo-zone/src/witness/generator.rs
@@ -1,0 +1,435 @@
+//! Witness generation pipeline.
+//!
+//! Takes recorded state accesses from [`RecordingDatabase`] and
+//! [`RecordingL1StateProvider`] and assembles a complete [`BatchWitness`]
+//! that can be passed to [`prove_zone_batch`](zone_stf::prove_zone_batch).
+//!
+//! ## MPT proof generation
+//!
+//! **Zone state proofs** are generated using reth's [`StateProofProvider::proof()`],
+//! which walks the on-disk Merkle Patricia Trie and returns inclusion proofs for
+//! requested accounts and their storage slots. These proofs enable the prover to
+//! re-derive account data and storage values from the zone state root alone.
+//!
+//! **Tempo L1 state proofs** are fetched from the Tempo L1 chain via `eth_getProof`.
+//! The caller is responsible for the async RPC calls; this module accepts pre-fetched
+//! [`EIP1186AccountProofResponse`]s and deduplicates all MPT nodes into a compact
+//! shared pool.
+//!
+//! [`EIP1186AccountProofResponse`]: alloy_rpc_types_eth::EIP1186AccountProofResponse
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256, map::HashMap};
+use alloy_rpc_types_eth::EIP1186AccountProofResponse;
+use reth_storage_api::StateProvider;
+use reth_trie_common::TrieInput;
+use tracing::{debug, info};
+use zone_stf::{
+    execute::{
+        TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
+        storage::{
+            TEMPO_STATE_BLOCK_HASH_SLOT, TEMPO_STATE_PACKED_SLOT, TEMPO_STATE_STATE_ROOT_SLOT,
+            ZONE_INBOX_PROCESSED_HASH_SLOT, ZONE_OUTBOX_LAST_BATCH_BASE_SLOT,
+        },
+    },
+    types::{
+        AccountWitness, BatchStateProof, BatchWitness, L1AccountProof, L1StateRead, PublicInputs,
+        ZoneBlock, ZoneHeader, ZoneStateWitness,
+    },
+};
+
+use super::recording_l1::RecordedL1Read;
+
+/// Configuration for the witness generator.
+#[derive(Debug, Clone)]
+pub struct WitnessGeneratorConfig {
+    /// Sequencer address (for public inputs).
+    pub sequencer: Address,
+}
+
+/// A pre-fetched L1 proof response, tagged with the Tempo block number
+/// it was fetched against.
+#[derive(Debug, Clone)]
+pub struct FetchedL1Proof {
+    /// The Tempo block number this proof was retrieved at.
+    pub tempo_block_number: u64,
+    /// The `eth_getProof` response from the Tempo L1 chain.
+    pub proof: EIP1186AccountProofResponse,
+}
+
+/// Generates a [`BatchWitness`] from recorded state accesses.
+///
+/// This is the bridge between the zone node's normal execution pipeline and
+/// the prover. After a batch of zone blocks has been executed with recording
+/// enabled, this generates the witness needed for proof generation.
+pub struct WitnessGenerator {
+    config: WitnessGeneratorConfig,
+}
+
+impl WitnessGenerator {
+    /// Create a new witness generator.
+    pub fn new(config: WitnessGeneratorConfig) -> Self {
+        Self { config }
+    }
+
+    /// Returns the sequencer address from the config.
+    pub fn sequencer(&self) -> Address {
+        self.config.sequencer
+    }
+
+    /// Generate a [`ZoneStateWitness`] from recorded state accesses.
+    ///
+    /// Uses [`StateProofProvider::proof()`] to generate real MPT proofs for each
+    /// accessed account and its storage slots against the given `state_root`.
+    ///
+    /// # Arguments
+    ///
+    /// * `state_provider` - Provider for reading current state and generating proofs
+    /// * `state_root` - The zone state root at the start of the batch
+    /// * `accessed_accounts` - Set of accounts accessed during execution
+    /// * `accessed_storage` - Map of storage slots accessed per account
+    pub fn generate_zone_state_witness(
+        &self,
+        state_provider: &dyn StateProvider,
+        state_root: B256,
+        accessed_accounts: &BTreeSet<Address>,
+        accessed_storage: &BTreeMap<Address, BTreeSet<U256>>,
+    ) -> eyre::Result<ZoneStateWitness> {
+        // The prover unconditionally reads predeploy storage slots outside of
+        // block execution (TempoState for initial block number and block hash,
+        // ZoneInbox for deposit queue hash, ZoneOutbox for last batch). Ensure
+        // these accounts and slots are always present in the witness regardless
+        // of whether EVM execution touched them.
+        let mut accessed_accounts = accessed_accounts.clone();
+        let mut accessed_storage = accessed_storage.clone();
+
+        // TempoState: slot 0 (block hash), slot 4 (state root), slot 7 (packed).
+        accessed_accounts.insert(TEMPO_STATE_ADDRESS);
+        accessed_storage
+            .entry(TEMPO_STATE_ADDRESS)
+            .or_default()
+            .extend([
+                TEMPO_STATE_BLOCK_HASH_SLOT,
+                TEMPO_STATE_STATE_ROOT_SLOT,
+                TEMPO_STATE_PACKED_SLOT,
+            ]);
+
+        // ZoneInbox: slot 0 (processed deposit queue hash).
+        accessed_accounts.insert(ZONE_INBOX_ADDRESS);
+        accessed_storage
+            .entry(ZONE_INBOX_ADDRESS)
+            .or_default()
+            .insert(ZONE_INBOX_PROCESSED_HASH_SLOT);
+
+        // ZoneOutbox: slot 5 (withdrawal queue hash) and slot 6 (batch index).
+        accessed_accounts.insert(ZONE_OUTBOX_ADDRESS);
+        accessed_storage
+            .entry(ZONE_OUTBOX_ADDRESS)
+            .or_default()
+            .extend([
+                ZONE_OUTBOX_LAST_BATCH_BASE_SLOT,
+                ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+            ]);
+
+        let mut accounts = HashMap::default();
+        let mut absent_accounts: HashMap<Address, Vec<Bytes>> = HashMap::default();
+
+        for &addr in &accessed_accounts {
+            // Collect storage slots as B256 keys for the proof request.
+            let slot_keys: Vec<B256> = accessed_storage
+                .get(&addr)
+                .map(|slots| slots.iter().map(|s| B256::from(s.to_be_bytes())).collect())
+                .unwrap_or_default();
+
+            // Generate MPT proofs via the state provider's trie.
+            // TrieInput::default() means no overlay — proofs are against the
+            // committed state that `state_provider` represents.
+            let account_proof_result = state_provider.proof(TrieInput::default(), addr, &slot_keys);
+
+            let acct_proof = account_proof_result
+                .map_err(|e| eyre::eyre!("MPT proof generation failed for {addr}: {e}"))?;
+
+            // If the account doesn't exist in the state trie, store it as an
+            // absent account with the exclusion proof so the prover can return
+            // Ok(None) from Database::basic() instead of an error.
+            if acct_proof.info.is_none() {
+                absent_accounts.insert(addr, acct_proof.proof);
+                continue;
+            }
+
+            let nonce = acct_proof.info.as_ref().map_or(0, |a| a.nonce);
+            let balance = acct_proof.info.as_ref().map_or(U256::ZERO, |a| a.balance);
+            let code_hash_from_proof = acct_proof.info.as_ref().and_then(|a| a.bytecode_hash);
+            let storage_root = acct_proof.storage_root;
+            let proof_nodes = acct_proof.proof;
+
+            // Convert storage proofs: StorageProof -> (U256, Vec<Bytes>)
+            let storage_proofs: HashMap<U256, Vec<Bytes>> = acct_proof
+                .storage_proofs
+                .into_iter()
+                .map(|sp| {
+                    let slot = U256::from_be_bytes(sp.key.0);
+                    (slot, sp.proof)
+                })
+                .collect();
+
+            // Read code separately (not included in the account proof).
+            let code = state_provider.account_code(&addr).ok().flatten();
+            // Use keccak256(code) if code is available, otherwise fall back to
+            // the bytecode_hash from the account proof. For accounts without
+            // code (EOAs), use KECCAK_EMPTY per Ethereum convention.
+            let keccak_empty = keccak256([]);
+            let code_hash = code
+                .as_ref()
+                .map(|c| keccak256(c.bytes_slice()))
+                .or(code_hash_from_proof)
+                .unwrap_or(keccak_empty);
+
+            // Read storage values (the proof gives us proof nodes but we also
+            // need the actual slot values in the witness).
+            let mut storage = HashMap::default();
+            if let Some(slots) = accessed_storage.get(&addr) {
+                for &slot in slots {
+                    let value = state_provider
+                        .storage(addr, B256::from(slot))
+                        .ok()
+                        .flatten()
+                        .unwrap_or(U256::ZERO);
+                    storage.insert(slot, value);
+                }
+            }
+
+            accounts.insert(
+                addr,
+                AccountWitness {
+                    nonce,
+                    balance,
+                    code_hash,
+                    storage_root,
+                    code: code.map(|c| Bytes::copy_from_slice(c.bytes_slice())),
+                    storage,
+                    account_proof: proof_nodes,
+                    storage_proofs,
+                },
+            );
+        }
+
+        debug!(
+            accounts = accounts.len(),
+            absent = absent_accounts.len(),
+            state_root = %state_root,
+            "Generated zone state witness with MPT proofs"
+        );
+
+        Ok(ZoneStateWitness {
+            accounts,
+            absent_accounts,
+            state_root,
+        })
+    }
+
+    /// Generate a [`BatchStateProof`] from recorded L1 reads and pre-fetched proofs.
+    ///
+    /// Each `FetchedL1Proof` is an `eth_getProof` response from the Tempo L1 chain.
+    /// All MPT nodes from account and storage proofs are deduplicated into a shared
+    /// pool, keyed by `keccak256(node_bytes)`. Each read is annotated with a
+    /// `storage_path` — the sequence of hashes through the pool that forms the
+    /// storage proof path. Account proofs are stored separately in `account_proofs`.
+    ///
+    /// # Arguments
+    ///
+    /// * `recorded_reads` - All L1 storage reads captured during batch execution
+    /// * `l1_proofs` - Pre-fetched `eth_getProof` results from the Tempo L1 chain
+    pub fn generate_tempo_state_proof(
+        &self,
+        recorded_reads: &[RecordedL1Read],
+        l1_proofs: &[FetchedL1Proof],
+    ) -> eyre::Result<BatchStateProof> {
+        let mut node_pool: HashMap<B256, Vec<u8>> = HashMap::default();
+
+        // Pre-compute storage proof hashes, keyed by (block_number, account, slot_b256).
+        let mut storage_proof_hashes: BTreeMap<(u64, Address, B256), Vec<B256>> = BTreeMap::new();
+
+        // Build L1AccountProof entries, deduplicated by (tempo_block_number, account).
+        let mut account_proofs_map: BTreeMap<(u64, Address), L1AccountProof> = BTreeMap::new();
+
+        for fetched in l1_proofs {
+            let block_num = fetched.tempo_block_number;
+            let proof = &fetched.proof;
+
+            // Add account proof nodes to the pool and record their hashes.
+            let acct_hashes: Vec<B256> = proof
+                .account_proof
+                .iter()
+                .map(|node| {
+                    let hash = keccak256(node);
+                    node_pool.entry(hash).or_insert_with(|| node.to_vec());
+                    hash
+                })
+                .collect();
+
+            // Build L1AccountProof from the eth_getProof response.
+            let key = (block_num, proof.address);
+            let candidate = L1AccountProof {
+                tempo_block_number: block_num,
+                account: proof.address,
+                nonce: proof.nonce,
+                balance: proof.balance,
+                storage_root: proof.storage_hash,
+                code_hash: proof.code_hash,
+                account_path: acct_hashes,
+            };
+            if let Some(existing) = account_proofs_map.get(&key) {
+                if existing != &candidate {
+                    return Err(eyre::eyre!(
+                        "conflicting duplicate L1 account proof for tempo_block={} account={}",
+                        block_num,
+                        proof.address
+                    ));
+                }
+            } else {
+                account_proofs_map.insert(key, candidate);
+            }
+
+            // Add storage proof nodes to the pool.
+            for sp in &proof.storage_proof {
+                let slot_b256 = sp.key.as_b256();
+                let sp_hashes: Vec<B256> = sp
+                    .proof
+                    .iter()
+                    .map(|node| {
+                        let hash = keccak256(node);
+                        node_pool.entry(hash).or_insert_with(|| node.to_vec());
+                        hash
+                    })
+                    .collect();
+                let key = (block_num, proof.address, slot_b256);
+                if let Some(existing) = storage_proof_hashes.get(&key) {
+                    if existing != &sp_hashes {
+                        return Err(eyre::eyre!(
+                            "conflicting duplicate L1 storage proof for tempo_block={} account={} slot={}",
+                            block_num,
+                            proof.address,
+                            slot_b256
+                        ));
+                    }
+                } else {
+                    storage_proof_hashes.insert(key, sp_hashes);
+                }
+            }
+        }
+
+        // Build reads with storage_path only (account proof is separate).
+        let mut reads: Vec<L1StateRead> = Vec::with_capacity(recorded_reads.len());
+        for r in recorded_reads {
+            if !account_proofs_map.contains_key(&(r.tempo_block_number, r.account)) {
+                return Err(eyre::eyre!(
+                    "missing L1 account proof for tempo_block={} account={}",
+                    r.tempo_block_number,
+                    r.account
+                ));
+            }
+
+            // Only the storage proof hashes for this specific slot.
+            let storage_path = storage_proof_hashes
+                .get(&(r.tempo_block_number, r.account, r.slot))
+                .cloned()
+                .ok_or_else(|| {
+                    eyre::eyre!(
+                        "missing L1 storage proof for tempo_block={} account={} slot={}",
+                        r.tempo_block_number,
+                        r.account,
+                        r.slot
+                    )
+                })?;
+
+            reads.push(L1StateRead {
+                zone_block_index: r.zone_block_index,
+                tempo_block_number: r.tempo_block_number,
+                account: r.account,
+                slot: U256::from_be_bytes(r.slot.0),
+                storage_path,
+                value: U256::from_be_bytes(r.value.0),
+            });
+        }
+
+        let account_proofs: Vec<L1AccountProof> = account_proofs_map.into_values().collect();
+
+        info!(
+            reads = reads.len(),
+            account_proofs = account_proofs.len(),
+            unique_nodes = node_pool.len(),
+            "Generated Tempo state proof ({} reads, {} account proofs, {} unique nodes)",
+            reads.len(),
+            account_proofs.len(),
+            node_pool.len(),
+        );
+
+        Ok(BatchStateProof {
+            node_pool,
+            reads,
+            account_proofs,
+        })
+    }
+
+    /// Assemble a complete [`BatchWitness`] from all components.
+    ///
+    /// # Arguments
+    ///
+    /// * `public_inputs` - Public inputs for the batch
+    /// * `chain_id` - Zone chain ID for EVM configuration
+    /// * `prev_block_header` - Previous batch's zone block header
+    /// * `zone_blocks` - Zone blocks in this batch
+    /// * `zone_state_witness` - Initial zone state with proofs
+    /// * `tempo_state_proofs` - Tempo L1 state proofs
+    /// * `tempo_ancestry_headers` - Tempo headers for ancestry verification
+    pub fn assemble_witness(
+        &self,
+        public_inputs: PublicInputs,
+        chain_id: u64,
+        prev_block_header: ZoneHeader,
+        zone_blocks: Vec<ZoneBlock>,
+        zone_state_witness: ZoneStateWitness,
+        tempo_state_proofs: BatchStateProof,
+        tempo_ancestry_headers: Vec<Vec<u8>>,
+    ) -> BatchWitness {
+        info!(
+            blocks = zone_blocks.len(),
+            accounts = zone_state_witness.accounts.len(),
+            tempo_reads = tempo_state_proofs.reads.len(),
+            chain_id,
+            "Assembled batch witness"
+        );
+
+        BatchWitness {
+            public_inputs,
+            chain_id,
+            prev_block_header,
+            zone_blocks,
+            initial_zone_state: zone_state_witness,
+            tempo_state_proofs,
+            tempo_ancestry_headers,
+        }
+    }
+}
+
+/// Convenience function: group recorded L1 reads by `(tempo_block_number, account)`
+/// and collect all unique slots per group.
+///
+/// The returned entries can be used to batch `eth_getProof` calls.
+pub fn group_l1_reads_for_proof_fetch(
+    recorded_reads: &[RecordedL1Read],
+) -> BTreeMap<(u64, Address), Vec<B256>> {
+    let mut groups: BTreeMap<(u64, Address), BTreeSet<B256>> = BTreeMap::new();
+    for r in recorded_reads {
+        groups
+            .entry((r.tempo_block_number, r.account))
+            .or_default()
+            .insert(r.slot);
+    }
+    groups
+        .into_iter()
+        .map(|(k, slots)| (k, slots.into_iter().collect()))
+        .collect()
+}

--- a/crates/tempo-zone/src/witness/mod.rs
+++ b/crates/tempo-zone/src/witness/mod.rs
@@ -1,0 +1,34 @@
+//! Witness generation for the zone prover.
+//!
+//! This module provides the components needed to record state accesses during
+//! zone block execution and generate the complete [`BatchWitness`] for the
+//! zone prover.
+//!
+//! ## Components
+//!
+//! - [`RecordingDatabase`] — wraps any revm `Database` to log all account and
+//!   storage accesses during EVM execution.
+//! - [`RecordingL1StateProvider`] — wraps the L1 state provider to capture all
+//!   Tempo L1 storage reads during `TempoStateReader` precompile calls.
+//! - [`WitnessGenerator`] — assembles the complete [`BatchWitness`] from recorded
+//!   accesses and state provider data.
+//!
+//! ## Flow
+//!
+//! 1. Wrap the zone database with [`RecordingDatabase`] before block execution.
+//! 2. Wrap the L1 state provider with [`RecordingL1StateProvider`].
+//! 3. Execute the zone block(s) normally.
+//! 4. Extract recorded accesses from both wrappers.
+//! 5. Use [`WitnessGenerator`] to produce the [`BatchWitness`].
+
+pub mod generator;
+pub mod recording_db;
+pub mod recording_l1;
+pub mod store;
+
+pub use generator::{
+    FetchedL1Proof, WitnessGenerator, WitnessGeneratorConfig, group_l1_reads_for_proof_fetch,
+};
+pub use recording_db::{RecordedAccesses, RecordingDatabase};
+pub use recording_l1::{RecordedL1Read, RecordingL1StateProvider, SharedRecordedReads};
+pub use store::{AccessSnapshot, BuiltBlockWitness, SharedWitnessStore, WitnessStore};

--- a/crates/tempo-zone/src/witness/recording_db.rs
+++ b/crates/tempo-zone/src/witness/recording_db.rs
@@ -1,0 +1,267 @@
+//! Recording database wrapper for witness generation.
+//!
+//! Wraps any revm [`Database`] to record which accounts and storage slots are
+//! accessed during EVM execution. After execution, the recorded accesses can be
+//! used to generate MPT proofs for the [`ZoneStateWitness`].
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, Mutex},
+};
+
+use alloy_primitives::{Address, B256, U256};
+use reth_errors::ProviderError;
+use reth_revm::Database;
+use revm::state::{AccountInfo, Bytecode};
+
+/// Shared handle to recorded state accesses.
+///
+/// This handle can be cloned before the `RecordingDatabase` is consumed by
+/// `State::builder().with_database(...)`, allowing the caller to retrieve
+/// recorded accesses after execution is complete.
+#[derive(Clone, Default)]
+pub struct RecordedAccesses {
+    inner: Arc<Mutex<RecordedAccessesInner>>,
+}
+
+/// Interior data for recorded accesses.
+#[derive(Default)]
+struct RecordedAccessesInner {
+    /// Accounts whose `basic()` was called.
+    accounts: BTreeSet<Address>,
+    /// Storage slots read per account.
+    storage: BTreeMap<Address, BTreeSet<U256>>,
+    /// Code hashes that were looked up.
+    code_hashes: BTreeSet<B256>,
+    /// Block hashes that were looked up.
+    block_hashes: BTreeSet<u64>,
+}
+
+impl RecordedAccesses {
+    /// Create a new empty handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a snapshot of all accessed account addresses.
+    pub fn accessed_accounts(&self) -> BTreeSet<Address> {
+        self.inner.lock().expect("poisoned").accounts.clone()
+    }
+
+    /// Returns a snapshot of all accessed storage slots, grouped by account.
+    pub fn accessed_storage(&self) -> BTreeMap<Address, BTreeSet<U256>> {
+        self.inner.lock().expect("poisoned").storage.clone()
+    }
+
+    /// Returns a snapshot of all accessed code hashes.
+    pub fn accessed_code_hashes(&self) -> BTreeSet<B256> {
+        self.inner.lock().expect("poisoned").code_hashes.clone()
+    }
+
+    /// Returns a snapshot of all accessed block numbers (for BLOCKHASH).
+    pub fn accessed_block_hashes(&self) -> BTreeSet<u64> {
+        self.inner.lock().expect("poisoned").block_hashes.clone()
+    }
+
+    /// Record an account access.
+    fn record_account(&self, address: Address) {
+        self.inner
+            .lock()
+            .expect("poisoned")
+            .accounts
+            .insert(address);
+    }
+
+    /// Record a storage slot access.
+    fn record_storage(&self, address: Address, slot: U256) {
+        let mut inner = self.inner.lock().expect("poisoned");
+        inner.accounts.insert(address);
+        inner.storage.entry(address).or_default().insert(slot);
+    }
+
+    /// Record a code hash access.
+    fn record_code_hash(&self, code_hash: B256) {
+        self.inner
+            .lock()
+            .expect("poisoned")
+            .code_hashes
+            .insert(code_hash);
+    }
+
+    /// Record a block hash access.
+    fn record_block_hash(&self, number: u64) {
+        self.inner
+            .lock()
+            .expect("poisoned")
+            .block_hashes
+            .insert(number);
+    }
+}
+
+/// A database wrapper that records all state accesses via a shared handle.
+///
+/// Delegates all reads to the inner database but logs every `basic()`,
+/// `storage()`, and `code_by_hash()` call to a [`RecordedAccesses`] handle.
+///
+/// The handle can be cloned before the database is consumed, allowing
+/// the caller to retrieve the accesses after execution.
+///
+/// # Usage
+///
+/// ```ignore
+/// let accesses = RecordedAccesses::new();
+/// let recording_db = RecordingDatabase::new(inner_db, accesses.clone());
+/// // ... wrap in State, execute blocks ...
+/// let accounts = accesses.accessed_accounts();
+/// let storage = accesses.accessed_storage();
+/// ```
+pub struct RecordingDatabase<DB> {
+    inner: DB,
+    accesses: RecordedAccesses,
+}
+
+impl<DB> std::fmt::Debug for RecordingDatabase<DB> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecordingDatabase")
+            .field("accesses", &"RecordedAccesses { ... }")
+            .finish()
+    }
+}
+
+impl<DB> RecordingDatabase<DB> {
+    /// Create a new recording wrapper around an existing database.
+    ///
+    /// The `accesses` handle is shared — clone it before passing it here
+    /// to retrieve recorded data after the database is consumed.
+    pub fn new(inner: DB, accesses: RecordedAccesses) -> Self {
+        Self { inner, accesses }
+    }
+
+    /// Consume the wrapper and return the inner database.
+    pub fn into_inner(self) -> DB {
+        self.inner
+    }
+
+    /// Get a reference to the inner database.
+    pub fn inner(&self) -> &DB {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner database.
+    pub fn inner_mut(&mut self) -> &mut DB {
+        &mut self.inner
+    }
+
+    /// Get a reference to the shared recorded accesses handle.
+    pub fn accesses(&self) -> &RecordedAccesses {
+        &self.accesses
+    }
+}
+
+impl<DB: Database<Error = ProviderError>> Database for RecordingDatabase<DB> {
+    type Error = ProviderError;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.accesses.record_account(address);
+        self.inner.basic(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.accesses.record_code_hash(code_hash);
+        self.inner.code_by_hash(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.accesses.record_storage(address, index);
+        self.inner.storage(address, index)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.accesses.record_block_hash(number);
+        // EIP-2935: also record the corresponding storage slot in the history
+        // contract so the proof generator includes it in the zone state witness.
+        // This allows the prover's WitnessDatabase to serve block hashes from
+        // the same MPT proofs used for regular storage, avoiding a separate
+        // block hash witness field.
+        self.accesses.record_storage(
+            alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS,
+            U256::from(number % alloy_eips::eip2935::HISTORY_SERVE_WINDOW as u64),
+        );
+        self.inner.block_hash(number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A simple in-memory database for testing.
+    struct TestDb;
+
+    impl Database for TestDb {
+        type Error = ProviderError;
+
+        fn basic(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Ok(None)
+        }
+
+        fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Ok(Bytecode::default())
+        }
+
+        fn storage(&mut self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+            Ok(U256::ZERO)
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    #[test]
+    fn test_recording_db_captures_accesses() {
+        let accesses = RecordedAccesses::new();
+        let mut db = RecordingDatabase::new(TestDb, accesses.clone());
+
+        let addr1 = Address::with_last_byte(1);
+        let addr2 = Address::with_last_byte(2);
+
+        // Access accounts
+        let _ = db.basic(addr1);
+        let _ = db.basic(addr2);
+        let _ = db.basic(addr1); // duplicate
+
+        // Access storage
+        let _ = db.storage(addr1, U256::from(10));
+        let _ = db.storage(addr1, U256::from(20));
+        let _ = db.storage(addr2, U256::from(30));
+
+        // Use the cloned handle to retrieve accesses.
+        assert_eq!(accesses.accessed_accounts().len(), 2);
+        assert!(accesses.accessed_accounts().contains(&addr1));
+        assert!(accesses.accessed_accounts().contains(&addr2));
+
+        let storage = accesses.accessed_storage();
+        assert_eq!(storage.len(), 2);
+        assert_eq!(storage[&addr1].len(), 2);
+        assert_eq!(storage[&addr2].len(), 1);
+    }
+
+    #[test]
+    fn test_shared_handle_after_consume() {
+        let accesses = RecordedAccesses::new();
+        let mut db = RecordingDatabase::new(TestDb, accesses.clone());
+
+        let addr = Address::with_last_byte(1);
+        let _ = db.basic(addr);
+        let _ = db.storage(addr, U256::from(42));
+
+        // Consume the database.
+        let _inner = db.into_inner();
+
+        // The shared handle still has the recorded accesses.
+        assert_eq!(accesses.accessed_accounts().len(), 1);
+        assert!(accesses.accessed_accounts().contains(&addr));
+        assert_eq!(accesses.accessed_storage()[&addr].len(), 1);
+    }
+}

--- a/crates/tempo-zone/src/witness/recording_l1.rs
+++ b/crates/tempo-zone/src/witness/recording_l1.rs
@@ -1,0 +1,105 @@
+//! Recording wrapper for L1 state reads.
+//!
+//! Wraps any [`L1StorageReader`] to capture all Tempo L1 storage reads performed
+//! during zone block execution. The recorded reads are used to build the
+//! [`BatchStateProof`] with deduplicated MPT node pool.
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
+
+use alloy_primitives::{Address, B256};
+use eyre::Result;
+
+use crate::l1_state::L1StorageReader;
+
+/// A recorded Tempo L1 storage read.
+#[derive(Debug, Clone)]
+pub struct RecordedL1Read {
+    /// The zone block index that triggered this read.
+    pub zone_block_index: u64,
+    /// The Tempo block number the read was against.
+    pub tempo_block_number: u64,
+    /// The L1 contract address read from.
+    pub account: Address,
+    /// The storage slot.
+    pub slot: B256,
+    /// The value returned.
+    pub value: B256,
+}
+
+/// Shared collection of recorded L1 reads, safe for concurrent access.
+pub type SharedRecordedReads = Arc<Mutex<Vec<RecordedL1Read>>>;
+
+/// An L1 state provider wrapper that records all storage reads.
+///
+/// Delegates to the inner [`L1StorageReader`] for the actual read, but captures
+/// every `get_storage` call in the shared [`RecordedL1Read`] collection.
+///
+/// The `zone_block_index` is set by the caller before each zone block is executed
+/// and used to tag reads with the correct block index. It uses `AtomicU64` so it
+/// can be updated through `&self` (the provider is behind `Arc<dyn L1StorageReader>`).
+#[derive(Clone)]
+pub struct RecordingL1StateProvider {
+    inner: Arc<dyn L1StorageReader>,
+    reads: SharedRecordedReads,
+    /// Current zone block index, shared across all clones.
+    zone_block_index: Arc<AtomicU64>,
+}
+
+impl std::fmt::Debug for RecordingL1StateProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecordingL1StateProvider")
+            .field("zone_block_index", &self.zone_block_index)
+            .finish()
+    }
+}
+
+impl RecordingL1StateProvider {
+    /// Create a new recording wrapper around any [`L1StorageReader`].
+    pub fn new(inner: Arc<dyn L1StorageReader>) -> Self {
+        Self {
+            inner,
+            reads: Arc::new(Mutex::new(Vec::new())),
+            zone_block_index: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Set the current zone block index for tagging subsequent reads.
+    ///
+    /// Uses atomic ordering so this can be called through `&self` (the provider
+    /// lives behind `Arc<dyn L1StorageReader>` in the EVM factory).
+    pub fn set_zone_block_index(&self, index: u64) {
+        self.zone_block_index.store(index, Ordering::Release);
+    }
+
+    /// Take all recorded reads, clearing the internal buffer.
+    pub fn take_reads(&self) -> Vec<RecordedL1Read> {
+        std::mem::take(&mut *self.reads.lock().expect("recording lock poisoned"))
+    }
+
+    /// Get a reference to the shared recorded reads.
+    pub fn recorded_reads(&self) -> SharedRecordedReads {
+        self.reads.clone()
+    }
+}
+
+impl L1StorageReader for RecordingL1StateProvider {
+    fn get_storage(&self, address: Address, slot: B256, block_number: u64) -> Result<B256> {
+        let value = self.inner.get_storage(address, slot, block_number)?;
+
+        self.reads
+            .lock()
+            .expect("recording lock poisoned")
+            .push(RecordedL1Read {
+                zone_block_index: self.zone_block_index.load(Ordering::Acquire),
+                tempo_block_number: block_number,
+                account: address,
+                slot,
+                value,
+            });
+
+        Ok(value)
+    }
+}

--- a/crates/tempo-zone/src/witness/store.rs
+++ b/crates/tempo-zone/src/witness/store.rs
@@ -1,0 +1,146 @@
+//! Per-block witness data store.
+//!
+//! The [`WitnessStore`] bridges the payload builder (which records state accesses
+//! during block execution) and the zone monitor (which generates the zone state
+//! witness, fetches L1 proofs, assembles the full [`BatchWitness`], and submits
+//! proofs to the ZonePortal).
+//!
+//! ## Flow
+//!
+//! 1. **Builder** executes a zone block with recording enabled, snapshots the
+//!    accessed accounts/storage, and stores a [`BuiltBlockWitness`].
+//! 2. **Monitor** processes a block range, calls [`WitnessStore::take_range`],
+//!    merges all accessed accounts/storage into a union, generates MPT proofs
+//!    against the initial state root S₀ via `eth_getProof`, fetches L1 proofs,
+//!    and assembles the [`BatchWitness`] for proof generation.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{Arc, Mutex},
+};
+
+use alloy_primitives::{Address, B256, U256};
+use zone_stf::types::{ZoneBlock, ZoneHeader};
+
+use super::recording_l1::RecordedL1Read;
+
+/// Snapshot of all state accesses recorded during a single block execution.
+///
+/// Plain-data equivalent of [`RecordedAccesses`](super::RecordedAccesses)
+/// without the `Arc<Mutex<>>` interior — suitable for storage and transfer.
+#[derive(Debug, Clone, Default)]
+pub struct AccessSnapshot {
+    /// Accounts whose `basic()` was called.
+    pub accounts: BTreeSet<Address>,
+    /// Storage slots read per account.
+    pub storage: BTreeMap<Address, BTreeSet<U256>>,
+}
+
+impl AccessSnapshot {
+    /// Merge another snapshot into this one (union of all accesses).
+    pub fn merge(&mut self, other: &Self) {
+        self.accounts.extend(&other.accounts);
+        for (addr, slots) in &other.storage {
+            self.storage.entry(*addr).or_default().extend(slots);
+        }
+    }
+}
+
+/// Data captured during a single zone block build.
+///
+/// Stored by the payload builder after each block and consumed by the
+/// zone monitor when assembling a batch for proof generation.
+#[derive(Debug)]
+pub struct BuiltBlockWitness {
+    /// Zone block in prover format (system txs + pool txs + deposits).
+    pub zone_block: ZoneBlock,
+
+    /// Snapshot of all EVM state accesses during this block's execution.
+    /// The monitor merges these across all blocks in the batch, then
+    /// generates MPT proofs against S₀ for the full union.
+    pub access_snapshot: AccessSnapshot,
+
+    /// Previous block header (for block hash verification by the prover).
+    pub prev_block_header: ZoneHeader,
+
+    /// Parent block hash — identifies the state root S_n this block was
+    /// built against. For the first block in a batch, this is S₀.
+    pub parent_block_hash: B256,
+
+    /// L1 storage reads recorded during this block's execution.
+    pub l1_reads: Vec<RecordedL1Read>,
+
+    /// Zone chain ID for EVM configuration.
+    pub chain_id: u64,
+
+    /// RLP-encoded Tempo header processed by `advanceTempo` in this block.
+    /// `None` if the block did not advance Tempo (binding carries over).
+    pub tempo_header_rlp: Option<Vec<u8>>,
+}
+
+/// Thread-safe store for per-block witness data.
+///
+/// Keyed by zone block number. The builder inserts after each block, and
+/// the monitor takes entries when submitting a batch.
+///
+/// TODO(production): Add a max entry cap or auto-pruning on insert. Currently,
+/// `prune_below` is only called by the proof generator. On nodes that don't
+/// generate proofs (validators, full nodes), the store will grow unbounded.
+/// Consider either a `max_size` limit that drops the oldest blocks on insert,
+/// or a periodic cleanup task independent of proof generation.
+#[derive(Debug, Default)]
+pub struct WitnessStore {
+    blocks: BTreeMap<u64, BuiltBlockWitness>,
+}
+
+impl WitnessStore {
+    /// Insert witness data for a built zone block.
+    ///
+    /// Overwrites any existing entry for the same block number (e.g., if
+    /// the builder rebuilt a block due to reorg).
+    pub fn insert(&mut self, block_number: u64, witness: BuiltBlockWitness) {
+        self.blocks.insert(block_number, witness);
+    }
+
+    /// Take witness data for a single block, removing it from the store.
+    pub fn take(&mut self, block_number: u64) -> Option<BuiltBlockWitness> {
+        self.blocks.remove(&block_number)
+    }
+
+    /// Take witness data for a range of blocks `[from, to]`, removing them
+    /// from the store. Returns entries in block-number order.
+    ///
+    /// Returns an error if any block in the range is missing from the store.
+    pub fn take_range(&mut self, from: u64, to: u64) -> Result<Vec<(u64, BuiltBlockWitness)>, u64> {
+        // Pre-check that all blocks exist before removing any.
+        for num in from..=to {
+            if !self.blocks.contains_key(&num) {
+                return Err(num);
+            }
+        }
+        let mut result = Vec::with_capacity((to - from + 1) as usize);
+        for num in from..=to {
+            // Safe: pre-check above guarantees existence.
+            result.push((num, self.blocks.remove(&num).unwrap()));
+        }
+        Ok(result)
+    }
+
+    /// Number of blocks currently stored.
+    pub fn len(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Returns true if the store is empty.
+    pub fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
+    /// Discard entries below a given block number (cleanup after batch submission).
+    pub fn prune_below(&mut self, block_number: u64) {
+        self.blocks = self.blocks.split_off(&block_number);
+    }
+}
+
+/// Shared, thread-safe witness store handle.
+pub type SharedWitnessStore = Arc<Mutex<WitnessStore>>;

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -26,7 +26,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
 use alloy_transport::layers::RetryBackoffLayer;
@@ -40,6 +40,7 @@ use alloy_sol_types::{ContractError, SolInterface as _};
 use crate::{
     abi::{self, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
     batch::{AnchorGapKind, BatchData, BatchSubmitter, ZoneBlockSnapshot, fetch_slot_withdrawals},
+    proof::BatchProofGenerator,
     withdrawals::SharedWithdrawalStore,
 };
 
@@ -116,6 +117,9 @@ pub struct ZoneMonitor {
     /// and incremented each time a batch with a non-zero
     /// `withdrawal_queue_hash` is successfully submitted to L1.
     portal_withdrawal_queue_tail: u64,
+    /// Node-internal proof generator — owns the witness store, state provider,
+    /// and L1 provider. The monitor calls a single method per batch.
+    proof_generator: Arc<dyn BatchProofGenerator>,
     /// Most recent zone block observed from the L2 RPC.
     latest_observed_zone_block: u64,
 }
@@ -126,11 +130,15 @@ impl ZoneMonitor {
     /// Builds a read-only HTTP provider (no wallet) pointed at the Zone L2 RPC,
     /// instantiates the on-chain contract handles, and creates a [`BatchSubmitter`]
     /// backed by the shared `l1_provider` for posting batches to the ZonePortal on L1.
+    ///
+    /// Proof generation is delegated entirely to the `proof_generator`, which runs
+    /// inside the node and has direct state provider access.
     pub async fn new(
         config: ZoneMonitorConfig,
         l1_provider: DynProvider<TempoNetwork>,
         withdrawal_store: SharedWithdrawalStore,
         withdrawal_notify: Arc<Notify>,
+        proof_generator: Arc<dyn BatchProofGenerator>,
     ) -> Result<Self> {
         let zone_rpc_url = config.zone_rpc_url.clone();
         let retry_layer = RetryBackoffLayer::new(
@@ -156,6 +164,7 @@ impl ZoneMonitor {
             l1_provider,
             withdrawal_store,
             withdrawal_notify,
+            proof_generator,
         )
         .await
     }
@@ -166,6 +175,7 @@ impl ZoneMonitor {
         l1_provider: DynProvider<TempoNetwork>,
         withdrawal_store: SharedWithdrawalStore,
         withdrawal_notify: Arc<Notify>,
+        proof_generator: Arc<dyn BatchProofGenerator>,
     ) -> Result<Self> {
         let metrics = crate::metrics::ZoneMonitorMetrics::default();
         let outbox = ZoneOutbox::new(config.outbox_address, provider.clone());
@@ -256,6 +266,7 @@ impl ZoneMonitor {
             prev_processed_deposit_hash,
             prev_zone_block_hash,
             portal_withdrawal_queue_tail,
+            proof_generator,
             latest_observed_zone_block: last_submitted_zone_block,
         })
     }
@@ -360,6 +371,8 @@ impl ZoneMonitor {
     /// withdrawals, we recompute the combined hash from the collected withdrawal structs.
     #[instrument(skip(self), fields(from, to))]
     async fn process_block_range(&mut self, from: u64, to: u64) -> Result<()> {
+        // TODO(production): Add a max batch size cap to prevent OOM on large
+        // block ranges (e.g., after a long outage). Chunk into sub-batches.
         let block_count = to - from + 1;
         info!(from, to, block_count, "Processing zone block range");
 
@@ -401,6 +414,28 @@ impl ZoneMonitor {
             );
         }
 
+        // --- 3. Generate proof for the batch ---
+        let portal_withdrawal_batch_index = self
+            .batch_submitter
+            .read_portal_withdrawal_batch_index()
+            .await?;
+        let expected_withdrawal_batch_index = portal_withdrawal_batch_index
+            .checked_add(1)
+            .ok_or_else(|| {
+                eyre::eyre!("portal withdrawalBatchIndex overflow: {portal_withdrawal_batch_index}")
+            })?;
+        let (verifier_config, proof) = self
+            .proof_generator
+            .generate_batch_proof(
+                from,
+                to,
+                end_state.tempo_block_number,
+                self.prev_zone_block_hash,
+                expected_withdrawal_batch_index,
+            )
+            .await?;
+
+        // --- 4. Build and submit BatchData ---
         let batch_data = BatchData {
             tempo_block_number: end_state.tempo_block_number,
             prev_block_hash: self.prev_zone_block_hash,
@@ -408,6 +443,8 @@ impl ZoneMonitor {
             prev_processed_deposit_hash: self.prev_processed_deposit_hash,
             next_processed_deposit_hash: end_state.processed_deposit_hash,
             withdrawal_queue_hash,
+            verifier_config,
+            proof,
         };
 
         self.submit_batch_with_retry(&batch_data, to, all_withdrawals)
@@ -482,6 +519,8 @@ impl ZoneMonitor {
                 prev_processed_deposit_hash: self.prev_processed_deposit_hash,
                 next_processed_deposit_hash: step_state.processed_deposit_hash,
                 withdrawal_queue_hash,
+                verifier_config: Bytes::new(),
+                proof: Bytes::new(),
             };
 
             info!(
@@ -793,11 +832,13 @@ impl ZoneMonitor {
 /// advances on successful submission.
 ///
 /// The `l1_provider` must already include the sequencer wallet for signing L1 transactions.
+/// Proof generation is delegated to the `proof_generator`.
 pub fn spawn_zone_monitor(
     config: ZoneMonitorConfig,
     l1_provider: DynProvider<TempoNetwork>,
     withdrawal_store: SharedWithdrawalStore,
     withdrawal_notify: Arc<Notify>,
+    proof_generator: Arc<dyn BatchProofGenerator>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut monitor = loop {
@@ -806,6 +847,7 @@ pub fn spawn_zone_monitor(
                 l1_provider.clone(),
                 withdrawal_store.clone(),
                 withdrawal_notify.clone(),
+                proof_generator.clone(),
             )
             .await
             {
@@ -849,6 +891,22 @@ mod tests {
     use alloy_transport::mock::Asserter;
     use tempo_alloy::rpc::TempoHeaderResponse;
     use tempo_primitives::TempoHeader;
+
+    struct NoopBatchProofGenerator;
+
+    #[async_trait::async_trait]
+    impl BatchProofGenerator for NoopBatchProofGenerator {
+        async fn generate_batch_proof(
+            &self,
+            _from: u64,
+            _to: u64,
+            _tempo_block_number: u64,
+            _prev_block_hash: B256,
+            _expected_withdrawal_batch_index: u64,
+        ) -> Result<(Bytes, Bytes)> {
+            Ok((Bytes::new(), Bytes::new()))
+        }
+    }
 
     fn mock_provider(asserter: Asserter) -> DynProvider<TempoNetwork> {
         ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -910,6 +968,7 @@ mod tests {
             prev_processed_deposit_hash: B256::repeat_byte(0xaa),
             prev_zone_block_hash: B256::repeat_byte(0xbb),
             portal_withdrawal_queue_tail: 3,
+            proof_generator: Arc::new(NoopBatchProofGenerator),
             latest_observed_zone_block: 50,
         }
     }
@@ -938,6 +997,7 @@ mod tests {
             mock_provider(l1.clone()),
             SharedWithdrawalStore::new(),
             Arc::new(Notify::new()),
+            Arc::new(NoopBatchProofGenerator),
         )
         .await
         {
@@ -1004,6 +1064,8 @@ mod tests {
             prev_processed_deposit_hash: B256::repeat_byte(0x77),
             next_processed_deposit_hash: B256::repeat_byte(0x66),
             withdrawal_queue_hash: B256::ZERO,
+            verifier_config: Bytes::new(),
+            proof: Bytes::new(),
         };
 
         monitor

--- a/crates/tempo-zone/tests/advance_tempo.rs
+++ b/crates/tempo-zone/tests/advance_tempo.rs
@@ -2,25 +2,11 @@
 //!
 //! Run with: `cargo test -p zone --test advance_tempo -- --nocapture`
 
-use alloy_evm::{Evm, EvmEnv, EvmFactory};
-use alloy_primitives::{Address, Bytes, U256, address};
+use alloy_evm::Evm;
+use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, sol};
-use revm::{
-    context::result::{ExecutionResult, Output},
-    database::{CacheDB, EmptyDB},
-    state::AccountInfo,
-};
-use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
-use tempo_revm::TempoBlockEnv;
-use zone_primitives::constants::zone_chain_id;
-
-const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
-const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
-const ZONE_OUTBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000002");
-const ZONE_CONFIG_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000003");
-
-const DEPLOYER: Address = address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+use revm::context::result::{ExecutionResult, Output};
+use zone_test_utils::{TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS};
 
 sol! {
     function advanceTempo(bytes calldata header, QueuedDeposit[] calldata deposits, DecryptionData[] calldata decryptions);
@@ -44,205 +30,10 @@ sol! {
     }
 }
 
-/// Load a Foundry artifact's creation bytecode from the specs output directory.
-fn load_artifact(name: &str) -> Vec<u8> {
-    #[derive(serde::Deserialize)]
-    struct FoundryArtifact {
-        bytecode: BytecodeField,
-    }
-    #[derive(serde::Deserialize)]
-    struct BytecodeField {
-        object: String,
-    }
-
-    // Workspace root is two levels up from the crate directory
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-    let specs_out = manifest_dir.join("../../docs/specs/out");
-    let path = specs_out
-        .join(format!("{name}.sol"))
-        .join(format!("{name}.json"));
-    let content =
-        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    let artifact: FoundryArtifact =
-        serde_json::from_str(&content).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
-    const_hex::decode(&artifact.bytecode.object).expect("decode bytecode hex")
-}
-
-/// Deploy a contract into the CacheDB via the EVM, then relocate it to the predeploy address.
-fn deploy_contract(
-    evm: &mut TempoEvm<CacheDB<EmptyDB>>,
-    creation_bytecode: &[u8],
-    constructor_args: &[u8],
-    predeploy_addr: Address,
-    name: &str,
-    chain_id: u64,
-    nonce: u64,
-) {
-    use alloy_primitives::TxKind;
-    use revm::context::TxEnv;
-    use tempo_revm::TempoTxEnv;
-
-    let mut initcode = Vec::with_capacity(creation_bytecode.len() + constructor_args.len());
-    initcode.extend_from_slice(creation_bytecode);
-    initcode.extend_from_slice(constructor_args);
-
-    let tx = TempoTxEnv {
-        inner: TxEnv {
-            caller: DEPLOYER,
-            gas_price: 0,
-            gas_limit: 30_000_000,
-            kind: TxKind::Create,
-            data: initcode.into(),
-            chain_id: Some(chain_id),
-            nonce,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    let result = evm
-        .transact_raw(tx)
-        .unwrap_or_else(|e| panic!("{name} deploy tx failed: {e:?}"));
-    let created_addr = match &result.result {
-        ExecutionResult::Success { output, .. } => match output {
-            Output::Create(_, Some(addr)) => *addr,
-            other => panic!("{name} deploy did not return address: {other:?}"),
-        },
-        ExecutionResult::Revert { output, .. } => panic!("{name} deploy reverted: {output}"),
-        ExecutionResult::Halt { reason, .. } => panic!("{name} deploy halted: {reason:?}"),
-    };
-
-    use revm::DatabaseCommit;
-    evm.db_mut().commit(result.state);
-
-    let db = evm.db_mut();
-    if let Some(mut created_account) = db.cache.accounts.remove(&created_addr) {
-        created_account.info.nonce = 1;
-        db.cache.accounts.insert(predeploy_addr, created_account);
-    } else {
-        panic!("{name} deployed to {created_addr} but not found in CacheDB");
-    }
-
-    println!("Deployed {name} at {predeploy_addr} (created at {created_addr})");
-}
-
-/// Build an EVM with the zone contracts deployed in-memory (same as xtask generate_zone_genesis).
-fn setup_zone_evm_with_contracts() -> TempoEvm<CacheDB<EmptyDB>> {
-    let chain_id = zone_chain_id(1);
-    let gas_limit = 30_000_000u64;
-
-    let db = CacheDB::default();
-    let mut env: EvmEnv<TempoHardfork, TempoBlockEnv> =
-        EvmEnv::default().with_timestamp(U256::ZERO);
-    env.cfg_env.chain_id = chain_id;
-    env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
-    env.block_env.inner.gas_limit = gas_limit;
-
-    let factory = TempoEvmFactory::default();
-    let mut evm = factory.create_evm(db, env);
-
-    // Fund the deployer
-    evm.db_mut().insert_account_info(
-        DEPLOYER,
-        AccountInfo {
-            balance: U256::from(1_000_000_000_000_000_000_000u128),
-            ..Default::default()
-        },
-    );
-
-    // A minimal RLP-encoded Tempo genesis header (all zeros / minimal valid).
-    // This is the same format used by TempoState constructor.
-    // We create a dummy header RLP: an RLP list of empty/zero fields.
-    // For testing, use a simple valid RLP that TempoState will accept.
-    let dummy_header_rlp = build_dummy_header_rlp();
-
-    let mut nonce = 0u64;
-
-    // 1. TempoState(bytes headerRlp)
-    let tempo_state_bytecode = load_artifact("TempoState");
-    let tempo_state_args =
-        alloy_sol_types::SolValue::abi_encode_params(&(Bytes::from(dummy_header_rlp),));
-    deploy_contract(
-        &mut evm,
-        &tempo_state_bytecode,
-        &tempo_state_args,
-        TEMPO_STATE_ADDRESS,
-        "TempoState",
-        chain_id,
-        nonce,
-    );
-    nonce += 1;
-
-    // 2. ZoneConfig(address tempoPortal, address tempoState)
-    let zone_config_bytecode = load_artifact("ZoneConfig");
-    let tempo_portal = Address::repeat_byte(0xbb); // dummy
-    let zone_config_args =
-        alloy_sol_types::SolValue::abi_encode_params(&(tempo_portal, TEMPO_STATE_ADDRESS));
-    deploy_contract(
-        &mut evm,
-        &zone_config_bytecode,
-        &zone_config_args,
-        ZONE_CONFIG_ADDRESS,
-        "ZoneConfig",
-        chain_id,
-        nonce,
-    );
-    nonce += 1;
-
-    // 3. ZoneInbox(address config, address tempoPortal, address tempoState)
-    let zone_inbox_bytecode = load_artifact("ZoneInbox");
-    let zone_inbox_args = alloy_sol_types::SolValue::abi_encode_params(&(
-        ZONE_CONFIG_ADDRESS,
-        tempo_portal,
-        TEMPO_STATE_ADDRESS,
-    ));
-    deploy_contract(
-        &mut evm,
-        &zone_inbox_bytecode,
-        &zone_inbox_args,
-        ZONE_INBOX_ADDRESS,
-        "ZoneInbox",
-        chain_id,
-        nonce,
-    );
-    nonce += 1;
-
-    // 4. ZoneOutbox(address config)
-    let zone_outbox_bytecode = load_artifact("ZoneOutbox");
-    let zone_outbox_args = alloy_sol_types::SolValue::abi_encode_params(&(ZONE_CONFIG_ADDRESS,));
-    deploy_contract(
-        &mut evm,
-        &zone_outbox_bytecode,
-        &zone_outbox_args,
-        ZONE_OUTBOX_ADDRESS,
-        "ZoneOutbox",
-        chain_id,
-        nonce,
-    );
-
-    println!("All zone contracts deployed successfully");
-    evm
-}
-
-/// Build a minimal valid RLP-encoded TempoHeader.
-///
-/// We look at the TempoHeader struct to determine which fields to encode.
-/// For a minimal genesis header, most fields are zeroed.
-fn build_dummy_header_rlp() -> Vec<u8> {
-    use alloy_rlp::Encodable;
-    use tempo_primitives::TempoHeader;
-
-    // Construct a minimal TempoHeader (genesis-like)
-    let header = TempoHeader::default();
-
-    let mut buf = Vec::new();
-    header.encode(&mut buf);
-    buf
-}
-
 #[test]
 fn advance_tempo_repro() {
-    let mut evm = setup_zone_evm_with_contracts();
+    let mut evm = zone_test_utils::setup_zone_evm_default();
+    zone_test_utils::register_mock_tempo_state_reader(&mut evm);
 
     // System txs use Address::ZERO which bypasses OnlySequencer in ZoneInbox/ZoneOutbox
     let sequencer = Address::ZERO;
@@ -417,6 +208,12 @@ fn advance_tempo_repro() {
         Err(e) => println!("advanceTempo() ERROR: {e:?}"),
     }
 
-    // The test should not panic; we want to see the output
+    // With the mock precompile registered, advanceTempo should now succeed.
+    let result = advance_result.expect("advanceTempo tx should not error");
+    assert!(
+        result.result.is_success(),
+        "advanceTempo should succeed with mock precompile, got: {:?}",
+        result.result,
+    );
     println!("\n=== Test complete ===");
 }

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2207,7 +2207,29 @@ pub(crate) async fn spawn_sequencer(
         batch_interval: Duration::from_millis(500),
     };
 
-    zone::spawn_zone_sequencer(config, sequencer_signer).await
+    let noop_proof_gen: Arc<dyn zone::proof::BatchProofGenerator> =
+        Arc::new(NoopBatchProofGenerator);
+    zone::spawn_zone_sequencer(config, sequencer_signer, noop_proof_gen).await
+}
+
+/// No-op proof generator for integration tests (POC mode — empty proof bytes).
+struct NoopBatchProofGenerator;
+
+#[async_trait::async_trait]
+impl zone::proof::BatchProofGenerator for NoopBatchProofGenerator {
+    async fn generate_batch_proof(
+        &self,
+        _from: u64,
+        _to: u64,
+        _tempo_block_number: u64,
+        _prev_block_hash: B256,
+        _expected_withdrawal_batch_index: u64,
+    ) -> eyre::Result<(alloy_primitives::Bytes, alloy_primitives::Bytes)> {
+        Ok((
+            alloy_primitives::Bytes::new(),
+            alloy_primitives::Bytes::new(),
+        ))
+    }
 }
 
 /// Start a local zone node with an L1Fixture already seeded for `seed_blocks` blocks.

--- a/crates/tempo-zone/tests/witness_pipeline.rs
+++ b/crates/tempo-zone/tests/witness_pipeline.rs
@@ -1,0 +1,1437 @@
+//! End-to-end test for the witness generation pipeline.
+//!
+//! Simulates the full builder -> WitnessStore -> ProofGenerator -> prover flow:
+//!
+//! 1. Deploy zone contracts into a CacheDB.
+//! 2. Build a `BuiltBlockWitness` as the builder would after executing a block.
+//! 3. Insert it into a `WitnessStore`.
+//! 4. Take the range and merge access snapshots (as `ProofGenerator` does).
+//! 5. Build the zone state witness from the merged access data.
+//! 6. Assemble the full `BatchWitness` and run the prover.
+//!
+//! This validates that the data structures flowing through the pipeline are
+//! compatible and that the prover accepts the result.
+
+use alloy_evm::Evm;
+use alloy_primitives::{Address, B256, U256};
+use std::collections::{BTreeMap, BTreeSet};
+use zone_stf::{
+    execute, prove_zone_batch,
+    testutil::{TestAccount, build_zone_state_fixture_with_absent, compute_state_root},
+    types::*,
+};
+use zone_test_utils::{
+    TEMPO_STATE_READER_ADDRESS, build_dummy_header_rlp, extract_db_accounts,
+    register_mock_tempo_state_reader, setup_zone_evm,
+};
+
+// Used by test_witness_pipeline_advance_user_tx_finalize
+
+const CHAIN_ID: u64 = 13371;
+const SEQUENCER: Address = Address::ZERO;
+
+fn snapshot_to_test_account(snap: &zone_test_utils::AccountSnapshot) -> TestAccount {
+    TestAccount {
+        nonce: snap.nonce,
+        balance: snap.balance,
+        code_hash: snap.code_hash,
+        code: snap.code.clone(),
+        storage: snap.storage.clone(),
+    }
+}
+
+/// Execute a zone block on a CacheDB to discover all state accesses.
+///
+/// Applies the EIP-2935 blockhash system call before other transactions
+/// to match the prover's behavior. Returns the post-accounts AND the
+/// CacheDB so callers can chain sequential blocks.
+fn reference_execute(
+    db: revm::database::CacheDB<revm::database::EmptyDB>,
+    block: &ZoneBlock,
+) -> (
+    Vec<(Address, TestAccount)>,
+    revm::database::CacheDB<revm::database::EmptyDB>,
+) {
+    use alloy_evm::{Evm, EvmEnv, EvmFactory};
+    use alloy_sol_types::SolCall;
+    use revm::{DatabaseCommit, context::BlockEnv};
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_evm::evm::TempoEvmFactory;
+    use tempo_revm::TempoBlockEnv;
+
+    let block_env = TempoBlockEnv {
+        inner: BlockEnv {
+            number: U256::from(block.number),
+            beneficiary: block.beneficiary,
+            timestamp: U256::from(block.timestamp),
+            gas_limit: block.gas_limit,
+            basefee: block.base_fee_per_gas,
+            ..Default::default()
+        },
+        timestamp_millis_part: 0,
+    };
+
+    let mut cfg_env = revm::context::CfgEnv::new_with_spec(TempoHardfork::T0);
+    cfg_env.chain_id = CHAIN_ID;
+    cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+
+    let env = EvmEnv { cfg_env, block_env };
+    let factory = TempoEvmFactory::default();
+    let mut evm = factory.create_evm(db, env);
+    register_mock_tempo_state_reader(&mut evm);
+
+    // EIP-2935: store parent block hash in the history contract, matching the
+    // prover's pre-execution system call.
+    if block.number > 0 {
+        let result = evm
+            .transact_system_call(
+                alloy_eips::eip4788::SYSTEM_ADDRESS,
+                alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS,
+                block.parent_hash.0.into(),
+            )
+            .expect("EIP-2935 system call should succeed");
+        evm.db_mut().commit(result.state);
+    }
+
+    if let Some(count) = block.finalize_withdrawal_batch_count {
+        let calldata = finalizeWithdrawalBatchCall {
+            count,
+            blockNumber: block.number,
+        }
+        .abi_encode();
+
+        let result = evm
+            .transact_system_call(
+                Address::ZERO,
+                execute::ZONE_OUTBOX_ADDRESS,
+                alloy_primitives::Bytes::from(calldata),
+            )
+            .expect("finalizeWithdrawalBatch should succeed");
+        assert!(result.result.is_success());
+        evm.db_mut().commit(result.state);
+    }
+
+    let (post_db, _) = evm.finish();
+    let accounts = post_db
+        .cache
+        .accounts
+        .iter()
+        .map(|(addr, acct)| {
+            let info = &acct.info;
+            let code = info.code.as_ref().map(|c| c.bytes().to_vec());
+            let storage: Vec<(U256, U256)> = acct.storage.iter().map(|(k, v)| (*k, *v)).collect();
+            (
+                *addr,
+                TestAccount {
+                    nonce: info.nonce,
+                    balance: info.balance,
+                    code_hash: info.code_hash,
+                    code,
+                    storage,
+                },
+            )
+        })
+        .collect();
+    (accounts, post_db)
+}
+
+fn filter_real_accounts(
+    post_accounts: Vec<(Address, TestAccount)>,
+    pre_accounts: &[(Address, TestAccount)],
+) -> Vec<(Address, TestAccount)> {
+    post_accounts
+        .into_iter()
+        .filter(|(addr, acct)| {
+            let in_pre = pre_accounts.iter().any(|(a, _)| a == addr);
+            let is_non_empty = acct.nonce > 0
+                || !acct.balance.is_zero()
+                || acct.code_hash != alloy_primitives::KECCAK256_EMPTY;
+            in_pre || is_non_empty
+        })
+        .collect()
+}
+
+/// Collect (address, slot) pairs from post-execution accounts + mandatory prover slots.
+fn collect_accessed_slots(
+    post_accounts: &[(Address, TestAccount)],
+    block_numbers: &[u64],
+) -> Vec<(Address, U256)> {
+    let mut slots: Vec<(Address, U256)> = post_accounts
+        .iter()
+        .flat_map(|(addr, acct)| acct.storage.iter().map(move |(slot, _)| (*addr, *slot)))
+        .collect();
+
+    let mandatory = [
+        (
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_BLOCK_HASH_SLOT,
+        ),
+        (
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_STATE_ROOT_SLOT,
+        ),
+        (
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_PACKED_SLOT,
+        ),
+        (
+            execute::ZONE_INBOX_ADDRESS,
+            execute::storage::ZONE_INBOX_PROCESSED_HASH_SLOT,
+        ),
+        (
+            execute::ZONE_OUTBOX_ADDRESS,
+            execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT,
+        ),
+        (
+            execute::ZONE_OUTBOX_ADDRESS,
+            execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+        ),
+    ];
+
+    for (addr, slot) in mandatory {
+        if !slots.iter().any(|(a, s)| *a == addr && *s == slot) {
+            slots.push((addr, slot));
+        }
+    }
+
+    // EIP-2935: the prover writes `parent_hash` to the history contract for
+    // each block. Include the storage slot so the WitnessDatabase has it.
+    let history_addr = alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS;
+    for &block_num in block_numbers {
+        if block_num > 0 {
+            let slot =
+                U256::from((block_num - 1) % alloy_eips::eip2935::HISTORY_SERVE_WINDOW as u64);
+            if !slots.iter().any(|(a, s)| *a == history_addr && *s == slot) {
+                slots.push((history_addr, slot));
+            }
+        }
+    }
+
+    slots
+}
+
+/// Build a witness fixture enriched with all accessed storage slots.
+fn build_witness_with_accessed_slots(
+    pre_accounts: &[(Address, TestAccount)],
+    accessed_slots: &[(Address, U256)],
+    absent_addresses: &[Address],
+) -> zone_stf::testutil::ZoneStateFixture {
+    let mut enriched: Vec<(Address, TestAccount)> = pre_accounts.to_vec();
+
+    for (addr, slot) in accessed_slots {
+        if let Some((_, acct)) = enriched.iter_mut().find(|(a, _)| a == addr)
+            && !acct.storage.iter().any(|(s, _)| s == slot)
+        {
+            acct.storage.push((*slot, U256::ZERO));
+        }
+    }
+
+    build_zone_state_fixture_with_absent(&enriched, absent_addresses)
+}
+
+fn find_storage_value(
+    accounts: &[(Address, TestAccount)],
+    target_addr: Address,
+    slot: U256,
+) -> U256 {
+    accounts
+        .iter()
+        .find(|(a, _)| *a == target_addr)
+        .and_then(|(_, acct)| {
+            acct.storage
+                .iter()
+                .find(|(s, _)| *s == slot)
+                .map(|(_, v)| *v)
+        })
+        .unwrap_or(U256::ZERO)
+}
+
+/// Full pipeline test: WitnessStore -> AccessSnapshot merge -> assemble -> prove.
+///
+/// This exercises the same data flow as `ProofGenerator::generate_batch_proof`,
+/// validating that the `BuiltBlockWitness` -> merge -> assemble -> prover path
+/// produces a valid proof.
+#[test]
+fn test_witness_pipeline_single_block() {
+    use zone::witness::{
+        AccessSnapshot, BuiltBlockWitness, WitnessGenerator, WitnessGeneratorConfig, WitnessStore,
+    };
+
+    let db = {
+        let mut evm = setup_zone_evm(CHAIN_ID);
+        use revm::state::AccountInfo;
+        if !evm.db_mut().cache.accounts.contains_key(&Address::ZERO) {
+            evm.db_mut()
+                .insert_account_info(Address::ZERO, AccountInfo::default());
+        }
+        let (db, _) = evm.finish();
+        db
+    };
+
+    let pre_accounts: Vec<(Address, TestAccount)> = extract_db_accounts(&db)
+        .into_iter()
+        .map(|(addr, snap)| (addr, snapshot_to_test_account(&snap)))
+        .collect();
+
+    let placeholder_root = compute_state_root(&pre_accounts);
+    let genesis_header = ZoneHeader {
+        parent_hash: B256::ZERO,
+        beneficiary: SEQUENCER,
+        state_root: placeholder_root,
+        transactions_root: alloy_trie::EMPTY_ROOT_HASH,
+        receipts_root: alloy_trie::EMPTY_ROOT_HASH,
+        number: 0,
+        timestamp: 0,
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    let zone_block = ZoneBlock {
+        number: 1,
+        parent_hash: genesis_hash,
+        timestamp: 1000,
+        beneficiary: SEQUENCER,
+        gas_limit: u64::MAX,
+        base_fee_per_gas: 0,
+        tempo_header_rlp: None,
+        deposits: vec![],
+        decryptions: vec![],
+        finalize_withdrawal_batch_count: Some(U256::ZERO),
+        transactions: vec![],
+        expected_state_root: B256::ZERO,
+    };
+
+    // Reference execution discovers all accessed accounts/storage.
+    let (raw_post, _post_db) = reference_execute(db, &zone_block);
+    let accessed_slots = collect_accessed_slots(&raw_post, &[zone_block.number]);
+    let absent = [
+        TEMPO_STATE_READER_ADDRESS,
+        alloy_eips::eip4788::SYSTEM_ADDRESS,
+    ];
+    let fixture = build_witness_with_accessed_slots(&pre_accounts, &accessed_slots, &absent);
+
+    let genesis_header = ZoneHeader {
+        state_root: fixture.state_root,
+        ..genesis_header
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    let post_accounts = filter_real_accounts(raw_post, &pre_accounts);
+    let expected_state_root = compute_state_root(&post_accounts);
+
+    let zone_block = ZoneBlock {
+        parent_hash: genesis_hash,
+        expected_state_root,
+        ..zone_block
+    };
+
+    // Build the AccessSnapshot as the builder would from RecordedAccesses.
+    let mut access_accounts = BTreeSet::new();
+    let mut access_storage: BTreeMap<Address, BTreeSet<U256>> = BTreeMap::new();
+    for (addr, slot) in &accessed_slots {
+        access_accounts.insert(*addr);
+        access_storage.entry(*addr).or_default().insert(*slot);
+    }
+    for (addr, _) in &pre_accounts {
+        access_accounts.insert(*addr);
+    }
+
+    let access_snapshot = AccessSnapshot {
+        accounts: access_accounts,
+        storage: access_storage,
+    };
+
+    // Store in WitnessStore (mimicking builder).
+    let mut store = WitnessStore::default();
+    let built_witness = BuiltBlockWitness {
+        zone_block: zone_block.clone(),
+        access_snapshot,
+        prev_block_header: genesis_header.clone(),
+        parent_block_hash: genesis_hash,
+        l1_reads: vec![],
+        chain_id: CHAIN_ID,
+        tempo_header_rlp: Some(build_dummy_header_rlp()),
+    };
+    store.insert(1, built_witness);
+
+    assert_eq!(store.len(), 1);
+
+    // Take from store (mimicking ProofGenerator).
+    let block_witnesses = store.take_range(1, 1).expect("block 1 should exist");
+    assert_eq!(block_witnesses.len(), 1);
+    assert!(store.is_empty());
+
+    // Merge access snapshots (trivial for single block, but exercises the path).
+    let mut merged = AccessSnapshot::default();
+    for (_, bw) in &block_witnesses {
+        merged.merge(&bw.access_snapshot);
+    }
+
+    // Assemble using WitnessGenerator.
+    let witness_gen = WitnessGenerator::new(WitnessGeneratorConfig {
+        sequencer: SEQUENCER,
+    });
+
+    let tempo_packed = find_storage_value(
+        &pre_accounts,
+        execute::TEMPO_STATE_ADDRESS,
+        execute::storage::TEMPO_STATE_PACKED_SLOT,
+    );
+    let tempo_block_number = execute::storage::extract_tempo_block_number(tempo_packed);
+    let tempo_block_hash = B256::from(
+        find_storage_value(
+            &pre_accounts,
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_BLOCK_HASH_SLOT,
+        )
+        .to_be_bytes(),
+    );
+    let outbox_wbi = find_storage_value(
+        &pre_accounts,
+        execute::ZONE_OUTBOX_ADDRESS,
+        execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+    )
+    .to::<u64>();
+
+    let public_inputs = PublicInputs {
+        prev_block_hash: genesis_hash,
+        tempo_block_number,
+        anchor_block_number: tempo_block_number,
+        anchor_block_hash: tempo_block_hash,
+        expected_withdrawal_batch_index: outbox_wbi,
+        sequencer: SEQUENCER,
+    };
+
+    let batch_witness = witness_gen.assemble_witness(
+        public_inputs,
+        CHAIN_ID,
+        genesis_header,
+        vec![zone_block],
+        fixture.witness,
+        BatchStateProof {
+            node_pool: alloy_primitives::map::HashMap::default(),
+            reads: vec![],
+            account_proofs: vec![],
+        },
+        vec![],
+    );
+
+    // Run the prover.
+    let output = prove_zone_batch(batch_witness)
+        .expect("prove_zone_batch should succeed through witness pipeline");
+
+    assert_eq!(output.block_transition.prev_block_hash, genesis_hash);
+    assert_ne!(output.block_transition.next_block_hash, genesis_hash);
+    assert_eq!(output.last_batch.withdrawal_batch_index, outbox_wbi);
+}
+
+/// Two-block pipeline test: verifies AccessSnapshot merging across blocks.
+///
+/// Block 1 is a non-final block (EIP-2935 only), block 2 is final with
+/// finalizeWithdrawalBatch. The merged access snapshot should be the union
+/// of both blocks' accesses.
+#[test]
+fn test_witness_pipeline_two_block_merge() {
+    use zone::witness::{
+        AccessSnapshot, BuiltBlockWitness, WitnessGenerator, WitnessGeneratorConfig, WitnessStore,
+    };
+
+    let make_db = || {
+        let mut evm = setup_zone_evm(CHAIN_ID);
+        use revm::state::AccountInfo;
+        if !evm.db_mut().cache.accounts.contains_key(&Address::ZERO) {
+            evm.db_mut()
+                .insert_account_info(Address::ZERO, AccountInfo::default());
+        }
+        let (db, _) = evm.finish();
+        db
+    };
+
+    let db_discovery = make_db();
+    let pre_accounts: Vec<(Address, TestAccount)> = extract_db_accounts(&db_discovery)
+        .into_iter()
+        .map(|(addr, snap)| (addr, snapshot_to_test_account(&snap)))
+        .collect();
+    let absent = [
+        TEMPO_STATE_READER_ADDRESS,
+        alloy_eips::eip4788::SYSTEM_ADDRESS,
+    ];
+
+    // Discovery pass: run both blocks to find all accessed slots.
+    let block1_disc = ZoneBlock {
+        number: 1,
+        parent_hash: B256::ZERO,
+        timestamp: 1000,
+        beneficiary: SEQUENCER,
+        gas_limit: u64::MAX,
+        base_fee_per_gas: 0,
+        tempo_header_rlp: None,
+        deposits: vec![],
+        decryptions: vec![],
+        finalize_withdrawal_batch_count: None,
+        transactions: vec![],
+        expected_state_root: B256::ZERO,
+    };
+    let block2_disc = ZoneBlock {
+        number: 2,
+        parent_hash: B256::ZERO,
+        timestamp: 2000,
+        beneficiary: SEQUENCER,
+        gas_limit: u64::MAX,
+        base_fee_per_gas: 0,
+        tempo_header_rlp: None,
+        deposits: vec![],
+        decryptions: vec![],
+        finalize_withdrawal_batch_count: Some(U256::ZERO),
+        transactions: vec![],
+        expected_state_root: B256::ZERO,
+    };
+
+    let (block1_post_disc, db_after1) = reference_execute(db_discovery, &block1_disc);
+    let (block2_post_disc, _) = reference_execute(db_after1, &block2_disc);
+
+    let block1_slots = collect_accessed_slots(&block1_post_disc, &[1]);
+    let block2_slots = collect_accessed_slots(&block2_post_disc, &[1, 2]);
+    let mut all_slots = block1_slots.clone();
+    for s in &block2_slots {
+        if !all_slots.contains(s) {
+            all_slots.push(*s);
+        }
+    }
+
+    let fixture = build_witness_with_accessed_slots(&pre_accounts, &all_slots, &absent);
+
+    let genesis_header = ZoneHeader {
+        parent_hash: B256::ZERO,
+        beneficiary: SEQUENCER,
+        state_root: fixture.state_root,
+        transactions_root: alloy_trie::EMPTY_ROOT_HASH,
+        receipts_root: alloy_trie::EMPTY_ROOT_HASH,
+        number: 0,
+        timestamp: 0,
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    // Final pass: run both blocks with correct parent hashes.
+    let db_final = make_db();
+    let block1 = ZoneBlock {
+        parent_hash: genesis_hash,
+        ..block1_disc
+    };
+
+    let (block1_post, db_after1) = reference_execute(db_final, &block1);
+    let block1_accounts = filter_real_accounts(block1_post, &pre_accounts);
+    let block1_state_root = compute_state_root(&block1_accounts);
+
+    let block1_header = ZoneHeader {
+        parent_hash: genesis_hash,
+        beneficiary: SEQUENCER,
+        state_root: block1_state_root,
+        transactions_root: alloy_trie::EMPTY_ROOT_HASH,
+        receipts_root: alloy_trie::EMPTY_ROOT_HASH,
+        number: 1,
+        timestamp: 1000,
+    };
+    let block1_hash = block1_header.block_hash();
+
+    let block2 = ZoneBlock {
+        parent_hash: block1_hash,
+        ..block2_disc
+    };
+    let (block2_post, _) = reference_execute(db_after1, &block2);
+    let block2_accounts = filter_real_accounts(block2_post, &pre_accounts);
+    let block2_state_root = compute_state_root(&block2_accounts);
+
+    let block1 = ZoneBlock {
+        expected_state_root: block1_state_root,
+        ..block1
+    };
+    let block2 = ZoneBlock {
+        expected_state_root: block2_state_root,
+        ..block2
+    };
+
+    // Build access snapshots for each block.
+    let snap1 = {
+        let mut accounts = BTreeSet::new();
+        let mut storage: BTreeMap<Address, BTreeSet<U256>> = BTreeMap::new();
+        for (addr, slot) in &block1_slots {
+            accounts.insert(*addr);
+            storage.entry(*addr).or_default().insert(*slot);
+        }
+        for (addr, _) in &pre_accounts {
+            accounts.insert(*addr);
+        }
+        AccessSnapshot { accounts, storage }
+    };
+
+    let snap2 = {
+        let mut accounts = BTreeSet::new();
+        let mut storage: BTreeMap<Address, BTreeSet<U256>> = BTreeMap::new();
+        for (addr, slot) in &block2_slots {
+            accounts.insert(*addr);
+            storage.entry(*addr).or_default().insert(*slot);
+        }
+        for (addr, _) in &pre_accounts {
+            accounts.insert(*addr);
+        }
+        AccessSnapshot { accounts, storage }
+    };
+
+    // Store both blocks in WitnessStore.
+    let mut store = WitnessStore::default();
+    store.insert(
+        1,
+        BuiltBlockWitness {
+            zone_block: block1.clone(),
+            access_snapshot: snap1.clone(),
+            prev_block_header: genesis_header.clone(),
+            parent_block_hash: genesis_hash,
+            l1_reads: vec![],
+            chain_id: CHAIN_ID,
+            tempo_header_rlp: Some(build_dummy_header_rlp()),
+        },
+    );
+    store.insert(
+        2,
+        BuiltBlockWitness {
+            zone_block: block2.clone(),
+            access_snapshot: snap2.clone(),
+            prev_block_header: block1_header,
+            parent_block_hash: block1_hash,
+            l1_reads: vec![],
+            chain_id: CHAIN_ID,
+            tempo_header_rlp: Some(build_dummy_header_rlp()),
+        },
+    );
+
+    assert_eq!(store.len(), 2);
+
+    let block_witnesses = store.take_range(1, 2).expect("blocks 1-2 should exist");
+    assert_eq!(block_witnesses.len(), 2);
+    assert!(store.is_empty());
+
+    let mut merged = AccessSnapshot::default();
+    for (_, bw) in &block_witnesses {
+        merged.merge(&bw.access_snapshot);
+    }
+
+    assert!(merged.accounts.len() >= snap1.accounts.len());
+    assert!(merged.accounts.len() >= snap2.accounts.len());
+
+    // Assemble and prove.
+    let witness_gen = WitnessGenerator::new(WitnessGeneratorConfig {
+        sequencer: SEQUENCER,
+    });
+
+    let tempo_packed = find_storage_value(
+        &pre_accounts,
+        execute::TEMPO_STATE_ADDRESS,
+        execute::storage::TEMPO_STATE_PACKED_SLOT,
+    );
+    let tempo_block_number = execute::storage::extract_tempo_block_number(tempo_packed);
+    let tempo_block_hash = B256::from(
+        find_storage_value(
+            &pre_accounts,
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_BLOCK_HASH_SLOT,
+        )
+        .to_be_bytes(),
+    );
+    let outbox_wbi = find_storage_value(
+        &pre_accounts,
+        execute::ZONE_OUTBOX_ADDRESS,
+        execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+    )
+    .to::<u64>();
+
+    let public_inputs = PublicInputs {
+        prev_block_hash: genesis_hash,
+        tempo_block_number,
+        anchor_block_number: tempo_block_number,
+        anchor_block_hash: tempo_block_hash,
+        expected_withdrawal_batch_index: outbox_wbi,
+        sequencer: SEQUENCER,
+    };
+
+    let batch_witness = witness_gen.assemble_witness(
+        public_inputs,
+        CHAIN_ID,
+        genesis_header,
+        vec![block1, block2],
+        fixture.witness,
+        BatchStateProof {
+            node_pool: alloy_primitives::map::HashMap::default(),
+            reads: vec![],
+            account_proofs: vec![],
+        },
+        vec![],
+    );
+
+    let output = prove_zone_batch(batch_witness).expect("two-block pipeline should succeed");
+
+    assert_eq!(output.block_transition.prev_block_hash, genesis_hash);
+    assert_ne!(output.block_transition.next_block_hash, genesis_hash);
+    assert_ne!(output.block_transition.next_block_hash, block1_hash);
+    assert_eq!(output.last_batch.withdrawal_batch_index, outbox_wbi);
+}
+
+/// Full pipeline test with advanceTempo + user transaction + finalizeWithdrawalBatch.
+///
+/// This is the most comprehensive witness pipeline test. It exercises:
+/// - advanceTempo system tx with a real child Tempo header and L1 state proofs
+/// - A real signed user transaction (ETH value transfer)
+/// - finalizeWithdrawalBatch system tx
+/// - Full witness pipeline: AccessSnapshot -> WitnessStore -> merge -> assemble -> prove
+///
+/// The user transaction creates state changes that the prover must handle:
+/// sender nonce increment, sender balance decrement, recipient account creation.
+#[test]
+fn test_witness_pipeline_advance_user_tx_finalize() {
+    use alloy_consensus::{Signed, TxLegacy, transaction::SignableTransaction};
+    use alloy_primitives::{Bytes, TxKind, keccak256, map::HashMap};
+    use alloy_rlp::Encodable;
+    use alloy_sol_types::SolCall;
+    use revm::state::AccountInfo;
+    use tempo_primitives::TempoTxEnvelope;
+    use zone::witness::{
+        AccessSnapshot, BuiltBlockWitness, WitnessGenerator, WitnessGeneratorConfig, WitnessStore,
+    };
+
+    // --- Setup: deploy zone contracts, create user wallet ---
+
+    let make_db = || {
+        let mut evm = setup_zone_evm(CHAIN_ID);
+        if !evm.db_mut().cache.accounts.contains_key(&Address::ZERO) {
+            evm.db_mut()
+                .insert_account_info(Address::ZERO, AccountInfo::default());
+        }
+        let (db, _) = evm.finish();
+        db
+    };
+
+    // User account: use a deterministic private key for reproducibility.
+    let user_signing_key =
+        alloy_primitives::b256!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+    let user_signer = alloy_signer_local::PrivateKeySigner::from_bytes(&user_signing_key)
+        .expect("valid private key");
+    let user_address = user_signer.address();
+    // User does a zero-value call (gas_price=0 bypasses Tempo fee token
+    // validation). This still exercises the full user tx path: RLP decode,
+    // signature recovery, nonce increment, and EVM execution.
+    let call_target = Address::with_last_byte(0xAA);
+
+    let inject_user = |db: &mut revm::database::CacheDB<revm::database::EmptyDB>| {
+        db.insert_account_info(
+            user_address,
+            AccountInfo {
+                nonce: 0,
+                balance: U256::ZERO,
+                code_hash: alloy_primitives::KECCAK256_EMPTY,
+                ..Default::default()
+            },
+        );
+    };
+
+    // --- Build the signed user transaction ---
+
+    let user_tx = TxLegacy {
+        chain_id: Some(CHAIN_ID),
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 21_000,
+        to: TxKind::Call(call_target),
+        value: U256::ZERO,
+        input: Default::default(),
+    };
+
+    let sig_hash = user_tx.signature_hash();
+    let signature = alloy::signers::SignerSync::sign_hash_sync(&user_signer, &sig_hash)
+        .expect("signing should succeed");
+    let signed_tx = Signed::new_unchecked(user_tx, signature, sig_hash);
+    let user_tx_envelope = TempoTxEnvelope::Legacy(signed_tx);
+
+    // Verify the sender recovers correctly.
+    {
+        use reth_primitives_traits::SignerRecoverable;
+        let recovered = user_tx_envelope
+            .clone()
+            .try_into_recovered()
+            .expect("signature recovery should succeed");
+        assert_eq!(recovered.signer(), user_address);
+    }
+
+    // RLP-encode for the ZoneBlock.transactions field.
+    let user_tx_rlp = {
+        let mut buf = Vec::new();
+        user_tx_envelope.encode(&mut buf);
+        buf
+    };
+
+    // --- Build Tempo header and L1 state proofs for advanceTempo ---
+
+    let genesis_tempo_rlp = build_dummy_header_rlp();
+    let genesis_tempo_hash = keccak256(&genesis_tempo_rlp);
+
+    // Build the child Tempo header (number=1, parent=genesis_tempo_hash).
+    let tempo_portal = Address::repeat_byte(0xbb);
+    let deposit_queue_slot = U256::from(4);
+    let new_tempo_block_number = 1u64;
+
+    // Build a minimal fake L1 state trie for the TempoStateReader precompile.
+    let (l1_state_root, tempo_state_proofs) = {
+        use alloy_trie::{
+            EMPTY_ROOT_HASH, HashBuilder, TrieAccount, nybbles::Nibbles, proof::ProofRetainer,
+        };
+
+        let l1_account = TrieAccount {
+            nonce: 0,
+            balance: U256::ZERO,
+            storage_root: EMPTY_ROOT_HASH,
+            code_hash: alloy_primitives::KECCAK256_EMPTY,
+        };
+
+        let key = Nibbles::unpack(keccak256(tempo_portal));
+        let mut encoded = Vec::new();
+        alloy_rlp::Encodable::encode(&l1_account, &mut encoded);
+
+        let retainer = ProofRetainer::new(vec![key]);
+        let mut builder = HashBuilder::default().with_proof_retainer(retainer);
+        builder.add_leaf(key, &encoded);
+
+        let l1_state_root = builder.root();
+        let proof_nodes = builder.take_proof_nodes();
+
+        let account_proof_bytes: Vec<Bytes> = proof_nodes
+            .matching_nodes_sorted(&key)
+            .into_iter()
+            .map(|(_, b)| b)
+            .collect();
+
+        let mut node_pool = HashMap::default();
+        let mut account_path_hashes = Vec::new();
+        for node in &account_proof_bytes {
+            let hash = keccak256(node.as_ref());
+            node_pool.insert(hash, node.to_vec());
+            account_path_hashes.push(hash);
+        }
+
+        let batch_proof = BatchStateProof {
+            node_pool,
+            reads: vec![L1StateRead {
+                zone_block_index: 0,
+                tempo_block_number: new_tempo_block_number,
+                account: tempo_portal,
+                slot: deposit_queue_slot,
+                storage_path: vec![],
+                value: U256::ZERO,
+            }],
+            account_proofs: vec![L1AccountProof {
+                tempo_block_number: new_tempo_block_number,
+                account: tempo_portal,
+                nonce: 0,
+                balance: U256::ZERO,
+                storage_root: EMPTY_ROOT_HASH,
+                code_hash: alloy_primitives::KECCAK256_EMPTY,
+                account_path: account_path_hashes,
+            }],
+        };
+
+        (l1_state_root, batch_proof)
+    };
+
+    let next_tempo_header = tempo_primitives::TempoHeader {
+        inner: alloy_consensus::Header {
+            number: 1,
+            parent_hash: genesis_tempo_hash,
+            state_root: l1_state_root,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let next_tempo_rlp = {
+        let mut buf = Vec::new();
+        next_tempo_header.encode(&mut buf);
+        buf
+    };
+    let new_tempo_block_hash = keccak256(&next_tempo_rlp);
+
+    // --- Discovery pass: reference-execute on CacheDB to find all accessed state ---
+
+    let db_discovery = {
+        let mut db = make_db();
+        inject_user(&mut db);
+        db
+    };
+
+    // extract_db_accounts picks up the injected user account automatically.
+    let pre_accounts: Vec<(Address, TestAccount)> = extract_db_accounts(&db_discovery)
+        .into_iter()
+        .map(|(addr, snap)| (addr, snapshot_to_test_account(&snap)))
+        .collect();
+    // Ensure the user account is treated as an EOA for EIP-3607 checks.
+    let mut pre_accounts = pre_accounts;
+    if let Some((_, acct)) = pre_accounts
+        .iter_mut()
+        .find(|(addr, _)| *addr == user_address)
+    {
+        acct.code_hash = alloy_primitives::KECCAK256_EMPTY;
+        acct.code = None;
+    }
+
+    // Build a discovery block with all transactions.
+    let block_disc = ZoneBlock {
+        number: 1,
+        parent_hash: B256::ZERO,
+        timestamp: 1000,
+        beneficiary: SEQUENCER,
+        gas_limit: u64::MAX,
+        base_fee_per_gas: 0,
+        tempo_header_rlp: Some(next_tempo_rlp.clone()),
+        deposits: vec![],
+        decryptions: vec![],
+        finalize_withdrawal_batch_count: Some(U256::ZERO),
+        transactions: vec![user_tx_rlp],
+        expected_state_root: B256::ZERO,
+    };
+
+    // Extended reference_execute that also handles advanceTempo + user txs.
+    let reference_execute_full = |db: revm::database::CacheDB<revm::database::EmptyDB>,
+                                  block: &ZoneBlock,
+                                  is_last: bool|
+     -> (
+        Vec<(Address, TestAccount)>,
+        revm::database::CacheDB<revm::database::EmptyDB>,
+    ) {
+        use alloy_evm::{Evm, EvmEnv, EvmFactory, FromRecoveredTx};
+        use revm::{DatabaseCommit, context::BlockEnv};
+        use tempo_chainspec::hardfork::TempoHardfork;
+        use tempo_evm::evm::TempoEvmFactory;
+        use tempo_revm::{TempoBlockEnv, TempoTxEnv};
+
+        let block_env = TempoBlockEnv {
+            inner: BlockEnv {
+                number: U256::from(block.number),
+                beneficiary: block.beneficiary,
+                timestamp: U256::from(block.timestamp),
+                gas_limit: block.gas_limit,
+                basefee: block.base_fee_per_gas,
+                ..Default::default()
+            },
+            timestamp_millis_part: 0,
+        };
+
+        let mut cfg_env = revm::context::CfgEnv::new_with_spec(TempoHardfork::T0);
+        cfg_env.chain_id = CHAIN_ID;
+        cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+
+        let env = EvmEnv { cfg_env, block_env };
+        let factory = TempoEvmFactory::default();
+        let mut evm = factory.create_evm(db, env);
+        register_mock_tempo_state_reader(&mut evm);
+
+        // EIP-2935
+        if block.number > 0 {
+            let result = evm
+                .transact_system_call(
+                    alloy_eips::eip4788::SYSTEM_ADDRESS,
+                    alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS,
+                    block.parent_hash.0.into(),
+                )
+                .expect("EIP-2935 system call should succeed");
+            evm.db_mut().commit(result.state);
+        }
+
+        // advanceTempo
+        if let Some(tempo_header_rlp) = &block.tempo_header_rlp {
+            let calldata = advanceTempoCall {
+                header: Bytes::copy_from_slice(tempo_header_rlp),
+                deposits: vec![],
+                decryptions: vec![],
+            }
+            .abi_encode();
+
+            let result = evm
+                .transact_system_call(
+                    Address::ZERO,
+                    execute::ZONE_INBOX_ADDRESS,
+                    Bytes::from(calldata),
+                )
+                .expect("advanceTempo should succeed");
+            assert!(
+                result.result.is_success(),
+                "advanceTempo reverted: {:?}",
+                result.result
+            );
+            evm.db_mut().commit(result.state);
+        }
+
+        // User transactions
+        for raw_tx in &block.transactions {
+            let envelope: TempoTxEnvelope =
+                alloy_rlp::Decodable::decode(&mut raw_tx.as_slice()).expect("valid tx rlp");
+            use reth_primitives_traits::SignerRecoverable;
+            let recovered = envelope
+                .try_into_recovered()
+                .expect("signature recovery should succeed");
+            let tx_env = <TempoTxEnv as FromRecoveredTx<TempoTxEnvelope>>::from_recovered_tx(
+                recovered.inner(),
+                recovered.signer(),
+            );
+            let revm::context::result::ResultAndState { result, state } =
+                evm.transact_raw(tx_env).expect("user tx should succeed");
+            assert!(result.is_success(), "user tx failed: {result:?}");
+            evm.db_mut().commit(state);
+        }
+
+        // finalizeWithdrawalBatch
+        if is_last && let Some(count) = block.finalize_withdrawal_batch_count {
+            let calldata = finalizeWithdrawalBatchCall {
+                count,
+                blockNumber: block.number,
+            }
+            .abi_encode();
+
+            let result = evm
+                .transact_system_call(
+                    Address::ZERO,
+                    execute::ZONE_OUTBOX_ADDRESS,
+                    Bytes::from(calldata),
+                )
+                .expect("finalizeWithdrawalBatch should succeed");
+            assert!(result.result.is_success());
+            evm.db_mut().commit(result.state);
+        }
+
+        let (post_db, _) = evm.finish();
+        let accounts = post_db
+            .cache
+            .accounts
+            .iter()
+            .map(|(addr, acct)| {
+                let info = &acct.info;
+                let code = info.code.as_ref().map(|c| c.bytes().to_vec());
+                let storage: Vec<(U256, U256)> =
+                    acct.storage.iter().map(|(k, v)| (*k, *v)).collect();
+                (
+                    *addr,
+                    TestAccount {
+                        nonce: info.nonce,
+                        balance: info.balance,
+                        code_hash: info.code_hash,
+                        code,
+                        storage,
+                    },
+                )
+            })
+            .collect();
+        (accounts, post_db)
+    };
+
+    // Discovery: run the block on a RecordingDatabase-wrapped CacheDB to
+    // capture ALL state accesses, including Tempo handler reads (fee manager
+    // lookups etc.) that aren't visible from the CacheDB post-state alone.
+    let (raw_post_disc, disc_accounts, disc_storage) = {
+        use alloy_evm::{Evm, EvmEnv, EvmFactory, FromRecoveredTx};
+        use revm::{DatabaseCommit, context::BlockEnv};
+        use std::{cell::RefCell, rc::Rc};
+        use tempo_chainspec::hardfork::TempoHardfork;
+        use tempo_evm::evm::TempoEvmFactory;
+        use tempo_revm::{TempoBlockEnv, TempoTxEnv};
+
+        let accessed_accts: Rc<RefCell<BTreeSet<Address>>> = Rc::new(RefCell::new(BTreeSet::new()));
+        let accessed_stor: Rc<RefCell<BTreeMap<Address, BTreeSet<U256>>>> =
+            Rc::new(RefCell::new(BTreeMap::new()));
+
+        struct TrackingDb {
+            inner: revm::database::CacheDB<revm::database::EmptyDB>,
+            accts: Rc<RefCell<BTreeSet<Address>>>,
+            stor: Rc<RefCell<BTreeMap<Address, BTreeSet<U256>>>>,
+        }
+
+        impl std::fmt::Debug for TrackingDb {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct("TrackingDb").finish()
+            }
+        }
+
+        impl revm::database_interface::Database for TrackingDb {
+            type Error = core::convert::Infallible;
+            fn basic(
+                &mut self,
+                address: Address,
+            ) -> Result<Option<revm::state::AccountInfo>, Self::Error> {
+                self.accts.borrow_mut().insert(address);
+                self.inner.basic(address)
+            }
+            fn code_by_hash(
+                &mut self,
+                code_hash: B256,
+            ) -> Result<revm::state::Bytecode, Self::Error> {
+                self.inner.code_by_hash(code_hash)
+            }
+            fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+                self.accts.borrow_mut().insert(address);
+                self.stor
+                    .borrow_mut()
+                    .entry(address)
+                    .or_default()
+                    .insert(index);
+                self.inner.storage(address, index)
+            }
+            fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+                self.inner.block_hash(number)
+            }
+        }
+        impl revm::database_interface::DatabaseCommit for TrackingDb {
+            fn commit(&mut self, changes: revm::state::EvmState) {
+                self.inner.commit(changes)
+            }
+        }
+
+        let db = TrackingDb {
+            inner: db_discovery,
+            accts: accessed_accts.clone(),
+            stor: accessed_stor.clone(),
+        };
+
+        let block_env = TempoBlockEnv {
+            inner: BlockEnv {
+                number: U256::from(block_disc.number),
+                beneficiary: block_disc.beneficiary,
+                timestamp: U256::from(block_disc.timestamp),
+                gas_limit: u64::MAX,
+                basefee: 0,
+                ..Default::default()
+            },
+            timestamp_millis_part: 0,
+        };
+
+        let mut cfg_env = revm::context::CfgEnv::new_with_spec(TempoHardfork::T0);
+        cfg_env.chain_id = CHAIN_ID;
+        cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+
+        let env = EvmEnv { cfg_env, block_env };
+        let factory = TempoEvmFactory::default();
+        let mut evm = factory.create_evm(db, env);
+        register_mock_tempo_state_reader(&mut evm);
+
+        // EIP-2935
+        if block_disc.number > 0 {
+            let result = evm
+                .transact_system_call(
+                    alloy_eips::eip4788::SYSTEM_ADDRESS,
+                    alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS,
+                    block_disc.parent_hash.0.into(),
+                )
+                .expect("EIP-2935 should succeed");
+            evm.db_mut().commit(result.state);
+        }
+
+        // advanceTempo
+        if let Some(tempo_header_rlp) = &block_disc.tempo_header_rlp {
+            let calldata = advanceTempoCall {
+                header: Bytes::copy_from_slice(tempo_header_rlp),
+                deposits: vec![],
+                decryptions: vec![],
+            }
+            .abi_encode();
+
+            let result = evm
+                .transact_system_call(
+                    Address::ZERO,
+                    execute::ZONE_INBOX_ADDRESS,
+                    Bytes::from(calldata),
+                )
+                .expect("advanceTempo should succeed");
+            assert!(result.result.is_success(), "advanceTempo reverted");
+            evm.db_mut().commit(result.state);
+        }
+
+        // User transaction
+        for raw_tx in &block_disc.transactions {
+            let envelope: TempoTxEnvelope =
+                alloy_rlp::Decodable::decode(&mut raw_tx.as_slice()).expect("valid tx rlp");
+            use reth_primitives_traits::SignerRecoverable;
+            let recovered = envelope.try_into_recovered().expect("signature recovery");
+            let tx_env = <TempoTxEnv as FromRecoveredTx<TempoTxEnvelope>>::from_recovered_tx(
+                recovered.inner(),
+                recovered.signer(),
+            );
+            let revm::context::result::ResultAndState { result, state } =
+                evm.transact_raw(tx_env).expect("user tx should succeed");
+            assert!(result.is_success(), "user tx failed: {result:?}");
+            evm.db_mut().commit(state);
+        }
+
+        // finalizeWithdrawalBatch
+        if let Some(count) = block_disc.finalize_withdrawal_batch_count {
+            let calldata = finalizeWithdrawalBatchCall {
+                count,
+                blockNumber: block_disc.number,
+            }
+            .abi_encode();
+
+            let result = evm
+                .transact_system_call(
+                    Address::ZERO,
+                    execute::ZONE_OUTBOX_ADDRESS,
+                    Bytes::from(calldata),
+                )
+                .expect("finalizeWithdrawalBatch should succeed");
+            assert!(result.result.is_success());
+            evm.db_mut().commit(result.state);
+        }
+
+        let (tracking_db, _) = evm.finish();
+        let accounts: Vec<(Address, TestAccount)> = tracking_db
+            .inner
+            .cache
+            .accounts
+            .iter()
+            .map(|(addr, acct)| {
+                let info = &acct.info;
+                let code: Option<Vec<u8>> = info.code.as_ref().map(|c| c.bytes().to_vec());
+                let storage: Vec<(U256, U256)> =
+                    acct.storage.iter().map(|(k, v)| (*k, *v)).collect();
+                (
+                    *addr,
+                    TestAccount {
+                        nonce: info.nonce,
+                        balance: info.balance,
+                        code_hash: info.code_hash,
+                        code,
+                        storage,
+                    },
+                )
+            })
+            .collect();
+        let disc_accts = accessed_accts.borrow().clone();
+        let disc_stor = accessed_stor.borrow().clone();
+        (accounts, disc_accts, disc_stor)
+    };
+
+    // Combine CacheDB post-state slots with RecordingDB-captured slots.
+    let mut all_slots = collect_accessed_slots(&raw_post_disc, &[1]);
+    for (addr, slots) in &disc_storage {
+        for slot in slots {
+            if !all_slots.iter().any(|(a, s)| a == addr && s == slot) {
+                all_slots.push((*addr, *slot));
+            }
+        }
+    }
+
+    // Accounts accessed but not in pre_accounts go to absent list.
+    let mut absent_vec = vec![
+        TEMPO_STATE_READER_ADDRESS,
+        alloy_eips::eip4788::SYSTEM_ADDRESS,
+        call_target,
+    ];
+    for addr in &disc_accounts {
+        if !pre_accounts.iter().any(|(a, _)| a == addr) && !absent_vec.contains(addr) {
+            absent_vec.push(*addr);
+        }
+    }
+    let fixture = build_witness_with_accessed_slots(&pre_accounts, &all_slots, &absent_vec);
+
+    // --- Final pass: execute with correct genesis hash ---
+
+    let genesis_header = ZoneHeader {
+        parent_hash: B256::ZERO,
+        beneficiary: SEQUENCER,
+        state_root: fixture.state_root,
+        transactions_root: alloy_trie::EMPTY_ROOT_HASH,
+        receipts_root: alloy_trie::EMPTY_ROOT_HASH,
+        number: 0,
+        timestamp: 0,
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    let db_final = {
+        let mut db = make_db();
+        inject_user(&mut db);
+        db
+    };
+    let zone_block = ZoneBlock {
+        parent_hash: genesis_hash,
+        ..block_disc
+    };
+
+    let (raw_post, _) = reference_execute_full(db_final, &zone_block, true);
+    let mut raw_post = raw_post;
+    if let Some((_, acct)) = raw_post.iter_mut().find(|(addr, _)| *addr == user_address) {
+        acct.code_hash = alloy_primitives::KECCAK256_EMPTY;
+        acct.code = None;
+    }
+    let post_accounts = filter_real_accounts(raw_post, &pre_accounts);
+    let expected_state_root = compute_state_root(&post_accounts);
+
+    let zone_block = ZoneBlock {
+        expected_state_root,
+        ..zone_block
+    };
+
+    // --- Build AccessSnapshot ---
+
+    let mut access_accounts = BTreeSet::new();
+    let mut access_storage: BTreeMap<Address, BTreeSet<U256>> = BTreeMap::new();
+    for (addr, slot) in &all_slots {
+        access_accounts.insert(*addr);
+        access_storage.entry(*addr).or_default().insert(*slot);
+    }
+    for (addr, _) in &pre_accounts {
+        access_accounts.insert(*addr);
+    }
+    access_accounts.insert(user_address);
+    access_accounts.insert(call_target);
+
+    let access_snapshot = AccessSnapshot {
+        accounts: access_accounts,
+        storage: access_storage,
+    };
+
+    // --- WitnessStore round-trip ---
+
+    let mut store = WitnessStore::default();
+    store.insert(
+        1,
+        BuiltBlockWitness {
+            zone_block: zone_block.clone(),
+            access_snapshot,
+            prev_block_header: genesis_header.clone(),
+            parent_block_hash: genesis_hash,
+            l1_reads: vec![],
+            chain_id: CHAIN_ID,
+            tempo_header_rlp: Some(next_tempo_rlp),
+        },
+    );
+
+    let block_witnesses = store.take_range(1, 1).expect("block 1 should exist");
+    assert_eq!(block_witnesses.len(), 1);
+
+    let mut merged = AccessSnapshot::default();
+    for (_, bw) in &block_witnesses {
+        merged.merge(&bw.access_snapshot);
+    }
+
+    // --- Assemble BatchWitness and prove ---
+
+    let witness_gen = WitnessGenerator::new(WitnessGeneratorConfig {
+        sequencer: SEQUENCER,
+    });
+
+    let outbox_wbi = find_storage_value(
+        &pre_accounts,
+        execute::ZONE_OUTBOX_ADDRESS,
+        execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+    )
+    .to::<u64>();
+
+    let public_inputs = PublicInputs {
+        prev_block_hash: genesis_hash,
+        tempo_block_number: new_tempo_block_number,
+        anchor_block_number: new_tempo_block_number,
+        anchor_block_hash: new_tempo_block_hash,
+        expected_withdrawal_batch_index: outbox_wbi,
+        sequencer: SEQUENCER,
+    };
+
+    let batch_witness = witness_gen.assemble_witness(
+        public_inputs,
+        CHAIN_ID,
+        genesis_header,
+        vec![zone_block],
+        fixture.witness,
+        tempo_state_proofs,
+        vec![],
+    );
+
+    let output = prove_zone_batch(batch_witness)
+        .expect("prove_zone_batch should succeed with advanceTempo + user tx + finalize");
+
+    // --- Assertions ---
+
+    assert_eq!(output.block_transition.prev_block_hash, genesis_hash);
+    assert_ne!(output.block_transition.next_block_hash, genesis_hash);
+    assert_eq!(output.last_batch.withdrawal_batch_index, outbox_wbi);
+
+    // The deposit queue hash should have changed because advanceTempo updated it.
+    // (Both prev and next should be B256::ZERO since there were no actual deposits,
+    // but advanceTempo still calls processDeposits with an empty array.)
+    // Just verify the transition is present.
+    assert_eq!(
+        output.deposit_queue_transition.prev_processed_hash,
+        output.deposit_queue_transition.next_processed_hash,
+        "No deposits were processed, so deposit queue hash should be unchanged"
+    );
+
+    println!("Full pipeline test passed!");
+    println!(
+        "  prev_block_hash: {}",
+        output.block_transition.prev_block_hash
+    );
+    println!(
+        "  next_block_hash: {}",
+        output.block_transition.next_block_hash
+    );
+}
+
+/// Verify that WitnessStore::prune_below discards stale entries.
+#[test]
+fn test_witness_store_pruning() {
+    use zone::witness::{AccessSnapshot, BuiltBlockWitness, WitnessStore};
+
+    let dummy_header = ZoneHeader {
+        parent_hash: B256::ZERO,
+        beneficiary: SEQUENCER,
+        state_root: B256::ZERO,
+        transactions_root: alloy_trie::EMPTY_ROOT_HASH,
+        receipts_root: alloy_trie::EMPTY_ROOT_HASH,
+        number: 0,
+        timestamp: 0,
+    };
+
+    let make_witness = |number: u64| BuiltBlockWitness {
+        zone_block: ZoneBlock {
+            number,
+            parent_hash: B256::ZERO,
+            timestamp: number * 1000,
+            beneficiary: SEQUENCER,
+            gas_limit: u64::MAX,
+            base_fee_per_gas: 0,
+            tempo_header_rlp: None,
+            deposits: vec![],
+            decryptions: vec![],
+            finalize_withdrawal_batch_count: None,
+            transactions: vec![],
+            expected_state_root: B256::ZERO,
+        },
+        access_snapshot: AccessSnapshot::default(),
+        prev_block_header: dummy_header.clone(),
+        parent_block_hash: B256::ZERO,
+        l1_reads: vec![],
+        chain_id: CHAIN_ID,
+        tempo_header_rlp: None,
+    };
+
+    let mut store = WitnessStore::default();
+    for i in 1..=10 {
+        store.insert(i, make_witness(i));
+    }
+    assert_eq!(store.len(), 10);
+
+    // Prune below 5 — keeps 5..=10.
+    store.prune_below(5);
+    assert_eq!(store.len(), 6);
+
+    // Blocks 1-4 should be gone.
+    assert!(store.take(1).is_none());
+    assert!(store.take(4).is_none());
+
+    // Block 5 should still be there.
+    assert!(store.take(5).is_some());
+    assert_eq!(store.len(), 5);
+
+    // Prune below 100 — clears everything.
+    store.prune_below(100);
+    assert!(store.is_empty());
+}

--- a/crates/zone-stf/Cargo.toml
+++ b/crates/zone-stf/Cargo.toml
@@ -51,3 +51,4 @@ alloy-rlp.workspace = true
 alloy-trie = "0.9"
 tempo-primitives.workspace = true
 zone-stf = { path = ".", features = ["test-utils"] }
+zone-test-utils.workspace = true

--- a/crates/zone-stf/tests/e2e_real_contracts.rs
+++ b/crates/zone-stf/tests/e2e_real_contracts.rs
@@ -1,0 +1,653 @@
+//! End-to-end integration test with real deployed Solidity contracts.
+//!
+//! This test deploys all four zone predeploy contracts (TempoState, ZoneConfig,
+//! ZoneInbox, ZoneOutbox) into an in-memory CacheDB, then builds a witness from
+//! the initial state and runs `prove_zone_batch` to verify that the prover can
+//! correctly execute real contract bytecode and compute the post-execution state
+//! root.
+//!
+//! Requires Foundry artifacts: run `forge build --skip test` in `docs/specs/`.
+
+use alloy_evm::Evm;
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256, map::HashMap};
+use revm::{
+    DatabaseCommit,
+    database::{CacheDB, EmptyDB},
+    state::AccountInfo,
+};
+use zone_stf::{
+    execute, prove_zone_batch,
+    testutil::{TestAccount, build_zone_state_fixture_with_absent, compute_state_root},
+    types::*,
+};
+use zone_test_utils::{build_dummy_header_rlp, extract_db_accounts, setup_zone_evm};
+
+const CHAIN_ID: u64 = 13371;
+const SEQUENCER: Address = Address::ZERO;
+
+/// Look up a storage slot value from the extracted account list.
+fn find_storage_value(
+    accounts: &[(Address, TestAccount)],
+    target_addr: Address,
+    slot: U256,
+) -> U256 {
+    accounts
+        .iter()
+        .find(|(a, _)| *a == target_addr)
+        .and_then(|(_, acct)| {
+            acct.storage
+                .iter()
+                .find(|(s, _)| *s == slot)
+                .map(|(_, v)| *v)
+        })
+        .unwrap_or(U256::ZERO)
+}
+
+/// Convert `AccountSnapshot` from zone-test-utils to `TestAccount` from zone-prover.
+fn snapshot_to_test_account(snap: &zone_test_utils::AccountSnapshot) -> TestAccount {
+    TestAccount {
+        nonce: snap.nonce,
+        balance: snap.balance,
+        code_hash: snap.code_hash,
+        code: snap.code.clone(),
+        storage: snap.storage.clone(),
+    }
+}
+
+/// Execute a zone block on a CacheDB using the standard TempoEvm, then extract
+/// all accounts from the post-state.
+///
+/// Uses `transact_system_call` for system transactions (same as the zone node),
+/// avoiding the prover's custom TempoStateReader precompile.
+///
+/// Returns post-state accounts with ALL accessed storage slots (including zero-valued).
+fn execute_on_cache_db(
+    db: CacheDB<EmptyDB>,
+    block: &ZoneBlock,
+    is_last_block: bool,
+) -> Vec<(Address, TestAccount)> {
+    use alloy_evm::{EvmEnv, EvmFactory};
+    use alloy_sol_types::SolCall;
+    use revm::context::BlockEnv;
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_evm::evm::TempoEvmFactory;
+    use tempo_revm::TempoBlockEnv;
+
+    let block_env = TempoBlockEnv {
+        inner: BlockEnv {
+            number: U256::from(block.number),
+            beneficiary: block.beneficiary,
+            timestamp: U256::from(block.timestamp),
+            gas_limit: block.gas_limit,
+            basefee: block.base_fee_per_gas,
+            ..Default::default()
+        },
+        timestamp_millis_part: 0,
+    };
+
+    let mut cfg_env = revm::context::CfgEnv::new_with_spec(TempoHardfork::T0);
+    cfg_env.chain_id = CHAIN_ID;
+    cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+
+    let env = EvmEnv { cfg_env, block_env };
+    let factory = TempoEvmFactory::default();
+    let mut evm = factory.create_evm(db, env);
+    zone_test_utils::register_mock_tempo_state_reader(&mut evm);
+
+    // EIP-2935: store the parent block hash in the history contract.
+    if block.number > 0 {
+        let result = evm
+            .transact_system_call(
+                alloy_eips::eip4788::SYSTEM_ADDRESS,
+                alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS,
+                block.parent_hash.0.into(),
+            )
+            .expect("EIP-2935 system call should succeed");
+        evm.db_mut().commit(result.state);
+    }
+
+    // 1. advanceTempo (if block advances Tempo).
+    if let Some(tempo_header_rlp) = &block.tempo_header_rlp {
+        let calldata = zone_stf::types::advanceTempoCall {
+            header: alloy_primitives::Bytes::copy_from_slice(tempo_header_rlp),
+            deposits: vec![],
+            decryptions: vec![],
+        }
+        .abi_encode();
+
+        let result = evm
+            .transact_system_call(
+                Address::ZERO,
+                execute::ZONE_INBOX_ADDRESS,
+                alloy_primitives::Bytes::from(calldata),
+            )
+            .expect("advanceTempo should succeed");
+        assert!(
+            result.result.is_success(),
+            "advanceTempo reverted: {:?}",
+            result.result
+        );
+        evm.db_mut().commit(result.state);
+    }
+
+    // 2. finalizeWithdrawalBatch (final block only).
+    if is_last_block && let Some(count) = block.finalize_withdrawal_batch_count {
+        let calldata = zone_stf::types::finalizeWithdrawalBatchCall {
+            count,
+            blockNumber: block.number,
+        }
+        .abi_encode();
+
+        let result = evm
+            .transact_system_call(
+                Address::ZERO,
+                execute::ZONE_OUTBOX_ADDRESS,
+                alloy_primitives::Bytes::from(calldata),
+            )
+            .expect("finalizeWithdrawalBatch should succeed");
+        assert!(
+            result.result.is_success(),
+            "finalizeWithdrawalBatch reverted: {:?}",
+            result.result
+        );
+        evm.db_mut().commit(result.state);
+    }
+
+    // Extract all accounts (including zero-valued storage slots cached by CacheDB).
+    let (post_db, _env) = evm.finish();
+    post_db
+        .cache
+        .accounts
+        .iter()
+        .map(|(addr, acct)| {
+            let info = &acct.info;
+            let code = info.code.as_ref().map(|c| c.bytes().to_vec());
+            let storage: Vec<(U256, U256)> = acct.storage.iter().map(|(k, v)| (*k, *v)).collect();
+            (
+                *addr,
+                TestAccount {
+                    nonce: info.nonce,
+                    balance: info.balance,
+                    code_hash: info.code_hash,
+                    code,
+                    storage,
+                },
+            )
+        })
+        .collect()
+}
+
+/// Deploy all zone contracts and return the CacheDB with the system sender added.
+fn deploy_zone_contracts() -> CacheDB<EmptyDB> {
+    let mut evm = setup_zone_evm(CHAIN_ID);
+
+    // Ensure Address::ZERO (system tx sender) exists in the state since
+    // the prover accesses it as the transaction caller.
+    if !evm.db_mut().cache.accounts.contains_key(&Address::ZERO) {
+        evm.db_mut()
+            .insert_account_info(Address::ZERO, AccountInfo::default());
+    }
+
+    let (db, _env) = evm.finish();
+    db
+}
+
+/// Build a `ZoneStateWitness` from pre-execution account data, including all storage
+/// slots that will be accessed during execution (discovered by the reference run).
+///
+/// `accessed_slots` contains (address, slot) pairs for every slot accessed during the
+/// reference execution. Zero-valued slots are included in the witness `storage` map
+/// so the prover can read them, but only non-zero slots get MPT storage proofs.
+///
+/// `absent_addresses` are addresses accessed during execution that don't exist in
+/// the pre-state (e.g., the TempoStateReader precompile). The fixture will include
+/// MPT absence proofs for these.
+fn build_witness_with_accessed_slots(
+    pre_accounts: &[(Address, TestAccount)],
+    accessed_slots: &[(Address, U256)],
+    absent_addresses: &[Address],
+) -> zone_stf::testutil::ZoneStateFixture {
+    let mut enriched: Vec<(Address, TestAccount)> = pre_accounts.to_vec();
+
+    for (addr, slot) in accessed_slots {
+        if let Some((_, acct)) = enriched.iter_mut().find(|(a, _)| a == addr)
+            && !acct.storage.iter().any(|(s, _)| s == slot)
+        {
+            acct.storage.push((*slot, U256::ZERO));
+        }
+    }
+
+    build_zone_state_fixture_with_absent(&enriched, absent_addresses)
+}
+
+/// Filter post-execution accounts to only include accounts that should appear
+/// in the state trie.
+///
+/// CacheDB caches ALL accessed accounts, including ones that were merely loaded
+/// (e.g., precompile addresses, STATICCALL targets). These "phantom" empty
+/// accounts shouldn't appear in the state trie. We keep an account if it was
+/// in the initial pre-state OR if it's non-empty (has nonce, balance, or code).
+fn filter_real_accounts(
+    post_accounts: Vec<(Address, TestAccount)>,
+    pre_accounts: &[(Address, TestAccount)],
+) -> Vec<(Address, TestAccount)> {
+    post_accounts
+        .into_iter()
+        .filter(|(addr, acct)| {
+            let in_pre = pre_accounts.iter().any(|(a, _)| a == addr);
+            let is_non_empty = acct.nonce > 0
+                || !acct.balance.is_zero()
+                || acct.code_hash != alloy_primitives::KECCAK256_EMPTY;
+            in_pre || is_non_empty
+        })
+        .collect()
+}
+
+/// Collect all (address, slot) pairs from the post-execution CacheDB,
+/// plus mandatory slots the prover reads outside of execute_zone_block.
+fn collect_accessed_slots(post_accounts: &[(Address, TestAccount)]) -> Vec<(Address, U256)> {
+    let mut slots: Vec<(Address, U256)> = post_accounts
+        .iter()
+        .flat_map(|(addr, acct)| acct.storage.iter().map(move |(slot, _)| (*addr, *slot)))
+        .collect();
+
+    // The prover reads these mandatory slots before/after block execution
+    // in prove_zone_batch (not inside execute_zone_block).
+    let mandatory = [
+        (
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_BLOCK_HASH_SLOT,
+        ),
+        (
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_STATE_ROOT_SLOT,
+        ),
+        (
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_PACKED_SLOT,
+        ),
+        (
+            execute::ZONE_INBOX_ADDRESS,
+            execute::storage::ZONE_INBOX_PROCESSED_HASH_SLOT,
+        ),
+        (
+            execute::ZONE_OUTBOX_ADDRESS,
+            execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT,
+        ),
+        (
+            execute::ZONE_OUTBOX_ADDRESS,
+            execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+        ),
+    ];
+
+    for (addr, slot) in mandatory {
+        if !slots.iter().any(|(a, s)| *a == addr && *s == slot) {
+            slots.push((addr, slot));
+        }
+    }
+
+    slots
+}
+
+/// Single-block test: finalizeWithdrawalBatch only (no advanceTempo).
+///
+/// Exercises the prover with real ZoneOutbox bytecode executing the finalization
+/// system transaction.
+#[test]
+fn test_real_contracts_finalize_only() {
+    let db = deploy_zone_contracts();
+
+    // Extract pre-execution accounts (non-zero storage only).
+    let pre_accounts: Vec<(Address, TestAccount)> = extract_db_accounts(&db)
+        .into_iter()
+        .map(|(addr, snap)| (addr, snapshot_to_test_account(&snap)))
+        .collect();
+
+    println!("Account count: {}", pre_accounts.len());
+
+    // Build a temporary genesis header with a placeholder state root — we'll
+    // rebuild it after discovering all accessed slots.
+    let placeholder_root = compute_state_root(&pre_accounts);
+
+    let genesis_header = ZoneHeader {
+        parent_hash: B256::ZERO,
+        beneficiary: SEQUENCER,
+        state_root: placeholder_root,
+        transactions_root: alloy_trie::EMPTY_ROOT_HASH,
+        receipts_root: alloy_trie::EMPTY_ROOT_HASH,
+        number: 0,
+        timestamp: 0,
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    let zone_block = ZoneBlock {
+        number: 1,
+        parent_hash: genesis_hash,
+        timestamp: 1000,
+        beneficiary: SEQUENCER,
+        gas_limit: u64::MAX,
+        base_fee_per_gas: 0,
+        tempo_header_rlp: None,
+        deposits: vec![],
+        decryptions: vec![],
+        finalize_withdrawal_batch_count: Some(U256::ZERO),
+        transactions: vec![],
+        expected_state_root: B256::ZERO, // placeholder
+    };
+
+    // Reference execution on CacheDB discovers all accessed slots and post-state.
+    let raw_post_accounts = execute_on_cache_db(db, &zone_block, true);
+
+    // Discover all accessed storage slots and build the witness with them.
+    let accessed_slots = collect_accessed_slots(&raw_post_accounts);
+    let absent = [alloy_eips::eip4788::SYSTEM_ADDRESS];
+    let fixture = build_witness_with_accessed_slots(&pre_accounts, &accessed_slots, &absent);
+
+    // The state root may differ from the placeholder if we added zero-valued slots.
+    // Zero-valued slots don't appear in the MPT so the root should be the same.
+    println!("Initial state root: {}", fixture.state_root);
+
+    // Rebuild the genesis header with the correct state root.
+    let genesis_header = ZoneHeader {
+        state_root: fixture.state_root,
+        ..genesis_header
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    // Filter phantom accounts (e.g., SYSTEM_ADDRESS) that CacheDB cached but that
+    // don't belong in the state trie, then compute the expected post-state root.
+    let post_accounts = filter_real_accounts(raw_post_accounts, &pre_accounts);
+    let expected_state_root = compute_state_root(&post_accounts);
+    println!("Expected post-state root: {expected_state_root}");
+
+    let zone_block = ZoneBlock {
+        parent_hash: genesis_hash,
+        expected_state_root,
+        ..zone_block
+    };
+
+    let tempo_packed = find_storage_value(
+        &pre_accounts,
+        execute::TEMPO_STATE_ADDRESS,
+        execute::storage::TEMPO_STATE_PACKED_SLOT,
+    );
+    let tempo_block_number = execute::storage::extract_tempo_block_number(tempo_packed);
+
+    let tempo_block_hash = B256::from(
+        find_storage_value(
+            &pre_accounts,
+            execute::TEMPO_STATE_ADDRESS,
+            execute::storage::TEMPO_STATE_BLOCK_HASH_SLOT,
+        )
+        .to_be_bytes(),
+    );
+
+    let outbox_wbi = find_storage_value(
+        &pre_accounts,
+        execute::ZONE_OUTBOX_ADDRESS,
+        execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+    )
+    .to::<u64>();
+
+    let public_inputs = PublicInputs {
+        prev_block_hash: genesis_hash,
+        tempo_block_number,
+        anchor_block_number: tempo_block_number,
+        anchor_block_hash: tempo_block_hash,
+        expected_withdrawal_batch_index: outbox_wbi,
+        sequencer: SEQUENCER,
+    };
+
+    let witness = BatchWitness {
+        public_inputs,
+        chain_id: CHAIN_ID,
+        prev_block_header: genesis_header,
+        zone_blocks: vec![zone_block],
+        initial_zone_state: fixture.witness,
+        tempo_state_proofs: BatchStateProof {
+            node_pool: HashMap::default(),
+            reads: vec![],
+            account_proofs: vec![],
+        },
+        tempo_ancestry_headers: vec![],
+    };
+
+    let output =
+        prove_zone_batch(witness).expect("prove_zone_batch should succeed with real contracts");
+
+    println!("Prover succeeded!");
+    println!(
+        "  prev_block_hash: {}",
+        output.block_transition.prev_block_hash
+    );
+    println!(
+        "  next_block_hash: {}",
+        output.block_transition.next_block_hash
+    );
+
+    assert_eq!(output.block_transition.prev_block_hash, genesis_hash);
+    assert_ne!(output.block_transition.next_block_hash, genesis_hash);
+}
+
+/// Build L1 state proof data for the prover's TempoStateReader precompile.
+///
+/// Creates a minimal fake L1 state trie containing the `tempoPortal` account
+/// (empty storage, no code). Returns the L1 state root and the `BatchStateProof`
+/// with account and storage proofs so the prover can verify the `readStorageAt`
+/// call that `advanceTempo` makes.
+fn build_l1_state_proof(
+    tempo_portal: Address,
+    tempo_block_number: u64,
+    zone_block_index: u64,
+    deposit_queue_hash_slot: U256,
+) -> (B256, BatchStateProof) {
+    use alloy_trie::{EMPTY_ROOT_HASH, HashBuilder, TrieAccount, proof::ProofRetainer};
+    use nybbles::Nibbles;
+
+    // The tempoPortal account exists on L1 with empty storage (slot 4 = 0).
+    let l1_account = TrieAccount {
+        nonce: 0,
+        balance: U256::ZERO,
+        storage_root: EMPTY_ROOT_HASH,
+        code_hash: alloy_primitives::KECCAK256_EMPTY,
+    };
+
+    // Build L1 state trie with the single account.
+    let key = Nibbles::unpack(keccak256(tempo_portal));
+    let mut encoded = Vec::new();
+    alloy_rlp::Encodable::encode(&l1_account, &mut encoded);
+
+    let retainer = ProofRetainer::new(vec![key]);
+    let mut builder = HashBuilder::default().with_proof_retainer(retainer);
+    builder.add_leaf(key, &encoded);
+
+    let l1_state_root = builder.root();
+    let proof_nodes = builder.take_proof_nodes();
+
+    // Collect account proof nodes and add them to the node pool.
+    let account_proof_bytes: Vec<Bytes> = proof_nodes
+        .matching_nodes_sorted(&key)
+        .into_iter()
+        .map(|(_, b)| b)
+        .collect();
+
+    let mut node_pool = HashMap::default();
+    let mut account_path_hashes = Vec::new();
+    for node in &account_proof_bytes {
+        let hash = keccak256(node.as_ref());
+        node_pool.insert(hash, node.to_vec());
+        account_path_hashes.push(hash);
+    }
+
+    // Storage proof for slot 4 in an empty trie is empty (absence proof).
+    let batch_proof = BatchStateProof {
+        node_pool,
+        reads: vec![L1StateRead {
+            zone_block_index,
+            tempo_block_number,
+            account: tempo_portal,
+            slot: deposit_queue_hash_slot,
+            storage_path: vec![], // empty trie → no proof nodes needed
+            value: U256::ZERO,
+        }],
+        account_proofs: vec![L1AccountProof {
+            tempo_block_number,
+            account: tempo_portal,
+            nonce: 0,
+            balance: U256::ZERO,
+            storage_root: EMPTY_ROOT_HASH,
+            code_hash: alloy_primitives::KECCAK256_EMPTY,
+            account_path: account_path_hashes,
+        }],
+    };
+
+    (l1_state_root, batch_proof)
+}
+
+/// Single-block test: advanceTempo + finalizeWithdrawalBatch with real contracts.
+///
+/// Exercises both system transactions with real TempoState and ZoneInbox bytecode.
+/// TempoState storage is mutated by finalizeTempo (called internally by advanceTempo).
+/// A mock TempoStateReader precompile is used for the reference CacheDB execution,
+/// while the prover uses its own proof-based precompile with L1 state proofs.
+#[test]
+fn test_real_contracts_advance_and_finalize() {
+    let db = deploy_zone_contracts();
+
+    let pre_accounts: Vec<(Address, TestAccount)> = extract_db_accounts(&db)
+        .into_iter()
+        .map(|(addr, snap)| (addr, snapshot_to_test_account(&snap)))
+        .collect();
+
+    let placeholder_root = compute_state_root(&pre_accounts);
+
+    let genesis_header = ZoneHeader {
+        parent_hash: B256::ZERO,
+        beneficiary: SEQUENCER,
+        state_root: placeholder_root,
+        transactions_root: alloy_trie::EMPTY_ROOT_HASH,
+        receipts_root: alloy_trie::EMPTY_ROOT_HASH,
+        number: 0,
+        timestamp: 0,
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    // Build a child Tempo header: number=1, parent_hash=genesis_hash.
+    let genesis_tempo_rlp = build_dummy_header_rlp();
+    let genesis_tempo_hash = keccak256(&genesis_tempo_rlp);
+
+    // Build L1 state proofs for the precompile. The contract reads
+    // PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT (slot 4) from tempoPortal.
+    let tempo_portal = alloy_primitives::Address::repeat_byte(0xbb);
+    let deposit_queue_slot = U256::from(4);
+    let new_tempo_block_number = 1u64;
+    let (l1_state_root, tempo_state_proofs) =
+        build_l1_state_proof(tempo_portal, new_tempo_block_number, 0, deposit_queue_slot);
+
+    // Set the Tempo header's state root to the L1 state root so the prover's
+    // precompile can verify account and storage proofs against it.
+    let next_tempo_header = tempo_primitives::TempoHeader {
+        inner: alloy_consensus::Header {
+            number: 1,
+            parent_hash: genesis_tempo_hash,
+            state_root: l1_state_root,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let next_tempo_rlp = {
+        use alloy_rlp::Encodable;
+        let mut buf = Vec::new();
+        next_tempo_header.encode(&mut buf);
+        buf
+    };
+
+    let zone_block = ZoneBlock {
+        number: 1,
+        parent_hash: genesis_hash,
+        timestamp: 1000,
+        beneficiary: SEQUENCER,
+        gas_limit: u64::MAX,
+        base_fee_per_gas: 0,
+        tempo_header_rlp: Some(next_tempo_rlp.clone()),
+        deposits: vec![],
+        decryptions: vec![],
+        finalize_withdrawal_batch_count: Some(U256::ZERO),
+        transactions: vec![],
+        expected_state_root: B256::ZERO,
+    };
+
+    // Reference execution (with mock precompile for TempoStateReader).
+    let raw_post_accounts = execute_on_cache_db(db, &zone_block, true);
+
+    let accessed_slots = collect_accessed_slots(&raw_post_accounts);
+    // The TempoStateReader precompile address doesn't exist as an account —
+    // generate an MPT absence proof so the prover can confirm it's not in the trie.
+    let absent = [
+        zone_test_utils::TEMPO_STATE_READER_ADDRESS,
+        alloy_eips::eip4788::SYSTEM_ADDRESS,
+    ];
+    let fixture = build_witness_with_accessed_slots(&pre_accounts, &accessed_slots, &absent);
+
+    let genesis_header = ZoneHeader {
+        state_root: fixture.state_root,
+        ..genesis_header
+    };
+    let genesis_hash = genesis_header.block_hash();
+
+    // Filter out phantom accounts that CacheDB cached but that don't belong in
+    // the state trie (e.g., the precompile address loaded during STATICCALL).
+    let post_accounts = filter_real_accounts(raw_post_accounts, &pre_accounts);
+    let expected_state_root = compute_state_root(&post_accounts);
+    println!("Expected post-state root: {expected_state_root}");
+
+    let zone_block = ZoneBlock {
+        parent_hash: genesis_hash,
+        expected_state_root,
+        ..zone_block
+    };
+
+    let new_tempo_block_hash = keccak256(&next_tempo_rlp);
+
+    let outbox_wbi = find_storage_value(
+        &pre_accounts,
+        execute::ZONE_OUTBOX_ADDRESS,
+        execute::storage::ZONE_OUTBOX_LAST_BATCH_BASE_SLOT + U256::from(1),
+    )
+    .to::<u64>();
+
+    let public_inputs = PublicInputs {
+        prev_block_hash: genesis_hash,
+        tempo_block_number: new_tempo_block_number,
+        anchor_block_number: new_tempo_block_number,
+        anchor_block_hash: new_tempo_block_hash,
+        expected_withdrawal_batch_index: outbox_wbi,
+        sequencer: SEQUENCER,
+    };
+
+    let witness = BatchWitness {
+        public_inputs,
+        chain_id: CHAIN_ID,
+        prev_block_header: genesis_header,
+        zone_blocks: vec![zone_block],
+        initial_zone_state: fixture.witness,
+        tempo_state_proofs,
+        tempo_ancestry_headers: vec![],
+    };
+
+    let output =
+        prove_zone_batch(witness).expect("prove_zone_batch with advanceTempo should succeed");
+
+    println!("Prover succeeded with advanceTempo!");
+    println!(
+        "  prev_block_hash: {}",
+        output.block_transition.prev_block_hash
+    );
+    println!(
+        "  next_block_hash: {}",
+        output.block_transition.next_block_hash
+    );
+
+    assert_eq!(output.block_transition.prev_block_hash, genesis_hash);
+    assert_ne!(output.block_transition.next_block_hash, genesis_hash);
+}

--- a/crates/zone-test-utils/Cargo.toml
+++ b/crates/zone-test-utils/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "zone-test-utils"
+description = "Shared test utilities for zone contract deployment and EVM setup"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# alloy
+alloy-consensus.workspace = true
+alloy-eips.workspace = true
+alloy-evm.workspace = true
+alloy-primitives = { workspace = true, features = ["map"] }
+alloy-rlp.workspace = true
+alloy-sol-types.workspace = true
+
+# revm
+revm.workspace = true
+
+# tempo
+tempo-chainspec.workspace = true
+tempo-evm = { workspace = true, features = ["rpc", "engine"] }
+tempo-primitives.workspace = true
+tempo-revm.workspace = true
+
+# misc
+const-hex.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/crates/zone-test-utils/src/lib.rs
+++ b/crates/zone-test-utils/src/lib.rs
@@ -1,0 +1,344 @@
+//! Shared test utilities for zone contract deployment and EVM setup.
+//!
+//! Provides helpers to load Foundry artifacts, deploy zone predeploy contracts,
+//! and build an in-memory EVM for integration testing against real contract bytecode.
+
+use alloy_evm::{Evm, EvmEnv, EvmFactory};
+use alloy_primitives::{Address, Bytes, U256, address};
+use revm::{
+    context::result::{ExecutionResult, Output},
+    database::{CacheDB, EmptyDB},
+    state::AccountInfo,
+};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
+use tempo_revm::TempoBlockEnv;
+
+pub const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
+pub const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
+pub const ZONE_OUTBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000002");
+pub const ZONE_CONFIG_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000003");
+pub const TEMPO_STATE_READER_ADDRESS: Address =
+    address!("0x1c00000000000000000000000000000000000004");
+
+pub const DEPLOYER: Address = address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+/// Load a Foundry artifact's creation bytecode from the specs output directory.
+///
+/// Resolves the artifact path relative to `CARGO_MANIFEST_DIR`, walking up to the
+/// workspace root and then into `docs/specs/out/<name>.sol/<name>.json`.
+pub fn load_artifact(name: &str) -> Vec<u8> {
+    load_artifact_from_root(name, None)
+}
+
+/// Load a Foundry artifact from a specified workspace root, or auto-detect it.
+pub fn load_artifact_from_root(name: &str, workspace_root: Option<&std::path::Path>) -> Vec<u8> {
+    #[derive(serde::Deserialize)]
+    struct FoundryArtifact {
+        bytecode: BytecodeField,
+    }
+    #[derive(serde::Deserialize)]
+    struct BytecodeField {
+        object: String,
+    }
+
+    let specs_out = if let Some(root) = workspace_root {
+        root.join("docs/specs/out")
+    } else {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        manifest_dir.join("../../docs/specs/out")
+    };
+
+    let path = specs_out
+        .join(format!("{name}.sol"))
+        .join(format!("{name}.json"));
+    let content =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let artifact: FoundryArtifact =
+        serde_json::from_str(&content).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    const_hex::decode(&artifact.bytecode.object).expect("decode bytecode hex")
+}
+
+/// Deploy a contract into the CacheDB via the EVM, then relocate it to the predeploy address.
+///
+/// This mirrors the `xtask generate_zone_genesis` process: the contract is deployed at
+/// a CREATE address, then the account is moved to the desired predeploy slot.
+pub fn deploy_contract(
+    evm: &mut TempoEvm<CacheDB<EmptyDB>>,
+    creation_bytecode: &[u8],
+    constructor_args: &[u8],
+    predeploy_addr: Address,
+    name: &str,
+    chain_id: u64,
+    nonce: u64,
+) {
+    use alloy_primitives::TxKind;
+    use revm::context::TxEnv;
+    use tempo_revm::TempoTxEnv;
+
+    let mut initcode = Vec::with_capacity(creation_bytecode.len() + constructor_args.len());
+    initcode.extend_from_slice(creation_bytecode);
+    initcode.extend_from_slice(constructor_args);
+
+    let tx = TempoTxEnv {
+        inner: TxEnv {
+            caller: DEPLOYER,
+            gas_price: 0,
+            gas_limit: 30_000_000,
+            kind: TxKind::Create,
+            data: initcode.into(),
+            chain_id: Some(chain_id),
+            nonce,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let result = evm
+        .transact_raw(tx)
+        .unwrap_or_else(|e| panic!("{name} deploy tx failed: {e:?}"));
+    let created_addr = match &result.result {
+        ExecutionResult::Success { output, .. } => match output {
+            Output::Create(_, Some(addr)) => *addr,
+            other => panic!("{name} deploy did not return address: {other:?}"),
+        },
+        ExecutionResult::Revert { output, .. } => panic!("{name} deploy reverted: {output}"),
+        ExecutionResult::Halt { reason, .. } => panic!("{name} deploy halted: {reason:?}"),
+    };
+
+    use revm::DatabaseCommit;
+    evm.db_mut().commit(result.state);
+
+    let db = evm.db_mut();
+    if let Some(mut created_account) = db.cache.accounts.remove(&created_addr) {
+        created_account.info.nonce = 1;
+        db.cache.accounts.insert(predeploy_addr, created_account);
+    } else {
+        panic!("{name} deployed to {created_addr} but not found in CacheDB");
+    }
+}
+
+/// Build a minimal valid RLP-encoded TempoHeader (genesis-like, all fields zeroed).
+pub fn build_dummy_header_rlp() -> Vec<u8> {
+    use alloy_rlp::Encodable;
+    use tempo_primitives::TempoHeader;
+
+    let header = TempoHeader::default();
+    let mut buf = Vec::new();
+    header.encode(&mut buf);
+    buf
+}
+
+/// Build an EVM with the four zone predeploy contracts deployed in-memory.
+///
+/// This mirrors the genesis setup from `xtask generate_zone_genesis`:
+/// 1. `TempoState` at `0x1c00..0000`
+/// 2. `ZoneConfig` at `0x1c00..0003`
+/// 3. `ZoneInbox` at `0x1c00..0001`
+/// 4. `ZoneOutbox` at `0x1c00..0002`
+///
+/// The returned EVM uses a `CacheDB<EmptyDB>` with the deployer funded and all
+/// contracts deployed. `chain_id` defaults to `13371`.
+pub fn setup_zone_evm(chain_id: u64) -> TempoEvm<CacheDB<EmptyDB>> {
+    let gas_limit = 30_000_000u64;
+
+    let db = CacheDB::default();
+    let mut env: EvmEnv<TempoHardfork, TempoBlockEnv> =
+        EvmEnv::default().with_timestamp(U256::ZERO);
+    env.cfg_env.chain_id = chain_id;
+    env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+    env.block_env.inner.gas_limit = gas_limit;
+
+    let factory = TempoEvmFactory::default();
+    let mut evm = factory.create_evm(db, env);
+
+    evm.db_mut().insert_account_info(
+        DEPLOYER,
+        AccountInfo {
+            balance: U256::from(1_000_000_000_000_000_000_000u128),
+            ..Default::default()
+        },
+    );
+
+    let dummy_header_rlp = build_dummy_header_rlp();
+
+    let mut nonce = 0u64;
+
+    // 1. TempoState(bytes headerRlp)
+    let tempo_state_bytecode = load_artifact("TempoState");
+    let tempo_state_args =
+        alloy_sol_types::SolValue::abi_encode_params(&(Bytes::from(dummy_header_rlp),));
+    deploy_contract(
+        &mut evm,
+        &tempo_state_bytecode,
+        &tempo_state_args,
+        TEMPO_STATE_ADDRESS,
+        "TempoState",
+        chain_id,
+        nonce,
+    );
+    nonce += 1;
+
+    // 2. ZoneConfig(address zoneToken, address tempoPortal, address tempoState)
+    let zone_config_bytecode = load_artifact("ZoneConfig");
+    let zone_token = Address::repeat_byte(0xaa);
+    let tempo_portal = Address::repeat_byte(0xbb);
+    let zone_config_args = alloy_sol_types::SolValue::abi_encode_params(&(
+        zone_token,
+        tempo_portal,
+        TEMPO_STATE_ADDRESS,
+    ));
+    deploy_contract(
+        &mut evm,
+        &zone_config_bytecode,
+        &zone_config_args,
+        ZONE_CONFIG_ADDRESS,
+        "ZoneConfig",
+        chain_id,
+        nonce,
+    );
+    nonce += 1;
+
+    // 3. ZoneInbox(address config, address tempoPortal, address tempoState, address zoneToken)
+    let zone_inbox_bytecode = load_artifact("ZoneInbox");
+    let zone_inbox_args = alloy_sol_types::SolValue::abi_encode_params(&(
+        ZONE_CONFIG_ADDRESS,
+        tempo_portal,
+        TEMPO_STATE_ADDRESS,
+        zone_token,
+    ));
+    deploy_contract(
+        &mut evm,
+        &zone_inbox_bytecode,
+        &zone_inbox_args,
+        ZONE_INBOX_ADDRESS,
+        "ZoneInbox",
+        chain_id,
+        nonce,
+    );
+    nonce += 1;
+
+    // 4. ZoneOutbox(address config, address zoneToken)
+    let zone_outbox_bytecode = load_artifact("ZoneOutbox");
+    let zone_outbox_args =
+        alloy_sol_types::SolValue::abi_encode_params(&(ZONE_CONFIG_ADDRESS, zone_token));
+    deploy_contract(
+        &mut evm,
+        &zone_outbox_bytecode,
+        &zone_outbox_args,
+        ZONE_OUTBOX_ADDRESS,
+        "ZoneOutbox",
+        chain_id,
+        nonce,
+    );
+
+    // Deploy EIP-2935 blockhash history contract (predeploy, not via CREATE).
+    {
+        let code = alloy_eips::eip2935::HISTORY_STORAGE_CODE.clone();
+        let code_hash = alloy_primitives::keccak256(&code);
+        let bytecode = revm::bytecode::Bytecode::new_raw(code);
+        evm.db_mut().insert_account_info(
+            alloy_eips::eip2935::HISTORY_STORAGE_ADDRESS,
+            AccountInfo {
+                nonce: 1,
+                code_hash,
+                code: Some(bytecode),
+                ..Default::default()
+            },
+        );
+    }
+
+    evm
+}
+
+/// Convenience wrapper that calls [`setup_zone_evm`] with the default chain ID (13371).
+pub fn setup_zone_evm_default() -> TempoEvm<CacheDB<EmptyDB>> {
+    setup_zone_evm(13371)
+}
+
+/// Snapshot of a single account extracted from a CacheDB.
+#[derive(Debug, Clone)]
+pub struct AccountSnapshot {
+    pub nonce: u64,
+    pub balance: U256,
+    pub code_hash: alloy_primitives::B256,
+    pub code: Option<Vec<u8>>,
+    /// Non-zero storage slots.
+    pub storage: Vec<(U256, U256)>,
+}
+
+/// Extract all accounts and their non-zero storage from a CacheDB.
+///
+/// Useful for building a `ZoneStateWitness` from a CacheDB that has contracts
+/// deployed via [`setup_zone_evm`].
+pub fn extract_db_accounts(db: &CacheDB<EmptyDB>) -> Vec<(Address, AccountSnapshot)> {
+    let mut accounts = Vec::new();
+    for (addr, account) in &db.cache.accounts {
+        let info = &account.info;
+        let code = info.code.as_ref().map(|c| c.bytes().to_vec());
+        let storage: Vec<(U256, U256)> = account
+            .storage
+            .iter()
+            .filter(|(_, v)| !v.is_zero())
+            .map(|(k, v)| (*k, *v))
+            .collect();
+        accounts.push((
+            *addr,
+            AccountSnapshot {
+                nonce: info.nonce,
+                balance: info.balance,
+                code_hash: info.code_hash,
+                code,
+                storage,
+            },
+        ));
+    }
+    accounts
+}
+
+/// Register a mock TempoStateReader precompile on a `TempoEvm`.
+///
+/// The mock returns `bytes32(0)` for `readStorageAt` and an array of zeros for
+/// `readStorageBatchAt`. This is sufficient for `advanceTempo` calls in tests
+/// where no real L1 data is needed (e.g., empty deposit queues).
+pub fn register_mock_tempo_state_reader<DB: alloy_evm::Database>(evm: &mut TempoEvm<DB>) {
+    use alloy_evm::precompiles::DynPrecompile;
+    use alloy_sol_types::SolCall;
+    use revm::precompile::{PrecompileId, PrecompileOutput};
+
+    alloy_sol_types::sol! {
+        function readStorageAt(address account, bytes32 slot, uint64 blockNumber) external view returns (bytes32);
+        function readStorageBatchAt(address account, bytes32[] calldata slots, uint64 blockNumber) external view returns (bytes32[] memory);
+    }
+
+    let mock = DynPrecompile::new_stateful(
+        PrecompileId::Custom("MockTempoStateReader".into()),
+        move |input| {
+            let data = input.data;
+            if data.len() < 4 {
+                return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            }
+
+            let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
+
+            if selector == readStorageAtCall::SELECTOR {
+                let encoded = readStorageAtCall::abi_encode_returns(&alloy_primitives::B256::ZERO);
+                Ok(PrecompileOutput::new(400, encoded.into()))
+            } else if selector == readStorageBatchAtCall::SELECTOR {
+                let call = readStorageBatchAtCall::abi_decode(data)
+                    .map_err(|_| revm::precompile::PrecompileError::other("ABI decode failed"))?;
+                let zeros = vec![alloy_primitives::B256::ZERO; call.slots.len()];
+                let encoded = readStorageBatchAtCall::abi_encode_returns(&zeros);
+                Ok(PrecompileOutput::new(
+                    200 + 200 * call.slots.len() as u64,
+                    encoded.into(),
+                ))
+            } else {
+                Ok(PrecompileOutput::new_reverted(0, Bytes::new()))
+            }
+        },
+    );
+
+    let (_, _, precompiles) = evm.components_mut();
+    precompiles.apply_precompile(&TEMPO_STATE_READER_ADDRESS, |_| Some(mock));
+}


### PR DESCRIPTION
Add witness recording pipeline (RecordingDatabase, RecordingL1StateProvider, WitnessStore), the ProofGenerator/BatchProofGenerator trait, and zone-test-utils. Integrates into builder, EVM config, node wiring, and zone monitor.

Stacked on #335.