### PR TITLE
docs: add spacing between README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You can get started today by [deploying a zone](#getting-started) on Tempo testn
 
 - **Fast withdrawals.** The zone processes transactions every 250ms and submits batches of withdrawals to Tempo, where blocks are produced every ~500ms. Once batches are accepted and the attached proof is validated, withdrawals are processed and funds are released from escrow.
 
+<br>
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 > This repository is actively under development and subject to rapid iteration.
 > APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
 
+<br>
+
 <p align="center">
   <a href="https://tempo.xyz/zones">
     <img src="assets/header.png" alt="Tempo Zones" width="100%">
@@ -12,6 +14,7 @@ Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/te
 
 You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](docs/ZONES.md), or exploring the [Zone specs](https://docs.tempo.xyz/protocol).
 
+<br>
 
 ## What Makes Zones Interesting
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can get started today by [deploying a zone](#getting-started) on Tempo testn
 Prerequisites: [Rust](https://rustup.rs/), [Foundry](https://book.getfoundry.sh/getting-started/installation), [`just`](https://github.com/casey/just#packages), [`jq`](https://jqlang.github.io/jq/download/)
 
 
-## Deploying a Zone
+### Deploying a Zone
 
 ```bash
 # Deploy and start a zone on Moderato testnet
@@ -50,7 +50,7 @@ The `deploy-zone` command generates a sequencer keypair, funds it on L1, deploys
 just zone-up my-zone
 ```
 
-## Depositing into a Zone
+### Depositing into a Zone
 
 ```bash
 export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
@@ -67,7 +67,7 @@ just send-deposit-encrypted 1000000                       # to your own address
 just send-deposit-encrypted 1000000 <recipient-address>   # to a specific address
 ```
 
-## Withdrawing from Zone to Tempo
+### Withdrawing from Zone to Tempo
 
 ```bash
 
@@ -79,7 +79,7 @@ just send-withdrawal 1000000 <recipient-address>  # withdraw to a specific addre
 The sequencer includes the withdrawal in the next batch submission to L1 and processes it automatically.
 
 
-## Querying the Private RPC
+### Querying the Private RPC
 
 Zone balances are private by default. Every RPC request must include a signed authorization token that proves you control the querying account.
 
@@ -98,6 +98,7 @@ just check-balance-private my-zone <token-address>
 
 See [docs/ZONES.md](docs/ZONES.md) for the full guide on deposits, withdrawals, private RPC, router demos, TIP-403 policy flows, and command references.
 
+<br> 
 
 ## License
 


### PR DESCRIPTION
Adds `<br>` tags for visual spacing between the disclaimer note and the banner, and between the intro text and the "What Makes Zones Interesting" section.

Prompted by: daniel