### PR TITLE
feat(node): separate private RPC from sequencer addons

### DIFF
--- a/crates/tempo-zone/src/cli.rs
+++ b/crates/tempo-zone/src/cli.rs
@@ -94,7 +94,9 @@ impl ZoneCli {
                     zone_id: args.zone_id,
                     zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
                     batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
-                    withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
+                    withdrawal_poll_interval: Duration::from_secs(
+                        args.withdrawal_poll_interval_secs,
+                    ),
                 });
             }
 

--- a/crates/tempo-zone/src/cli.rs
+++ b/crates/tempo-zone/src/cli.rs
@@ -9,7 +9,7 @@ use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 
 use crate::{
-    ZoneNode, ZoneSequencerAddOnsConfig, evm::ZoneEvmConfig,
+    ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig, evm::ZoneEvmConfig,
     rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 
@@ -80,13 +80,16 @@ impl ZoneCli {
                 args.l1_fetch_concurrency,
                 retry_interval,
             )
-            .with_sequencer_addons(ZoneSequencerAddOnsConfig {
-                sequencer_signer,
+            .with_private_rpc(ZonePrivateRpcConfig {
                 private_rpc_port: args.private_rpc_port,
                 zone_id: args.zone_id,
                 max_auth_token_validity: Duration::from_secs(
                     args.private_rpc_max_auth_token_validity_secs,
                 ),
+            })
+            .with_sequencer_addons(ZoneSequencerAddOnsConfig {
+                sequencer_signer,
+                zone_id: args.zone_id,
                 zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
                 batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
                 withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),

--- a/crates/tempo-zone/src/cli.rs
+++ b/crates/tempo-zone/src/cli.rs
@@ -9,7 +9,7 @@ use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 
 use crate::{
-    ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig, evm::ZoneEvmConfig,
+    ZoneNode, ZoneSequencerAddOnsConfig, evm::ZoneEvmConfig,
     rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 
@@ -80,16 +80,14 @@ impl ZoneCli {
                 args.l1_fetch_concurrency,
                 retry_interval,
             )
-            .with_private_rpc(ZonePrivateRpcConfig {
-                private_rpc_port: args.private_rpc_port,
-                zone_id: args.zone_id,
-                max_auth_token_validity: Duration::from_secs(
-                    args.private_rpc_max_auth_token_validity_secs,
-                ),
-            })
             .with_sequencer_addons(ZoneSequencerAddOnsConfig {
                 sequencer_signer,
                 zone_id: args.zone_id,
+                private_rpc_port: args.private_rpc_port,
+                max_auth_token_validity: Duration::from_secs(
+                    args.private_rpc_max_auth_token_validity_secs,
+                ),
+                enable_sequencer: args.enable_sequencer,
                 zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
                 batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
                 withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
@@ -187,6 +185,11 @@ pub struct ZoneArgs {
         default_value_t = DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS
     )]
     pub private_rpc_max_auth_token_validity_secs: u64,
+
+    /// Enable the sequencer background tasks (batch submission, withdrawal processing).
+    /// When omitted, only the private RPC server is launched.
+    #[arg(long = "sequencer", env = "SEQUENCER")]
+    pub enable_sequencer: bool,
 }
 
 fn prepend_log_filter(filter: &mut String, directives: &str) {

--- a/crates/tempo-zone/src/cli.rs
+++ b/crates/tempo-zone/src/cli.rs
@@ -9,7 +9,7 @@ use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 
 use crate::{
-    ZoneNode, ZoneSequencerAddOnsConfig, evm::ZoneEvmConfig,
+    ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig, evm::ZoneEvmConfig,
     rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 
@@ -71,7 +71,7 @@ impl ZoneCli {
 
             let retry_interval = Duration::from_millis(args.l1_retry_connection_interval_ms);
 
-            let node = ZoneNode::new(
+            let mut node = ZoneNode::new(
                 args.l1_rpc_url,
                 args.portal_address,
                 args.l1_genesis_block_number,
@@ -80,18 +80,23 @@ impl ZoneCli {
                 args.l1_fetch_concurrency,
                 retry_interval,
             )
-            .with_sequencer_addons(ZoneSequencerAddOnsConfig {
-                sequencer_signer,
-                zone_id: args.zone_id,
+            .with_private_rpc(ZonePrivateRpcConfig {
                 private_rpc_port: args.private_rpc_port,
+                zone_id: args.zone_id,
                 max_auth_token_validity: Duration::from_secs(
                     args.private_rpc_max_auth_token_validity_secs,
                 ),
-                enable_sequencer: args.enable_sequencer,
-                zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
-                batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
-                withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
             });
+
+            if args.enable_sequencer {
+                node = node.with_sequencer(ZoneSequencerAddOnsConfig {
+                    sequencer_signer,
+                    zone_id: args.zone_id,
+                    zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
+                    batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
+                    withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
+                });
+            }
 
             let handle = builder.node(node).launch_with_debug_capabilities().await?;
             handle.wait_for_node_exit().await

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -34,7 +34,7 @@ pub use l1::{
     L1PortalEvents, L1SequencerEvent, L1Subscriber, L1SubscriberConfig,
 };
 pub use l1_state::{PolicyProvider, SharedL1StateCache, SharedPolicyCache};
-pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};
+pub use node::{ZoneExecutorBuilder, ZoneNode, ZoneSequencerAddOnsConfig};
 pub use payload::{ZonePayloadAttributes, ZonePayloadTypes};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};
 pub use zonemonitor::{ZoneMonitorConfig, spawn_zone_monitor};

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -34,7 +34,7 @@ pub use l1::{
     L1PortalEvents, L1SequencerEvent, L1Subscriber, L1SubscriberConfig,
 };
 pub use l1_state::{PolicyProvider, SharedL1StateCache, SharedPolicyCache};
-pub use node::{ZoneExecutorBuilder, ZoneNode, ZoneSequencerAddOnsConfig};
+pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};
 pub use payload::{ZonePayloadAttributes, ZonePayloadTypes};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};
 pub use zonemonitor::{ZoneMonitorConfig, spawn_zone_monitor};

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -371,13 +371,13 @@ where
         self.policy_cache.set_last_l1_block(tempo_block_number);
         info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber");
 
+        // Save values needed after ctx/self fields are consumed.
         let l1_url = self.l1_config.l1_rpc_url.clone();
         let portal_address = self.l1_config.portal_address;
         let retry_connection_interval = self.l1_config.retry_connection_interval;
         let sequencer_addons_config = self.sequencer_addons_config.take();
         let sequencer_addr = self.fee_recipient;
 
-        // Connect L1 provider upfront so startup failures are immediately visible.
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
                 &l1_url,
@@ -386,38 +386,92 @@ where
             .await?
             .erased();
 
-        // Resolve enabled tokens — use pre-configured list if available, otherwise
-        // query L1 via RPC as a fallback.
+        self.resolve_and_seed_tokens(portal_address, &l1_provider)
+            .await?;
+        self.spawn_l1_subscriber(&ctx);
+        self.spawn_policy_tasks(&l1_provider, &ctx);
+        self.spawn_zone_engine(l1_provider, &ctx)?;
+
+        let task_executor = ctx.node.task_executor().clone();
+        let chain_id = ctx
+            .node
+            .provider()
+            .chain_spec()
+            .inner
+            .genesis()
+            .config
+            .chain_id;
+        let handle = self.inner.launch_add_ons(ctx).await?;
+
+        if let Some(config) = sequencer_addons_config {
+            Self::launch_sequencer(
+                config,
+                &handle,
+                &task_executor,
+                l1_url,
+                portal_address,
+                retry_connection_interval,
+                sequencer_addr,
+                chain_id,
+            )
+            .await?;
+        }
+
+        Ok(handle)
+    }
+}
+
+/// Helper methods for [`ZoneAddOns::launch_add_ons`].
+impl<N> ZoneAddOns<N>
+where
+    N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>,
+    N::Pool: reth_transaction_pool::TransactionPool<
+            Transaction = tempo_transaction_pool::transaction::TempoPooledTransaction,
+        >,
+    ZoneEthApiBuilder:
+        EthApiBuilder<N, EthApi: reth_rpc_eth_api::EthApiTypes<NetworkTypes = TempoNetwork>>,
+{
+    /// Resolve enabled tokens and seed the policy cache.
+    async fn resolve_and_seed_tokens(
+        &mut self,
+        portal_address: alloy_primitives::Address,
+        l1_provider: &alloy_provider::DynProvider<TempoNetwork>,
+    ) -> eyre::Result<()> {
         let tracked_tokens = if let Some(tokens) = self.initial_tokens.take() {
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Using pre-configured initial tokens");
             tokens
         } else {
-            let tokens = crate::abi::ZonePortal::new(portal_address, &l1_provider)
+            let tokens = crate::abi::ZonePortal::new(portal_address, l1_provider)
                 .enabled_tokens()
                 .await?;
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Discovered enabled tokens from L1");
             tokens
         };
 
-        // Seed the policy cache with current transferPolicyId for each tracked token
-        // before spawning the subscriber, so errors propagate to the caller.
         self.policy_cache
-            .seed_token_policies(portal_address, &tracked_tokens, &l1_provider)
+            .seed_token_policies(portal_address, &tracked_tokens, l1_provider)
             .await?;
         info!(target: "reth::cli", "Seeded token policies from L1");
+        Ok(())
+    }
 
-        // Spawn unified L1 subscriber (deposits + policy events + L1 state anchor).
+    /// Spawn the unified L1 subscriber (deposits + policy events + L1 state anchor).
+    fn spawn_l1_subscriber(&mut self, ctx: &AddOnsContext<'_, N>) {
         L1Subscriber::spawn(
-            self.l1_config,
+            self.l1_config.clone(),
             ctx.node.provider().clone(),
             self.deposit_queue.clone(),
             ctx.node.task_executor().clone(),
         );
-        info!(target: "reth::cli", "Unified L1 subscriber started (deposits + policy events + L1 state anchor)");
+        info!(target: "reth::cli", "Unified L1 subscriber started");
+    }
 
-        // Spawn policy resolution task for pre-fetching authorization data from L1.
-        // The pool prefetch task feeds it with sender/recipient addresses from
-        // incoming transactions so the cache is warm by the time we build blocks.
+    /// Spawn TIP-403 policy resolution and pool prefetch tasks.
+    fn spawn_policy_tasks(
+        &self,
+        l1_provider: &alloy_provider::DynProvider<TempoNetwork>,
+        ctx: &AddOnsContext<'_, N>,
+    ) {
         let policy_task_handle = crate::l1_state::spawn_policy_resolution_task(
             self.policy_cache.clone(),
             l1_provider.clone(),
@@ -431,10 +485,16 @@ where
             ctx.node.task_executor().clone(),
         );
         info!(target: "reth::cli", "TIP-403 policy prefetch tasks started");
+    }
 
-        // Build and spawn the ZoneEngine — L1-event-driven block production
+    /// Build and spawn the [`ZoneEngine`] for L1-event-driven block production.
+    fn spawn_zone_engine(
+        &mut self,
+        l1_provider: alloy_provider::DynProvider<TempoNetwork>,
+        ctx: &AddOnsContext<'_, N>,
+    ) -> eyre::Result<()> {
         let policy_provider = crate::l1_state::PolicyProvider::new(
-            self.policy_cache,
+            self.policy_cache.clone(),
             l1_provider,
             tokio::runtime::Handle::current(),
         );
@@ -446,115 +506,112 @@ where
             provider.chain_spec(),
             ctx.beacon_engine_handle.clone(),
             ctx.node.payload_builder_handle().clone(),
-            self.deposit_queue,
+            self.deposit_queue.clone(),
             last_header,
             self.fee_recipient,
-            self.sequencer_key,
+            self.sequencer_key.clone(),
             self.portal_address,
             policy_provider,
         );
-        let task_executor = ctx.node.task_executor().clone();
-        let chain_id = provider.chain_spec().inner.genesis().config.chain_id;
-        task_executor.spawn_critical_task("zone-engine", engine.run());
-        info!(target: "reth::cli", "ZoneEngine spawned — L1-driven block production active");
+        ctx.node
+            .task_executor()
+            .spawn_critical_task("zone-engine", engine.run());
+        info!(target: "reth::cli", "ZoneEngine spawned");
+        Ok(())
+    }
 
-        let handle = self.inner.launch_add_ons(ctx).await?;
-
-        // Launch sequencer add-ons (private RPC + background tasks) if configured.
-        if let Some(config) = sequencer_addons_config {
-            // Verify the chain ID matches the deterministic derivation from the zone ID.
-            // Skip when zone_id is 0 (local testing default).
-            if config.zone_id != 0 {
-                let expected_chain_id = zone_primitives::constants::zone_chain_id(config.zone_id);
-                if chain_id != expected_chain_id {
-                    eyre::bail!(
-                        "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-                        config.zone_id,
-                        expected_chain_id,
-                        chain_id,
-                    );
-                }
+    /// Launch sequencer add-ons: chain ID validation, private RPC, background tasks,
+    /// and engine shutdown hook.
+    async fn launch_sequencer(
+        config: ZoneSequencerAddOnsConfig,
+        handle: &<Self as NodeAddOns<N>>::Handle,
+        task_executor: &reth_tasks::TaskExecutor,
+        l1_rpc_url: String,
+        portal_address: alloy_primitives::Address,
+        retry_connection_interval: std::time::Duration,
+        sequencer_addr: alloy_primitives::Address,
+        chain_id: u64,
+    ) -> eyre::Result<()> {
+        if config.zone_id != 0 {
+            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
+            if chain_id != expected {
+                eyre::bail!(
+                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
+                    config.zone_id,
+                    expected,
+                    chain_id,
+                );
             }
-
-            // Launch the private zone RPC server.
-            let eth_handlers = handle.eth_handlers().clone();
-            let zone_rpc_url = handle
-                .rpc_server_handles
-                .rpc
-                .http_url()
-                .expect("HTTP RPC server must be enabled for sequencer mode");
-            let private_rpc_config = zone_rpc::PrivateRpcConfig {
-                listen_addr: ([0, 0, 0, 0], config.private_rpc_port).into(),
-                l1_rpc_url: l1_url.clone(),
-                zone_rpc_url: zone_rpc_url.clone(),
-                retry_connection_interval,
-                zone_id: config.zone_id,
-                chain_id,
-                max_auth_token_validity: config.max_auth_token_validity,
-                zone_portal: portal_address,
-                sequencer: sequencer_addr,
-            };
-            let api: Arc<dyn crate::rpc::ZoneRpcApi> = Arc::new(
-                crate::rpc::TempoZoneRpc::new(eth_handlers, private_rpc_config.clone()).await?,
-            );
-            let local_addr = crate::rpc::start_private_rpc(private_rpc_config, api).await?;
-            info!(target: "reth::cli", %local_addr, "Private zone RPC server started");
-
-            // Spawn sequencer background tasks.
-            info!(
-                target: "reth::cli",
-                %sequencer_addr,
-                "Starting sequencer background tasks"
-            );
-
-            let sequencer_config = crate::ZoneSequencerConfig {
-                portal_address,
-                l1_rpc_url: l1_url,
-                retry_connection_interval,
-                withdrawal_poll_interval: config.withdrawal_poll_interval,
-                outbox_address: crate::abi::ZONE_OUTBOX_ADDRESS,
-                inbox_address: crate::abi::ZONE_INBOX_ADDRESS,
-                tempo_state_address: crate::abi::TEMPO_STATE_ADDRESS,
-                zone_rpc_url,
-                zone_poll_interval: config.zone_poll_interval,
-                batch_interval: config.batch_interval,
-            };
-
-            let seq_handle =
-                crate::spawn_zone_sequencer(sequencer_config, config.sequencer_signer).await;
-
-            info!(
-                target: "reth::cli",
-                "Sequencer tasks spawned: zone monitor (with batch submission), withdrawal processor"
-            );
-
-            // Spawn as critical tasks — node shuts down if either exits.
-            task_executor.spawn_critical_task("zone-monitor", async move {
-                tokio::select! {
-                    res = seq_handle.withdrawal_handle => {
-                        tracing::error!(target: "reth::cli", ?res, "Withdrawal processor task exited");
-                    }
-                    res = seq_handle.monitor_handle => {
-                        tracing::error!(target: "reth::cli", ?res, "Zone monitor task exited");
-                    }
-                }
-            });
-
-            // Ensure all unpersisted blocks are flushed when the node exits.
-            let engine_shutdown = handle.engine_shutdown.clone();
-            task_executor.spawn_critical_with_graceful_shutdown_signal(
-                "zone-engine-shutdown",
-                |shutdown| async move {
-                    let _guard = shutdown.await;
-                    info!(target: "reth::cli", "Shutdown signal received — flushing engine state");
-                    if let Some(done) = engine_shutdown.shutdown() {
-                        let _ = done.await;
-                    }
-                },
-            );
         }
 
-        Ok(handle)
+        // Private RPC server.
+        let eth_handlers = handle.eth_handlers().clone();
+        let zone_rpc_url = handle
+            .rpc_server_handles
+            .rpc
+            .http_url()
+            .expect("HTTP RPC server must be enabled for sequencer mode");
+        let private_rpc_config = zone_rpc::PrivateRpcConfig {
+            listen_addr: ([0, 0, 0, 0], config.private_rpc_port).into(),
+            l1_rpc_url: l1_rpc_url.clone(),
+            zone_rpc_url: zone_rpc_url.clone(),
+            retry_connection_interval,
+            zone_id: config.zone_id,
+            chain_id,
+            max_auth_token_validity: config.max_auth_token_validity,
+            zone_portal: portal_address,
+            sequencer: sequencer_addr,
+        };
+        let api: Arc<dyn crate::rpc::ZoneRpcApi> = Arc::new(
+            crate::rpc::TempoZoneRpc::new(eth_handlers, private_rpc_config.clone()).await?,
+        );
+        let local_addr = crate::rpc::start_private_rpc(private_rpc_config, api).await?;
+        info!(target: "reth::cli", %local_addr, "Private zone RPC server started");
+
+        // Sequencer background tasks.
+        info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
+        let sequencer_config = crate::ZoneSequencerConfig {
+            portal_address,
+            l1_rpc_url,
+            retry_connection_interval,
+            withdrawal_poll_interval: config.withdrawal_poll_interval,
+            outbox_address: crate::abi::ZONE_OUTBOX_ADDRESS,
+            inbox_address: crate::abi::ZONE_INBOX_ADDRESS,
+            tempo_state_address: crate::abi::TEMPO_STATE_ADDRESS,
+            zone_rpc_url,
+            zone_poll_interval: config.zone_poll_interval,
+            batch_interval: config.batch_interval,
+        };
+        let seq_handle =
+            crate::spawn_zone_sequencer(sequencer_config, config.sequencer_signer).await;
+        info!(target: "reth::cli", "Sequencer tasks spawned");
+
+        // Critical task — node shuts down if either exits.
+        task_executor.spawn_critical_task("zone-monitor", async move {
+            tokio::select! {
+                res = seq_handle.withdrawal_handle => {
+                    tracing::error!(target: "reth::cli", ?res, "Withdrawal processor task exited");
+                }
+                res = seq_handle.monitor_handle => {
+                    tracing::error!(target: "reth::cli", ?res, "Zone monitor task exited");
+                }
+            }
+        });
+
+        // Flush unpersisted blocks on shutdown.
+        let engine_shutdown = handle.engine_shutdown.clone();
+        task_executor.spawn_critical_with_graceful_shutdown_signal(
+            "zone-engine-shutdown",
+            |shutdown| async move {
+                let _guard = shutdown.await;
+                info!(target: "reth::cli", "Shutdown signal received — flushing engine state");
+                if let Some(done) = engine_shutdown.shutdown() {
+                    let _ = done.await;
+                }
+            },
+        );
+
+        Ok(())
     }
 }
 

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -80,7 +80,7 @@ pub struct ZoneSequencerAddOnsConfig {
 /// Configuration for the private RPC server.
 ///
 /// Always launched when provided via [`ZoneNode::with_private_rpc`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ZonePrivateRpcConfig {
     /// Port for the private zone RPC server (0 for OS-assigned).
     pub private_rpc_port: u16,
@@ -116,8 +116,8 @@ pub struct ZoneNode {
     /// Optional pre-configured list of enabled token addresses. When set, the
     /// startup L1 RPC query for `enabledTokenCount`/`enabledTokens` is skipped.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional private RPC config. Always launched when set.
-    private_rpc_config: Option<ZonePrivateRpcConfig>,
+    /// Private RPC config.
+    private_rpc_config: ZonePrivateRpcConfig,
     /// Optional sequencer config. When set, sequencer tasks are spawned.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
 }
@@ -173,14 +173,14 @@ impl ZoneNode {
             sequencer_key,
             portal_address,
             initial_tokens: None,
-            private_rpc_config: None,
+            private_rpc_config: ZonePrivateRpcConfig::default(),
             sequencer_config: None,
         }
     }
 
-    /// Set the private RPC configuration. Always launched when set.
+    /// Set the private RPC configuration.
     pub fn with_private_rpc(mut self, config: ZonePrivateRpcConfig) -> Self {
-        self.private_rpc_config = Some(config);
+        self.private_rpc_config = config;
         self
     }
 
@@ -306,8 +306,8 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     portal_address: alloy_primitives::Address,
     /// Optional pre-configured list of enabled token addresses.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional private RPC config.
-    private_rpc_config: Option<ZonePrivateRpcConfig>,
+    /// Private RPC config.
+    private_rpc_config: ZonePrivateRpcConfig,
     /// Optional sequencer config.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
 }
@@ -333,7 +333,7 @@ where
         sequencer_key: k256::SecretKey,
         portal_address: alloy_primitives::Address,
         initial_tokens: Option<Vec<alloy_primitives::Address>>,
-        private_rpc_config: Option<ZonePrivateRpcConfig>,
+        private_rpc_config: ZonePrivateRpcConfig,
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
     ) -> Self {
         Self {
@@ -406,18 +406,16 @@ where
             .chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
-        if let Some(config) = self.private_rpc_config.take() {
-            Self::launch_private_rpc(
-                config,
-                &handle,
-                self.l1_config.l1_rpc_url.clone(),
-                self.l1_config.retry_connection_interval,
-                self.l1_config.portal_address,
-                self.fee_recipient,
-                chain_id,
-            )
-            .await?;
-        }
+        Self::launch_private_rpc(
+            self.private_rpc_config,
+            &handle,
+            self.l1_config.l1_rpc_url.clone(),
+            self.l1_config.retry_connection_interval,
+            self.l1_config.portal_address,
+            self.fee_recipient,
+            chain_id,
+        )
+        .await?;
 
         if let Some(config) = self.sequencer_config.take() {
             Self::launch_sequencer_tasks(

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -64,21 +64,31 @@ use crate::builder::ZonePayloadFactory;
 /// Network primitives for Zone.
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
-/// Configuration for the zone sequencer add-ons launched after the node starts.
+/// Configuration for the private RPC server launched after the node starts.
 ///
-/// When provided via [`ZoneNode::with_sequencer_addons`], the private RPC server
-/// and sequencer background tasks (batch submission, withdrawal processing) are
+/// When provided via [`ZoneNode::with_private_rpc`], the private RPC server is
 /// automatically spawned during [`ZoneAddOns::launch_add_ons`].
 #[derive(Debug, Clone)]
-pub struct ZoneSequencerAddOnsConfig {
-    /// Sequencer private key signer for signing L1 transactions.
-    pub sequencer_signer: alloy_signer_local::PrivateKeySigner,
+pub struct ZonePrivateRpcConfig {
     /// Port for the private zone RPC server (0 for OS-assigned).
     pub private_rpc_port: u16,
     /// Zone ID for chain ID validation and private RPC auth.
     pub zone_id: u32,
     /// Maximum auth token validity for the private RPC.
     pub max_auth_token_validity: std::time::Duration,
+}
+
+/// Configuration for the zone sequencer background tasks launched after the node starts.
+///
+/// When provided via [`ZoneNode::with_sequencer_addons`], the sequencer background
+/// tasks (batch submission, withdrawal processing) are automatically spawned
+/// during [`ZoneAddOns::launch_add_ons`].
+#[derive(Debug, Clone)]
+pub struct ZoneSequencerAddOnsConfig {
+    /// Sequencer private key signer for signing L1 transactions.
+    pub sequencer_signer: alloy_signer_local::PrivateKeySigner,
+    /// Zone ID for chain ID validation.
+    pub zone_id: u32,
     /// How often the zone monitor polls for new L2 blocks.
     pub zone_poll_interval: std::time::Duration,
     /// Maximum time to accumulate zone blocks before batch submission.
@@ -113,7 +123,10 @@ pub struct ZoneNode {
     /// Optional pre-configured list of enabled token addresses. When set, the
     /// startup L1 RPC query for `enabledTokenCount`/`enabledTokens` is skipped.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional sequencer add-ons config. When set, the private RPC and sequencer
+    /// Optional private RPC config. When set, the private RPC server is
+    /// automatically spawned during node launch.
+    private_rpc_config: Option<ZonePrivateRpcConfig>,
+    /// Optional sequencer add-ons config. When set, the sequencer
     /// background tasks are automatically spawned during node launch.
     sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
 }
@@ -169,15 +182,25 @@ impl ZoneNode {
             sequencer_key,
             portal_address,
             initial_tokens: None,
+            private_rpc_config: None,
             sequencer_addons_config: None,
         }
     }
 
+    /// Set the private RPC configuration.
+    ///
+    /// When set, the private RPC server is automatically spawned during node
+    /// launch via [`ZoneAddOns::launch_add_ons`].
+    pub fn with_private_rpc(mut self, config: ZonePrivateRpcConfig) -> Self {
+        self.private_rpc_config = Some(config);
+        self
+    }
+
     /// Set the sequencer add-ons configuration.
     ///
-    /// When set, the private RPC server and sequencer background tasks
-    /// (batch submission, withdrawal processing) are automatically spawned
-    /// during node launch via [`ZoneAddOns::launch_add_ons`].
+    /// When set, the sequencer background tasks (batch submission, withdrawal
+    /// processing) are automatically spawned during node launch via
+    /// [`ZoneAddOns::launch_add_ons`].
     pub fn with_sequencer_addons(mut self, config: ZoneSequencerAddOnsConfig) -> Self {
         self.sequencer_addons_config = Some(config);
         self
@@ -298,7 +321,9 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     portal_address: alloy_primitives::Address,
     /// Optional pre-configured list of enabled token addresses.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional sequencer add-ons config for private RPC + sequencer tasks.
+    /// Optional private RPC config.
+    private_rpc_config: Option<ZonePrivateRpcConfig>,
+    /// Optional sequencer add-ons config for sequencer background tasks.
     sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
 }
 
@@ -323,6 +348,7 @@ where
         sequencer_key: k256::SecretKey,
         portal_address: alloy_primitives::Address,
         initial_tokens: Option<Vec<alloy_primitives::Address>>,
+        private_rpc_config: Option<ZonePrivateRpcConfig>,
         sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
     ) -> Self {
         Self {
@@ -340,6 +366,7 @@ where
             sequencer_key,
             portal_address,
             initial_tokens,
+            private_rpc_config,
             sequencer_addons_config,
         }
     }
@@ -383,6 +410,7 @@ where
         self.spawn_zone_engine(l1_provider, &ctx)?;
 
         let task_executor = ctx.node.task_executor().clone();
+
         let chain_id = ctx
             .node
             .provider()
@@ -393,8 +421,21 @@ where
             .chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
+        if let Some(config) = self.private_rpc_config.take() {
+            Self::launch_private_rpc(
+                config,
+                &handle,
+                self.l1_config.l1_rpc_url.clone(),
+                self.l1_config.retry_connection_interval,
+                self.l1_config.portal_address,
+                self.fee_recipient,
+                chain_id,
+            )
+            .await?;
+        }
+
         if let Some(config) = self.sequencer_addons_config.take() {
-            Self::launch_sequencer(
+            Self::launch_sequencer_tasks(
                 config,
                 &handle,
                 &task_executor,
@@ -510,9 +551,57 @@ where
         Ok(())
     }
 
-    /// Launch sequencer add-ons: chain ID validation, private RPC, background tasks,
+    /// Launch the private RPC server independently of sequencer tasks.
+    async fn launch_private_rpc(
+        config: ZonePrivateRpcConfig,
+        handle: &<Self as NodeAddOns<N>>::Handle,
+        l1_rpc_url: String,
+        retry_connection_interval: std::time::Duration,
+        portal_address: alloy_primitives::Address,
+        sequencer_addr: alloy_primitives::Address,
+        chain_id: u64,
+    ) -> eyre::Result<()> {
+        if config.zone_id != 0 {
+            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
+            if chain_id != expected {
+                eyre::bail!(
+                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
+                    config.zone_id,
+                    expected,
+                    chain_id,
+                );
+            }
+        }
+
+        let eth_handlers = handle.eth_handlers().clone();
+        let zone_rpc_url = handle
+            .rpc_server_handles
+            .rpc
+            .http_url()
+            .expect("HTTP RPC server must be enabled for private RPC");
+        let private_rpc_config = zone_rpc::PrivateRpcConfig {
+            listen_addr: ([0, 0, 0, 0], config.private_rpc_port).into(),
+            l1_rpc_url,
+            zone_rpc_url,
+            retry_connection_interval,
+            zone_id: config.zone_id,
+            chain_id,
+            max_auth_token_validity: config.max_auth_token_validity,
+            zone_portal: portal_address,
+            sequencer: sequencer_addr,
+        };
+        let api: Arc<dyn crate::rpc::ZoneRpcApi> = Arc::new(
+            crate::rpc::TempoZoneRpc::new(eth_handlers, private_rpc_config.clone()).await?,
+        );
+        let local_addr = crate::rpc::start_private_rpc(private_rpc_config, api).await?;
+        info!(target: "reth::cli", %local_addr, "Private zone RPC server started");
+
+        Ok(())
+    }
+
+    /// Launch sequencer background tasks: batch submission, withdrawal processing,
     /// and engine shutdown hook.
-    async fn launch_sequencer(
+    async fn launch_sequencer_tasks(
         config: ZoneSequencerAddOnsConfig,
         handle: &<Self as NodeAddOns<N>>::Handle,
         task_executor: &reth_tasks::TaskExecutor,
@@ -534,31 +623,12 @@ where
             }
         }
 
-        // Private RPC server.
-        let eth_handlers = handle.eth_handlers().clone();
         let zone_rpc_url = handle
             .rpc_server_handles
             .rpc
             .http_url()
             .expect("HTTP RPC server must be enabled for sequencer mode");
-        let private_rpc_config = zone_rpc::PrivateRpcConfig {
-            listen_addr: ([0, 0, 0, 0], config.private_rpc_port).into(),
-            l1_rpc_url: l1_rpc_url.clone(),
-            zone_rpc_url: zone_rpc_url.clone(),
-            retry_connection_interval,
-            zone_id: config.zone_id,
-            chain_id,
-            max_auth_token_validity: config.max_auth_token_validity,
-            zone_portal: portal_address,
-            sequencer: sequencer_addr,
-        };
-        let api: Arc<dyn crate::rpc::ZoneRpcApi> = Arc::new(
-            crate::rpc::TempoZoneRpc::new(eth_handlers, private_rpc_config.clone()).await?,
-        );
-        let local_addr = crate::rpc::start_private_rpc(private_rpc_config, api).await?;
-        info!(target: "reth::cli", %local_addr, "Private zone RPC server started");
 
-        // Sequencer background tasks.
         info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
         let sequencer_config = crate::ZoneSequencerConfig {
             portal_address,
@@ -668,6 +738,7 @@ where
             self.sequencer_key.clone(),
             self.portal_address,
             self.initial_tokens.clone(),
+            self.private_rpc_config.clone(),
             self.sequencer_addons_config.clone(),
         )
     }

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -364,30 +364,20 @@ where
     > as NodeAddOns<N>>::Handle;
 
     async fn launch_add_ons(mut self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
-        // Read the zone's current tempoBlockNumber from local state so policy
-        // cache fallback queries start from the correct L1 height.
         let sp = ctx.node.provider().latest()?;
         let tempo_block_number = sp.tempo_block_number()?;
         self.policy_cache.set_last_l1_block(tempo_block_number);
         info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber");
 
-        // Save values needed after ctx/self fields are consumed.
-        let l1_url = self.l1_config.l1_rpc_url.clone();
-        let portal_address = self.l1_config.portal_address;
-        let retry_connection_interval = self.l1_config.retry_connection_interval;
-        let sequencer_addons_config = self.sequencer_addons_config.take();
-        let sequencer_addr = self.fee_recipient;
-
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
-                &l1_url,
-                crate::rpc_connection_config(retry_connection_interval),
+                &self.l1_config.l1_rpc_url,
+                crate::rpc_connection_config(self.l1_config.retry_connection_interval),
             )
             .await?
             .erased();
 
-        self.resolve_and_seed_tokens(portal_address, &l1_provider)
-            .await?;
+        self.resolve_and_seed_tokens(&l1_provider).await?;
         self.spawn_l1_subscriber(&ctx);
         self.spawn_policy_tasks(&l1_provider, &ctx);
         self.spawn_zone_engine(l1_provider, &ctx)?;
@@ -403,15 +393,15 @@ where
             .chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
-        if let Some(config) = sequencer_addons_config {
+        if let Some(config) = self.sequencer_addons_config.take() {
             Self::launch_sequencer(
                 config,
                 &handle,
                 &task_executor,
-                l1_url,
-                portal_address,
-                retry_connection_interval,
-                sequencer_addr,
+                self.l1_config.l1_rpc_url,
+                self.l1_config.portal_address,
+                self.l1_config.retry_connection_interval,
+                self.fee_recipient,
                 chain_id,
             )
             .await?;
@@ -434,14 +424,14 @@ where
     /// Resolve enabled tokens and seed the policy cache.
     async fn resolve_and_seed_tokens(
         &mut self,
-        portal_address: alloy_primitives::Address,
         l1_provider: &alloy_provider::DynProvider<TempoNetwork>,
     ) -> eyre::Result<()> {
+        let portal = self.portal_address;
         let tracked_tokens = if let Some(tokens) = self.initial_tokens.take() {
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Using pre-configured initial tokens");
             tokens
         } else {
-            let tokens = crate::abi::ZonePortal::new(portal_address, l1_provider)
+            let tokens = crate::abi::ZonePortal::new(portal, l1_provider)
                 .enabled_tokens()
                 .await?;
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Discovered enabled tokens from L1");
@@ -449,7 +439,7 @@ where
         };
 
         self.policy_cache
-            .seed_token_policies(portal_address, &tracked_tokens, l1_provider)
+            .seed_token_policies(portal, &tracked_tokens, l1_provider)
             .await?;
         info!(target: "reth::cli", "Seeded token policies from L1");
         Ok(())

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -64,25 +64,29 @@ use crate::builder::ZonePayloadFactory;
 /// Network primitives for Zone.
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
-/// Configuration for zone add-ons launched after the node starts.
+/// Configuration for the private RPC server.
 ///
-/// When provided via [`ZoneNode::with_sequencer_addons`], the private RPC
-/// server is always launched and the sequencer background tasks (batch
-/// submission, withdrawal processing) are optionally spawned based on
-/// [`enable_sequencer`](Self::enable_sequencer).
+/// Always launched when provided via [`ZoneNode::with_private_rpc`].
+#[derive(Debug, Clone)]
+pub struct ZonePrivateRpcConfig {
+    /// Port for the private zone RPC server (0 for OS-assigned).
+    pub private_rpc_port: u16,
+    /// Zone ID for chain ID validation and private RPC auth.
+    pub zone_id: u32,
+    /// Maximum auth token validity for the private RPC.
+    pub max_auth_token_validity: std::time::Duration,
+}
+
+/// Configuration for the sequencer background tasks.
+///
+/// When provided via [`ZoneNode::with_sequencer`], the batch submission
+/// and withdrawal processing tasks are spawned during node launch.
 #[derive(Debug, Clone)]
 pub struct ZoneSequencerAddOnsConfig {
     /// Sequencer private key signer for signing L1 transactions.
     pub sequencer_signer: alloy_signer_local::PrivateKeySigner,
-    /// Zone ID for chain ID validation and private RPC auth.
+    /// Zone ID for chain ID validation.
     pub zone_id: u32,
-    /// Port for the private zone RPC server (0 for OS-assigned).
-    pub private_rpc_port: u16,
-    /// Maximum auth token validity for the private RPC.
-    pub max_auth_token_validity: std::time::Duration,
-    /// Whether to launch the sequencer background tasks (batch submission,
-    /// withdrawal processing). When `false`, only the private RPC is started.
-    pub enable_sequencer: bool,
     /// How often the zone monitor polls for new L2 blocks.
     pub zone_poll_interval: std::time::Duration,
     /// Maximum time to accumulate zone blocks before batch submission.
@@ -117,9 +121,10 @@ pub struct ZoneNode {
     /// Optional pre-configured list of enabled token addresses. When set, the
     /// startup L1 RPC query for `enabledTokenCount`/`enabledTokens` is skipped.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional sequencer add-ons config. When set, the private RPC server
-    /// is always launched and sequencer tasks are optionally spawned.
-    sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Optional private RPC config. Always launched when set.
+    private_rpc_config: Option<ZonePrivateRpcConfig>,
+    /// Optional sequencer config. When set, sequencer tasks are spawned.
+    sequencer_config: Option<ZoneSequencerAddOnsConfig>,
 }
 
 impl ZoneNode {
@@ -173,17 +178,21 @@ impl ZoneNode {
             sequencer_key,
             portal_address,
             initial_tokens: None,
-            sequencer_addons_config: None,
+            private_rpc_config: None,
+            sequencer_config: None,
         }
     }
 
-    /// Set the sequencer add-ons configuration.
-    ///
-    /// When set, the private RPC server is always launched and sequencer
-    /// background tasks are optionally spawned based on
-    /// [`enable_sequencer`](ZoneSequencerAddOnsConfig::enable_sequencer).
-    pub fn with_sequencer_addons(mut self, config: ZoneSequencerAddOnsConfig) -> Self {
-        self.sequencer_addons_config = Some(config);
+    /// Set the private RPC configuration. Always launched when set.
+    pub fn with_private_rpc(mut self, config: ZonePrivateRpcConfig) -> Self {
+        self.private_rpc_config = Some(config);
+        self
+    }
+
+    /// Set the sequencer configuration. When set, batch submission and
+    /// withdrawal processing tasks are spawned during node launch.
+    pub fn with_sequencer(mut self, config: ZoneSequencerAddOnsConfig) -> Self {
+        self.sequencer_config = Some(config);
         self
     }
 
@@ -302,8 +311,10 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     portal_address: alloy_primitives::Address,
     /// Optional pre-configured list of enabled token addresses.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional sequencer add-ons config (private RPC + sequencer tasks).
-    sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Optional private RPC config.
+    private_rpc_config: Option<ZonePrivateRpcConfig>,
+    /// Optional sequencer config.
+    sequencer_config: Option<ZoneSequencerAddOnsConfig>,
 }
 
 impl<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>> std::fmt::Debug
@@ -327,7 +338,8 @@ where
         sequencer_key: k256::SecretKey,
         portal_address: alloy_primitives::Address,
         initial_tokens: Option<Vec<alloy_primitives::Address>>,
-        sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
+        private_rpc_config: Option<ZonePrivateRpcConfig>,
+        sequencer_config: Option<ZoneSequencerAddOnsConfig>,
     ) -> Self {
         Self {
             inner: RpcAddOns::new(
@@ -344,7 +356,8 @@ where
             sequencer_key,
             portal_address,
             initial_tokens,
-            sequencer_addons_config,
+            private_rpc_config,
+            sequencer_config,
         }
     }
 }
@@ -398,10 +411,9 @@ where
             .chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
-        if let Some(config) = self.sequencer_addons_config.take() {
-            // Private RPC always launches with sequencer add-ons
+        if let Some(config) = self.private_rpc_config.take() {
             Self::launch_private_rpc(
-                &config,
+                config,
                 &handle,
                 self.l1_config.l1_rpc_url.clone(),
                 self.l1_config.retry_connection_interval,
@@ -410,20 +422,20 @@ where
                 chain_id,
             )
             .await?;
+        }
 
-            if config.enable_sequencer {
-                Self::launch_sequencer_tasks(
-                    config,
-                    &handle,
-                    &task_executor,
-                    self.l1_config.l1_rpc_url,
-                    self.l1_config.portal_address,
-                    self.l1_config.retry_connection_interval,
-                    self.fee_recipient,
-                    chain_id,
-                )
-                .await?;
-            }
+        if let Some(config) = self.sequencer_config.take() {
+            Self::launch_sequencer_tasks(
+                config,
+                &handle,
+                &task_executor,
+                self.l1_config.l1_rpc_url,
+                self.l1_config.portal_address,
+                self.l1_config.retry_connection_interval,
+                self.fee_recipient,
+                chain_id,
+            )
+            .await?;
         }
 
         Ok(handle)
@@ -531,7 +543,7 @@ where
 
     /// Launch the private RPC server.
     async fn launch_private_rpc(
-        config: &ZoneSequencerAddOnsConfig,
+        config: ZonePrivateRpcConfig,
         handle: &<Self as NodeAddOns<N>>::Handle,
         l1_rpc_url: String,
         retry_connection_interval: std::time::Duration,
@@ -716,7 +728,8 @@ where
             self.sequencer_key.clone(),
             self.portal_address,
             self.initial_tokens.clone(),
-            self.sequencer_addons_config.clone(),
+            self.private_rpc_config.clone(),
+            self.sequencer_config.clone(),
         )
     }
 }

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -61,6 +61,9 @@ use crate::{
 
 use crate::builder::ZonePayloadFactory;
 
+/// Network primitives for Zone.
+type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
+
 /// Configuration for the sequencer background tasks.
 ///
 /// When provided via [`ZoneNode::with_sequencer`], the batch submission
@@ -78,9 +81,6 @@ pub struct ZoneSequencerAddOnsConfig {
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: std::time::Duration,
 }
-
-/// Network primitives for Zone.
-type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
 /// Configuration for the private RPC server.
 ///

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -61,22 +61,6 @@ use crate::{
 
 use crate::builder::ZonePayloadFactory;
 
-/// Network primitives for Zone.
-type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
-
-/// Configuration for the private RPC server.
-///
-/// Always launched when provided via [`ZoneNode::with_private_rpc`].
-#[derive(Debug, Clone)]
-pub struct ZonePrivateRpcConfig {
-    /// Port for the private zone RPC server (0 for OS-assigned).
-    pub private_rpc_port: u16,
-    /// Zone ID for chain ID validation and private RPC auth.
-    pub zone_id: u32,
-    /// Maximum auth token validity for the private RPC.
-    pub max_auth_token_validity: std::time::Duration,
-}
-
 /// Configuration for the sequencer background tasks.
 ///
 /// When provided via [`ZoneNode::with_sequencer`], the batch submission
@@ -93,6 +77,22 @@ pub struct ZoneSequencerAddOnsConfig {
     pub batch_interval: std::time::Duration,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: std::time::Duration,
+}
+
+/// Network primitives for Zone.
+type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
+
+/// Configuration for the private RPC server.
+///
+/// Always launched when provided via [`ZoneNode::with_private_rpc`].
+#[derive(Debug, Clone)]
+pub struct ZonePrivateRpcConfig {
+    /// Port for the private zone RPC server (0 for OS-assigned).
+    pub private_rpc_port: u16,
+    /// Zone ID for chain ID validation and private RPC auth.
+    pub zone_id: u32,
+    /// Maximum auth token validity for the private RPC.
+    pub max_auth_token_validity: std::time::Duration,
 }
 
 /// Tempo Zone node type configuration.

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -64,37 +64,31 @@ use crate::builder::ZonePayloadFactory;
 /// Network primitives for Zone.
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
-/// Configuration for the zone sequencer background tasks launched after the node starts.
+/// Configuration for zone add-ons launched after the node starts.
 ///
-/// When provided via [`ZoneNode::with_sequencer_addons`], the sequencer background
-/// tasks (batch submission, withdrawal processing) are automatically spawned
-/// during [`ZoneAddOns::launch_add_ons`].
+/// When provided via [`ZoneNode::with_sequencer_addons`], the private RPC
+/// server is always launched and the sequencer background tasks (batch
+/// submission, withdrawal processing) are optionally spawned based on
+/// [`enable_sequencer`](Self::enable_sequencer).
 #[derive(Debug, Clone)]
 pub struct ZoneSequencerAddOnsConfig {
     /// Sequencer private key signer for signing L1 transactions.
     pub sequencer_signer: alloy_signer_local::PrivateKeySigner,
-    /// Zone ID for chain ID validation.
+    /// Zone ID for chain ID validation and private RPC auth.
     pub zone_id: u32,
+    /// Port for the private zone RPC server (0 for OS-assigned).
+    pub private_rpc_port: u16,
+    /// Maximum auth token validity for the private RPC.
+    pub max_auth_token_validity: std::time::Duration,
+    /// Whether to launch the sequencer background tasks (batch submission,
+    /// withdrawal processing). When `false`, only the private RPC is started.
+    pub enable_sequencer: bool,
     /// How often the zone monitor polls for new L2 blocks.
     pub zone_poll_interval: std::time::Duration,
     /// Maximum time to accumulate zone blocks before batch submission.
     pub batch_interval: std::time::Duration,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: std::time::Duration,
-}
-
-/// Configuration for the private RPC server launched after the node starts.
-///
-/// When provided via [`ZoneNode::with_private_rpc`], the private RPC server is
-/// automatically spawned during [`ZoneAddOns::launch_add_ons`].
-#[derive(Debug, Clone)]
-pub struct ZonePrivateRpcConfig {
-    /// Port for the private zone RPC server (0 for OS-assigned).
-    pub private_rpc_port: u16,
-    /// Zone ID for chain ID validation and private RPC auth.
-    pub zone_id: u32,
-    /// Maximum auth token validity for the private RPC.
-    pub max_auth_token_validity: std::time::Duration,
 }
 
 /// Tempo Zone node type configuration.
@@ -123,11 +117,8 @@ pub struct ZoneNode {
     /// Optional pre-configured list of enabled token addresses. When set, the
     /// startup L1 RPC query for `enabledTokenCount`/`enabledTokens` is skipped.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional private RPC config. When set, the private RPC server is
-    /// automatically spawned during node launch.
-    private_rpc_config: Option<ZonePrivateRpcConfig>,
-    /// Optional sequencer add-ons config. When set, the sequencer
-    /// background tasks are automatically spawned during node launch.
+    /// Optional sequencer add-ons config. When set, the private RPC server
+    /// is always launched and sequencer tasks are optionally spawned.
     sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
 }
 
@@ -182,25 +173,15 @@ impl ZoneNode {
             sequencer_key,
             portal_address,
             initial_tokens: None,
-            private_rpc_config: None,
             sequencer_addons_config: None,
         }
     }
 
-    /// Set the private RPC configuration.
-    ///
-    /// When set, the private RPC server is automatically spawned during node
-    /// launch via [`ZoneAddOns::launch_add_ons`].
-    pub fn with_private_rpc(mut self, config: ZonePrivateRpcConfig) -> Self {
-        self.private_rpc_config = Some(config);
-        self
-    }
-
     /// Set the sequencer add-ons configuration.
     ///
-    /// When set, the sequencer background tasks (batch submission, withdrawal
-    /// processing) are automatically spawned during node launch via
-    /// [`ZoneAddOns::launch_add_ons`].
+    /// When set, the private RPC server is always launched and sequencer
+    /// background tasks are optionally spawned based on
+    /// [`enable_sequencer`](ZoneSequencerAddOnsConfig::enable_sequencer).
     pub fn with_sequencer_addons(mut self, config: ZoneSequencerAddOnsConfig) -> Self {
         self.sequencer_addons_config = Some(config);
         self
@@ -321,9 +302,7 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     portal_address: alloy_primitives::Address,
     /// Optional pre-configured list of enabled token addresses.
     initial_tokens: Option<Vec<alloy_primitives::Address>>,
-    /// Optional private RPC config.
-    private_rpc_config: Option<ZonePrivateRpcConfig>,
-    /// Optional sequencer add-ons config for sequencer background tasks.
+    /// Optional sequencer add-ons config (private RPC + sequencer tasks).
     sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
 }
 
@@ -348,7 +327,6 @@ where
         sequencer_key: k256::SecretKey,
         portal_address: alloy_primitives::Address,
         initial_tokens: Option<Vec<alloy_primitives::Address>>,
-        private_rpc_config: Option<ZonePrivateRpcConfig>,
         sequencer_addons_config: Option<ZoneSequencerAddOnsConfig>,
     ) -> Self {
         Self {
@@ -366,7 +344,6 @@ where
             sequencer_key,
             portal_address,
             initial_tokens,
-            private_rpc_config,
             sequencer_addons_config,
         }
     }
@@ -421,9 +398,10 @@ where
             .chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
-        if let Some(config) = self.private_rpc_config.take() {
+        if let Some(config) = self.sequencer_addons_config.take() {
+            // Private RPC always launches with sequencer add-ons
             Self::launch_private_rpc(
-                config,
+                &config,
                 &handle,
                 self.l1_config.l1_rpc_url.clone(),
                 self.l1_config.retry_connection_interval,
@@ -432,20 +410,20 @@ where
                 chain_id,
             )
             .await?;
-        }
 
-        if let Some(config) = self.sequencer_addons_config.take() {
-            Self::launch_sequencer_tasks(
-                config,
-                &handle,
-                &task_executor,
-                self.l1_config.l1_rpc_url,
-                self.l1_config.portal_address,
-                self.l1_config.retry_connection_interval,
-                self.fee_recipient,
-                chain_id,
-            )
-            .await?;
+            if config.enable_sequencer {
+                Self::launch_sequencer_tasks(
+                    config,
+                    &handle,
+                    &task_executor,
+                    self.l1_config.l1_rpc_url,
+                    self.l1_config.portal_address,
+                    self.l1_config.retry_connection_interval,
+                    self.fee_recipient,
+                    chain_id,
+                )
+                .await?;
+            }
         }
 
         Ok(handle)
@@ -551,9 +529,9 @@ where
         Ok(())
     }
 
-    /// Launch the private RPC server independently of sequencer tasks.
+    /// Launch the private RPC server.
     async fn launch_private_rpc(
-        config: ZonePrivateRpcConfig,
+        config: &ZoneSequencerAddOnsConfig,
         handle: &<Self as NodeAddOns<N>>::Handle,
         l1_rpc_url: String,
         retry_connection_interval: std::time::Duration,
@@ -738,7 +716,6 @@ where
             self.sequencer_key.clone(),
             self.portal_address,
             self.initial_tokens.clone(),
-            self.private_rpc_config.clone(),
             self.sequencer_addons_config.clone(),
         )
     }

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -64,20 +64,6 @@ use crate::builder::ZonePayloadFactory;
 /// Network primitives for Zone.
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
-/// Configuration for the private RPC server launched after the node starts.
-///
-/// When provided via [`ZoneNode::with_private_rpc`], the private RPC server is
-/// automatically spawned during [`ZoneAddOns::launch_add_ons`].
-#[derive(Debug, Clone)]
-pub struct ZonePrivateRpcConfig {
-    /// Port for the private zone RPC server (0 for OS-assigned).
-    pub private_rpc_port: u16,
-    /// Zone ID for chain ID validation and private RPC auth.
-    pub zone_id: u32,
-    /// Maximum auth token validity for the private RPC.
-    pub max_auth_token_validity: std::time::Duration,
-}
-
 /// Configuration for the zone sequencer background tasks launched after the node starts.
 ///
 /// When provided via [`ZoneNode::with_sequencer_addons`], the sequencer background
@@ -95,6 +81,20 @@ pub struct ZoneSequencerAddOnsConfig {
     pub batch_interval: std::time::Duration,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: std::time::Duration,
+}
+
+/// Configuration for the private RPC server launched after the node starts.
+///
+/// When provided via [`ZoneNode::with_private_rpc`], the private RPC server is
+/// automatically spawned during [`ZoneAddOns::launch_add_ons`].
+#[derive(Debug, Clone)]
+pub struct ZonePrivateRpcConfig {
+    /// Port for the private zone RPC server (0 for OS-assigned).
+    pub private_rpc_port: u16,
+    /// Zone ID for chain ID validation and private RPC auth.
+    pub zone_id: u32,
+    /// Maximum auth token validity for the private RPC.
+    pub max_auth_token_validity: std::time::Duration,
 }
 
 /// Tempo Zone node type configuration.

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -4,10 +4,16 @@
 //! It reuses Tempo's EVM, primitives, and pool, but with noop consensus/network/payload.
 
 use crate::{
+    ZoneEngine,
+    builder::ZonePayloadFactory,
+    evm::ZoneEvmConfig,
     ext::TempoStateExt,
+    l1::L1Subscriber,
+    l1_state::{L1StateProvider, L1StateProviderConfig, SharedL1StateCache},
     payload::{ZonePayloadAttributes, ZonePayloadTypes},
 };
 use alloy_primitives::U256;
+use alloy_provider::Provider as _;
 use reth_eth_wire_types::primitives::BasicNetworkPrimitives;
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, InvalidPayloadAttributesError,
@@ -49,17 +55,6 @@ use tempo_transaction_pool::{
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
 use tracing::{debug, info};
-
-use alloy_provider::Provider as _;
-
-use crate::{
-    ZoneEngine,
-    evm::ZoneEvmConfig,
-    l1::L1Subscriber,
-    l1_state::{L1StateProvider, L1StateProviderConfig, SharedL1StateCache},
-};
-
-use crate::builder::ZonePayloadFactory;
 
 /// Network primitives for Zone.
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;


### PR DESCRIPTION
This PR extracts private RPC configuration into its own `ZonePrivateRpcConfig` so it can be launched independently of sequencer background tasks. Nodes running in sequencer mode now pass a `--sequencer` flag.

This enables infra setups where additional nodes serve private RPC traffic for state queries and load balancing without sequencing the chain.

This PR also refactors the monolithic `launch_add_ons` into focused helper methods for readability.


```rust
impl<N> NodeAddOns<N> for ZoneAddOns<N>
{
    async fn launch_add_ons(mut self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
        // --snip--

        self.resolve_and_seed_tokens(&l1_provider).await?;
        self.spawn_l1_subscriber(&ctx);
        self.spawn_policy_tasks(&l1_provider, &ctx);
        self.spawn_zone_engine(l1_provider, &ctx)?;

       // --snip--
}
```