### PR TITLE
docs: Add IZoneFactory NatSpec docs

### DIFF
--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -442,13 +442,36 @@ interface IZoneFactory {
     error InsufficientGas();
     error ZoneIdOverflow();
 
+    /// @notice Returns whether a verifier contract is approved for zone creation.
+    /// @param verifier The verifier contract address to check.
+    /// @return valid True if `verifier` can be passed to `createZone`.
     function isValidVerifier(address verifier) external view returns (bool);
+
+    /// @notice Creates a new zone and deploys its portal and messenger contracts.
+    /// @param params The initial token, sequencer, verifier, and genesis parameters for the zone.
+    /// @return zoneId The newly assigned zone ID.
+    /// @return portal The deployed portal address for the new zone.
     function createZone(CreateZoneParams calldata params)
         external
         returns (uint32 zoneId, address portal);
+
+    /// @notice Returns the number of zones created so far.
+    /// @return count The total number of created zones, excluding reserved zone ID 0.
     function zoneCount() external view returns (uint32);
+
+    /// @notice Returns the stored metadata for a zone.
+    /// @param zoneId The zone ID to query.
+    /// @return info The zone metadata recorded for `zoneId`.
     function zones(uint32 zoneId) external view returns (ZoneInfo memory);
+
+    /// @notice Returns whether an address is a portal deployed by this factory.
+    /// @param portal The portal address to check.
+    /// @return isPortal True if `portal` was created by this factory.
     function isZonePortal(address portal) external view returns (bool);
+
+    /// @notice Returns whether an address is a messenger deployed by this factory.
+    /// @param messenger The messenger address to check.
+    /// @return isMessenger True if `messenger` was created by this factory.
     function isZoneMessenger(address messenger) external view returns (bool);
 
 }


### PR DESCRIPTION
## Summary
- add NatSpec documentation for the `IZoneFactory` interface methods requested in `docs/specs/src/zone/IZone.sol`
- document the verifier check, zone creation entrypoint, and the zone/portal/messenger lookup helpers
- keep the diff scoped to interface comments only

## Why
These factory methods were missing inline interface documentation, which made the expected inputs and return values harder to understand from the ABI surface alone.

## Validation
- `git diff --check`
- `forge build src/zone/IZone.sol` (from `docs/specs`)

## Notes
- `forge fmt --check docs/specs/src/zone/IZone.sol` was intentionally not applied because the file already has broad pre-existing formatting drift and reformatting it would create unrelated churn in this PR.