### PR TITLE
feat(xtask): add routed withdrawal and encrypted payload helpers

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -95,16 +95,38 @@ send-deposit amount="1000000" to="" token="0x20C00000000000000000000000000000000
 
 [group('zone')]
 [doc('Sends an encrypted deposit to the ZonePortal on L1 (recipient and memo are hidden on-chain). Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and PRIVATE_KEY env vars. Run max-approve-portal first.')]
-send-deposit-encrypted amount="1000000" to="" memo="0x0000000000000000000000000000000000000000000000000000000000000000" token="0x20C0000000000000000000000000000000000000" rpc=zone_rpc:
+send-deposit-encrypted amount="1000000" to="" memo="0x0000000000000000000000000000000000000000000000000000000000000000" token="0x20C0000000000000000000000000000000000000" payload-file="" rpc=zone_rpc:
     #!/bin/bash
     set -euo pipefail
     PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
-    TO="{{to}}"
-    if [[ -z "$TO" ]]; then
-        TO=$(cast wallet address "$PK")
+    ARGS=(--amount "{{amount}}" --token "{{token}}" --zone-rpc-url "{{rpc}}" --private-key "$PK")
+    if [[ -n "{{payload-file}}" ]]; then
+        ARGS+=(--payload-file "{{payload-file}}")
+        if [[ -n "{{to}}" ]]; then
+            ARGS+=(--to "{{to}}")
+        fi
+    else
+        TO="{{to}}"
+        if [[ -z "$TO" ]]; then
+            TO=$(cast wallet address "$PK")
+        fi
+        ARGS+=(--memo "{{memo}}" --to "$TO")
     fi
-    ARGS="--amount {{amount}} --token {{token}} --memo {{memo}} --to $TO --zone-rpc-url {{rpc}}"
-    cargo run -p tempo-xtask -- encrypted-deposit --private-key "$PK" $ARGS
+    cargo run -p tempo-xtask -- encrypted-deposit "${ARGS[@]}"
+
+[group('zone')]
+[doc('Builds reusable encrypted deposit payload JSON for a target zone. Target zone may be a name, zone ID, or portal address. Defaults recipient to the PRIVATE_KEY signer address. Requires L1_RPC_URL; PRIVATE_KEY is only needed when omitting the recipient.')]
+build-encrypted-deposit-payload target-zone recipient="" memo="0x0000000000000000000000000000000000000000000000000000000000000000":
+    #!/bin/bash
+    set -euo pipefail
+    ARGS=(--target-zone "{{target-zone}}" --memo "{{memo}}")
+    if [[ -n "{{recipient}}" ]]; then
+        ARGS+=(--recipient "{{recipient}}")
+    fi
+    if [[ -n "${PRIVATE_KEY:-}" ]]; then
+        ARGS+=(--private-key "$PRIVATE_KEY")
+    fi
+    cargo run -p tempo-xtask -- build-encrypted-deposit-payload "${ARGS[@]}"
 
 [group('zone')]
 [doc('Fetches and prints zone info from the ZoneFactory. Pass a zone ID (integer) or portal address (0x...).')]
@@ -312,6 +334,39 @@ send-withdrawal amount="1000000" to="" token="0x20C00000000000000000000000000000
         fi
         sleep 0.25
     done
+
+[group('zone')]
+[doc('Approves the source token on the source zone, builds encrypted router callback data, and submits a routed withdrawal in one command. Source and target zones may be names, zone IDs, or portal addresses. Swaps require min-out. Requires L1_RPC_URL and PRIVATE_KEY env vars.')]
+send-routed-withdrawal source-zone source-token target-zone target-token amount="1000000" recipient="" memo="0x0000000000000000000000000000000000000000000000000000000000000000" min-out="" router="" source-rpc=zone_rpc target-rpc="" fallback-recipient="":
+    #!/bin/bash
+    set -euo pipefail
+    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
+    ARGS=(
+        --source-zone "{{source-zone}}"
+        --source-token "{{source-token}}"
+        --target-zone "{{target-zone}}"
+        --target-token "{{target-token}}"
+        --amount "{{amount}}"
+        --source-rpc-url "{{source-rpc}}"
+        --private-key "$PK"
+        --memo "{{memo}}"
+    )
+    if [[ -n "{{recipient}}" ]]; then
+        ARGS+=(--recipient "{{recipient}}")
+    fi
+    if [[ -n "{{min-out}}" ]]; then
+        ARGS+=(--min-amount-out "{{min-out}}")
+    fi
+    if [[ -n "{{router}}" ]]; then
+        ARGS+=(--router "{{router}}")
+    fi
+    if [[ -n "{{target-rpc}}" ]]; then
+        ARGS+=(--target-rpc-url "{{target-rpc}}")
+    fi
+    if [[ -n "{{fallback-recipient}}" ]]; then
+        ARGS+=(--fallback-recipient "{{fallback-recipient}}")
+    fi
+    cargo run -p tempo-xtask -- send-routed-withdrawal "${ARGS[@]}"
 
 [group('zone')]
 [doc('Enables a TIP-20 token on the ZonePortal for bridging. Token can be an address or alias (pathusd, alphausd, betausd). Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and SEQUENCER_KEY env vars.')]

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -216,6 +216,31 @@ export ZONE_RPC_URL="http://localhost:8546"
 just send-deposit-encrypted 1000000
 ```
 
+#### Reusable Encrypted Payload Builder
+
+If you want to separate encryption from submission, build the encrypted `(recipient, memo)` payload once and reuse it later for encrypted deposits or routed withdrawals. The helper prints JSON, which makes it easy to stash in a file or pipe into another command.
+
+```bash
+# Build reusable payload JSON for the zone's current sequencer key
+just build-encrypted-deposit-payload my-zone
+
+# Build reusable payload JSON for a specific recipient and memo
+just build-encrypted-deposit-payload my-zone <recipient-address> 0x0000000000000000000000000000000000000000000000000000000000000042
+```
+
+To reuse the output with an encrypted deposit, write it to a file and pass it back in:
+
+```bash
+just build-encrypted-deposit-payload my-zone > /tmp/encrypted-payload.json
+cargo run -p tempo-xtask -- encrypted-deposit \
+  --amount 1000000 \
+  --payload-file /tmp/encrypted-payload.json \
+  --private-key "$PRIVATE_KEY" \
+  --zone-rpc-url "${ZONE_RPC_URL:-http://localhost:8546}"
+```
+
+The helper is read-only: it uses the target portal's currently active encryption key and fails if no active key is registered.
+
 #### Check balance on the zone
 
 ```bash
@@ -234,9 +259,58 @@ just send-withdrawal 1000000 <recipient-address>   # withdraw to a specific addr
 
 The sequencer includes the withdrawal in the next batch submission to L1 and processes it automatically.
 
+#### Routed Withdrawal via Router
+
+Use this when you want to route a withdrawal through the L1 router and deposit the result into a target zone. The source and target zones can be the same for a same-zone swap-and-deposit flow, or different for a cross-zone transfer. When the source and target tokens differ, pass `min-out` to protect the L1 swap.
+
+For optional overrides like `min-out`, `router`, and `target-rpc`, use the xtask directly because it is clearer than positional `just` arguments:
+
+```bash
+# Same-zone routed swap and deposit
+cargo run -p tempo-xtask -- send-routed-withdrawal \
+  --source-zone my-zone \
+  --source-token alphausd \
+  --target-zone my-zone \
+  --target-token betausd \
+  --amount 100000000 \
+  --min-amount-out 950000 \
+  --source-rpc-url http://localhost:8546 \
+  --target-rpc-url http://localhost:8546 \
+  --private-key "$PRIVATE_KEY"
+
+# Cross-zone transfer with the same token on both sides
+cargo run -p tempo-xtask -- send-routed-withdrawal \
+  --source-zone zone-a \
+  --source-token pathusd \
+  --target-zone zone-b \
+  --target-token pathusd \
+  --amount 1000000 \
+  --source-rpc-url http://localhost:8546 \
+  --target-rpc-url http://localhost:8547 \
+  --private-key "$PRIVATE_KEY"
+```
+
+If the source zone's metadata does not already contain the router address, pass it explicitly with `router=<address>`. You can also use zone IDs or portal addresses instead of names when you already know them:
+
+```bash
+cargo run -p tempo-xtask -- send-routed-withdrawal \
+  --source-zone 1 \
+  --source-token alphausd \
+  --target-zone 0x8f2aecbC9eC1dc5875f5f602d821a73F8b1826cD \
+  --target-token betausd \
+  --amount 100000000 \
+  --min-amount-out 950000 \
+  --router 0x032969016bC8C2fd8CaB0B51cbd41F55525e3724 \
+  --source-rpc-url http://localhost:8546 \
+  --target-rpc-url http://localhost:8547 \
+  --private-key "$PRIVATE_KEY"
+```
+
 #### Router Swap + Deposit Demo (Same Zone)
 
-This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone via an encrypted deposit. If the portal does not already have the current sequencer encryption key registered, the demo registers it automatically before building the routed callback payload.
+This is the full self-contained same-zone demo. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone via the reusable encrypted payload path. If the portal does not already have the current sequencer encryption key registered, the demo registers it automatically before building the routed callback payload.
+
+If you only want the reusable building blocks, use `just build-encrypted-deposit-payload ...` and `just send-routed-withdrawal ...` instead.
 
 Prerequisites:
 - A running zone with an active sequencer
@@ -486,9 +560,11 @@ graph TB
 | `just max-approve-portal` | Approve portal to spend tokens on L1 |
 | `just send-deposit [to]` | Deposit tokens from L1 to zone (defaults to sender) |
 | `just send-deposit-encrypted [to]` | Encrypted deposit — hides recipient and memo on-chain |
+| `just build-encrypted-deposit-payload <target-zone> [recipient] [memo]` | Build reusable encrypted deposit payload JSON for a target zone |
 | `just enable-token <token>` | Enable a TIP-20 token on the portal for bridging (sequencer only) |
 | `just max-approve-outbox` | Approve outbox to spend tokens on zone |
 | `just send-withdrawal [to]` | Withdraw tokens from zone to L1 (defaults to sender) |
+| `just send-routed-withdrawal <source-zone> <source-token> <target-zone> <target-token>` | Route a withdrawal through the router and deposit into the target zone |
 | `just demo-swap-and-deposit <name>` | Self-contained same-zone router demo: create tokens, seed DEX liquidity, swap on L1, deposit output back into the zone |
 | `just check-balance <addr>` | Check token balance on the zone |
 | `just zone-auth-token <name>` | Generate a signed private RPC auth token (10 min TTL) |

--- a/xtask/src/bridge_utils.rs
+++ b/xtask/src/bridge_utils.rs
@@ -1,0 +1,795 @@
+use alloy::{
+    primitives::{Address, B256, Bytes, FixedBytes, U256, address},
+    providers::Provider,
+    signers::{Signer, local::PrivateKeySigner},
+    sol_types::SolValue,
+};
+use eyre::{WrapErr as _, eyre};
+use k256::{AffinePoint, ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    io::{self, Read as _},
+    path::{Path, PathBuf},
+};
+use tempo_alloy::TempoNetwork;
+use zone::{
+    abi::{
+        EncryptedDepositPayload, SwapAndDepositRouterEncryptedCallback, ZoneFactory, ZonePortal,
+    },
+    precompiles::ecies::encrypt_deposit,
+};
+
+use crate::zone_utils::{MODERATO_ZONE_FACTORY, ZoneMetadata, check};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedZone {
+    pub(crate) reference: String,
+    pub(crate) portal: Address,
+    pub(crate) zone_id: Option<u32>,
+    pub(crate) zone_dir: Option<PathBuf>,
+    pub(crate) sequencer_key: Option<String>,
+    pub(crate) router: Option<Address>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BuiltEncryptedDepositPayload {
+    pub(crate) target_portal: Address,
+    pub(crate) key_index: U256,
+    pub(crate) encrypted_deposit_payload: EncryptedDepositPayload,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum EncryptionKeyMode<'a> {
+    ReadOnly {
+        expected_sequencer_private_key: Option<&'a str>,
+    },
+    EnsureRegistered {
+        sequencer_private_key: &'a str,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct BuiltEncryptedDepositPayloadJson {
+    #[serde(rename = "targetPortal")]
+    pub(crate) target_portal: String,
+    #[serde(rename = "keyIndex")]
+    pub(crate) key_index: String,
+    #[serde(rename = "encryptedDepositPayload")]
+    pub(crate) encrypted_deposit_payload: EncryptedDepositPayloadJson,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct EncryptedDepositPayloadJson {
+    #[serde(rename = "ephemeralPubkeyX")]
+    pub(crate) ephemeral_pubkey_x: String,
+    #[serde(rename = "ephemeralPubkeyYParity")]
+    pub(crate) ephemeral_pubkey_y_parity: u8,
+    pub(crate) ciphertext: String,
+    pub(crate) nonce: String,
+    pub(crate) tag: String,
+}
+
+impl BuiltEncryptedDepositPayloadJson {
+    pub(crate) fn from_built(payload: &BuiltEncryptedDepositPayload) -> Self {
+        Self {
+            target_portal: payload.target_portal.to_string(),
+            key_index: payload.key_index.to_string(),
+            encrypted_deposit_payload: EncryptedDepositPayloadJson {
+                ephemeral_pubkey_x: payload
+                    .encrypted_deposit_payload
+                    .ephemeralPubkeyX
+                    .to_string(),
+                ephemeral_pubkey_y_parity: payload.encrypted_deposit_payload.ephemeralPubkeyYParity,
+                ciphertext: hex_string(payload.encrypted_deposit_payload.ciphertext.as_ref()),
+                nonce: hex_string(payload.encrypted_deposit_payload.nonce.as_slice()),
+                tag: hex_string(payload.encrypted_deposit_payload.tag.as_slice()),
+            },
+        }
+    }
+
+    pub(crate) fn into_built(self) -> eyre::Result<BuiltEncryptedDepositPayload> {
+        let ciphertext = Bytes::from(decode_hex(&self.encrypted_deposit_payload.ciphertext)?);
+        let nonce = fixed_bytes::<12>(&self.encrypted_deposit_payload.nonce)?;
+        let tag = fixed_bytes::<16>(&self.encrypted_deposit_payload.tag)?;
+
+        Ok(BuiltEncryptedDepositPayload {
+            target_portal: self
+                .target_portal
+                .parse()
+                .wrap_err("invalid targetPortal in payload JSON")?,
+            key_index: self
+                .key_index
+                .parse()
+                .wrap_err("invalid keyIndex in payload JSON")?,
+            encrypted_deposit_payload: EncryptedDepositPayload {
+                ephemeralPubkeyX: self
+                    .encrypted_deposit_payload
+                    .ephemeral_pubkey_x
+                    .parse()
+                    .wrap_err("invalid ephemeralPubkeyX in payload JSON")?,
+                ephemeralPubkeyYParity: self.encrypted_deposit_payload.ephemeral_pubkey_y_parity,
+                ciphertext,
+                nonce,
+                tag,
+            },
+        })
+    }
+}
+
+pub(crate) fn payload_json_to_string(
+    payload: &BuiltEncryptedDepositPayload,
+) -> eyre::Result<String> {
+    serde_json::to_string_pretty(&BuiltEncryptedDepositPayloadJson::from_built(payload))
+        .wrap_err("failed to encode payload JSON")
+}
+
+pub(crate) fn read_payload_json(path: &str) -> eyre::Result<BuiltEncryptedDepositPayload> {
+    let contents = if path == "-" {
+        let mut input = String::new();
+        io::stdin()
+            .read_to_string(&mut input)
+            .wrap_err("failed to read payload JSON from stdin")?;
+        input
+    } else {
+        fs::read_to_string(path)
+            .wrap_err_with(|| format!("failed reading payload JSON from {path}"))?
+    };
+
+    let json: BuiltEncryptedDepositPayloadJson =
+        serde_json::from_str(&contents).wrap_err("failed to parse payload JSON")?;
+    json.into_built()
+}
+
+pub(crate) fn parse_private_key(private_key: &str) -> eyre::Result<PrivateKeySigner> {
+    private_key
+        .strip_prefix("0x")
+        .unwrap_or(private_key)
+        .parse()
+        .wrap_err("invalid private key")
+}
+
+pub(crate) fn signer_address_from_private_key(private_key: &str) -> eyre::Result<Address> {
+    Ok(parse_private_key(private_key)?.address())
+}
+
+pub(crate) fn resolve_token_ref(reference: &str) -> eyre::Result<Address> {
+    let normalized = reference.to_ascii_lowercase();
+    match normalized.as_str() {
+        "pathusd" | "path-usd" | "path_usd" => {
+            Ok(address!("0x20C0000000000000000000000000000000000000"))
+        }
+        "alphausd" | "alpha-usd" | "alpha_usd" => {
+            Ok(address!("0x20c0000000000000000000000000000000000001"))
+        }
+        "betausd" | "beta-usd" | "beta_usd" => {
+            Ok(address!("0x20c0000000000000000000000000000000000002"))
+        }
+        _ => reference
+            .parse()
+            .wrap_err_with(|| format!("invalid token reference: {reference}")),
+    }
+}
+
+pub(crate) async fn resolve_zone_ref<P: Provider<TempoNetwork>>(
+    reference: &str,
+    l1: &P,
+    zone_factory: Option<Address>,
+) -> eyre::Result<ResolvedZone> {
+    resolve_zone_ref_in(reference, Path::new("generated"), l1, zone_factory).await
+}
+
+pub(crate) async fn resolve_zone_ref_in<P: Provider<TempoNetwork>>(
+    reference: &str,
+    generated_root: &Path,
+    l1: &P,
+    zone_factory: Option<Address>,
+) -> eyre::Result<ResolvedZone> {
+    if reference.starts_with("0x") {
+        let portal: Address = reference
+            .parse()
+            .wrap_err_with(|| format!("invalid portal address: {reference}"))?;
+        if let Some(local) = find_local_zone_by_portal(generated_root, portal)? {
+            return Ok(local);
+        }
+
+        return Ok(ResolvedZone {
+            reference: reference.to_string(),
+            portal,
+            zone_id: None,
+            zone_dir: None,
+            sequencer_key: None,
+            router: None,
+        });
+    }
+
+    if let Ok(zone_id) = reference.parse::<u32>() {
+        if let Some(local) = find_local_zone_by_zone_id(generated_root, zone_id)? {
+            return Ok(local);
+        }
+
+        let factory = ZoneFactory::new(zone_factory.unwrap_or(MODERATO_ZONE_FACTORY), l1);
+        let info = factory
+            .zones(zone_id)
+            .call()
+            .await
+            .wrap_err_with(|| format!("failed to resolve zone ID {zone_id} via ZoneFactory"))?;
+        if info.portal == Address::ZERO {
+            return Err(eyre!("zone {zone_id} does not exist"));
+        }
+
+        return Ok(ResolvedZone {
+            reference: reference.to_string(),
+            portal: info.portal,
+            zone_id: Some(zone_id),
+            zone_dir: None,
+            sequencer_key: None,
+            router: None,
+        });
+    }
+
+    load_named_zone(reference, generated_root)
+}
+
+pub(crate) fn build_encrypted_router_callback(
+    token_out: Address,
+    payload: &BuiltEncryptedDepositPayload,
+    min_amount_out: u128,
+) -> Bytes {
+    let callback = SwapAndDepositRouterEncryptedCallback {
+        token_out,
+        target_portal: payload.target_portal,
+        key_index: payload.key_index,
+        encrypted: payload.encrypted_deposit_payload.clone(),
+        min_amount_out,
+    };
+
+    Bytes::from(callback.abi_encode())
+}
+
+pub(crate) async fn build_encrypted_deposit_payload<P: Provider<TempoNetwork>>(
+    l1: &P,
+    target_portal: Address,
+    recipient: Address,
+    memo: B256,
+    key_mode: EncryptionKeyMode<'_>,
+) -> eyre::Result<BuiltEncryptedDepositPayload> {
+    let portal = ZonePortal::new(target_portal, l1);
+    let (key, key_index) = match key_mode {
+        EncryptionKeyMode::ReadOnly {
+            expected_sequencer_private_key,
+        } => {
+            let (key, key_index) = fetch_active_encryption_key(&portal).await?;
+            if let Some(private_key) = expected_sequencer_private_key {
+                validate_expected_sequencer_key(private_key, &key)?;
+            }
+            (key, key_index)
+        }
+        EncryptionKeyMode::EnsureRegistered {
+            sequencer_private_key,
+        } => ensure_sequencer_encryption_key(&portal, target_portal, sequencer_private_key).await?,
+    };
+
+    let y_parity = key.normalized_y_parity().ok_or_else(|| {
+        eyre!(
+            "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
+            key.yParity
+        )
+    })?;
+
+    let encrypted = encrypt_deposit(&key.x, y_parity, recipient, memo, target_portal, key_index)
+        .ok_or_else(|| eyre!("ECIES encryption failed — invalid active portal key?"))?;
+
+    Ok(BuiltEncryptedDepositPayload {
+        target_portal,
+        key_index,
+        encrypted_deposit_payload: EncryptedDepositPayload {
+            ephemeralPubkeyX: encrypted.eph_pub_x,
+            ephemeralPubkeyYParity: encrypted.eph_pub_y_parity,
+            ciphertext: Bytes::from(encrypted.ciphertext),
+            nonce: encrypted.nonce.into(),
+            tag: encrypted.tag.into(),
+        },
+    })
+}
+
+pub(crate) async fn build_encrypted_deposit_payload_for_zone<P: Provider<TempoNetwork>>(
+    l1: &P,
+    target_zone: &ResolvedZone,
+    recipient: Address,
+    memo: B256,
+) -> eyre::Result<BuiltEncryptedDepositPayload> {
+    build_encrypted_deposit_payload(
+        l1,
+        target_zone.portal,
+        recipient,
+        memo,
+        EncryptionKeyMode::ReadOnly {
+            expected_sequencer_private_key: target_zone.sequencer_key.as_deref(),
+        },
+    )
+    .await
+}
+
+pub(crate) async fn fetch_active_encryption_key<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+) -> eyre::Result<(ZonePortal::sequencerEncryptionKeyReturn, U256)> {
+    let key_count = portal
+        .encryptionKeyCount()
+        .call()
+        .await
+        .wrap_err("failed to read portal encryption key count")?;
+    if key_count == U256::ZERO {
+        return Err(eyre!("no active portal encryption key is registered"));
+    }
+
+    let key = portal
+        .sequencerEncryptionKey()
+        .call()
+        .await
+        .wrap_err("failed to read the active portal encryption key")?;
+    let key_index = key_count - U256::from(1);
+    Ok((key, key_index))
+}
+
+pub(crate) async fn ensure_sequencer_encryption_key<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+    portal_address: Address,
+    sequencer_private_key: &str,
+) -> eyre::Result<(ZonePortal::sequencerEncryptionKeyReturn, U256)> {
+    let (expected_x, expected_y_parity) = derive_encryption_public_key(sequencer_private_key)
+        .wrap_err("failed to derive the sequencer encryption public key from SEQUENCER_KEY")?;
+    let key_count = portal
+        .encryptionKeyCount()
+        .call()
+        .await
+        .wrap_err("failed to read portal encryption key count")?;
+
+    let needs_registration = if key_count == U256::ZERO {
+        true
+    } else {
+        let current_key = portal
+            .sequencerEncryptionKey()
+            .call()
+            .await
+            .wrap_err("failed to read the active sequencer encryption key")?;
+        let current_y_parity = current_key.normalized_y_parity().ok_or_else(|| {
+            eyre!(
+                "unexpected portal yParity {:#x}, expected 0/1 or 0x02/0x03",
+                current_key.yParity
+            )
+        })?;
+        current_key.x != expected_x || current_y_parity != expected_y_parity
+    };
+
+    if needs_registration {
+        register_sequencer_encryption_key(portal, portal_address, sequencer_private_key).await?;
+    }
+
+    fetch_active_encryption_key(portal).await
+}
+
+pub(crate) fn derive_encryption_public_key(
+    sequencer_private_key: &str,
+) -> eyre::Result<(B256, u8)> {
+    let key_str = sequencer_private_key
+        .strip_prefix("0x")
+        .unwrap_or(sequencer_private_key);
+    let enc_key = k256::SecretKey::from_slice(&const_hex::decode(key_str)?)?;
+    let scalar: Scalar = *enc_key.to_nonzero_scalar();
+    let pub_point = AffinePoint::from(ProjectivePoint::GENERATOR * scalar);
+    let encoded = pub_point.to_encoded_point(true);
+    let x = B256::from_slice(encoded.x().unwrap().as_slice());
+    let y_parity = encoded.as_bytes()[0];
+    Ok((x, y_parity))
+}
+
+fn validate_expected_sequencer_key(
+    sequencer_private_key: &str,
+    active_key: &ZonePortal::sequencerEncryptionKeyReturn,
+) -> eyre::Result<()> {
+    let (expected_x, expected_y_parity) = derive_encryption_public_key(sequencer_private_key)
+        .wrap_err("failed to derive the expected local sequencer encryption public key")?;
+    let active_y_parity = active_key.normalized_y_parity().ok_or_else(|| {
+        eyre!(
+            "unexpected portal yParity {:#x}, expected 0/1 or 0x02/0x03",
+            active_key.yParity
+        )
+    })?;
+    if active_key.x != expected_x || active_y_parity != expected_y_parity {
+        return Err(eyre!(
+            "active portal encryption key does not match the local sequencerKey metadata"
+        ));
+    }
+    Ok(())
+}
+
+async fn register_sequencer_encryption_key<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+    portal_address: Address,
+    sequencer_private_key: &str,
+) -> eyre::Result<()> {
+    let (x, y_parity) = derive_encryption_public_key(sequencer_private_key)
+        .wrap_err("failed to derive the sequencer encryption public key")?;
+    let signer = parse_private_key(sequencer_private_key)?;
+    let message =
+        alloy::primitives::keccak256((portal_address, x, U256::from(y_parity)).abi_encode());
+    let sig = signer
+        .sign_hash(&message)
+        .await
+        .wrap_err("failed to sign the encryption key proof-of-possession")?;
+    let pop_v = sig.v() as u8 + 27;
+    let pop_r = B256::from(sig.r().to_be_bytes::<32>());
+    let pop_s = B256::from(sig.s().to_be_bytes::<32>());
+
+    let receipt = portal
+        .setSequencerEncryptionKey(x, y_parity, pop_v, pop_r, pop_s)
+        .send_sync()
+        .await
+        .wrap_err("failed to send setSequencerEncryptionKey")?;
+    check(&receipt, "setSequencerEncryptionKey")
+}
+
+fn load_named_zone(reference: &str, generated_root: &Path) -> eyre::Result<ResolvedZone> {
+    let zone_dir = generated_root.join(reference);
+    if !zone_dir.join("zone.json").is_file() {
+        return Err(eyre!(
+            "{} not found. Expected {}",
+            reference,
+            zone_dir.join("zone.json").display()
+        ));
+    }
+    load_zone_from_dir(reference.to_string(), &zone_dir)
+}
+
+fn find_local_zone_by_portal(
+    generated_root: &Path,
+    portal: Address,
+) -> eyre::Result<Option<ResolvedZone>> {
+    find_single_local_zone(generated_root, &format!("portal {portal}"), |zone| {
+        Ok(zone.portal == portal)
+    })
+}
+
+fn find_local_zone_by_zone_id(
+    generated_root: &Path,
+    zone_id: u32,
+) -> eyre::Result<Option<ResolvedZone>> {
+    find_single_local_zone(generated_root, &format!("zone ID {zone_id}"), |zone| {
+        Ok(zone.zone_id == Some(zone_id))
+    })
+}
+
+fn find_single_local_zone<F>(
+    generated_root: &Path,
+    description: &str,
+    mut predicate: F,
+) -> eyre::Result<Option<ResolvedZone>>
+where
+    F: FnMut(&ResolvedZone) -> eyre::Result<bool>,
+{
+    let mut matches = Vec::new();
+    for zone in list_local_zones(generated_root)? {
+        if predicate(&zone)? {
+            matches.push(zone);
+        }
+    }
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        _ => Err(eyre!(
+            "multiple local zones matched {description}: {}",
+            matches
+                .iter()
+                .map(|zone| zone
+                    .zone_dir
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| zone.reference.clone()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn list_local_zones(generated_root: &Path) -> eyre::Result<Vec<ResolvedZone>> {
+    let mut zones = Vec::new();
+    if !generated_root.exists() {
+        return Ok(zones);
+    }
+
+    for entry in fs::read_dir(generated_root)
+        .wrap_err_with(|| format!("failed reading {}", generated_root.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let zone_dir = entry.path();
+        if !zone_dir.join("zone.json").is_file() {
+            continue;
+        }
+        zones.push(load_zone_from_dir(
+            entry.file_name().to_string_lossy().into_owned(),
+            &zone_dir,
+        )?);
+    }
+
+    Ok(zones)
+}
+
+fn load_zone_from_dir(reference: String, zone_dir: &Path) -> eyre::Result<ResolvedZone> {
+    let metadata = ZoneMetadata::load(zone_dir)?;
+    let portal = metadata.get_required_address("portal")?;
+    Ok(ResolvedZone {
+        reference,
+        portal,
+        zone_id: metadata.get_optional_u32("zoneId")?,
+        zone_dir: zone_dir
+            .canonicalize()
+            .ok()
+            .or_else(|| Some(zone_dir.to_path_buf())),
+        sequencer_key: metadata.get_optional_string("sequencerKey"),
+        router: metadata.get_optional_address("swapAndDepositRouter")?,
+    })
+}
+
+fn decode_hex(value: &str) -> eyre::Result<Vec<u8>> {
+    const_hex::decode(value.trim_start_matches("0x"))
+        .wrap_err_with(|| format!("invalid hex string: {value}"))
+}
+
+fn fixed_bytes<const N: usize>(value: &str) -> eyre::Result<FixedBytes<N>> {
+    let bytes = decode_hex(value)?;
+    if bytes.len() != N {
+        return Err(eyre!("expected {N} bytes, got {}", bytes.len()));
+    }
+    Ok(FixedBytes::<N>::from_slice(&bytes))
+}
+
+fn hex_string(bytes: &[u8]) -> String {
+    format!("0x{}", const_hex::encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::providers::ProviderBuilder;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn make_generated_root() -> eyre::Result<PathBuf> {
+        let root = std::env::temp_dir().join(format!(
+            "tempo-xtask-bridge-utils-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root)?;
+        Ok(root)
+    }
+
+    fn write_zone_json(
+        generated_root: &Path,
+        name: &str,
+        zone_id: u32,
+        portal: &str,
+        sequencer_key: Option<&str>,
+        router: Option<&str>,
+    ) -> eyre::Result<()> {
+        let zone_dir = generated_root.join(name);
+        fs::create_dir_all(&zone_dir)?;
+        let mut value = serde_json::json!({
+            "zoneId": zone_id,
+            "portal": portal,
+        });
+        if let Some(sequencer_key) = sequencer_key {
+            value["sequencerKey"] = serde_json::Value::String(sequencer_key.to_string());
+        }
+        if let Some(router) = router {
+            value["swapAndDepositRouter"] = serde_json::Value::String(router.to_string());
+        }
+        fs::write(
+            zone_dir.join("zone.json"),
+            serde_json::to_string_pretty(&value)?,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_named_zone_from_generated_directory() -> eyre::Result<()> {
+        let generated_root = make_generated_root()?;
+        write_zone_json(
+            &generated_root,
+            "zone-a",
+            1,
+            "0x1000000000000000000000000000000000000001",
+            None,
+            Some("0x2000000000000000000000000000000000000002"),
+        )?;
+
+        let zone = load_named_zone("zone-a", &generated_root)?;
+        assert_eq!(
+            zone.portal,
+            "0x1000000000000000000000000000000000000001".parse::<Address>()?
+        );
+        assert_eq!(zone.zone_id, Some(1));
+        assert_eq!(
+            zone.router,
+            Some("0x2000000000000000000000000000000000000002".parse::<Address>()?)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_zone_ref_accepts_local_name() -> eyre::Result<()> {
+        let generated_root = make_generated_root()?;
+        write_zone_json(
+            &generated_root,
+            "zone-a",
+            11,
+            "0x1100000000000000000000000000000000000011",
+            None,
+            Some("0x2200000000000000000000000000000000000022"),
+        )?;
+
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let zone = resolve_zone_ref_in("zone-a", &generated_root, &provider, None).await?;
+        assert_eq!(zone.reference, "zone-a");
+        assert_eq!(zone.zone_id, Some(11));
+        assert_eq!(
+            zone.portal,
+            "0x1100000000000000000000000000000000000011".parse::<Address>()?
+        );
+        assert_eq!(
+            zone.router,
+            Some("0x2200000000000000000000000000000000000022".parse::<Address>()?)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_zone_by_local_zone_id() -> eyre::Result<()> {
+        let generated_root = make_generated_root()?;
+        write_zone_json(
+            &generated_root,
+            "zone-a",
+            7,
+            "0x7000000000000000000000000000000000000007",
+            None,
+            None,
+        )?;
+
+        let zone = find_local_zone_by_zone_id(&generated_root, 7)?
+            .ok_or_else(|| eyre!("expected a local zone match"))?;
+        assert_eq!(zone.reference, "zone-a");
+        assert_eq!(
+            zone.portal,
+            "0x7000000000000000000000000000000000000007".parse::<Address>()?
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_zone_ref_accepts_local_zone_id() -> eyre::Result<()> {
+        let generated_root = make_generated_root()?;
+        write_zone_json(
+            &generated_root,
+            "zone-id-match",
+            12,
+            "0x1200000000000000000000000000000000000012",
+            Some("0x1234"),
+            None,
+        )?;
+
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let zone = resolve_zone_ref_in("12", &generated_root, &provider, None).await?;
+        assert_eq!(zone.reference, "zone-id-match");
+        assert_eq!(zone.zone_id, Some(12));
+        assert_eq!(
+            zone.portal,
+            "0x1200000000000000000000000000000000000012".parse::<Address>()?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_zone_by_local_portal() -> eyre::Result<()> {
+        let generated_root = make_generated_root()?;
+        write_zone_json(
+            &generated_root,
+            "zone-b",
+            8,
+            "0x8000000000000000000000000000000000000008",
+            Some("0x1234"),
+            None,
+        )?;
+
+        let zone = find_local_zone_by_portal(
+            &generated_root,
+            "0x8000000000000000000000000000000000000008".parse()?,
+        )?
+        .ok_or_else(|| eyre!("expected a local zone match"))?;
+        assert_eq!(zone.reference, "zone-b");
+        assert_eq!(zone.sequencer_key.as_deref(), Some("0x1234"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn resolve_zone_ref_accepts_local_portal_address() -> eyre::Result<()> {
+        let generated_root = make_generated_root()?;
+        write_zone_json(
+            &generated_root,
+            "zone-portal-match",
+            13,
+            "0x1300000000000000000000000000000000000013",
+            None,
+            None,
+        )?;
+
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let zone = resolve_zone_ref_in(
+            "0x1300000000000000000000000000000000000013",
+            &generated_root,
+            &provider,
+            None,
+        )
+        .await?;
+        assert_eq!(zone.reference, "zone-portal-match");
+        assert_eq!(zone.zone_id, Some(13));
+        assert_eq!(
+            zone.portal,
+            "0x1300000000000000000000000000000000000013".parse::<Address>()?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn payload_json_round_trips() -> eyre::Result<()> {
+        let payload = BuiltEncryptedDepositPayload {
+            target_portal: "0x9000000000000000000000000000000000000009".parse()?,
+            key_index: U256::from(3),
+            encrypted_deposit_payload: EncryptedDepositPayload {
+                ephemeralPubkeyX:
+                    "0x0000000000000000000000000000000000000000000000000000000000001234".parse()?,
+                ephemeralPubkeyYParity: 2,
+                ciphertext: Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
+                nonce: FixedBytes::<12>::from_slice(&[0x11; 12]),
+                tag: FixedBytes::<16>::from_slice(&[0x22; 16]),
+            },
+        };
+
+        let json = payload_json_to_string(&payload)?;
+        let reparsed: BuiltEncryptedDepositPayloadJson = serde_json::from_str(&json)?;
+        let reparsed = reparsed.into_built()?;
+        assert_eq!(reparsed.target_portal, payload.target_portal);
+        assert_eq!(reparsed.key_index, payload.key_index);
+        assert_eq!(
+            reparsed.encrypted_deposit_payload.ciphertext,
+            payload.encrypted_deposit_payload.ciphertext
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_token_aliases() -> eyre::Result<()> {
+        assert_eq!(
+            resolve_token_ref("pathusd")?,
+            "0x20C0000000000000000000000000000000000000".parse::<Address>()?
+        );
+        assert_eq!(
+            resolve_token_ref("alpha-usd")?,
+            "0x20c0000000000000000000000000000000000001".parse::<Address>()?
+        );
+        assert_eq!(
+            resolve_token_ref("0x20c0000000000000000000000000000000000002")?,
+            "0x20c0000000000000000000000000000000000002".parse::<Address>()?
+        );
+        Ok(())
+    }
+}

--- a/xtask/src/build_encrypted_deposit_payload.rs
+++ b/xtask/src/build_encrypted_deposit_payload.rs
@@ -1,0 +1,66 @@
+use alloy::{
+    primitives::{Address, B256},
+    providers::ProviderBuilder,
+};
+use eyre::eyre;
+use tempo_alloy::TempoNetwork;
+
+use crate::{
+    bridge_utils::{
+        build_encrypted_deposit_payload_for_zone, payload_json_to_string, resolve_zone_ref,
+        signer_address_from_private_key,
+    },
+    zone_utils::normalize_http_rpc,
+};
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct BuildEncryptedDepositPayload {
+    /// Target zone reference: name, zone ID, or portal address.
+    #[arg(long)]
+    target_zone: String,
+
+    /// Recipient address on the target zone. Defaults to the PRIVATE_KEY signer address.
+    #[arg(long)]
+    recipient: Option<Address>,
+
+    /// Memo bytes32 for the downstream encrypted deposit.
+    #[arg(long, default_value_t = B256::ZERO)]
+    memo: B256,
+
+    /// Tempo L1 RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// Optional private key used only to derive the default recipient.
+    #[arg(long, env = "PRIVATE_KEY")]
+    private_key: Option<String>,
+
+    /// ZoneFactory contract address used to resolve zone IDs when local metadata is unavailable.
+    #[arg(long)]
+    zone_factory: Option<Address>,
+}
+
+impl BuildEncryptedDepositPayload {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let http_rpc = normalize_http_rpc(&self.l1_rpc_url);
+        let l1 = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&http_rpc)
+            .await?;
+        let target_zone = resolve_zone_ref(&self.target_zone, &l1, self.zone_factory).await?;
+        let recipient = match (self.recipient, self.private_key.as_deref()) {
+            (Some(recipient), _) => recipient,
+            (None, Some(private_key)) => signer_address_from_private_key(private_key)?,
+            (None, None) => {
+                return Err(eyre!(
+                    "recipient not provided and PRIVATE_KEY is unavailable to derive a default"
+                ));
+            }
+        };
+
+        let payload =
+            build_encrypted_deposit_payload_for_zone(&l1, &target_zone, recipient, self.memo)
+                .await?;
+        println!("{}", payload_json_to_string(&payload)?);
+        Ok(())
+    }
+}

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -1,31 +1,28 @@
 use alloy::{
     network::EthereumWallet,
-    primitives::{Address, B256, Bytes, U256, keccak256},
+    primitives::{Address, B256, Bytes, U256},
     providers::{Provider, ProviderBuilder},
-    signers::{Signer, local::PrivateKeySigner},
     sol,
-    sol_types::SolValue,
 };
 use eyre::{WrapErr as _, eyre};
-use k256::{AffinePoint, ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
 use std::{path::PathBuf, time::Duration};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::{
     IRolesAuth, ITIP20 as TIP20Token, ITIP20Factory as TIP20Factory,
 };
 use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS, tip20::ISSUER_ROLE};
-use zone::{
-    abi::{
-        EncryptedDepositPayload, SwapAndDepositRouterEncryptedCallback, ZONE_OUTBOX_ADDRESS,
-        ZoneOutbox, ZonePortal,
-    },
-    precompiles::ecies::encrypt_deposit,
-};
+use zone::abi::{ZONE_OUTBOX_ADDRESS, ZoneOutbox, ZonePortal};
 
-use crate::zone_utils::{
-    ROUTER_CALLBACK_GAS_LIMIT, STABLECOIN_DEX_ADDRESS, ZoneMetadata, check, fund_l1_wallet,
-    normalize_http_rpc, token_balance, wait_for_balance, wait_for_deposit_processed,
-    wait_for_token_enabled, wait_for_withdrawal_processed,
+use crate::{
+    bridge_utils::{
+        EncryptionKeyMode, build_encrypted_deposit_payload, build_encrypted_router_callback,
+        parse_private_key,
+    },
+    zone_utils::{
+        ROUTER_CALLBACK_GAS_LIMIT, STABLECOIN_DEX_ADDRESS, ZoneMetadata, check, fund_l1_wallet,
+        normalize_http_rpc, token_balance, wait_for_balance, wait_for_deposit_processed,
+        wait_for_token_enabled, wait_for_withdrawal_processed,
+    },
 };
 
 const DEMO_PATHUSD_GAS_NET: u128 = 5_000_000;
@@ -314,17 +311,17 @@ impl DemoSwapAndDeposit {
             receipt.transaction_hash
         );
 
-        let portal_contract_seq = ZonePortal::new(portal, &l1_seq);
-        let callback_data = build_encrypted_router_callback(
-            &portal_contract_seq,
+        let payload = build_encrypted_deposit_payload(
+            &l1_seq,
             portal,
-            beta,
             operator,
             B256::ZERO,
-            expected_beta,
-            &sequencer_key,
+            EncryptionKeyMode::EnsureRegistered {
+                sequencer_private_key: &sequencer_key,
+            },
         )
         .await?;
+        let callback_data = build_encrypted_router_callback(beta, &payload, expected_beta);
         let l1_from_block = l1.get_block_number().await.unwrap_or(0);
         let receipt = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &l2_operator)
             .requestWithdrawal(
@@ -546,142 +543,4 @@ async fn enable_token_with_retry<P: Provider<TempoNetwork>>(
     Err(last_err
         .map(|err| eyre!(err))
         .unwrap_or_else(|| eyre!("enableToken failed after retries")))
-}
-
-fn parse_private_key(private_key: &str) -> eyre::Result<PrivateKeySigner> {
-    private_key
-        .strip_prefix("0x")
-        .unwrap_or(private_key)
-        .parse()
-        .wrap_err("invalid private key")
-}
-
-async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
-    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
-    portal_address: Address,
-    token_out: Address,
-    recipient: Address,
-    memo: B256,
-    min_amount_out: u128,
-    sequencer_private_key: &str,
-) -> eyre::Result<Bytes> {
-    let (key, key_index) =
-        ensure_sequencer_encryption_key(portal, portal_address, sequencer_private_key).await?;
-    let y_parity = key.normalized_y_parity().ok_or_else(|| {
-        eyre!(
-            "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
-            key.yParity
-        )
-    })?;
-
-    let encrypted =
-        encrypt_deposit(&key.x, y_parity, recipient, memo, portal_address, key_index)
-            .ok_or_else(|| eyre!("ECIES encryption failed — invalid sequencer public key?"))?;
-
-    let callback = SwapAndDepositRouterEncryptedCallback {
-        token_out,
-        target_portal: portal_address,
-        key_index,
-        encrypted: EncryptedDepositPayload {
-            ephemeralPubkeyX: encrypted.eph_pub_x,
-            ephemeralPubkeyYParity: encrypted.eph_pub_y_parity,
-            ciphertext: Bytes::from(encrypted.ciphertext),
-            nonce: encrypted.nonce.into(),
-            tag: encrypted.tag.into(),
-        },
-        min_amount_out,
-    };
-
-    Ok(Bytes::from(callback.abi_encode()))
-}
-
-async fn ensure_sequencer_encryption_key<P: Provider<TempoNetwork>>(
-    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
-    portal_address: Address,
-    sequencer_private_key: &str,
-) -> eyre::Result<(ZonePortal::sequencerEncryptionKeyReturn, U256)> {
-    let (expected_x, expected_y_parity) = derive_encryption_public_key(sequencer_private_key)
-        .wrap_err("failed to derive the sequencer encryption public key from SEQUENCER_KEY")?;
-    let key_count = portal
-        .encryptionKeyCount()
-        .call()
-        .await
-        .wrap_err("failed to read portal encryption key count")?;
-
-    let needs_registration = if key_count == U256::ZERO {
-        println!("  Registering the sequencer encryption key on the portal");
-        true
-    } else {
-        let current_key = portal
-            .sequencerEncryptionKey()
-            .call()
-            .await
-            .wrap_err("failed to read the active sequencer encryption key")?;
-        let current_y_parity = current_key.normalized_y_parity().ok_or_else(|| {
-            eyre!(
-                "unexpected portal yParity {:#x}, expected 0/1 or 0x02/0x03",
-                current_key.yParity
-            )
-        })?;
-        if current_key.x == expected_x && current_y_parity == expected_y_parity {
-            false
-        } else {
-            println!(
-                "  Portal encryption key does not match SEQUENCER_KEY; registering the current sequencer key"
-            );
-            true
-        }
-    };
-
-    if needs_registration {
-        register_sequencer_encryption_key(portal, portal_address, sequencer_private_key).await?;
-    }
-
-    portal
-        .encryption_key()
-        .await
-        .wrap_err("failed to fetch the active sequencer encryption key")
-}
-
-async fn register_sequencer_encryption_key<P: Provider<TempoNetwork>>(
-    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
-    portal_address: Address,
-    sequencer_private_key: &str,
-) -> eyre::Result<()> {
-    let (x, y_parity) = derive_encryption_public_key(sequencer_private_key)
-        .wrap_err("failed to derive the sequencer encryption public key")?;
-    let signer = parse_private_key(sequencer_private_key)?;
-    let message = keccak256((portal_address, x, U256::from(y_parity)).abi_encode());
-    let sig = signer
-        .sign_hash(&message)
-        .await
-        .wrap_err("failed to sign the encryption key proof-of-possession")?;
-    let pop_v = sig.v() as u8 + 27;
-    let pop_r = B256::from(sig.r().to_be_bytes::<32>());
-    let pop_s = B256::from(sig.s().to_be_bytes::<32>());
-
-    let receipt = portal
-        .setSequencerEncryptionKey(x, y_parity, pop_v, pop_r, pop_s)
-        .send_sync()
-        .await
-        .wrap_err("failed to send setSequencerEncryptionKey")?;
-    check(&receipt, "setSequencerEncryptionKey")?;
-    println!(
-        "  Sequencer encryption key registered on L1  [tx: {}]",
-        receipt.transaction_hash
-    );
-    Ok(())
-}
-
-fn derive_encryption_public_key(sequencer_private_key: &str) -> eyre::Result<(B256, u8)> {
-    let key_str = sequencer_private_key
-        .strip_prefix("0x")
-        .unwrap_or(sequencer_private_key);
-    let enc_key = k256::SecretKey::from_slice(&const_hex::decode(key_str)?)?;
-    let scalar: Scalar = *enc_key.to_nonzero_scalar();
-    let pub_point = AffinePoint::from(ProjectivePoint::GENERATOR * scalar);
-    let encoded = pub_point.to_encoded_point(true);
-    let x = B256::from_slice(encoded.x().unwrap().as_slice());
-    let y_parity = encoded.as_bytes()[0];
-    Ok((x, y_parity))
 }

--- a/xtask/src/encrypted_deposit.rs
+++ b/xtask/src/encrypted_deposit.rs
@@ -5,17 +5,19 @@
 
 use alloy::{
     network::{EthereumWallet, primitives::ReceiptResponse},
-    primitives::{Address, B256, Bytes, address},
+    primitives::{Address, B256, U256, address},
     providers::{Provider, ProviderBuilder},
-    rpc::types::Filter,
-    signers::local::PrivateKeySigner,
-    sol_types::SolEvent,
 };
 use eyre::{WrapErr as _, eyre};
 use tempo_alloy::TempoNetwork;
-use zone::{
-    abi::{EncryptedDepositPayload, ZoneInbox, ZonePortal},
-    precompiles::ecies::encrypt_deposit,
+use zone::abi::ZonePortal;
+
+use crate::{
+    bridge_utils::{
+        BuiltEncryptedDepositPayload, EncryptionKeyMode, build_encrypted_deposit_payload,
+        parse_private_key, read_payload_json, resolve_zone_ref,
+    },
+    zone_utils::{EncryptedDepositResult, wait_for_encrypted_deposit_result},
 };
 
 #[derive(Debug, clap::Parser)]
@@ -26,7 +28,7 @@ pub(crate) struct EncryptedDeposit {
 
     /// ZonePortal contract address on Tempo L1.
     #[arg(long, env = "L1_PORTAL_ADDRESS")]
-    portal: Address,
+    portal: Option<Address>,
 
     /// Private key (hex) for signing the deposit transaction.
     #[arg(long, env = "PRIVATE_KEY")]
@@ -48,6 +50,10 @@ pub(crate) struct EncryptedDeposit {
     #[arg(long, default_value_t = B256::ZERO)]
     memo: B256,
 
+    /// Read a prebuilt encrypted payload JSON file from disk, or '-' for stdin.
+    #[arg(long)]
+    payload_file: Option<String>,
+
     /// Zone L2 RPC URL. If set, waits for the deposit to be processed on L2.
     #[arg(long, env = "ZONE_RPC_URL")]
     zone_rpc_url: Option<String>,
@@ -55,13 +61,8 @@ pub(crate) struct EncryptedDeposit {
 
 impl EncryptedDeposit {
     pub(crate) async fn run(self) -> eyre::Result<()> {
-        let key_str = self
-            .private_key
-            .strip_prefix("0x")
-            .unwrap_or(&self.private_key);
-        let signer: PrivateKeySigner = key_str.parse()?;
+        let signer = parse_private_key(&self.private_key)?;
         let sender = signer.address();
-        let to = self.to.unwrap_or(sender);
         let wallet = EthereumWallet::from(signer);
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
@@ -76,46 +77,44 @@ impl EncryptedDeposit {
             None
         };
 
-        let portal = ZonePortal::new(self.portal, &provider);
+        let default_to = self.to.unwrap_or(sender);
+        let (portal_address, key_index, payload, wait_to, wait_memo) =
+            if let Some(payload_file) = self.payload_file.as_deref() {
+                resolve_prebuilt_payload(self.portal, self.to, read_payload_json(payload_file)?)?
+            } else {
+                let portal_address = self.portal.ok_or_else(|| {
+                    eyre!("portal address is required unless --payload-file is provided")
+                })?;
+                let resolved_zone =
+                    resolve_zone_ref(&portal_address.to_string(), &provider, None).await?;
+                let built = build_encrypted_deposit_payload(
+                    &provider,
+                    portal_address,
+                    default_to,
+                    self.memo,
+                    EncryptionKeyMode::ReadOnly {
+                        expected_sequencer_private_key: resolved_zone.sequencer_key.as_deref(),
+                    },
+                )
+                .await?;
+                (
+                    portal_address,
+                    built.key_index,
+                    built.encrypted_deposit_payload,
+                    Some(default_to),
+                    Some(self.memo),
+                )
+            };
 
-        // Fetch sequencer encryption key
-        println!("Fetching sequencer encryption key...");
-        let (key, key_index) = portal
-            .encryption_key()
-            .await
-            .wrap_err("failed to fetch encryption key — is one set?")?;
+        let portal = ZonePortal::new(portal_address, &provider);
 
-        let seq_pub_x = key.x;
-        let seq_pub_y_parity = key.normalized_y_parity().ok_or_else(|| {
-            eyre!(
-                "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
-                key.yParity
-            )
-        })?;
         println!(
-            "Encryption key index: {key_index}, x: {seq_pub_x}, parity: {seq_pub_y_parity:#x}"
+            "Sending encrypted deposit of {} to portal {}...",
+            self.amount, portal_address
         );
-
-        // Encrypt (to, memo) to the sequencer's public key
-        let enc = encrypt_deposit(
-            &seq_pub_x,
-            seq_pub_y_parity,
-            to,
-            self.memo,
-            self.portal,
-            key_index,
-        )
-        .ok_or_else(|| eyre!("ECIES encryption failed — invalid sequencer public key?"))?;
-
-        let payload = EncryptedDepositPayload {
-            ephemeralPubkeyX: enc.eph_pub_x,
-            ephemeralPubkeyYParity: enc.eph_pub_y_parity,
-            ciphertext: Bytes::from(enc.ciphertext),
-            nonce: enc.nonce.into(),
-            tag: enc.tag.into(),
+        if let Some(wait_to) = wait_to {
+            println!("  Expected recipient on zone: {wait_to}");
         };
-
-        println!("Sending encrypted deposit of {} to {to}...", self.amount);
         let receipt = portal
             .depositEncrypted(self.token, self.amount, key_index, payload)
             .send_sync()
@@ -133,8 +132,10 @@ impl EncryptedDeposit {
 
         // Wait for L2 processing if zone RPC is provided
         if let (Some(zone_rpc), Some(from_block)) = (&self.zone_rpc_url, l2_from_block) {
-            self.wait_for_l2_processing(zone_rpc, from_block, sender, to)
-                .await?;
+            self.wait_for_l2_processing(
+                zone_rpc, from_block, sender, wait_to, self.token, wait_memo,
+            )
+            .await?;
         }
 
         Ok(())
@@ -146,61 +147,168 @@ impl EncryptedDeposit {
         zone_rpc: &str,
         from_block: u64,
         sender: Address,
-        to: Address,
+        to: Option<Address>,
+        token: Address,
+        memo: Option<B256>,
     ) -> eyre::Result<()> {
-        use zone::abi::ZONE_INBOX_ADDRESS;
-
         println!("Waiting for encrypted deposit to be processed on L2...");
-        let l2 = ProviderBuilder::new().connect(zone_rpc).await?;
-
-        let processed_filter = Filter::new()
-            .address(ZONE_INBOX_ADDRESS)
-            .event_signature(ZoneInbox::EncryptedDepositProcessed::SIGNATURE_HASH)
-            .from_block(from_block);
-
-        let failed_filter = Filter::new()
-            .address(ZONE_INBOX_ADDRESS)
-            .event_signature(ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH)
-            .from_block(from_block);
-
-        loop {
-            // Check for successful processing
-            let logs = l2.get_logs(&processed_filter).await.unwrap_or_default();
-            for log in &logs {
-                if let Ok(event) = ZoneInbox::EncryptedDepositProcessed::decode_log(&log.inner)
-                    && event.data.sender == sender
-                    && event.data.to == to
-                {
-                    let block = log.block_number.unwrap_or(0);
-                    println!("Encrypted deposit processed on L2! (block {block})");
-                    println!("  Token:  {}", event.data.token);
-                    println!("  Sender: {}", event.data.sender);
-                    println!("  To:     {}", event.data.to);
-                    println!("  Amount: {}", event.data.amount);
-                    println!("  Memo:   {}", event.data.memo);
-                    return Ok(());
-                }
+        let l2 = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(zone_rpc)
+            .await?;
+        match wait_for_encrypted_deposit_result(&l2, from_block, sender, to, Some(token), memo)
+            .await?
+        {
+            EncryptedDepositResult::Processed {
+                block,
+                token,
+                sender,
+                to,
+                amount,
+                memo,
+            } => {
+                println!("Encrypted deposit processed on L2! (block {block})");
+                println!("  Token:  {token}");
+                println!("  Sender: {sender}");
+                println!("  To:     {to}");
+                println!("  Amount: {amount}");
+                println!("  Memo:   {memo}");
             }
-
-            // Check for failure
-            let failed_logs = l2.get_logs(&failed_filter).await.unwrap_or_default();
-            for log in &failed_logs {
-                if let Ok(event) = ZoneInbox::EncryptedDepositFailed::decode_log(&log.inner)
-                    && event.data.sender == sender
-                {
-                    let block = log.block_number.unwrap_or(0);
-                    println!(
-                        "WARNING: Encrypted deposit FAILED on L2 (block {block}). \
-                         Funds returned to sender."
-                    );
-                    println!("  Token:  {}", event.data.token);
-                    println!("  Sender: {}", event.data.sender);
-                    println!("  Amount: {}", event.data.amount);
-                    return Ok(());
-                }
+            EncryptedDepositResult::Failed {
+                block,
+                token,
+                sender,
+                amount,
+            } => {
+                println!(
+                    "WARNING: Encrypted deposit FAILED on L2 (block {block}). Funds returned to sender."
+                );
+                println!("  Token:  {token}");
+                println!("  Sender: {sender}");
+                println!("  Amount: {amount}");
             }
-
-            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         }
+
+        Ok(())
+    }
+}
+
+fn resolve_prebuilt_payload(
+    cli_portal: Option<Address>,
+    cli_to: Option<Address>,
+    built: BuiltEncryptedDepositPayload,
+) -> eyre::Result<(
+    Address,
+    U256,
+    zone::abi::EncryptedDepositPayload,
+    Option<Address>,
+    Option<B256>,
+)> {
+    let portal_address = match cli_portal {
+        Some(portal) if portal != built.target_portal => {
+            return Err(eyre!(
+                "--portal {} does not match targetPortal {} from payload file",
+                portal,
+                built.target_portal
+            ));
+        }
+        Some(portal) => portal,
+        None => built.target_portal,
+    };
+
+    Ok((
+        portal_address,
+        built.key_index,
+        built.encrypted_deposit_payload,
+        cli_to,
+        None,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bridge_utils::{BuiltEncryptedDepositPayloadJson, payload_json_to_string};
+    use clap::Parser as _;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use zone::abi::EncryptedDepositPayload;
+
+    fn temp_payload_path() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "tempo-xtask-encrypted-deposit-{}-{}.json",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ))
+    }
+
+    fn sample_payload() -> eyre::Result<BuiltEncryptedDepositPayload> {
+        Ok(BuiltEncryptedDepositPayload {
+            target_portal: "0x9000000000000000000000000000000000000009".parse()?,
+            key_index: U256::from(7),
+            encrypted_deposit_payload: EncryptedDepositPayload {
+                ephemeralPubkeyX:
+                    "0x0000000000000000000000000000000000000000000000000000000000001234".parse()?,
+                ephemeralPubkeyYParity: 3,
+                ciphertext: vec![0xaa, 0xbb, 0xcc].into(),
+                nonce: [0x11; 12].into(),
+                tag: [0x22; 16].into(),
+            },
+        })
+    }
+
+    #[test]
+    fn payload_file_args_parse_without_portal() -> eyre::Result<()> {
+        let path = temp_payload_path();
+        fs::write(&path, payload_json_to_string(&sample_payload()?)?)?;
+
+        let args = EncryptedDeposit::try_parse_from([
+            "tempo-xtask",
+            "--l1-rpc-url",
+            "http://127.0.0.1:8545",
+            "--private-key",
+            "0x59c6995e998f97a5a0044966f094538e7dca4a5c7f75b61e8eac2e5c9c1b06f2",
+            "--amount",
+            "1000000",
+            "--payload-file",
+            path.to_str().unwrap(),
+        ])?;
+
+        assert_eq!(args.payload_file.as_deref(), path.to_str());
+        assert!(args.portal.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn prebuilt_payload_branch_reuses_file_contents() -> eyre::Result<()> {
+        let path = temp_payload_path();
+        let expected = sample_payload()?;
+        fs::write(&path, payload_json_to_string(&expected)?)?;
+
+        let round_tripped: BuiltEncryptedDepositPayloadJson =
+            serde_json::from_str(&fs::read_to_string(&path)?)?;
+        let built = round_tripped.into_built()?;
+        let (portal, key_index, payload, wait_to, wait_memo) = resolve_prebuilt_payload(
+            None,
+            Some("0x1000000000000000000000000000000000000001".parse()?),
+            built,
+        )?;
+
+        assert_eq!(portal, expected.target_portal);
+        assert_eq!(key_index, expected.key_index);
+        assert_eq!(
+            payload.ciphertext,
+            expected.encrypted_deposit_payload.ciphertext
+        );
+        assert_eq!(
+            wait_to,
+            Some("0x1000000000000000000000000000000000000001".parse()?)
+        );
+        assert_eq!(wait_memo, None);
+        Ok(())
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,19 +1,23 @@
 //! xtask is a Swiss army knife of tools that help with running and testing tempo.
 use crate::{
-    create_zone::CreateZone, demo_blacklist::DemoBlacklist,
-    demo_swap_and_deposit::DemoSwapAndDeposit, deploy_router::DeployRouter,
-    encrypted_deposit::EncryptedDeposit, generate_zone_genesis::GenerateZoneGenesis,
+    build_encrypted_deposit_payload::BuildEncryptedDepositPayload, create_zone::CreateZone,
+    demo_blacklist::DemoBlacklist, demo_swap_and_deposit::DemoSwapAndDeposit,
+    deploy_router::DeployRouter, encrypted_deposit::EncryptedDeposit,
+    generate_zone_genesis::GenerateZoneGenesis, send_routed_withdrawal::SendRoutedWithdrawal,
     set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;
 
+mod bridge_utils;
+mod build_encrypted_deposit_payload;
 mod create_zone;
 mod demo_blacklist;
 mod demo_swap_and_deposit;
 mod deploy_router;
 mod encrypted_deposit;
 mod generate_zone_genesis;
+mod send_routed_withdrawal;
 mod set_encryption_key;
 mod spam_deposits;
 mod zone_info;
@@ -27,6 +31,10 @@ async fn main() -> eyre::Result<()> {
 
     let args = Args::parse();
     match args.action {
+        Action::BuildEncryptedDepositPayload(args) => args
+            .run()
+            .await
+            .wrap_err("failed to build encrypted deposit payload"),
         Action::CreateZone(args) => args.run().await.wrap_err("failed to create zone"),
         Action::DemoBlacklist(args) => args.run().await.wrap_err("failed to run blacklist demo"),
         Action::DemoSwapAndDeposit(args) => args
@@ -41,6 +49,10 @@ async fn main() -> eyre::Result<()> {
         Action::GenerateZoneGenesis(args) => {
             args.run().await.wrap_err("failed to generate zone genesis")
         }
+        Action::SendRoutedWithdrawal(args) => args
+            .run()
+            .await
+            .wrap_err("failed to send routed withdrawal"),
         Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
         Action::SpamDeposits(args) => args.run().await.wrap_err("failed to spam deposits"),
         Action::ZoneInfo(args) => args.run().await.wrap_err("failed to fetch zone info"),
@@ -59,12 +71,14 @@ struct Args {
 
 #[derive(Debug, clap::Subcommand)]
 enum Action {
+    BuildEncryptedDepositPayload(BuildEncryptedDepositPayload),
     CreateZone(CreateZone),
     DemoBlacklist(DemoBlacklist),
     DemoSwapAndDeposit(DemoSwapAndDeposit),
     DeployRouter(DeployRouter),
     EncryptedDeposit(EncryptedDeposit),
     GenerateZoneGenesis(GenerateZoneGenesis),
+    SendRoutedWithdrawal(SendRoutedWithdrawal),
     SetEncryptionKey(SetEncryptionKey),
     SpamDeposits(SpamDeposits),
     ZoneInfo(ZoneInfoCmd),

--- a/xtask/src/send_routed_withdrawal.rs
+++ b/xtask/src/send_routed_withdrawal.rs
@@ -1,0 +1,315 @@
+use alloy::{
+    network::EthereumWallet,
+    primitives::{Address, B256, Bytes, U256},
+    providers::{Provider, ProviderBuilder},
+};
+use eyre::{WrapErr as _, eyre};
+use tempo_alloy::TempoNetwork;
+use tempo_contracts::precompiles::ITIP20 as TIP20Token;
+use zone::abi::{ZONE_OUTBOX_ADDRESS, ZoneOutbox, ZonePortal};
+
+use crate::{
+    bridge_utils::{
+        build_encrypted_deposit_payload_for_zone, build_encrypted_router_callback,
+        parse_private_key, resolve_token_ref, resolve_zone_ref,
+    },
+    zone_utils::{
+        EncryptedDepositResult, ROUTER_CALLBACK_GAS_LIMIT, check, normalize_http_rpc,
+        wait_for_encrypted_deposit_result, wait_for_withdrawal_processed,
+    },
+};
+
+const APPROVAL_GAS_LIMIT: u64 = 150_000;
+const WITHDRAWAL_TX_GAS: u64 = 1_000_000;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SendRoutedWithdrawal {
+    /// Source zone reference: name, zone ID, or portal address.
+    #[arg(long)]
+    source_zone: String,
+
+    /// Source token reference: alias or address.
+    #[arg(long)]
+    source_token: String,
+
+    /// Target zone reference: name, zone ID, or portal address.
+    #[arg(long)]
+    target_zone: String,
+
+    /// Target token reference: alias or address.
+    #[arg(long)]
+    target_token: String,
+
+    /// Withdrawal amount in token base units.
+    #[arg(long)]
+    amount: u128,
+
+    /// Target recipient on the destination zone. Defaults to the PRIVATE_KEY signer address.
+    #[arg(long)]
+    recipient: Option<Address>,
+
+    /// Memo for the downstream encrypted deposit.
+    #[arg(long, default_value_t = B256::ZERO)]
+    memo: B256,
+
+    /// Minimum acceptable L1 swap output. Required when source and target tokens differ.
+    #[arg(long)]
+    min_amount_out: Option<u128>,
+
+    /// Optional router override. Otherwise sourced from the source zone metadata.
+    #[arg(long)]
+    router: Option<Address>,
+
+    /// Optional fallback recipient on the source zone if the router callback fails.
+    #[arg(long)]
+    fallback_recipient: Option<Address>,
+
+    /// Tempo L1 RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// Source zone L2 RPC URL used to submit the withdrawal.
+    #[arg(long, env = "ZONE_RPC_URL", default_value = "http://localhost:8546")]
+    source_rpc_url: String,
+
+    /// Optional target zone L2 RPC URL used to verify the downstream encrypted deposit.
+    #[arg(long)]
+    target_rpc_url: Option<String>,
+
+    /// Private key used to sign the source-zone withdrawal request.
+    #[arg(long, env = "PRIVATE_KEY")]
+    private_key: String,
+
+    /// ZoneFactory contract address used to resolve zone IDs when local metadata is unavailable.
+    #[arg(long)]
+    zone_factory: Option<Address>,
+}
+
+impl SendRoutedWithdrawal {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let signer = parse_private_key(&self.private_key)?;
+        let signer_address = signer.address();
+        let recipient = self.recipient.unwrap_or(signer_address);
+        let fallback_recipient = self.fallback_recipient.unwrap_or(signer_address);
+        let http_rpc = normalize_http_rpc(&self.l1_rpc_url);
+
+        let l1 = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&http_rpc)
+            .await?;
+        l1.client()
+            .set_poll_interval(std::time::Duration::from_secs(1));
+
+        let source_zone = resolve_zone_ref(&self.source_zone, &l1, self.zone_factory).await?;
+        let target_zone = resolve_zone_ref(&self.target_zone, &l1, self.zone_factory).await?;
+        let source_token = resolve_token_ref(&self.source_token)?;
+        let target_token = resolve_token_ref(&self.target_token)?;
+        let router = self
+            .router
+            .or(source_zone.router)
+            .ok_or_else(|| eyre!("router not provided and not found in source zone metadata"))?;
+        let min_amount_out =
+            effective_min_amount_out(source_token, target_token, self.min_amount_out)?;
+
+        ensure_token_enabled(&l1, source_zone.portal, source_token, "source").await?;
+        ensure_token_enabled(&l1, target_zone.portal, target_token, "target").await?;
+
+        let payload =
+            build_encrypted_deposit_payload_for_zone(&l1, &target_zone, recipient, self.memo)
+                .await?;
+        let callback_data = build_encrypted_router_callback(target_token, &payload, min_amount_out);
+
+        let l2_wallet = EthereumWallet::from(parse_private_key(&self.private_key)?);
+        let source_l2 = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(l2_wallet)
+            .connect(&self.source_rpc_url)
+            .await?;
+
+        let effective_target_rpc_url = self.target_rpc_url.clone().or_else(|| {
+            (source_zone.portal == target_zone.portal).then(|| self.source_rpc_url.clone())
+        });
+        let target_l2 = if let Some(ref target_rpc_url) = effective_target_rpc_url {
+            Some(
+                ProviderBuilder::new_with_network::<TempoNetwork>()
+                    .connect(target_rpc_url)
+                    .await?,
+            )
+        } else {
+            None
+        };
+        let target_from_block = if let Some(ref target_l2) = target_l2 {
+            Some(target_l2.get_block_number().await.unwrap_or(0))
+        } else {
+            None
+        };
+
+        println!("Requesting routed withdrawal");
+        println!("  Signer:            {signer_address}");
+        println!("  Source zone:       {}", source_zone.reference);
+        println!("  Source portal:     {}", source_zone.portal);
+        println!("  Source token:      {source_token}");
+        println!("  Target zone:       {}", target_zone.reference);
+        println!("  Target portal:     {}", target_zone.portal);
+        println!("  Target token:      {target_token}");
+        println!("  Router:            {router}");
+        println!("  Recipient:         {recipient}");
+        println!("  Fallback recipient:{fallback_recipient}");
+        println!("  Amount:            {}", self.amount);
+        println!("  Min amount out:    {min_amount_out}");
+
+        let receipt = TIP20Token::new(source_token, &source_l2)
+            .approve(ZONE_OUTBOX_ADDRESS, U256::MAX)
+            .gas(APPROVAL_GAS_LIMIT)
+            .send()
+            .await
+            .wrap_err("failed to submit source token approval for the outbox")?
+            .get_receipt()
+            .await
+            .wrap_err("failed to approve source token for the outbox")?;
+        check(&receipt, "approve source token for outbox")?;
+        println!(
+            "  Outbox approved on source zone  [tx: {}]",
+            receipt.transaction_hash
+        );
+
+        let l1_from_block = l1.get_block_number().await.unwrap_or(0);
+        let receipt = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &source_l2)
+            .requestWithdrawal(
+                source_token,
+                router,
+                self.amount,
+                self.memo,
+                ROUTER_CALLBACK_GAS_LIMIT,
+                fallback_recipient,
+                callback_data,
+                Bytes::new(),
+            )
+            .gas(WITHDRAWAL_TX_GAS)
+            .send()
+            .await
+            .wrap_err("failed to submit routed withdrawal request on the source zone")?
+            .get_receipt()
+            .await
+            .wrap_err("failed to request routed withdrawal on the source zone")?;
+        check(&receipt, "request routed withdrawal")?;
+        println!(
+            "  Routed withdrawal requested on source zone  [tx: {}]",
+            receipt.transaction_hash
+        );
+
+        let l1_block = wait_for_withdrawal_processed(
+            &l1,
+            l1_from_block,
+            source_zone.portal,
+            router,
+            source_token,
+            self.amount,
+            true,
+        )
+        .await?;
+        println!("  Router callback processed on L1 (block {l1_block})");
+
+        if let (Some(target_l2), Some(from_block)) = (target_l2.as_ref(), target_from_block) {
+            match wait_for_encrypted_deposit_result(
+                target_l2,
+                from_block,
+                router,
+                Some(recipient),
+                Some(target_token),
+                Some(self.memo),
+            )
+            .await?
+            {
+                EncryptedDepositResult::Processed {
+                    block,
+                    token,
+                    amount,
+                    memo,
+                    ..
+                } => {
+                    if token != target_token {
+                        return Err(eyre!(
+                            "unexpected target token in encrypted deposit result: expected {target_token}, got {token}"
+                        ));
+                    }
+                    if memo != self.memo {
+                        return Err(eyre!(
+                            "unexpected memo in encrypted deposit result: expected {}, got {memo}",
+                            self.memo
+                        ));
+                    }
+                    println!("  Encrypted deposit processed on target zone (block {block})");
+                    println!("  Target amount received: {amount}");
+                }
+                EncryptedDepositResult::Failed {
+                    block,
+                    token,
+                    amount,
+                    ..
+                } => {
+                    return Err(eyre!(
+                        "encrypted deposit failed on target zone (block {block}, token {token}, amount {amount})"
+                    ));
+                }
+            }
+        } else {
+            println!("  Skipped target zone verification because target-rpc-url was not provided");
+        }
+
+        Ok(())
+    }
+}
+
+fn effective_min_amount_out(
+    source_token: Address,
+    target_token: Address,
+    min_amount_out: Option<u128>,
+) -> eyre::Result<u128> {
+    if source_token == target_token {
+        return Ok(min_amount_out.unwrap_or(0));
+    }
+
+    min_amount_out.ok_or_else(|| {
+        eyre!("min-amount-out is required when source-token and target-token differ")
+    })
+}
+
+async fn ensure_token_enabled<P: Provider<TempoNetwork>>(
+    l1: &P,
+    portal: Address,
+    token: Address,
+    label: &str,
+) -> eyre::Result<()> {
+    let enabled = ZonePortal::new(portal, l1)
+        .isTokenEnabled(token)
+        .call()
+        .await
+        .wrap_err_with(|| format!("failed to query {label} portal token enablement"))?;
+    if !enabled {
+        return Err(eyre!(
+            "{label} token {token} is not enabled on portal {portal}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requires_min_amount_out_for_swaps() -> eyre::Result<()> {
+        let source = resolve_token_ref("alphausd")?;
+        let target = resolve_token_ref("betausd")?;
+        let err = effective_min_amount_out(source, target, None).unwrap_err();
+        assert!(err.to_string().contains("min-amount-out is required"));
+        Ok(())
+    }
+
+    #[test]
+    fn defaults_min_amount_out_to_zero_for_same_token_routing() -> eyre::Result<()> {
+        let token = resolve_token_ref("pathusd")?;
+        assert_eq!(effective_min_amount_out(token, token, None)?, 0);
+        assert_eq!(effective_min_amount_out(token, token, Some(42))?, 42);
+        Ok(())
+    }
+}

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -1,6 +1,6 @@
 use alloy::{
     network::primitives::ReceiptResponse,
-    primitives::{Address, U256, address},
+    primitives::{Address, B256, U256, address},
     providers::Provider,
     rpc::types::Filter,
     sol_types::SolEvent,
@@ -76,6 +76,22 @@ impl ZoneMetadata {
             .transpose()
     }
 
+    pub(crate) fn get_optional_u32(&self, key: &str) -> eyre::Result<Option<u32>> {
+        self.value
+            .get(key)
+            .map(|value| {
+                value
+                    .as_u64()
+                    .ok_or_else(|| eyre!("{key} in {} is not an integer", self.path.display()))
+                    .and_then(|value| {
+                        u32::try_from(value).map_err(|_| {
+                            eyre!("{key} in {} does not fit in u32", self.path.display())
+                        })
+                    })
+            })
+            .transpose()
+    }
+
     pub(crate) fn get_optional_string(&self, key: &str) -> Option<String> {
         self.value
             .get(key)
@@ -105,6 +121,24 @@ pub(crate) fn check(receipt: &impl ReceiptResponse, label: &str) -> eyre::Result
         return Err(eyre!("{label} reverted"));
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EncryptedDepositResult {
+    Processed {
+        block: u64,
+        token: Address,
+        sender: Address,
+        to: Address,
+        amount: u128,
+        memo: B256,
+    },
+    Failed {
+        block: u64,
+        token: Address,
+        sender: Address,
+        amount: u128,
+    },
 }
 
 pub(crate) async fn fund_l1_wallet<P: Provider<TempoNetwork>>(
@@ -238,4 +272,61 @@ pub(crate) async fn wait_for_withdrawal_processed<P: Provider<TempoNetwork>>(
     Err(eyre!(
         "timeout waiting for WithdrawalProcessed(to={to}, token={token}, amount={amount}, callbackSuccess={callback_success})"
     ))
+}
+
+pub(crate) async fn wait_for_encrypted_deposit_result<P: Provider<TempoNetwork>>(
+    l2: &P,
+    from_block: u64,
+    sender: Address,
+    to: Option<Address>,
+    token: Option<Address>,
+    memo: Option<B256>,
+) -> eyre::Result<EncryptedDepositResult> {
+    let processed_filter = Filter::new()
+        .address(zone::abi::ZONE_INBOX_ADDRESS)
+        .event_signature(ZoneInbox::EncryptedDepositProcessed::SIGNATURE_HASH)
+        .from_block(from_block);
+
+    let failed_filter = Filter::new()
+        .address(zone::abi::ZONE_INBOX_ADDRESS)
+        .event_signature(ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH)
+        .from_block(from_block);
+
+    loop {
+        let logs = l2.get_logs(&processed_filter).await.unwrap_or_default();
+        for log in &logs {
+            if let Ok(event) = ZoneInbox::EncryptedDepositProcessed::decode_log(&log.inner)
+                && event.data.sender == sender
+                && to.is_none_or(|to| event.data.to == to)
+                && token.is_none_or(|token| event.data.token == token)
+                && memo.is_none_or(|memo| event.data.memo == memo)
+            {
+                return Ok(EncryptedDepositResult::Processed {
+                    block: log.block_number.unwrap_or(0),
+                    token: event.data.token,
+                    sender: event.data.sender,
+                    to: event.data.to,
+                    amount: event.data.amount,
+                    memo: event.data.memo,
+                });
+            }
+        }
+
+        let failed_logs = l2.get_logs(&failed_filter).await.unwrap_or_default();
+        for log in &failed_logs {
+            if let Ok(event) = ZoneInbox::EncryptedDepositFailed::decode_log(&log.inner)
+                && event.data.sender == sender
+                && token.is_none_or(|token| event.data.token == token)
+            {
+                return Ok(EncryptedDepositResult::Failed {
+                    block: log.block_number.unwrap_or(0),
+                    token: event.data.token,
+                    sender: event.data.sender,
+                    amount: event.data.amount,
+                });
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 }


### PR DESCRIPTION
## What changed

This adds a higher-level routed-withdrawal flow and a reusable encrypted-payload builder for zone deposits.

- add `tempo-xtask build-encrypted-deposit-payload` for reusable encrypted deposit payload JSON
- add `tempo-xtask send-routed-withdrawal` for source-zone withdrawal -> L1 router -> target-zone encrypted deposit
- extract shared zone resolution, token resolution, encryption-key lookup, payload JSON, and router callback helpers into a new `bridge_utils` module
- refactor `encrypted-deposit` to reuse the shared payload builder and accept `--payload-file`
- refactor the same-zone swap-and-deposit demo to use the shared encrypted payload path
- add `just build-encrypted-deposit-payload` and `just send-routed-withdrawal`
- update `docs/ZONES.md` with reusable payload and routed-withdrawal examples, using direct xtask commands where `just` positional args would be ambiguous

## Why

The repo already had the building blocks for encrypted deposits and router callbacks, but the reusable encryption path was buried inside demos. This change exposes those pieces as operator-facing commands so we can build encrypted callback data once, reuse it for direct encrypted deposits, and submit routed withdrawals in one step.

## Validation

- `cargo test -p tempo-xtask`
- `cargo test -p zone --test it test_swap_and_deposit_into_same_zone -- --nocapture`
- `cargo test -p zone --test it test_cross_zone_withdrawal -- --nocapture`
- `cargo test -p zone --test it test_cross_zone_send -- --nocapture`
- `cargo test -p zone --test it test_encrypted_deposit_and_withdrawal -- --nocapture`
- `just --show build-encrypted-deposit-payload`
- `just --show send-routed-withdrawal`
- `just --show send-deposit-encrypted`
