### PR TITLE
docs: add moderato zonefactory to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ just deploy-zone my-zone alphausd
 - Generate `generated/<name>/genesis.json` and `generated/<name>/zone.json`
 - Register the sequencer encryption key and start the zone node
 
+### Key Addresses
+
+| Contract | Address | Explorer |
+|----------|---------|----------|
+| ZoneFactory (moderato) | `0x7Cc496Dc634b718289c192b59CF90262C5228545` | [View on Moderato explorer](https://explore.moderato.tempo.xyz/address/0x7Cc496Dc634b718289c192b59CF90262C5228545) |
+
 `zone.json` stores the deployed portal address, zone ID, anchor block, and sequencer metadata used by later commands such as `just zone-up` and `just deploy-router`.
 
 To restart the same zone later:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ just deploy-zone my-zone alphausd
 |----------|---------|----------|
 | ZoneFactory (moderato) | `0x7Cc496Dc634b718289c192b59CF90262C5228545` | [View on Moderato explorer](https://explore.moderato.tempo.xyz/address/0x7Cc496Dc634b718289c192b59CF90262C5228545) |
 
+`just create-zone`, `just deploy-zone`, and `just zone-info` default to this Moderato `ZoneFactory`. `just deploy-router` also falls back to it when `zone.json` does not already include `zoneFactory`.
+
 `zone.json` stores the deployed portal address, zone ID, anchor block, and sequencer metadata used by later commands such as `just zone-up` and `just deploy-router`.
 
 To restart the same zone later:

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -449,6 +449,8 @@ graph TB
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
 | ZoneFactory (moderato) | `0x7Cc496Dc634b718289c192b59CF90262C5228545` |
 
+The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` falls back to it when `zone.json` does not already record `zoneFactory`.
+
 ### Zone Node CLI Options
 
 | Flag | Default | Description |

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -64,7 +64,7 @@ pub(crate) struct CreateZone {
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.
-    /// Default is the ZoneFactory deployed on moderato.
+    /// Defaults to `MODERATO_ZONE_FACTORY`, the shared Moderato deployment.
     #[arg(long, default_value_t = MODERATO_ZONE_FACTORY)]
     zone_factory: Address,
 

--- a/xtask/src/deploy_router.rs
+++ b/xtask/src/deploy_router.rs
@@ -33,7 +33,8 @@ pub(crate) struct DeployRouter {
     #[arg(long, env = "PRIVATE_KEY")]
     private_key: String,
 
-    /// ZoneFactory contract address. Falls back to zone.json, then the moderato default.
+    /// ZoneFactory contract address.
+    /// Falls back to `zone.json`, then `MODERATO_ZONE_FACTORY` on Moderato.
     #[arg(long)]
     zone_factory: Option<Address>,
 

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -18,6 +18,7 @@ pub(crate) struct ZoneInfoCmd {
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.
+    /// Defaults to `MODERATO_ZONE_FACTORY`, the shared Moderato deployment.
     #[arg(long, default_value_t = MODERATO_ZONE_FACTORY)]
     zone_factory: Address,
 }

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -16,6 +16,11 @@ use tempo_contracts::precompiles::ITIP20 as TIP20Token;
 use zone::abi::{ZoneInbox, ZonePortal};
 
 pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
+/// Shared ZoneFactory deployed on Moderato Tempo L1.
+/// `create-zone`, `deploy-router`, and `zone-info` use this as their default
+/// factory unless the caller overrides `--zone-factory` or `zone.json` already
+/// provides a zone-specific value.
+/// Explorer: https://explore.moderato.tempo.xyz/address/0x7Cc496Dc634b718289c192b59CF90262C5228545
 pub(crate) const MODERATO_ZONE_FACTORY: Address =
     address!("0x7Cc496Dc634b718289c192b59CF90262C5228545");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =


### PR DESCRIPTION
## Summary
- add the Moderato `ZoneFactory` address to the top-level README
- include a direct explorer link for the deployed contract address

## Why
The address already exists in `docs/ZONES.md`, but the main README did not surface it for users starting from the repository landing page.

## Validation
- reviewed the README diff locally
- confirmed the address and explorer URL match `docs/ZONES.md`
