### PR TITLE
chore(deps): bump to latest tempo main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,21 +88,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f312b60857fb4f8e0c723a17ae9c687c0e83a3c6b7940a30d4d5a26af091"
+checksum = "85805c194576017df6c11057504e1d60b36f3913f8e365945486931f6ee81e40"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -127,14 +127,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+checksum = "8dbe4e5e9107bf6854e7550b666ca654ff2027eabf8153913e2e31ac4b089779"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -155,24 +155,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+checksum = "88fc7bbfb98cf5605a35aadf0ba43a7d9f1608d6f220d05e4fbd5144d3b0b625"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa68d4b6fbbf44b9597684f27509573c5de3ef897907122376157f25b1f378e"
+checksum = "f4c16fa30b623e40a5b216da00f3b61870f5cbe863b59816ac1ecc2489515a40"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -293,15 +293,38 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb4919fa34b268842f434bfafa9c09136ab7b1a87ce0dd40a61befa35b5408c"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.0",
  "arbitrary",
  "auto_impl",
  "borsh",
  "c-kzg",
  "derive_more",
  "either",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2 0.10.9",
@@ -309,12 +332,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.29.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6ba2dafd6327f78f2b59ae539bd5c39c57a01dc76763e92942619d934a7bb"
+checksum = "5f107d0e588e5d25fcf2db216390445d5804b875a22a419407ad0389b925bb4d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -322,8 +345,6 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy",
- "op-revm",
  "revm",
  "thiserror 2.0.18",
  "tracing",
@@ -331,13 +352,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6173ced325833e40ccb781bb372c720df638a966bad6ed6733682b6bff63d855"
+checksum = "1e111e22c1a2133e9ebfd9051ea0eaf63559594d2f50d43cbc6762fbb95fc3c2"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-trie",
  "borsh",
  "serde",
@@ -372,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae95062f48461967424eecb1e1ab703e493b6a7aca7f9c327cc1c06758eb6ec2"
+checksum = "31b6af6f374c1eeef8ab8dc26232cd440db167322a4207a3debd3d1ee565ca47"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -387,19 +408,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464d9c2c5bca3ff3f020f2ab502629043486a1b3645c5c11613c1dade4eb6f5e"
+checksum = "f0a3f5a7f3678b71d33fcc45b714fab8928dbc647d5aff2145e72032d5c849bb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -413,14 +434,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+checksum = "fb50dc1fb0e0b2c8748d5bee1aa7acdd18f9e036311bc93a71d97be624030317"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
@@ -456,13 +477,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b08405e82effb4985f7cbe83d5067730e79893c8699793c1e113043ffeac9d"
+checksum = "f2ba5468f78c8893be2d68a7f2fda61753336e5653f006af19781001b5f99e6c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -502,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f39b713fb8fd7abb6ee7601d467f71d2c2541b7799dd02d3a8f9f650d1d3f6d"
+checksum = "ffcefb5d3391a320eadb95d398e4135f8cc35c7bf29a6bdb357eadcfc5ee5638"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -524,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -535,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -546,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96846729dd095dd5a87bf5bd8efea2345ca41ceab6dda212c49f5c8ca6e2a536"
+checksum = "222fd4efff0fb9a25184684742c44fe9fa9a16c4ab5bf97583e71c86598ef8f0"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -572,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f20059ff046049aae59f6e19d96462214ad3290cf9920394309dd7ffc284390"
+checksum = "974df1e56405c27cb8242381f45d8b212ba9df5006046ccf704764a2a4634366"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -583,15 +604,15 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3468c7d973491c4c02a373a29273cb747aa4a99cf2e54a6178b564d97462db50"
+checksum = "5f1d057dcbacf8be8f689a7737e0d697fd40a2dc5b664c9035f182ff016649ea"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -601,39 +622,43 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aca954ee74bb38b24399da5bd861a2511fb76d40cca7ae700d2289ff96fb90"
+checksum = "06bc10b0dca4f5bfc3cd30ed46eab5d651b5bb2cd300d683bdcdf5d2bfe6e82c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b71da7e5cdd0d5ffebc459f5987888fd3380969c2f94f8cb652ad91ae51bba"
+checksum = "949c0f16a94ae33cdb1139b8dbf9e34d7f26ebfe97962e2a4d620b5f65f48fe4"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3569433bc2cddd4f00b1dd533a38a07512b55e62d11f662fde20930b613b57"
+checksum = "7a8f7fa8ca056bb797a368aeed329e6ace6b62ee4271432ac36ab8ae87a5e60d"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_json",
  "serde_with",
@@ -644,11 +669,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d9d9a32059dff4809fe4db016db13ba1a20babf767c4cd26e97c93ee9efe4c"
+checksum = "301249e3c9e43661cfd7ebbb4746a00af6ce1ef58b5c968451882cd60438417d"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more",
  "serde",
  "serde_with",
@@ -656,18 +682,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
+checksum = "e59bc947935732cae5b072753e5e034c0b70a8b031c2839f45e2659ba07df9ae"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
@@ -676,17 +702,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+checksum = "cc280a41931bd419af86e9e859dd9726b73313aaa2e479b33c0e344f4b892ddb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -698,28 +724,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b6ca72affc6669e0a456af7d3c15d6b2edf75797d7906bc3900a8b1e094348"
+checksum = "286c40ce0d715217a5bfa9fb452779b11e6769e56680afa0de691ae8f3a848ac"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00e2d5ab1f7310c7ecd69962af8c99d2557335ff8cf1baf39c8ff6eec9c171d"
+checksum = "ede0458c51bef23620aa6bd01a0b4f608be7bcb61d98e91b8530208ae545f3c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -727,13 +753,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154695f4a24dd749368fd46a4bdac1ec806b4376abc40112e3028018fee5b593"
+checksum = "d3f4df183248b57f3e0b99054b1b6786769d3fdff6d01a702234068140c8ba76"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
@@ -744,6 +770,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4848831ff994c88b1c32b7df9c4c1c3eedea4b535bde5eb3c421ef0bdc5ac052"
+dependencies = [
+ "alloy-primitives",
  "arbitrary",
  "serde",
  "serde_json",
@@ -751,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f59de30d9d3b13ce6a1b90e85270dc086e4e4733aaa12b250fb30e1eb35849"
+checksum = "84b8ad9890b212e224291024b1aecfeef72127d27a2f6eebc5e347c40275c4bf"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -766,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e64733ea58cfb393c901047638e9ff6890c0a45dc5855bfa077f8bace0f9f9"
+checksum = "3c67d2372aada343130d41e249b59a3cef29b1678dcd3fd80f1c2c4d6b5318f2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -858,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9c680a7ee0879aa27ea2e347f14e3a973a262e4325964fa1ab062b8a796064"
+checksum = "32b7b755e64ae6b5de0d762ed2c780e072167ea5e542076a559e00314352a0bf"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -881,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9abaedb9123ebe4b1527bc88a0409d65b2727c3de89a289284ba91ad70ae99"
+checksum = "a29980e69119444ed26b75e7ee5bed2043870f904a64318297e55800db686564"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -897,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74911eda4fd7ef12f446b1661f11787f9fb31bde4ab4a0a68efcac9b98cfdf"
+checksum = "7b27802653330740c88c28394cdaf1d55190b15b48ef9b99a946f37c9cdb19fa"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -917,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130762ef3e6c0fb7dc1b855d4f359eb8ea6f2df2f800f40aa52d27737bf640f1"
+checksum = "e4b71dc951db66795cfb52eef835f64cf15163bc93b656e061b457ce5ebff370"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -956,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+checksum = "8d8228b9236479ff16b03041b64b86c2bd4e53da1caa45d59b5868cd1571131e"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1017,7 +1054,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1028,7 +1065,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2172,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af69c7b97ba7225a934e29fad444f35b5d365322efaaf724e1af66c99c8c6c3"
+checksum = "f06e32817f35fb517ceb6102d984f9a85fde85666c96f053638e323b8597f2f7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2187,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf9bba8bf1ad51f54c57bee0824987bb397bedb60a09917d6a93509828a2dff"
+checksum = "f0f09b55dd5510c3b7613a573606a41961c2788709ffde053d4e644bec0bff2c"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -2222,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8da60f9fe8357927327729fa7838b44555f4c578e4b07c12a2964664230a98"
+checksum = "4cd313d9299e13bf995999c7a0ed8cc570eef6cd0972fcffc6e2c682cfba6663"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2232,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c4e1e7a838cff536ffbe38f441c555eee99322d755aed3e06af9407c127fd3"
+checksum = "dbc385e646d91b5397c93816985421878d627839834f7cf85a8da2ac9f8b98b7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2245,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a44f73b02286843967888c7aa750a7a91a5cd3ac8b9bc48cd1d81331836bbb"
+checksum = "e5d834ed8bf601e113b9cd2ba284dd0e95adf558933dc727f52f8879434cb286"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2259,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a590a49ee5d5389a2b966008b3367275772da7f336719fdb0f046ad257f6849"
+checksum = "db29306a40279ad54d06b42c623a05fbb5333546b5003c921796bc856b423106"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2270,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06938675df074ca7749a6d531c4706bcc339e842105e73b03a76d45bd860b349"
+checksum = "8d4ae4c804d0d9c1df615b1c7846e4e5e64fdb4228685487cb67803e67388411"
 dependencies = [
  "axum",
  "bytes",
@@ -2307,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192eb390e3e0277770982e5e63de72f3c116c810873f3250318cae9ff0206560"
+checksum = "faf66d7b5c89489d71b0669bda2e014e7c9ffcdf65629ae31886efe5361b1179"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3218,14 +3255,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "ethereum_hashing"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
+checksum = "5aa93f58bb1eb3d1e556e4f408ef1dac130bad01ac37db4e7ade45de40d1c86a"
 dependencies = [
  "cpufeatures",
  "ring",
@@ -3247,21 +3284,6 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
@@ -3273,18 +3295,6 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4046,6 +4056,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4100,7 +4111,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4679,16 +4690,18 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
@@ -5149,9 +5162,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -5302,7 +5315,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5481,121 +5494,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "op-alloy"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95dd0974d5e60ffe9342a70cc0033d299244fab01cb16a958eb7352ddba1fa7"
-dependencies = [
- "op-alloy-consensus",
- "op-alloy-network",
- "op-alloy-provider",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadcb964b0aa645d12e952d470c7585d23286d8bcf1ac41589410b6724216b68"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "derive_more",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-alloy-network"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ea44162d493219cc678aaca1253d46c3aa73aa361326dfa9d406f086dfa135"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
-]
-
-[[package]]
-name = "op-alloy-provider"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83aa8dc34bdf077c8e6d48ff75beff4ac14b428d982c9722483ccd7473c0e114"
-dependencies = [
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-engine",
- "alloy-transport",
- "async-trait",
- "op-alloy-rpc-types-engine",
-]
-
-[[package]]
-name = "op-alloy-rpc-types"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9d16ec9f7810e0623a37edc293d1c05fe9c58a5647f6973fdd93e0b4795015"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "derive_more",
- "op-alloy-consensus",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0ac5c5ddcbffadcd097d278c717d34849bcc629f6e4f8514eb000ec862def8"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "alloy-serde",
- "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
- "op-alloy-consensus",
- "serde",
- "sha2 0.10.9",
- "snap",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-revm"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a98f3a512a7e02a1dcf1242b57302d83657b265a665d50ad98d0b158efaf2c"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -6599,16 +6497,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -6668,16 +6572,17 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "futures-core",
  "futures-util",
  "metrics",
  "reth-chain-state",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -6686,6 +6591,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
+ "reth-trie-parallel",
  "serde",
  "tokio",
  "tracing",
@@ -6693,11 +6599,11 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -6725,12 +6631,12 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -6745,8 +6651,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6758,12 +6664,12 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -6841,8 +6747,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6851,10 +6757,10 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "cfg-if",
  "eyre",
@@ -6870,12 +6776,12 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1df733d93427eb197cf80a7aaa68bff8949e1b59d34cde1ad410351a24136d"
+checksum = "a79b3247ae4fbb1d4d35ce83a11fc596428a4c6ea836c98a75a55340192578a4"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -6891,9 +6797,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14acf8feadf1eed0734d1766b55b6c19a374d4cb140bc862880f96da33e7e5a"
+checksum = "df5dbae40c272b8a1b4fcc08ee2d4e77d3b0ccdb187c1313f412a73ff54ff2a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6902,8 +6808,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6918,8 +6824,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6931,11 +6837,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -6944,11 +6850,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -6970,8 +6876,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -6998,8 +6904,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7024,8 +6930,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7054,10 +6960,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -7069,8 +6975,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7094,8 +7000,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7118,8 +7024,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7142,11 +7048,11 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -7177,8 +7083,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7205,8 +7111,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7228,11 +7134,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -7253,12 +7159,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -7266,6 +7172,7 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "futures",
+ "indexmap 2.13.0",
  "metrics",
  "moka",
  "parking_lot",
@@ -7309,8 +7216,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7337,23 +7244,23 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
- "ethereum_ssz 0.10.1",
- "ethereum_ssz_derive 0.10.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "snap",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7368,8 +7275,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7390,8 +7297,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7401,8 +7308,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7429,12 +7336,12 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -7450,8 +7357,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -7490,8 +7397,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "clap",
  "eyre",
@@ -7513,11 +7420,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -7529,10 +7436,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -7545,8 +7452,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7558,11 +7465,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -7573,6 +7480,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-execution-cache",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7587,11 +7495,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -7601,8 +7509,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7611,11 +7519,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -7635,11 +7543,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -7655,8 +7563,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -7673,8 +7581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7686,11 +7594,11 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -7705,11 +7613,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -7743,10 +7651,10 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -7757,8 +7665,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "serde",
  "serde_json",
@@ -7767,8 +7675,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7795,8 +7703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "bytes",
  "futures",
@@ -7815,8 +7723,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -7832,8 +7740,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "bindgen",
  "cc",
@@ -7841,8 +7749,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "futures",
  "metrics",
@@ -7853,8 +7761,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -7862,8 +7770,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7876,11 +7784,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -7933,8 +7841,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7958,11 +7866,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -7981,8 +7889,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7996,8 +7904,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8010,8 +7918,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8027,8 +7935,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8051,11 +7959,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -8119,11 +8027,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -8174,10 +8082,10 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8212,8 +8120,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8236,11 +8144,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -8260,8 +8168,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "bytes",
  "eyre",
@@ -8284,8 +8192,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8296,20 +8204,23 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types",
+ "derive_more",
  "futures-util",
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-trie-parallel",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8317,8 +8228,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8329,17 +8240,16 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
  "either",
- "op-alloy-rpc-types-engine",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -8354,8 +8264,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8364,12 +8274,12 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03650bb740d1bca0d974c007248177ae7a7e38c50c9f46eb02292c5d9bc01252"
+checksum = "cc759fd87c3f65440e5d3bfa3107fe8a13a61a6807cd485c62c49d63c7bf6717"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -8397,11 +8307,11 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8443,11 +8353,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -8472,8 +8382,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8488,10 +8398,12 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8501,13 +8413,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -8523,7 +8435,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -8579,11 +8491,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -8597,7 +8509,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -8610,8 +8522,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8653,8 +8565,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8662,21 +8574,21 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-signer",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
  "reth-evm",
  "reth-primitives-traits",
+ "reth-rpc-traits",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8704,12 +8616,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -8717,7 +8630,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -8742,17 +8655,18 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
+ "serde_json",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -8796,8 +8710,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8810,10 +8724,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -8825,12 +8739,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-stages"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+name = "reth-rpc-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b766da61ec7c46596386b4bc88d9b57d1939d3da2bc9e927567a8a23650e5ce9"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-stages"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -8878,10 +8807,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -8906,8 +8835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8920,8 +8849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8940,8 +8869,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8955,11 +8884,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8979,10 +8908,10 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -8997,8 +8926,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9018,11 +8947,11 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-genesis",
  "alloy-primitives",
  "rand 0.8.5",
@@ -9034,8 +8963,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9044,8 +8973,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "clap",
  "eyre",
@@ -9061,8 +8990,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "clap",
  "eyre",
@@ -9078,11 +9007,11 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -9122,11 +9051,11 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -9148,14 +9077,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -9175,8 +9104,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9195,12 +9124,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
+ "alloy-eip7928",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
+ "crossbeam-utils",
  "derive_more",
  "itertools 0.14.0",
  "metrics",
@@ -9213,14 +9145,15 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-sparse",
+ "revm-state",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b33057#0b33057414c8815ed499e0aa837ae52d4d366150"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9241,18 +9174,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be2e9bda3e45c5d87cfbe811676bfb9cb1f0e6fa82d1dd6a3e8cd996512f236"
+checksum = "82fa54c341d926ec9b0f7fc0c87f831aa4959de699e69caab1a0bfd914326c09"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "36.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
+checksum = "11353f234577a63048066df974d8a56e8c090d4de8b5f7d5f2a0d0c3a1ffaa2d"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -9269,9 +9202,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "phf",
@@ -9281,9 +9214,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
+checksum = "c0e3d41127977e351ed795689147e6e59b0fa88e387840f921e46c440bb2fb44"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9298,9 +9231,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
+checksum = "dd61f0f2f646ae74a75e12e7f1d57554868e2dc5c83fc9a761cb95735cb58309"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -9314,11 +9247,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "12.0.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
+checksum = "54f97178ab32358be770d09649d6fa86303923cab7afb95577353e7305a04193"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -9328,9 +9261,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
+checksum = "68e48ddde8f5ef2adaf1e920ccbf57fa6ef2c63c11e3e37d7d9137657873eecc"
 dependencies = [
  "auto_impl",
  "either",
@@ -9342,9 +9275,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
+checksum = "f18b03319aee860ecc4631c9180abb0828480f5a4c39507fc735a417bd906984"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -9361,9 +9294,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
+checksum = "f33e8327376dff859eb18dea3623aa55ef5d580fe38fa0fd4bb92bd95ace60ad"
 dependencies = [
  "auto_impl",
  "either",
@@ -9379,9 +9312,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.36.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9487362b728f80dd2033ef5f4d0688453435bbe7caa721fa7e3b8fa25d89242b"
+checksum = "e41c7dc3d85c6186e57ec1438a426e7ddfac579d8255930cf8ed324a6c317e79"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -9397,9 +9330,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
+checksum = "8e5f438f47d40d9830c0498fa3ca16a447b3148ab7b78742cbb1b27a51a50963"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -9410,9 +9343,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+checksum = "1c07bfcc9361f7b23970a68cbd17bfe255e70182cfb1a8896d06832217fc5439"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -9426,6 +9359,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
+ "revm-context-interface",
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
@@ -9434,9 +9368,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -9446,9 +9380,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+checksum = "0e480426a7d76b458789e4a1be3ffbce9df798f0145f0520c1cdf967755cfcbf"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
@@ -9647,7 +9581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9706,7 +9640,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9727,7 +9661,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10262,7 +10196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10472,23 +10406,24 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "alloy-signer-local",
+ "alloy-sol-types",
  "alloy-transport",
  "async-trait",
  "dashmap",
@@ -10509,10 +10444,10 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -10530,8 +10465,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10546,8 +10481,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10557,8 +10492,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10587,14 +10522,15 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
+ "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
  "async-trait",
  "clap",
  "commonware-runtime",
@@ -10603,9 +10539,11 @@ dependencies = [
  "jiff",
  "jsonrpsee",
  "reqwest 0.13.2",
+ "reth-chainspec",
  "reth-errors",
  "reth-ethereum",
  "reth-evm",
+ "reth-network-api",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
@@ -10614,6 +10552,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc",
+ "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
@@ -10638,8 +10577,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10665,6 +10604,7 @@ dependencies = [
  "tempo-consensus",
  "tempo-evm",
  "tempo-payload-types",
+ "tempo-precompiles",
  "tempo-primitives",
  "tempo-transaction-pool",
  "tracing",
@@ -10672,10 +10612,10 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10690,8 +10630,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10703,14 +10643,15 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-precompiles-macros",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10720,18 +10661,20 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.0",
+ "aws-lc-rs",
  "base64 0.22.1",
  "derive_more",
+ "ed25519-consensus",
  "modular-bitfield",
  "once_cell",
  "p256",
@@ -10749,8 +10692,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10772,11 +10715,11 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=bb08bb905b6ee13fafe046aa9531aea2cdf60651#bb08bb905b6ee13fafe046aa9531aea2cdf60651"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-primitives",
  "alloy-sol-types",
@@ -10790,6 +10733,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-revm",
  "reth-storage-api",
  "reth-tracing",
  "reth-transaction-pool",
@@ -10810,7 +10754,7 @@ name = "tempo-xtask"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-rlp",
  "clap",
  "const-hex",
@@ -11029,9 +10973,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -11046,9 +10990,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11432,24 +11376,24 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
+checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "ethereum_ssz 0.9.1",
+ "ethereum_ssz",
  "smallvec",
  "typenum",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
+checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11975,7 +11919,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12779,7 +12723,7 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -12894,7 +12838,7 @@ name = "zone-rpc"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,23 +78,23 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false, features = ["serde"] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false, features = ["serde"] }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
 
 # zones
 zone-precompiles = { path = "crates/precompiles", default-features = false }
@@ -102,55 +102,55 @@ zone-primitives = { path = "crates/primitives", default-features = false }
 zone-rpc = { path = "crates/rpc" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-primitives-traits = { version = "0.1.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0", features = [
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-primitives-traits = { version = "0.3.0", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-revm = { version = "36.0.0", features = ["optional_fee_charge"] }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0b33057" }
+revm = { version = "37.0.0", features = ["optional_fee_charge"], default-features = false }
 
 # alloy
-alloy = { version = "1.6.1", default-features = false }
-alloy-consensus = { version = "1.6.1", default-features = false }
-alloy-contract = { version = "1.6.1", default-features = false }
-alloy-eips = { version = "1.8.3", default-features = false }
-alloy-evm = "0.29.2"
-alloy-network = { version = "1.6.1", default-features = false }
+alloy = { version = "2.0.0", default-features = false }
+alloy-consensus = { version = "2.0.0", default-features = false }
+alloy-contract = { version = "2.0.0", default-features = false }
+alloy-eips = { version = "2.0.0", default-features = false }
+alloy-evm = { version = "0.32.0", default-features = false }
+alloy-network = { version = "2.0.0", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-provider = { version = "1.6.1", default-features = false }
-alloy-rlp = { version = "0.3.13", default-features = false }
-alloy-rpc-client = "1.6.1"
-alloy-rpc-types-engine = "1.8.3"
-alloy-rpc-types-eth = { version = "1.8.3" }
-alloy-signer = "1.6.1"
-alloy-signer-local = "1.6.1"
+alloy-provider = { version = "2.0.0", default-features = false }
+alloy-rlp = { version = "0.3.15", default-features = false }
+alloy-rpc-client = "2.0.0"
+alloy-rpc-types-engine = "2.0.0"
+alloy-rpc-types-eth = { version = "2.0.0" }
+alloy-signer = "2.0.0"
+alloy-signer-local = "2.0.0"
 alloy-sol-types = { version = "1.5.7", default-features = false }
-alloy-transport = "1.6.1"
+alloy-transport = "2.0.0"
 
 # commonware
 commonware-codec = "2026.2.0"

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -20,14 +20,14 @@ tempo-contracts = { workspace = true, default-features = false }
 tempo-precompiles = { workspace = true, default-features = false }
 tempo-precompiles-macros.workspace = true
 
-# alloy (direct versions for no_std — workspace versions have default-features = true)
-alloy = { version = "1.6.1", default-features = false }
-alloy-evm = { version = "0.29.2", default-features = false }
-alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-sol-types = { version = "1.5.7", default-features = false }
+# alloy
+alloy = { workspace = true, default-features = false }
+alloy-evm = { workspace = true, default-features = false }
+alloy-primitives = { workspace = true, default-features = false }
+alloy-sol-types = { workspace = true, default-features = false }
 
 # revm
-revm = { version = "36.0.0", default-features = false }
+revm = { workspace = true, default-features = false }
 
 # crypto
 aes-gcm = { version = "0.10.3", default-features = false, features = ["aes", "alloc"] }

--- a/crates/precompiles/src/aes_gcm.rs
+++ b/crates/precompiles/src/aes_gcm.rs
@@ -16,7 +16,7 @@ use aes_gcm::{
 use alloy_evm::precompiles::{DynPrecompile, Precompile, PrecompileInput};
 use alloy_primitives::{Address, Bytes, address};
 use alloy_sol_types::SolCall;
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, warn};
 
 /// AES-256-GCM Decrypt precompile address on Zone L2.
@@ -57,19 +57,21 @@ impl Precompile for AesGcmDecrypt {
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResult {
         let data = input.data;
         if data.len() < 4 {
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
         if selector != decryptCall::SELECTOR {
             warn!(target: "zone::precompile", ?selector, "AesGcmDecrypt: unknown selector");
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         debug!(target: "zone::precompile", "AesGcmDecrypt: decrypt");
 
-        let call = decryptCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+        let call = match decryptCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir)),
+        };
 
         let gas = AES_GCM_BASE_GAS + AES_GCM_PER_BYTE_GAS * call.ciphertext.len() as u64;
 
@@ -86,7 +88,7 @@ impl Precompile for AesGcmDecrypt {
             valid,
         };
         let encoded = decryptCall::abi_encode_returns(&ret);
-        Ok(PrecompileOutput::new(gas, encoded.into()))
+        Ok(PrecompileOutput::new(gas, encoded.into(), input.reservoir))
     }
 }
 

--- a/crates/precompiles/src/chaum_pedersen.rs
+++ b/crates/precompiles/src/chaum_pedersen.rs
@@ -20,7 +20,7 @@ use k256::{
         sec1::{FromEncodedPoint, ToEncodedPoint},
     },
 };
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, warn};
 
 /// Chaum-Pedersen Verify precompile address on Zone L2.
@@ -73,19 +73,21 @@ impl Precompile for ChaumPedersenVerify {
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResult {
         let data = input.data;
         if data.len() < 4 {
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
         if selector != verifyProofCall::SELECTOR {
             warn!(target: "zone::precompile", ?selector, "ChaumPedersenVerify: unknown selector");
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         debug!(target: "zone::precompile", "ChaumPedersenVerify: verifyProof");
 
-        let call = verifyProofCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+        let call = match verifyProofCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir)),
+        };
 
         let valid = verify_chaum_pedersen(
             &call.ephemeralPubX.0,
@@ -99,7 +101,11 @@ impl Precompile for ChaumPedersenVerify {
         );
 
         let encoded = verifyProofCall::abi_encode_returns(&valid);
-        Ok(PrecompileOutput::new(CP_VERIFY_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            CP_VERIFY_GAS,
+            encoded.into(),
+            input.reservoir,
+        ))
     }
 }
 

--- a/crates/precompiles/src/ecies.rs
+++ b/crates/precompiles/src/ecies.rs
@@ -93,8 +93,8 @@ pub fn compute_ecdh_proof(
     Some(EcdhProofResult {
         shared_secret: B256::from(shared_secret_x),
         shared_secret_y_parity,
-        cp_proof_s: B256::from(s.to_repr().as_ref()),
-        cp_proof_c: B256::from(c.to_repr().as_ref()),
+        cp_proof_s: B256::from_slice(s.to_repr().as_ref()),
+        cp_proof_c: B256::from_slice(c.to_repr().as_ref()),
     })
 }
 

--- a/crates/precompiles/src/tip20_factory.rs
+++ b/crates/precompiles/src/tip20_factory.rs
@@ -14,11 +14,9 @@
 //! Only [`ZONE_INBOX_ADDRESS`] may call this precompile; all other callers are
 //! reverted with `OnlyZoneInbox()`.
 
-use alloc::format;
-
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolError};
-use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
+use revm::precompile::PrecompileResult;
 use tempo_precompiles::{
     PATH_USD_ADDRESS, Precompile as TempoPrecompile, TIP20_FACTORY_ADDRESS,
     tip20::{ISSUER_ROLE, TIP20Token},
@@ -98,15 +96,17 @@ impl ZoneTokenFactory {
             PrecompileId::Custom("ZoneTokenFactory".into()),
             move |input| {
                 if !input.is_direct_call() {
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         SolError::abi_encode(&DelegateCallNotAllowed {}).into(),
+                        input.reservoir,
                     ));
                 }
 
                 let mut storage = EvmPrecompileStorageProvider::new(
                     input.internals,
                     input.gas,
+                    input.reservoir,
                     spec,
                     input.is_static,
                     gas_params.clone(),
@@ -120,19 +120,21 @@ impl ZoneTokenFactory {
 
 impl TempoPrecompile for ZoneTokenFactory {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        let storage = tempo_precompiles::storage::StorageCtx;
+
         if msg_sender != ZONE_INBOX_ADDRESS {
-            return Ok(PrecompileOutput::new_reverted(
-                0,
-                OnlyZoneInbox {}.abi_encode().into(),
-            ));
+            return Ok(storage.revert_output(OnlyZoneInbox {}.abi_encode().into()));
         }
 
-        let call = enableTokenCall::abi_decode(calldata)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+        let call = match enableTokenCall::abi_decode(calldata) {
+            Ok(call) => call,
+            Err(_) => return Ok(storage.revert_output(Bytes::new())),
+        };
 
-        self.enable_token(call)
-            .map_err(|e| PrecompileError::other(format!("{e}")))?;
+        if let Err(err) = self.enable_token(call) {
+            return storage.error_result(err);
+        }
 
-        Ok(PrecompileOutput::new(0, Bytes::new()))
+        Ok(storage.success_output(Bytes::new()))
     }
 }

--- a/crates/precompiles/src/tip403_proxy.rs
+++ b/crates/precompiles/src/tip403_proxy.rs
@@ -105,21 +105,22 @@ impl<P: PolicyCheck + Clone + Send + Sync + 'static> ZoneTip403ProxyRegistry<P> 
             move |input| {
                 if !input.is_direct_call() {
                     warn!(target: "zone::precompile", "ZoneTip403ProxyRegistry called via DELEGATECALL — rejecting");
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         ReadOnlyRegistry {}.abi_encode().into(),
+                        input.reservoir,
                     ));
                 }
 
                 let data = input.data;
                 if data.len() < 4 {
                     warn!(target: "zone::precompile", data_len = data.len(), "ZoneTip403ProxyRegistry called with insufficient data");
-                    return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                    return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
                 }
 
                 let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
 
-                registry.dispatch(selector, data)
+                registry.dispatch(selector, data, input.reservoir)
             },
         )
     }
@@ -127,31 +128,31 @@ impl<P: PolicyCheck + Clone + Send + Sync + 'static> ZoneTip403ProxyRegistry<P> 
 
 impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
     /// Dispatch based on the 4-byte selector.
-    fn dispatch(&self, selector: [u8; 4], data: &[u8]) -> PrecompileResult {
+    fn dispatch(&self, selector: [u8; 4], data: &[u8], reservoir: u64) -> PrecompileResult {
         // View functions — served from cache/RPC
         if selector == ITIP403Registry::isAuthorizedCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::Transfer);
+            return self.handle_is_authorized(data, AuthRole::Transfer, reservoir);
         }
         if selector == ITIP403Registry::isAuthorizedSenderCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::Sender);
+            return self.handle_is_authorized(data, AuthRole::Sender, reservoir);
         }
         if selector == ITIP403Registry::isAuthorizedRecipientCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::Recipient);
+            return self.handle_is_authorized(data, AuthRole::Recipient, reservoir);
         }
         if selector == ITIP403Registry::isAuthorizedMintRecipientCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::MintRecipient);
+            return self.handle_is_authorized(data, AuthRole::MintRecipient, reservoir);
         }
         if selector == ITIP403Registry::policyDataCall::SELECTOR {
-            return self.handle_policy_data(data);
+            return self.handle_policy_data(data, reservoir);
         }
         if selector == ITIP403Registry::compoundPolicyDataCall::SELECTOR {
-            return self.handle_compound_policy_data(data);
+            return self.handle_compound_policy_data(data, reservoir);
         }
         if selector == ITIP403Registry::policyExistsCall::SELECTOR {
-            return self.handle_policy_exists(data);
+            return self.handle_policy_exists(data, reservoir);
         }
         if selector == ITIP403Registry::policyIdCounterCall::SELECTOR {
-            return self.handle_policy_id_counter();
+            return self.handle_policy_id_counter(reservoir);
         }
 
         // Mutating functions — all reverted on zone
@@ -163,34 +164,48 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
             || selector == ITIP403Registry::modifyPolicyBlacklistCall::SELECTOR
         {
             debug!(target: "zone::precompile", ?selector, "ZoneTip403ProxyRegistry: mutating call reverted");
-            return Ok(PrecompileOutput::new_reverted(
+            return Ok(PrecompileOutput::revert(
                 0,
                 ReadOnlyRegistry {}.abi_encode().into(),
+                reservoir,
             ));
         }
 
         // Unknown selector
         warn!(target: "zone::precompile", ?selector, "ZoneTip403ProxyRegistry: unknown selector");
-        Ok(PrecompileOutput::new_reverted(0, Bytes::new()))
+        Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir))
     }
 
     /// Handle `isAuthorized(policyId, user)` and the directional variants.
     ///
     /// All four share the same ABI shape: `(uint64 policyId, address user) → bool`.
-    fn handle_is_authorized(&self, data: &[u8], role: AuthRole) -> PrecompileResult {
-        let call = ITIP403Registry::isAuthorizedCall::abi_decode_raw(&data[4..])
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_is_authorized(
+        &self,
+        data: &[u8],
+        role: AuthRole,
+        reservoir: u64,
+    ) -> PrecompileResult {
+        let call = match ITIP403Registry::isAuthorizedCall::abi_decode_raw(&data[4..]) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let authorized = self.is_authorized(call.policyId, call.user, role)?;
 
         let encoded = ITIP403Registry::isAuthorizedCall::abi_encode_returns(&authorized);
-        Ok(PrecompileOutput::new(AUTH_CHECK_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            AUTH_CHECK_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `policyData(policyId) → (PolicyType, address admin)`.
-    fn handle_policy_data(&self, data: &[u8]) -> PrecompileResult {
-        let call = ITIP403Registry::policyDataCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_policy_data(&self, data: &[u8], reservoir: u64) -> PrecompileResult {
+        let call = match ITIP403Registry::policyDataCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         // Builtins: reject-all is an empty whitelist, allow-all is an empty blacklist
         let builtin_type = match call.policyId {
@@ -204,7 +219,11 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
                 admin: Address::ZERO,
             };
             let encoded = ITIP403Registry::policyDataCall::abi_encode_returns(&ret);
-            return Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()));
+            return Ok(PrecompileOutput::new(
+                POLICY_DATA_GAS,
+                encoded.into(),
+                reservoir,
+            ));
         }
 
         let policy_type = self.provider.policy_type_sync(call.policyId)?;
@@ -214,13 +233,19 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
             admin: Address::ZERO,
         };
         let encoded = ITIP403Registry::policyDataCall::abi_encode_returns(&ret);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `compoundPolicyData(policyId) → (uint64, uint64, uint64)`.
-    fn handle_compound_policy_data(&self, data: &[u8]) -> PrecompileResult {
-        let call = ITIP403Registry::compoundPolicyDataCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_compound_policy_data(&self, data: &[u8], reservoir: u64) -> PrecompileResult {
+        let call = match ITIP403Registry::compoundPolicyDataCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let (sender, recipient, mint_recipient) =
             self.provider.compound_policy_data(call.policyId)?;
@@ -231,29 +256,47 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
             mintRecipientPolicyId: mint_recipient,
         };
         let encoded = ITIP403Registry::compoundPolicyDataCall::abi_encode_returns(&ret);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `policyExists(policyId) → bool`.
-    fn handle_policy_exists(&self, data: &[u8]) -> PrecompileResult {
-        let call = ITIP403Registry::policyExistsCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_policy_exists(&self, data: &[u8], reservoir: u64) -> PrecompileResult {
+        let call = match ITIP403Registry::policyExistsCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         // Builtins always exist
         if matches!(call.policyId, REJECT_ALL_POLICY_ID | ALLOW_ALL_POLICY_ID) {
             let encoded = ITIP403Registry::policyExistsCall::abi_encode_returns(&true);
-            return Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()));
+            return Ok(PrecompileOutput::new(
+                POLICY_DATA_GAS,
+                encoded.into(),
+                reservoir,
+            ));
         }
 
         let exists = self.provider.policy_exists(call.policyId)?;
         let encoded = ITIP403Registry::policyExistsCall::abi_encode_returns(&exists);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `policyIdCounter() → uint64`.
-    fn handle_policy_id_counter(&self) -> PrecompileResult {
+    fn handle_policy_id_counter(&self, reservoir: u64) -> PrecompileResult {
         let counter = self.provider.policy_id_counter();
         let encoded = ITIP403Registry::policyIdCounterCall::abi_encode_returns(&counter);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 }

--- a/crates/precompiles/src/ztip20.rs
+++ b/crates/precompiles/src/ztip20.rs
@@ -15,7 +15,9 @@ use alloc::sync::Arc;
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolError, SolInterface};
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{
+    PrecompileError, PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult,
+};
 use tempo_precompiles::{
     DelegateCallNotAllowed, Precompile as TempoPrecompile,
     storage::{StorageCtx, evm::EvmPrecompileStorageProvider},
@@ -45,7 +47,7 @@ macro_rules! decode_or_revert {
         match <$call_ty>::abi_decode_raw($args) {
             Ok(c) => c,
             Err(_) => {
-                return Some(Ok(PrecompileOutput::new_reverted(0, Bytes::new())));
+                return Some(Ok(StorageCtx::default().revert_output(Bytes::new())));
             }
         }
     };
@@ -105,7 +107,6 @@ impl<P: PolicyCheck> ZoneTip20Token<P> {
         match result {
             Ok(mut output) => {
                 output.gas_used = FIXED_TRANSFER_GAS;
-                output.gas_refunded = 0;
                 Ok(output)
             }
             Err(err) => Err(err),
@@ -313,20 +314,21 @@ impl<P: PolicyCheck> ZoneTip20Token<P> {
     }
 
     fn unauthorized_output() -> PrecompileOutput {
-        PrecompileOutput::new_reverted(0, Unauthorized {}.abi_encode().into())
+        StorageCtx::default().revert_output(Unauthorized {}.abi_encode().into())
     }
 
     fn roles_unauthorized_output() -> PrecompileOutput {
-        PrecompileOutput::new_reverted(0, RolesAuthError::unauthorized().selector().into())
+        StorageCtx::default().revert_output(RolesAuthError::unauthorized().selector().into())
     }
 
     /// Build a reverted output with the `policyForbids()` error selector.
     fn policy_forbids_output() -> PrecompileOutput {
-        PrecompileOutput::new_reverted(
+        PrecompileOutput::revert(
             AUTH_CHECK_GAS,
             tempo_contracts::precompiles::TIP20Error::policy_forbids()
                 .selector()
                 .into(),
+            StorageCtx::default().reservoir(),
         )
     }
 }
@@ -357,21 +359,26 @@ where
             PrecompileId::Custom("ZoneTip20Token".into()),
             move |input| {
                 if !input.is_direct_call() {
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         SolError::abi_encode(&DelegateCallNotAllowed {}).into(),
+                        input.reservoir,
                     ));
                 }
 
                 let selector = Self::selector(input.data);
                 let is_fixed_gas = selector.is_some_and(Self::is_fixed_gas_selector);
                 if is_fixed_gas && input.gas < FIXED_TRANSFER_GAS {
-                    return Err(PrecompileError::OutOfGas);
+                    return Ok(PrecompileOutput::halt(
+                        PrecompileHalt::OutOfGas,
+                        input.reservoir,
+                    ));
                 }
 
                 let mut storage = EvmPrecompileStorageProvider::new(
                     input.internals,
                     if is_fixed_gas { u64::MAX } else { input.gas },
+                    input.reservoir,
                     spec,
                     input.is_static,
                     gas_params.clone(),
@@ -406,18 +413,16 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::{
-        primitives::{Address, U256, address},
-        sol_types::SolCall,
-    };
+    use alloy::primitives::{Address, U256, address};
     use alloy_evm::{
         EvmInternals,
         precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},
     };
+    use alloy_sol_types::SolCall;
     use revm::{
         Context,
         database::{CacheDB, EmptyDB},
-        precompile::PrecompileResult,
+        precompile::{PrecompileHalt, PrecompileResult},
     };
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_precompiles::{
@@ -475,7 +480,7 @@ mod tests {
 
         fn resolve_transfer_policy_id(&self, _token: Address) -> Result<u64, PrecompileError> {
             if self.fail_policy_id_resolution {
-                return Err(PrecompileError::other("RPC unavailable"));
+                return Err(PrecompileError::Fatal("RPC unavailable".into()));
             }
             Ok(self.policy_id)
         }
@@ -616,7 +621,7 @@ mod tests {
             let gas_params = ctx.cfg.gas_params.clone();
             let internals = EvmInternals::from_context(ctx);
             let mut storage =
-                EvmPrecompileStorageProvider::new(internals, gas_limit, spec, false, gas_params);
+                EvmPrecompileStorageProvider::new(internals, gas_limit, 0, spec, false, gas_params);
             f(&mut storage)
         }
 
@@ -634,6 +639,7 @@ mod tests {
                     caller,
                     internals: EvmInternals::from_context(&mut self.ctx),
                     gas,
+                    reservoir: 0,
                     value: U256::ZERO,
                     is_static,
                     target_address: self.token,
@@ -683,7 +689,7 @@ mod tests {
         );
 
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -718,7 +724,7 @@ mod tests {
         );
 
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -738,7 +744,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             true,
         )?;
-        assert!(private_balance.reverted);
+        assert!(private_balance.is_revert());
         assert_eq!(
             private_balance.bytes,
             Bytes::from(Unauthorized {}.abi_encode())
@@ -755,7 +761,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             false,
         )?;
-        assert!(!transfer.reverted);
+        assert!(transfer.is_success());
         assert_eq!(transfer.gas_used, FIXED_TRANSFER_GAS);
         assert_eq!(harness.balance_of(harness.bob)?, U256::from(12_345u64));
 
@@ -777,7 +783,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!inbox_mint.reverted);
+        assert!(inbox_mint.is_success());
         assert_eq!(harness.balance_of(harness.bob)?, U256::from(50_000u64));
 
         let outbox_burn = harness.call(
@@ -790,7 +796,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!outbox_burn.reverted);
+        assert!(outbox_burn.is_success());
         assert_eq!(harness.balance_of(ZONE_OUTBOX_ADDRESS)?, U256::ZERO);
 
         let crossed_mint = harness.call(
@@ -804,7 +810,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(crossed_mint.reverted);
+        assert!(crossed_mint.is_revert());
         assert_eq!(
             crossed_mint.bytes,
             Bytes::from(RolesAuthError::unauthorized().selector().to_vec())
@@ -820,7 +826,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(crossed_burn.reverted);
+        assert!(crossed_burn.is_revert());
         assert_eq!(
             crossed_burn.bytes,
             Bytes::from(RolesAuthError::unauthorized().selector().to_vec())
@@ -837,7 +843,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!issuer_mint.reverted);
+        assert!(issuer_mint.is_success());
 
         let issuer_burn = harness.call(
             harness.issuer,
@@ -849,7 +855,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!issuer_burn.reverted);
+        assert!(issuer_burn.is_success());
 
         Ok(())
     }
@@ -870,7 +876,7 @@ mod tests {
             false,
         )?;
         assert_eq!(approve.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(approve.gas_refunded, 0);
+        assert_eq!(approve.state_gas_used, 0);
 
         let approve_update = harness.call(
             harness.alice,
@@ -884,7 +890,7 @@ mod tests {
             false,
         )?;
         assert_eq!(approve_update.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(approve_update.gas_refunded, 0);
+        assert_eq!(approve_update.state_gas_used, 0);
 
         let transfer_new = harness.call(
             harness.alice,
@@ -898,7 +904,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_new.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_new.gas_refunded, 0);
+        assert_eq!(transfer_new.state_gas_used, 0);
 
         let transfer_existing = harness.call(
             harness.alice,
@@ -912,7 +918,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_existing.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_existing.gas_refunded, 0);
+        assert_eq!(transfer_existing.state_gas_used, 0);
 
         let transfer_with_memo = harness.call(
             harness.alice,
@@ -927,7 +933,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_with_memo.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_with_memo.gas_refunded, 0);
+        assert_eq!(transfer_with_memo.state_gas_used, 0);
 
         let transfer_from = harness.call(
             harness.spender,
@@ -942,7 +948,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_from.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_from.gas_refunded, 0);
+        assert_eq!(transfer_from.state_gas_used, 0);
 
         let transfer_from_with_memo = harness.call(
             harness.spender,
@@ -958,7 +964,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_from_with_memo.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_from_with_memo.gas_refunded, 0);
+        assert_eq!(transfer_from_with_memo.state_gas_used, 0);
 
         Ok(())
     }
@@ -1003,10 +1009,11 @@ mod tests {
             .abi_encode()
             .into(),
         ] {
-            assert!(matches!(
-                harness.call(harness.alice, calldata, FIXED_TRANSFER_GAS - 1, false),
-                Err(PrecompileError::OutOfGas)
-            ));
+            let output = harness
+                .call(harness.alice, calldata, FIXED_TRANSFER_GAS - 1, false)
+                .expect("out of gas is returned as a halted precompile output");
+            assert!(output.is_halt());
+            assert_eq!(output.halt_reason(), Some(&PrecompileHalt::OutOfGas));
         }
 
         Ok(())
@@ -1027,7 +1034,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             false,
         )?;
-        assert!(!approve.reverted);
+        assert!(approve.is_success());
         assert_eq!(
             harness.allowance(harness.alice, harness.spender)?,
             U256::from(123_456u64)
@@ -1044,7 +1051,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             false,
         )?;
-        assert!(!transfer.reverted);
+        assert!(transfer.is_success());
         assert_eq!(harness.balance_of(harness.bob)?, U256::from(7_654u64));
 
         Ok(())
@@ -1061,15 +1068,15 @@ mod tests {
 
         // Owner can query their own reward info
         let owner = harness.call(harness.alice, calldata.clone(), 100_000, true)?;
-        assert!(!owner.reverted);
+        assert!(owner.is_success());
 
         // Sequencer can query anyone's reward info
         let sequencer = harness.call(harness.sequencer, calldata.clone(), 100_000, true)?;
-        assert!(!sequencer.reverted);
+        assert!(sequencer.is_success());
 
         // Outsider is rejected
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -1086,15 +1093,15 @@ mod tests {
 
         // Owner can query their own pending rewards
         let owner = harness.call(harness.alice, calldata.clone(), 100_000, true)?;
-        assert!(!owner.reverted);
+        assert!(owner.is_success());
 
         // Sequencer can query anyone's pending rewards
         let sequencer = harness.call(harness.sequencer, calldata.clone(), 100_000, true)?;
-        assert!(!sequencer.reverted);
+        assert!(sequencer.is_success());
 
         // Outsider is rejected
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -1152,15 +1159,15 @@ mod tests {
 
         // Owner can query their own roles
         let owner = harness.call(harness.alice, calldata.clone(), 100_000, true)?;
-        assert!(!owner.reverted);
+        assert!(owner.is_success());
 
         // Sequencer can query anyone's roles
         let sequencer = harness.call(harness.sequencer, calldata.clone(), 100_000, true)?;
-        assert!(!sequencer.reverted);
+        assert!(sequencer.is_success());
 
         // Outsider is rejected
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -273,7 +273,7 @@ async fn handle_subscribe(
             let filter = match params.unwrap_or_default() {
                 SubscriptionParams::None => Filter::default(),
                 SubscriptionParams::Logs(filter) => *filter,
-                SubscriptionParams::Bool(_) => {
+                SubscriptionParams::Bool(_) | SubscriptionParams::TransactionReceipts(_) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
                         JsonRpcError::invalid_params("eth_subscribe(logs) expects a filter object"),
@@ -295,7 +295,7 @@ async fn handle_subscribe(
             let full = match params.unwrap_or(SubscriptionParams::None) {
                 SubscriptionParams::None | SubscriptionParams::Bool(false) => false,
                 SubscriptionParams::Bool(true) => true,
-                SubscriptionParams::Logs(_) => {
+                SubscriptionParams::Logs(_) | SubscriptionParams::TransactionReceipts(_) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
                         JsonRpcError::invalid_params(
@@ -320,6 +320,12 @@ async fn handle_subscribe(
             }
         }
         SubscriptionKind::Syncing => {
+            return WsDispatchResult::response_only(JsonRpcResponse::error(
+                req.id.clone(),
+                JsonRpcError::method_disabled(),
+            ));
+        }
+        SubscriptionKind::TransactionReceipts => {
             return WsDispatchResult::response_only(JsonRpcResponse::error(
                 req.id.clone(),
                 JsonRpcError::method_disabled(),

--- a/crates/rpc/test-utils/auth_tokens.rs
+++ b/crates/rpc/test-utils/auth_tokens.rs
@@ -39,7 +39,7 @@ pub(crate) fn sign_p256_signature(
     Ok(TempoSignature::Primitive(PrimitiveSignature::P256(
         tempo_primitives::transaction::tt_signature::P256SignatureWithPreHash {
             r: B256::from_slice(&sig_bytes[0..32]),
-            s: normalize_p256_s(&sig_bytes[32..64]),
+            s: normalize_p256_s(&sig_bytes[32..64]).map_err(|err| eyre::eyre!(err))?,
             pub_key_x,
             pub_key_y,
             pre_hash: true,
@@ -73,7 +73,7 @@ pub(crate) fn sign_webauthn_signature(
         WebAuthnSignature {
             webauthn_data: Bytes::from(webauthn_data),
             r: B256::from_slice(&sig_bytes[0..32]),
-            s: normalize_p256_s(&sig_bytes[32..64]),
+            s: normalize_p256_s(&sig_bytes[32..64]).map_err(|err| eyre::eyre!(err))?,
             pub_key_x,
             pub_key_y,
         },

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -488,6 +488,14 @@ impl BatchSubmitter {
         Ok(head)
     }
 
+    /// Read the current `lastProcessedDepositNumber` from the ZonePortal on L1.
+    ///
+    /// Used as the source of truth when the monitor needs to reconstruct its
+    /// local deposit-transition anchor after a restart or resync.
+    pub async fn read_portal_last_processed_deposit_number(&self) -> Result<u64> {
+        Ok(self.portal.lastProcessedDepositNumber().call().await?)
+    }
+
     /// Check if the withdrawal queue has capacity for another batch.
     ///
     /// The portal uses a ring buffer with 100 slots. Returns an error if the

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -488,14 +488,6 @@ impl BatchSubmitter {
         Ok(head)
     }
 
-    /// Read the current `lastProcessedDepositNumber` from the ZonePortal on L1.
-    ///
-    /// Used as the source of truth when the monitor needs to reconstruct its
-    /// local deposit-transition anchor after a restart or resync.
-    pub async fn read_portal_last_processed_deposit_number(&self) -> Result<u64> {
-        Ok(self.portal.lastProcessedDepositNumber().call().await?)
-    }
-
     /// Check if the withdrawal queue has capacity for another batch.
     ///
     /// The portal uses a ring buffer with 100 slots. Returns an error if the

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -49,7 +49,7 @@ use tracing::{error, info, warn};
 
 use super::node::ZoneNode;
 
-use alloy_evm::block::BlockExecutor;
+use alloy_evm::block::{BlockExecutor, TxResult};
 
 #[derive(Clone)]
 struct RequestedWithdrawalContext {
@@ -111,6 +111,7 @@ where
             config,
             cancel,
             best_payload: _,
+            ..
         } = args;
         let PayloadConfig {
             parent_header,
@@ -215,12 +216,14 @@ where
                         parent_beacon_block_root: attributes.parent_beacon_block_root(),
                         withdrawals: attributes.withdrawals().cloned().map(Withdrawals::new),
                         extra_data: attributes.extra_data(),
+                        slot_number: attributes.slot_number(),
                     },
                     // Zones don't use L1 gas sections. These fields are required
                     // by TempoNextBlockEnvAttributes but ignored by the zone executor.
                     general_gas_limit: 0,
                     shared_gas_limit: block_gas_limit,
                     timestamp_millis_part: attributes.timestamp_millis_part(),
+                    consensus_context: None,
                     subblock_fee_recipients: Default::default(),
                 },
             )
@@ -236,13 +239,14 @@ where
             let advance_tx = build_advance_tempo_tx(prepared);
             let mut reverted = false;
             match builder.execute_transaction_with_result_closure(advance_tx, |result| {
-                if !result.is_success() {
-                    let revert_data = result.output().cloned().unwrap_or_default();
+                let evm_result = result.result();
+                if !evm_result.result.is_success() {
+                    let revert_data = evm_result.result.output().cloned().unwrap_or_default();
                     error!(
                         target: "zone::payload",
                         l1_block = prepared.header.inner.number,
                         deposits = total_deposits,
-                        is_halt = result.is_halt(),
+                        is_halt = evm_result.result.is_halt(),
                         revert_data = %revert_data,
                         "advanceTempo system tx reverted on-chain"
                     );
@@ -377,12 +381,13 @@ where
         );
         let mut finalize_reverted = false;
         match builder.execute_transaction_with_result_closure(finalize_tx, |result| {
-            if !result.is_success() {
-                let revert_data = result.output().cloned().unwrap_or_default();
+            let evm_result = result.result();
+            if !evm_result.result.is_success() {
+                let revert_data = evm_result.result.output().cloned().unwrap_or_default();
                 error!(
                     target: "zone::payload",
                     block_number,
-                    is_halt = result.is_halt(),
+                    is_halt = evm_result.result.is_halt(),
                     revert_data = %revert_data,
                     "finalizeWithdrawalBatch system tx reverted on-chain"
                 );
@@ -406,7 +411,7 @@ where
             hashed_state,
             trie_updates,
             block,
-        } = builder.finish(&state_provider)?;
+        } = builder.finish(&*state_provider, None)?;
 
         let requests = chain_spec
             .is_prague_active_at_timestamp(attributes.timestamp())
@@ -427,7 +432,7 @@ where
             "Built zone payload"
         );
 
-        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests);
+        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None);
 
         let execution_output = BlockExecutionOutput {
             result: execution_result,
@@ -463,6 +468,8 @@ where
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         self.try_build(BuildArguments::new(
             Default::default(),
+            None,
+            None,
             config,
             Default::default(),
             Default::default(),

--- a/crates/tempo-zone/src/engine.rs
+++ b/crates/tempo-zone/src/engine.rs
@@ -230,6 +230,7 @@ impl ZoneEngine {
                     .chain_spec
                     .is_cancun_active_at_timestamp(timestamp_secs)
                     .then_some(B256::ZERO),
+                slot_number: None,
             },
             timestamp_millis_part,
             l1_block,

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -339,6 +339,7 @@ impl ConfigureEvm for ZoneEvmConfig {
             general_gas_limit: 0,
             shared_gas_limit: 0,
             validator_set: None,
+            consensus_context: block.header().consensus_context,
             subblock_fee_recipients: Default::default(),
         })
     }

--- a/crates/tempo-zone/src/executor.rs
+++ b/crates/tempo-zone/src/executor.rs
@@ -7,7 +7,10 @@
 use alloy_consensus::transaction::TxHashRef;
 use alloy_evm::{
     Database, Evm, RecoveredTx,
-    block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, OnStateHook},
+    block::{
+        BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, GasOutput,
+        OnStateHook,
+    },
     eth::{EthBlockExecutor, EthTxResult},
 };
 use reth_evm::block::StateDB;
@@ -100,21 +103,11 @@ where
             .execute_transaction_without_commit((tx_env, recovered))
     }
 
-    fn commit_transaction(&mut self, output: Self::Result) -> Result<u64, BlockExecutionError> {
-        let gas_used = self.inner.commit_transaction(output)?;
-
-        // Collect revert logs (same as Tempo L1 executor).
-        let logs = self.inner.evm.take_revert_logs();
-        if !logs.is_empty() {
-            self.inner
-                .receipts
-                .last_mut()
-                .expect("receipt was just pushed")
-                .logs
-                .extend(logs);
-        }
-
-        Ok(gas_used)
+    fn commit_transaction(
+        &mut self,
+        output: Self::Result,
+    ) -> Result<GasOutput, BlockExecutionError> {
+        self.inner.commit_transaction(output)
     }
 
     fn finish(
@@ -227,7 +220,7 @@ mod tests {
                 // Zone executor override: validatorTokens[sequencer] = fee_token.
                 fee_manager.validator_tokens[sequencer].write(*token)?;
 
-                fee_manager.collect_fee_pre_tx(user, *token, *max, sequencer)?;
+                fee_manager.collect_fee_pre_tx(user, *token, *max, sequencer, false)?;
                 fee_manager.collect_fee_post_tx(user, *used, *max - *used, *token, sequencer)?;
             }
 

--- a/crates/tempo-zone/src/l1_state/precompile.rs
+++ b/crates/tempo-zone/src/l1_state/precompile.rs
@@ -27,7 +27,7 @@
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolError};
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, error, warn};
 
 use super::provider::L1StateProvider;
@@ -80,29 +80,30 @@ impl TempoStateReader {
             move |input| {
                 if !input.is_direct_call() {
                     warn!(target: "zone::precompile", "TempoStateReader called via DELEGATECALL — rejecting");
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         DelegateCallNotAllowed {}.abi_encode().into(),
+                        input.reservoir,
                     ));
                 }
 
                 let data = input.data;
                 if data.len() < 4 {
                     warn!(target: "zone::precompile", data_len = data.len(), "TempoStateReader called with insufficient data");
-                    return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                    return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
                 }
 
                 let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
 
                 let result = if selector == readStorageAtCall::SELECTOR {
                     debug!(target: "zone::precompile", "TempoStateReader: readStorageAt");
-                    Self::handle_single_slot(&provider, data)
+                    Self::handle_single_slot(&provider, data, input.reservoir)
                 } else if selector == readStorageBatchAtCall::SELECTOR {
                     debug!(target: "zone::precompile", "TempoStateReader: readStorageBatchAt");
-                    Self::handle_multi_slot(&provider, data)
+                    Self::handle_multi_slot(&provider, data, input.reservoir)
                 } else {
                     warn!(target: "zone::precompile", selector = ?selector, "TempoStateReader: unknown selector");
-                    Ok(PrecompileOutput::new_reverted(0, Bytes::new()))
+                    Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir))
                 };
 
                 match &result {
@@ -125,9 +126,15 @@ impl TempoStateReader {
     /// Decodes the ABI calldata, performs a synchronous lookup via the provider at the specified
     /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32`
     /// value. Returns a hard [`PrecompileError`] if both the cache and RPC fallback fail.
-    fn handle_single_slot(provider: &L1StateProvider, data: &[u8]) -> PrecompileResult {
-        let call = readStorageAtCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_single_slot(
+        provider: &L1StateProvider,
+        data: &[u8],
+        reservoir: u64,
+    ) -> PrecompileResult {
+        let call = match readStorageAtCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let gas = BASE_GAS + PER_SLOT_GAS;
 
@@ -141,7 +148,7 @@ impl TempoStateReader {
             })?;
 
         let encoded = readStorageAtCall::abi_encode_returns(&value);
-        Ok(PrecompileOutput::new(gas, encoded.into()))
+        Ok(PrecompileOutput::new(gas, encoded.into(), reservoir))
     }
 
     /// Handle a `readStorageBatchAt(address, bytes32[], uint64)` call.
@@ -150,9 +157,15 @@ impl TempoStateReader {
     /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32[]`
     /// result. If **any** slot fails both cache and RPC lookup, the entire call fails with a
     /// hard [`PrecompileError`].
-    fn handle_multi_slot(provider: &L1StateProvider, data: &[u8]) -> PrecompileResult {
-        let call = readStorageBatchAtCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_multi_slot(
+        provider: &L1StateProvider,
+        data: &[u8],
+        reservoir: u64,
+    ) -> PrecompileResult {
+        let call = match readStorageBatchAtCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let num_slots = call.slots.len() as u64;
         let gas = BASE_GAS + PER_SLOT_GAS * num_slots;
@@ -171,6 +184,6 @@ impl TempoStateReader {
         }
 
         let encoded = readStorageBatchAtCall::abi_encode_returns(&results);
-        Ok(PrecompileOutput::new(gas, encoded.into()))
+        Ok(PrecompileOutput::new(gas, encoded.into(), reservoir))
     }
 }

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -652,7 +652,9 @@ impl PolicyCheck for PolicyProvider {
 
     fn policy_exists(&self, policy_id: u64) -> Result<bool, PrecompileError> {
         self.policy_exists_sync(policy_id).map_err(|e| {
-            PrecompileError::other(format!("policyExists failed for policy {policy_id}: {e}"))
+            zone_precompiles::zone_rpc_error(format!(
+                "policyExists failed for policy {policy_id}: {e}"
+            ))
         })
     }
 

--- a/crates/tempo-zone/src/payload.rs
+++ b/crates/tempo-zone/src/payload.rs
@@ -55,6 +55,10 @@ impl reth_node_api::PayloadAttributes for ZonePayloadAttributes {
     fn parent_beacon_block_root(&self) -> Option<B256> {
         self.inner.parent_beacon_block_root
     }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number
+    }
 }
 
 impl ZonePayloadAttributes {

--- a/crates/tempo-zone/src/tx_context.rs
+++ b/crates/tempo-zone/src/tx_context.rs
@@ -72,9 +72,10 @@ impl ZoneTxContext {
                     target: "zone::precompile",
                     "ZoneTxContext called via DELEGATECALL — rejecting"
                 );
-                return Ok(PrecompileOutput::new_reverted(
+                return Ok(PrecompileOutput::revert(
                     0,
                     DelegateCallNotAllowed {}.abi_encode().into(),
+                    input.reservoir,
                 ));
             }
 
@@ -85,7 +86,7 @@ impl ZoneTxContext {
                     data_len = data.len(),
                     "ZoneTxContext called with insufficient data"
                 );
-                return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
             }
 
             let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
@@ -95,14 +96,14 @@ impl ZoneTxContext {
                     ?selector,
                     "ZoneTxContext: unknown selector"
                 );
-                return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
             }
 
             debug!(target: "zone::precompile", "ZoneTxContext: currentTxHash");
 
             let tx_hash = current_tx_hash().unwrap_or_else(|| synthetic_tx_hash(&input));
             let encoded = currentTxHashCall::abi_encode_returns(&tx_hash);
-            Ok(PrecompileOutput::new(20, encoded.into()))
+            Ok(PrecompileOutput::new(20, encoded.into(), input.reservoir))
         })
     }
 }

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -197,9 +197,14 @@ impl ZoneMonitor {
             genesis_tempo_block_number,
         );
 
-        let (prev_zone_block_hash, portal_withdrawal_queue_tail) = tokio::try_join!(
+        let (
+            prev_zone_block_hash,
+            portal_withdrawal_queue_tail,
+            portal_last_processed_deposit_number,
+        ) = tokio::try_join!(
             batch_submitter.read_portal_block_hash(),
             batch_submitter.read_portal_withdrawal_queue_tail(),
+            batch_submitter.read_portal_last_processed_deposit_number(),
         )
         .wrap_err("failed to read portal state during zone monitor startup")?;
 
@@ -211,8 +216,12 @@ impl ZoneMonitor {
             B256::ZERO,
         )
         .await;
-        let prev_processed_deposit_number =
-            Self::read_processed_deposit_number_at_block(&inbox, last_submitted_zone_block).await;
+        let prev_processed_deposit_number = Self::read_processed_deposit_number_at_block(
+            &inbox,
+            last_submitted_zone_block,
+            portal_last_processed_deposit_number,
+        )
+        .await;
 
         info!(
             last_submitted_zone_block,
@@ -780,8 +789,10 @@ impl ZoneMonitor {
         match tokio::try_join!(
             self.batch_submitter.read_portal_block_hash(),
             self.batch_submitter.read_portal_withdrawal_queue_tail(),
+            self.batch_submitter
+                .read_portal_last_processed_deposit_number(),
         ) {
-            Ok((portal_hash, portal_tail)) => {
+            Ok((portal_hash, portal_tail, portal_last_processed_deposit_number)) => {
                 let last_submitted_zone_block =
                     Self::resolve_zone_block_number(&self.provider, portal_hash).await;
                 let deposit_hash = Self::read_processed_deposit_hash_at_block(
@@ -793,6 +804,7 @@ impl ZoneMonitor {
                 let deposit_number = Self::read_processed_deposit_number_at_block(
                     &self.inbox,
                     last_submitted_zone_block,
+                    portal_last_processed_deposit_number,
                 )
                 .await;
 
@@ -903,6 +915,7 @@ impl ZoneMonitor {
     async fn read_processed_deposit_number_at_block(
         inbox: &ZoneInbox::ZoneInboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
         zone_block_number: u64,
+        fallback: u64,
     ) -> u64 {
         if zone_block_number == 0 {
             return 0;
@@ -918,10 +931,11 @@ impl ZoneMonitor {
             Err(e) => {
                 warn!(
                     zone_block_number,
+                    fallback,
                     error = %e,
                     "Failed to read processedDepositNumber at portal-confirmed zone block"
                 );
-                0
+                fallback
             }
         }
     }

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -197,14 +197,9 @@ impl ZoneMonitor {
             genesis_tempo_block_number,
         );
 
-        let (
-            prev_zone_block_hash,
-            portal_withdrawal_queue_tail,
-            portal_last_processed_deposit_number,
-        ) = tokio::try_join!(
+        let (prev_zone_block_hash, portal_withdrawal_queue_tail) = tokio::try_join!(
             batch_submitter.read_portal_block_hash(),
             batch_submitter.read_portal_withdrawal_queue_tail(),
-            batch_submitter.read_portal_last_processed_deposit_number(),
         )
         .wrap_err("failed to read portal state during zone monitor startup")?;
 
@@ -216,12 +211,8 @@ impl ZoneMonitor {
             B256::ZERO,
         )
         .await;
-        let prev_processed_deposit_number = Self::read_processed_deposit_number_at_block(
-            &inbox,
-            last_submitted_zone_block,
-            portal_last_processed_deposit_number,
-        )
-        .await;
+        let prev_processed_deposit_number =
+            Self::read_processed_deposit_number_at_block(&inbox, last_submitted_zone_block).await;
 
         info!(
             last_submitted_zone_block,
@@ -789,10 +780,8 @@ impl ZoneMonitor {
         match tokio::try_join!(
             self.batch_submitter.read_portal_block_hash(),
             self.batch_submitter.read_portal_withdrawal_queue_tail(),
-            self.batch_submitter
-                .read_portal_last_processed_deposit_number(),
         ) {
-            Ok((portal_hash, portal_tail, portal_last_processed_deposit_number)) => {
+            Ok((portal_hash, portal_tail)) => {
                 let last_submitted_zone_block =
                     Self::resolve_zone_block_number(&self.provider, portal_hash).await;
                 let deposit_hash = Self::read_processed_deposit_hash_at_block(
@@ -804,7 +793,6 @@ impl ZoneMonitor {
                 let deposit_number = Self::read_processed_deposit_number_at_block(
                     &self.inbox,
                     last_submitted_zone_block,
-                    portal_last_processed_deposit_number,
                 )
                 .await;
 
@@ -915,7 +903,6 @@ impl ZoneMonitor {
     async fn read_processed_deposit_number_at_block(
         inbox: &ZoneInbox::ZoneInboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
         zone_block_number: u64,
-        fallback: u64,
     ) -> u64 {
         if zone_block_number == 0 {
             return 0;
@@ -931,11 +918,10 @@ impl ZoneMonitor {
             Err(e) => {
                 warn!(
                     zone_block_number,
-                    fallback,
                     error = %e,
                     "Failed to read processedDepositNumber at portal-confirmed zone block"
                 );
-                fallback
+                0
             }
         }
     }

--- a/crates/tempo-zone/tests/advance_tempo.rs
+++ b/crates/tempo-zone/tests/advance_tempo.rs
@@ -263,7 +263,7 @@ fn advance_tempo_repro() {
     match &config_result {
         Ok(result) => {
             println!("config() result: {:?}", result.result);
-            let gas_used = result.result.gas_used();
+            let gas_used = result.result.tx_gas_used();
             match &result.result {
                 ExecutionResult::Success { output, .. } => {
                     if let Output::Call(data) = output {
@@ -291,7 +291,7 @@ fn advance_tempo_repro() {
         evm.transact_system_call(sequencer, TEMPO_STATE_ADDRESS, Bytes::from(hash_calldata));
     match &hash_result {
         Ok(result) => {
-            let gas_used = result.result.gas_used();
+            let gas_used = result.result.tx_gas_used();
             match &result.result {
                 ExecutionResult::Success { output, .. } => {
                     if let Output::Call(data) = output {
@@ -393,7 +393,7 @@ fn advance_tempo_repro() {
         evm.transact_system_call(sequencer, ZONE_INBOX_ADDRESS, Bytes::from(advance_calldata));
     match &advance_result {
         Ok(result) => {
-            let gas_used = result.result.gas_used();
+            let gas_used = result.result.tx_gas_used();
             match &result.result {
                 ExecutionResult::Success { output, .. } => {
                     if let Output::Call(data) = output {

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2661,7 +2661,7 @@ impl PrivateRpcTestCtx {
             .connect_http(self.zone.http_url().clone());
         let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &provider);
         let pending = keychain
-            .authorizeKey(key_id, signature_type, expiry, false, vec![])
+            .authorizeKey_0(key_id, signature_type, expiry, false, vec![])
             .send()
             .await?;
         self.fixture.inject_empty_block(self.zone.deposit_queue());

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -13,7 +13,7 @@ use alloy::{
 };
 use alloy_eips::Encodable2718;
 use eyre::{Context as _, eyre};
-use std::{collections::BTreeMap, time::Instant};
+use std::{collections::BTreeMap, num::NonZeroU64, time::Instant};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP20;
 use tempo_primitives::{
@@ -209,7 +209,9 @@ impl SpamDeposits {
                     }],
                     nonce_key,
                     nonce: 0,
-                    valid_after: Some(target_ts),
+                    valid_after: Some(
+                        NonZeroU64::new(target_ts).expect("target timestamp is always non-zero"),
+                    ),
                     ..Default::default()
                 };
 


### PR DESCRIPTION
## What changed
- bump the workspace to Tempo main at `bb08bb905b6ee13fafe046aa9531aea2cdf60651`
- align the related `reth`, `revm`, and Alloy dependency line with the new Tempo main dependency graph
- update zone precompile wrappers and tests for the newer precompile output / reservoir / halt APIs
- update zone RPC and zone EVM builder/executor code for the latest Alloy, Reth, and Tempo interfaces
- fix follow-on compatibility changes in xtask and integration helpers introduced by the dependency upgrade

## Why
The previous workspace was pinned to an older Tempo revision and no longer matched the current Tempo main APIs. Pulling forward to the latest Tempo main required coordinated dependency bumps plus source updates for the resulting breaking changes.

## Impact
- zones now build against the latest Tempo main dependency set
- zone precompiles and RPC compile and test successfully against the new interfaces
- zone block building / execution code is updated for the current Tempo and Reth abstractions

## Validation
- `cargo check --workspace --all-targets`
- `cargo test -p zone-precompiles --lib`
- `cargo test -p zone-rpc --lib`