### PR TITLE
docs: fmt, fix wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@
 > This repository is actively under development and subject to rapid iteration.
 > APIs, interfaces, and behavior may change without notice. Not recommended for production use yet.
 
-Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo) *(currently available in testnet only),* with native support for confidential balances and transactions. Zones inherit compliance via TIP403 policies from Tempo and support interoperability with Tempo for moving assets in and out of zones.
+Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo) *(currently available in testnet only),* with native support for confidential balances and transactions. Zones inherit compliance via TIP403 policies from Tempo and support interoperability with Tempo for moving assets in and out of Zones.
 
-You can get started today by [deploying a zone](#getting-started) on Tempo testnet, reading the [zones documentation](https://docs.tempo.xyz/guide/private-zones), or exploring the [Zone spec](docs/specs/zone_spec.md).
+You can get started today by [deploying a Zone](#getting-started) on Tempo testnet, reading the [Zones documentation](https://docs.tempo.xyz/guide/private-zones), or exploring the [Zone spec](docs/specs/zone_spec.md).
 
 <br>
 
 ## What Makes Zones Interesting
 
-- **Private balances and transactions.** State access requires account authentication at the RPC layer. This ensures that only the authorized account holder can access balances and transaction history. The zone operator maintains full visibility into state for compliance.
+- **Private balances and transactions.** State access requires account authentication at the RPC layer. This ensures that only the authorized account holder can access balances and transaction history. The Zone operator maintains full visibility into state for compliance.
 
-- **Encrypted deposits and withdrawals.** When depositing into a zone, users can encrypt the recipient to not reveal who receives funds inside the zone. Encrypted withdrawals are also possible, allowing the sender to be replaced with a commitment, preserving recipient verifiability without exposing the sender when withdrawing to Tempo mainnet.
+- **Encrypted deposits and withdrawals.** When depositing into a Zone, users can encrypt the recipient to not reveal who receives funds inside the Zone. Encrypted withdrawals are also possible, allowing the sender to be replaced with a commitment, preserving recipient verifiability without exposing the sender when withdrawing to Tempo mainnet.
 
-- **Zone to zone transfers.** Zones interoperate with Tempo via withdrawals with optional calldata. Withdrawal calldata can execute on Tempo and deposit into another zone, enabling flows like zone to zone transfers or executing a swap between sending amounts to another zone.
+- **Zone to Zone transfers.** Zones interoperate with Tempo via withdrawals with optional calldata. Withdrawal calldata can execute on Tempo and deposit into another Zone, enabling flows like Zone to Zone transfers or executing a swap between sending amounts to another Zone.
 
-- **Compliance inherited from Tempo.** [TIP-403](https://docs.tempo.xyz/protocol/tip403/overview) policies (whitelist, blacklist) are mirrored from Tempo and enforced on zones. Issuers set the policy once on Tempo and the zone picks it up automatically. If an issuer freezes an address or updates a blacklist on Tempo, the zone inherits the change in the next block in the zone.
+- **Compliance inherited from Tempo.** [TIP-403](https://docs.tempo.xyz/protocol/tip403/overview) policies (whitelist, blacklist) are mirrored from Tempo and enforced on Zones. Issuers set the policy once on Tempo and the Zone picks it up automatically. If an issuer freezes an address or updates a blacklist on Tempo, the Zone inherits the change in the next block in the Zone.
 
-- **Fast withdrawals.** The zone processes transactions every 250ms and submits batches of withdrawals to Tempo, where blocks are produced every ~500ms. Once batches are accepted and the attached proof is validated, withdrawals are processed and funds are released from escrow.
+- **Fast withdrawals.** The Zone processes transactions every 250ms and submits batches of withdrawals to Tempo, where blocks are produced every ~500ms. Once batches are accepted and the attached proof is validated, withdrawals are processed and funds are released from escrow.
 
 <br>
 


### PR DESCRIPTION
Capitalize "zone" to "Zone" for consistency throughout the README.

Co-Authored-By: 0xKitsune <77890308+0xKitsune@users.noreply.github.com>

Prompted by: daniel