### PR TITLE
feat: add portal token listing recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -358,6 +358,19 @@ enable-token token:
         sleep 0.5
     done
 
+[group('zone')]
+[doc('Lists TIP-20 token addresses currently enabled on the ZonePortal. Pass a portal address or set L1_PORTAL_ADDRESS. Requires L1_RPC_URL.')]
+list-enabled-tokens portal="":
+    #!/bin/bash
+    set -euo pipefail
+    RPC="${L1_RPC_URL:?Set L1_RPC_URL env var}"
+    PORTAL="{{portal}}"
+    if [[ -z "$PORTAL" ]]; then
+        PORTAL="${L1_PORTAL_ADDRESS:?Set L1_PORTAL_ADDRESS env var or pass a portal address}"
+    fi
+    HTTP_RPC=$(echo "$RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
+    for ((i=0,n=$(cast call "$PORTAL" "enabledTokenCount()(uint256)" --rpc-url "$HTTP_RPC"); i<n; i++)); do cast call "$PORTAL" "enabledTokenAt(uint256)(address)" "$i" --rpc-url "$HTTP_RPC"; done
+
 [group('tip403')]
 [doc('Creates a new TIP-20 token on L1 via TIP20Factory. Returns the token address. Requires L1_RPC_URL and PRIVATE_KEY env vars.')]
 create-token name symbol salt="0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890":


### PR DESCRIPTION
## What changed
- add `just list-enabled-tokens` under the zone recipes
- keep the portal query as a compact `cast`-only one-liner over `enabledTokenCount()` and `enabledTokenAt()`
- allow passing the portal address as a positional recipe argument while still falling back to `L1_PORTAL_ADDRESS`

## Why
We wanted a quick way to inspect all currently enabled portal tokens directly from the `Justfile` without reaching for a longer shell snippet.

## Impact
This gives operators a small repo-native command for reading enabled TIP-20 token addresses from a portal:

```bash
just list-enabled-tokens 0xPortal
```

or, with env vars already set:

```bash
just list-enabled-tokens
```

## Validation
- `just --summary`
- `just --show list-enabled-tokens`