### PR TITLE
ci: add least-privilege permissions and persist-credentials: false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
           - "maxperf"
           - "profiling"
 
+permissions:
+  contents: read
+
 concurrency:
   group: build-${{ github.head_ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -30,6 +33,8 @@ jobs:
         binary: [tempo, tempo-bench, tempo-sidecar]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9

--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,9 @@ on:
     - cron: "5 9 * * *"
     - cron: "30 20 * * *"
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io/tempoxyz
 
@@ -33,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 

--- a/.github/workflows/docs-specs.yml
+++ b/.github/workflows/docs-specs.yml
@@ -19,6 +19,9 @@ on:
       - "crates/tempo-zone/**"
       - ".github/workflows/docs-specs.yml"
 
+permissions:
+  contents: read
+
 env:
   FOUNDRY_PROFILE: ci
   CARGO_TERM_COLOR: always
@@ -32,6 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
@@ -50,6 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
@@ -65,6 +70,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
@@ -84,12 +90,14 @@ jobs:
         with:
           submodules: recursive
           path: tempo
+          persist-credentials: false
 
       - name: Checkout tempo-foundry
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: tempoxyz/tempo-foundry
           path: tempo-foundry
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Label PRs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
@@ -52,6 +55,8 @@ jobs:
     if: ${{ github.event.inputs.dry_run != 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Verify crate version matches tag
         # Check that the Cargo version starts with the tag,
@@ -87,6 +92,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -163,6 +170,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -198,6 +206,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Harden workflow permissions across all 9 workflows:

- Add top-level `permissions: contents: read` to 5 workflows missing it (`build.yml`, `docker.yml`, `docs-specs.yml`, `pr-audit.yml`, `release.yml`)
- Add `persist-credentials: false` to all 17 `actions/checkout` steps (was only set in `lint.yml` and `test.yml`)
- `docker.yml` gets top-level permissions since it doubles as a reusable workflow (`workflow_call`) — without it, it inherits the caller's (potentially elevated) permissions

Jobs that need elevated permissions (`create-release`, `build-and-push`, `label_prs`) already have job-level `permissions:` blocks that override the top-level default.

No code or build changes — CI-only.

Prompted by: horsefacts

Co-Authored-By: horsefacts <109845214+horsefacts@users.noreply.github.com>