### PR TITLE
docs: remove draft disclaimer sentence from overview

### DIFF
--- a/docs/specs/privacy/overview.md
+++ b/docs/specs/privacy/overview.md
@@ -1,7 +1,5 @@
 # Tempo Zones (Draft)
 
-This document proposes a new validium protocol designed for Tempo. It is a design overview, not a full specification.
-
 ## Goals
 
 - Create a Tempo-native validium called a zone.


### PR DESCRIPTION
Removes the sentence: "This document proposes a new validium protocol designed for Tempo. It is a design overview, not a full specification." from `docs/specs/privacy/overview.md`.

Prompted by: dankrad