### PR TITLE
feat(rpc): make auth token max validity configurable

### DIFF
--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -116,7 +116,7 @@ struct ZoneArgs {
     pub private_rpc_port: u16,
 
     /// Maximum auth token validity window the private RPC accepts, in seconds.
-    /// Must be less than or equal to the protocol maximum of 2592000 seconds (30 days).
+    /// The effective limit is capped at the 30 day protocol maximum.
     #[arg(
         long = "private-rpc.max-auth-token-validity-secs",
         env = "PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS",

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -16,7 +16,7 @@ use reth_ethereum::cli::Cli;
 use reth_ethereum::chainspec::EthChainSpec;
 use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
-use zone::{ZoneNode, evm::ZoneEvmConfig};
+use zone::{ZoneNode, evm::ZoneEvmConfig, rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS};
 use zone_primitives::constants::zone_chain_id;
 
 type ZoneCli = Cli<TempoChainSpecParser, ZoneArgs>;
@@ -114,6 +114,15 @@ struct ZoneArgs {
         default_value_t = 8544
     )]
     pub private_rpc_port: u16,
+
+    /// Maximum auth token validity window the private RPC accepts, in seconds.
+    /// Must be less than or equal to the protocol maximum of 2592000 seconds (30 days).
+    #[arg(
+        long = "private-rpc.max-auth-token-validity-secs",
+        env = "PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS",
+        default_value_t = DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS
+    )]
+    pub private_rpc_max_auth_token_validity_secs: u64,
 }
 
 fn prepend_log_filter(filter: &mut String, directives: &str) {
@@ -220,6 +229,9 @@ fn main() {
                 ),
                 zone_id: args.zone_id,
                 chain_id: handle.node.chain_spec().chain().id(),
+                max_auth_token_validity: Duration::from_secs(
+                    args.private_rpc_max_auth_token_validity_secs,
+                ),
                 zone_portal: args.portal_address,
                 sequencer: sequencer_addr,
             };

--- a/crates/rpc/src/auth/mod.rs
+++ b/crates/rpc/src/auth/mod.rs
@@ -4,5 +4,7 @@ mod token;
 
 pub use crate::error::AuthError;
 pub use token::{
-    AuthContext, AuthorizationToken, X_AUTHORIZATION_TOKEN, build_token_fields, parse_auth_header,
+    AuthContext, AuthorizationToken, DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
+    DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS, X_AUTHORIZATION_TOKEN, build_token_fields,
+    parse_auth_header,
 };

--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::{Address, B256, hex, keccak256};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::error::AuthError;
 
@@ -20,6 +20,13 @@ const TOKEN_FIELDS_LEN: usize = 1 + 4 + 8 + 8 + 8; // 29 bytes
 
 /// HTTP header name for the authorization token.
 pub const X_AUTHORIZATION_TOKEN: &str = "x-authorization-token";
+
+/// Protocol default maximum validity window for authorization tokens.
+pub const DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS: u64 = 2_592_000;
+
+/// Protocol default maximum validity window for authorization tokens.
+pub const DEFAULT_MAX_AUTH_TOKEN_VALIDITY: Duration =
+    Duration::from_secs(DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS);
 
 /// The authenticated caller context extracted from a valid authorization token.
 #[derive(Debug, Clone)]
@@ -101,6 +108,21 @@ impl AuthorizationToken {
     ///
     /// A `zone_id` of `0` is unscoped and accepted for any zone.
     pub fn validate(&self, expected_zone_id: u32, expected_chain_id: u64) -> Result<(), AuthError> {
+        self.validate_with_max_auth_token_validity(
+            expected_zone_id,
+            expected_chain_id,
+            DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
+        )
+    }
+
+    /// Validate token fields against the server's zone configuration and
+    /// a caller-provided maximum validity window.
+    pub fn validate_with_max_auth_token_validity(
+        &self,
+        expected_zone_id: u32,
+        expected_chain_id: u64,
+        max_auth_token_validity: Duration,
+    ) -> Result<(), AuthError> {
         if self.version != 0 {
             return Err(AuthError::UnsupportedVersion(self.version));
         }
@@ -110,7 +132,7 @@ impl AuthorizationToken {
         if self.chain_id != expected_chain_id {
             return Err(AuthError::ChainIdMismatch);
         }
-        if self.expires_at.saturating_sub(self.issued_at) > 2_592_000 {
+        if self.expires_at.saturating_sub(self.issued_at) > max_auth_token_validity.as_secs() {
             return Err(AuthError::WindowTooLarge);
         }
 

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -3,8 +3,6 @@
 use alloy_primitives::Address;
 use std::{net::SocketAddr, time::Duration};
 
-use crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY;
-
 /// Configuration for the private zone RPC server.
 #[derive(Debug, Clone)]
 pub struct PrivateRpcConfig {
@@ -29,19 +27,4 @@ pub struct PrivateRpcConfig {
     pub zone_portal: Address,
     /// The sequencer address — callers matching this get unredacted responses.
     pub sequencer: Address,
-}
-
-impl PrivateRpcConfig {
-    /// Validate the private RPC configuration before starting the server.
-    pub fn validate(&self) -> eyre::Result<()> {
-        if self.max_auth_token_validity > DEFAULT_MAX_AUTH_TOKEN_VALIDITY {
-            eyre::bail!(
-                "private RPC max auth token validity ({}s) exceeds protocol maximum ({}s)",
-                self.max_auth_token_validity.as_secs(),
-                DEFAULT_MAX_AUTH_TOKEN_VALIDITY.as_secs(),
-            );
-        }
-
-        Ok(())
-    }
 }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -3,6 +3,8 @@
 use alloy_primitives::Address;
 use std::{net::SocketAddr, time::Duration};
 
+use crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY;
+
 /// Configuration for the private zone RPC server.
 #[derive(Debug, Clone)]
 pub struct PrivateRpcConfig {
@@ -18,8 +20,28 @@ pub struct PrivateRpcConfig {
     pub zone_id: u32,
     /// The zone's chain ID.
     pub chain_id: u64,
+    /// Maximum authorization token validity window this server accepts.
+    ///
+    /// This may be configured lower than the protocol default to tighten local
+    /// policy, but it must not exceed the protocol maximum.
+    pub max_auth_token_validity: Duration,
     /// The ZonePortal contract address on L1 (used for querying deposits, not for auth tokens).
     pub zone_portal: Address,
     /// The sequencer address — callers matching this get unredacted responses.
     pub sequencer: Address,
+}
+
+impl PrivateRpcConfig {
+    /// Validate the private RPC configuration before starting the server.
+    pub fn validate(&self) -> eyre::Result<()> {
+        if self.max_auth_token_validity > DEFAULT_MAX_AUTH_TOKEN_VALIDITY {
+            eyre::bail!(
+                "private RPC max auth token validity ({}s) exceeds protocol maximum ({}s)",
+                self.max_auth_token_validity.as_secs(),
+                DEFAULT_MAX_AUTH_TOKEN_VALIDITY.as_secs(),
+            );
+        }
+
+        Ok(())
+    }
 }

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -16,7 +16,7 @@ pub enum AuthError {
     ZoneIdMismatch,
     #[error("chain ID mismatch")]
     ChainIdMismatch,
-    #[error("validity window too large (max 2592000s)")]
+    #[error("validity window too large")]
     WindowTooLarge,
     #[error("authorization token expired")]
     Expired,

--- a/crates/rpc/src/provider.rs
+++ b/crates/rpc/src/provider.rs
@@ -33,7 +33,9 @@ pub struct ZoneProviderConfig {
     pub zone_id: u32,
     /// Chain identifier.
     pub chain_id: u64,
-    /// How long each generated token is valid. Default: 600s, max: 2592000s (30 days).
+    /// How long each generated token is valid. Default: 600s.
+    /// Must not exceed the server's configured maximum validity window
+    /// (default protocol limit: 2592000s / 30 days).
     pub token_ttl: Duration,
     /// The private zone RPC URL.
     pub rpc_url: url::Url,

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -56,7 +56,6 @@ pub async fn start_private_rpc(
     config: PrivateRpcConfig,
     api: Arc<dyn ZoneRpcApi>,
 ) -> eyre::Result<std::net::SocketAddr> {
-    config.validate()?;
     let listen_addr = config.listen_addr;
     let state = Arc::new(RpcState {
         config,
@@ -218,12 +217,15 @@ pub(crate) async fn authenticate_token(
     api: &dyn ZoneRpcApi,
 ) -> Result<AuthContext, AuthenticateError> {
     let token = auth::parse_auth_header(token_value)?;
+    let max_auth_token_validity = config
+        .max_auth_token_validity
+        .min(auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY);
 
     // Validate token fields against server config
     token.validate_with_max_auth_token_validity(
         config.zone_id,
         config.chain_id,
-        config.max_auth_token_validity,
+        max_auth_token_validity,
     )?;
 
     let signature =
@@ -401,15 +403,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn config_rejects_auth_token_validity_over_protocol_maximum() {
-        let mut config = test_config();
-        config.max_auth_token_validity =
-            crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY + std::time::Duration::from_secs(1);
-
-        assert!(config.validate().is_err());
-    }
-
     #[tokio::test]
     async fn configured_auth_token_validity_limit_is_enforced() {
         let mut config = test_config();
@@ -427,6 +420,36 @@ mod tests {
         let err = authenticate_token(&token, &config, &api)
             .await
             .expect_err("token window should exceed configured maximum");
+        assert!(matches!(
+            err,
+            AuthenticateError::Invalid(crate::auth::AuthError::WindowTooLarge)
+        ));
+        assert_eq!(err.status_code(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn protocol_max_auth_token_validity_is_enforced_even_if_configured_higher() {
+        let mut config = test_config();
+        config.max_auth_token_validity =
+            crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY + std::time::Duration::from_secs(60);
+
+        let now = now_secs();
+        let (fields, _digest) = build_token_fields(
+            ZONE_ID,
+            CHAIN_ID,
+            now,
+            now + crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY.as_secs() + 1,
+        );
+        let mut blob = vec![0u8; 65];
+        blob.extend_from_slice(&fields);
+        let token = alloy_primitives::hex::encode(blob);
+        let api = TestApi {
+            key_infos: Mutex::new(HashMap::new()),
+        };
+
+        let err = authenticate_token(&token, &config, &api)
+            .await
+            .expect_err("token window should exceed protocol maximum");
         assert!(matches!(
             err,
             AuthenticateError::Invalid(crate::auth::AuthError::WindowTooLarge)

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -56,6 +56,7 @@ pub async fn start_private_rpc(
     config: PrivateRpcConfig,
     api: Arc<dyn ZoneRpcApi>,
 ) -> eyre::Result<std::net::SocketAddr> {
+    config.validate()?;
     let listen_addr = config.listen_addr;
     let state = Arc::new(RpcState {
         config,
@@ -219,7 +220,11 @@ pub(crate) async fn authenticate_token(
     let token = auth::parse_auth_header(token_value)?;
 
     // Validate token fields against server config
-    token.validate(config.zone_id, config.chain_id)?;
+    token.validate_with_max_auth_token_validity(
+        config.zone_id,
+        config.chain_id,
+        config.max_auth_token_validity,
+    )?;
 
     let signature =
         TempoSignature::from_bytes(&token.signature).map_err(|_| AuthError::InvalidSignature)?;
@@ -390,9 +395,43 @@ mod tests {
             retry_connection_interval: std::time::Duration::from_millis(100),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
+            max_auth_token_validity: crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
             zone_portal: PORTAL,
             sequencer: Address::ZERO,
         }
+    }
+
+    #[test]
+    fn config_rejects_auth_token_validity_over_protocol_maximum() {
+        let mut config = test_config();
+        config.max_auth_token_validity =
+            crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY + std::time::Duration::from_secs(1);
+
+        assert!(config.validate().is_err());
+    }
+
+    #[tokio::test]
+    async fn configured_auth_token_validity_limit_is_enforced() {
+        let mut config = test_config();
+        config.max_auth_token_validity = std::time::Duration::from_secs(60);
+
+        let now = now_secs();
+        let (fields, _digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
+        let mut blob = vec![0u8; 65];
+        blob.extend_from_slice(&fields);
+        let token = alloy_primitives::hex::encode(blob);
+        let api = TestApi {
+            key_infos: Mutex::new(HashMap::new()),
+        };
+
+        let err = authenticate_token(&token, &config, &api)
+            .await
+            .expect_err("token window should exceed configured maximum");
+        assert!(matches!(
+            err,
+            AuthenticateError::Invalid(crate::auth::AuthError::WindowTooLarge)
+        ));
+        assert_eq!(err.status_code(), StatusCode::FORBIDDEN);
     }
 
     #[tokio::test]

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -285,6 +285,7 @@ impl TestContext {
             retry_connection_interval: std::time::Duration::from_millis(100),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
+            max_auth_token_validity: zone_rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
             zone_portal: Address::ZERO,
             sequencer: signer.address(),
         };

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2768,6 +2768,7 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
         retry_connection_interval: Duration::from_millis(100),
         zone_id: 0,
         chain_id,
+        max_auth_token_validity: zone::rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
         zone_portal: Address::ZERO,
         sequencer: sequencer_address,
     };
@@ -2833,6 +2834,7 @@ async fn start_zone_with_private_rpc_l1_inner(
         retry_connection_interval: Duration::from_millis(100),
         zone_id: 1,
         chain_id,
+        max_auth_token_validity: zone::rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
         zone_portal: portal_address,
         sequencer: l1.dev_address(),
     };

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -464,7 +464,7 @@ graph TB
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
 | `--private-rpc.port` | 8544 | Private RPC server port |
-| `--private-rpc.max-auth-token-validity-secs` | 2592000 | Maximum auth token validity the private RPC accepts, in seconds (up to 30 days) |
+| `--private-rpc.max-auth-token-validity-secs` | 2592000 | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 
 ### Environment Variables
 
@@ -474,7 +474,7 @@ graph TB
 | `SEQUENCER_KEY` | For sequencing | Sequencer private key |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
-| `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds (up to 30 days) |
+| `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 
 ## Justfile Commands Reference

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -464,6 +464,7 @@ graph TB
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
 | `--private-rpc.port` | 8544 | Private RPC server port |
+| `--private-rpc.max-auth-token-validity-secs` | 2592000 | Maximum auth token validity the private RPC accepts, in seconds (up to 30 days) |
 
 ### Environment Variables
 
@@ -473,6 +474,7 @@ graph TB
 | `SEQUENCER_KEY` | For sequencing | Sequencer private key |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
+| `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds (up to 30 days) |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 
 ## Justfile Commands Reference

--- a/docs/pages/protocol/privacy/rpc.md
+++ b/docs/pages/protocol/privacy/rpc.md
@@ -118,11 +118,13 @@ The RPC server MUST reject authorization tokens where:
 
 - `zoneId` does not equal the zone's configured `zoneId` **and** `zoneId` is not `0` (an unscoped token with `zoneId == 0` is valid for any zone — see [Unscoped tokens](#unscoped-tokens)).
 - `chainId` does not equal the zone's configured chain ID (`eth_chainId`).
-- `expiresAt - issuedAt > 2592000` (maximum validity window is 30 days).
+- `expiresAt - issuedAt > 2592000` (protocol maximum validity window is 30 days).
 - `expiresAt <= now` (key has expired).
 - `issuedAt > now + 60` (clock skew tolerance of 60 seconds into the future).
 - The signature is malformed or does not verify.
 - For Keychain signatures: the signing key is not authorized, is revoked, or is expired in the AccountKeychain.
+
+Implementations MAY enforce a shorter local maximum validity window as configuration, but they MUST NOT accept tokens longer than 30 days.
 
 ### Sequencer access
 


### PR DESCRIPTION
## Summary

Make the private RPC server's maximum accepted auth-token validity window configurable while keeping the current 30 day default.

## What changed

- added `PrivateRpcConfig.max_auth_token_validity` and server-side config validation
- preserved the existing public `AuthorizationToken::validate(...)` default behavior, and added a configurable validation path for the server
- exposed `--private-rpc.max-auth-token-validity-secs` / `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` in `tempo-zone`
- kept the default at `2592000` seconds and rejected server configs above the protocol maximum
- updated RPC tests and docs to reflect the new server-side setting

## Why

The private RPC previously hardcoded the maximum auth-token validity window at 30 days in server-side validation. This change keeps the current default but lets operators tighten that server policy through config/CLI without changing token generation code.

## Validation

- `cargo test -p zone-rpc`
- `CARGO_TARGET_DIR=/Users/Matthias/git/rust/zones/target CARGO_INCREMENTAL=0 cargo check -p zone --tests`
- `CARGO_TARGET_DIR=/Users/Matthias/git/rust/zones/target CARGO_INCREMENTAL=0 cargo check -p tempo-zone --bin tempo-zone`

## Notes

- The configurable server-side maximum is capped at the existing 30 day protocol limit.
- I had to switch the latter two validations to `cargo check` because the machine ran low on disk space while linking large test binaries; the code changes themselves compiled successfully.