### PR TITLE
chore: pin Docker base images, pin cargo install versions, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-
     cargo build --profile ${RUST_PROFILE} \
         --bin tempo-zone --features "jemalloc"
 
-FROM debian:bookworm-slim AS base
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/Dockerfile.chef
+++ b/Dockerfile.chef
@@ -1,6 +1,6 @@
-FROM rust:1.93-bookworm AS chef
+FROM rust:1.93-bookworm@sha256:7c4ae649a84014c467d79319bbf17ce2632ae8b8be123ac2fb2ea5be46823f31 AS chef
 
-RUN cargo install cargo-chef sccache
+RUN cargo install cargo-chef@0.1.77 sccache@0.14.0 --locked
 
 WORKDIR /app
 


### PR DESCRIPTION
Dockerfile hardening and automated dependency updates:

**Dockerfile pinning:**
- `debian:bookworm-slim` → pinned to digest (`sha256:4724b8...655d`)
- `rust:1.93-bookworm` → pinned to digest (`sha256:7c4ae6...3f31`)
- `cargo install cargo-chef sccache` → pinned to `cargo-chef@0.1.77 sccache@0.14.0 --locked`

**Dependabot:**
- Added `.github/dependabot.yml` covering `cargo` + `github-actions` ecosystems
- Weekly schedule with 7-day cooldown on both

Prompted by: horsefacts

Co-Authored-By: horsefacts <109845214+horsefacts@users.noreply.github.com>