### PR TITLE
fix(contracts): enforce usd based enabled tokens

### DIFF
--- a/docs/specs/src/zone/IZone.sol
+++ b/docs/specs/src/zone/IZone.sol
@@ -573,6 +573,7 @@ interface IZonePortal {
     error TokenNotEnabled();
     error DepositsNotActive();
     error TokenAlreadyEnabled();
+    error InvalidCurrency();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);

--- a/docs/specs/src/zone/ZonePortal.sol
+++ b/docs/specs/src/zone/ZonePortal.sol
@@ -209,6 +209,9 @@ contract ZonePortal is IZonePortal {
     function enableToken(address _token) external onlySequencer {
         if (_tokenConfigs[_token].enabled) revert TokenAlreadyEnabled();
         if (!TempoUtilities.isTIP20(_token)) revert TokenNotEnabled();
+        if (keccak256(bytes(ITIP20(_token).currency())) != keccak256(bytes("USD"))) {
+            revert InvalidCurrency();
+        }
         _enableTokenInternal(_token);
     }
 

--- a/docs/specs/test/zone/ZonePortal.t.sol
+++ b/docs/specs/test/zone/ZonePortal.t.sol
@@ -2397,4 +2397,31 @@ contract ZonePortalTest is BaseTest {
         );
     }
 
+    /*//////////////////////////////////////////////////////////////
+                         ENABLE TOKEN TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_enableToken_succeeds_for_usd() public {
+        // Create a USD token
+        TIP20 usdToken = TIP20(
+            factory.createToken("AlphaUSD", "aUSD", "USD", pathUSD, admin, bytes32("alphaUsd"))
+        );
+
+        // Enable it on the portal (admin is the sequencer)
+        portal.enableToken(address(usdToken));
+
+        assertTrue(portal.isTokenEnabled(address(usdToken)), "USD token should be enabled");
+    }
+
+    function test_enableToken_reverts_for_non_usd() public {
+        // Create a non-USD token (EUR)
+        TIP20 eurToken = TIP20(
+            factory.createToken("EuroStable", "EURs", "EUR", pathUSD, admin, bytes32("eurToken"))
+        );
+
+        // Enabling a non-USD token on the portal should revert
+        vm.expectRevert(IZonePortal.InvalidCurrency.selector);
+        portal.enableToken(address(eurToken));
+    }
+
 }


### PR DESCRIPTION
This PR restricts `ZonePortal.enableToken()` to only accept USD denominated TIP-20 tokens, reverting with `InvalidCurrency` for non USD tokens. This PR also adds spec tests verifying USD tokens enable successfully and non-USD tokens are rejected.