### PR TITLE
docs: update banner link to docs.tempo.xyz/guide/private-zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br>
 
 <p align="center">
-  <a href="https://tempo.xyz/zones">
+  <a href="https://docs.tempo.xyz/guide/private-zones">
     <img src="assets/header.png" alt="Tempo Zones" width="100%">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br>
 
 <p align="center">
-  <a href="https://docs.tempo.xyz/guide/private-zones">
+  <a href="https://tempo.xyz/blog/introducing-tempo-zones">
     <img src="assets/header.png" alt="Tempo Zones" width="100%">
   </a>
 </p>


### PR DESCRIPTION
Updates the README header banner link from `https://tempo.xyz/zones` to `https://docs.tempo.xyz/guide/private-zones` so it points to the full documentation.

Co-Authored-By: 0xKitsune <77890308+0xKitsune@users.noreply.github.com>

Prompted by: daniel