### PR TITLE
fix(zone): harden withdrawal repair resync

### DIFF
--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -122,6 +122,7 @@ pub async fn spawn_zone_sequencer(
 
     let withdrawal_store: SharedWithdrawalStore = Default::default();
     let withdrawal_notify = Arc::new(Notify::new());
+    let withdrawal_repair_notify = Arc::new(Notify::new());
 
     let withdrawal_config = WithdrawalProcessorConfig {
         portal_address: config.portal_address,
@@ -145,12 +146,14 @@ pub async fn spawn_zone_sequencer(
         l1_provider.clone(),
         withdrawal_store.clone(),
         withdrawal_notify.clone(),
+        withdrawal_repair_notify.clone(),
     );
     let monitor_handle = spawn_zone_monitor(
         monitor_config,
         l1_provider,
         withdrawal_store,
         withdrawal_notify,
+        withdrawal_repair_notify,
     );
 
     ZoneSequencerHandle {

--- a/crates/tempo-zone/src/metrics.rs
+++ b/crates/tempo-zone/src/metrics.rs
@@ -111,4 +111,7 @@ pub(crate) struct ZoneMonitorMetrics {
 
     /// Number of times local monitor state was resynced from the portal.
     pub resync_from_portal_total: Counter,
+
+    /// Failed attempts to rebuild the in-memory withdrawal store from chain state.
+    pub withdrawal_store_restore_failure_total: Counter,
 }

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -109,6 +109,11 @@ impl WithdrawalStore {
         self.batches.insert(batch_index, withdrawals);
     }
 
+    /// Replace the entire store with an authoritative set of pending batches.
+    pub(crate) fn replace_batches(&mut self, batches: BTreeMap<u64, Vec<abi::Withdrawal>>) {
+        self.batches = batches;
+    }
+
     /// Get all withdrawals for a batch.
     pub fn get_batch(&self, batch_index: u64) -> Option<&Vec<abi::Withdrawal>> {
         self.batches.get(&batch_index)
@@ -125,6 +130,32 @@ impl WithdrawalStore {
 
     pub fn batch_count(&self) -> usize {
         self.batches.len()
+    }
+
+    /// Return the smallest and largest portal slot indices currently present.
+    fn slot_range(&self) -> Option<(u64, u64)> {
+        let first = *self.batches.keys().next()?;
+        let last = *self.batches.keys().next_back()?;
+        Some((first, last))
+    }
+
+    /// Return a compact summary of the store as `(batch_count, first_slot, last_slot)`.
+    pub(crate) fn summary(&self) -> (usize, Option<u64>, Option<u64>) {
+        let (first_slot, last_slot) = self
+            .slot_range()
+            .map_or((None, None), |(first, last)| (Some(first), Some(last)));
+        (self.batch_count(), first_slot, last_slot)
+    }
+
+    /// Return the nearest populated slots before and after `slot`, if any exist.
+    fn neighboring_slots(&self, slot: u64) -> (Option<u64>, Option<u64>) {
+        let prev = self.batches.range(..slot).next_back().map(|(&idx, _)| idx);
+        let next = self
+            .batches
+            .range(slot.saturating_add(1)..)
+            .next()
+            .map(|(&idx, _)| idx);
+        (prev, next)
     }
 }
 
@@ -173,6 +204,8 @@ pub struct WithdrawalProcessor {
     portal: ZonePortal::ZonePortalInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     store: SharedWithdrawalStore,
     notify: Arc<Notify>,
+    repair_notify: Arc<Notify>,
+    last_repair_request_at: Option<Instant>,
     metrics: WithdrawalProcessorMetrics,
 }
 
@@ -185,6 +218,7 @@ impl WithdrawalProcessor {
         provider: DynProvider<TempoNetwork>,
         store: SharedWithdrawalStore,
         notify: Arc<Notify>,
+        repair_notify: Arc<Notify>,
     ) -> Self {
         let portal = ZonePortal::new(config.portal_address, provider);
 
@@ -193,8 +227,25 @@ impl WithdrawalProcessor {
             portal,
             store,
             notify,
+            repair_notify,
+            last_repair_request_at: None,
             metrics: WithdrawalProcessorMetrics::default(),
         }
+    }
+
+    /// Request a monitor-side repair, but no more frequently than the fallback poll interval.
+    fn request_monitor_repair(&mut self) -> bool {
+        let now = Instant::now();
+        if self
+            .last_repair_request_at
+            .is_some_and(|last| now.duration_since(last) < self.config.fallback_poll_interval)
+        {
+            return false;
+        }
+
+        self.last_repair_request_at = Some(now);
+        self.repair_notify.notify_one();
+        true
     }
 
     /// Run the processor loop. This method never returns under normal operation.
@@ -229,7 +280,27 @@ impl WithdrawalProcessor {
 
         let head_val: u64 = head.try_into().map_err(|_| eyre::eyre!("head overflow"))?;
         let tail_val: u64 = tail.try_into().map_err(|_| eyre::eyre!("tail overflow"))?;
-        let store_batch_count = self.store.lock().batch_count();
+        let (
+            store_batch_count,
+            withdrawals,
+            store_first_slot,
+            store_last_slot,
+            prev_store_slot,
+            next_store_slot,
+        ) = {
+            let store = self.store.lock();
+            let (store_batch_count, store_first_slot, store_last_slot) = store.summary();
+            let withdrawals = store.get_batch(head_val).cloned();
+            let (prev_store_slot, next_store_slot) = store.neighboring_slots(head_val);
+            (
+                store_batch_count,
+                withdrawals,
+                store_first_slot,
+                store_last_slot,
+                prev_store_slot,
+                next_store_slot,
+            )
+        };
         self.record_queue_metrics(head_val, tail_val, store_batch_count);
 
         if head_val == tail_val {
@@ -245,18 +316,21 @@ impl WithdrawalProcessor {
             "Withdrawal queue has pending slots"
         );
 
-        let withdrawals = {
-            let store = self.store.lock();
-            store.get_batch(head_val).cloned()
-        };
-
         let withdrawals = match withdrawals {
             Some(w) if !w.is_empty() => w,
             _ => {
+                let repair_request_sent = self.request_monitor_repair();
                 warn!(
                     slot = head_val,
-                    store_batches = self.store.lock().batch_count(),
-                    "No withdrawal data in store for current head slot, waiting for data"
+                    tail = tail_val,
+                    pending_slots,
+                    store_batches = store_batch_count,
+                    store_first_slot,
+                    store_last_slot,
+                    prev_store_slot,
+                    next_store_slot,
+                    repair_request_sent,
+                    "No withdrawal data in store for current head slot"
                 );
                 return Ok(());
             }
@@ -413,9 +487,11 @@ pub fn spawn_withdrawal_processor(
     provider: DynProvider<TempoNetwork>,
     store: SharedWithdrawalStore,
     notify: Arc<Notify>,
+    repair_notify: Arc<Notify>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let mut processor = WithdrawalProcessor::new(config, provider, store, notify);
+        let mut processor =
+            WithdrawalProcessor::new(config, provider, store, notify, repair_notify);
         loop {
             if let Err(e) = processor.run().await {
                 error!(error = %e, "Withdrawal processor failed, restarting in 5s");
@@ -429,8 +505,22 @@ pub fn spawn_withdrawal_processor(
 mod tests {
     use super::*;
     use crate::abi::EMPTY_SENTINEL;
-    use alloy_primitives::{address, keccak256};
+    use alloy_primitives::{Bytes, U256, address, keccak256};
+    use alloy_provider::{Provider, ProviderBuilder};
     use alloy_sol_types::SolValue;
+    use alloy_transport::mock::Asserter;
+    use tempo_alloy::TempoNetwork;
+    use tokio::time::timeout;
+
+    fn mock_provider(asserter: Asserter) -> DynProvider<TempoNetwork> {
+        ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_mocked_client(asserter)
+            .erased()
+    }
+
+    fn abi_encode_u64(value: u64) -> Bytes {
+        Bytes::copy_from_slice(&U256::from(value).to_be_bytes::<32>())
+    }
 
     fn test_withdrawal(to: Address, amount: u128) -> abi::Withdrawal {
         abi::Withdrawal {
@@ -586,5 +676,100 @@ mod tests {
 
         store.add_batch(1, vec![test_withdrawal(addr, 999)]);
         assert_eq!(store.batch_count(), 2);
+    }
+
+    #[test]
+    fn store_replace_batches_reconciles_authoritative_view() {
+        let mut store = WithdrawalStore::new();
+        let addr = address!("0x0000000000000000000000000000000000000042");
+
+        store.add_batch(0, vec![test_withdrawal(addr, 100)]);
+        store.add_batch(9, vec![test_withdrawal(addr, 900)]);
+
+        let mut reconciled = BTreeMap::new();
+        reconciled.insert(5, vec![test_withdrawal(addr, 500)]);
+        reconciled.insert(6, vec![test_withdrawal(addr, 600)]);
+
+        store.replace_batches(reconciled);
+
+        assert!(!store.has_batch(0));
+        assert!(!store.has_batch(9));
+        assert!(store.has_batch(5));
+        assert!(store.has_batch(6));
+        assert_eq!(store.batch_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn process_queue_requests_monitor_resync_when_head_slot_missing() {
+        let l1 = Asserter::new();
+        l1.push_success(&abi_encode_u64(51));
+        l1.push_success(&abi_encode_u64(71));
+
+        let config = WithdrawalProcessorConfig {
+            portal_address: address!("0x7069DeC4E64Fd07334A0933eDe836C17259c9B23"),
+            l1_rpc_url: "http://unused.test".to_string(),
+            fallback_poll_interval: Duration::from_secs(1),
+        };
+        let notify = Arc::new(Notify::new());
+        let repair_notify = Arc::new(Notify::new());
+        let mut processor = WithdrawalProcessor::new(
+            config,
+            mock_provider(l1.clone()),
+            SharedWithdrawalStore::new(),
+            notify,
+            repair_notify.clone(),
+        );
+
+        processor.process_queue().await.unwrap();
+
+        timeout(Duration::from_millis(50), repair_notify.notified())
+            .await
+            .expect("missing head slot should request a monitor resync");
+        assert!(l1.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_queue_throttles_repeated_monitor_repair_requests() {
+        let l1 = Asserter::new();
+        for _ in 0..3 {
+            l1.push_success(&abi_encode_u64(51));
+            l1.push_success(&abi_encode_u64(71));
+        }
+
+        let config = WithdrawalProcessorConfig {
+            portal_address: address!("0x7069DeC4E64Fd07334A0933eDe836C17259c9B23"),
+            l1_rpc_url: "http://unused.test".to_string(),
+            fallback_poll_interval: Duration::from_millis(50),
+        };
+        let notify = Arc::new(Notify::new());
+        let repair_notify = Arc::new(Notify::new());
+        let mut processor = WithdrawalProcessor::new(
+            config,
+            mock_provider(l1.clone()),
+            SharedWithdrawalStore::new(),
+            notify,
+            repair_notify.clone(),
+        );
+
+        processor.process_queue().await.unwrap();
+        timeout(Duration::from_millis(20), repair_notify.notified())
+            .await
+            .expect("first missing head slot should request a monitor resync");
+
+        processor.process_queue().await.unwrap();
+        assert!(
+            timeout(Duration::from_millis(20), repair_notify.notified())
+                .await
+                .is_err(),
+            "repeat repair requests should be throttled"
+        );
+
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        processor.process_queue().await.unwrap();
+        timeout(Duration::from_millis(20), repair_notify.notified())
+            .await
+            .expect("repair requests should resume after the cooldown");
+        assert!(l1.read_q().is_empty());
     }
 }

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -205,7 +205,6 @@ pub struct WithdrawalProcessor {
     store: SharedWithdrawalStore,
     notify: Arc<Notify>,
     repair_notify: Arc<Notify>,
-    last_repair_request_at: Option<Instant>,
     metrics: WithdrawalProcessorMetrics,
 }
 
@@ -228,24 +227,8 @@ impl WithdrawalProcessor {
             store,
             notify,
             repair_notify,
-            last_repair_request_at: None,
             metrics: WithdrawalProcessorMetrics::default(),
         }
-    }
-
-    /// Request a monitor-side repair, but no more frequently than the fallback poll interval.
-    fn request_monitor_repair(&mut self) -> bool {
-        let now = Instant::now();
-        if self
-            .last_repair_request_at
-            .is_some_and(|last| now.duration_since(last) < self.config.fallback_poll_interval)
-        {
-            return false;
-        }
-
-        self.last_repair_request_at = Some(now);
-        self.repair_notify.notify_one();
-        true
     }
 
     /// Run the processor loop. This method never returns under normal operation.
@@ -319,7 +302,7 @@ impl WithdrawalProcessor {
         let withdrawals = match withdrawals {
             Some(w) if !w.is_empty() => w,
             _ => {
-                let repair_request_sent = self.request_monitor_repair();
+                self.repair_notify.notify_one();
                 warn!(
                     slot = head_val,
                     tail = tail_val,
@@ -329,7 +312,6 @@ impl WithdrawalProcessor {
                     store_last_slot,
                     prev_store_slot,
                     next_store_slot,
-                    repair_request_sent,
                     "No withdrawal data in store for current head slot"
                 );
                 return Ok(());
@@ -725,51 +707,6 @@ mod tests {
         timeout(Duration::from_millis(50), repair_notify.notified())
             .await
             .expect("missing head slot should request a monitor resync");
-        assert!(l1.read_q().is_empty());
-    }
-
-    #[tokio::test]
-    async fn process_queue_throttles_repeated_monitor_repair_requests() {
-        let l1 = Asserter::new();
-        for _ in 0..3 {
-            l1.push_success(&abi_encode_u64(51));
-            l1.push_success(&abi_encode_u64(71));
-        }
-
-        let config = WithdrawalProcessorConfig {
-            portal_address: address!("0x7069DeC4E64Fd07334A0933eDe836C17259c9B23"),
-            l1_rpc_url: "http://unused.test".to_string(),
-            fallback_poll_interval: Duration::from_millis(50),
-        };
-        let notify = Arc::new(Notify::new());
-        let repair_notify = Arc::new(Notify::new());
-        let mut processor = WithdrawalProcessor::new(
-            config,
-            mock_provider(l1.clone()),
-            SharedWithdrawalStore::new(),
-            notify,
-            repair_notify.clone(),
-        );
-
-        processor.process_queue().await.unwrap();
-        timeout(Duration::from_millis(20), repair_notify.notified())
-            .await
-            .expect("first missing head slot should request a monitor resync");
-
-        processor.process_queue().await.unwrap();
-        assert!(
-            timeout(Duration::from_millis(20), repair_notify.notified())
-                .await
-                .is_err(),
-            "repeat repair requests should be throttled"
-        );
-
-        tokio::time::sleep(Duration::from_millis(60)).await;
-
-        processor.process_queue().await.unwrap();
-        timeout(Duration::from_millis(20), repair_notify.notified())
-            .await
-            .expect("repair requests should resume after the cooldown");
         assert!(l1.read_q().is_empty());
     }
 }

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -240,6 +240,10 @@ impl WithdrawalProcessor {
         }
     }
 
+    /// Read the current store contents relevant to `slot` under a single lock.
+    ///
+    /// This keeps the diagnostic fields used in missing-slot logs consistent
+    /// with each other and with the batch lookup result.
     fn capture_store_snapshot(&self, slot: u64) -> StoreSnapshot {
         let store = self.store.lock();
         let (batch_count, first_slot, last_slot) = store.summary();

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -186,6 +186,15 @@ pub fn compute_remaining_queue(withdrawals: &[abi::Withdrawal], processed_count:
 //  Withdrawal processor
 // ---------------------------------------------------------------------------
 
+struct StoreSnapshot {
+    batch_count: usize,
+    first_slot: Option<u64>,
+    last_slot: Option<u64>,
+    prev_slot: Option<u64>,
+    next_slot: Option<u64>,
+    withdrawals: Option<Vec<abi::Withdrawal>>,
+}
+
 /// Background task that processes withdrawals from the ZonePortal queue on Tempo L1.
 ///
 /// The processor waits for a [`Notify`] signal from the batch submitter (indicating a batch
@@ -206,15 +215,6 @@ pub struct WithdrawalProcessor {
     notify: Arc<Notify>,
     repair_notify: Arc<Notify>,
     metrics: WithdrawalProcessorMetrics,
-}
-
-struct StoreSnapshot {
-    batch_count: usize,
-    first_slot: Option<u64>,
-    last_slot: Option<u64>,
-    prev_slot: Option<u64>,
-    next_slot: Option<u64>,
-    withdrawals: Option<Vec<abi::Withdrawal>>,
 }
 
 impl WithdrawalProcessor {

--- a/crates/tempo-zone/src/withdrawals.rs
+++ b/crates/tempo-zone/src/withdrawals.rs
@@ -208,6 +208,15 @@ pub struct WithdrawalProcessor {
     metrics: WithdrawalProcessorMetrics,
 }
 
+struct StoreSnapshot {
+    batch_count: usize,
+    first_slot: Option<u64>,
+    last_slot: Option<u64>,
+    prev_slot: Option<u64>,
+    next_slot: Option<u64>,
+    withdrawals: Option<Vec<abi::Withdrawal>>,
+}
+
 impl WithdrawalProcessor {
     /// Create a new withdrawal processor from a shared L1 provider.
     ///
@@ -228,6 +237,21 @@ impl WithdrawalProcessor {
             notify,
             repair_notify,
             metrics: WithdrawalProcessorMetrics::default(),
+        }
+    }
+
+    fn capture_store_snapshot(&self, slot: u64) -> StoreSnapshot {
+        let store = self.store.lock();
+        let (batch_count, first_slot, last_slot) = store.summary();
+        let (prev_slot, next_slot) = store.neighboring_slots(slot);
+
+        StoreSnapshot {
+            batch_count,
+            first_slot,
+            last_slot,
+            prev_slot,
+            next_slot,
+            withdrawals: store.get_batch(slot).cloned(),
         }
     }
 
@@ -263,27 +287,14 @@ impl WithdrawalProcessor {
 
         let head_val: u64 = head.try_into().map_err(|_| eyre::eyre!("head overflow"))?;
         let tail_val: u64 = tail.try_into().map_err(|_| eyre::eyre!("tail overflow"))?;
-        let (
-            store_batch_count,
+        let StoreSnapshot {
+            batch_count: store_batch_count,
+            first_slot: store_first_slot,
+            last_slot: store_last_slot,
+            prev_slot: prev_store_slot,
+            next_slot: next_store_slot,
             withdrawals,
-            store_first_slot,
-            store_last_slot,
-            prev_store_slot,
-            next_store_slot,
-        ) = {
-            let store = self.store.lock();
-            let (store_batch_count, store_first_slot, store_last_slot) = store.summary();
-            let withdrawals = store.get_batch(head_val).cloned();
-            let (prev_store_slot, next_store_slot) = store.neighboring_slots(head_val);
-            (
-                store_batch_count,
-                withdrawals,
-                store_first_slot,
-                store_last_slot,
-                prev_store_slot,
-                next_store_slot,
-            )
-        };
+        } = self.capture_store_snapshot(head_val);
         self.record_queue_metrics(head_val, tail_val, store_batch_count);
 
         if head_val == tail_val {

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -104,6 +104,9 @@ pub struct ZoneMonitor {
     /// Notifier for the withdrawal processor — signalled after each successful
     /// batch submission so it can process newly enqueued withdrawal slots.
     withdrawal_notify: Arc<Notify>,
+    /// Notifier from the withdrawal processor when the current portal head slot
+    /// is missing from the in-memory store and a full portal resync is needed.
+    repair_notify: Arc<Notify>,
     /// Last **Zone L2** block number that was successfully submitted to L1.
     last_submitted_zone_block: u64,
     /// Deposit queue hash from the previous block, used to construct the
@@ -134,6 +137,7 @@ impl ZoneMonitor {
         l1_provider: DynProvider<TempoNetwork>,
         withdrawal_store: SharedWithdrawalStore,
         withdrawal_notify: Arc<Notify>,
+        repair_notify: Arc<Notify>,
     ) -> Result<Self> {
         let zone_rpc_url = config.zone_rpc_url.clone();
         let retry_layer = RetryBackoffLayer::new(
@@ -159,6 +163,7 @@ impl ZoneMonitor {
             l1_provider,
             withdrawal_store,
             withdrawal_notify,
+            repair_notify,
         )
         .await
     }
@@ -169,6 +174,7 @@ impl ZoneMonitor {
         l1_provider: DynProvider<TempoNetwork>,
         withdrawal_store: SharedWithdrawalStore,
         withdrawal_notify: Arc<Notify>,
+        repair_notify: Arc<Notify>,
     ) -> Result<Self> {
         let metrics = crate::metrics::ZoneMonitorMetrics::default();
         let outbox = ZoneOutbox::new(config.outbox_address, provider.clone());
@@ -211,32 +217,6 @@ impl ZoneMonitor {
             "Initialized from portal state"
         );
 
-        // Restore pending withdrawal data from zone L2 events so the
-        // withdrawal processor can pick up where it left off.
-        let pending = batch_submitter
-            .fetch_pending_withdrawals(&provider, config.outbox_address)
-            .await
-            .wrap_err("failed to restore pending withdrawals during zone monitor startup")?;
-
-        if !pending.is_empty() {
-            let mut store = withdrawal_store.lock();
-            let mut total = 0usize;
-            for (portal_slot, withdrawals) in pending {
-                let count = withdrawals.len();
-                store.add_batch(portal_slot, withdrawals);
-                info!(
-                    portal_slot,
-                    count, "Restored withdrawals for portal queue slot"
-                );
-                total += count;
-            }
-            drop(store);
-            info!(total, "Restored pending withdrawals from zone L2 events");
-            withdrawal_notify.notify_one();
-        } else {
-            info!("No pending withdrawals to restore");
-        }
-
         metrics
             .latest_zone_block_observed
             .set(last_submitted_zone_block as f64);
@@ -245,7 +225,7 @@ impl ZoneMonitor {
             .set(last_submitted_zone_block as f64);
         metrics.zone_to_l1_submission_lag_blocks.set(0.0);
 
-        Ok(Self {
+        let monitor = Self {
             config,
             metrics,
             provider,
@@ -255,12 +235,22 @@ impl ZoneMonitor {
             withdrawal_store,
             batch_submitter,
             withdrawal_notify,
+            repair_notify,
             last_submitted_zone_block,
             prev_processed_deposit_hash,
             prev_zone_block_hash,
             portal_withdrawal_queue_tail,
             latest_observed_zone_block: last_submitted_zone_block,
-        })
+        };
+
+        // Restore pending withdrawal data from zone L2 events so the
+        // withdrawal processor can pick up where it left off.
+        monitor
+            .restore_pending_withdrawals_from_chain()
+            .await
+            .wrap_err("failed to restore pending withdrawals during zone monitor startup")?;
+
+        Ok(monitor)
     }
 
     /// Run the monitor loop. This method never returns under normal operation.
@@ -285,7 +275,13 @@ impl ZoneMonitor {
         let mut batch_deadline = tokio::time::Instant::now();
 
         loop {
-            poll.tick().await;
+            tokio::select! {
+                _ = poll.tick() => {}
+                _ = self.repair_notify.notified() => {
+                    self.repair_missing_withdrawal_slot().await;
+                    continue;
+                }
+            }
 
             let Ok(latest_zone_block) = self.provider.get_block_number().await else {
                 continue;
@@ -309,6 +305,72 @@ impl ZoneMonitor {
 
             batch_deadline = tokio::time::Instant::now() + self.config.batch_interval;
         }
+    }
+
+    /// Rebuild the in-memory withdrawal store from authoritative chain state.
+    ///
+    /// The L1 portal only stores queue hashes, so the monitor reconstructs the
+    /// pending withdrawal payloads from L1 + zone-L2 events and replaces the
+    /// local store with that result. Used during startup and after a portal
+    /// resync when local withdrawal data may be stale or missing.
+    async fn restore_pending_withdrawals_from_chain(&self) -> Result<()> {
+        let pending = match self
+            .batch_submitter
+            .fetch_pending_withdrawals(&self.provider, self.config.outbox_address)
+            .await
+        {
+            Ok(pending) => pending,
+            Err(err) => {
+                self.metrics
+                    .withdrawal_store_restore_failure_total
+                    .increment(1);
+                return Err(err);
+            }
+        };
+        let restored_withdrawals = pending.values().map(Vec::len).sum::<usize>();
+        let reconciled_first_slot = pending.keys().next().copied();
+        let reconciled_last_slot = pending.keys().next_back().copied();
+
+        let mut store = self.withdrawal_store.lock();
+        let (previous_slots, previous_first_slot, previous_last_slot) = store.summary();
+        store.replace_batches(pending);
+        let reconciled_slots = store.batch_count();
+        drop(store);
+
+        if reconciled_slots > 0 {
+            info!(
+                previous_slots,
+                previous_first_slot,
+                previous_last_slot,
+                reconciled_slots,
+                reconciled_first_slot,
+                reconciled_last_slot,
+                restored_withdrawals,
+                "Restored pending withdrawals from chain"
+            );
+            self.withdrawal_notify.notify_one();
+        } else if previous_slots > 0 {
+            info!(
+                previous_slots,
+                previous_first_slot,
+                previous_last_slot,
+                "Cleared stale withdrawal batches after restoring pending withdrawals from chain"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Repair monitor state after the withdrawal processor reports a missing head slot.
+    ///
+    /// This intentionally goes through a full portal resync rather than only
+    /// rebuilding the withdrawal store. An ambiguous `submitBatch` outcome can
+    /// leave both the portal anchor and the in-memory withdrawal data stale, so
+    /// the monitor first reloads the portal-confirmed anchor and then rebuilds
+    /// pending withdrawals from chain state.
+    async fn repair_missing_withdrawal_slot(&mut self) {
+        warn!("Withdrawal processor reported a missing portal head slot");
+        self.resync_from_portal().await;
     }
 
     /// Check if any zone blocks since `last_submitted_zone_block` contain finalized
@@ -689,6 +751,14 @@ impl ZoneMonitor {
         let old_hash = self.prev_zone_block_hash;
         let old_tail = self.portal_withdrawal_queue_tail;
         let old_last_submitted = self.last_submitted_zone_block;
+        let (
+            store_batches_before_resync,
+            store_first_slot_before_resync,
+            store_last_slot_before_resync,
+        ) = {
+            let store = self.withdrawal_store.lock();
+            store.summary()
+        };
         match tokio::try_join!(
             self.batch_submitter.read_portal_block_hash(),
             self.batch_submitter.read_portal_withdrawal_queue_tail(),
@@ -710,6 +780,9 @@ impl ZoneMonitor {
                     new_last_submitted_zone_block = last_submitted_zone_block,
                     old_portal_tail = old_tail,
                     new_portal_tail = portal_tail,
+                    store_batches_before_resync,
+                    store_first_slot_before_resync,
+                    store_last_slot_before_resync,
                     %deposit_hash,
                     "Resynced from portal and zone state"
                 );
@@ -721,6 +794,21 @@ impl ZoneMonitor {
                     .latest_zone_block_submitted_to_l1
                     .set(last_submitted_zone_block as f64);
                 self.update_submission_lag();
+                if let Err(e) = self.restore_pending_withdrawals_from_chain().await {
+                    let (stale_store_batches, stale_store_first_slot, stale_store_last_slot) = {
+                        let mut store = self.withdrawal_store.lock();
+                        let summary = store.summary();
+                        store.replace_batches(Default::default());
+                        summary
+                    };
+                    error!(
+                        error = %e,
+                        stale_store_batches,
+                        stale_store_first_slot,
+                        stale_store_last_slot,
+                        "Failed to restore pending withdrawals during portal resync; cleared local withdrawal store"
+                    );
+                }
             }
             Err(e) => {
                 error!(
@@ -815,6 +903,7 @@ pub fn spawn_zone_monitor(
     l1_provider: DynProvider<TempoNetwork>,
     withdrawal_store: SharedWithdrawalStore,
     withdrawal_notify: Arc<Notify>,
+    repair_notify: Arc<Notify>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut monitor = loop {
@@ -823,6 +912,7 @@ pub fn spawn_zone_monitor(
                 l1_provider.clone(),
                 withdrawal_store.clone(),
                 withdrawal_notify.clone(),
+                repair_notify.clone(),
             )
             .await
             {
@@ -923,6 +1013,7 @@ mod tests {
             withdrawal_store: SharedWithdrawalStore::new(),
             batch_submitter: BatchSubmitter::new(portal_address, l1_provider, 0),
             withdrawal_notify: Arc::new(Notify::new()),
+            repair_notify: Arc::new(Notify::new()),
             last_submitted_zone_block: 10,
             prev_processed_deposit_hash: B256::repeat_byte(0xaa),
             prev_zone_block_hash: B256::repeat_byte(0xbb),
@@ -955,6 +1046,7 @@ mod tests {
             mock_provider(l1.clone()),
             SharedWithdrawalStore::new(),
             Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
         )
         .await
         {
@@ -981,6 +1073,8 @@ mod tests {
 
         l1.push_success(&abi_encode_b256(portal_hash));
         l1.push_success(&abi_encode_u64(7));
+        l1.push_success(&abi_encode_u64(7));
+        l1.push_success(&abi_encode_u64(7));
 
         zone.push_success(&Some(mock_block(portal_hash, confirmed_zone_block)));
         zone.push_success(&abi_encode_b256(confirmed_deposit_hash));
@@ -993,7 +1087,96 @@ mod tests {
         assert_eq!(monitor.last_submitted_zone_block, confirmed_zone_block);
         assert_eq!(monitor.prev_processed_deposit_hash, confirmed_deposit_hash);
         assert_eq!(monitor.portal_withdrawal_queue_tail, 7);
-        assert!(l1.read_q().is_empty());
+        assert!(zone.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn repair_missing_withdrawal_slot_resyncs_portal_and_rebuilds_withdrawal_store() {
+        let l1 = Asserter::new();
+        let zone = Asserter::new();
+
+        let portal_hash = B256::from(U256::from(7).to_be_bytes::<32>());
+        let confirmed_zone_block = 42;
+        let confirmed_deposit_hash = B256::repeat_byte(0x33);
+
+        l1.push_success(&abi_encode_b256(portal_hash));
+        l1.push_success(&abi_encode_u64(7));
+        l1.push_success(&abi_encode_u64(7));
+        l1.push_success(&abi_encode_u64(7));
+
+        zone.push_success(&Some(mock_block(portal_hash, confirmed_zone_block)));
+        zone.push_success(&abi_encode_b256(confirmed_deposit_hash));
+
+        let mut monitor = test_monitor(l1.clone(), zone.clone());
+        monitor.withdrawal_store.lock().add_withdrawal(
+            3,
+            abi::Withdrawal {
+                token: Address::repeat_byte(0x10),
+                senderTag: B256::repeat_byte(0x11),
+                to: Address::repeat_byte(0x12),
+                amount: 100,
+                fee: 0,
+                memo: B256::ZERO,
+                gasLimit: 0,
+                fallbackRecipient: Address::repeat_byte(0x12),
+                callbackData: Default::default(),
+                encryptedSender: Default::default(),
+            },
+        );
+
+        monitor.repair_missing_withdrawal_slot().await;
+
+        let store = monitor.withdrawal_store.lock();
+        assert_eq!(store.batch_count(), 0);
+        assert_eq!(monitor.prev_zone_block_hash, portal_hash);
+        assert_eq!(monitor.last_submitted_zone_block, confirmed_zone_block);
+        assert_eq!(monitor.prev_processed_deposit_hash, confirmed_deposit_hash);
+        assert_eq!(monitor.portal_withdrawal_queue_tail, 7);
+        assert!(zone.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn resync_clears_stale_withdrawal_store_when_restore_fails() {
+        let l1 = Asserter::new();
+        let zone = Asserter::new();
+
+        let portal_hash = B256::from(U256::from(7).to_be_bytes::<32>());
+        let confirmed_zone_block = 42;
+        let confirmed_deposit_hash = B256::repeat_byte(0x33);
+
+        l1.push_success(&abi_encode_b256(portal_hash));
+        l1.push_success(&abi_encode_u64(7));
+        l1.push_failure_msg("head read failed");
+        l1.push_failure_msg("tail read failed");
+
+        zone.push_success(&Some(mock_block(portal_hash, confirmed_zone_block)));
+        zone.push_success(&abi_encode_b256(confirmed_deposit_hash));
+
+        let mut monitor = test_monitor(l1.clone(), zone.clone());
+        monitor.withdrawal_store.lock().add_withdrawal(
+            3,
+            abi::Withdrawal {
+                token: Address::repeat_byte(0x10),
+                senderTag: B256::repeat_byte(0x11),
+                to: Address::repeat_byte(0x12),
+                amount: 100,
+                fee: 0,
+                memo: B256::ZERO,
+                gasLimit: 0,
+                fallbackRecipient: Address::repeat_byte(0x12),
+                callbackData: Default::default(),
+                encryptedSender: Default::default(),
+            },
+        );
+
+        monitor.resync_from_portal().await;
+
+        let store = monitor.withdrawal_store.lock();
+        assert_eq!(store.batch_count(), 0);
+        assert_eq!(monitor.prev_zone_block_hash, portal_hash);
+        assert_eq!(monitor.last_submitted_zone_block, confirmed_zone_block);
+        assert_eq!(monitor.prev_processed_deposit_hash, confirmed_deposit_hash);
+        assert_eq!(monitor.portal_withdrawal_queue_tail, 7);
         assert!(zone.read_q().is_empty());
     }
 
@@ -1008,6 +1191,8 @@ mod tests {
 
         l1.push_success(&abi_encode_b256(portal_hash));
         l1.push_success(&abi_encode_b256(portal_hash));
+        l1.push_success(&abi_encode_u64(7));
+        l1.push_success(&abi_encode_u64(7));
         l1.push_success(&abi_encode_u64(7));
 
         zone.push_success(&Some(mock_block(portal_hash, confirmed_zone_block)));


### PR DESCRIPTION
## Summary
- add a dedicated monitor repair path for missing withdrawal head slots and document why it performs a full portal resync
- throttle repeated repair requests to the withdrawal processor fallback interval and take one consistent store snapshot for diagnostics
- fail closed when post-resync withdrawal restore fails by clearing the stale local store and incrementing a restore-failure metric
- extend tests to cover repair request throttling, the repair path, and the restore-failure case

## Why
Withdrawals could stop processing when the portal queue still had pending slots but the in-memory withdrawal store no longer contained the current head slot. A restart fixed the issue because startup rebuilt pending withdrawals from chain state. This change teaches the live monitor to do the same repair path without needing a restart, while avoiding back-to-back resync churn if reconstruction still cannot see the head slot yet.

## Impact
The sequencer can now detect this desync at runtime, resync from portal-confirmed state, and rebuild pending withdrawals in place. If the rebuild fails after the portal anchor has already advanced, the node no longer continues with stale withdrawal data silently; it clears the local store and emits a metric so the failure is visible.

## Validation
- `cargo fmt --package zone`
- `cargo test -p zone --lib`