### PR TITLE
docs: link zone specs to in-repo paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This repository is actively under development and subject to rapid iteration.
-> APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
 
 <br>
 
@@ -9,6 +6,12 @@
     <img src="assets/header.png" alt="Tempo Zones" width="100%">
   </a>
 </p>
+
+# Zones
+
+> [!NOTE]
+> This repository is actively under development and subject to rapid iteration.
+> APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
 
 Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo), with native support for confidential balances and transactions. Zones inherit compliance from Tempo L1 and support interoperability with Tempo for moving assets in and out of zones.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo), with native support for confidential balances and transactions. Zones inherit compliance from Tempo L1 and support interoperability with Tempo for moving assets in and out of zones.
 
-You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](docs/ZONES.md), or exploring the [Zone specs](https://docs.tempo.xyz/protocol).
+You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](docs/ZONES.md), or exploring the [Zone spec](docs/specs/zone_spec.md) and [Solidity specs](docs/specs).
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo), with native support for confidential balances and transactions. Zones inherit compliance from Tempo L1 and support interoperability with Tempo for moving assets in and out of zones.
 
-You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](docs/ZONES.md), or exploring the [Zone spec](docs/specs/zone_spec.md) and [Solidity specs](docs/specs).
+You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](docs/ZONES.md), or exploring the [Zone spec](docs/specs/zone_spec.md).
 
 <br>
 


### PR DESCRIPTION
Updates the README specs link.

Prompted by: daniel