### PR TITLE
docs: update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo) *(currently available in testnet only),* with native support for confidential balances and transactions. Zones inherit compliance via TIP403 policies from Tempo and support interoperability with Tempo for moving assets in and out of zones.
 
-You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](https://tempo.xyz/blog/introducing-tempo-zones), or exploring the [Zone spec](docs/specs/zone_spec.md).
+You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [full zone documentation](https://docs.tempo.xyz/guide/private-zones), or exploring the [Zone spec](docs/specs/zone_spec.md).
 
 <br>
 


### PR DESCRIPTION
Points the "full zone documentation" link to docs.tempo.xyz/guide/private-zones.

Co-Authored-By: 0xKitsune <77890308+0xKitsune@users.noreply.github.com>

Prompted by: daniel