### PR TITLE
fix: remove embedded rpc auth from defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prerequisites:
 Deploy and start a zone on Moderato:
 
 ```bash
-export L1_RPC_URL="wss://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+export L1_RPC_URL="wss://rpc.moderato.tempo.xyz"
 just deploy-zone my-zone
 ```
 

--- a/crates/tempo-zone/tests/l1_state_reader.rs
+++ b/crates/tempo-zone/tests/l1_state_reader.rs
@@ -16,7 +16,7 @@ const ZONE_PORTAL: Address = address!("0x1bc99e6a8c4689f1884527152ba542f01231614
 
 fn l1_rpc_url() -> String {
     std::env::var("L1_RPC_URL")
-        .unwrap_or_else(|_| "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz".into())
+        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".into())
 }
 
 async fn make_provider() -> L1StateProvider {

--- a/crates/tempo-zone/tests/l1_state_reader.rs
+++ b/crates/tempo-zone/tests/l1_state_reader.rs
@@ -15,8 +15,7 @@ use zone::l1_state::{L1StateProvider, L1StateProviderConfig, SharedL1StateCache}
 const ZONE_PORTAL: Address = address!("0x1bc99e6a8c4689f1884527152ba542f012316149");
 
 fn l1_rpc_url() -> String {
-    std::env::var("L1_RPC_URL")
-        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".into())
+    std::env::var("L1_RPC_URL").unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".into())
 }
 
 async fn make_provider() -> L1StateProvider {

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -9,7 +9,7 @@ Zones are L2 chains anchored to Tempo L1. Each zone has its own sequencer, genes
 The fastest way to deploy and run a zone on moderato:
 
 ```bash
-export L1_RPC_URL="wss://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+export L1_RPC_URL="wss://rpc.moderato.tempo.xyz"
 just deploy-zone my-zone
 ```
 
@@ -74,12 +74,12 @@ All zone commands need an L1 RPC URL.
 
 **Moderato testnet:**
 ```bash
-export L1_RPC_URL="wss://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+export L1_RPC_URL="wss://rpc.moderato.tempo.xyz"
 ```
 
 **Devnet:**
 ```bash
-export L1_RPC_URL="wss://eng:bold-raman-silly-torvalds@rpc.devnet.tempoxyz.dev"
+export L1_RPC_URL="wss://rpc.devnet.tempoxyz.dev"
 ```
 
 ### 2. Generate a Sequencer Key

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -59,7 +59,7 @@ pub(crate) struct CreateZone {
     /// Tempo L1 HTTP RPC URL used to fetch headers and send the createZone transaction.
     #[arg(
         long,
-        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+        default_value = "https://rpc.moderato.tempo.xyz"
     )]
     l1_rpc_url: String,
 

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -57,10 +57,7 @@ pub(crate) struct CreateZone {
     output: PathBuf,
 
     /// Tempo L1 HTTP RPC URL used to fetch headers and send the createZone transaction.
-    #[arg(
-        long,
-        default_value = "https://rpc.moderato.tempo.xyz"
-    )]
+    #[arg(long, default_value = "https://rpc.moderato.tempo.xyz")]
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.

--- a/xtask/src/demo_blacklist.rs
+++ b/xtask/src/demo_blacklist.rs
@@ -84,7 +84,7 @@ pub(crate) struct DemoBlacklist {
     #[arg(
         long,
         env = "L1_RPC_URL",
-        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+        default_value = "https://rpc.moderato.tempo.xyz"
     )]
     l1_rpc_url: String,
 

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -53,7 +53,7 @@ pub(crate) struct DemoSwapAndDeposit {
     #[arg(
         long,
         env = "L1_RPC_URL",
-        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+        default_value = "https://rpc.moderato.tempo.xyz"
     )]
     l1_rpc_url: String,
 

--- a/xtask/src/deploy_router.rs
+++ b/xtask/src/deploy_router.rs
@@ -25,7 +25,7 @@ pub(crate) struct DeployRouter {
     #[arg(
         long,
         env = "L1_RPC_URL",
-        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+        default_value = "https://rpc.moderato.tempo.xyz"
     )]
     l1_rpc_url: String,
 

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -11,10 +11,7 @@ pub(crate) struct ZoneInfoCmd {
     identifier: String,
 
     /// Tempo L1 HTTP RPC URL.
-    #[arg(
-        long,
-        default_value = "https://rpc.moderato.tempo.xyz"
-    )]
+    #[arg(long, default_value = "https://rpc.moderato.tempo.xyz")]
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -13,7 +13,7 @@ pub(crate) struct ZoneInfoCmd {
     /// Tempo L1 HTTP RPC URL.
     #[arg(
         long,
-        default_value = "https://eng:bold-raman-silly-torvalds@rpc.moderato.tempo.xyz"
+        default_value = "https://rpc.moderato.tempo.xyz"
     )]
     l1_rpc_url: String,
 


### PR DESCRIPTION
## What changed
- removed the embedded auth segment from default Tempo RPC URLs in the zone xtasks
- updated README and zone docs examples to use the same RPC endpoints without inline credentials
- updated the live-RPC test fallback URL to the unauthenticated Moderato endpoint

## Why
These defaults and examples were still baking inline auth directly into RPC URLs. That leaks internal auth material into user-facing docs and CLI defaults.

## Impact
Developers still hit the same Moderato and Devnet RPC endpoints, but they now do so without checked-in inline credentials.

## Root cause
Older bootstrap examples and command defaults were copied forward with an authenticated RPC URL instead of a neutral public/default endpoint form.

## Validation
- `cargo test -p zone --test l1_state_reader --no-run`
- `cargo check -p tempo-xtask`
