### PR TITLE
fix(evm): disable dex on zones

### DIFF
--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -4,8 +4,17 @@
 //! [`TempoStateReader`](crate::l1_state::TempoStateReader) precompile at
 //! [`TEMPO_STATE_READER_ADDRESS`](crate::abi::TEMPO_STATE_READER_ADDRESS).
 
-use std::sync::Arc;
-
+use crate::{
+    abi::{TEMPO_STATE_READER_ADDRESS, ZONE_TX_CONTEXT_ADDRESS},
+    executor::ZoneBlockExecutor,
+    l1_state::{L1StateProvider, PolicyProvider, SharedL1StateCache, TempoStateReader},
+    precompiles::{
+        AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
+        ZONE_TIP20_FACTORY_ADDRESS, ZONE_TIP403_PROXY_ADDRESS, ZoneTip20Token,
+        ZoneTip403ProxyRegistry, ZoneTokenFactory,
+    },
+    tx_context::ZoneTxContext,
+};
 use alloy_evm::{
     Database, Evm, EvmEnv, EvmFactory,
     block::{BlockExecutorFactory, BlockExecutorFor},
@@ -19,6 +28,7 @@ use reth_evm::{
     execute::{BlockAssembler, BlockAssemblerInput},
 };
 use reth_primitives_traits::{SealedBlock, SealedHeader};
+use std::sync::Arc;
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::TempoChainSpec;
 use tempo_evm::{
@@ -27,20 +37,14 @@ use tempo_evm::{
     evm::{TempoEvm, TempoEvmFactory},
 };
 use tempo_payload_types::TempoExecutionData;
-use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope};
-
-use crate::executor::ZoneBlockExecutor;
-
-use crate::{
-    abi::{TEMPO_STATE_READER_ADDRESS, ZONE_TX_CONTEXT_ADDRESS},
-    l1_state::{L1StateProvider, PolicyProvider, SharedL1StateCache, TempoStateReader},
-    precompiles::{
-        AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
-        ZONE_TIP20_FACTORY_ADDRESS, ZONE_TIP403_PROXY_ADDRESS, ZoneTip20Token,
-        ZoneTip403ProxyRegistry, ZoneTokenFactory,
-    },
-    tx_context::ZoneTxContext,
+use tempo_precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+    account_keychain::AccountKeychain, nonce::NonceManager, tip_fee_manager::TipFeeManager,
+    tip20::is_tip20_prefix, validator_config::ValidatorConfig,
+    validator_config_v2::ValidatorConfigV2,
 };
+use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope};
 
 type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
 
@@ -109,15 +113,6 @@ impl ZoneEvmFactory {
         // static map via `apply_precompile` and take priority over this.
         let zone_cfg = cfg.clone();
         precompiles.set_precompile_lookup(move |address: &alloy_primitives::Address| {
-            use tempo_precompiles::{
-                ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
-                TIP_FEE_MANAGER_ADDRESS, VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
-                account_keychain::AccountKeychain, nonce::NonceManager,
-                stablecoin_dex::StablecoinDEX, tip_fee_manager::TipFeeManager,
-                tip20::is_tip20_prefix, validator_config::ValidatorConfig,
-                validator_config_v2::ValidatorConfigV2,
-            };
-
             if is_tip20_prefix(*address) {
                 Some(ZoneTip20Token::create(
                     *address,
@@ -128,7 +123,9 @@ impl ZoneEvmFactory {
             } else if *address == TIP_FEE_MANAGER_ADDRESS {
                 Some(TipFeeManager::create_precompile(&zone_cfg))
             } else if *address == STABLECOIN_DEX_ADDRESS {
-                Some(StablecoinDEX::create_precompile(&zone_cfg))
+                // StablecoinDEX is disabled on zones, calls to this address
+                // fall through to `None` and revert as an empty account.
+                None
             } else if *address == NONCE_PRECOMPILE_ADDRESS {
                 Some(NonceManager::create_precompile(&zone_cfg))
             } else if *address == VALIDATOR_CONFIG_ADDRESS {

--- a/crates/tempo-zone/tests/it/main.rs
+++ b/crates/tempo-zone/tests/it/main.rs
@@ -5,6 +5,7 @@ mod deposit;
 mod e2e;
 mod enable_token;
 mod l1_e2e;
+mod precompiles;
 mod private_rpc;
 mod private_rpc_e2e;
 mod restart_e2e;

--- a/crates/tempo-zone/tests/it/precompiles.rs
+++ b/crates/tempo-zone/tests/it/precompiles.rs
@@ -1,0 +1,32 @@
+//! Tests for zone-specific precompile availability.
+
+use tempo_precompiles::PATH_USD_ADDRESS;
+
+use crate::utils::{
+    DEFAULT_TIMEOUT, TestStablecoinDEX, start_local_zone_with_fixture, STABLECOIN_DEX_ADDRESS,
+};
+
+/// The StablecoinDEX precompile should be disabled on zones — any call to
+/// it must revert.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dex_disabled_on_zone() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
+
+    // Inject an empty block so the zone is alive and processing.
+    fixture.inject_empty_block(zone.deposit_queue());
+    zone.wait_for_tempo_block_number(1, DEFAULT_TIMEOUT).await?;
+
+    // Attempt to call createPair on the DEX — should revert because the
+    // precompile is not registered on the zone.
+    let dex = TestStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, zone.provider());
+    let result = dex.createPair(PATH_USD_ADDRESS).call().await;
+
+    assert!(
+        result.is_err(),
+        "StablecoinDEX should be disabled on zones — createPair must revert"
+    );
+
+    Ok(())
+}

--- a/crates/tempo-zone/tests/it/precompiles.rs
+++ b/crates/tempo-zone/tests/it/precompiles.rs
@@ -3,7 +3,7 @@
 use tempo_precompiles::PATH_USD_ADDRESS;
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, TestStablecoinDEX, start_local_zone_with_fixture, STABLECOIN_DEX_ADDRESS,
+    DEFAULT_TIMEOUT, STABLECOIN_DEX_ADDRESS, TestStablecoinDEX, start_local_zone_with_fixture,
 };
 
 /// The StablecoinDEX precompile should be disabled on zones — any call to


### PR DESCRIPTION
This PR updates the Zone precompile dispatch logic to disable the StablecoinDEX on zones. 