### PR TITLE
chore: remove unused precompiles and gas divisor logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12833,7 +12833,6 @@ dependencies = [
  "sha2 0.10.9",
  "tempo-alloy",
  "tempo-chainspec",
- "tempo-consensus",
  "tempo-contracts",
  "tempo-evm",
  "tempo-node",

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 # tempo
 tempo-chainspec.workspace = true
-tempo-consensus.workspace = true
 tempo-evm = { workspace = true, features = ["rpc", "engine"] }
 tempo-revm.workspace = true
 tempo-node.workspace = true

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -38,7 +38,6 @@ use reth_transaction_pool::{
 };
 use std::{sync::Arc, time::Instant};
 use tempo_chainspec::spec::TempoChainSpec;
-use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
 use tempo_evm::TempoNextBlockEnvAttributes;
 use tempo_payload_types::TempoBuiltPayload;
 use tempo_primitives::{
@@ -197,8 +196,6 @@ where
         let chain_spec = self.provider.chain_spec();
 
         let block_gas_limit = parent_header.gas_limit();
-        let shared_gas_limit = block_gas_limit / TEMPO_SHARED_GAS_DIVISOR;
-        let general_gas_limit = 0;
 
         let mut cumulative_gas_used = 0u64;
         let total_fees = U256::ZERO;
@@ -219,8 +216,10 @@ where
                         withdrawals: attributes.withdrawals().cloned().map(Withdrawals::new),
                         extra_data: attributes.extra_data(),
                     },
-                    general_gas_limit,
-                    shared_gas_limit,
+                    // Zones don't use L1 gas sections. These fields are required
+                    // by TempoNextBlockEnvAttributes but ignored by the zone executor.
+                    general_gas_limit: 0,
+                    shared_gas_limit: block_gas_limit,
                     timestamp_millis_part: attributes.timestamp_millis_part(),
                     subblock_fee_recipients: Default::default(),
                 },
@@ -289,7 +288,7 @@ where
                 );
                 continue;
             }
-            let gas_limit_left = block_gas_limit.saturating_sub(shared_gas_limit);
+            let gas_limit_left = block_gas_limit;
             if cumulative_gas_used + pool_tx.gas_limit() > gas_limit_left {
                 best_txs.mark_invalid(
                     &pool_tx,

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -39,10 +39,8 @@ use tempo_evm::{
 use tempo_payload_types::TempoExecutionData;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
-    TIP_FEE_MANAGER_ADDRESS, VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
-    account_keychain::AccountKeychain, nonce::NonceManager, tip_fee_manager::TipFeeManager,
-    tip20::is_tip20_prefix, validator_config::ValidatorConfig,
-    validator_config_v2::ValidatorConfigV2,
+    TIP_FEE_MANAGER_ADDRESS, account_keychain::AccountKeychain, nonce::NonceManager,
+    tip_fee_manager::TipFeeManager, tip20::is_tip20_prefix,
 };
 use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope};
 
@@ -107,8 +105,8 @@ impl ZoneEvmFactory {
         // one, it still applies privacy, fixed-gas, and bridge-auth rules.
         //
         // This replaces the upstream `extend_tempo_precompiles` lookup, so we
-        // must also handle the non-TIP-20 Tempo precompiles that are only
-        // registered via that lookup (FeeManager, StablecoinDEX, etc.).
+        // must also handle the non-TIP-20 Tempo precompiles that are zone-relevant
+        // (FeeManager, NonceManager, AccountKeychain).
         // Zone-specific overrides (TIP20Factory, TIP403Proxy) are in the
         // static map via `apply_precompile` and take priority over this.
         let zone_cfg = cfg.clone();
@@ -123,17 +121,11 @@ impl ZoneEvmFactory {
             } else if *address == TIP_FEE_MANAGER_ADDRESS {
                 Some(TipFeeManager::create_precompile(&zone_cfg))
             } else if *address == STABLECOIN_DEX_ADDRESS {
-                // StablecoinDEX is disabled on zones, calls to this address
-                // fall through to `None` and revert as an empty account.
                 None
             } else if *address == NONCE_PRECOMPILE_ADDRESS {
                 Some(NonceManager::create_precompile(&zone_cfg))
-            } else if *address == VALIDATOR_CONFIG_ADDRESS {
-                Some(ValidatorConfig::create_precompile(&zone_cfg))
             } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
                 Some(AccountKeychain::create_precompile(&zone_cfg))
-            } else if *address == VALIDATOR_CONFIG_V2_ADDRESS {
-                Some(ValidatorConfigV2::create_precompile(&zone_cfg))
             } else {
                 None
             }


### PR DESCRIPTION
Removes `ValidatorConfig`, `ValidatorConfigV2`, and the `tempo-consensus` dependency from the zone runtime since zones have no validators and don't use L1 gas sections.

The zone builder now uses the full block gas limit directly instead of computing shared/general gas splits that the executor ignores.