### PR TITLE
fix(tempo-zone): prefetch TIP-403 policies for batch calls and transferFrom

### DIFF
--- a/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
@@ -7,6 +7,8 @@
 //! via the [`PolicyTaskHandle`](super::PolicyTaskHandle), warming the policy cache
 //! before block building.
 
+use std::collections::HashSet;
+
 use alloy_primitives::TxKind;
 use alloy_sol_types::SolCall;
 use reth_transaction_pool::TransactionPool;
@@ -74,9 +76,13 @@ where
         // Resolve the fee payer (may differ from sender for AA txs with delegated fees)
         let fee_payer = tx.transaction.inner().fee_payer(sender).unwrap_or(sender);
 
+        let mut prefetched = HashSet::new();
+
         // Pre-fetch fee payer authorization for the fee token (every tx pays fees)
-        debug!(%fee_token, %fee_payer, "Pre-fetching TIP-403 fee token authorization");
-        let _ = handle.send_resolve_policy(fee_token, fee_payer, AuthRole::Sender);
+        if prefetched.insert((fee_token, fee_payer, AuthRole::Sender)) {
+            debug!(%fee_token, %fee_payer, "Pre-fetching TIP-403 fee token authorization");
+            let _ = handle.send_resolve_policy(fee_token, fee_payer, AuthRole::Sender);
+        }
 
         for (kind, input) in tx.transaction.inner().calls() {
             let TxKind::Call(token) = kind else {
@@ -115,13 +121,15 @@ where
                 continue;
             };
 
-            if token != fee_token || transfer_sender != fee_payer {
+            if prefetched.insert((token, transfer_sender, AuthRole::Sender)) {
                 debug!(%token, %transfer_sender, "Pre-fetching TIP-403 sender authorization");
                 let _ = handle.send_resolve_policy(token, transfer_sender, AuthRole::Sender);
             }
 
-            debug!(%token, recipient = %recipient, "Pre-fetching TIP-403 recipient authorization");
-            let _ = handle.send_resolve_policy(token, recipient, AuthRole::Recipient);
+            if prefetched.insert((token, recipient, AuthRole::Recipient)) {
+                debug!(%token, recipient = %recipient, "Pre-fetching TIP-403 recipient authorization");
+                let _ = handle.send_resolve_policy(token, recipient, AuthRole::Recipient);
+            }
         }
     }
 

--- a/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
@@ -1,16 +1,13 @@
 //! Pool transaction prefetch task for TIP-403 policy cache warming.
 //!
 //! Subscribes to new pending transactions from the transaction pool and
-//! extracts sender/recipient addresses from TIP-20 transfer calls, including
-//! batched Tempo AA calls. For each address, a
-//! [`ResolveAuthorization`](super::PolicyTaskMessage::ResolveAuthorization)
+//! extracts sender/recipient addresses from TIP-20 transfer calls. For each
+//! address, a [`ResolveAuthorization`](super::PolicyTaskMessage::ResolveAuthorization)
 //! request is sent to the [`PolicyResolutionTask`](super::PolicyResolutionTask)
-//! via the [`PolicyTaskHandle`](super::PolicyTaskHandle), warming the policy
-//! cache before block building.
+//! via the [`PolicyTaskHandle`](super::PolicyTaskHandle), warming the policy cache
+//! before block building.
 
-use std::collections::HashSet;
-
-use alloy_primitives::{Address, Bytes, TxKind};
+use alloy_primitives::TxKind;
 use alloy_sol_types::SolCall;
 use reth_transaction_pool::TransactionPool;
 use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIP20};
@@ -21,19 +18,6 @@ use tracing::debug;
 
 use super::{AuthRole, task::PolicyTaskHandle};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct PrefetchRequest {
-    token: Address,
-    user: Address,
-    role: AuthRole,
-}
-
-impl PrefetchRequest {
-    const fn new(token: Address, user: Address, role: AuthRole) -> Self {
-        Self { token, user, role }
-    }
-}
-
 /// Spawns a background task that watches for new pool transactions and
 /// pre-fetches TIP-403 authorization data for sender/recipient addresses.
 ///
@@ -42,14 +26,14 @@ impl PrefetchRequest {
 /// 1. **Fee payer** — the address paying gas fees, resolved as `AuthRole::Sender`
 ///    against the transaction's fee token (defaults to pathUSD). AA transactions
 ///    may specify a different fee token or delegate fee payment to another address.
-/// 2. **Transfer sender** — for TIP-20 transfer calls, the actual transfer sender is
-///    resolved against the transfer token. For `transferFrom*`, this is the decoded
-///    `from` address rather than the transaction sender.
+/// 2. **Transfer sender** — for TIP-20 transfer calls, the sender is resolved
+///    against the transfer token. For `transferFrom*`, this is the decoded `from`
+///    address rather than the transaction sender.
 /// 3. **Transfer recipient** — for `transfer`, `transferWithMemo`, `transferFrom`,
 ///    and `transferFromWithMemo` calls, the `to` address is decoded from calldata
 ///    and resolved as `AuthRole::Recipient`.
-/// 4. **Batch calls** — Tempo AA transactions can include multiple top-level calls;
-///    each call is inspected independently so later batched transfers are warmed too.
+/// 4. **Batch calls** — Tempo AA transactions can include multiple top-level calls,
+///    and each call is inspected independently.
 ///
 /// The resolution task fetches the latest L1 block number for each request,
 /// so callers don't need to track block heights.
@@ -90,210 +74,56 @@ where
         // Resolve the fee payer (may differ from sender for AA txs with delegated fees)
         let fee_payer = tx.transaction.inner().fee_payer(sender).unwrap_or(sender);
 
-        for request in
-            collect_prefetch_requests(sender, fee_payer, fee_token, tx.transaction.inner().calls())
-        {
-            debug!(
-                %request.token,
-                %request.user,
-                ?request.role,
-                "Pre-fetching TIP-403 authorization"
-            );
-            let _ = handle.send_resolve_policy(request.token, request.user, request.role);
+        // Pre-fetch fee payer authorization for the fee token (every tx pays fees)
+        debug!(%fee_token, %fee_payer, "Pre-fetching TIP-403 fee token authorization");
+        let _ = handle.send_resolve_policy(fee_token, fee_payer, AuthRole::Sender);
+
+        for (kind, input) in tx.transaction.inner().calls() {
+            let TxKind::Call(token) = kind else {
+                continue;
+            };
+            if !is_tip20_prefix(token) {
+                continue;
+            }
+
+            let Some(selector) = input.first_chunk::<4>() else {
+                continue;
+            };
+            let args = &input[4..];
+
+            let (transfer_sender, recipient) = if *selector == ITIP20::transferCall::SELECTOR {
+                let Ok(call) = ITIP20::transferCall::abi_decode_raw(args) else {
+                    continue;
+                };
+                (sender, call.to)
+            } else if *selector == ITIP20::transferWithMemoCall::SELECTOR {
+                let Ok(call) = ITIP20::transferWithMemoCall::abi_decode_raw(args) else {
+                    continue;
+                };
+                (sender, call.to)
+            } else if *selector == ITIP20::transferFromCall::SELECTOR {
+                let Ok(call) = ITIP20::transferFromCall::abi_decode_raw(args) else {
+                    continue;
+                };
+                (call.from, call.to)
+            } else if *selector == ITIP20::transferFromWithMemoCall::SELECTOR {
+                let Ok(call) = ITIP20::transferFromWithMemoCall::abi_decode_raw(args) else {
+                    continue;
+                };
+                (call.from, call.to)
+            } else {
+                continue;
+            };
+
+            if token != fee_token || transfer_sender != fee_payer {
+                debug!(%token, %transfer_sender, "Pre-fetching TIP-403 sender authorization");
+                let _ = handle.send_resolve_policy(token, transfer_sender, AuthRole::Sender);
+            }
+
+            debug!(%token, recipient = %recipient, "Pre-fetching TIP-403 recipient authorization");
+            let _ = handle.send_resolve_policy(token, recipient, AuthRole::Recipient);
         }
     }
 
     debug!("Pool prefetch task shutting down");
-}
-
-fn collect_prefetch_requests<'a, I>(
-    sender: Address,
-    fee_payer: Address,
-    fee_token: Address,
-    calls: I,
-) -> Vec<PrefetchRequest>
-where
-    I: IntoIterator<Item = (TxKind, &'a Bytes)>,
-{
-    let mut seen = HashSet::new();
-    let mut requests = Vec::new();
-
-    push_prefetch_request(
-        PrefetchRequest::new(fee_token, fee_payer, AuthRole::Sender),
-        &mut seen,
-        &mut requests,
-    );
-
-    for (kind, input) in calls {
-        let TxKind::Call(token) = kind else {
-            continue;
-        };
-        if !is_tip20_prefix(token) {
-            continue;
-        }
-
-        let Some((transfer_sender, recipient)) = decode_transfer_participants(sender, input) else {
-            continue;
-        };
-
-        push_prefetch_request(
-            PrefetchRequest::new(token, transfer_sender, AuthRole::Sender),
-            &mut seen,
-            &mut requests,
-        );
-        push_prefetch_request(
-            PrefetchRequest::new(token, recipient, AuthRole::Recipient),
-            &mut seen,
-            &mut requests,
-        );
-    }
-
-    requests
-}
-
-fn push_prefetch_request(
-    request: PrefetchRequest,
-    seen: &mut HashSet<PrefetchRequest>,
-    requests: &mut Vec<PrefetchRequest>,
-) {
-    if seen.insert(request) {
-        requests.push(request);
-    }
-}
-
-fn decode_transfer_participants(caller: Address, input: &[u8]) -> Option<(Address, Address)> {
-    let selector = *input.first_chunk::<4>()?;
-    let args = &input[4..];
-
-    match selector {
-        ITIP20::transferCall::SELECTOR => {
-            let call = ITIP20::transferCall::abi_decode_raw(args).ok()?;
-            Some((caller, call.to))
-        }
-        ITIP20::transferWithMemoCall::SELECTOR => {
-            let call = ITIP20::transferWithMemoCall::abi_decode_raw(args).ok()?;
-            Some((caller, call.to))
-        }
-        ITIP20::transferFromCall::SELECTOR => {
-            let call = ITIP20::transferFromCall::abi_decode_raw(args).ok()?;
-            Some((call.from, call.to))
-        }
-        ITIP20::transferFromWithMemoCall::SELECTOR => {
-            let call = ITIP20::transferFromWithMemoCall::abi_decode_raw(args).ok()?;
-            Some((call.from, call.to))
-        }
-        _ => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_primitives::{Address, U256, address};
-
-    #[test]
-    fn collects_transfer_from_sender_from_calldata() {
-        let sender = Address::repeat_byte(0x11);
-        let fee_payer = Address::repeat_byte(0x22);
-        let fee_token = address!("0x20C0000000000000000000000000000000000003");
-        let token = address!("0x20C0000000000000000000000000000000000001");
-        let from = Address::repeat_byte(0x44);
-        let to = Address::repeat_byte(0x55);
-        let amount = U256::from(7_u64);
-        let input: Bytes = ITIP20::transferFromCall { from, to, amount }
-            .abi_encode()
-            .into();
-        let calls = [(TxKind::Call(token), input)];
-
-        let requests = collect_prefetch_requests(
-            sender,
-            fee_payer,
-            fee_token,
-            calls.iter().map(|(kind, input)| (*kind, input)),
-        );
-
-        assert_eq!(
-            requests,
-            vec![
-                PrefetchRequest::new(fee_token, fee_payer, AuthRole::Sender),
-                PrefetchRequest::new(token, from, AuthRole::Sender),
-                PrefetchRequest::new(token, to, AuthRole::Recipient),
-            ]
-        );
-    }
-
-    #[test]
-    fn collects_all_batched_transfer_calls() {
-        let sender = Address::repeat_byte(0x11);
-        let fee_payer = Address::repeat_byte(0x22);
-        let fee_token = address!("0x20C0000000000000000000000000000000000003");
-        let token_a = address!("0x20C0000000000000000000000000000000000001");
-        let token_b = address!("0x20C0000000000000000000000000000000000002");
-        let to_a = Address::repeat_byte(0x44);
-        let from_b = Address::repeat_byte(0x55);
-        let to_b = Address::repeat_byte(0x66);
-        let amount = U256::from(7_u64);
-        let calls = [
-            (
-                TxKind::Call(token_a),
-                Bytes::from(ITIP20::transferCall { to: to_a, amount }.abi_encode()),
-            ),
-            (
-                TxKind::Call(token_b),
-                Bytes::from(
-                    ITIP20::transferFromCall {
-                        from: from_b,
-                        to: to_b,
-                        amount,
-                    }
-                    .abi_encode(),
-                ),
-            ),
-        ];
-
-        let requests = collect_prefetch_requests(
-            sender,
-            fee_payer,
-            fee_token,
-            calls.iter().map(|(kind, input)| (*kind, input)),
-        );
-
-        assert_eq!(
-            requests,
-            vec![
-                PrefetchRequest::new(fee_token, fee_payer, AuthRole::Sender),
-                PrefetchRequest::new(token_a, sender, AuthRole::Sender),
-                PrefetchRequest::new(token_a, to_a, AuthRole::Recipient),
-                PrefetchRequest::new(token_b, from_b, AuthRole::Sender),
-                PrefetchRequest::new(token_b, to_b, AuthRole::Recipient),
-            ]
-        );
-    }
-
-    #[test]
-    fn keeps_transfer_sender_when_fee_payer_differs_on_same_token() {
-        let sender = Address::repeat_byte(0x11);
-        let fee_payer = Address::repeat_byte(0x22);
-        let token = address!("0x20C0000000000000000000000000000000000001");
-        let to = Address::repeat_byte(0x44);
-        let amount = U256::from(7_u64);
-        let input: Bytes = ITIP20::transferCall { to, amount }.abi_encode().into();
-        let calls = [(TxKind::Call(token), input)];
-
-        let requests = collect_prefetch_requests(
-            sender,
-            fee_payer,
-            token,
-            calls.iter().map(|(kind, input)| (*kind, input)),
-        );
-
-        assert_eq!(
-            requests,
-            vec![
-                PrefetchRequest::new(token, fee_payer, AuthRole::Sender),
-                PrefetchRequest::new(token, sender, AuthRole::Sender),
-                PrefetchRequest::new(token, to, AuthRole::Recipient),
-            ]
-        );
-    }
 }

--- a/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/pool_prefetch.rs
@@ -1,20 +1,38 @@
 //! Pool transaction prefetch task for TIP-403 policy cache warming.
 //!
 //! Subscribes to new pending transactions from the transaction pool and
-//! extracts sender/recipient addresses from TIP-20 transfer calls. For each
-//! address, a [`ResolveAuthorization`](super::PolicyTaskMessage::ResolveAuthorization)
+//! extracts sender/recipient addresses from TIP-20 transfer calls, including
+//! batched Tempo AA calls. For each address, a
+//! [`ResolveAuthorization`](super::PolicyTaskMessage::ResolveAuthorization)
 //! request is sent to the [`PolicyResolutionTask`](super::PolicyResolutionTask)
-//! via the [`PolicyTaskHandle`](super::PolicyTaskHandle), warming the policy cache
-//! before block building.
+//! via the [`PolicyTaskHandle`](super::PolicyTaskHandle), warming the policy
+//! cache before block building.
 
-use alloy_consensus::Transaction;
+use std::collections::HashSet;
+
+use alloy_primitives::{Address, Bytes, TxKind};
 use alloy_sol_types::SolCall;
 use reth_transaction_pool::TransactionPool;
 use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIP20};
+use tempo_precompiles::tip20::is_tip20_prefix;
+use tempo_revm::TempoTx;
 use tempo_transaction_pool::transaction::TempoPooledTransaction;
 use tracing::debug;
 
 use super::{AuthRole, task::PolicyTaskHandle};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PrefetchRequest {
+    token: Address,
+    user: Address,
+    role: AuthRole,
+}
+
+impl PrefetchRequest {
+    const fn new(token: Address, user: Address, role: AuthRole) -> Self {
+        Self { token, user, role }
+    }
+}
 
 /// Spawns a background task that watches for new pool transactions and
 /// pre-fetches TIP-403 authorization data for sender/recipient addresses.
@@ -24,11 +42,14 @@ use super::{AuthRole, task::PolicyTaskHandle};
 /// 1. **Fee payer** — the address paying gas fees, resolved as `AuthRole::Sender`
 ///    against the transaction's fee token (defaults to pathUSD). AA transactions
 ///    may specify a different fee token or delegate fee payment to another address.
-/// 2. **Transfer sender** — for TIP-20 payment transactions, the sender is resolved
-///    against the transfer token if it differs from the fee token.
+/// 2. **Transfer sender** — for TIP-20 transfer calls, the actual transfer sender is
+///    resolved against the transfer token. For `transferFrom*`, this is the decoded
+///    `from` address rather than the transaction sender.
 /// 3. **Transfer recipient** — for `transfer`, `transferWithMemo`, `transferFrom`,
 ///    and `transferFromWithMemo` calls, the `to` address is decoded from calldata
 ///    and resolved as `AuthRole::Recipient`.
+/// 4. **Batch calls** — Tempo AA transactions can include multiple top-level calls;
+///    each call is inspected independently so later batched transfers are warmed too.
 ///
 /// The resolution task fetches the latest L1 block number for each request,
 /// so callers don't need to track block heights.
@@ -69,55 +90,210 @@ where
         // Resolve the fee payer (may differ from sender for AA txs with delegated fees)
         let fee_payer = tx.transaction.inner().fee_payer(sender).unwrap_or(sender);
 
-        // Pre-fetch fee payer authorization for the fee token (every tx pays fees)
-        debug!(%fee_token, %fee_payer, "Pre-fetching TIP-403 fee token authorization");
-        let _ = handle.send_resolve_policy(fee_token, fee_payer, AuthRole::Sender);
-
-        // For TIP-20 payment transactions, also pre-fetch transfer-specific data
-        if tx.transaction.is_payment() {
-            let Some(token) = tx.to() else {
-                continue;
-            };
-
-            // Pre-fetch sender for the transfer token (may differ from fee token)
-            if token != fee_token {
-                let _ = handle.send_resolve_policy(token, sender, AuthRole::Sender);
-            }
-
-            // Pre-fetch recipient authorization for all transfer variants
-            let recipient = if tx.transaction.function_selector()
-                == Some(&ITIP20::transferCall::SELECTOR.into())
-                && let Ok(call) = ITIP20::transferCall::abi_decode_raw(&tx.transaction.input()[4..])
-            {
-                Some(call.to)
-            } else if tx.transaction.function_selector()
-                == Some(&ITIP20::transferWithMemoCall::SELECTOR.into())
-                && let Ok(call) =
-                    ITIP20::transferWithMemoCall::abi_decode_raw(&tx.transaction.input()[4..])
-            {
-                Some(call.to)
-            } else if tx.transaction.function_selector()
-                == Some(&ITIP20::transferFromCall::SELECTOR.into())
-                && let Ok(call) =
-                    ITIP20::transferFromCall::abi_decode_raw(&tx.transaction.input()[4..])
-            {
-                Some(call.to)
-            } else if tx.transaction.function_selector()
-                == Some(&ITIP20::transferFromWithMemoCall::SELECTOR.into())
-                && let Ok(call) =
-                    ITIP20::transferFromWithMemoCall::abi_decode_raw(&tx.transaction.input()[4..])
-            {
-                Some(call.to)
-            } else {
-                None
-            };
-
-            if let Some(to) = recipient {
-                debug!(%token, recipient = %to, "Pre-fetching TIP-403 recipient authorization");
-                let _ = handle.send_resolve_policy(token, to, AuthRole::Recipient);
-            }
+        for request in
+            collect_prefetch_requests(sender, fee_payer, fee_token, tx.transaction.inner().calls())
+        {
+            debug!(
+                %request.token,
+                %request.user,
+                ?request.role,
+                "Pre-fetching TIP-403 authorization"
+            );
+            let _ = handle.send_resolve_policy(request.token, request.user, request.role);
         }
     }
 
     debug!("Pool prefetch task shutting down");
+}
+
+fn collect_prefetch_requests<'a, I>(
+    sender: Address,
+    fee_payer: Address,
+    fee_token: Address,
+    calls: I,
+) -> Vec<PrefetchRequest>
+where
+    I: IntoIterator<Item = (TxKind, &'a Bytes)>,
+{
+    let mut seen = HashSet::new();
+    let mut requests = Vec::new();
+
+    push_prefetch_request(
+        PrefetchRequest::new(fee_token, fee_payer, AuthRole::Sender),
+        &mut seen,
+        &mut requests,
+    );
+
+    for (kind, input) in calls {
+        let TxKind::Call(token) = kind else {
+            continue;
+        };
+        if !is_tip20_prefix(token) {
+            continue;
+        }
+
+        let Some((transfer_sender, recipient)) = decode_transfer_participants(sender, input) else {
+            continue;
+        };
+
+        push_prefetch_request(
+            PrefetchRequest::new(token, transfer_sender, AuthRole::Sender),
+            &mut seen,
+            &mut requests,
+        );
+        push_prefetch_request(
+            PrefetchRequest::new(token, recipient, AuthRole::Recipient),
+            &mut seen,
+            &mut requests,
+        );
+    }
+
+    requests
+}
+
+fn push_prefetch_request(
+    request: PrefetchRequest,
+    seen: &mut HashSet<PrefetchRequest>,
+    requests: &mut Vec<PrefetchRequest>,
+) {
+    if seen.insert(request) {
+        requests.push(request);
+    }
+}
+
+fn decode_transfer_participants(caller: Address, input: &[u8]) -> Option<(Address, Address)> {
+    let selector = *input.first_chunk::<4>()?;
+    let args = &input[4..];
+
+    match selector {
+        ITIP20::transferCall::SELECTOR => {
+            let call = ITIP20::transferCall::abi_decode_raw(args).ok()?;
+            Some((caller, call.to))
+        }
+        ITIP20::transferWithMemoCall::SELECTOR => {
+            let call = ITIP20::transferWithMemoCall::abi_decode_raw(args).ok()?;
+            Some((caller, call.to))
+        }
+        ITIP20::transferFromCall::SELECTOR => {
+            let call = ITIP20::transferFromCall::abi_decode_raw(args).ok()?;
+            Some((call.from, call.to))
+        }
+        ITIP20::transferFromWithMemoCall::SELECTOR => {
+            let call = ITIP20::transferFromWithMemoCall::abi_decode_raw(args).ok()?;
+            Some((call.from, call.to))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, U256, address};
+
+    #[test]
+    fn collects_transfer_from_sender_from_calldata() {
+        let sender = Address::repeat_byte(0x11);
+        let fee_payer = Address::repeat_byte(0x22);
+        let fee_token = address!("0x20C0000000000000000000000000000000000003");
+        let token = address!("0x20C0000000000000000000000000000000000001");
+        let from = Address::repeat_byte(0x44);
+        let to = Address::repeat_byte(0x55);
+        let amount = U256::from(7_u64);
+        let input: Bytes = ITIP20::transferFromCall { from, to, amount }
+            .abi_encode()
+            .into();
+        let calls = [(TxKind::Call(token), input)];
+
+        let requests = collect_prefetch_requests(
+            sender,
+            fee_payer,
+            fee_token,
+            calls.iter().map(|(kind, input)| (*kind, input)),
+        );
+
+        assert_eq!(
+            requests,
+            vec![
+                PrefetchRequest::new(fee_token, fee_payer, AuthRole::Sender),
+                PrefetchRequest::new(token, from, AuthRole::Sender),
+                PrefetchRequest::new(token, to, AuthRole::Recipient),
+            ]
+        );
+    }
+
+    #[test]
+    fn collects_all_batched_transfer_calls() {
+        let sender = Address::repeat_byte(0x11);
+        let fee_payer = Address::repeat_byte(0x22);
+        let fee_token = address!("0x20C0000000000000000000000000000000000003");
+        let token_a = address!("0x20C0000000000000000000000000000000000001");
+        let token_b = address!("0x20C0000000000000000000000000000000000002");
+        let to_a = Address::repeat_byte(0x44);
+        let from_b = Address::repeat_byte(0x55);
+        let to_b = Address::repeat_byte(0x66);
+        let amount = U256::from(7_u64);
+        let calls = [
+            (
+                TxKind::Call(token_a),
+                Bytes::from(ITIP20::transferCall { to: to_a, amount }.abi_encode()),
+            ),
+            (
+                TxKind::Call(token_b),
+                Bytes::from(
+                    ITIP20::transferFromCall {
+                        from: from_b,
+                        to: to_b,
+                        amount,
+                    }
+                    .abi_encode(),
+                ),
+            ),
+        ];
+
+        let requests = collect_prefetch_requests(
+            sender,
+            fee_payer,
+            fee_token,
+            calls.iter().map(|(kind, input)| (*kind, input)),
+        );
+
+        assert_eq!(
+            requests,
+            vec![
+                PrefetchRequest::new(fee_token, fee_payer, AuthRole::Sender),
+                PrefetchRequest::new(token_a, sender, AuthRole::Sender),
+                PrefetchRequest::new(token_a, to_a, AuthRole::Recipient),
+                PrefetchRequest::new(token_b, from_b, AuthRole::Sender),
+                PrefetchRequest::new(token_b, to_b, AuthRole::Recipient),
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_transfer_sender_when_fee_payer_differs_on_same_token() {
+        let sender = Address::repeat_byte(0x11);
+        let fee_payer = Address::repeat_byte(0x22);
+        let token = address!("0x20C0000000000000000000000000000000000001");
+        let to = Address::repeat_byte(0x44);
+        let amount = U256::from(7_u64);
+        let input: Bytes = ITIP20::transferCall { to, amount }.abi_encode().into();
+        let calls = [(TxKind::Call(token), input)];
+
+        let requests = collect_prefetch_requests(
+            sender,
+            fee_payer,
+            token,
+            calls.iter().map(|(kind, input)| (*kind, input)),
+        );
+
+        assert_eq!(
+            requests,
+            vec![
+                PrefetchRequest::new(token, fee_payer, AuthRole::Sender),
+                PrefetchRequest::new(token, sender, AuthRole::Sender),
+                PrefetchRequest::new(token, to, AuthRole::Recipient),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- prefetch TIP-403 policy requests across every top-level Tempo batch call instead of only the first exposed `kind()/input()` view
- decode `transferFrom*` calldata and warm the actual `from` sender rather than only the transaction sender
- dedupe repeated `(token, user, role)` prefetch requests within a single transaction before enqueueing them