### PR TITLE
feat(fees): add isFeeToken flag to TIP-20 for fee token eligibility

### DIFF
--- a/docs/specs/src/FeeManager.sol
+++ b/docs/specs/src/FeeManager.sol
@@ -19,21 +19,26 @@ contract FeeManager is IFeeManager, FeeAMM {
         _;
     }
 
+    function _requireFeeToken(address token) internal view {
+        if (!ITIP20(token).isFeeToken()) revert NotFeeToken();
+    }
+
     function setValidatorToken(address token) external onlyDirectCall {
         require(msg.sender != block.coinbase, "CANNOT_CHANGE_WITHIN_BLOCK");
-        _requireUSDTIP20(token);
+        _requireFeeToken(token);
         validatorTokens[msg.sender] = token;
         emit ValidatorTokenSet(msg.sender, token);
     }
 
     function setUserToken(address token) external onlyDirectCall {
-        _requireUSDTIP20(token);
+        _requireFeeToken(token);
         userTokens[msg.sender] = token;
         emit UserTokenSet(msg.sender, token);
     }
 
     function collectFeePreTx(address user, address userToken, uint256 maxAmount) external {
         require(msg.sender == address(0), "ONLY_PROTOCOL");
+        _requireFeeToken(userToken);
 
         address validatorToken = validatorTokens[block.coinbase];
         if (validatorToken == address(0)) {
@@ -56,6 +61,7 @@ contract FeeManager is IFeeManager, FeeAMM {
         external
     {
         require(msg.sender == address(0), "ONLY_PROTOCOL");
+        _requireFeeToken(userToken);
 
         address feeRecipient = block.coinbase;
         address validatorToken = validatorTokens[feeRecipient];

--- a/docs/specs/src/TIP20.sol
+++ b/docs/specs/src/TIP20.sol
@@ -58,6 +58,11 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
         nextQuoteToken = _quoteToken;
         // No currency registry; all tokens use 6 decimals by default
 
+        // USD-denominated tokens are eligible for fee payment by default
+        if (keccak256(bytes(_currency)) == keccak256(bytes("USD"))) {
+            isFeeToken = true;
+        }
+
         hasRole[admin][DEFAULT_ADMIN_ROLE] = true; // Grant admin role to first admin.
         emit RoleMembershipUpdated(DEFAULT_ADMIN_ROLE, admin, sender, true);
     }
@@ -75,6 +80,7 @@ contract TIP20 is ITIP20, TIP20RolesAuth {
     //////////////////////////////////////////////////////////////*/
 
     bool public paused = false;
+    bool public isFeeToken = false;
     uint256 public supplyCap = type(uint128).max; // Default to cap at uint128.max
 
     /*//////////////////////////////////////////////////////////////

--- a/docs/specs/src/interfaces/IFeeManager.sol
+++ b/docs/specs/src/interfaces/IFeeManager.sol
@@ -5,6 +5,8 @@ import { IFeeAMM } from "./IFeeAMM.sol";
 
 interface IFeeManager is IFeeAMM {
 
+    error NotFeeToken();
+
     event UserTokenSet(address indexed user, address indexed token);
     event ValidatorTokenSet(address indexed validator, address indexed token);
     event FeesDistributed(address indexed validator, address indexed token, uint256 amount);

--- a/docs/specs/src/interfaces/ITIP20.sol
+++ b/docs/specs/src/interfaces/ITIP20.sol
@@ -144,6 +144,9 @@ interface ITIP20 {
 
     function decimals() external pure returns (uint8);
 
+    /// @notice Returns whether this token can be used to pay transaction fees.
+    function isFeeToken() external view returns (bool);
+
     function globalRewardPerToken() external view returns (uint256);
 
     /// @notice Mints new tokens to a specified address.

--- a/docs/specs/test/FeeManager.t.sol
+++ b/docs/specs/test/FeeManager.t.sol
@@ -105,14 +105,13 @@ contract FeeManagerTest is BaseTest {
     }
 
     function test_setValidatorToken_RevertsIf_NonUSDToken() public {
-        vm.prank(validator);
-        vm.coinbase(validator);
+        vm.prank(validator, validator);
 
         TIP20 eurToken =
             TIP20(factory.createToken("EuroToken", "EUR", "EUR", pathUSD, admin, bytes32("eur")));
 
         if (!isTempo) {
-            vm.expectRevert("INVALID_TOKEN");
+            vm.expectRevert(IFeeManager.NotFeeToken.selector);
         }
 
         try amm.setValidatorToken(address(eurToken)) {
@@ -187,6 +186,63 @@ contract FeeManagerTest is BaseTest {
         } catch {
             // Expected to revert
         }
+    }
+
+    function test_collectFeePreTx_RevertsIf_NonFeeToken() public {
+        TIP20 eurToken =
+            TIP20(factory.createToken("EuroToken", "EUR", "EUR", pathUSD, admin, bytes32("eur2")));
+
+        vm.startPrank(admin);
+        eurToken.grantRole(_ISSUER_ROLE, admin);
+        eurToken.mint(user, 10_000e18);
+        vm.stopPrank();
+
+        vm.prank(address(0));
+        vm.coinbase(validator);
+
+        if (!isTempo) {
+            vm.expectRevert(IFeeManager.NotFeeToken.selector);
+        }
+
+        try amm.collectFeePreTx(user, address(eurToken), 100e18) {
+            if (isTempo) {
+                revert CallShouldHaveReverted();
+            }
+        } catch {
+            // Expected to revert
+        }
+    }
+
+    function test_collectFeePostTx_RevertsIf_NonFeeToken() public {
+        TIP20 eurToken =
+            TIP20(factory.createToken("EuroToken2", "EUR2", "EUR", pathUSD, admin, bytes32("eur3")));
+
+        vm.prank(address(0));
+        vm.coinbase(validator);
+
+        if (!isTempo) {
+            vm.expectRevert(IFeeManager.NotFeeToken.selector);
+        }
+
+        try amm.collectFeePostTx(user, 100e18, 80e18, address(eurToken)) {
+            if (isTempo) {
+                revert CallShouldHaveReverted();
+            }
+        } catch {
+            // Expected to revert
+        }
+    }
+
+    function test_isFeeToken_TrueForUSD() public view {
+        assertTrue(userToken.isFeeToken());
+        assertTrue(validatorToken.isFeeToken());
+        assertTrue(pathUSD.isFeeToken());
+    }
+
+    function test_isFeeToken_FalseForNonUSD() public {
+        TIP20 eurToken =
+            TIP20(factory.createToken("EuroToken3", "EUR3", "EUR", pathUSD, admin, bytes32("eur4")));
+        assertFalse(eurToken.isFeeToken());
     }
 
     function test_collectFeePreTx_RevertsIf_InsufficientLiquidity() public {


### PR DESCRIPTION
Adds a per-token `isFeeToken` boolean to TIP-20 that controls whether a token can be used for fee payment.

## Motivation

Zones don't have a FeeAMM, so the L1 approach of calling `_requireUSDTIP20()` (which lives in FeeAMM) doesn't apply. Instead, a per-token flag gives fine-grained control: USD tokens get `isFeeToken = true` at creation, and in the future individual USD tokens can be disabled or non-USD tokens enabled without code changes.

## Changes

- **`TIP20.sol`**: add `bool public isFeeToken`, set to `true` in constructor when `currency == "USD"`
- **`ITIP20.sol`**: add `isFeeToken()` to the interface
- **`IFeeManager.sol`**: add `NotFeeToken` error
- **`FeeManager.sol`**: replace `_requireUSDTIP20()` calls with `_requireFeeToken()` that checks the flag; add validation to `collectFeePreTx` and `collectFeePostTx`
- **`FeeManager.t.sol`**: add tests for non-fee-token rejection in `setValidatorToken`, `collectFeePreTx`, `collectFeePostTx`, and flag correctness

## Testing

```
forge test --match-contract FeeManagerTest -vvv
# 23 passed, 0 failed
```

Prompted by: dankrad