### PR TITLE
docs: restore privacy specs to docs/specs/

### DIFF
--- a/docs/specs/privacy/execution.md
+++ b/docs/specs/privacy/execution.md
@@ -1,0 +1,105 @@
+# Privacy Zone Execution Environment (Draft)
+
+This document specifies how the EVM execution environment of a privacy zone differs from a standard Tempo zone. These changes are enforced at the execution level (inside the zone's TIP-20 precompile, gas accounting, and EVM configuration), not at the RPC layer. They apply to all code paths — user transactions, sequencer system calls, `eth_call` simulations, and prover re-execution.
+
+For RPC-level access controls (authentication, method filtering, event scoping), see the [Zone RPC Specification](./rpc).
+
+A reference Solidity specification of all TIP-20 modifications is available at [`PrivateZoneToken.sol`](/specs/src/zone/PrivateZoneToken.sol).
+
+## TIP-20 modifications
+
+Privacy zones modify the zone token's TIP-20 precompile in four areas: balance privacy, allowance privacy, fixed gas accounting, and system mint/burn permissions.
+
+### Balance privacy: `balanceOf` access control
+
+On a standard zone (and on Tempo), `balanceOf(address account)` is a public view function — any caller can read any account's balance. On a privacy zone, the function enforces caller restrictions:
+
+- If `msg.sender == account`, the call succeeds and returns the balance.
+- If `msg.sender` is the sequencer (as read from `ZoneConfig.sequencer()`), the call succeeds.
+- Otherwise, the call reverts with `Unauthorized()`.
+
+This means:
+
+- **User transactions**: A contract calling `balanceOf(someOtherAddress)` will revert. Only self-queries succeed.
+- **`eth_call` simulations**: The RPC server sets `from` to the authenticated account, so `balanceOf` only works for the caller's own address. See [RPC spec](./rpc).
+- **Sequencer and system calls**: The sequencer retains full read access, which is required for block production, deposit processing, and fee accounting.
+
+**Rationale**: On a public chain, anyone can read any balance. On a privacy zone, balances are private. Enforcing this at the EVM level (not just at the RPC layer) ensures that even on-chain composition cannot leak balances — a contract deployed on the zone cannot be used to read and re-emit another account's balance.
+
+### Allowance privacy: `allowance` access control
+
+The `allowance(address owner, address spender)` function is similarly restricted:
+
+- If `msg.sender == owner` or `msg.sender == spender`, the call succeeds and returns the allowance.
+- If `msg.sender` is the sequencer, the call succeeds.
+- Otherwise, the call reverts with `Unauthorized()`.
+
+**Rationale**: A non-zero allowance reveals that `owner` has interacted with `spender` — a relationship that should be private on a privacy zone. Restricting reads to the two parties involved preserves standard ERC-20 approval flows (both the owner and the spender can check the allowance) without leaking relationship information to third parties.
+
+**Unchanged views**: `totalSupply()`, `name()`, `symbol()`, `decimals()`, and other non-per-account view functions remain unrestricted.
+
+### Fixed gas: constant transfer cost
+
+All TIP-20 transfer operations on a privacy zone charge a fixed gas cost of **100,000 gas**, regardless of execution-dependent factors:
+
+| Function | Gas cost |
+|----------|----------|
+| `transfer(to, amount)` | 100,000 |
+| `transferFrom(from, to, amount)` | 100,000 |
+| `transferWithMemo(to, amount, memo)` | 100,000 |
+| `transferFromWithMemo(from, to, amount, memo)` | 100,000 |
+| `approve(spender, amount)` | 100,000 |
+
+On a standard EVM chain, gas cost varies depending on whether a transfer writes to a previously empty storage slot (zero → non-zero costs 20,000 gas more than non-zero → non-zero). This difference reveals whether the recipient has previously received tokens — a binary signal about account existence.
+
+By fixing the gas cost:
+
+- All transfer receipts have identical `gasUsed` for the TIP-20 portion, removing the side channel.
+- Observers (including the sender, who sees their own receipt) cannot distinguish transfers to new vs. existing accounts.
+- The fixed cost of 100,000 gas matches the zone's `FIXED_DEPOSIT_GAS` constant, providing a consistent gas unit across deposits and transfers.
+
+**Implementation**: The zone's TIP-20 precompile always charges exactly 100,000 gas for any transfer-family call, regardless of the actual storage operations required. If the transaction provides less than 100,000 gas to the precompile call, it reverts with out-of-gas. Excess gas beyond 100,000 is returned to the caller as usual.
+
+**Unchanged operations**: System functions (`systemTransferFrom`, `transferFeePreTx`, `transferFeePostTx`) retain their standard gas costs. These are restricted to precompile-only callers where the gas side channel is not exploitable.
+
+### System mint and burn permissions
+
+On Tempo, `mint()` and `burn()` on a TIP-20 require the caller to hold `ISSUER_ROLE`. On a zone, the token is a bridged representation — tokens are minted when deposits arrive from Tempo and burned when withdrawals are requested. `ISSUER_ROLE` is not used on zones. The sole mint/burn authorities are the zone system contracts:
+
+| Operation | Standard TIP-20 (Tempo) | Zone access |
+|-----------|------------------------|-------------|
+| `mint(to, amount)` | `ISSUER_ROLE` only | ZoneInbox (`0x1c...0001`) only |
+| `burn(from, amount)` | `ISSUER_ROLE` only | ZoneOutbox (`0x1c...0002`) only |
+
+Authorization is **operation-specific**: ZoneInbox access applies to `mint` only, and ZoneOutbox access applies to `burn` only. Implementations MUST NOT use a shared "inbox-or-outbox" check for both operations.
+
+**ZoneInbox mints** during deposit processing in `advanceTempo()`:
+
+- Regular deposit: `mint(deposit.to, deposit.amount)` — credits the recipient on the zone.
+- Encrypted deposit (decryption succeeded): `mint(decrypted.to, deposit.amount)` — credits the decrypted recipient on the zone.
+- Encrypted deposit (decryption failed): `mint(deposit.sender, deposit.amount)` — credits the depositor's address on the zone (same address as their L1 account). The L1 funds remain escrowed in the portal.
+
+**ZoneOutbox burns** during withdrawal requests in `requestWithdrawal()`:
+
+- The user approves the ZoneOutbox to spend `amount + fee`.
+- ZoneOutbox calls `transferFrom(user, self, amount + fee)`, then `burn(self, amount + fee)`.
+- The burned tokens are released on Tempo when the sequencer processes the withdrawal.
+
+**Gas costs**: `mint` and `burn` retain standard variable gas costs (not the fixed 100,000). These functions are only called by system contracts during sequencer operations, so there is no user-exploitable gas side channel.
+
+## EVM restrictions
+
+### Contract creation disabled
+
+Privacy zones disable the `CREATE` and `CREATE2` opcodes. The zone runs a fixed set of predeploys (system contracts and the zone token); user-deployed contracts are not supported. Any transaction or call that attempts contract creation reverts.
+
+**Rationale**: Arbitrary contract deployment would allow users to deploy contracts that circumvent execution-level privacy protections — for example, a contract that calls `balanceOf` on behalf of a third party and emits the result as an event.
+
+## Interaction with RPC
+
+These execution-level changes are the first line of defense. The [RPC specification](./rpc) adds a second layer of access control (authentication, method restrictions, event filtering). Both layers are required:
+
+- **Execution alone is insufficient**: Without RPC restrictions, a caller could use `eth_getStorageAt` to read TIP-20 balance mapping slots directly, bypassing the `balanceOf` access control entirely.
+- **RPC alone is insufficient**: Without execution-level changes, a caller could deploy or call a contract via `eth_call` that reads another account's balance and returns it, bypassing RPC-level filtering.
+
+The two layers are complementary: execution-level changes protect against in-EVM information leaks, and RPC-level changes protect against raw state inspection.

--- a/docs/specs/privacy/overview.md
+++ b/docs/specs/privacy/overview.md
@@ -1,0 +1,1982 @@
+# Tempo Zones (Draft)
+
+This document proposes a new validium protocol designed for Tempo. It is a design overview, not a full specification.
+
+## Goals
+
+- Create a Tempo-native validium called a zone.
+- Each zone has exactly one permissioned sequencer.
+- Each zone supports multiple TIP-20 tokens for bridging. The sequencer can enable additional TIP-20 tokens at any time. All enabled tokens are usable as gas tokens on the zone (no feeAMMs).
+- Settlement uses fast validity proofs or TEE attestations (ZK or TEE). Data availability is fully trusted to the sequencer.
+- Cross-chain operations are Tempo-centric: bridge in (simple deposit), bridge out (with optional callback to receiver contracts for Tempo composability).
+- Verifier is abstracted behind a minimal `IVerifier` interface.
+- Liveness (including exits) is wholly dependent on the permissioned sequencer; there is no permissionless fallback.
+- Non-custodial withdrawal guarantee: once a token is enabled, withdrawals for that token can never be disabled.
+
+## Non-goals
+
+- No attempt to solve data availability, forced inclusion, or censorship resistance.
+- No governance model. Upgradeability is handled via Tempo L1 hard forks (see [Hard fork activation](#hard-fork-activation)).
+- No general messaging. Multi-asset bridging is supported for all TIP-20 tokens enabled by the sequencer.
+
+## Terminology
+
+- Tempo: the base chain.
+- Zone: the validium chain anchored to Tempo.
+- Enabled tokens: TIP-20 tokens that the sequencer has enabled for bridging in/out. Each zone starts with an initial token and the sequencer can enable more. Token enablement is permanent (append-only).
+- Portal: the Tempo-side contract that escrows enabled tokens and finalizes exits.
+- Batch: a sequencer-produced commitment covering one or more zone blocks. The batch **must** end with a single `finalizeWithdrawalBatch()` call in the final block, and intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The sequencer controls batch frequency.
+
+## System overview
+
+### Actors
+
+- Zone sequencer: permissioned operator that orders zone transactions, provides data, and posts batches to Tempo. The sequencer is the only actor that submits transactions to the portal.
+- Verifier: ZK proof system or TEE attester. Abstracted via `IVerifier`.
+- Users: deposit TIP-20 from Tempo to the zone or exit back to Tempo.
+
+### Tempo contracts
+
+- `ZoneFactory`: creates zones and registers parameters.
+- `ZonePortal`: per-zone portal that escrows enabled tokens on Tempo and finalizes exits. Manages the token registry.
+
+### Zone components (off-chain or zone-side)
+
+- `ZoneSequencer`: collects transactions and creates batches.
+- `ZoneExecutor`: executes the zone state transition.
+- `ZoneProver` or `ZoneAttester`: produces proof/attestation for each batch.
+
+## Zone creation
+
+A zone is created via `ZoneFactory.createZone(...)` with:
+
+- `initialToken`: the first Tempo TIP-20 address to enable. The sequencer can enable additional tokens later via `ZonePortal.enableToken()`.
+- `sequencer`: permissioned sequencer address.
+- `verifier`: `IVerifier` implementation for proof or attestation.
+- `zoneParams`: initial configuration (genesis block hash, genesis Tempo block hash/number).
+
+The factory deploys a `ZonePortal` that escrows enabled tokens on Tempo and a `ZoneMessenger` for withdrawal callbacks. The initial token is automatically enabled at deployment.
+
+### Chain ID
+
+Each zone has a unique EIP-155 chain ID derived deterministically from its on-chain zone ID:
+
+```
+chain_id = 4217000000 + zone_id
+```
+
+The prefix `4217` corresponds to the Tempo L1 chain ID. This ensures replay protection between zones — a transaction signed for one zone cannot be replayed on another. The chain ID is set in the zone's genesis configuration during creation and validated by the zone node at startup.
+
+### Token management
+
+The sequencer manages which tokens are available for bridging:
+
+- `enableToken(address token)`: Enable a new TIP-20 for bridging. **Irreversible** — once enabled, a token can never be disabled.
+- `pauseDeposits(address token)`: Pause new deposits for a token (sequencer-only). Does not affect withdrawals.
+- `resumeDeposits(address token)`: Resume deposits for a previously paused token.
+
+The portal maintains a `TokenConfig` per token with `enabled` (permanent) and `depositsActive` (toggleable) flags, and an append-only `enabledTokens` list for enumeration. This design enforces the **non-custodial withdrawal guarantee**: the sequencer can halt deposits but can never prevent users from withdrawing an enabled token.
+
+### Sequencer transfer
+
+The sequencer can transfer control to a new address via a two-step process on **Tempo L1 only**:
+
+1. Current sequencer calls `ZonePortal.transferSequencer(newSequencer)` to nominate a new sequencer
+2. New sequencer calls `ZonePortal.acceptSequencer()` to accept the transfer
+
+**Sequencer management is centralized on L1 (Tempo).** Zone-side system contracts (`ZoneInbox`, `ZoneOutbox`) read the sequencer from L1 via `ZoneConfig`, which queries `TempoState` to get the sequencer address from the finalized `ZonePortal` storage. This eliminates duplicate sequencer management logic and ensures L1 is the single source of truth. The two-step pattern prevents accidental transfers to incorrect addresses.
+
+## Execution and fees
+
+- The zone reuses Tempo's fee units and accounting model.
+- Zone transactions specify which enabled TIP-20 token to use for gas fees via a `feeToken` field. The sequencer is required to accept all enabled tokens as gas (no feeAMMs on the zone).
+- Transactions use Tempo transaction semantics for fee payer, max fee per gas, and gas limit.
+
+### Deposit fees
+
+Deposits incur a processing fee to compensate the sequencer for zone-side processing costs:
+
+- **Zone gas rate**: Sequencer publishes `zoneGasRate` (token units per gas unit)
+- **Fixed gas value**: `FIXED_DEPOSIT_GAS` is fixed at 100,000 gas
+- **Total fee**: `FIXED_DEPOSIT_GAS * zoneGasRate` = `100,000 * zoneGasRate`
+
+The fee is paid in the **same token being deposited**. The sequencer configures `zoneGasRate` via `ZonePortal.setZoneGasRate()`. The fixed gas value of 100,000 provides a stable pricing basis for deposits while allowing the sequencer flexibility to adjust the rate based on operational costs and future deposit mechanism variations. A single uniform `zoneGasRate` applies to all tokens (stablecoins of the same value).
+
+The fee is deducted from the deposit amount and paid to the sequencer immediately on Tempo. The deposit queue stores the net amount (`amount - fee`) which is minted on the zone.
+
+### Withdrawal processing fees
+
+Withdrawals incur a processing fee to compensate the sequencer for Tempo-side gas costs:
+
+- **Tempo gas rate**: Sequencer publishes `tempoGasRate` (token units per gas unit)
+- **Gas limit**: User specifies `gasLimit` covering all execution costs (processing + callback)
+- **Total fee**: `gasLimit * tempoGasRate`
+
+The fee is paid in the **same token being withdrawn**. The user must estimate total gas needed for their withdrawal, including `processWithdrawal` overhead and any callback. The sequencer configures `tempoGasRate` via `ZoneOutbox.setTempoGasRate()` and takes the risk on Tempo gas price fluctuations. If actual Tempo gas is higher, the sequencer covers the difference; if lower, they keep the surplus.
+
+Users burn `amount + fee` of the specified token when requesting a withdrawal. On success, `amount` goes to the recipient and `fee` goes to the sequencer. On failure (bounce-back), only `amount` is re-deposited to `fallbackRecipient`; the sequencer keeps the fee.
+
+## Batch submission
+
+The sequencer posts batches to Tempo via a single `submitBatch` call (sequencer-only) that:
+
+1. Verifies the proof/attestation for the state transition (including chain integrity via `prevBlockHash`).
+2. Updates the portal's `withdrawalBatchIndex`, `blockHash`, and `lastSyncedTempoBlockNumber`.
+3. Updates the withdrawal queue (adds new withdrawals to the next slot in the fixed-size ring buffer).
+
+Each batch submission includes:
+
+- `tempoBlockNumber` - Block zone committed to (from zone's TempoState)
+- `recentTempoBlockNumber` - Optional recent block for ancestry proof (0 = direct lookup)
+- `blockTransition` - Zone block hash transition (prevBlockHash → nextBlockHash)
+- `depositQueueTransition` - Deposit queue processing (prevProcessedHash → nextProcessedHash)
+- `withdrawalQueueTransition` - Withdrawal queue hash (hash chain for this batch, or 0 if none)
+- `verifierConfig` - Opaque payload for verifier (domain separation/attestation)
+- `proof` - Validity proof or TEE attestation
+
+The portal tracks `withdrawalBatchIndex`, `blockHash` (last proven batch block), `lastSyncedTempoBlockNumber` (Tempo block zone synced to), `currentDepositQueueHash` (deposit queue head), and a fixed-size ring buffer for withdrawals.
+
+**Ancestry proofs for historical blocks**: If `tempoBlockNumber` is outside the EIP-2935 window (~8192 blocks), use `recentTempoBlockNumber` to specify a recent block still in EIP-2935. The proof verifies the ancestry chain (via parent hashes) from `tempoBlockNumber` to `recentTempoBlockNumber` inside the ZK proof, avoiding expensive on-chain header verification. This prevents zone bricking after extended downtime.
+
+The portal calls the verifier to validate the batch:
+
+```solidity
+/// @notice Block transition for zone batch proofs
+/// @dev Uses block hash instead of state root to commit to full block structure
+struct BlockTransition {
+    bytes32 prevBlockHash;
+    bytes32 nextBlockHash;
+}
+
+/// @notice Deposit queue transition inputs/outputs for batch proofs
+/// @dev The proof reads currentDepositQueueHash from Tempo state to validate
+///      that nextProcessedHash matches currentDepositQueueHash for now. 
+struct DepositQueueTransition {
+    bytes32 prevProcessedHash;     // where proof starts (verified against zone state)
+    bytes32 nextProcessedHash;     // where zone processed up to (proof output)
+}
+
+interface IVerifier {
+    /// @notice Verify a batch proof
+    /// @dev The proof validates:
+    ///      1. Valid state transition from prevBlockHash to nextBlockHash
+    ///      2. Zone committed to tempoBlockNumber (via TempoState)
+    ///      3. If anchorBlockNumber == tempoBlockNumber: zone's hash matches anchorBlockHash
+    ///      4. If anchorBlockNumber > tempoBlockNumber: ancestry chain verified via parent hashes
+    ///      5. ZoneOutbox.lastBatch().withdrawalBatchIndex == expectedWithdrawalBatchIndex
+    ///      6. ZoneOutbox.lastBatch().withdrawalQueueHash matches withdrawalQueueTransition
+    ///      7. Zone block beneficiary matches sequencer
+    ///      8. Deposit processing is correct (validated via Tempo state read inside proof)
+    function verify(
+        uint64 tempoBlockNumber,
+        uint64 anchorBlockNumber,
+        bytes32 anchorBlockHash,
+        uint64 expectedWithdrawalBatchIndex,
+        address sequencer,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata verifierConfig,
+        bytes calldata proof
+    ) external view returns (bool);
+}
+```
+
+The verifier validates:
+1. State transition from `prevBlockHash` to `nextBlockHash` is correct.
+2. Zone committed to `tempoBlockNumber` via TempoState.
+3. **Direct mode** (`anchorBlockNumber == tempoBlockNumber`): Zone's `tempoBlockHash()` matches `anchorBlockHash`.
+4. **Ancestry mode** (`anchorBlockNumber > tempoBlockNumber`): Proof includes Tempo headers from `tempoBlockNumber + 1` to `anchorBlockNumber` as witness data, verifying the parent hash chain inside the ZK proof. Final hash must equal `anchorBlockHash`.
+5. `ZoneOutbox.lastBatch()` has correct `withdrawalBatchIndex` and `withdrawalQueueHash`.
+6. Deposit processing is correct (zone read `currentDepositQueueHash` from Tempo state).
+7. Zone block `beneficiary` matches sequencer.
+
+The zone has access to Tempo state via the TempoState predeploy, so the proof can read `currentDepositQueueHash` directly from Tempo storage at the proven block. This eliminates the need for an on-chain "ceiling" slot.
+
+`verifierData` + `proof` are opaque to the portal: ZK systems can ignore `verifierData`, while TEEs can pack attestation envelopes/quotes and measurement checks into `verifierData` for the verifier contract to enforce.
+
+`submitBatch` verifies that `prevBlockHash == blockHash`, then calls the verifier. On success it updates `withdrawalBatchIndex`, `blockHash`, `lastSyncedTempoBlockNumber`, adds withdrawals to the queue, and emits `BatchSubmitted` with `withdrawalBatchIndex`, `nextProcessedDepositQueueHash`, `nextBlockHash`, and `withdrawalQueueHash` for off-chain auditing.
+
+### Ancestry proofs for historical blocks
+
+EIP-2935 provides access to the last ~8192 block hashes. If a zone is inactive for longer than this window, `tempoBlockNumber` rotates out of EIP-2935, preventing batch submission and permanently bricking the zone.
+
+**Solution**: The proof verifies ancestry inside the ZK circuit, avoiding expensive on-chain verification:
+
+1. Portal reads `recentTempoBlockNumber` hash from EIP-2935 (must be recent)
+2. Prover includes Tempo headers from `tempoBlockNumber + 1` to `recentTempoBlockNumber` as witness data
+3. Proof verifies the parent hash chain: each header's parent hash must match the previous header's hash, starting from zone's committed `tempoBlockHash()` and ending at `anchorBlockHash`
+4. Portal verifies the (constant-size) proof against the recent block hash
+
+**Usage constraints**:
+- `recentTempoBlockNumber = 0` → **direct mode**: portal reads `tempoBlockNumber` hash from EIP-2935
+- `recentTempoBlockNumber > tempoBlockNumber` → **ancestry mode**: portal reads `recentTempoBlockNumber` hash, proof verifies parent chain
+- `recentTempoBlockNumber` must be **strictly greater** than `tempoBlockNumber` (passing equal values reverts; use `0` for direct mode)
+- Both `tempoBlockNumber` and `recentTempoBlockNumber` must be `>= genesisTempoBlockNumber`
+
+**Cost**: Proving time increases linearly with the block gap, but verification remains constant. A 15k block gap adds ~15k keccak operations inside the proof but doesn't increase on-chain gas costs beyond the normal verification.
+
+**Note**: This feature changes the `IVerifier.verify()` signature (adds `anchorBlockNumber` parameter). Verifier implementations must be upgraded alongside the portal.
+
+### Deposit queue
+
+Tempo to zone communication uses a single `depositQueue` chain. Each deposit is hashed into a chain:
+
+```
+newHash = keccak256(abi.encode(deposit, prevHash))
+```
+
+Where `deposit` is a `Deposit` struct containing the sender, recipient, amount, and memo. Tempo state advancement and deposit processing are combined in the ZoneInbox's `advanceTempo()` function, which calls `TempoState.finalizeTempo()` internally.
+
+The portal tracks `currentDepositQueueHash` where new deposits land. The zone tracks its own `processedDepositQueueHash` in EVM state.
+
+**Proof requirements**: The proof validates deposit processing by reading `currentDepositQueueHash` from Tempo state inside the proof. The zone's `advanceTempo()` function processes deposits and updates the zone's `processedDepositQueueHash`. The proof ensures this was done correctly by validating the Tempo state read. For now, the on-chain inbox requires an exact match.
+
+**After batch accepted**:
+1. `lastSyncedTempoBlockNumber = tempoBlockNumber` (record how far Tempo state was synced)
+
+New deposits continue to land in `currentDepositQueueHash` while proofs are in flight. Users can check if their deposit is processed by comparing their deposit's Tempo block number against `lastSyncedTempoBlockNumber`.
+
+Proofs or attestations are assumed to be fast. No data availability is required by the verifier.
+
+## Withdrawal queue
+
+Withdrawals use a fixed-size ring buffer (capacity `WITHDRAWAL_QUEUE_CAPACITY = 100`) that allows the sequencer to process withdrawals independently of proof generation. Each batch gets its own slot, and the sequencer processes withdrawals from the oldest slot while new batches add to the next available slot. Head and tail are raw counters that never wrap; modular arithmetic (`index % WITHDRAWAL_QUEUE_CAPACITY`) is used only for slot indexing.
+
+The portal tracks:
+- `head` - slot index of the oldest unprocessed batch (where sequencer removes)
+- `tail` - slot index where the next batch will write (where proofs add)
+- `slots` - mapping of slot index to hash chain (`EMPTY_SENTINEL` = empty)
+
+The queue reverts with `WithdrawalQueueFull` if `tail - head >= WITHDRAWAL_QUEUE_CAPACITY` (i.e., all 100 slots are occupied).
+
+### Hash chain structure
+
+Each slot contains a hash chain with the **oldest withdrawal at the outermost layer**, making FIFO processing efficient. The innermost element wraps `EMPTY_SENTINEL` (0xffffffff...fff) instead of 0x00 to avoid clearing storage:
+
+```
+slot = keccak256(abi.encode(w1, keccak256(abi.encode(w2, keccak256(abi.encode(w3, EMPTY_SENTINEL))))))
+      // w1 is oldest (outermost), w3 is newest (innermost)
+```
+
+To process the oldest withdrawal, the sequencer provides the withdrawal data and the remaining queue hash. The portal verifies the hash and updates the slot:
+
+```solidity
+function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) external onlySequencer {
+    uint256 head = _withdrawalQueue.head;
+
+    // Check if queue is empty
+    if (head == _withdrawalQueue.tail) {
+        revert NoWithdrawalsInQueue();
+    }
+
+    uint256 slotIndex = head % WITHDRAWAL_QUEUE_CAPACITY;
+    bytes32 currentSlot = _withdrawalQueue.slots[slotIndex];
+
+    // Verify this is the head of the current slot
+    // The remainingQueue for the last item should be 0 (we convert to EMPTY_SENTINEL internally)
+    bytes32 expectedRemainingQueue = remainingQueue == bytes32(0) ? EMPTY_SENTINEL : remainingQueue;
+    require(keccak256(abi.encode(w, expectedRemainingQueue)) == currentSlot, "invalid");
+
+    _executeWithdrawal(w);
+
+    if (remainingQueue == bytes32(0)) {
+        // Slot exhausted, mark as empty and advance head
+        _withdrawalQueue.slots[slotIndex] = EMPTY_SENTINEL;
+        _withdrawalQueue.head = head + 1;
+    } else {
+        // More withdrawals in this slot
+        _withdrawalQueue.slots[slotIndex] = remainingQueue;
+    }
+}
+```
+
+### Batch submission adds withdrawals
+
+When a batch is submitted with withdrawals, they go into the slot at `tail`, then `tail` advances:
+
+```solidity
+function submitBatch(...) external onlySequencer {
+    // ... verify proof ...
+
+    // If no withdrawals in this batch, nothing to do
+    if (withdrawalQueueTransition.withdrawalQueueHash == bytes32(0)) {
+        return;
+    }
+
+    uint256 tail = _withdrawalQueue.tail;
+
+    // Revert if all slots are occupied
+    if (tail - _withdrawalQueue.head >= WITHDRAWAL_QUEUE_CAPACITY) {
+        revert WithdrawalQueueFull();
+    }
+
+    // Write the withdrawal hash chain to this slot (modular indexing)
+    _withdrawalQueue.slots[tail % WITHDRAWAL_QUEUE_CAPACITY] = withdrawalQueueTransition.withdrawalQueueHash;
+
+    // Advance tail
+    _withdrawalQueue.tail = tail + 1;
+}
+```
+
+This design eliminates race conditions entirely - each batch has its own independent slot, and the sequencer processes slots in order. The fixed-size ring buffer (capacity 100) bounds storage usage while providing ample room for normal operation.
+
+## Interfaces and functions
+
+This section defines the functions and interfaces used by the design. The signatures are Solidity-style and focus on the minimum surface area.
+
+### Common types
+
+```solidity
+/// @notice Interface for the zone's zone token (TIP-20 with mint/burn for system)
+interface IZoneToken {
+    function mint(address to, uint256 amount) external;
+    function burn(address from, uint256 amount) external;
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+struct ZoneInfo {
+    uint32 zoneId;
+    address portal;
+    address messenger;
+    address initialToken;       // first TIP-20 enabled at creation
+    address sequencer;
+    address verifier;
+    bytes32 genesisBlockHash;
+    bytes32 genesisTempoBlockHash;
+    uint64 genesisTempoBlockNumber;
+}
+
+struct ZoneParams {
+    bytes32 genesisBlockHash;
+    bytes32 genesisTempoBlockHash;
+    uint64 genesisTempoBlockNumber;
+}
+
+/// @notice Per-token configuration in the portal's token registry
+struct TokenConfig {
+    bool enabled;          // true once sequencer enables this token (permanent)
+    bool depositsActive;   // sequencer can pause/unpause deposits
+}
+
+struct Deposit {
+    address token;          // TIP-20 token being deposited
+    address sender;
+    address to;
+    uint128 amount;
+    bytes32 memo;
+}
+
+struct Withdrawal {
+    address token;              // TIP-20 token being withdrawn
+    bytes32 senderTag;          // keccak256(abi.encodePacked(sender, txHash)) — see Authenticated withdrawals
+    address to;                 // Tempo recipient
+    uint128 amount;             // amount to send to recipient (excludes fee)
+    uint128 fee;                // processing fee for sequencer (calculated at request time)
+    bytes32 memo;
+    uint64 gasLimit;            // max gas for IWithdrawalReceiver callback (0 = no callback)
+    address fallbackRecipient;  // zone address for bounce-back if call fails
+    bytes callbackData;         // calldata for IWithdrawalReceiver (if gasLimit > 0, max 1KB)
+    bytes encryptedSender;      // ECDH-encrypted (sender, txHash) for revealTo key, or empty
+}
+```
+
+### Verifier
+
+```solidity
+interface IVerifier {
+    function verify(
+        uint64 tempoBlockNumber,
+        uint64 anchorBlockNumber,
+        bytes32 anchorBlockHash,
+        uint64 expectedWithdrawalBatchIndex,
+        address sequencer,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata verifierConfig,
+        bytes calldata proof
+    ) external view returns (bool);
+}
+```
+
+The verifier receives `tempoBlockNumber`, `anchorBlockNumber`, and `anchorBlockHash` (looked up on-chain via the EIP-2935 block hash history precompile), `expectedWithdrawalBatchIndex` (portal's current batch index + 1), `sequencer` (the registered sequencer address), block transition, deposit queue transition, withdrawal queue transition, and the proof. The proof must demonstrate that the zone committed to `tempoBlockNumber` via TempoState, that the anchor hash is correct (direct or ancestry mode), that the state transition is valid, that `ZoneOutbox.lastBatch().withdrawalBatchIndex` equals `expectedWithdrawalBatchIndex`, that the zone block `beneficiary` matches `sequencer`, and that `ZoneOutbox.lastBatch().withdrawalQueueHash` matches `withdrawalQueueTransition.withdrawalQueueHash` (read from state root, not events).
+
+### Queue libraries
+
+The portal uses two queue libraries that encapsulate the hash chain management patterns:
+
+#### DepositQueueLib
+
+Handles Tempo→L2 deposits. The Tempo portal only tracks `currentDepositQueueHash` (the head of the queue where new deposits land). The zone tracks its own `processedDepositQueueHash` in EVM state, and the proof validates deposit processing by reading `currentDepositQueueHash` from Tempo state.
+
+```solidity
+library DepositQueueLib {
+    /// @notice Enqueue a new deposit into the queue (on-chain operation)
+    /// @dev Hash chain: newHash = keccak256(abi.encode(deposit, prevHash))
+    /// @param currentHash The current head of the deposit queue
+    /// @param depositData The deposit to enqueue
+    /// @return newHash The new head of the deposit queue
+    function enqueue(bytes32 currentHash, Deposit memory depositData) internal pure returns (bytes32 newHash);
+}
+```
+
+#### WithdrawalQueueLib (fixed-size ring buffer)
+
+Handles L2→Tempo withdrawals where the producer (proof) is slow and the consumer (on-chain) is fast. Each batch gets its own slot in a fixed-size ring buffer with capacity `WITHDRAWAL_QUEUE_CAPACITY = 100`.
+
+```solidity
+/// @dev Sentinel value for empty slots. Using 0xff...ff instead of 0x00 to avoid
+///      clearing storage (which would refund gas and create incentive issues).
+bytes32 constant EMPTY_SENTINEL = bytes32(type(uint256).max);
+
+
+uint256 constant WITHDRAWAL_QUEUE_CAPACITY = 100;
+
+struct WithdrawalQueue {
+    uint256 head;     // logical index of oldest unprocessed batch
+    uint256 tail;     // logical index where next batch will write
+    mapping(uint256 => bytes32) slots;  // hash chains per batch (EMPTY_SENTINEL = empty)
+}
+
+library WithdrawalQueueLib {
+    /// @notice Add a batch's withdrawals to the queue (called during batch submission)
+    /// @dev Writes to slot at tail % WITHDRAWAL_QUEUE_CAPACITY, then advances tail.
+    ///      Reverts with WithdrawalQueueFull if tail - head >= WITHDRAWAL_QUEUE_CAPACITY.
+    function enqueue(WithdrawalQueue storage q, WithdrawalQueueTransition memory transition) internal;
+
+    /// @notice Pop the next withdrawal from the queue (on-chain operation)
+    /// @dev Verifies the withdrawal is at the head of the current slot and advances.
+    ///      When a slot is exhausted, it's set to EMPTY_SENTINEL and head advances.
+    function dequeue(WithdrawalQueue storage q, Withdrawal calldata w, bytes32 remainingQueue) internal;
+
+    /// @notice Check if the queue has any pending withdrawals
+    function hasWithdrawals(WithdrawalQueue storage q) internal view returns (bool);
+
+    /// @notice Get current queue length
+    function length(WithdrawalQueue storage q) internal view returns (uint256);
+}
+```
+
+**Gas note**: The ring buffer reuses slots via modular indexing, so storage writes to already-occupied slots cost less gas (warm storage). New storage charges only apply when the queue grows into a slot that has never been used.
+
+
+| Queue | Tempo operation | Zone/Proof operation |
+|-------|--------------|---------------------|
+| Deposit | `enqueue` (users deposit) | Process via `advanceTempo()` |
+| Withdrawal | `dequeue` (sequencer processes) | Create via `finalizeWithdrawalBatch()` |
+
+### Tempo contracts
+
+#### Zone factory
+
+```solidity
+interface IZoneFactory {
+    struct CreateZoneParams {
+        address initialToken;   // first TIP-20 to enable (sequencer can enable more later)
+        address sequencer;
+        address verifier;
+        ZoneParams zoneParams;
+    }
+
+    event ZoneCreated(
+        uint32 indexed zoneId,
+        address indexed portal,
+        address indexed messenger,
+        address initialToken,
+        address sequencer,
+        address verifier,
+        bytes32 genesisBlockHash,
+        bytes32 genesisTempoBlockHash,
+        uint64 genesisTempoBlockNumber
+    );
+
+    function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
+    function zoneCount() external view returns (uint32);
+    function zones(uint32 zoneId) external view returns (ZoneInfo memory);
+    function isZonePortal(address portal) external view returns (bool);
+}
+```
+
+#### Zone portal
+
+```solidity
+interface IZonePortal {
+    event DepositMade(
+        bytes32 indexed newCurrentDepositQueueHash,
+        address indexed sender,
+        address token,
+        address to,
+        uint128 netAmount,
+        uint128 fee,
+        bytes32 memo
+    );
+
+    event BatchSubmitted(
+        uint64 indexed withdrawalBatchIndex,
+        bytes32 nextProcessedDepositQueueHash,
+        bytes32 nextBlockHash,
+        bytes32 withdrawalQueueHash
+    );
+
+    event WithdrawalProcessed(
+        address indexed to,
+        uint128 amount,
+        bool callbackSuccess
+    );
+
+    event BounceBack(
+        bytes32 indexed newCurrentDepositQueueHash,
+        address indexed fallbackRecipient,
+        uint128 amount
+    );
+
+    event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
+    event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+
+    /// @notice Emitted when an encrypted deposit is made (recipient/memo not revealed)
+    event EncryptedDepositMade(
+        bytes32 indexed newCurrentDepositQueueHash,
+        address indexed sender,
+        address token,
+        uint128 netAmount,
+        uint128 fee,
+        uint256 keyIndex,
+        bytes32 ephemeralPubkeyX,
+        uint8 ephemeralPubkeyYParity,
+        bytes ciphertext,
+        bytes12 nonce,
+        bytes16 tag
+    );
+
+    /// @notice Emitted when sequencer updates their encryption key
+    event SequencerEncryptionKeyUpdated(
+        bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock
+    );
+    event ZoneGasRateUpdated(uint128 zoneGasRate);
+
+    error NotSequencer();
+    error NotPendingSequencer();
+    error InvalidProof();
+    error InvalidTempoBlockNumber();
+    error CallbackRejected();
+    error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
+    error InvalidEncryptionKeyIndex(uint256 keyIndex);
+    error NoEncryptionKeySet();
+    error NoEncryptionKeyAtBlock(uint64 blockNumber);
+    error InvalidEphemeralPubkey();
+    error InvalidCiphertextLength(uint256 actual, uint256 expected);
+    error InvalidProofOfPossession();
+    error DepositTooSmall();
+
+    /// @notice Fixed gas value for deposit fee calculation (100,000 gas).
+    function FIXED_DEPOSIT_GAS() external view returns (uint64);
+
+    function zoneId() external view returns (uint64);
+    function messenger() external view returns (address);
+    function sequencer() external view returns (address);
+    function pendingSequencer() external view returns (address);
+    function zoneGasRate() external view returns (uint128);
+    function verifier() external view returns (address);
+    function genesisTempoBlockNumber() external view returns (uint64);
+
+    /// @notice Token registry (multi-asset support)
+    function isTokenEnabled(address token) external view returns (bool);
+    function areDepositsActive(address token) external view returns (bool);
+    function enabledTokenCount() external view returns (uint256);
+    function enabledTokenAt(uint256 index) external view returns (address);
+    function enableToken(address token) external;
+    function pauseDeposits(address token) external;
+    function resumeDeposits(address token) external;
+    function withdrawalBatchIndex() external view returns (uint64);
+    function blockHash() external view returns (bytes32);
+    function currentDepositQueueHash() external view returns (bytes32);
+    function lastSyncedTempoBlockNumber() external view returns (uint64);
+    function withdrawalQueueHead() external view returns (uint256);
+    function withdrawalQueueTail() external view returns (uint256);
+    function withdrawalQueueSlot(uint256 slot) external view returns (bytes32);
+
+    /// @notice Start a sequencer transfer. Only callable by current sequencer.
+    function transferSequencer(address newSequencer) external;
+
+    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
+    function acceptSequencer() external;
+
+    /// @notice Set zone gas rate. Only callable by sequencer.
+    function setZoneGasRate(uint128 _zoneGasRate) external;
+
+    /// @notice Calculate the fee for a deposit.
+    function calculateDepositFee() external view returns (uint128 fee);
+
+    /// @notice Deposit a TIP-20 token into the zone. Fee is deducted from amount.
+    function deposit(address token, address to, uint128 amount, bytes32 memo) external returns (bytes32 newCurrentDepositQueueHash);
+
+    /// @notice Deposit with encrypted recipient and memo. Fee is deducted from amount.
+    function depositEncrypted(
+        address token,
+        uint128 amount,
+        uint256 keyIndex,
+        EncryptedDepositPayload calldata encrypted
+    ) external returns (bytes32 newCurrentDepositQueueHash);
+
+    /// @notice Get the current sequencer encryption key.
+    /// @dev Reverts with NoEncryptionKeySet() if no key has been set.
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+
+    /// @notice Set sequencer encryption key with proof of possession.
+    /// @dev Requires ECDSA signature proving control of the corresponding private key.
+    function setSequencerEncryptionKey(
+        bytes32 x, uint8 yParity, uint8 popV, bytes32 popR, bytes32 popS
+    ) external;
+
+    /// @notice Number of encryption keys in history.
+    function encryptionKeyCount() external view returns (uint256);
+
+    /// @notice Get a historical encryption key entry by index.
+    function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory);
+
+    /// @notice Get the encryption key active at a specific block.
+    /// @dev Reverts with NoEncryptionKeyAtBlock() if no key was active at that block.
+    function encryptionKeyAtBlock(uint64 tempoBlockNumber)
+        external view returns (bytes32 x, uint8 yParity, uint256 keyIndex);
+
+    /// @notice Check if an encryption key is still valid for new deposits.
+    function isEncryptionKeyValid(uint256 keyIndex)
+        external view returns (bool valid, uint64 expiresAtBlock);
+
+    /// @notice Process the next withdrawal from the queue. Only callable by the sequencer.
+    function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
+
+    /// @notice Submit a batch and verify the proof. Only callable by the sequencer.
+    function submitBatch(
+        uint64 tempoBlockNumber,
+        uint64 recentTempoBlockNumber,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata verifierConfig,
+        bytes calldata proof
+    ) external;
+}
+```
+
+#### Zone messenger (Tempo)
+
+Each zone has a dedicated messenger contract on Tempo. The portal gives the messenger max approval for each enabled token (granted when `enableToken()` is called). Withdrawal callbacks originate from this contract, not the portal.
+
+```solidity
+interface IZoneMessenger {
+    /// @notice Returns the zone's portal address
+    function portal() external view returns (address);
+
+    /// @notice Relay a withdrawal message. Only callable by the portal.
+    /// @dev Transfers tokens from portal to target via transferFrom, then executes callback.
+    ///      If callback reverts, the entire call reverts (including the transfer).
+    /// @param token The TIP-20 token to transfer
+    /// @param sender The L2 origin address
+    /// @param target The Tempo recipient
+    /// @param amount Tokens to transfer from portal to target
+    /// @param gasLimit Max gas for the callback
+    /// @param data Calldata for the target
+    function relayMessage(
+        address token,
+        bytes32 senderTag,
+        address target,
+        uint128 amount,
+        uint64 gasLimit,
+        bytes calldata data
+    ) external;
+}
+```
+
+The messenger does `ITIP20(token).transferFrom(portal, target, amount)` then calls the target with `data`. Both are atomic: if the callback reverts, the transfer is also reverted. Receivers check `msg.sender == zoneMessenger` to authenticate the call, and receive the `senderTag` in `onWithdrawalReceived` (see [Authenticated withdrawals](#authenticated-withdrawals)). This enables composable withdrawals where funds can flow directly into Tempo contracts (e.g., DEX swaps, staking, cross-zone deposits).
+
+#### Withdrawal receiver
+
+Contracts that receive withdrawals with callbacks must implement this interface:
+
+```solidity
+interface IWithdrawalReceiver {
+    /// @notice Called when a withdrawal with callback is received
+    /// @param sender The L2 origin address
+    /// @param token The TIP-20 token transferred
+    /// @param amount The amount of tokens transferred
+    /// @param callbackData The callback data from the withdrawal request
+    /// @return The function selector to confirm successful handling
+    function onWithdrawalReceived(
+        bytes32 senderTag,
+        address token,
+        uint128 amount,
+        bytes calldata callbackData
+    ) external returns (bytes4);
+}
+```
+
+The receiver must return `IWithdrawalReceiver.onWithdrawalReceived.selector` to confirm successful handling. If the receiver reverts or returns the wrong selector, the withdrawal fails and bounces back.
+
+### Zone predeploys
+
+Zones have four system contract predeploys at fixed addresses:
+
+- **TempoState** (0x1c00000000000000000000000000000000000000) - Stores finalized Tempo state and provides storage read access
+- **ZoneInbox** (0x1c00000000000000000000000000000000000001) - Advances Tempo state and processes deposits
+- **ZoneOutbox** (0x1c00000000000000000000000000000000000002) - Handles withdrawal requests back to Tempo
+- **ZoneConfig** (0x1c00000000000000000000000000000000000003) - Central configuration that reads sequencer from L1
+
+#### Zone token model
+
+Zones have **no TIP-20 factory**. All TIP-20 tokens on a zone are bridged representations of Tempo tokens — there is no mechanism to create or issue new tokens on the zone itself. Contract creation is disabled (`CREATE` and `CREATE2` revert), so users cannot deploy token contracts either.
+
+Each enabled TIP-20 token is deployed on the zone at the **same address** as on Tempo. When the sequencer calls `enableToken(token)` on the L1 portal, the zone node provisions a zone-side TIP-20 precompile at that address in the next genesis or state update. Users interact with zone tokens via the standard TIP-20 interface for transfers and approvals.
+
+The total supply of each zone token is controlled exclusively by the bridge:
+
+- **Mint on deposit**: `ZoneInbox` mints tokens when processing deposits from Tempo.
+- **Burn on withdrawal**: `ZoneOutbox` burns tokens when users request withdrawals back to Tempo.
+
+The zone-side supply of each token always equals the net deposits minus net withdrawals for that token. The corresponding Tempo-side tokens are held in escrow by the `ZonePortal`. No other actor can mint or burn zone tokens — system contracts (`ZoneInbox`, `ZoneOutbox`) are the sole mint/burn authorities.
+
+#### ZoneConfig predeploy
+
+ZoneConfig is the central zone configuration contract that provides access to zone metadata and reads the sequencer from L1. It is deployed at **0x1c00000000000000000000000000000000000003**.
+
+```solidity
+interface IZoneConfig {
+    error NotSequencer();
+    error NoEncryptionKeySet();
+
+    /// @notice L1 ZonePortal address
+    function tempoPortal() external view returns (address);
+
+    /// @notice TempoState predeploy for L1 reads
+    function tempoState() external view returns (ITempoState);
+
+    /// @notice Get current sequencer by reading from L1 ZonePortal
+    function sequencer() external view returns (address);
+
+    /// @notice Get pending sequencer by reading from L1 ZonePortal
+    function pendingSequencer() external view returns (address);
+
+    /// @notice Get sequencer's encryption public key by reading from L1 ZonePortal
+    /// @dev Reverts with NoEncryptionKeySet() if no key has been set.
+    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+
+    /// @notice Check if an address is the current sequencer
+    function isSequencer(address account) external view returns (bool);
+
+    /// @notice Check if a token is enabled by reading from L1 ZonePortal
+    function isEnabledToken(address token) external view returns (bool);
+}
+```
+
+ZoneConfig reads the sequencer address and token registry from the finalized L1 `ZonePortal` storage via `TempoState.readTempoStorageSlot()`. This makes L1 the **single source of truth** for sequencer management and token enablement, eliminating duplicate logic on zone-side contracts. Zone system contracts (`ZoneInbox`, `ZoneOutbox`) reference `ZoneConfig` for sequencer checks.
+
+#### TempoState predeploy
+
+The TempoState predeploy allows zones to verify they have a correct view of Tempo state. It stores the Tempo wrapper fields and selected inner Ethereum header fields, and provides storage reading functionality for system contracts. Deployed at **0x1c00000000000000000000000000000000000000**.
+
+```solidity
+interface ITempoState {
+    event TempoBlockFinalized(bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot);
+
+    /// @notice Current finalized Tempo block hash (keccak256 of RLP-encoded header)
+    function tempoBlockHash() external view returns (bytes32);
+
+    // Tempo wrapper fields
+    function generalGasLimit() external view returns (uint64);
+    function sharedGasLimit() external view returns (uint64);
+
+    // Inner Ethereum header fields
+    function tempoParentHash() external view returns (bytes32);
+    function tempoBeneficiary() external view returns (address);
+    function tempoStateRoot() external view returns (bytes32);
+    function tempoTransactionsRoot() external view returns (bytes32);
+    function tempoReceiptsRoot() external view returns (bytes32);
+    function tempoBlockNumber() external view returns (uint64);
+    function tempoGasLimit() external view returns (uint64);
+    function tempoGasUsed() external view returns (uint64);
+    function tempoTimestamp() external view returns (uint64);
+    function tempoTimestampMillis() external view returns (uint64);
+    function tempoPrevRandao() external view returns (bytes32);
+
+    /// @notice Finalize a Tempo block header. Only callable by ZoneInbox.
+    /// @dev Validates chain continuity (parent hash must match, number must be +1).
+    ///      Called by ZoneInbox.advanceTempo(). Executor enforces ZoneInbox-only access.
+    /// @param header RLP-encoded Tempo header
+    function finalizeTempo(bytes calldata header) external;
+
+    /// @notice Read a storage slot from a Tempo contract
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig).
+    ///      Used to read ZonePortal and TIP-403 policy state from Tempo.
+    function readTempoStorageSlot(address account, bytes32 slot) external view returns (bytes32);
+
+    /// @notice Read multiple storage slots from a Tempo contract
+    /// @dev RESTRICTED: Only callable by zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig).
+    function readTempoStorageSlots(address account, bytes32[] calldata slots) external view returns (bytes32[] memory);
+}
+```
+
+Tempo headers are RLP encoded as `rlp([general_gas_limit, shared_gas_limit, timestamp_millis_part, inner])`, where `inner` is a standard Ethereum header. The inner header uses trailing-field semantics for optional fields: `baseFeePerGas` (EIP-1559), `withdrawalsRoot` (EIP-4895), `blobGasUsed`/`excessBlobGas` (EIP-4844), `parentBeaconBlockRoot` (EIP-4788), and `requestsHash` (EIP-7685). TempoState skips these trailing optional fields and does not expose them.
+
+The TempoState stores the Tempo wrapper fields and the inner fields needed by the zone/proof logic; the `tempoBlockHash` is always `keccak256(RLP(TempoHeader))`, so proofs still commit to the complete header contents.
+
+**How it works:**
+
+1. ZoneInbox calls `finalizeTempo()` when the sequencer chooses to advance Tempo for a block, which decodes the RLP header, validates chain continuity, and stores the wrapper fields and selected inner fields. If a block omits `advanceTempo`, the Tempo binding carries over from the previous block.
+2. When submitting a batch, the prover specifies a `tempoBlockNumber` and optionally a `recentTempoBlockNumber`. The portal reads the hash for `anchorBlockNumber` via the EIP-2935 block hash history precompile.
+3. The proof must demonstrate that the zone's `tempoBlockHash` (from TempoState) matches the portal's `anchorBlockHash` in direct mode, or that the parent-hash chain from `tempoBlockNumber` reaches `anchorBlockHash` in ancestry mode.
+4. The `readTempoStorageSlot` functions are **precompile stubs restricted to system contracts only** - actual implementation is in the zone node, validated against `tempoStateRoot`. Only ZoneInbox (0x1c00...0001), ZoneOutbox (0x1c00...0002), and ZoneConfig (0x1c00...0003) can call these functions. User transactions cannot directly read Tempo state.
+
+Tempo state staleness depends on how frequently the sequencer updates tempo state using `advanceTempo()`. The zone client must only finalize Tempo headers after finality; proofs should only reference finalized Tempo blocks to avoid reorg risk. The prover includes Merkle proofs for each unique account and storage slot accessed by system contracts during the batch.
+
+#### TIP-403 registry
+
+The zone has a `TIP403Registry` contract deployed at the **same address** as Tempo. This contract is read-only—it and does not support writing policies. Its `isAuthorized` function reads policy state from Tempo via the Tempo state reader precompile, so zone-side TIP-20 transfers enforce Tempo TIP-403 policies automatically.
+
+#### Zone inbox
+
+The zone inbox is a system contract that advances Tempo state and processes deposits from Tempo in a single atomic operation. It is called by the sequencer at the start of a block when Tempo is advanced; blocks may omit this call and carry forward the existing Tempo binding.
+
+```solidity
+interface IZoneInbox {
+    event TempoAdvanced(
+        bytes32 indexed tempoBlockHash,
+        uint64 indexed tempoBlockNumber,
+        uint256 depositsProcessed,
+        bytes32 newProcessedDepositQueueHash
+    );
+
+    event DepositProcessed(
+        bytes32 indexed depositHash,
+        address indexed sender,
+        address indexed to,
+        address token,
+        uint128 amount,
+        bytes32 memo
+    );
+
+    /// @notice Emitted when an encrypted deposit is processed (decrypted and credited)
+    event EncryptedDepositProcessed(
+        bytes32 indexed depositHash,
+        address indexed sender,
+        address indexed to,
+        address token,
+        uint128 amount,
+        bytes32 memo
+    );
+
+    /// @notice Emitted when an encrypted deposit fails (invalid ciphertext, funds returned to sender)
+    event EncryptedDepositFailed(
+        bytes32 indexed depositHash, address indexed sender, address token, uint128 amount
+    );
+
+    error OnlySequencer();
+    error InvalidDepositQueueHash();
+    error MissingDecryptionData();
+    error ExtraDecryptionData();
+    error InvalidSharedSecretProof();
+
+    /// @notice Zone configuration (reads sequencer from L1)
+    function config() external view returns (IZoneConfig);
+
+    /// @notice The Tempo portal address (for reading deposit queue hash).
+    function tempoPortal() external view returns (address);
+
+    /// @notice The TempoState predeploy address.
+    function tempoState() external view returns (ITempoState);
+
+    /// @notice The zone's last processed deposit queue hash.
+    function processedDepositQueueHash() external view returns (bytes32);
+
+    /// @notice Advance Tempo state and process deposits in a single sequencer-only call.
+    /// @dev This is the main entry point for the sequencer at block start.
+    ///      1. Advances the zone's view of Tempo by processing the header
+    ///      2. Processes deposits from the unified deposit queue (regular + encrypted)
+    ///      3. Validates the resulting hash against Tempo's currentDepositQueueHash
+    /// @param header RLP-encoded Tempo block header
+    /// @param deposits Array of queued deposits to process (oldest first, must be contiguous)
+    /// @param decryptions Decryption data for encrypted deposits (1:1 with encrypted deposits, in order)
+    function advanceTempo(
+        bytes calldata header,
+        QueuedDeposit[] calldata deposits,
+        DecryptionData[] calldata decryptions
+    ) external;
+}
+```
+
+The sequencer observes `DepositMade` events on the Tempo portal and relays them to the zone via `advanceTempo`. This function:
+
+1. Calls `TempoState.finalizeTempo(header)` to advance the zone's view of Tempo
+2. Processes deposits in order, building the hash chain and minting the correct zone-side TIP-20 tokens
+3. Reads `currentDepositQueueHash` from the Tempo portal's storage via `TempoState.readTempoStorageSlot()`
+4. Validates the resulting hash matches Tempo's current state
+
+This combined approach ensures Tempo state advancement and deposit processing are atomic, and the deposit hash is validated against the actual Tempo state at the newly finalized block.
+
+#### Zone outbox
+
+The zone outbox handles withdrawal requests. Users approve the outbox to spend their tokens, then call `requestWithdrawal(token, ...)` specifying which TIP-20 to withdraw. The outbox stores pending withdrawals in an array. When the sequencer is ready to finalize a **batch**, it calls `finalizeWithdrawalBatch(count)` at the end of the **final block** in that batch. This constructs the withdrawal queue hash on-chain and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to storage. Intermediate blocks **must not** call `finalizeWithdrawalBatch()`. The call is required even if there are zero withdrawals (use `count = 0`) so the withdrawal batch index advances. The event is emitted for observability, but the proof reads from state (via the `lastBatch` storage) rather than parsing event logs.
+
+```solidity
+/// @notice Withdrawal batch parameters stored in state for proof access
+struct LastBatch {
+    bytes32 withdrawalQueueHash;
+    uint64 withdrawalBatchIndex;
+}
+
+interface IZoneOutbox {
+    /// @notice Maximum callback data size (1KB)
+    function MAX_CALLBACK_DATA_SIZE() external view returns (uint256);
+
+    event WithdrawalRequested(
+        uint64 indexed withdrawalIndex,
+        address indexed sender,
+        address token,
+        address to,
+        uint128 amount,
+        uint128 fee,
+        bytes32 memo,
+        uint64 gasLimit,
+        address fallbackRecipient,
+        bytes data,
+        bytes revealTo
+    );
+
+    event TempoGasRateUpdated(uint128 tempoGasRate);
+
+    /// @notice Emitted when sequencer finalizes a batch at end of block.
+    /// @dev Kept for observability. Proof reads from lastBatch storage instead.
+    event BatchFinalized(
+        bytes32 indexed withdrawalQueueHash,
+        uint64 withdrawalBatchIndex
+    );
+
+    event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
+    event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+
+    /// @notice Tempo gas rate (token units per gas unit on Tempo).
+    /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
+    function tempoGasRate() external view returns (uint128);
+
+    /// @notice Next withdrawal index (monotonically increasing).
+    function nextWithdrawalIndex() external view returns (uint64);
+
+    /// @notice Current withdrawal batch index (monotonically increasing).
+    function withdrawalBatchIndex() external view returns (uint64);
+
+    /// @notice Last finalized batch parameters (for proof access via state root).
+    function lastBatch() external view returns (LastBatch memory);
+
+    /// @notice Number of pending withdrawals waiting to be batched.
+    function pendingWithdrawalsCount() external view returns (uint256);
+
+    /// @notice Start a sequencer transfer. Only callable by current sequencer.
+    function transferSequencer(address newSequencer) external;
+
+    /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
+    function acceptSequencer() external;
+
+    /// @notice Set Tempo gas rate. Only callable by sequencer.
+    function setTempoGasRate(uint128 _tempoGasRate) external;
+
+    /// @notice Maximum number of withdrawal requests per zone block (0 = unlimited).
+    function maxWithdrawalsPerBlock() external view returns (uint256);
+
+    /// @notice Set maximum withdrawal requests per zone block. Only callable by sequencer.
+    /// @dev Set to 0 for unlimited. Provides rate-limiting in addition to the gas fee.
+    function setMaxWithdrawalsPerBlock(uint256 _maxWithdrawalsPerBlock) external;
+
+    /// @notice Calculate the fee for a withdrawal with the given gasLimit.
+    /// @dev Fee = gasLimit * tempoGasRate. User must estimate total gas needed.
+    function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128);
+
+    /// @notice Request a withdrawal from the zone back to Tempo.
+    /// @dev Caller must have approved the outbox to spend `amount + fee` of the specified token.
+    ///      The token must be enabled on the portal. Withdrawals can never be disabled
+    ///      for an enabled token (non-custodial guarantee).
+    ///      Subject to maxWithdrawalsPerBlock cap if set by the sequencer.
+    ///      Tokens are burned immediately and withdrawal is stored in pending array.
+    /// @param token The TIP-20 token to withdraw.
+    /// @param to The Tempo recipient address.
+    /// @param amount Amount to send to recipient (fee is additional).
+    /// @param memo User-provided context (e.g., payment reference).
+    /// @param gasLimit Gas limit for messenger callback (0 = no callback).
+    /// @param fallbackRecipient Zone address for bounce-back if callback fails.
+    /// @param data Calldata for the target (max 1KB).
+    /// @param revealTo Compressed secp256k1 public key (33 bytes) to encrypt sender reveal to, or empty.
+    function requestWithdrawal(
+        address token,
+        address to,
+        uint128 amount,
+        bytes32 memo,
+        uint64 gasLimit,
+        address fallbackRecipient,
+        bytes calldata data,
+        bytes calldata revealTo
+    ) external;
+
+    /// @notice Finalize batch at end of final block - build withdrawal hash and write to state.
+    /// @dev Only callable by sequencer in the final block of a batch.
+    ///      Must be called exactly once per batch (count may be 0). Writes `withdrawalQueueHash`
+    ///      and `withdrawalBatchIndex` to lastBatch storage for proof access.
+    /// @param count Max number of withdrawals to process (limits per-call gas cost).
+    /// @return withdrawalQueueHash The hash chain for Tempo batch submission.
+    function finalizeWithdrawalBatch(uint256 count) external returns (bytes32 withdrawalQueueHash);
+}
+```
+
+The `finalizeWithdrawalBatch()` function constructs the hash chain on-chain by processing withdrawals in reverse order (newest to oldest), so the oldest ends up outermost for O(1) Tempo removal:
+
+```
+// On-chain hash chain construction (inside finalizeWithdrawalBatch())
+withdrawalQueueHash = EMPTY_SENTINEL
+for i from (pendingCount - 1) down to 0:
+    withdrawalQueueHash = keccak256(abi.encode(withdrawals[i], withdrawalQueueHash))
+    pop withdrawal from storage
+```
+
+### External dependencies
+
+#### TIP-20 (minimal)
+
+```solidity
+interface ITIP20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+```
+
+## Queue design rationale
+
+Both the deposit queue and withdrawal queue are FIFO queues that require constant on-chain storage. They have symmetric but inverted requirements:
+
+|                      | Deposit queue | Withdrawal queue |
+|----------------------|---------------|------------------|
+| On-chain operation   | Add (users deposit) | Remove (sequencer processes) |
+| Proven operation     | Remove (zone consumes) | Add (zone creates) |
+| Efficient on-chain   | Addition | Removal |
+| Stable proving target| For removals | For additions |
+
+Both use hash chains, but with different models:
+
+- **Deposit queue**: Tempo tracks only `currentDepositQueueHash` (where new deposits land). The zone tracks its own `processedDepositQueueHash` in EVM state. The proof validates deposit processing by reading `currentDepositQueueHash` from Tempo state inside the proof.
+- **Withdrawal queue**: fixed-size ring buffer with `WITHDRAWAL_QUEUE_CAPACITY = 100` (each batch gets its own slot, `head` points to oldest unprocessed batch, `tail` points to where next batch writes, slots are indexed via `head/tail % WITHDRAWAL_QUEUE_CAPACITY`)
+
+The hash chains are structured differently to optimize for their on-chain operation:
+
+### Deposit queue: newest-outermost
+
+```
+Newest deposit wraps the outside (O(1) addition):
+
+                    ┌─────────────────────────────────────────┐
+                    │ hash(d3, ┌─────────────────────────┐ ) │  ← currentDepositQueueHash
+                    │          │ hash(d2, ┌───────────┐ ) │  │
+                    │          │          │ hash(d1,0) │   │  │
+                    │          │          └───────────┘   │  │
+                    │          └─────────────────────────┘  │
+                    └─────────────────────────────────────────┘
+                      ▲                              ▲
+                      │                              │
+                    newest                        oldest
+                   (outermost)                  (innermost)
+
+Adding d4: currentDepositQueueHash = keccak256(abi.encode(deposit4, currentDepositQueueHash))
+```
+
+- **On-chain addition is O(1)**: `currentDepositQueueHash = keccak256(abi.encode(deposit, currentDepositQueueHash))` — wrap the outside.
+- **Zone processing**: The zone's `advanceTempo()` processes deposits in FIFO order (oldest first, working outward from its `processedDepositQueueHash`), and validates the result matches `currentDepositQueueHash` (read from Tempo state).
+- **After batch**: Tempo updates `lastSyncedTempoBlockNumber` to record how far Tempo state was synced.
+
+### Withdrawal queue: oldest-outermost per slot
+
+```
+Oldest withdrawal on the outside (O(1) removal):
+
+                    ┌────────────────────────────────────────────────────┐
+                    │ hash(w1, ┌──────────────────────────────────────┐) │  ← slots[head]
+                    │          │ hash(w2, ┌───────────────────────┐ ) │  │
+                    │          │          │ hash(w3, EMPTY_SENTINEL) │  │  │
+                    │          │          └───────────────────────┘  │  │
+                    │          └──────────────────────────────────────┘  │
+                    └────────────────────────────────────────────────────┘
+                      ▲                                     ▲
+                      │                                     │
+                    oldest                              newest
+                   (outermost)                       (innermost)
+
+Removing w1: verify hash(w1, remainingQueue) == slots[head], then slots[head] = remainingQueue
+When slot exhausted: slots[head] = EMPTY_SENTINEL, head++
+```
+
+- **On-chain removal is O(1)**: Sequencer provides withdrawal + remaining hash, portal verifies and unwraps one layer.
+- **Proving additions**: Proof builds queue with new withdrawals at innermost (O(N) inside ZKP), writes to slot at tail.
+- **Fixed-size ring buffer**: Each batch gets its own slot (capacity 100). Sequencer processes from `head`, proofs add at `tail`. Reverts with `WithdrawalQueueFull` if all slots are occupied.
+
+```
+Fixed-size ring buffer (WITHDRAWAL_QUEUE_CAPACITY = 100):
+
+     head                              tail
+      │                                 │
+      ▼                                 ▼
+  ┌─────┬─────┬─────┬─────┬─────┬─────┐
+  │ w1  │ w4  │ w6  │EMPTY│EMPTY│     │  ... (100 slots, indexed via % 100)
+  │ w2  │ w5  │     │     │     │     │
+  │ w3  │     │     │     │     │     │
+  └─────┴─────┴─────┴─────┴─────┴─────┘
+  slot 0 slot 1 slot 2 ...        slot 99
+
+- Batches write to slots[tail % 100], then tail++
+- Sequencer processes from slots[head % 100], then head++ when slot exhausted
+- Reverts with WithdrawalQueueFull if tail - head >= 100
+```
+
+The key insight: structure the hash chain so the **on-chain operation touches the outermost layer**. Additions wrap the outside; removals unwrap from the outside. The expensive operation (processing the full queue) happens inside the ZKP where O(N) is acceptable. Using `EMPTY_SENTINEL` (0xffffffff...fff) instead of 0x00 avoids storage clearing and gas refund incentive issues.
+
+## Bridging in (Tempo to zone)
+
+1. User calls `ZonePortal.deposit(token, to, amount, memo)` on Tempo, specifying which enabled TIP-20 to deposit.
+2. `ZonePortal` validates the token is enabled and deposits are active, transfers `amount` of the specified token into escrow, and appends a deposit to the queue: `currentDepositQueueHash = keccak256(abi.encode(DepositType.Regular, deposit, currentDepositQueueHash))`. The `Deposit` struct includes the `token` field.
+3. The sequencer observes `DepositMade` events and processes deposits in order via `ZoneInbox.advanceTempo()`, minting the correct zone-side TIP-20 to the recipient: `IZoneToken(d.token).mint(d.to, d.amount)`. Deposits always succeed—there is no callback or bounce mechanism.
+4. A batch proof/attestation must prove the zone correctly processed deposits by validating the Tempo state read inside the proof.
+5. After the batch is accepted, `lastSyncedTempoBlockNumber` is updated to record how far Tempo state was synced.
+
+Notes:
+
+- Deposits are simple token credits. There are no callbacks or failure modes on the zone side.
+- Deposits are finalized for Tempo once the batch is verified.
+- There is no forced inclusion. If the sequencer withholds deposits, funds are stuck in escrow.
+- The portal only stores `currentDepositQueueHash`, not individual deposits. The sequencer must track deposits off-chain.
+- Tempo state advancement is combined with deposit processing in `ZoneInbox.advanceTempo()`, which calls `TempoState.finalizeTempo()` internally.
+- The proof validates an exact match to `currentDepositQueueHash` from Tempo state, ensuring it cannot claim to process fake deposits.
+- Each enabled TIP-20 is deployed at the **same address** on the zone as on Tempo. Zone tokens are precompiles provisioned by the zone node — there is no TIP-20 factory on zones.
+
+### Encrypted deposits
+
+For privacy-sensitive use cases, users can make **encrypted deposits** where the recipient and memo are encrypted using the sequencer's public key. Only the sequencer can decrypt and credit the correct recipient on the zone.
+
+**Encryption scheme**: ECIES with secp256k1
+
+1. Sequencer publishes a secp256k1 encryption public key via `setSequencerEncryptionKey(x, yParity, popV, popR, popS)` with a proof of possession
+2. User generates an ephemeral keypair and derives a shared secret via ECDH
+3. User encrypts `(to || memo)` with AES-256-GCM using the derived key
+4. User calls `depositEncrypted(amount, keyIndex, encryptedPayload)` on the portal
+
+```solidity
+/// @notice Encrypted deposit payload
+struct EncryptedDepositPayload {
+    bytes32 ephemeralPubkeyX;     // Ephemeral public key X coordinate (for ECDH)
+    uint8 ephemeralPubkeyYParity; // Y coordinate parity (0x02 or 0x03)
+    bytes ciphertext;             // AES-256-GCM encrypted (to || memo || padding)
+    bytes12 nonce;                // GCM nonce
+    bytes16 tag;                  // GCM authentication tag
+}
+
+/// @notice Encrypted deposit stored in the queue
+struct EncryptedDeposit {
+    address token;               // TIP-20 token (public, for escrow accounting)
+    address sender;              // Depositor (public, for refunds)
+    uint128 amount;              // Amount (public, for accounting)
+    uint256 keyIndex;            // Index of encryption key used (specified by depositor)
+    EncryptedDepositPayload encrypted; // Encrypted (to, memo)
+}
+```
+
+**What's public vs. private:**
+
+| Field | Visibility | Reason |
+|-------|------------|--------|
+| `token` | Public | Needed for on-chain escrow accounting and zone-side minting |
+| `sender` | Public | Needed for potential refunds if decryption fails |
+| `amount` | Public | Needed for on-chain accounting/escrow |
+| `to` | Encrypted | Privacy - only sequencer knows recipient |
+| `memo` | Encrypted | Privacy - only sequencer knows payment context |
+
+**Processing flow:**
+
+1. User calls `depositEncrypted(token, amount, keyIndex, encrypted)` on Tempo portal
+2. Portal escrows funds, adds to the **unified deposit queue**, and emits `EncryptedDepositMade`
+3. Sequencer decrypts the payload off-chain using their private key
+4. When processing the zone block, sequencer calls `advanceTempo()` with deposits from the unified queue
+5. For each encrypted deposit, sequencer provides decrypted `(to, memo)` alongside the encrypted data
+6. Zone/proof validates decryption and credits the recipient
+
+**Unified deposit queue:**
+
+Regular and encrypted deposits share a single ordered queue with a type discriminator in the hash chain:
+
+```solidity
+enum DepositType { Regular, Encrypted }
+
+// Regular deposit hash:
+keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
+
+// Encrypted deposit hash:
+keccak256(abi.encode(DepositType.Encrypted, encryptedDeposit, prevHash))
+```
+
+This ensures deposits are processed in the exact order they were made, regardless of type.
+
+**Security considerations:**
+
+- **Sequencer trust**: Users trust the sequencer to decrypt correctly and credit the right recipient. A malicious sequencer could steal encrypted deposits.
+- **On-chain verification**: The sequencer provides the ECDH shared secret, which enables on-chain decryption verification via GCM tag validation without revealing the private key. See "On-chain decryption verification" below.
+- **Key rotation**: The portal maintains a history of encryption keys. Each encrypted deposit includes the `keyIndex` the user encrypted to, allowing the prover to look up the correct key for decryption. See "Encryption key history" below.
+- **Malformed ciphertext**: If decryption fails (invalid ciphertext, wrong key, corrupted data), the zone mints tokens to `sender`'s address on the zone — the same address as their L1 account. The L1 funds remain escrowed in the portal. This ensures chain progress is never blocked by invalid encrypted deposits.
+
+**On-chain decryption verification:**
+
+The zone can verify encrypted deposit decryption on-chain without the sequencer revealing their private key. The sequencer provides the ECDH shared secret alongside the decrypted data:
+
+```solidity
+struct DecryptionData {
+    bytes32 sharedSecret;       // ECDH shared secret (x-coordinate of privSeq * ephemeralPub)
+    uint8 sharedSecretYParity;  // Y coordinate parity of the shared secret point (0x02 or 0x03)
+    address to;                 // Decrypted recipient
+    bytes32 memo;               // Decrypted memo
+    ChaumPedersenProof cpProof; // Proof of correct shared secret derivation
+}
+```
+
+Verification works by leveraging the AES-GCM authentication tag:
+
+1. Sequencer computes: `sharedSecret = ECDH(sequencerPriv, ephemeralPub)`
+2. On-chain, derive AES key from `sharedSecret` using HKDF-SHA256
+3. Attempt to decrypt the ciphertext with AES-256-GCM
+4. **The GCM tag will only validate if the shared secret is correct**
+5. If tag validates, the decrypted `(to, memo)` are cryptographically proven authentic
+
+**Griefing attack prevention:**
+
+Without additional checks, a malicious user could submit an encrypted deposit with invalid ciphertext (garbage data or encrypted to the wrong key). The sequencer wouldn't be able to decrypt it, but also couldn't prove it's invalid, blocking chain progress.
+
+**Solution**: Use a **Chaum-Pedersen zero-knowledge proof** to prove the shared secret was correctly derived, without exposing the sequencer's private key to the EVM.
+
+The sequencer provides a Chaum-Pedersen proof that proves: "I know `privSeq` such that `pubSeq = privSeq * G` AND `sharedSecretPoint = privSeq * ephemeralPub`"
+
+This proof allows on-chain verification without revealing the private key:
+
+```solidity
+// Step 1: Look up sequencer's public key from on-chain key history
+(bytes32 seqPubX, uint8 seqPubYParity) = _readEncryptionKey(ed.keyIndex);
+
+// Step 2: Verify Chaum-Pedersen proof of correct shared secret derivation
+bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
+    ed.encrypted.ephemeralPubX,
+    ed.encrypted.ephemeralPubYParity,
+    dec.sharedSecret,
+    dec.sharedSecretYParity,
+    seqPubX,          // looked up on-chain, not from dec
+    seqPubYParity,    // looked up on-chain, not from dec
+    dec.cpProof
+);
+if (!proofValid) revert InvalidSharedSecretProof();
+
+// Step 3: Derive AES key using HKDF-SHA256 (in Solidity)
+// Note: Encryption key validity is already validated on Tempo side in ZonePortal.depositEncrypted()
+bytes32 aesKey = _hkdfSha256(
+    dec.sharedSecret,
+    "ecies-aes-key",
+    abi.encodePacked(tempoPortal, ed.keyIndex, ed.encrypted.ephemeralPubkeyX)
+);
+
+// Step 4: Try to decrypt using AES-GCM precompile
+(bytes memory plaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(...);
+
+// Step 5: If decryption fails, credit depositor's address on zone (L1 funds stay escrowed)
+if (!valid) {
+    IZoneToken(ed.token).mint(ed.sender, ed.amount);
+    emit EncryptedDepositFailed(...);
+}
+```
+
+This prevents griefing: users can't block the chain with invalid encryptions, and the sequencer's private key never touches the EVM.
+
+**Chaum-Pedersen proof protocol:**
+
+1. **Prover (sequencer) computes off-chain:**
+   - Pick random `r`
+   - `R1 = r * G`
+   - `R2 = r * ephemeralPub`
+   - `c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)` (Fiat-Shamir challenge)
+   - `s = r + c * privSeq (mod n)`
+   - Proof is `(s, c)`
+
+2. **Verifier (on-chain) checks:**
+   - Reconstruct: `R1 = s*G - c*pubSeq`
+   - Reconstruct: `R2 = s*ephemeralPub - c*sharedSecretPoint`
+   - Recompute: `c' = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)`
+   - Verify: `c == c'`
+
+**Chaum-Pedersen verification precompile** (at `0x1c00000000000000000000000000000000000100`):
+
+```solidity
+interface IChaumPedersenVerify {
+    function verifyProof(
+        bytes32 ephemeralPubX,
+        uint8 ephemeralPubYParity,
+        bytes32 sharedSecret,
+        uint8 sharedSecretYParity,
+        bytes32 sequencerPubX,
+        uint8 sequencerPubYParity,
+        ChaumPedersenProof calldata proof
+    ) external view returns (bool valid);
+}
+```
+
+**AES-GCM decryption precompile** (at `0x1c00000000000000000000000000000000000101`):
+
+This is a minimal precompile that only performs AES-256-GCM decryption. HKDF-SHA256 key derivation is implemented in Solidity using the existing SHA256 precompile (0x02), making the precompile simpler and more auditable.
+
+```solidity
+interface IAesGcmDecrypt {
+    /// @notice Decrypt AES-256-GCM ciphertext and verify authentication tag
+    /// @dev Returns empty bytes and false if tag verification fails.
+    /// @param key AES-256 key (32 bytes)
+    /// @param nonce GCM nonce (12 bytes)
+    /// @param ciphertext The encrypted data
+    /// @param aad Additional authenticated data (empty for ECIES)
+    /// @param tag GCM authentication tag (16 bytes)
+    /// @return plaintext The decrypted data (empty if verification fails)
+    /// @return valid True if the tag verifies and decryption succeeds
+    function decrypt(
+        bytes32 key,
+        bytes12 nonce,
+        bytes calldata ciphertext,
+        bytes calldata aad,
+        bytes16 tag
+    ) external view returns (bytes memory plaintext, bool valid);
+}
+```
+
+Usage in `ZoneInbox.advanceTempo()`:
+
+```solidity
+// Step 1: Look up sequencer's public key from on-chain key history
+(bytes32 seqPubX, uint8 seqPubYParity) = _readEncryptionKey(ed.keyIndex);
+
+// Step 2: Verify Chaum-Pedersen proof of correct shared secret derivation
+bool proofValid = IChaumPedersenVerify(CHAUM_PEDERSEN_VERIFY).verifyProof(
+    ed.encrypted.ephemeralPubX,
+    ed.encrypted.ephemeralPubYParity,
+    dec.sharedSecret,
+    dec.sharedSecretYParity,
+    seqPubX,          // looked up on-chain, not from dec
+    seqPubYParity,    // looked up on-chain, not from dec
+    dec.cpProof
+);
+if (!proofValid) revert InvalidSharedSecretProof();
+
+// Step 3: Derive AES key from shared secret using HKDF-SHA256 (in Solidity)
+bytes32 aesKey = _hkdfSha256(
+    dec.sharedSecret,
+    "ecies-aes-key",
+    abi.encodePacked(tempoPortal, ed.keyIndex, ed.encrypted.ephemeralPubkeyX)
+);
+
+// Step 4: Decrypt using AES-256-GCM precompile
+(bytes memory decryptedPlaintext, bool valid) = IAesGcmDecrypt(AES_GCM_DECRYPT).decrypt(
+    aesKey,
+    ed.encrypted.nonce,
+    ed.encrypted.ciphertext,
+    "",  // empty AAD
+    ed.encrypted.tag
+);
+
+// Step 5: Verify decrypted plaintext matches claimed (to, memo)
+// Plaintext is packed as [address(20 bytes)][memo(32 bytes)][padding(12 bytes)] = 64 bytes
+if (valid && decryptedPlaintext.length == ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE) {
+    (address decryptedTo, bytes32 decryptedMemo) = EncryptedDepositLib.decodePlaintext(decryptedPlaintext);
+    valid = (decryptedTo == dec.to && decryptedMemo == dec.memo);
+} else {
+    valid = false;
+}
+
+// Step 6: Handle success or failure
+if (!valid) {
+    // Decryption failed - credit depositor's address on zone (L1 funds stay escrowed)
+    IZoneToken(ed.token).mint(ed.sender, ed.amount);
+    emit EncryptedDepositFailed(currentHash, ed.sender, ed.token, ed.amount);
+} else {
+    // Decryption succeeded - mint correct zone-side TIP-20 to decrypted recipient
+    IZoneToken(ed.token).mint(dec.to, ed.amount);
+    emit EncryptedDepositProcessed(currentHash, ed.sender, dec.to, ed.token, ed.amount, dec.memo);
+}
+```
+
+**Key properties:**
+- **Zero-knowledge security**: Chaum-Pedersen proof verifies shared secret without exposing sequencer's private key to EVM
+- **Griefing resistance**: Invalid encryptions can be detected and rejected, preventing chain blockage
+- **Graceful failure**: Invalid encrypted deposits return funds to sender instead of reverting
+- **Cryptographic proof**: GCM tag validation proves decryption correctness
+- **On-chain verification**: All verification happens on-chain via precompiles
+- **Standard crypto**: Uses well-established ECIES, ECDH, Chaum-Pedersen, HKDF-SHA256, and AES-256-GCM
+
+**Precompile implementation notes:**
+
+*Chaum-Pedersen Verify (`0x1c00000000000000000000000000000000000100`):*
+- Input: ephemeralPub, sharedSecret, sequencerPub, proof (s, c)
+- Reconstruct commitments: `R1 = s*G - c*pubSeq`, `R2 = s*ephemeralPub - c*sharedSecretPoint`
+- where `sharedSecretPoint` is derived by lifting sharedSecret to curve (requires Y-coordinate recovery)
+- Recompute challenge: `c' = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)`
+- Verify: `c == c'`
+- Gas cost: ~8000 gas (2 point multiplications + 2 point additions + hash)
+
+*AES-GCM Decrypt (`0x1c00000000000000000000000000000000000101`):*
+- Input: AES key (32 bytes), nonce (12 bytes), ciphertext, AAD, tag (16 bytes)
+- Decrypt: `plaintext = AES-256-GCM-Decrypt(key, nonce, ciphertext, aad, tag)`
+- Return decrypted plaintext and `true` if tag validates, or empty bytes and `false` otherwise
+- Gas cost: ~1000 gas base + ~500 per 32 bytes of ciphertext
+- Much simpler than full ECIES precompile - only handles symmetric encryption
+
+*HKDF-SHA256 (implemented in Solidity):*
+- Uses existing SHA256 precompile (0x02) to implement HMAC-SHA256 and HKDF
+- HMAC-SHA256: `HMAC(key, msg) = SHA256((key ⊕ opad) || SHA256((key ⊕ ipad) || msg))`
+- HKDF-Extract: `PRK = HMAC-SHA256(salt, IKM)`
+- HKDF-Expand: `OKM = HMAC-SHA256(PRK, info || 0x01)`
+- Gas cost: ~5-10k gas for full HKDF (depends on message sizes, dominated by SHA256 calls)
+- Tradeoff: Higher gas cost than native implementation, but keeps precompile minimal and auditable
+
+**Encryption key history:**
+
+To support key rotation, the portal stores all historical encryption keys. Users explicitly specify which key index they encrypted to, solving the race condition where a key might rotate between transaction signing and block inclusion.
+
+```solidity
+/// @notice Historical record of an encryption key with its activation block
+struct EncryptionKeyEntry {
+    bytes32 x;              // X coordinate of the public key
+    uint8 yParity;          // Y coordinate parity (0x02 or 0x03)
+    uint64 activationBlock; // Tempo block number when this key became active
+}
+
+/// @notice Encrypted deposit includes the key index and token used for encryption
+struct EncryptedDeposit {
+    address token;               // TIP-20 token (public, for escrow accounting)
+    address sender;              // Depositor (public, for refunds)
+    uint128 amount;              // Amount (public, for accounting)
+    uint256 keyIndex;            // Index of encryption key used (specified by depositor)
+    EncryptedDepositPayload encrypted; // Encrypted (to, memo)
+}
+
+/// @notice Deposit function requires explicit key index and token
+function depositEncrypted(
+    address token,                          // Token is public (needed for escrow)
+    uint128 amount,
+    uint256 keyIndex,                      // User specifies which key they encrypted to
+    EncryptedDepositPayload calldata encrypted
+) external returns (bytes32 newCurrentDepositQueueHash);
+```
+
+Key management functions:
+
+- `setSequencerEncryptionKey(x, yParity, popV, popR, popS)` - Appends a new key to history, active from current Tempo block. Requires a proof of possession (ECDSA signature over `keccak256(abi.encode(portalAddress, x, yParity))` by the corresponding private key)
+- `encryptionKeyCount()` - Returns total number of keys in history
+- `encryptionKeyAt(index)` - Returns a historical key entry by index
+- `encryptionKeyAtBlock(tempoBlockNumber)` - Returns the key that was active at a specific block
+- `isEncryptionKeyValid(keyIndex)` - Check if a key can still be used for new deposits
+
+**Why keyIndex instead of block number:**
+
+The user specifies `keyIndex` at signing time (when they know which key they're encrypting to). This avoids race conditions:
+- If key rotates *after* signing but *before* inclusion, the deposit still references the correct key
+- The portal can validate that `keyIndex` is a valid historical key
+- The prover looks up `encryptionKeyAt(keyIndex)` to get the decryption key
+
+**Key expiration:**
+
+Old encryption keys expire after a grace period to limit how long the sequencer must retain old private keys:
+
+```solidity
+/// 1 day at 1 second block time = 86400 blocks
+uint64 constant ENCRYPTION_KEY_GRACE_PERIOD = 86400;
+
+error EncryptionKeyExpired(uint256 keyIndex, uint64 activationBlock, uint64 supersededAtBlock);
+```
+
+- When a new key is set, the previous key remains valid for `ENCRYPTION_KEY_GRACE_PERIOD` blocks
+- After that, deposits using the old key are rejected with `EncryptionKeyExpired`
+- Users should call `isEncryptionKeyValid(keyIndex)` before signing to check if their key is still valid
+- The current (latest) key never expires
+
+Example timeline:
+1. Block 1000: Key 0 is set (current)
+2. Block 5000: Key 1 is set (current), Key 0 expires at block 5000 + 86400 = 91400
+3. Block 91400: Deposits with Key 0 start being rejected
+4. Sequencer can delete Key 0's private key after block 91400
+
+This allows:
+1. Users to verify they're encrypting to the current key before signing
+2. The prover to determine which key to use for any deposit via explicit `keyIndex`
+3. Seamless key rotation with a grace period for in-flight transactions
+4. Sequencer to safely delete old private keys after expiration
+
+## Bridging out (zone to Tempo)
+
+Users withdraw by creating a withdrawal on the zone. Withdrawals are processed in two steps:
+
+1. **Batch submission**: The sequencer calls `finalizeWithdrawalBatch()` at the end of the final block in the batch (even if `count = 0`), which constructs the withdrawal hash and emits a `BatchFinalized` event with the current `withdrawalBatchIndex`. The proof validates `ZoneOutbox.lastBatch()` state and adds the withdrawal hash to Tempo's queue.
+2. **Withdrawal processing**: The sequencer calls `processWithdrawal` to process withdrawals from the oldest slot (`head`).
+
+The `withdrawalBatchIndex` ensures batches are submitted in order: each batch's `withdrawalBatchIndex` must match the Tempo portal's expected next batch. This prevents the sequencer from omitting batches that contain withdrawals.
+
+### Withdrawal execution
+
+When the sequencer processes a withdrawal via `processWithdrawal`, the withdrawal is **popped unconditionally** (even on failure). If the transfer or messenger call fails, funds are bounced back via a new deposit.
+
+```solidity
+function processWithdrawal(Withdrawal calldata w, bytes32 remainingQueue) external onlySequencer {
+    uint256 head = _withdrawalQueue.head;
+
+    // Check if queue is empty
+    if (head == _withdrawalQueue.tail) {
+        revert NoWithdrawalsInQueue();
+    }
+
+    uint256 slotIndex = head % WITHDRAWAL_QUEUE_CAPACITY;
+    bytes32 currentSlot = _withdrawalQueue.slots[slotIndex];
+
+    // Verify head (remainingQueue of 0 means last item, we check against EMPTY_SENTINEL)
+    bytes32 expectedRemainingQueue = remainingQueue == bytes32(0) ? EMPTY_SENTINEL : remainingQueue;
+    require(keccak256(abi.encode(w, expectedRemainingQueue)) == currentSlot, "invalid");
+
+    // Pop the withdrawal regardless of success/failure
+    if (remainingQueue == bytes32(0)) {
+        // Slot exhausted, mark as empty and advance head
+        _withdrawalQueue.slots[slotIndex] = EMPTY_SENTINEL;
+        _withdrawalQueue.head = head + 1;
+    } else {
+        // More withdrawals in this slot
+        _withdrawalQueue.slots[slotIndex] = remainingQueue;
+    }
+
+    if (w.gasLimit == 0) {
+        ITIP20(w.token).transfer(w.to, w.amount);
+        return;
+    }
+
+    // Try callback via messenger for atomicity
+    try IZoneMessenger(messenger).relayMessage(w.token, w.senderTag, w.to, w.amount, w.gasLimit, w.callbackData) {
+        // Success: tokens transferred and callback executed
+    } catch {
+        // Callback failed: bounce back to zone
+        _enqueueBounceBack(w.token, w.amount, w.fallbackRecipient);
+    }
+}
+```
+
+The messenger does `ITIP20(token).transferFrom(portal, target, amount)` then executes the callback. Both are atomic: if the callback reverts, the transferFrom reverts too, and funds remain in the portal for bounce-back. Receivers check `msg.sender == messenger` to authenticate the call, and receive the `senderTag` in `onWithdrawalReceived` (see [Authenticated withdrawals](#authenticated-withdrawals)). This enables composable withdrawals where funds can flow directly into Tempo contracts (e.g., DEX swaps, staking, cross-zone deposits).
+
+## Withdrawal failure and bounce-back
+
+Withdrawals can fail if the token transfer or messenger callback reverts (out of gas, logic error, TIP-403 policy, token pause, etc.). When this happens, the portal "bounces back" the funds by re-depositing into the same zone to the withdrawal's `fallbackRecipient`.
+
+```solidity
+function _enqueueBounceBack(address token, uint128 amount, address fallbackRecipient) internal {
+    Deposit memory d = Deposit({
+        token: token,           // same token from the failed withdrawal
+        sender: address(this),
+        to: fallbackRecipient,
+        amount: amount,
+        memo: bytes32(0)
+    });
+    currentDepositQueueHash = keccak256(abi.encode(DepositType.Regular, d, currentDepositQueueHash));
+    emit BounceBack(...);
+}
+```
+
+The zone processes bounce-back deposits and credits the `fallbackRecipient`. This allows withdrawals to fail gracefully without blocking the queue.
+
+## Data availability and liveness
+
+- Zone data availability is fully trusted to the sequencer.
+- If the sequencer withholds data or halts, users cannot reconstruct zone state or force exits; batch posting and withdrawal processing are sequencer-only.
+- The design assumes users accept this risk in exchange for low-cost and fast settlement.
+
+## Withdrawal failure details
+
+Withdrawals can fail for various reasons. The system handles failures gracefully via bounce-back:
+
+### Failure reasons
+
+Withdrawals can fail due to:
+- **Transfer failure**: `transfer` or `transferFrom` reverts (includes gasLimit = 0 cases)
+- **TIP-403 policy**: Recipient not authorized under the token's transfer policy
+- **Token paused**: The token is globally paused
+- **Callback revert**: The receiver contract reverts (out of gas, logic error, etc.)
+- **Callback rejection**: Receiver returns wrong selector
+
+### Withdrawal failures (Tempo-side)
+
+When a withdrawal fails on Tempo:
+1. The TIP-20 transfer or callback reverts
+2. The portal enqueues a bounce-back deposit to `fallbackRecipient` on the zone
+3. Funds return to zone via the normal deposit flow
+
+### TIP-403 specific considerations
+
+Tempo TIP-20 tokens use TIP-403 for transfer authorization:
+- Every transfer checks `isAuthorized(policyId, from)` AND `isAuthorized(policyId, to)`
+- Policy types: WHITELIST (must be in set) or BLACKLIST (must not be in set)
+- Policy ID 1 is "always-allow" (default for most tokens)
+
+Zone creators SHOULD choose tokens with `transferPolicyId == 1` to avoid complexity. If using restricted policies:
+- The portal address MUST be whitelisted
+- Users should set `fallbackRecipient` to an address they control
+
+## Security considerations
+
+- Sequencer can halt the zone without recourse due to missing data availability.
+- The verifier is a trust anchor. A faulty verifier can steal or lock funds.
+- Withdrawals with callbacks go through the zone messenger with a user-specified gas limit. The messenger does `transferFrom` + callback atomically; any transfer or callback failure triggers a bounce-back to `fallbackRecipient`.
+- Deposits are locked on Tempo until a verified batch consumes them.
+- **Bounce-back guarantees**: Failed withdrawals bounce back to zone `fallbackRecipient`. Users always retain their funds.
+- **TIP-403 policy changes**: If a token's policy restricts the portal, withdrawals for that token will fail and bounce back.
+- **Token pause**: If a token is paused, withdrawals for that token bounce back to zone.
+
+## Implementation architecture
+
+This section describes the concrete implementation approach for zone nodes.
+
+### Node architecture
+
+Each zone runs as separate Tempo zone node (based on the Tempo client). It uses chain notifications to subscribe to all finalized updates on contracts that are read from on L1.
+
+### Execution model
+
+- **Payloads**: TIP-20 payloads are submitted via a simple RPC interface (not full reth RPC).
+- **TIP-20 precompile**: Payloads are executed through a TIP-20 payments precompile that handles token transfers and fee accounting.
+- **revm**: Execution uses revm with custom precompile injections for TIP-20 and payment logic.
+- **In-memory backstore**: Zone state is held in an in-memory database for fast access. State is persisted to disk for recovery.
+
+### State commitments
+
+- **Zone block hash**: Computed from the zone block header after execution. The zone block header is a simplified Ethereum header that includes:
+  - `parentHash`, `beneficiary`, `stateRoot`, `transactionsRoot`, `receiptsRoot`, `number`, `timestamp`, `protocolVersion`
+  - **Omitted fields**: `gasLimit`, `gasUsed` (zones have no hard gas limit), `logsBloom`, `extraData` (not needed for proofs)
+- **Transactions/receipts roots**: Computed over the full ordered list `[advanceTempo?, user txs..., finalizeWithdrawalBatch?]`.
+- **Transactions root**: Committed in the block hash but not proven on-chain. This prevents sequencer revisionism (claiming different transactions led to the state) while avoiding expensive transaction proof verification.
+- **Receipts root**: Committed in the block hash but not proven on-chain. Batch parameters are read from `lastBatch` state storage instead of event logs.
+- **Tempo anchoring**: The zone maintains its view of Tempo state via the TempoState predeploy. A zone block may start with a sequencer-only call to `ZoneInbox.advanceTempo()`, which internally calls `TempoState.finalizeTempo()` with the Tempo block header; if omitted, the binding carries over from the previous block. When submitting a batch, the prover specifies a `tempoBlockNumber` and an `anchorBlockNumber`; the proof must demonstrate the zone committed to `tempoBlockNumber` and that the anchor hash matches either the same block (direct mode) or a verified ancestry chain (ancestry mode) ending at `anchorBlockHash` from the EIP-2935 history precompile.
+
+#### Block header field coverage
+
+| Field | In Hash | Proven | How verified |
+|-------|---------|--------|--------------|
+| `parentHash` | ✓ | ✓ | Portal checks `prevBlockHash == blockHash`; proof validates chain continuity |
+| `beneficiary` | ✓ | ✓ | Proof validates beneficiary matches the registered sequencer address |
+| `stateRoot` | ✓ | ✓ | Core of proof; `lastBatch` and other state reads validated against this |
+| `transactionsRoot` | ✓ | ✗ | Committed but not proven on-chain; prevents sequencer revisionism |
+| `receiptsRoot` | ✓ | ✗ | Committed but not proven on-chain; batch params read from state instead |
+| `number` | ✓ | ✓ | Proof validates block number as part of the header transition |
+| `timestamp` | ✓ | ✓ | Proof validates timestamp is monotonically increasing from previous block |
+| `protocolVersion` | ✓ | ✓ | Proof validates version matches the expected fork for the imported L1 block |
+| `gasLimit` | ✗ | N/A | Omitted — zones have no hard gas limit |
+| `gasUsed` | ✗ | N/A | Omitted — zones have no hard gas limit |
+| `logsBloom` | ✗ | N/A | Omitted — not needed for proofs |
+| `extraData` | ✗ | N/A | Omitted — not needed for proofs |
+
+### Batching and proofs
+
+- **Batch interval**: Batches are produced every 250 milliseconds.
+- **SP1 proofs**: Validity proofs are generated using Succinct's SP1 prover.
+- **Mock proofs**: For development, proofs are mocked but data structures (public inputs, proof envelope) must match the real format.
+- **Sequencer posting only**: Only the configured sequencer posts batch proofs to the Tempo portal. The proof includes block hash and processed deposits.
+
+```solidity
+struct BatchProof {
+    bytes32 nextBlockHash;
+    uint64 withdrawalBatchIndex;            // withdrawal batch index from ZoneOutbox.lastBatch (must equal portal.withdrawalBatchIndex + 1)
+    uint64 tempoBlockNumber;      // Tempo block the zone synced to (must equal TempoState.tempoBlockNumber)
+    bytes32 withdrawalQueueHash;  // hash chain of withdrawals for this batch (0 if none)
+    bytes verifierConfig;         // opaque payload to IVerifier (TEE/ZK envelope)
+    bytes proof;                  // SP1 proof bytes (or TEE attestation)
+}
+```
+The portal provides `blockHash` and `withdrawalBatchIndex` as the previous batch's values. The proof reads `withdrawalBatchIndex` and `withdrawalQueueHash` from `ZoneOutbox.lastBatch()` state storage, and validates that `TempoState.tempoBlockHash()` and `TempoState.tempoBlockNumber()` match the EIP-2935 history precompile value and `tempoBlockNumber`.
+
+### Deposits and withdrawals
+
+- **Deposit contract**: Tempo portal escrows TIP-20 tokens. The ExEx watches `DepositMade` events and queues deposits for zone processing.
+- **Combined sequencer call**: A zone block may start with a sequencer-only call to `ZoneInbox.advanceTempo(header, deposits)`. This atomically advances the zone's Tempo view and processes pending deposits, validating the deposit hash against Tempo state. If omitted, no deposits are processed and the Tempo binding is unchanged for that block.
+- **Withdrawal requests**: Users trigger withdrawals on the zone via RPC. The withdrawal is added to the pending exits and included in the next batch's exit list.
+
+### RPC interface
+
+The zone exposes a minimal RPC (not full reth JSON-RPC):
+
+```
+zone_sendPayload(payload) -> txHash
+zone_requestWithdrawal(recipient, amount) -> withdrawalId
+zone_getState(address) -> balance
+zone_getReceipt(txHash) -> receipt
+```
+
+### Multi-zone ExEx structure
+
+```
+Tempo Node
+├── ExEx: Zone A (multi-asset: USDC, USDT, DAI, ...)
+│   ├── TIP-20 Precompiles (per enabled token)
+│   ├── Payments Precompile
+│   ├── In-memory State Store
+│   └── SP1 Prover (mock for dev)
+│
+└── ExEx: Zone B (multi-asset: USDC, EURC, ...)
+    ├── TIP-20 Precompiles (per enabled token)
+    ├── Payments Precompile
+    ├── In-memory State Store
+    └── SP1 Prover (mock for dev)
+```
+
+## Hard fork activation
+
+Zones activate hard fork upgrades in lockstep with Tempo L1 using same-block activation. The trigger is importing the fork L1 block: the zone block whose `advanceTempo` imports the fork L1 block uses the new execution rules for its entire scope. The new verifier is deployed on L1 as part of the Tempo hard fork; no on-chain action is required from the zone operator.
+
+### Definitions
+
+A zone hard fork is defined by:
+
+- Fork L1 block number (`F`): the L1 block number at which the fork activates. This is embedded in the zone node's chain specification and the prover program; the portal does not need to know it.
+- `forkVerifier`: the new `IVerifier` contract deployed on Tempo L1 as part of the hard fork.
+
+A zone block is a **post-fork zone block** if the L1 block it imports via `advanceTempo` has number `>= F`. A **fork-spanning batch** is a batch whose zone blocks include both pre-fork and post-fork zone blocks.
+
+### Activation rule
+
+The fork activates in the zone block that imports the fork L1 block, not the following block. The entire zone block — `advanceTempo`, user transactions, `finalizeWithdrawalBatch` — uses new execution rules. The EVM is configured with the new ruleset at the start of the block, before any transaction executes.
+
+The trigger is L1 block number, not timestamp. Each zone block maps to exactly one L1 block, so the block number is unambiguous even when the zone is catching up from behind.
+
+Same-block activation is necessary for correctness: if the fork changes the L1 header format, the new parsing code must be active in the zone block that first encounters the new format. Running `advanceTempo` under old rules against a post-fork L1 header would require fragile forward-compatibility shims.
+
+### Verifier routing
+
+The portal maintains two verifier slots. The batch submitter specifies which verifier to use; the portal checks that the specified address is one of the two active verifiers:
+
+```solidity
+address public verifier;              // pre-fork verifier
+address public forkVerifier;          // post-fork verifier (address(0) if no fork yet)
+uint64  public forkActivationBlock;   // L1 block at which forkVerifier was set (0 = no fork)
+
+function submitBatch(address targetVerifier, uint64 tempoBlockNumber, ...) external {
+    require(
+        targetVerifier == verifier || targetVerifier == forkVerifier,
+        "unknown verifier"
+    );
+    if (targetVerifier == verifier && forkActivationBlock != 0) {
+        require(tempoBlockNumber < forkActivationBlock, "use fork verifier");
+    }
+    require(IVerifier(targetVerifier).verify(...), "invalid proof");
+    ...
+}
+```
+
+The sequencer knows which prover it used and passes the corresponding verifier. The portal enforces that the old verifier is only used for batches whose `tempoBlockNumber` predates the fork. `forkActivationBlock` is set to `block.number` during `setForkVerifier` — no explicit `F` parameter is needed since the system transaction executes at the fork block itself.
+
+This prevents a non-upgraded node (or a malicious one that bypasses fork signaling) from submitting post-fork batches proved under old rules to the old verifier.
+
+The `IVerifier` interface is unchanged across forks. New proof parameters are passed via the opaque `verifierConfig` bytes.
+
+### Two-verifier invariant
+
+At most two verifiers are active at any time. When a new fork occurs, the previous fork's verifier is promoted to the `verifier` slot, and the new fork verifier takes the `forkVerifier` slot. The verifier that was in the `verifier` slot (from two forks ago) is deprecated.
+
+The L1 hard fork executes:
+
+```
+verifier            = forkVerifier       // promote previous fork verifier
+forkVerifier        = new_fork_verifier  // set new fork verifier
+forkActivationBlock = block.number       // record cutoff for old verifier
+```
+
+For the first fork, `verifier` retains its original value (set at zone creation) and `forkVerifier` is populated for the first time.
+
+This means the previous verifier remains active between forks, allowing zones that are behind to submit pre-fork batches. At the next fork, the N-2 verifier is deprecated. A zone that has not caught up past the N-2 fork boundary by the time the N-1 fork arrives can no longer submit those old batches.
+
+### Prover selection
+
+The zone node decides which prover to invoke. The new prover produces proofs against a new verification key, which only the fork verifier accepts. Since the fork verifier is not deployed until block `F`, the node must use the old prover for all batches submitted before `F`:
+
+- **Pre-fork batches** (all zone blocks import L1 block `< F`): proved with the old prover, submitted to the old verifier.
+- **Post-fork and fork-spanning batches** (any zone block imports L1 block `>= F`): proved with the new prover, submitted to the fork verifier. These can only be submitted after block `F`.
+
+The node determines which prover to use by checking the L1 block numbers in the batch against `F` from its chain specification.
+
+### Prover behavior
+
+The new prover program contains both old and new execution rules. For each zone block in a batch, it checks the L1 block number imported by `advanceTempo` and applies the corresponding rules:
+
+- Blocks importing L1 block `< F`: old rules
+- Blocks importing L1 block `>= F`: new rules
+
+The fork L1 block number is hardcoded in the prover program (same as how Ethereum clients embed fork block numbers). The resulting verification key reflects the complete dual-rule program. The fork verifier is deployed with this key.
+
+Each successive prover program is a superset: the fork N prover uses the fork N-1 prover's complete logic as its "old rules" branch. This means the fork N verifier can verify batches containing blocks from before fork N-1 as well — it applies old rules correctly for those blocks.
+
+Fork-spanning batches (containing both pre-fork and post-fork zone blocks) are proven in a single proof by the fork prover. The fork verifier validates them.
+
+### Zone node behavior
+
+The zone node determines the ruleset by inspecting the next L1 block in the deposit queue before building each zone block. The fork L1 block number is embedded in the node's chain specification. If the next L1 block has number `>= F`, the EVM is configured with new rules for that zone block.
+
+If the fork changes zone predeploy contract behavior (TempoState, ZoneInbox, ZoneOutbox, ZoneConfig), new contract bytecode is injected at the predeploy addresses as part of the fork zone block's state transition, before `advanceTempo` executes.
+
+#### Fork signaling
+
+`ZoneFactory` maintains a `protocolVersion` counter, incremented at each hard fork. Each zone node binary embeds the highest protocol version it supports. Before building a zone block, the node checks whether the L1 block it is about to import bumped `protocolVersion` beyond its supported version. If so, the node refuses to produce the block and halts with a clear error directing the operator to upgrade.
+
+This guarantees that an outdated node never produces zone blocks under incorrect rules — the zone halts cleanly rather than diverging.
+
+### L1 hard fork actions
+
+The Tempo L1 hard fork block executes:
+
+1. Deploy the fork `IVerifier` contract with the verification key for the new prover program.
+2. Call `ZoneFactory.setForkVerifier(forkVerifier)` via system transaction, which rotates verifiers on all registered portals and updates `_validVerifiers`.
+3. Increment `ZoneFactory.protocolVersion`.
+4. New zones created after the fork use the fork verifier as their initial verifier.
+
+### Sequencer upgrade path
+
+The new zone node binary and prover program are released before the fork. Operators upgrade off-chain at their convenience — no on-chain transaction is needed. When the fork L1 block arrives, the zone node activates new rules automatically and the sequencer uses the new prover for post-fork batches.
+
+If the operator does not upgrade before the fork, the zone node detects the unsupported protocol version and halts cleanly — no invalid blocks are produced. Settlement pauses because no new batches are submitted. User funds in the portal remain safe; the zone resumes once the operator upgrades.
+
+### Open questions
+
+- **Portal interface changes**: If a fork needs to change `submitBatch` or `IVerifier` signatures, portal bytecode must be upgraded. The `verifierConfig` opaque bytes handle most parameter extensions, but not interface-level changes.
+- **Predeploy upgrade mechanism**: Zone predeploy bytecode updates at fork time should be specified per-fork. A general injection mechanism (analogous to Ethereum EIPs specifying state changes at fork blocks) may be worth standardizing.
+- **L1 block number vs timestamp**: If L1 forks are timestamp-based, the zone node and prover must derive `F` as the first L1 block at or after the fork timestamp. Since the portal no longer needs `F`, this is purely an off-chain concern.
+
+## Authenticated withdrawals
+
+Zone transactions are private — the zone is a validium and transaction data is not published on L1. However, when a withdrawal is processed on L1 via `processWithdrawal`, the full `Withdrawal` struct (including `sender`) is passed in calldata and is publicly visible. This leaks the sender's identity.
+
+Authenticated withdrawals replace the plaintext sender with a commitment that only the sender can open, enabling selective disclosure: the recipient (or any other party the sender chooses) can verify the sender's identity, while the public cannot.
+
+### Sender tag
+
+The `sender` field in the `Withdrawal` struct is replaced with a `senderTag` and a new `encryptedSender` field:
+
+```solidity
+struct Withdrawal {
+    address token;
+    bytes32 senderTag;          // keccak256(abi.encodePacked(sender, txHash))
+    address to;
+    uint128 amount;
+    uint128 fee;
+    bytes32 memo;
+    uint64 gasLimit;
+    address fallbackRecipient;
+    bytes callbackData;
+    bytes encryptedSender;      // ECDH-encrypted (sender, txHash) for a target key, or empty
+}
+```
+
+The sequencer computes both fields when building the withdrawal in `finalizeWithdrawalBatch`:
+
+```
+senderTag       = keccak256(abi.encodePacked(sender, txHash))
+encryptedSender = ECDH_Encrypt((sender, txHash), revealTo)   // empty if no revealTo
+```
+
+where `sender` is the address that called `requestWithdrawal` on the zone and `txHash` is the hash of that transaction. The `txHash` acts as a 32-byte blinding factor — it is private to the zone (transaction data is not published on L1) and known only to the sender and the sequencer.
+
+The sender cannot encrypt `txHash` into the withdrawal transaction themselves (the hash depends on the transaction contents, creating a circular dependency). Instead, the sequencer performs the encryption post-hoc: it knows `sender`, `txHash`, and the target key after processing the transaction.
+
+### Reveal key
+
+The sender specifies an optional `revealTo` public key when requesting the withdrawal:
+
+```solidity
+function requestWithdrawal(
+    address token,
+    address to,
+    uint128 amount,
+    bytes32 memo,
+    uint64 gasLimit,
+    address fallbackRecipient,
+    bytes calldata data,
+    bytes calldata revealTo     // compressed secp256k1 public key (33 bytes), or empty
+) external;
+```
+
+If `revealTo` is provided, the sequencer encrypts `(sender, txHash)` to that key using ECDH (same scheme as encrypted deposits) and populates `encryptedSender` in the L1-facing `Withdrawal` struct. If empty, `encryptedSender` is empty and the sender can reveal `txHash` manually.
+
+The `revealTo` key is stored in the zone's pending withdrawal state so the sequencer can use it during `finalizeWithdrawalBatch`. It does not appear in the L1-facing struct — only the encrypted output does.
+
+### Encrypted sender format
+
+When `revealTo` is specified, `encryptedSender` contains:
+
+```
+ephemeralPubKey (33 bytes) || ciphertext (52 bytes) || mac (16 bytes)
+```
+
+The sequencer generates an ephemeral key pair `(r, R = r*G)`, derives a shared secret `S = r * revealTo`, and encrypts `abi.encodePacked(sender, txHash)` (52 bytes) using a symmetric cipher keyed by `S`. The holder of the private key corresponding to `revealTo` derives the same shared secret via `S = privKey * R` and decrypts.
+
+### Selective disclosure
+
+Two disclosure modes:
+
+**Manual reveal** (`revealTo` empty): The sender reveals `txHash` to any party off-chain. The verifier checks `keccak256(abi.encodePacked(sender_address, txHash)) == senderTag`.
+
+**Encrypted reveal** (`revealTo` specified): The holder of the `revealTo` private key decrypts `encryptedSender` to obtain `(sender, txHash)` and verifies against `senderTag`. No off-chain communication with the sender is needed.
+
+The sender can use both modes: specify `revealTo` for a primary recipient (e.g., target zone sequencer) and later reveal `txHash` manually to additional parties.
+
+### Zone-to-zone transfers
+
+For cross-zone withdrawals (Zone A to Zone B), the sender sets `revealTo` to Zone B's sequencer public key. The flow:
+
+1. Sender on Zone A calls `requestWithdrawal` with `revealTo = pubKeySeqB`.
+2. Zone A's sequencer processes the transaction, computes `senderTag` and `encryptedSender`.
+3. The withdrawal is proven and submitted to L1. `processWithdrawal` transfers tokens to Zone B's portal.
+4. Zone B's sequencer observes the incoming deposit, reads `encryptedSender` from the withdrawal data.
+5. Zone B's sequencer decrypts with its private key to learn `(sender, txHash)`.
+6. Zone B's sequencer verifies `keccak256(sender || txHash) == senderTag`.
+7. Zone B can now attribute the deposit to the sender, enabling sender-aware processing on Zone B.
+
+Each zone sequencer's public key is already published (used for encrypted deposits), so the sender can look it up without additional infrastructure.
+
+### Trust model
+
+The sequencer computes `senderTag` and `encryptedSender`, and includes them in the `Withdrawal` struct. The struct is hashed into the withdrawal queue chain, which is committed in the batch proof. The sequencer is trusted to compute both correctly — a malicious sequencer could insert incorrect values, and the batch proof would still be valid since the prover does not verify the tag's preimage or the encryption.
+
+This is a modest extension of the existing trust model: the sequencer is already trusted for liveness, transaction ordering, and withdrawal processing. Adding honest sender tag computation and encryption to that set is a small incremental assumption.
+
+To upgrade to trustless sender authentication, the `senderTag` computation can be moved into the ZK circuit. The prover would verify `senderTag == keccak256(abi.encodePacked(sender, txHash))` for the actual sender of each withdrawal transaction. The encryption would remain sequencer-mediated (ZK-proving ECDH encryption is expensive), but the commitment would be trustless. The on-chain interface and reveal flow remain unchanged.
+
+### Impact on callback withdrawals
+
+For simple withdrawals (`gasLimit == 0`), the sender field is not used in execution — only `to` and `amount` matter. The `senderTag` replacement has no functional impact.
+
+For callback withdrawals (`gasLimit > 0`), `IWithdrawalReceiver.onWithdrawalReceived` receives `bytes32 senderTag` instead of `address sender`:
+
+```solidity
+function onWithdrawalReceived(
+    bytes32 senderTag,
+    address token,
+    uint128 amount,
+    bytes calldata callbackData
+) external returns (bytes4);
+```
+
+Receiving contracts that need the sender's identity can decrypt `encryptedSender` off-chain (if they hold the `revealTo` key) or receive `txHash` via `callbackData` or a separate channel.
+
+### Zone-side changes
+
+`ZoneOutbox.requestWithdrawal` records the pending withdrawal with the plaintext `sender` and the `revealTo` key. The sequencer computes `senderTag` and `encryptedSender` when building the L1-facing `Withdrawal` struct in `finalizeWithdrawalBatch`. The zone-side `WithdrawalRequested` event continues to include the plaintext `sender` since zone events are private.
+
+### Open questions
+
+- **Sequencer-signed tag**: A per-withdrawal sequencer signature over `senderTag` would let recipients verify authenticity without trusting the batch proof context. This adds ~65 bytes per withdrawal. Whether this overhead is justified depends on the verification use case.
+- **revealTo for non-zone recipients**: Individual L1 recipients could also publish a public key (e.g., via ENS or an on-chain registry) to receive encrypted sender reveals without manual coordination.
+
+## Open questions
+
+- Should deposits be cancellable if not consumed within a timeout?

--- a/docs/specs/privacy/prover-design.md
+++ b/docs/specs/privacy/prover-design.md
@@ -1,0 +1,574 @@
+# Zone Prover Design
+
+## State Transition Function
+
+The zone prover implements a pure state transition function in Rust with `no_std` compatibility, allowing it to run in both ZKVMs like SP1 and TEEs like SGX or TDX.
+
+The function takes a complete witness of zone blocks and their dependencies, executes the EVM state transitions (including sequencer-only protocol transactions), and outputs commitments for on-chain verification.
+The core commitment is the **zone block hash transition** (not the raw state root), matching the privacy zone spec and Solidity reference implementation.
+
+## Interface
+
+```rust
+#![no_std]
+
+/// Pure state transition function for zone batch proving
+pub fn prove_zone_batch(witness: BatchWitness) -> Result<BatchOutput, Error>
+```
+
+## Witness Structure
+
+```rust
+pub struct PublicInputs {
+    /// Previous batch's block hash (must equal portal.blockHash)
+    pub prev_block_hash: B256,
+
+    /// Tempo block number for the batch (must equal portal's tempoBlockNumber)
+    pub tempo_block_number: u64,
+
+    /// Anchor Tempo block number (tempo_block_number or recent block in EIP-2935 window)
+    pub anchor_block_number: u64,
+
+    /// Anchor Tempo block hash (must equal portal's EIP-2935 lookup)
+    pub anchor_block_hash: B256,
+
+    /// Expected withdrawal batch index (passed by portal as withdrawalBatchIndex + 1)
+    pub expected_withdrawal_batch_index: u64,
+
+    /// Registered sequencer (passed by portal; zone block beneficiary must match)
+    pub sequencer: Address,
+}
+
+pub struct BatchWitness {
+    /// Public inputs committed by the proof system
+    pub public_inputs: PublicInputs,
+
+    /// Previous batch's block header (for state-root binding)
+    pub prev_block_header: ZoneHeader,
+
+    /// Zone blocks to execute
+    pub zone_blocks: Vec<ZoneBlock>,
+
+    /// Initial zone state
+    pub initial_zone_state: ZoneStateWitness,
+
+    /// Tempo state proofs for Tempo reads
+    pub tempo_state_proofs: BatchStateProof,
+
+    /// Tempo headers for ancestry verification (only in ancestry mode)
+    /// Ordered from tempo_block_number + 1 to anchor_block_number.
+    pub tempo_ancestry_headers: Vec<Vec<u8>>,
+}
+
+pub struct BatchOutput {
+    /// Zone block hash transition (prev -> final)
+    pub block_transition: BlockTransition,
+
+    /// Deposit queue processing
+    pub deposit_queue_transition: DepositQueueTransition,
+
+    /// Withdrawal queue hash chain for this batch (0 if no withdrawals)
+    pub withdrawal_queue_hash: B256,
+
+    /// Withdrawal batch parameters read from ZoneOutbox.lastBatch
+    pub last_batch: LastBatchCommitment,
+}
+
+pub struct LastBatchCommitment {
+    pub withdrawal_batch_index: u64,
+}
+
+/// Mirrors the Solidity `LastBatch` struct from ZoneOutbox.
+/// Used internally when reading from zone state; fields are split across
+/// `withdrawal_queue_hash` and `LastBatchCommitment` (index) in output.
+pub struct LastBatch {
+    pub withdrawal_queue_hash: B256,
+    pub withdrawal_batch_index: u64,
+}
+
+pub struct ZoneHeader {
+    pub parent_hash: B256,
+    pub beneficiary: Address,
+    pub state_root: B256,
+    pub transactions_root: B256,
+    pub receipts_root: B256,
+    pub number: u64,
+    pub timestamp: u64,
+    pub protocol_version: u64,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidProof,
+    ExecutionError(String),
+    InconsistentState,
+}
+```
+
+## Components
+
+### Zone Blocks
+
+```rust
+pub struct ZoneBlock {
+    /// Block number
+    pub number: u64,
+
+    /// Parent block hash
+    pub parent_hash: B256,
+
+    /// Timestamp
+    pub timestamp: u64,
+
+    /// Beneficiary (must match registered sequencer)
+    pub beneficiary: Address,
+
+    /// Tempo header RLP used by the call (ZoneInbox.advanceTempo).
+    /// If None, the block does not advance Tempo and the binding carries over.
+    pub tempo_header_rlp: Option<Vec<u8>>,
+
+    /// Deposits processed by the system tx (oldest first, unified queue).
+    /// Must be empty if tempo_header_rlp is None.
+    pub deposits: Vec<QueuedDeposit>,
+
+    /// Decryption data for encrypted deposits in the system tx.
+    /// Must be empty if tempo_header_rlp is None.
+    pub decryptions: Vec<DecryptionData>,
+
+    /// Sequencer-only: finalize a batch (only in final block, must be last)
+    /// Required for the final block in a batch; must be absent in intermediate blocks.
+    /// Uses U256 to match Solidity `finalizeWithdrawalBatch(uint256 count)`.
+    pub finalize_withdrawal_batch_count: Option<U256>,
+
+    /// Transactions to execute
+    pub transactions: Vec<Transaction>,
+}
+```
+
+### Deposit and Decryption Types
+
+```rust
+/// Mirrors the Solidity `QueuedDeposit` struct from IZone.sol
+pub struct QueuedDeposit {
+    pub deposit_type: DepositType,
+    pub deposit_data: Vec<u8>, // abi.encode(Deposit) or abi.encode(EncryptedDeposit)
+}
+
+pub enum DepositType {
+    Plain,
+    Encrypted,
+}
+
+/// Mirrors the Solidity `DecryptionData` struct from IZone.sol
+/// Provided by the sequencer for each encrypted deposit
+pub struct DecryptionData {
+    pub shared_secret: B256,  // ECDH shared secret (x-coordinate)
+    pub to: Address,          // Decrypted recipient
+    pub memo: B256,           // Decrypted memo
+    pub cp_proof: ChaumPedersenProof, // Proof of correct shared secret derivation
+}
+
+pub struct ChaumPedersenProof {
+    pub s: B256, // Response: s = r + c * privSeq (mod n)
+    pub c: B256, // Challenge: c = hash(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)
+}
+```
+
+Each zone block contains the required system transactions plus user transactions that will be executed using `revm`.
+The system transactions must mirror the Solidity reference implementation:
+- `ZoneInbox.advanceTempo(tempo_header_rlp, deposits, decryptions)` at the start of the block
+- `ZoneOutbox.finalizeWithdrawalBatch(count)` at the end of the block **only if this is the final block of the batch**
+If `advanceTempo` is omitted for a block, the Tempo binding carries over from the previous block.
+
+The executor must enforce at most one `advanceTempo` at the start of each block
+(or zero, for blocks that do not advance Tempo), and enforce `finalizeWithdrawalBatch` only in the
+final block of the batch. The block hash is computed from the simplified zone header:
+`parentHash`, `beneficiary`, `stateRoot`, `transactionsRoot`, `receiptsRoot`, `number`, `timestamp`, `protocolVersion`.
+The transactions and receipts roots are computed over the full ordered list of zone transactions.
+
+### Zone State Witness
+
+```rust
+pub struct ZoneStateWitness {
+    /// Account data with storage proofs
+    pub accounts: HashMap<Address, AccountWitness>,
+
+    /// Zone state root at start of batch
+    pub state_root: B256,
+}
+
+pub struct AccountWitness {
+    pub nonce: u64,
+    pub balance: U256,
+    pub code_hash: B256,
+    pub code: Option<Vec<u8>>,
+
+    /// Storage slots with values
+    pub storage: HashMap<U256, U256>,
+
+    /// MPT proof for account
+    pub account_proof: Vec<Vec<u8>>,
+
+    /// MPT proofs for storage slots
+    pub storage_proofs: HashMap<U256, Vec<Vec<u8>>>,
+}
+```
+
+The witness only includes accounts and storage slots that will be accessed during batch execution. Standard MPT proofs allow verification against the zone state root. Any
+account or storage access not present in the witness must be treated as an error (do not
+default to zero) so the prover cannot omit non-zero state.
+
+### Tempo State Proofs
+
+```rust
+pub struct BatchStateProof {
+    /// Deduplicated pool of all MPT nodes
+    pub node_pool: HashMap<B256, Vec<u8>>,
+
+    /// Tempo state reads with proof paths
+    pub reads: Vec<L1StateRead>,
+}
+
+pub struct L1StateRead {
+    /// Which zone block performed this read
+    pub zone_block_index: u64,
+
+    /// Which Tempo block to read from (must match TempoState for this block)
+    pub tempo_block_number: u64,
+
+    /// Tempo account and storage slot
+    pub account: Address,
+    pub slot: U256,
+
+    /// Path through node_pool from leaf to state root
+    pub node_path: Vec<B256>,
+
+    /// Expected value
+    pub value: U256,
+}
+```
+
+The `BatchStateProof` structure enables efficient proving of potentially thousands of Tempo state reads across multiple zone blocks.
+
+**Binding to Tempo:**
+- Tempo headers are validated whenever `ZoneInbox.advanceTempo` executes. Each call runs
+  `TempoState.finalizeTempo`, updating `tempoBlockNumber`, `tempoBlockHash`, and `tempoStateRoot`
+  in the proven zone state.
+- `TempoState.tempoBlockNumber()` at end of batch must equal `public_inputs.tempo_block_number`.
+- Each Tempo read is verified against the `tempoStateRoot` currently bound in `TempoState`
+  at the time of the read. The precompile must reject reads if the block is not yet bound.
+- For any Tempo read, the `tempo_block_number` must match the value currently bound in
+  `TempoState` at the time of the read. If a block contains no `advanceTempo` calls, reads
+  use the binding from the previous block.
+- Tempo reads performed inside `advanceTempo` (e.g., deposit queue hash) must be bound to the
+  Tempo header finalized by that specific call.
+
+Inside execution, `TempoState.readTempoStorageSlot` is modeled to read from the current `tempoStateRoot` (derived from the finalized header), so the proof and the precompile agree on the same root.
+
+#### Deduplication Strategy
+
+The key optimization is the **deduplicated node pool**. Instead of including separate MPT proofs for each Tempo storage read, all proofs share a single pool of verified nodes.
+
+**Why this matters:**
+- A batch might perform 100,000 Tempo state reads across 100 zone blocks
+- Many reads access the same accounts (shared account trie paths)
+- Many reads access slots in nearby addresses (shared storage trie paths)
+- Across multiple Tempo blocks, unchanged state shares identical nodes
+
+**How it works:**
+
+1. `node_pool` contains every unique MPT node, keyed by `keccak256(rlp(node))`
+2. Each `L1StateRead` has a `node_path` that references nodes in the pool by hash
+3. During proving:
+   - Verify each node in the pool exactly once: `keccak256(node) == hash`
+   - For each read, walk the `node_path` through verified nodes
+   - No node is ever hashed more than once
+
+**Example:**
+
+```
+Zone block 0: Read Account A slot 5 from Tempo block 1000
+Zone block 1: Read Account A slot 6 from Tempo block 1000
+Zone block 2: Read Account A slot 5 from Tempo block 1001
+
+Traditional approach:
+  - 3 separate proofs × 8 nodes each = 24 node verifications
+  - Many nodes overlap but are verified multiple times
+
+Deduplicated approach:
+  node_pool = {
+    0xaaa... -> [branch node],      // shared by all 3 reads
+    0xbbb... -> [branch node],      // shared by all 3 reads
+    0xccc... -> [extension node],   // shared by all 3 reads
+    0xddd... -> [leaf for A[5] in block 1000],
+    0xeee... -> [leaf for A[6] in block 1000],
+    0xfff... -> [leaf for A[5] in block 1001],
+  }
+  Total: ~11 unique nodes verified once each
+```
+
+**Proof size reduction:**
+- Traditional: 100,000 reads × 8 nodes × 32 bytes = 25.6 MB
+- Deduplicated: ~50,000 unique nodes × 32 bytes = 1.6 MB
+- **Compression: ~16x smaller**
+
+**Prover cost reduction:**
+- Traditional: 800,000 keccak operations
+- Deduplicated: 50,000 keccak operations
+- **Speedup: ~16x faster**
+
+## Implementation
+
+```rust
+pub fn prove_zone_batch(witness: BatchWitness) -> Result<BatchOutput, Error> {
+    // Phase 1: Verify Tempo state proofs
+    let tempo_state = verify_tempo_proofs(&witness.tempo_state_proofs)?;
+
+    // Phase 2: Initialize zone state
+    let mut zone_state = ZoneState::from_witness(&witness.initial_zone_state)?;
+
+    // Bind initial state root to the previous block hash
+    if zone_state.state_root() != witness.prev_block_header.state_root {
+        return Err(Error::InconsistentState);
+    }
+    if keccak256(rlp_encode(&witness.prev_block_header)) != witness.public_inputs.prev_block_hash {
+        return Err(Error::InvalidProof);
+    }
+
+    // Capture deposit queue start
+    let deposit_prev = zone_state.zone_inbox_processed_hash()?;
+
+    // Phase 3: Execute zone blocks and compute block hashes
+    let mut prev_block_hash = witness.public_inputs.prev_block_hash;
+    let mut prev_header = witness.prev_block_header;
+
+    for (idx, block) in witness.zone_blocks.iter().enumerate() {
+        let is_last_block = idx + 1 == witness.zone_blocks.len();
+
+        if block.parent_hash != prev_block_hash {
+            return Err(Error::InconsistentState);
+        }
+        if block.number != prev_header.number + 1 {
+            return Err(Error::InconsistentState);
+        }
+        // Timestamps must be non-decreasing (equal is allowed, matching EVM rules)
+        if block.timestamp < prev_header.timestamp {
+            return Err(Error::InconsistentState);
+        }
+        if block.beneficiary != witness.public_inputs.sequencer {
+            return Err(Error::InconsistentState);
+        }
+
+        if is_last_block {
+            if block.finalize_withdrawal_batch_count.is_none() {
+                return Err(Error::InconsistentState);
+            }
+        } else if block.finalize_withdrawal_batch_count.is_some() {
+            return Err(Error::InconsistentState);
+        }
+
+        // Execute block with sequencer calls + user txs, and Tempo access via tempo_state
+        let (tx_root, receipts_root) =
+            execute_zone_block(&mut zone_state, block, &tempo_state, idx)?;
+
+        // Build the zone block header and compute the block hash
+        let header = ZoneHeader {
+            parent_hash: prev_block_hash,
+            beneficiary: block.beneficiary,
+            state_root: zone_state.state_root(),
+            transactions_root: tx_root,
+            receipts_root: receipts_root,
+            number: block.number,
+            timestamp: block.timestamp,
+            protocol_version: block.protocol_version,
+        };
+        prev_block_hash = keccak256(rlp_encode(header));
+        prev_header = header;
+
+        // Tempo header binding is validated inside the advanceTempo call.
+    }
+
+    // Phase 4: Extract output commitments
+    let deposit_next = zone_state.zone_inbox_processed_hash()?;
+    let last_batch = zone_state.zone_outbox_last_batch()?;
+    let tempo_number = zone_state.tempo_state_block_number()?;
+
+    // Ensure TempoState is bound to public inputs for this batch
+    let tempo_hash = tempo_state
+        .block_hash(tempo_number)
+        .ok_or(Error::InvalidProof)?;
+    if tempo_number != witness.public_inputs.tempo_block_number {
+        return Err(Error::InconsistentState);
+    }
+
+    // Anchor validation:
+    // - Direct mode: anchor_block_number == tempo_block_number and hashes match
+    // - Ancestry mode: verify parent-hash chain from tempo_block_number to anchor_block_number
+    if witness.public_inputs.anchor_block_number == tempo_number {
+        if tempo_hash != witness.public_inputs.anchor_block_hash {
+            return Err(Error::InconsistentState);
+        }
+    } else {
+        verify_tempo_ancestry_chain(
+            tempo_hash,
+            tempo_number,
+            witness.public_inputs.anchor_block_number,
+            witness.public_inputs.anchor_block_hash,
+            &witness.tempo_ancestry_headers,
+        )?;
+    }
+
+    Ok(BatchOutput {
+        block_transition: BlockTransition {
+            prev_block_hash: witness.public_inputs.prev_block_hash,
+            next_block_hash: prev_block_hash,
+        },
+        deposit_queue_transition: DepositQueueTransition {
+            prev_processed_hash: deposit_prev,
+            next_processed_hash: deposit_next,
+        },
+        withdrawal_queue_hash: last_batch.withdrawal_queue_hash,
+        last_batch: LastBatchCommitment {
+            withdrawal_batch_index: last_batch.withdrawal_batch_index,
+        },
+    })
+}
+
+fn verify_tempo_proofs(
+    proofs: &BatchStateProof,
+) -> Result<TempoStateAccessor, Error> {
+    // Verify each node in pool exactly once
+    let mut verified_nodes = HashMap::new();
+    for (claimed_hash, rlp_data) in &proofs.node_pool {
+        let actual_hash = keccak256(rlp_data);
+        if actual_hash != *claimed_hash {
+            return Err(Error::InvalidProof);
+        }
+        verified_nodes.insert(*claimed_hash, MptNode::decode(rlp_data)?);
+    }
+
+    // Index read proofs for on-demand verification during execution
+    let mut read_index = HashMap::new();
+    for read in &proofs.reads {
+        read_index.insert(
+            (read.zone_block_index, read.account, read.slot),
+            read,
+        );
+    }
+
+    Ok(TempoStateAccessor { verified_nodes, read_index })
+}
+
+fn execute_zone_block(
+    zone_state: &mut ZoneState,
+    block: &ZoneBlock,
+    tempo_state: &TempoStateAccessor,
+    block_index: usize,
+) -> Result<(B256, B256), Error> {
+    // Set up revm with TempoState precompile
+    let mut evm = revm::EVM::builder()
+        .with_db(zone_state)
+        .with_block_env(block_env_from(block))
+        .with_precompile(
+            TEMPO_STATE_ADDRESS,
+            TempoStatePrecompile::new(tempo_state, block_index),
+        )
+        .build();
+
+    // System tx: advance Tempo and process deposits.
+    // The TempoState precompile must bind reads during this call to the newly finalized
+    // Tempo header, and reject any unbound reads.
+    if let Some(tempo_header_rlp) = &block.tempo_header_rlp {
+        evm.transact_commit(system_tx_advance_tempo(
+            tempo_header_rlp,
+            &block.deposits,
+            &block.decryptions,
+        ))
+        .map_err(|e| Error::ExecutionError(e.to_string()))?;
+
+        let tempo_number = zone_state.tempo_state_block_number()?;
+        tempo_state.bind_block(block_index, tempo_number)?;
+
+        let expected_tempo_hash = tempo_state
+            .block_hash(tempo_number)
+            .ok_or(Error::InvalidProof)?;
+        if expected_tempo_hash != keccak256(tempo_header_rlp) {
+            return Err(Error::InconsistentState);
+        }
+    } else if !block.deposits.is_empty() || !block.decryptions.is_empty() {
+        return Err(Error::InconsistentState);
+    }
+
+    // Execute user transactions in order.
+    for tx in &block.transactions {
+        evm.transact_commit(tx)
+            .map_err(|e| Error::ExecutionError(e.to_string()))?;
+    }
+
+    // Sequencer finalizes the batch at the end of the final block.
+    if let Some(count) = block.finalize_withdrawal_batch_count {
+        evm.transact_commit(sequencer_tx_finalize_withdrawal_batch(count))
+            .map_err(|e| Error::ExecutionError(e.to_string()))?;
+    }
+
+    // Compute roots for block hash commitment
+    let tx_root = compute_transactions_root_from_block(block);
+    let receipts_root = compute_receipts_root(evm.last_block_receipts());
+
+    Ok((tx_root, receipts_root))
+}
+```
+
+## Deployment Modes
+
+### ZKVM (SP1)
+
+```rust
+#[cfg(target_os = "zkvm")]
+fn main() {
+    let witness: BatchWitness = zkvm::io::read();
+    let output = prove_zone_batch(witness).expect("proof generation failed");
+    zkvm::io::commit(&output);
+}
+```
+
+### TEE (SGX/TDX)
+
+```rust
+#[cfg(target_env = "sgx")]
+#[no_mangle]
+pub extern "C" fn ecall_prove_batch(
+    witness_ptr: *const u8,
+    witness_len: usize,
+) -> BatchOutput {
+    let witness = unsafe { deserialize(witness_ptr, witness_len) };
+    prove_zone_batch(witness).expect("proof generation failed")
+}
+```
+
+## On-Chain Verification
+
+The portal contract receives:
+- `tempoBlockNumber` - block zone committed to (from zone's TempoState)
+- `recentTempoBlockNumber` - optional recent block for ancestry proofs (0 = direct lookup)
+- `blockTransition` - from `BatchOutput` (block hash based)
+- `proof` - ZKVM proof or TEE attestation
+
+The portal passes the following to the verifier:
+- `tempoBlockNumber`
+- `anchorBlockNumber` and `anchorBlockHash` (from EIP-2935)
+- `expectedWithdrawalBatchIndex` (portal's `withdrawalBatchIndex + 1`)
+- `sequencer` (the registered sequencer address)
+- `blockTransition`, `depositQueueTransition`, `withdrawalQueueTransition`
+- `verifierConfig` and `proof`
+
+The verifier validates that the prover correctly executed the state transition and produced the output commitments.
+In particular, the proof must enforce:
+- `TempoState.tempoBlockNumber == tempoBlockNumber`
+- **Direct mode** (`anchorBlockNumber == tempoBlockNumber`): `TempoState.tempoBlockHash == anchorBlockHash`
+- **Ancestry mode** (`anchorBlockNumber > tempoBlockNumber`): parent-hash chain from `tempoBlockNumber` to `anchorBlockNumber`, ending at `anchorBlockHash`
+- `ZoneOutbox.lastBatch().withdrawalBatchIndex == expectedWithdrawalBatchIndex` (passed by portal)
+- `ZoneOutbox.lastBatch().withdrawalQueueHash == withdrawalQueueTransition.withdrawalQueueHash`
+- Zone block `beneficiary` equals `sequencer` (passed by portal)
+- `DepositQueueTransition` matches `ZoneInbox.processedDepositQueueHash` changes
+- `BlockTransition` is computed from the zone block header hash (not raw state root)

--- a/docs/specs/privacy/rpc.md
+++ b/docs/specs/privacy/rpc.md
@@ -1,0 +1,510 @@
+# Zone RPC Specification (Draft)
+
+This document specifies the RPC interface for Tempo privacy zones. The design starts from the standard Ethereum JSON-RPC and restricts it to enforce privacy guarantees: callers can only observe state and history relevant to their own account.
+
+## Goals
+
+- Expose a familiar Ethereum JSON-RPC so that existing tooling (wallets, SDKs, block explorers) can connect with minimal changes.
+- Authenticate every request via a short-lived authorization token tied to an Ethereum account.
+- Ensure that no RPC call leaks information about accounts other than the caller's own.
+- Work in concert with the [execution environment modifications](./execution) that enforce privacy at the EVM level.
+
+## Non-goals
+
+- Public block explorers or permissionless indexing. The zone is a private validium; only authenticated participants and the sequencer can observe state.
+- Support for arbitrary smart contract deployment. Zones run a fixed set of predeploys; contract creation is disabled.
+
+## Authorization tokens
+
+Every RPC request must include an authorization token in the `X-Authorization-Token` HTTP header (or as the first element of a JSON-RPC batch params wrapper — see [Transport](#transport)). The authorization token proves that the caller controls a Tempo account and scopes all responses to that account.
+
+Tempo accounts support multiple signature types (secp256k1, P256, and WebAuthn), so the authorization token scheme must support all of them. Additionally, accounts that have authorized Access Keys via the [AccountKeychain](/protocol/transactions/AccountKeychain) precompile can use those Access Keys to authenticate to the RPC on behalf of their root account. The RPC server uses the same signature parser and recovery rules as Tempo transactions, so auth tokens accept the same wire formats as transaction signatures.
+
+### Message
+
+The signed message is the `keccak256` hash of the following packed encoding:
+
+```solidity
+bytes32 authorizationTokenHash = keccak256(abi.encodePacked(
+    bytes32(0x54656d706f5a6f6e65525043),  // "TempoZoneRPC" magic prefix
+    uint8(version),                         // spec version (currently 0)
+    uint32(zoneId),                         // zone this key is valid for (0 = unscoped)
+    uint64(chainId),                        // zone chain ID (replay protection)
+    uint64(issuedAt),                       // unix timestamp (seconds) of issuance
+    uint64(expiresAt)                       // unix timestamp (seconds) of expiry
+));
+```
+
+The `version` field MUST be `0` for this version of the spec. The RPC server MUST reject authorization tokens with an unrecognized version. This allows future revisions to change authorization token semantics (e.g., adding scoped permissions) without ambiguity.
+
+This hash is the challenge that must be signed. Using a raw `keccak256` hash (rather than EIP-191 personal messages or EIP-712 typed data) allows all Tempo signature types to sign the same message consistently — P256 and WebAuthn signers cannot produce EIP-191 prefixed signatures. The `"TempoZoneRPC"` magic prefix provides domain separation, ensuring that authorization token hashes cannot collide with Tempo transaction hashes or other signing contexts.
+
+### Unscoped tokens
+
+A `zoneId` of `0` indicates an **unscoped** authorization token that is valid for any zone. Zone IDs are assigned by `ZoneFactory` starting at 1, so `0` is never a valid zone ID.
+
+When the RPC server receives a token with `zoneId == 0`, it MUST skip the zone ID check and accept the token for any zone. All other validation rules (version, chain ID, expiry, signature) still apply. The `chainId` field continues to provide cross-network replay protection.
+
+Unscoped tokens are useful for applications and SDKs that interact with multiple zones on the same network without managing separate tokens per zone. Since authorization tokens are read-only credentials (no RPC method authenticated solely by a token may modify state), the additional exposure is limited to read access across zones the user has accounts in.
+
+### Signature types
+
+The authorization token signature follows the same format as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types). The signature type is determined by the first byte and length:
+
+| Type | Detection | Address derivation |
+|------|-----------|-------------------|
+| **secp256k1** | Exactly 65 bytes, no type prefix | `address(uint160(uint256(keccak256(abi.encode(x, y)))))` — standard `ecrecover` |
+| **P256** | First byte `0x01`, 130 bytes total | `address(uint160(uint256(keccak256(abi.encodePacked(pubKeyX, pubKeyY)))))` — public key is embedded in the signature |
+| **WebAuthn** | First byte `0x02`, variable length (max 2KB) | Same as P256 (WebAuthn uses P256 keys) |
+| **Keychain** | First byte `0x03` (legacy V1) or `0x04` (V2), variable length | Authenticated account is the `user_address` field, not the signing key's address (see [Keychain Access Keys](#keychain-access-keys)) |
+
+#### secp256k1
+
+Standard Ethereum signature. The RPC server recovers the public key via `ecrecover(authorizationTokenHash, v, r, s)` and derives the account address.
+
+#### P256
+
+The signature includes the public key coordinates, so the server verifies the P256 signature directly and derives the address from the embedded public key. If the `pre_hash` flag is set, the server applies `sha256(authorizationTokenHash)` before verification.
+
+#### WebAuthn
+
+The authorization token hash is embedded as the WebAuthn challenge (Base64URL-encoded). Verification follows the same rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#webauthn-signatures):
+
+**Verified:**
+
+- `authenticatorData` minimum length (37 bytes: 32-byte rpIdHash + 1-byte flags + 4-byte signCount).
+- User Presence (UP) or User Verification (UV) flag is set (at least one required).
+- AT (attested credential data) flag is NOT set (must be an assertion, not a registration).
+- ED (extension data) flag is NOT set (extensions are not supported).
+- `clientDataJSON.type` equals `"webauthn.get"`.
+- `clientDataJSON.challenge` matches `authorizationTokenHash` (Base64URL-encoded, no padding).
+- P256 signature over `sha256(authenticatorData || sha256(clientDataJSON))` is valid.
+
+**Intentionally skipped:**
+
+- **RP ID hash** (`authenticatorData` bytes 0–31): Not validated. In traditional WebAuthn, the server checks that `rpIdHash` matches its own domain to prevent cross-site credential use. Tempo has no single relying party — users interact through many frontends (wallets, dApps, SDKs), each with a different RP ID. The challenge binding to `authorizationTokenHash` provides the security guarantee instead: even if a signature is obtained from an unexpected origin, it is only valid for the specific authorization token parameters that were signed.
+- **`clientDataJSON.origin`**: Not validated, for the same reason — there is no canonical origin to check against.
+- **Signature counter**: Not checked. Anti-cloning detection is left to the application layer.
+
+The account address is derived from the public key in the signature, following the same derivation as P256.
+
+#### Keychain Access Keys
+
+Accounts that have authorized Access Keys via the zone's `AccountKeychain` precompile can use those keys to authenticate to the RPC. The zone has its own independent `AccountKeychain` instance — it is **not** mirrored from Tempo L1. Users must register Keychain keys on the zone directly via transactions submitted to the zone's `AccountKeychain` precompile. This means a key registered on Tempo L1 does not automatically grant RPC access to the zone; the user must separately authorize it on the zone.
+
+A Keychain signature wraps an inner signature (secp256k1, P256, or WebAuthn) and includes the root account address. The RPC server accepts both the legacy V1 and current V2 encodings supported by Tempo transaction signatures:
+
+```
+keychain_signature_v1 = 0x03 || user_address (20 bytes) || inner_signature
+keychain_signature_v2 = 0x04 || user_address (20 bytes) || inner_signature
+```
+
+V2 is recommended. V2 binds `user_address` into the access-key signing hash, while V1 signs the raw authorization-token hash directly for backward compatibility.
+
+The server:
+
+1. Parses the signature using the same rules as Tempo transactions.
+2. Verifies the inner signature against `authorizationTokenHash` for V1, or against `keccak256(0x04 || authorizationTokenHash || user_address)` for V2.
+3. Derives the signing key's address from the inner signature.
+4. Queries the zone's `AccountKeychain` precompile to verify that `user_address` has authorized the signing key (i.e., `getKey(user_address, keyId)` returns an active, non-expired, non-revoked key).
+5. Verifies that the stored `signatureType` matches the inner signature type (secp256k1, P256, or WebAuthn).
+6. Sets the authenticated account to `user_address` (the root account), not the Access Key's address.
+
+This allows session keys and scoped Access Keys to authenticate to the RPC with the same permissions as the root account. The AccountKeychain's spending limits and expiry are orthogonal to the RPC authorization token — the Keychain key must be active to authenticate, but its token-spending limits only apply to on-chain transactions, not RPC reads.
+
+### Validation
+
+The RPC server MUST reject authorization tokens where:
+
+- `zoneId` does not equal the zone's configured `zoneId` **and** `zoneId` is not `0` (an unscoped token with `zoneId == 0` is valid for any zone — see [Unscoped tokens](#unscoped-tokens)).
+- `chainId` does not equal the zone's configured chain ID (`eth_chainId`).
+- `expiresAt - issuedAt > 2592000` (protocol maximum validity window is 30 days).
+- `expiresAt <= now` (key has expired).
+- `issuedAt > now + 60` (clock skew tolerance of 60 seconds into the future).
+- The signature is malformed or does not verify.
+- For Keychain signatures: the signing key is not authorized, is revoked, or is expired in the AccountKeychain.
+
+Implementations MAY enforce a shorter local maximum validity window as configuration, but they MUST NOT accept tokens longer than 30 days.
+
+### Sequencer access
+
+The zone sequencer is identified by the `sequencer` address registered in the `ZonePortal` on Tempo. When the authenticated account equals the sequencer address, all restrictions are lifted: the sequencer has universal read access to all state, transactions, and events. This is necessary for the sequencer to produce blocks and batches.
+
+### Transport
+
+Authorization tokens are sent as an HTTP header on every request:
+
+```
+POST /
+X-Authorization-Token: <hex-encoded authorization token>
+Content-Type: application/json
+
+{"jsonrpc":"2.0","method":"eth_getBalance","params":[...],"id":1}
+```
+
+The `X-Authorization-Token` value is a single hex-encoded blob containing the concatenation of the signature and the authorization token fields:
+
+```
+<signature bytes><version: 1 byte><zoneId: 4 bytes><chainId: 8 bytes><issuedAt: 8 bytes><expiresAt: 8 bytes>
+```
+
+The authorization token fields are always exactly 29 bytes (1 + 4 + 8 + 8 + 8). To parse the blob, the RPC server reads the **last 29 bytes** as the authorization token fields, and treats everything before them as the signature. The signature is then parsed using the same detection rules as [Tempo transaction signatures](/protocol/transactions/spec-tempo-transaction#signature-types) (secp256k1 is exactly 65 bytes; P256 starts with `0x01` and is 130 bytes; WebAuthn starts with `0x02` and is variable-length; Keychain starts with `0x03` for legacy V1 or `0x04` for V2 and is variable-length). Parsing from the end avoids any ambiguity with variable-length signature types.
+
+Requests without an authorization token receive a `401 Unauthorized` HTTP response. Requests with an expired, malformed, or unauthorized token receive `403 Forbidden`. If Keychain token verification fails because the server cannot read `AccountKeychain.getKey(...)`, the server returns `500 Internal Server Error`.
+
+## RPC method access control
+
+The zone RPC starts from the standard Ethereum JSON-RPC method set and applies per-method restrictions. Each method falls into one of four categories: **allowed** (unrestricted), **scoped** (filtered to the authenticated account), **restricted** (sequencer-only), or **disabled** (not available).
+
+**Default deny**: Any method not explicitly listed below MUST return error code `-32601` (method not found). This ensures that new methods added by future Ethereum specs or node implementations are not accidentally exposed without privacy review.
+
+### Allowed methods
+
+These methods return public zone information and are available to any authenticated caller.
+
+| Method | Notes |
+|--------|-------|
+| `eth_chainId` | Returns the zone's chain ID |
+| `eth_blockNumber` | Returns the latest block number |
+| `eth_gasPrice` | Returns the current gas price |
+| `eth_maxPriorityFeePerGas` | Returns the current priority fee |
+| `eth_feeHistory` | Fee history is public |
+| `eth_getBlockByNumber` | Returns block headers **without transaction details** (see [Block responses](#block-responses)) |
+| `eth_getBlockByHash` | Returns block headers **without transaction details** |
+| `eth_subscribe("newHeads")` | Pushes block headers on new blocks. The `logsBloom` field is zeroed (see [Block responses](#block-responses)). |
+| `eth_syncing` | Returns sync status. Low risk — reveals node state, not account data. |
+| `eth_coinbase` | Returns the sequencer address (already public via `zone_getZoneInfo`). |
+| `net_version` | Network ID |
+| `net_listening` | Node status |
+| `web3_clientVersion` | Client version |
+| `web3_sha3` | Pure Keccak-256 hash — no state access |
+
+### Scoped methods
+
+These methods are available to any authenticated caller but filter results to only include data relevant to the authenticated account.
+
+#### State queries
+
+| Method | Scoping rule |
+|--------|-------------|
+| `eth_getBalance` | Returns the native balance for the authenticated account only. Queries for other accounts return `0x0`. |
+| `eth_getTransactionCount` | Returns the nonce for the authenticated account only. Queries for other accounts return `0x0`. |
+| `eth_call` | Executes the call with `from` set to the authenticated account. The [execution environment](./execution) enforces `balanceOf` access control at the EVM level, so callers can only query their own balance. Calls that attempt to read other accounts' state will revert. |
+| `eth_estimateGas` | Only allowed when `from` equals the authenticated account. TIP-20 transfers always return the [fixed 100,000 gas](./execution#fixed-gas-constant-transfer-cost). |
+
+#### Transaction access
+
+| Method | Scoping rule |
+|--------|-------------|
+| `eth_getTransactionByHash` | Returns the transaction only if the authenticated account is the `from` (sender) of the transaction. Returns `null` for transactions sent by other accounts. |
+| `eth_getTransactionReceipt` | Returns the receipt only if the authenticated account is the sender. Returns `null` otherwise. Logs within the receipt are filtered (see [Event filtering](#event-filtering)). |
+| `eth_sendRawTransaction` | Accepts and broadcasts the transaction. The zone validates that the transaction sender matches the authenticated account. Transactions from mismatched accounts are rejected with error code `-32003` (transaction rejected). |
+
+#### Transaction simulation
+
+| Method | Scoping rule |
+|--------|-------------|
+| `eth_call` | The `from` field MUST equal the authenticated account. If `from` is omitted, the RPC server sets it to the authenticated account. If `from` is present and does not match, the call is rejected with error code `-32004` (account mismatch). Requests from non-sequencer callers that include a state override set or block override object (client-specific simulation extensions) MUST be rejected with `-32602` (invalid params). |
+| `eth_estimateGas` | Same restriction as `eth_call`: only the authenticated account can simulate transactions. Returns `-32004` on mismatch. Requests from non-sequencer callers that include a state override set or block override object MUST be rejected with `-32602` (invalid params). |
+
+**Rationale**: Transaction simulation could reveal state about other accounts (e.g., simulating a transfer to probe whether a recipient exists). Restricting simulation to the caller's own transactions prevents this.
+
+#### Timing side channels and the 100 ms speed bump
+
+Several scoped methods must fetch data from the database before the server can determine whether the authenticated account is authorized to see it. The time difference between "data does not exist" (fast) and "data exists but belongs to another account" (slow fetch, then return `null`) leaks whether the queried object exists at all. For example, `eth_getTransactionByHash` with an unknown hash returns `null` immediately, but the same method with a valid hash belonging to another user takes longer to fetch the transaction, check the sender, and then return `null`.
+
+To close this side channel, the RPC server MUST enforce a **minimum response time of 100 ms** on the following methods:
+
+| Method | Why it needs the speed bump |
+|--------|-----------------------------|
+| `eth_getTransactionByHash` | Must fetch the transaction to check if `from` matches the caller. Timing leaks whether the tx hash is valid. |
+| `eth_getTransactionReceipt` | Must fetch the receipt to check the sender. Same timing leak as above. |
+| `eth_getLogs` | Must query logs then post-filter by account. Response time correlates with total log volume, not just the caller's logs. |
+| `eth_getFilterLogs` | Same as `eth_getLogs`. |
+| `eth_getFilterChanges` | Same as `eth_getLogs`. |
+
+**Implementation**: The server records the wall-clock time at the start of request processing. After computing the response, if less than 100 ms have elapsed, the server sleeps for the remainder before sending the response. This applies regardless of whether the response is populated or empty. The 100 ms floor is chosen to be comfortably above the worst-case database lookup time while remaining imperceptible to interactive users.
+
+Methods that do **not** need the speed bump include those where authorization can be checked before any data fetch:
+- `eth_getBalance` / `eth_getTransactionCount`: The server checks if the queried address matches the caller *before* reading state. Non-matching addresses return `0x0` without a lookup.
+- `eth_call` / `eth_estimateGas`: The `from` field is validated against the authenticated account before execution begins.
+- `eth_sendRawTransaction`: Sender verification happens during transaction decoding, before any state access.
+
+#### Event filtering
+
+| Method | Scoping rule |
+|--------|-------------|
+| `eth_getLogs` | Filtered to only return **TIP-20 events** where the authenticated account is a relevant party. See [Event filtering rules](#event-filtering-rules) below. |
+| `eth_getFilterLogs` | Same filtering as `eth_getLogs`. |
+| `eth_getFilterChanges` | Same filtering. Only returns new events matching the filter since last poll. |
+| `eth_newFilter` | Creates a filter. The filter is implicitly scoped to the authenticated account. |
+| `eth_subscribe("logs")` | WebSocket equivalent of `eth_newFilter` + `eth_getFilterChanges`. The subscription is implicitly scoped to the authenticated account using the same [event filtering rules](#event-filtering-rules). |
+| `eth_newBlockFilter` | Allowed. Returns new block hashes. |
+| `eth_uninstallFilter` | Allowed. Removes a previously created filter. |
+
+### Restricted methods (sequencer-only)
+
+These methods are only available when the authenticated account is the sequencer.
+
+| Method | Notes |
+|--------|-------|
+| `eth_createAccessList` | Returns the set of storage slots a transaction would access. Could reveal storage layout of accounts the transaction interacts with, especially if smart contracts are added in the future. |
+| `eth_getCode` | Zone predeploys are precompiles (no EVM bytecode); user accounts never have code. Raw code inspection has no legitimate non-sequencer use case. |
+| `eth_getStorageAt` | Raw storage reads bypass all access control. A caller could read TIP-20 balance mappings directly, defeating [execution-level `balanceOf` restrictions](./execution#balance-privacy-balanceof-access-control), or probe account existence via nonce/storage slots. |
+| `eth_getBlockByNumber` (with `true`) | Full block with all transactions — sequencer only |
+| `eth_getBlockByHash` (with `true`) | Full block with all transactions — sequencer only |
+| `eth_getBlockTransactionCountByNumber` | Transaction counts reveal activity levels |
+| `eth_getBlockTransactionCountByHash` | Same as above |
+| `eth_getTransactionByBlockNumberAndIndex` | Arbitrary transaction access — sequencer only |
+| `eth_getTransactionByBlockHashAndIndex` | Same as above |
+| `eth_getBlockReceipts` | Returns all receipts in a block, bypassing per-sender receipt scoping |
+| `eth_getUncleCountByBlockNumber` | Sequencer only (always returns 0, but restricted for consistency) |
+| `eth_getUncleCountByBlockHash` | Same as above |
+| `debug_*` | All debug namespace methods |
+| `admin_*` | All admin namespace methods |
+| `txpool_*` | Transaction pool inspection |
+
+### Disabled methods
+
+These methods are not supported on privacy zones.
+
+| Method | Reason |
+|--------|--------|
+| `eth_getUncleByBlockNumberAndIndex` | Zones have no uncles |
+| `eth_getUncleByBlockHashAndIndex` | Zones have no uncles |
+| `eth_mining` | Zones have no mining |
+| `eth_hashrate` | Zones have no mining |
+| `eth_getWork` | Zones have no mining |
+| `eth_submitWork` | Zones have no mining |
+| `eth_submitHashrate` | Zones have no mining |
+| `eth_getProof` | Merkle proofs include sibling hashes that reveal state trie structure (number of accounts, address prefix distribution, slot occupancy), leaking information beyond the queried account |
+| `eth_getFilterLogs` (unscoped) | All log access goes through the scoped path |
+| `eth_newPendingTransactionFilter` | Polling equivalent of `eth_subscribe("newPendingTransactions")` — mempool observation |
+| `eth_subscribe("newPendingTransactions")` | Mempool observation reveals all pending activity. Other subscription types (`newHeads`, `logs`) are classified above. |
+
+Disabled methods return error code `-32601` (method not found).
+
+## Block responses
+
+Block responses are modified to protect transaction privacy:
+
+### Non-sequencer callers
+
+When `eth_getBlockByNumber`, `eth_getBlockByHash`, or `eth_subscribe("newHeads")` returns a block header to a non-sequencer:
+
+- The `transactions` field is **always an empty array** `[]`, regardless of the `include_transactions` parameter. If the parameter is `true`, the request is rejected (sequencer-only).
+- The `logsBloom` field MUST be replaced with the zero Bloom (`0x` followed by 512 zero bytes). The Bloom filter is a compressed summary of all log topics and emitting addresses in the block — returning the real value would allow any caller to probe whether a specific address had activity in that block, completely defeating per-account event scoping. The zeroed `logsBloom` is still present in the response for schema compatibility.
+- All other header fields (`number`, `hash`, `parentHash`, `timestamp`, `stateRoot`, `transactionsRoot`, `receiptsRoot`, `gasUsed`, `gasLimit`, `baseFeePerGas`, `extraData`) are returned normally.
+
+**Rationale**: Transaction ordering and per-address activity within a block reveals information that could allow correlation attacks. Aggregate activity metrics (`gasUsed`, `gasLimit`) are intentionally public — the zone does not attempt to hide overall transaction volume, only per-account details.
+
+### Sequencer callers
+
+The sequencer receives full block data including all transactions and receipts.
+
+## Event filtering rules
+
+Event filtering is the primary mechanism for users to discover activity relevant to their account. All log queries are restricted to TIP-20 events on the zone token contract.
+
+### Permitted events
+
+Only the following TIP-20 events can be returned by `eth_getLogs` and related methods:
+
+| Event | Signature | Relevant if |
+|-------|-----------|-------------|
+| `Transfer` | `Transfer(address indexed from, address indexed to, uint256 amount)` | `from == caller` OR `to == caller` |
+| `Approval` | `Approval(address indexed owner, address indexed spender, uint256 amount)` | `owner == caller` OR `spender == caller` |
+| `TransferWithMemo` | `TransferWithMemo(address indexed from, address indexed to, uint256 amount, bytes32 indexed memo)` | `from == caller` OR `to == caller` |
+| `Mint` | `Mint(address indexed to, uint256 amount)` | `to == caller` |
+| `Burn` | `Burn(address indexed from, uint256 amount)` | `from == caller` |
+
+All other event topics are filtered out, including system events (`DepositProcessed`, `BatchFinalized`, etc.), role events, and configuration events.
+
+### Filter enforcement
+
+When a user creates a log filter or calls `eth_getLogs`:
+
+1. **Address restriction**: The `address` filter parameter MUST be the zone token address, or omitted (in which case only the zone token address is matched). Filters specifying any other address return empty results.
+
+2. **Topic injection**: The RPC server appends a topic filter that restricts indexed address parameters to the authenticated account. For example, a `Transfer` event filter is automatically constrained so that `topic1` (from) or `topic2` (to) matches the caller's address.
+
+3. **Post-filtering**: After retrieving matching logs, the server performs a final pass to remove any log where the authenticated account is not a relevant party per the table above.
+
+### Example
+
+An authenticated user (address `0xAlice`) calls:
+
+```json
+{
+  "method": "eth_getLogs",
+  "params": [{
+    "fromBlock": "0x1",
+    "toBlock": "latest",
+    "topics": [
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+    ]
+  }]
+}
+```
+
+This requests all `Transfer` events. The RPC server returns only `Transfer` events where `from == 0xAlice` or `to == 0xAlice`. Transfer events between two other parties are never returned.
+
+## Zone-specific RPC methods
+
+In addition to the Ethereum JSON-RPC methods, the zone exposes zone-specific methods under the `zone_` namespace.
+
+| Method | Access | Description |
+|--------|--------|-------------|
+| `zone_getAuthorizationTokenInfo` | Any authenticated | Returns the authenticated account address and token expiry. Useful for verifying the authorization token is valid. |
+| `zone_getZoneInfo` | Any authenticated | Returns zone metadata: `zoneId`, `zoneTokens`, `sequencer` (address only, not private key), `chainId`. |
+| `zone_getDepositStatus(tempoBlockNumber)` | Scoped | Returns whether deposits from the given Tempo block have been processed on the zone. Only returns information about deposits where the sender or recipient is the authenticated account. |
+
+All integer fields in these responses use Ethereum JSON-RPC quantity encoding (hex strings such as `0x1`).
+
+### `zone_getAuthorizationTokenInfo`
+
+**Request**
+
+```json
+{
+  "method": "zone_getAuthorizationTokenInfo",
+  "params": []
+}
+```
+
+**Response**
+
+```json
+{
+  "account": "0x1234...",
+  "expiresAt": "0x67d2d7c0"
+}
+```
+
+- `account`: the authenticated account address recovered from the authorization token.
+- `expiresAt`: the token expiry timestamp (unix seconds).
+
+### `zone_getZoneInfo`
+
+**Request**
+
+```json
+{
+  "method": "zone_getZoneInfo",
+  "params": []
+}
+```
+
+**Response**
+
+```json
+{
+  "zoneId": "0x1",
+  "zoneTokens": [
+    "0x20c0000000000000000000000000000000000000",
+    "0x20c0000000000000000000000000000000aa0001"
+  ],
+  "sequencer": "0xabcd...",
+  "chainId": "0x2a"
+}
+```
+
+- `zoneId`: the configured zone identifier.
+- `zoneTokens`: the zone's currently enabled TIP-20 token addresses.
+- `sequencer`: the configured sequencer address.
+- `chainId`: the zone chain ID.
+
+### `zone_getDepositStatus(tempoBlockNumber)`
+
+**Request**
+
+```json
+{
+  "method": "zone_getDepositStatus",
+  "params": ["0x2a"]
+}
+```
+
+`tempoBlockNumber` MUST be supplied as a JSON-RPC hex quantity string.
+
+**Response**
+
+```json
+{
+  "tempoBlockNumber": "0x2a",
+  "zoneProcessedThrough": "0x2a",
+  "processed": true,
+  "deposits": [
+    {
+      "depositHash": "0xfeed...",
+      "kind": "regular",
+      "token": "0x20c0000000000000000000000000000000000000",
+      "sender": "0xaaaa...",
+      "recipient": "0xbbbb...",
+      "amount": "0xf4240",
+      "memo": "0x1111...",
+      "status": "processed"
+    }
+  ]
+}
+```
+
+- `tempoBlockNumber`: the queried Tempo L1 block number.
+- `zoneProcessedThrough`: the latest Tempo block number the zone has processed on L2.
+- `processed`: `true` if the zone has advanced through `tempoBlockNumber` and every deposit visible to the authenticated caller from that block has reached a terminal status.
+- `deposits`: only deposits relevant to the authenticated caller.
+
+Each deposit entry has:
+
+- `depositHash`: the deposit queue hash (`newCurrentDepositQueueHash`) for that deposit.
+- `kind`: `"regular"` or `"encrypted"`.
+- `token`: the deposited token address.
+- `sender`: the L1 depositor address.
+- `recipient`: the plaintext recipient address when visible; otherwise `null`.
+- `amount`: the post-fee deposit amount.
+- `memo`: the deposit memo when visible; otherwise `null`.
+- `status`: `"pending"`, `"processed"`, or `"failed"`.
+
+Visibility rules:
+
+- Regular deposits are returned only when the authenticated account is the sender or the plaintext recipient.
+- Encrypted deposits are returned immediately to the sender.
+- Encrypted deposits are returned to a recipient-only caller only after the zone has emitted `EncryptedDepositProcessed` on L2, which reveals the recipient.
+- Pending encrypted deposits MUST keep `recipient` and `memo` as `null`; implementations MUST NOT decrypt or reveal hidden recipient data just to answer RPC.
+
+**Withdrawals**: To request a withdrawal, the caller MUST construct and sign a transaction calling `ZoneOutbox.requestWithdrawal(...)` and submit it via `eth_sendRawTransaction`. There is no server-side convenience method — authorization tokens are read-only credentials and MUST NOT be sufficient to authorize state-changing operations such as token transfers or withdrawals. Requiring a full transaction signature ensures that a stolen or replayed authorization token cannot be used to move funds.
+
+## Error codes
+
+In addition to standard JSON-RPC error codes, the zone RPC uses:
+
+| Code | Message | Meaning |
+|------|---------|---------|
+| `-32001` | `Authorization token required` | No authorization token provided |
+| `-32002` | `Authorization token expired` | The authorization token has expired |
+| `-32003` | `Transaction rejected` | Transaction sender does not match authenticated account (`eth_sendRawTransaction`) |
+| `-32004` | `Account mismatch` | The `from` field does not match the authenticated account (`eth_call`, `eth_estimateGas`) |
+| `-32005` | `Sequencer only` | Method requires sequencer access |
+| `-32006` | `Method disabled` | Method is not available on privacy zones |
+
+**Error vs. silent response**: Methods where the user explicitly provides a mismatched parameter (`eth_sendRawTransaction` with wrong sender, `eth_call` with wrong `from`) return explicit errors — the user already knows the address they supplied, so the error leaks nothing. Methods that query *about* other accounts (`eth_getBalance`, `eth_getTransactionByHash`, etc.) return silent dummy values (`0x0`, `null`, empty results) instead of errors — an error would reveal "this data exists but you can't see it," which leaks information.
+
+## Security considerations
+
+- **Side channels via timing**: Scoped methods that must fetch data before checking authorization are subject to a mandatory 100 ms response floor (see [Timing side channels and the 100 ms speed bump](#timing-side-channels-and-the-100-ms-speed-bump)). This ensures that `eth_getTransactionByHash` for a non-existent transaction and for another user's transaction have indistinguishable response times.
+- **Nonce privacy**: `eth_getTransactionCount` for non-authenticated accounts returns `0x0` rather than an error. This avoids revealing whether an account exists. The constant `0x0` response is indistinguishable from a genuinely new account.
+- **Authorization token replay**: Authorization tokens are scoped to a specific zone (`zoneId`) and network (`chainId`), with a maximum 30-day validity window. When `zoneId` is `0` (unscoped), the token is valid across all zones on that network. Authorization tokens are strictly read-only credentials — no RPC method that is authenticated solely by an authorization token may modify state (see [Withdrawals](#zone-specific-rpc-methods)). The RPC server SHOULD implement nonce tracking or rate limiting to further reduce the window for abuse if a token is intercepted, but replay of a read-only token cannot move funds.
+- **Simulation override extensions**: Some Ethereum clients support non-standard simulation extensions (state override sets and block override objects) on `eth_call`/`eth_estimateGas`. Privacy zones MUST reject these extensions for non-sequencer callers, because they can bypass or distort normal state access assumptions used by this spec's privacy model.
+- **Keychain key revocation and expiry**: When a root account revokes a Keychain key on-chain, the RPC server MUST stop accepting that key within 1 second of importing the block that contains the revocation. Cached Keychain verifications MUST also honor key expiry: a cache entry MUST expire no later than `min(authorizationToken.expiresAt, keyExpiry)` where `keyExpiry` is read from `AccountKeychain.getKey(...)`. In the current `AccountKeychain` implementation, inactive or revoked keys are surfaced as `keyId == 0` and `expiry == 0`, so those results MUST be treated as immediately invalid rather than "never expires." The recommended implementation is event-driven: the zone node watches for `KeyRevoked(account, publicKey)` events emitted by the AccountKeychain precompile during block execution and immediately evicts matching entries from the authorization token cache. This requires no cryptography — just a cache lookup and delete. As a fallback, implementations MAY poll the precompile via `getKey(user_address, keyId)`, but the 1-second deadline still applies.
+- **P256/WebAuthn key compromise**: Unlike secp256k1, P256 and WebAuthn keys include the public key in the signature. This means the public key is visible to the RPC server on every request. This is not a security concern (public keys are public), but implementations should be aware that the key material is transmitted in the clear over the connection.
+- **Metadata leakage**: Even with content-level privacy, connection-level metadata (IP addresses, request timing, request frequency) can leak information. Deployments SHOULD use TLS and MAY require additional transport-level privacy measures.
+- **Fixed gas and transfer receipts**: The [fixed 100,000 gas cost](./execution#fixed-gas-constant-transfer-cost) on TIP-20 transfers ensures that `gasUsed` in transaction receipts is identical for all transfers. Without this, an observer who obtains a receipt (e.g., the sender) could infer whether the recipient was a new or existing account.
+- **Block header sanitization**: Block headers returned to non-sequencer callers have `logsBloom` zeroed (see [Block responses](#block-responses)). The Bloom filter would otherwise allow probing whether a specific address had activity in a given block, defeating per-account event scoping. This applies to all code paths that return block headers: `eth_getBlockByNumber`, `eth_getBlockByHash`, and `eth_subscribe("newHeads")`. Aggregate fields like `gasUsed` are intentionally public — the zone does not hide overall activity volume, only per-account details.
+
+## Implementation notes
+
+- The zone node enforces access control at two layers: the RPC server (request filtering) and the [EVM execution environment](./execution) (TIP-20 modifications). Both layers are required — see [Interaction with RPC](./execution#interaction-with-rpc) for why neither layer alone is sufficient.
+- Filter state (from `eth_newFilter`) is stored per-authenticated-account. Filters created by one authorization token are accessible by subsequent authorization tokens for the same account.
+- The zone node SHOULD cache authorization token verification results for the duration of token validity to avoid repeated signature recovery. For Keychain Access Keys, cache entries MUST have a TTL bounded by the earlier of authorization-token expiry and the active key's `expiry`, and MUST be invalidated within 1 second of importing a block that revokes the key (see [Keychain key revocation and expiry](#security-considerations)). The recommended approach is to hook into block import and evict cache entries when `KeyRevoked` events are observed.
+- P256 and WebAuthn signature verification is more expensive than secp256k1. The RPC server SHOULD aggressively cache verified authorization tokens to amortize the verification cost. A verified authorization token can be cached by its hash for the remaining duration of its validity.
+- WebSocket connections (`eth_subscribe`) follow the same authorization-token model. The authorization token is provided during the WebSocket handshake and scopes all subscriptions for that connection. The connection is terminated when the authorization token expires; clients must reconnect with a fresh token. For Keychain-authenticated WebSocket connections, the server MUST also terminate the connection within 1 second of importing a block that revokes the Keychain key, following the same deadline as [Keychain key revocation](#security-considerations).

--- a/docs/specs/privacy/upgrades.md
+++ b/docs/specs/privacy/upgrades.md
@@ -1,0 +1,115 @@
+# Zone upgrade process
+
+This document describes the end-to-end process for executing a zone hard fork. For the protocol rules governing activation, verifier routing, and fork signaling, see [Hard fork activation](./overview.md#hard-fork-activation).
+
+## Artifacts
+
+Each zone hard fork requires the following artifacts. All are prepared before the fork and deployed or released atomically at fork time.
+
+| Artifact | Embeds `F` | Description |
+|----------|:----------:|-------------|
+| Zone node binary | Yes | Contains both old and new execution rules. Embeds `F` in the chain spec and `MAX_SUPPORTED_PROTOCOL_VERSION` for fork signaling. |
+| Prover program | Yes | Dual-rule binary. Applies old rules for blocks importing L1 `< F`, new rules for `>= F`. Produces a new verification key covering the complete program. |
+| Verifier contract | No | `IVerifier` deployed on Tempo L1 with the verification key from the new prover program. |
+| Predeploy bytecode | N/A | Updated bytecode for zone predeploys (TempoState, ZoneInbox, ZoneOutbox, ZoneConfig) if the fork changes their behavior. Not every fork requires this. |
+| L1 system transaction payload | No | Encoded call to `ZoneFactory.setForkVerifier(forkVerifier)` and `protocolVersion` increment, executed as part of the L1 hard fork block. |
+
+## Timeline
+
+A zone hard fork proceeds in three phases:
+
+```
+Pre-fork                          Fork block F                    Post-fork
+─────────────────────────────────┬──────────────────────────────┬──────────────────────────
+Build artifacts                  │ Deploy verifier contract     │ Zones activate new rules
+Release node binary + prover     │ setForkVerifier() rotates    │   on import of block F
+Operators upgrade nodes          │   verifiers on all portals   │ Provers use new rules for
+                                 │ Increment protocolVersion    │   post-fork blocks
+                                 │                              │ Settlement resumes with
+                                 │                              │   fork verifier
+```
+
+### Pre-fork
+
+1. **Determine `F`.** Choose the L1 block number at which the fork activates. If the L1 fork uses a timestamp, `F` is the first L1 block at or after that timestamp — this derivation is an off-chain concern since the portal does not store `F`.
+
+2. **Build the prover program.** The new prover is a superset of the previous one: it uses the previous prover's complete logic as its "old rules" branch and adds the new rules for blocks at `>= F`. Build the program and extract the verification key.
+
+3. **Build the verifier contract.** Compile the `IVerifier` contract parameterized with the new verification key. Prepare the deployment bytecode for inclusion in the L1 fork block.
+
+4. **Build the zone node binary.** The binary embeds `F` in its chain spec and sets `MAX_SUPPORTED_PROTOCOL_VERSION` to the new protocol version. It contains both old and new execution rules, switching based on the L1 block number imported by `advanceTempo`.
+
+5. **Prepare predeploy bytecode diffs** (if applicable). If the fork changes zone predeploy contracts, prepare the new bytecode. The node binary must include the injection logic: new bytecode is written to the predeploy addresses at the start of the fork zone block's state transition, before `advanceTempo` executes.
+
+6. **Prepare the L1 system transaction payload.** Encode the calls that the L1 fork block will execute:
+   - Deploy the verifier contract.
+   - `ZoneFactory.setForkVerifier(forkVerifier)` — rotates verifiers on all registered portals.
+   - Increment `ZoneFactory.protocolVersion`.
+
+7. **Release binaries.** Publish the zone node binary and prover program. Operators can upgrade at their convenience — no on-chain transaction is required. The node runs under old rules until the fork L1 block arrives.
+
+8. **Announce the upgrade window.** Communicate `F`, the expected fork date, and the required binary versions to zone operators.
+
+### Fork block execution
+
+The Tempo L1 hard fork block executes the following as system transactions:
+
+1. Deploy the fork `IVerifier` contract with the new verification key.
+2. Call `ZoneFactory.setForkVerifier(forkVerifier)`. For each registered portal, this performs verifier rotation:
+   - `portal.verifier = portal.forkVerifier` (promote previous fork verifier)
+   - `portal.forkVerifier = new_fork_verifier` (install new fork verifier)
+   - `portal.forkActivationBlock = block.number` (record cutoff — old verifier rejected for batches at or past this L1 block)
+   - For the first fork, `verifier` retains its original value and `forkVerifier` is populated for the first time.
+3. Increment `ZoneFactory.protocolVersion`.
+
+After this block, new zones created via the factory use the fork verifier as their initial verifier.
+
+### Post-fork
+
+No manual action is needed. Each zone transitions automatically:
+
+1. The zone node imports L1 blocks sequentially. When it reaches block `F`, it detects the fork and configures the EVM with new rules for that zone block (same-block activation).
+2. If the fork includes predeploy changes, the node injects new bytecode at the predeploy addresses before `advanceTempo` runs.
+3. The zone block header's `protocol_version` field is set to the new protocol version.
+4. The node decides which prover to invoke per batch. Pre-fork batches (all L1 blocks `< F`) use the old prover and target the old verifier. Post-fork or fork-spanning batches (any L1 block `>= F`) use the new prover and target the fork verifier. The new prover applies old rules for pre-fork blocks and new rules for post-fork blocks within the same proof.
+5. The fork verifier is available on-chain from block `F`, so post-fork proofs can be submitted immediately.
+
+## Failure modes
+
+### Operator did not upgrade
+
+The outdated zone node binary does not know about `F`. When it encounters the L1 block that bumped `protocolVersion`, it detects that the new version exceeds its `MAX_SUPPORTED_PROTOCOL_VERSION` and halts with an error directing the operator to upgrade.
+
+No invalid blocks are produced. Settlement pauses because no new batches are submitted. User funds in the portal remain safe. The zone resumes normal operation once the operator installs the new binary.
+
+### Node upgraded but prover is stale
+
+The zone node produces correct post-fork blocks, but with only the old prover available it cannot generate proofs acceptable to the fork verifier. The node continues producing blocks, but settlement of post-fork batches pauses. Pre-fork batches already proven can still be submitted to the old verifier. Once the new prover is installed, it can prove the backlog of post-fork batches.
+
+### Zone is behind L1
+
+If a zone is catching up and has not yet reached L1 block `F`, the fork does not activate until the zone imports block `F`. The zone continues under old rules for all blocks importing L1 blocks `< F`. This is by design — the trigger is the L1 block number the zone imports, not the current L1 head.
+
+A zone that falls more than one full fork cycle behind risks having its oldest batches become unsubmittable. The two-verifier invariant means the N-2 verifier is deprecated when fork N activates. If the zone still has unproven batches from before fork N-1, those batches can no longer be verified.
+
+## Verifier lifecycle
+
+The portal maintains two verifier slots and a `forkActivationBlock` cutoff. The batch submitter specifies which verifier to use; the portal checks that it is one of the two recognized addresses and that the old verifier is only used for batches predating the fork. Across successive forks, the slots rotate:
+
+| Event | `verifier` | `forkVerifier` | `forkActivationBlock` |
+|-------|-----------|----------------|----------------------|
+| Zone creation | V0 | `address(0)` | 0 |
+| Fork 1 (block F1) | V0 | V1 | F1 |
+| Fork 2 (block F2) | V1 | V2 | F2 |
+| Fork 3 (block F3) | V2 | V3 | F3 |
+
+At each fork, the previous `forkVerifier` is promoted to `verifier`, the new fork verifier takes the `forkVerifier` slot, and `forkActivationBlock` is updated to the current L1 block number. The verifier that was in the `verifier` slot is deprecated.
+
+The `forkActivationBlock` enforces compliance: submissions targeting `verifier` must have `tempoBlockNumber < forkActivationBlock`. This prevents a non-upgraded or malicious node from submitting post-fork batches proved under old rules to the old verifier.
+
+This means:
+- Between fork 1 and fork 2: V0 accepts batches with `tempoBlockNumber < F1`, V1 accepts all batches. Zones still catching up can submit pre-fork-1 batches using V0.
+- After fork 2: V0 is deprecated. V1 accepts batches with `tempoBlockNumber < F2`, V2 accepts all batches.
+- The pattern continues: at any point, exactly the two most recent verifiers are active, with the older one restricted to pre-fork batches.
+
+Each prover program is a superset of the previous one (fork N's prover includes fork N-1's logic as its old-rules branch), so the fork N verifier can verify batches containing blocks from any prior era.


### PR DESCRIPTION
The privacy protocol docs were removed in #366 as part of a bulk docs cleanup. This restores the 5 files to `docs/specs/privacy/` as they existed at [`c8ce4a1`](https://github.com/tempoxyz/zones/tree/c8ce4a1617fac1131b6393b99b7386d74bc73922/docs/pages/protocol/privacy) (last commit before deletion):

- `overview.md` — full privacy protocol spec
- `execution.md` — private execution model
- `prover-design.md` — ZK prover architecture
- `rpc.md` — private RPC spec
- `upgrades.md` — upgrade path

Prompted by: daniel