### PR TITLE
fix: chunk zone log queries

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -57,6 +57,12 @@ const EIP2935_EFFECTIVE_WINDOW: u64 = EIP2935_HISTORY_WINDOW - EIP2935_SAFETY_MA
 /// Maximum number of pending withdrawal queue slots in the portal ring buffer.
 const WITHDRAWAL_QUEUE_CAPACITY: u64 = 100;
 
+/// Maximum zone-block span for a single `eth_getLogs` request during catch-up.
+///
+/// Large backlog scans can exceed the zone node's RPC response size limit if we
+/// query the entire unsent range in one request.
+pub(crate) const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
+
 /// Data required to submit a single batch to the ZonePortal on L1.
 ///
 /// Produced by the zone block builder and sent to [`BatchSubmitter`] via channel.
@@ -800,6 +806,9 @@ pub(crate) async fn fetch_slot_withdrawals(
         .WithdrawalRequested_filter()
         .from_block(from)
         .to_block(to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .concurrent(2)
         .query()
         .await?
         .into_iter()
@@ -821,6 +830,9 @@ pub(crate) async fn fetch_slot_withdrawals(
         .BatchFinalized_filter()
         .from_block(from)
         .to_block(to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .concurrent(2)
         .query()
         .await?
         .into_iter()
@@ -905,6 +917,20 @@ pub(crate) async fn fetch_slot_withdrawals(
     }
 
     Ok(withdrawals)
+}
+
+/// Lazily split an inclusive block range into bounded query windows.
+pub(crate) fn log_query_ranges(from: u64, to: u64) -> impl Iterator<Item = (u64, u64)> {
+    std::iter::successors(Some(from), move |&start| {
+        let end = start.saturating_add(LOG_QUERY_BLOCK_CHUNK - 1).min(to);
+        if end >= to { None } else { end.checked_add(1) }
+    })
+    .map(move |start| {
+        (
+            start,
+            start.saturating_add(LOG_QUERY_BLOCK_CHUNK - 1).min(to),
+        )
+    })
 }
 
 /// Classification of the EIP-2935 gap, returned by
@@ -1052,6 +1078,23 @@ mod tests {
         let withdrawals = vec![w0, w1, w2];
         let hash = abi::Withdrawal::queue_hash(&withdrawals[2..]);
         assert_eq!(find_processed_offset(&withdrawals, hash), Some(2));
+    }
+
+    #[test]
+    fn log_query_ranges_chunk_large_ranges() {
+        let end = 100 + (LOG_QUERY_BLOCK_CHUNK * 2) + 234;
+        let ranges: Vec<_> = log_query_ranges(100, end).collect();
+
+        assert_eq!(ranges.len(), 3);
+        assert_eq!(ranges[0], (100, 100 + LOG_QUERY_BLOCK_CHUNK - 1));
+        assert_eq!(
+            ranges[1],
+            (
+                100 + LOG_QUERY_BLOCK_CHUNK,
+                100 + (LOG_QUERY_BLOCK_CHUNK * 2) - 1
+            )
+        );
+        assert_eq!(ranges[2], (100 + (LOG_QUERY_BLOCK_CHUNK * 2), end));
     }
 
     fn test_batch_event(withdrawal_queue_hash: B256) -> abi::ZonePortal::BatchSubmitted {

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -39,7 +39,10 @@ use alloy_sol_types::{ContractError, SolInterface as _};
 
 use crate::{
     abi::{self, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
-    batch::{AnchorGapKind, BatchData, BatchSubmitter, ZoneBlockSnapshot, fetch_slot_withdrawals},
+    batch::{
+        AnchorGapKind, BatchData, BatchSubmitter, ZoneBlockSnapshot, fetch_slot_withdrawals,
+        log_query_ranges,
+    },
     withdrawals::SharedWithdrawalStore,
 };
 
@@ -316,22 +319,36 @@ impl ZoneMonitor {
     /// correct signal is `BatchFinalized` events with non-zero withdrawal hashes.
     async fn has_pending_withdrawals(&self, latest_block: u64) -> bool {
         let from = self.last_submitted_zone_block + 1;
-        match self
-            .outbox
-            .BatchFinalized_filter()
-            .from_block(from)
-            .to_block(latest_block)
-            .query()
-            .await
-        {
-            Ok(events) => events
-                .iter()
-                .any(|(event, _)| !event.withdrawalQueueHash.is_zero()),
-            Err(e) => {
-                warn!(error = %e, "Failed to check for finalized withdrawal batches");
-                false
+        for (chunk_from, chunk_to) in log_query_ranges(from, latest_block) {
+            match self
+                .outbox
+                .BatchFinalized_filter()
+                .from_block(chunk_from)
+                .to_block(chunk_to)
+                .query()
+                .await
+            {
+                Ok(events) => {
+                    if events
+                        .iter()
+                        .any(|(event, _)| !event.withdrawalQueueHash.is_zero())
+                    {
+                        return true;
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        from = chunk_from,
+                        to = chunk_to,
+                        error = %e,
+                        "Failed to check for finalized withdrawal batches"
+                    );
+                    return false;
+                }
             }
         }
+
+        false
     }
 
     /// Process a range of zone blocks as a single batch, or split into multiple


### PR DESCRIPTION
## Summary
- bound large zone log scans during catch-up to avoid oversized RPC responses from the zone node
- use Alloy `chunked()` queries for `fetch_slot_withdrawals()` on `WithdrawalRequested` and `BatchFinalized`
- keep `has_pending_withdrawals()` on a small manual chunk loop so it can short-circuit on the first non-zero withdrawal batch

## Why
When the zone monitor falls far behind, it can end up querying a very large `[from, to]` block range. That can make the zone node's `eth_getLogs` response exceed the RPC server size limit and leave the monitor stuck retrying the same backlog.

## Impact
This keeps the catch-up path from depending on a single huge log response while preserving the existing batching behavior.

## Validation
- `cargo fmt --all -- crates/tempo-zone/src/batch.rs crates/tempo-zone/src/zonemonitor.rs`
- `cargo test --manifest-path crates/tempo-zone/Cargo.toml log_query_ranges_chunk_large_ranges -- --nocapture`
- `cargo nextest run -p zone` in progress
- `cargo clippy -p zone --all-targets -- -D warnings` in progress