### PR TITLE
[codex] cleanup zones README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Zones are sidechains anchored to Tempo. Each zone has its own sequencer, genesis state, and portal contract that escrows deposits and processes withdrawals.
 
-**Explorers:** [Moderato](https://explore.moderato.tempo.xyz/) · [Devnet](https://explore.devnet.tempo.xyz/)
+**Explorers:** [Moderato](https://explore.moderato.tempo.xyz/)
 
 This repository contains the `tempo-zone` node, zone-specific precompiles and RPC support, and the `just` workflows for deploying and operating zones on Tempo.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tempo Zones
 
-Zones are L2 chains anchored to Tempo L1. Each zone has its own sequencer, genesis state, and portal contract on L1 that escrows deposits and processes withdrawals.
+Zones are sidechains anchored to Tempo L1. Each zone has its own sequencer, genesis state, and portal contract on L1 that escrows deposits and processes withdrawals.
 
 **Explorers:** [Moderato](https://explore.moderato.tempo.xyz/) · [Devnet](https://explore.devnet.tempo.xyz/)
 
@@ -48,7 +48,7 @@ just zone-up my-zone false release
 ## How Zones Work
 
 - A zone sequencer subscribes to Tempo L1 for headers, deposits, and token-enablement events, including backfill from the zone's anchor block.
-- The zone builds one L2 block per L1 block, processing L1-driven state transitions through system transactions before app transactions.
+- The zone builds one sidechain block per L1 block, processing L1-driven state transitions through system transactions before app transactions.
 - The zone monitor batches zone blocks back to L1 and processes withdrawals from the zone back to L1 users.
 
 ## More Docs

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Tempo Zones
 
-Zones are sidechains anchored to Tempo L1. Each zone has its own sequencer, genesis state, and portal contract on L1 that escrows deposits and processes withdrawals.
+Zones are sidechains anchored to Tempo. Each zone has its own sequencer, genesis state, and portal contract that escrows deposits and processes withdrawals.
 
 **Explorers:** [Moderato](https://explore.moderato.tempo.xyz/) · [Devnet](https://explore.devnet.tempo.xyz/)
 
-This repository contains the `tempo-zone` node, zone-specific precompiles and RPC support, and the `just` workflows for deploying and operating zones on Tempo L1.
+This repository contains the `tempo-zone` node, zone-specific precompiles and RPC support, and the `just` workflows for deploying and operating zones on Tempo.
+
+For the main Tempo repository, see [tempoxyz/tempo](https://github.com/tempoxyz/tempo).
 
 ## Quick Start
 
@@ -31,9 +33,9 @@ just deploy-zone my-zone alphausd
 `just deploy-zone` will:
 
 - Generate a fresh sequencer keypair
-- Fund the sequencer on L1 via `tempo_fundAddress`
+- Fund the sequencer via `tempo_fundAddress`
 - Build the Solidity specs
-- Deploy a zone on L1 via `ZoneFactory`
+- Deploy a zone via `ZoneFactory`
 - Generate `generated/<name>/genesis.json` and `generated/<name>/zone.json`
 - Register the sequencer encryption key and start the zone node
 
@@ -47,9 +49,9 @@ just zone-up my-zone false release
 
 ## How Zones Work
 
-- A zone sequencer subscribes to Tempo L1 for headers, deposits, and token-enablement events, including backfill from the zone's anchor block.
-- The zone builds one sidechain block per L1 block, processing L1-driven state transitions through system transactions before app transactions.
-- The zone monitor batches zone blocks back to L1 and processes withdrawals from the zone back to L1 users.
+- A zone sequencer subscribes to Tempo for headers, deposits, and token-enablement events, including backfill from the zone's anchor block.
+- The zone builds one sidechain block per Tempo block, processing Tempo-driven state transitions through system transactions before app transactions.
+- The zone monitor batches zone blocks back to Tempo and processes withdrawals from the zone back to Tempo users.
 
 ## More Docs
 

--- a/README.md
+++ b/README.md
@@ -1,139 +1,78 @@
-<br>
-<br>
+# Tempo Zones
 
-<p align="center">
-  <a href="https://tempo.xyz">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tempoxyz/.github/refs/heads/main/assets/combomark-dark.svg">
-      <img alt="tempo combomark" src="https://raw.githubusercontent.com/tempoxyz/.github/refs/heads/main/assets/combomark-bright.svg" width="auto" height="120">
-    </picture>
-  </a>
-</p>
+Zones are L2 chains anchored to Tempo L1. Each zone has its own sequencer, genesis state, and portal contract on L1 that escrows deposits and processes withdrawals.
 
-<br>
-<br>
+**Explorers:** [Moderato](https://explore.moderato.tempo.xyz/) · [Devnet](https://explore.devnet.tempo.xyz/)
 
-# Tempo
+This repository contains the `tempo-zone` node, zone-specific precompiles and RPC support, and the `just` workflows for deploying and operating zones on Tempo L1.
 
-The blockchain for payments at scale.
+## Quick Start
 
-[Tempo](https://docs.tempo.xyz/) is a blockchain designed specifically for stablecoin payments. Its architecture focuses on high throughput, low cost, and features that financial institutions, payment service providers, and fintech platforms expect from modern payment infrastructure.
+Prerequisites:
 
-You can get started today by integrating with the [Tempo testnet](https://docs.tempo.xyz/quickstart/integrate-tempo), [building on Tempo](https://docs.tempo.xyz/guide/use-accounts), [running a Tempo node](https://docs.tempo.xyz/guide/node), reading the [Tempo protocol specs](https://docs.tempo.xyz/protocol) or by [building with Tempo SDKs](https://docs.tempo.xyz/sdk).
+- [Rust toolchain](https://rustup.rs/)
+- [Foundry](https://book.getfoundry.sh/getting-started/installation) (`cast`, `forge`)
+- [`just`](https://github.com/casey/just#packages)
+- [`jq`](https://jqlang.github.io/jq/download/)
 
-## What makes Tempo different
-
-- [TIP‑20 token standard](https://docs.tempo.xyz/protocol/tip20/overview) (enshrined ERC‑20 extensions)
-
-  - Predictable payment throughput via dedicated payment lanes reserved for TIP‑20 transfers (eliminates noisy‑neighbor contention).
-  - Native reconciliation with on‑transfer memos and commitment patterns (hash/locator) for off‑chain PII and large data.
-  - Built‑in compliance through [TIP‑403 Policy Registry](https://docs.tempo.xyz/protocol/tip403/overview): single policy shared across multiple tokens, updated once and enforced everywhere.
-
-- Low, predictable fees in [stablecoins](https://docs.tempo.xyz/learn/stablecoins)
-
-  - Users pay gas directly in USD-stablecoins at launch; the [Fee AMM](https://docs.tempo.xyz/protocol/fees/fee-amm#fee-amm-overview) automatically converts to the validator’s preferred stablecoin.
-  - TIP‑20 transfers target sub‑millidollar costs (<$0.001).
-
-- [Tempo Transactions](https://docs.tempo.xyz/guide/tempo-transaction) (native “smart accounts”)
-
-  - Batched payments: atomic multi‑operation payouts (payroll, settlements, refunds).
-  - Fee sponsorship: apps can pay users' gas to streamline onboarding and flows.
-  - Scheduled payments: protocol‑level time windows for recurring and timed disbursements.
-  - Modern authentication: passkeys via WebAuthn/P256 (biometric sign‑in, secure enclave, cross‑device sync).
-
-- Performance and finality
-
-  - Built on the [Reth SDK](https://github.com/paradigmxyz/reth), the most performant and flexible EVM (Ethereum Virtual Machine) execution client.
-  - Simplex Consensus (via [Commonware](https://commonware.xyz/)): fast, sub‑second finality in normal conditions; graceful degradation under adverse networks.
-
-- Coming soon
-
-  - On‑chain FX and non‑USD stablecoin support for direct on‑chain liquidity; pay fees in more currencies.
-  - Native private token standard: opt‑in privacy for balances/transfers coexisting with issuer compliance and auditability.
-
-## What makes Tempo familiar
-
-- Fully compatible with the Ethereum Virtual Machine (EVM), targeting the Osaka hardfork.
-- Deploy and interact with smart contracts using the same tools, languages, and frameworks used on Ethereum, such as Solidity, Foundry, and Hardhat.
-- All Ethereum JSON-RPC methods work out of the box.
-
-While the execution environment mirrors Ethereum's, Tempo introduces some differences optimized for payments, described [here](https://docs.tempo.xyz/quickstart/evm-compatibility).
-
-## Getting Started
-
-### As a user
-
-You can connect to Tempo's public testnet using the following details:
-
-| Property           | Value                              |
-| ------------------ | ---------------------------------- |
-| **Network Name**   | Tempo Testnet (Moderato)           |
-| **Currency**       | `USD`                              |
-| **Chain ID**       | `42431`                            |
-| **HTTP URL**       | `https://rpc.moderato.tempo.xyz`   |
-| **WebSocket URL**  | `wss://rpc.moderato.tempo.xyz`     |
-| **Block Explorer** | `https://explore.tempo.xyz`        |
-
-Next, grab some stablecoins to test with from Tempo's [Faucet](https://docs.tempo.xyz/quickstart/faucet#faucet).
-
-Alternatively, use [`cast`](https://github.com/tempoxyz/tempo-foundry):
+Deploy and start a zone on Moderato:
 
 ```bash
-cast rpc tempo_fundAddress <ADDRESS> --rpc-url https://rpc.moderato.tempo.xyz
+export L1_RPC_URL="wss://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+just deploy-zone my-zone
 ```
 
-### As an operator
-
-We provide three different installation paths: installing a pre-built binary, building from source or using our provided Docker image.
-
-- [Pre-built Binary](https://docs.tempo.xyz/guide/node/installation#pre-built-binary)
-- [Build from Source](https://docs.tempo.xyz/guide/node/installation#build-from-source)
-- [Docker](https://docs.tempo.xyz/guide/node/installation#docker)
-
-See the [Tempo documentation](https://docs.tempo.xyz/guide/node) for instructions on how to install and run Tempo.
-
-### As a developer
-
-Tempo has several SDKs to help you get started building on Tempo:
-
-- [TypeScript](https://docs.tempo.xyz/sdk/typescript)
-- [Rust](https://docs.tempo.xyz/sdk/rust)
-- [Go](https://docs.tempo.xyz/sdk/go)
-- [Foundry](https://docs.tempo.xyz/sdk/foundry)
-
-Want to contribute?
-
-First, clone the repository:
-
-```
-git clone https://github.com/tempoxyz/tempo
-cd tempo
-```
-
-Next, install [`just`](https://github.com/casey/just?tab=readme-ov-file#packages).
-
-Install the dependencies:
+To choose a different initial TIP-20 on the portal at deploy time, pass it as the second positional argument:
 
 ```bash
-just
+just deploy-zone my-zone alphausd
 ```
 
-Build Tempo:
+`just deploy-zone` will:
+
+- Generate a fresh sequencer keypair
+- Fund the sequencer on L1 via `tempo_fundAddress`
+- Build the Solidity specs
+- Deploy a zone on L1 via `ZoneFactory`
+- Generate `generated/<name>/genesis.json` and `generated/<name>/zone.json`
+- Register the sequencer encryption key and start the zone node
+
+`zone.json` stores the deployed portal address, zone ID, anchor block, and sequencer metadata used by later commands such as `just zone-up` and `just deploy-router`.
+
+To restart the same zone later:
 
 ```bash
-just build-all
+just zone-up my-zone false release
 ```
 
-Run the tests:
+## How Zones Work
+
+- A zone sequencer subscribes to Tempo L1 for headers, deposits, and token-enablement events, including backfill from the zone's anchor block.
+- The zone builds one L2 block per L1 block, processing L1-driven state transitions through system transactions before app transactions.
+- The zone monitor batches zone blocks back to L1 and processes withdrawals from the zone back to L1 users.
+
+## More Docs
+
+See [docs/ZONES.md](docs/ZONES.md) for:
+
+- Step-by-step setup and deployment
+- Deposits, withdrawals, and private RPC usage
+- Router demos and TIP-403 policy flows
+- Architecture, configuration, and command reference
+
+## Development
 
 ```bash
-cargo nextest run
+git clone https://github.com/tempoxyz/zones.git
+cd zones
+cargo build --bin tempo-zone
+cargo test --workspace
 ```
 
-Start a `localnet`:
+The main binary in this repository is `tempo-zone`:
 
 ```bash
-just localnet
+cargo run --bin tempo-zone -- node --help
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary

This updates the top-level README so it reads like the `zones` repository instead of a copied landing page from the main Tempo repository.

## What changed

- replaced the upstream Tempo marketing and product overview with a repo-specific `Tempo Zones` introduction
- kept a short top-level quickstart centered on `just deploy-zone`
- added a compact high-level section describing how zones work
- moved the more detailed operational walkthrough out of the README and pointed readers to `docs/ZONES.md`
- preserved the existing Contributing, Security, and License sections as requested

## Why

The previous README contained a lot of Tempo-wide content that was not specific to this repository. That made the top-level docs less useful for someone landing in `tempoxyz/zones` and increased the risk of stale or misleading links.

## Impact

Developers landing in this repo should get a faster explanation of what this project is, how to start a zone, and where to go for the deeper operating guide.

## Validation

- reviewed the final README diff locally
- ran `git diff --check`
- did not run tests because this is a docs-only change
