### PR TITLE
docs: add development disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-> [!NOTE]
+> [!WARNING]
 > This repository is actively under development and subject to rapid iteration.
 > APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
+> [!NOTE]
+> This repository is actively under development and subject to rapid iteration.
+> APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
+
 <p align="center">
   <a href="https://tempo.xyz/zones">
     <img src="assets/header.png" alt="Tempo Zones" width="100%">
   </a>
 </p>
-
-> [!NOTE]
-> This repository is actively under development and subject to rapid iteration.
-> APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
 
 Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo), with native support for confidential balances and transactions. Zones inherit compliance from Tempo L1 and support interoperability with Tempo for moving assets in and out of zones.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
   </a>
 </p>
 
+> [!NOTE]
+> This repository is actively under development and subject to rapid iteration.
+> APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
+
 Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo), with native support for confidential balances and transactions. Zones inherit compliance from Tempo L1 and support interoperability with Tempo for moving assets in and out of zones.
 
 You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](docs/ZONES.md), or exploring the [Zone specs](https://docs.tempo.xyz/protocol).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-> [!WARNING]
+> [!NOTE]
 > This repository is actively under development and subject to rapid iteration.
 > APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
 


### PR DESCRIPTION
Adds a warning banner to the top of the README indicating the repo is under active development and not yet recommended for production use.

Prompted by: daniel