### PR TITLE
docs: add private RPC cast examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ To restart the same zone later:
 just zone-up my-zone false release
 ```
 
+## Query the Private RPC
+
+With `PRIVATE_KEY` set to your zone wallet, you can hit the private RPC on `http://localhost:8544` with a one-liner. `just zone-auth-token` reads `generated/<name>/zone.json`, signs a short-lived auth token, and `cast rpc` passes it through the `X-Authorization-Token` header:
+
+```bash
+cast rpc zone_getAuthorizationTokenInfo \
+  --rpc-url http://localhost:8544 \
+  --rpc-headers "X-Authorization-Token: $(just zone-auth-token my-zone)"
+```
+
+See [docs/ZONES.md](docs/ZONES.md) for more private RPC examples, including reusable tokens and `eth_call` queries.
+
 ## How Zones Work
 
 - A zone sequencer subscribes to Tempo for headers, deposits, and token-enablement events, including backfill from the zone's anchor block.

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -266,21 +266,55 @@ just demo-swap-and-deposit my-zone amount=100000000 tick=0
 
 This is a same-zone demo only. The command creates its own temporary tokens and DEX liquidity automatically, so you do not need to pre-create assets or seed the order book yourself.
 
-#### Check balance via Private RPC
+#### Query the Private RPC
 
-The private RPC (port 8544) requires a signed auth token derived from your private key. This ensures only the account owner can query their own balance.
+The private RPC (port 8544) requires a signed auth token derived from your private key. This ensures only the account owner can query their own scoped state.
+
+Use the built-in helper if you only want a quick balance check:
 
 ```bash
-# Check your balance (generates auth token automatically)
 just check-balance-private my-zone
-
-# Generate a reusable auth token (valid for 10 minutes)
-TOKEN=$(just zone-auth-token my-zone)
-curl -s http://localhost:8544 \
-  -H "Content-Type: application/json" \
-  -H "x-authorization-token: $TOKEN" \
-  -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```
+
+For direct RPC calls, `just zone-auth-token` generates a 10-minute token from `generated/<name>/zone.json`, and `cast rpc` forwards it with `X-Authorization-Token`.
+HTTP header names are case-insensitive, so `x-authorization-token` works too, but the examples here use the canonical casing from the spec.
+
+One-liner to verify the private endpoint and inspect the authenticated account:
+
+```bash
+cast rpc zone_getAuthorizationTokenInfo \
+  --rpc-url http://localhost:8544 \
+  --rpc-headers "X-Authorization-Token: $(just zone-auth-token my-zone)"
+```
+
+If you want to make multiple requests, generate the token once and reuse it:
+
+```bash
+TOKEN=$(just zone-auth-token my-zone)
+
+cast rpc zone_getAuthorizationTokenInfo \
+  --rpc-url http://localhost:8544 \
+  --rpc-headers "X-Authorization-Token: $TOKEN"
+
+cast rpc eth_blockNumber \
+  --rpc-url http://localhost:8544 \
+  --rpc-headers "X-Authorization-Token: $TOKEN"
+```
+
+To query your own TIP-20 balance directly with `eth_call`, derive the authenticated account from `PRIVATE_KEY`, encode `balanceOf(address)`, and send the call through the private endpoint:
+
+```bash
+ADDR=$(cast wallet address "$PRIVATE_KEY")
+DATA=$(cast calldata "balanceOf(address)" "$ADDR")
+
+cast rpc eth_call \
+  "{\"from\":\"$ADDR\",\"to\":\"0x20C0000000000000000000000000000000000000\",\"data\":\"$DATA\"}" \
+  latest \
+  --rpc-url http://localhost:8544 \
+  --rpc-headers "X-Authorization-Token: $TOKEN"
+```
+
+Swap the `to` address above if you want to query a different zone TIP-20.
 
 #### Check portal status on L1
 


### PR DESCRIPTION
## Summary

This PR expands the zone private-RPC documentation with `cast rpc` examples that use `just zone-auth-token` to generate a short-lived auth token.

It also switches the examples to the canonical `X-Authorization-Token` header spelling and notes that lowercase still works because HTTP header names are case-insensitive.

## Changes

- add a short private-RPC `cast rpc` one-liner to the main README
- replace the old curl-only private-RPC example in `docs/ZONES.md`
- add more detailed `docs/ZONES.md` examples for reusable tokens and `eth_call`
- document the header-casing behavior explicitly

## Validation

- `git diff --check`
- verified the local `cast` CLI help and `--curl` output for `cast rpc --rpc-headers`

## Notes

- docs-only change; no test suite run