### PR TITLE
test(zone): cover configurable batch anchor stepping

### DIFF
--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -9,22 +9,22 @@
 //!
 //! # POC limitations
 //!
-//! Proof validation is currently **skipped**: both `verifierConfig` and `proof`
-//! are submitted as empty bytes. The L1 verifier contract must be configured to
-//! accept empty proofs for this to work.
+//! Proof validation is currently **skipped** by the stub verifier. Both direct
+//! and ancestry submissions use empty proof bytes until real proof generation is
+//! implemented.
 //!
 //! # Anchor modes
 //!
 //! | Gap | Mode | Description |
 //! |-----|------|-------------|
-//! | < [`EIP2935_EFFECTIVE_WINDOW`] | Direct | Portal reads hash from EIP-2935. |
-//! | ≥ [`EIP2935_EFFECTIVE_WINDOW`] | Stepping | Split into multiple direct-mode submissions. |
+//! | < configured effective window | Direct | Portal reads hash from EIP-2935. |
+//! | ≥ configured effective window | Stepping | Split into smaller submissions; each submission may still use ancestry if needed. |
 //!
 //! [`AnchorGapKind`] classifies the gap in the zone monitor before
 //! `submit_batch` is called. Inside `submit_batch`, [`AnchorMode`] handles
-//! the rare case where the gap lands between [`EIP2935_EFFECTIVE_WINDOW`] and
-//! [`EIP2935_HISTORY_WINDOW`] (e.g. due to timing) by falling back to ancestry
-//! mode — a recent anchor block plus a parent-hash header chain.
+//! submissions whose `tempoBlockNumber` is still outside the configured direct
+//! window by falling back to ancestry mode — a recent anchor block plus a
+//! locally validated parent-hash header chain.
 
 use std::collections::BTreeMap;
 
@@ -43,16 +43,71 @@ use tracing::{info, instrument, warn};
 use crate::nonce_keys::SUBMIT_BATCH_NONCE_KEY;
 
 /// EIP-2935 stores the last 8192 block hashes (~68 min at 500ms block time).
-const EIP2935_HISTORY_WINDOW: u64 = 8192;
+const DEFAULT_EIP2935_HISTORY_WINDOW: u64 = 8192;
 
 /// Safety margin (~3 min at 500ms block time) to avoid race conditions where
 /// the block falls out of the window between our check and on-chain execution.
-const EIP2935_SAFETY_MARGIN: u64 = 360;
+const DEFAULT_EIP2935_SAFETY_MARGIN: u64 = 360;
 
-/// Effective EIP-2935 window after subtracting the safety margin. Batches with
-/// a gap below this threshold use direct mode; gaps at or above it require
-/// stepping (splitting into multiple direct-mode submissions).
-const EIP2935_EFFECTIVE_WINDOW: u64 = EIP2935_HISTORY_WINDOW - EIP2935_SAFETY_MARGIN;
+/// EIP-2935 anchor limits used by the batch submitter.
+///
+/// Production uses the real 8192-block EIP-2935 history window with a safety
+/// margin. This type exists primarily so tests can shrink that otherwise large
+/// window and exercise stepping/ancestry behavior without mining thousands of
+/// L1 blocks. Production code should normally use [`Default`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchAnchorConfig {
+    /// Total L1 block-hash history window to treat as available for EIP-2935
+    /// anchoring.
+    history_window: u64,
+    /// Number of most-recent L1 blocks to avoid when choosing an anchor, reducing
+    /// the chance that an anchor ages out before the on-chain transaction lands.
+    safety_margin: u64,
+}
+
+impl BatchAnchorConfig {
+    /// Build an anchor config with explicit limits.
+    pub fn new(history_window: u64, safety_margin: u64) -> Result<Self> {
+        if history_window == 0 {
+            return Err(eyre::eyre!("EIP-2935 history window must be non-zero"));
+        }
+
+        if safety_margin >= history_window {
+            return Err(eyre::eyre!(
+                "EIP-2935 safety margin ({safety_margin}) must be smaller than history window ({history_window})"
+            ));
+        }
+
+        Ok(Self {
+            history_window,
+            safety_margin,
+        })
+    }
+
+    /// Configured history window in L1 blocks.
+    pub const fn history_window(self) -> u64 {
+        self.history_window
+    }
+
+    /// Configured safety margin in L1 blocks.
+    pub const fn safety_margin(self) -> u64 {
+        self.safety_margin
+    }
+
+    /// Effective direct-submission window after subtracting the safety margin.
+    pub const fn effective_window(self) -> u64 {
+        self.history_window - self.safety_margin
+    }
+}
+
+impl Default for BatchAnchorConfig {
+    fn default() -> Self {
+        Self {
+            history_window: DEFAULT_EIP2935_HISTORY_WINDOW,
+            safety_margin: DEFAULT_EIP2935_SAFETY_MARGIN,
+        }
+    }
+}
 
 /// Maximum number of pending withdrawal queue slots in the portal ring buffer.
 const WITHDRAWAL_QUEUE_CAPACITY: u64 = 100;
@@ -105,6 +160,8 @@ pub struct BatchSubmitter {
     genesis_tempo_block_number: u64,
     /// Concurrency for pipelined L1 header fetching in ancestry mode.
     l1_fetch_concurrency: usize,
+    /// EIP-2935 history and safety-margin limits used for anchor decisions.
+    anchor_config: BatchAnchorConfig,
 }
 
 impl BatchSubmitter {
@@ -116,6 +173,21 @@ impl BatchSubmitter {
         l1_provider: DynProvider<TempoNetwork>,
         genesis_tempo_block_number: u64,
     ) -> Self {
+        Self::with_anchor_config(
+            portal_address,
+            l1_provider,
+            genesis_tempo_block_number,
+            BatchAnchorConfig::default(),
+        )
+    }
+
+    /// Create a new batch submitter with custom EIP-2935 anchor limits.
+    pub fn with_anchor_config(
+        portal_address: Address,
+        l1_provider: DynProvider<TempoNetwork>,
+        genesis_tempo_block_number: u64,
+        anchor_config: BatchAnchorConfig,
+    ) -> Self {
         let portal = ZonePortal::new(portal_address, l1_provider.clone());
         Self {
             portal_address,
@@ -123,6 +195,7 @@ impl BatchSubmitter {
             portal,
             genesis_tempo_block_number,
             l1_fetch_concurrency: 16,
+            anchor_config,
         }
     }
 
@@ -130,18 +203,18 @@ impl BatchSubmitter {
     ///
     /// Resolves the anchor mode based on how old `tempo_block_number` is:
     ///
-    /// - **Direct** — `tempo_block_number` is within [`EIP2935_EFFECTIVE_WINDOW`],
+    /// - **Direct** — `tempo_block_number` is within the configured effective window,
     ///   the portal reads its hash directly from EIP-2935.
-    /// - **Ancestry** — `tempo_block_number` is outside the effective window but
-    ///   still within [`EIP2935_HISTORY_WINDOW`]. A recent anchor block is used
-    ///   and ancestry headers are collected (for future prover integration).
+    /// - **Ancestry** — `tempo_block_number` is outside the effective window. A
+    ///   recent anchor block is used and ancestry headers are collected (for
+    ///   future prover integration).
     ///
-    /// The caller must ensure `tempo_block_number` is within the
-    /// [`EIP2935_HISTORY_WINDOW`] — use [`classify_anchor_gap`](Self::classify_anchor_gap)
-    /// first and split via stepping if the gap is too large.
+    /// Callers should use [`classify_anchor_gap`](Self::classify_anchor_gap)
+    /// first so large gaps can be split into stepping submissions before this
+    /// method performs ancestry header fetching.
     ///
-    /// `verifierConfig` and `proof` are set to empty bytes — the verifier
-    /// contract must be configured to accept empty proofs.
+    /// `verifierConfig` and `proof` are empty until real proof generation is
+    /// implemented.
     // TODO: pass real proof bytes once proof generation is implemented.
     #[instrument(skip_all, fields(
         portal = %self.portal_address,
@@ -212,6 +285,7 @@ impl BatchSubmitter {
                 block_transition,
                 deposit_transition,
                 batch.withdrawal_queue_hash,
+                // verifierConfig and proof stay empty until real proof generation is wired in.
                 Bytes::new(),
                 Bytes::new(),
             )
@@ -280,25 +354,23 @@ impl BatchSubmitter {
 
         let gap = current_l1_block.saturating_sub(tempo_block_number);
 
-        if gap < EIP2935_EFFECTIVE_WINDOW {
+        let effective_window = self.anchor_config.effective_window();
+        if gap < effective_window {
             Ok(AnchorGapKind::Direct)
         } else {
             Ok(AnchorGapKind::Ancestry {
-                step_size: EIP2935_EFFECTIVE_WINDOW,
+                step_size: effective_window,
             })
         }
     }
 
     /// Resolve the anchor mode for the given `tempo_block_number`.
     ///
-    /// - **Direct** (gap < [`EIP2935_EFFECTIVE_WINDOW`]): the portal reads the
+    /// - **Direct** (gap < configured effective window): the portal reads the
     ///   hash directly from EIP-2935.
-    /// - **Ancestry** (gap within [`EIP2935_HISTORY_WINDOW`]): a recent L1 block
-    ///   within the window is used as anchor. Ancestry headers are collected
-    ///   and validated for future prover integration.
-    ///
-    /// Returns an error if the gap exceeds [`EIP2935_HISTORY_WINDOW`] — the
-    /// caller must split via stepping before calling this.
+    /// - **Ancestry** (gap ≥ configured effective window): a recent L1 block
+    ///   behind the configured safety margin is used as anchor. Ancestry headers
+    ///   are collected and validated for future prover integration.
     async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<AnchorMode> {
         let current_l1_block = self.l1_provider.get_block_number().await?;
 
@@ -311,11 +383,11 @@ impl BatchSubmitter {
 
         let gap = current_l1_block.saturating_sub(tempo_block_number);
 
-        if gap < EIP2935_EFFECTIVE_WINDOW {
+        if gap < self.anchor_config.effective_window() {
             return Ok(AnchorMode::Direct);
         }
 
-        let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
+        let anchor_block = current_l1_block.saturating_sub(self.anchor_config.safety_margin());
         let ancestry_headers = self
             .fetch_ancestry_headers(tempo_block_number, anchor_block)
             .await?;
@@ -420,11 +492,16 @@ impl BatchSubmitter {
         current_l1_block: u64,
         step_size: u64,
         max_zone_block: u64,
+        safety_margin: u64,
     ) -> Vec<StepPoint> {
         let mut step_points = Vec::new();
+        if step_size == 0 {
+            return step_points;
+        }
+
         let mut target = from_tempo + step_size;
 
-        while target < current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN) {
+        while target < current_l1_block.saturating_sub(safety_margin) {
             let zone_block = from_zone_block + (target - from_tempo);
             if zone_block > max_zone_block {
                 break;
@@ -442,6 +519,11 @@ impl BatchSubmitter {
     /// Returns a reference to the L1 provider.
     pub(crate) fn l1_provider(&self) -> &DynProvider<TempoNetwork> {
         &self.l1_provider
+    }
+
+    /// Return the configured EIP-2935 anchor limits.
+    pub(crate) const fn anchor_config(&self) -> BatchAnchorConfig {
+        self.anchor_config
     }
 
     /// Read the portal's `genesisTempoBlockNumber` from L1.
@@ -933,14 +1015,14 @@ pub(crate) fn log_query_ranges(from: u64, to: u64) -> impl Iterator<Item = (u64,
 
 /// Classification of the EIP-2935 gap, returned by
 /// [`BatchSubmitter::classify_anchor_gap`].
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum AnchorGapKind {
-    /// Gap < [`EIP2935_EFFECTIVE_WINDOW`] — the portal can read the block hash
+    /// Gap < configured effective window — the portal can read the block hash
     /// directly from EIP-2935. No extra proof data needed.
     Direct,
-    /// Gap ≥ [`EIP2935_EFFECTIVE_WINDOW`] — `tempo_block_number` is too old
-    /// for a direct EIP-2935 lookup. The batch must be split into multiple
-    /// direct-mode sub-range submissions (stepping).
+    /// Gap ≥ configured effective window — `tempo_block_number` is too old
+    /// for a direct EIP-2935 lookup. The batch must be split into smaller
+    /// sub-range submissions (stepping).
     Ancestry {
         /// Each sub-batch covers at most this many L1 blocks.
         step_size: u64,
@@ -950,18 +1032,17 @@ pub(crate) enum AnchorGapKind {
 /// How the batch submitter anchors `tempoBlockNumber` for EIP-2935 verification.
 ///
 /// Resolved by [`BatchSubmitter::resolve_anchor_mode`] inside `submit_batch`.
-/// Stepping is handled at a higher level by [`AnchorGapKind`] — by the time
-/// `submit_batch` is called, the gap must already be within
-/// [`EIP2935_HISTORY_WINDOW`].
+/// Stepping is handled at a higher level by [`AnchorGapKind`]. `submit_batch`
+/// can still use ancestry mode when the original `tempoBlockNumber` has fallen
+/// outside the configured direct-submission window.
 #[derive(Debug)]
 #[allow(dead_code)] // Ancestry::ancestry_headers is collected but not yet consumed — available for prover integration
 enum AnchorMode {
     /// `tempoBlockNumber` is within the effective EIP-2935 window — the portal
     /// reads its hash directly. No extra proof data required.
     Direct,
-    /// `tempoBlockNumber` is outside the effective window but within the full
-    /// history window. A recent L1 block is used as anchor, and the collected
-    /// headers prove the parent-hash chain.
+    /// `tempoBlockNumber` is outside the effective window. A recent L1 block is
+    /// used as anchor, and the collected headers prove the parent-hash chain.
     Ancestry {
         /// Recent L1 block number within the EIP-2935 window, used as the
         /// on-chain anchor for hash verification.
@@ -986,7 +1067,7 @@ impl AnchorMode {
 
 /// A step split point for stepping mode: identifies a zone L2 block at which
 /// to cut an intermediate batch submission.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[allow(dead_code)]
 pub(crate) struct StepPoint {
     /// Zone L2 block number at which to cut the intermediate batch.
@@ -1026,6 +1107,51 @@ mod tests {
             callbackData: Default::default(),
             encryptedSender: Default::default(),
         }
+    }
+
+    #[test]
+    fn batch_anchor_config_validates_effective_window() {
+        let config = BatchAnchorConfig::new(10, 4).unwrap();
+        assert_eq!(config.history_window(), 10);
+        assert_eq!(config.safety_margin(), 4);
+        assert_eq!(config.effective_window(), 6);
+
+        assert!(BatchAnchorConfig::new(0, 0).is_err());
+        assert!(BatchAnchorConfig::new(10, 10).is_err());
+        assert!(BatchAnchorConfig::new(10, 11).is_err());
+    }
+
+    #[test]
+    fn compute_step_points_respects_custom_safety_margin() {
+        let config = BatchAnchorConfig::new(10, 4).unwrap();
+        let points = BatchSubmitter::compute_step_points(
+            1,
+            100,
+            119,
+            config.effective_window(),
+            20,
+            config.safety_margin(),
+        );
+
+        assert_eq!(
+            points,
+            vec![
+                StepPoint {
+                    zone_block: 7,
+                    target_tempo_block: 106,
+                },
+                StepPoint {
+                    zone_block: 13,
+                    target_tempo_block: 112,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_step_points_handles_zero_step_size() {
+        let points = BatchSubmitter::compute_step_points(1, 100, 119, 0, 20, 4);
+        assert!(points.is_empty());
     }
 
     #[test]

--- a/crates/tempo-zone/src/cli.rs
+++ b/crates/tempo-zone/src/cli.rs
@@ -11,8 +11,8 @@ use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 
 use crate::{
-    ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig, evm::ZoneEvmConfig,
-    rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
+    BatchAnchorConfig, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig,
+    evm::ZoneEvmConfig, rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 
 const MAX_LOGS_PER_RESPONSE: u64 = 1_000_000;
@@ -84,6 +84,7 @@ impl ZoneCli {
                     zone_id: args.zone_id,
                     zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
                     batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
+                    batch_anchor_config: BatchAnchorConfig::default(),
                     withdrawal_poll_interval: Duration::from_secs(
                         args.withdrawal_poll_interval_secs,
                     ),

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -28,7 +28,7 @@ mod tx_context;
 pub mod withdrawals;
 pub mod zonemonitor;
 
-pub use batch::{BatchData, BatchSubmitter};
+pub use batch::{BatchAnchorConfig, BatchData, BatchSubmitter};
 pub use engine::ZoneEngine;
 pub use l1::{
     Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1BlockDeposits, L1Deposit,

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -4,7 +4,8 @@
 //! It reuses Tempo's EVM, primitives, and pool, but with noop consensus/network/payload.
 
 use crate::{
-    DepositQueue, L1SubscriberConfig, PolicyCache, ZoneEngine, ZoneSequencerConfig,
+    BatchAnchorConfig, DepositQueue, L1SubscriberConfig, PolicyCache, ZoneEngine,
+    ZoneSequencerConfig,
     abi::{TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal},
     evm::ZoneEvmConfig,
     ext::TempoStateExt,
@@ -83,6 +84,8 @@ pub struct ZoneSequencerAddOnsConfig {
     pub zone_poll_interval: Duration,
     /// Maximum time to accumulate zone blocks before batch submission.
     pub batch_interval: Duration,
+    /// EIP-2935 history and safety-margin limits used by the batch submitter.
+    pub batch_anchor_config: BatchAnchorConfig,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: Duration,
 }
@@ -569,6 +572,7 @@ where
             zone_rpc_url,
             zone_poll_interval: config.zone_poll_interval,
             batch_interval: config.batch_interval,
+            batch_anchor_config: config.batch_anchor_config,
         };
         let seq_handle = spawn_zone_sequencer(sequencer_config, config.sequencer_signer).await;
         info!(target: "reth::cli", "Sequencer tasks spawned");

--- a/crates/tempo-zone/src/sequencer.rs
+++ b/crates/tempo-zone/src/sequencer.rs
@@ -9,8 +9,8 @@ use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 use tokio::sync::Notify;
 
 use crate::{
-    SharedWithdrawalStore, WithdrawalProcessorConfig, ZoneMonitorConfig, spawn_zone_monitor,
-    withdrawals,
+    BatchAnchorConfig, SharedWithdrawalStore, WithdrawalProcessorConfig, ZoneMonitorConfig,
+    spawn_zone_monitor, withdrawals,
 };
 
 /// Configuration for all zone sequencer background tasks.
@@ -36,6 +36,8 @@ pub struct ZoneSequencerConfig {
     pub zone_poll_interval: Duration,
     /// Maximum time to accumulate zone blocks before submitting a batch to L1.
     pub batch_interval: Duration,
+    /// EIP-2935 history and safety-margin limits used by the batch submitter.
+    pub batch_anchor_config: BatchAnchorConfig,
 }
 
 /// Handles returned by [`spawn_zone_sequencer`] for managing background tasks.
@@ -93,6 +95,7 @@ pub async fn spawn_zone_sequencer(
         poll_interval: config.zone_poll_interval,
         batch_interval: config.batch_interval,
         portal_address: config.portal_address,
+        batch_anchor_config: config.batch_anchor_config,
     };
 
     let withdrawal_handle = withdrawals::spawn_withdrawal_processor(

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -40,8 +40,8 @@ use alloy_sol_types::{ContractError, SolInterface as _};
 use crate::{
     abi::{self, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
     batch::{
-        AnchorGapKind, BatchData, BatchSubmitter, ZoneBlockSnapshot, fetch_slot_withdrawals,
-        log_query_ranges,
+        AnchorGapKind, BatchAnchorConfig, BatchData, BatchSubmitter, ZoneBlockSnapshot,
+        fetch_slot_withdrawals, log_query_ranges,
     },
     withdrawals::SharedWithdrawalStore,
 };
@@ -73,6 +73,8 @@ pub struct ZoneMonitorConfig {
     pub batch_interval: Duration,
     /// ZonePortal contract address on Tempo L1.
     pub portal_address: Address,
+    /// EIP-2935 history and safety-margin limits used by the batch submitter.
+    pub batch_anchor_config: BatchAnchorConfig,
 }
 
 /// Monitors the Zone L2 chain for new blocks, aggregates them into batches, and
@@ -191,10 +193,11 @@ impl ZoneMonitor {
                 .await
                 .wrap_err("failed to read genesisTempoBlockNumber during zone monitor startup")?;
 
-        let batch_submitter = BatchSubmitter::new(
+        let batch_submitter = BatchSubmitter::with_anchor_config(
             config.portal_address,
             l1_provider,
             genesis_tempo_block_number,
+            config.batch_anchor_config,
         );
 
         let (prev_zone_block_hash, portal_withdrawal_queue_tail) = tokio::try_join!(
@@ -428,10 +431,10 @@ impl ZoneMonitor {
     ///
     /// ## Stepping mode
     ///
-    /// When the zone's `tempoBlockNumber` has fallen far outside the EIP-2935 window
-    /// (gap > 8192 blocks), a single submission would fail. The monitor splits the
-    /// range into multiple direct-mode submissions at intermediate zone blocks whose
-    /// `tempoBlockNumber` falls within the window relative to the current L1 tip.
+    /// When the zone's `tempoBlockNumber` has fallen outside the configured
+    /// direct-submission window, the monitor splits the range into multiple
+    /// submissions at intermediate zone blocks whose `tempoBlockNumber` reduces
+    /// the gap toward the current L1 tip.
     ///
     /// ## Withdrawal handling
     ///
@@ -504,8 +507,8 @@ impl ZoneMonitor {
         Ok(())
     }
 
-    /// Process a block range using stepping mode: split into multiple direct-mode
-    /// sub-range submissions.
+    /// Process a block range using stepping mode: split into multiple sub-range
+    /// submissions.
     async fn process_block_range_stepping(
         &mut self,
         from: u64,
@@ -527,6 +530,7 @@ impl ZoneMonitor {
             current_l1_block,
             step_size,
             to,
+            self.batch_submitter.anchor_config().safety_margin(),
         );
 
         if step_points.is_empty() {
@@ -1050,6 +1054,7 @@ mod tests {
             poll_interval: Duration::from_secs(1),
             batch_interval: Duration::from_secs(1),
             portal_address,
+            batch_anchor_config: BatchAnchorConfig::default(),
         };
         let zone_provider = mock_provider(zone);
         let l1_provider = mock_provider(l1);
@@ -1088,6 +1093,7 @@ mod tests {
             poll_interval: Duration::from_secs(1),
             batch_interval: Duration::from_secs(1),
             portal_address,
+            batch_anchor_config: BatchAnchorConfig::default(),
         };
 
         l1.push_failure_msg("boom");

--- a/crates/tempo-zone/tests/it/stepping_e2e.rs
+++ b/crates/tempo-zone/tests/it/stepping_e2e.rs
@@ -5,20 +5,94 @@
 //! submit batches successfully once it comes back. This exercises the
 //! long-downtime ancestry path instead of the simpler direct-mode case.
 
-use crate::utils::{L1TestNode, ZoneTestNode, poll_until, spawn_sequencer};
+use crate::utils::{
+    L1TestNode, ZoneTestNode, poll_until, spawn_sequencer, spawn_sequencer_with_anchor_config,
+};
 use alloy::providers::Provider;
+use alloy_sol_types::SolCall;
 use std::time::Duration;
-use zone::abi::ZonePortal;
+use zone::{BatchAnchorConfig, abi::ZonePortal};
 
 const EIP2935_HISTORY_WINDOW: u64 = 8192;
 const EIP2935_SAFETY_MARGIN: u64 = 360;
 const EIP2935_EFFECTIVE_WINDOW: u64 = EIP2935_HISTORY_WINDOW - EIP2935_SAFETY_MARGIN;
 const EXTENDED_GAP_BLOCKS: u64 = EIP2935_HISTORY_WINDOW + EIP2935_EFFECTIVE_WINDOW + 64;
 
+const SHORT_EIP2935_HISTORY_WINDOW: u64 = 10;
+const SHORT_EIP2935_SAFETY_MARGIN: u64 = 4;
+const SHORT_EIP2935_EFFECTIVE_WINDOW: u64 =
+    SHORT_EIP2935_HISTORY_WINDOW - SHORT_EIP2935_SAFETY_MARGIN;
+const SHORT_EXTENDED_GAP_BLOCKS: u64 =
+    SHORT_EIP2935_HISTORY_WINDOW + SHORT_EIP2935_EFFECTIVE_WINDOW + 1;
+const SHORT_MULTI_STEP_BATCH_COUNT: u64 = 3;
+const SHORT_MULTI_STEP_GAP_BLOCKS: u64 = SHORT_EIP2935_HISTORY_WINDOW
+    + SHORT_EIP2935_EFFECTIVE_WINDOW * SHORT_MULTI_STEP_BATCH_COUNT
+    + 1;
+
 /// Extended timeout for stepping tests — the L1 needs to mine >16k blocks and
 /// the zone must replay enough history to cross the first stepping boundary.
 const STEPPING_TIMEOUT: Duration = Duration::from_secs(300);
 const BATCH_TIMEOUT: Duration = Duration::from_secs(90);
+const SHORT_STEPPING_TIMEOUT: Duration = Duration::from_secs(60);
+
+async fn fetch_submit_batch_call(
+    l1: &L1TestNode,
+    tx_hash: alloy_primitives::B256,
+) -> eyre::Result<(ZonePortal::submitBatchCall, u64)> {
+    let response: serde_json::Value = reqwest::Client::new()
+        .post(l1.http_url().clone())
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_getTransactionByHash",
+            "params": [format!("{tx_hash:#x}")],
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+
+    if let Some(error) = response.get("error") {
+        eyre::bail!("eth_getTransactionByHash failed for {tx_hash}: {error}");
+    }
+
+    let tx = response
+        .get("result")
+        .filter(|value| !value.is_null())
+        .ok_or_else(|| eyre::eyre!("submitBatch tx {tx_hash} not found"))?;
+
+    let input = tx
+        .get("input")
+        .and_then(|value| value.as_str())
+        .filter(|input| *input != "0x")
+        .or_else(|| {
+            tx.get("calls")
+                .and_then(|value| value.as_array())
+                .and_then(|calls| {
+                    calls
+                        .iter()
+                        .filter_map(|call| call.get("input").and_then(|value| value.as_str()))
+                        .find(|input| *input != "0x")
+                })
+        })
+        .ok_or_else(|| eyre::eyre!("submitBatch tx {tx_hash} has no calldata input"))?;
+
+    let calldata = const_hex::decode(input.strip_prefix("0x").unwrap_or(input)).map_err(|err| {
+        eyre::eyre!("failed to hex-decode submitBatch calldata for {tx_hash}: {err}")
+    })?;
+    let call = ZonePortal::submitBatchCall::abi_decode(&calldata)
+        .map_err(|err| eyre::eyre!("failed to decode submitBatch calldata: {err}"))?;
+
+    let block_number = tx
+        .get("blockNumber")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| eyre::eyre!("submitBatch tx {tx_hash} is missing blockNumber"))?;
+    let block_number =
+        u64::from_str_radix(block_number.strip_prefix("0x").unwrap_or(block_number), 16)?;
+
+    Ok((call, block_number))
+}
 
 /// Test that batch submission works after the zone's `tempoBlockNumber` has
 /// fallen far enough behind L1 that the first stepped sub-batch still lands
@@ -132,6 +206,348 @@ async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
         first_step_tempo,
         first_step_gap = l1_tip.saturating_sub(first_step_tempo),
         "Batch submission succeeded after extended L1 gap"
+    );
+
+    Ok(())
+}
+
+/// Same stepping scenario as the ignored long-gap test, but with a 10-block
+/// configured EIP-2935 window so it runs in regular integration test time.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let anchor_config =
+        BatchAnchorConfig::new(SHORT_EIP2935_HISTORY_WINDOW, SHORT_EIP2935_SAFETY_MARGIN)?;
+
+    let l1 = L1TestNode::start_with(|cfg| {
+        cfg.dev.block_time = Some(Duration::from_millis(20));
+    })
+    .await?;
+
+    let portal_address = l1.deploy_zone().await?;
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    let genesis_block = portal.genesisTempoBlockNumber().call().await?;
+    let target_block = genesis_block + SHORT_EXTENDED_GAP_BLOCKS;
+
+    poll_until(
+        SHORT_STEPPING_TIMEOUT,
+        Duration::from_millis(50),
+        "L1 advanced past configured short EIP-2935 window",
+        || {
+            let provider = l1.provider();
+            async move {
+                let current = provider.get_block_number().await?;
+                if current >= target_block {
+                    Ok(Some(current))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    )
+    .await?;
+
+    let zone =
+        ZoneTestNode::start_from_l1_portal_genesis(l1.http_url(), l1.ws_url(), portal_address)
+            .await?;
+
+    let first_step_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW;
+    zone.wait_for_tempo_block_number(first_step_tempo, SHORT_STEPPING_TIMEOUT)
+        .await?;
+
+    let l1_tip = l1.provider().get_block_number().await?;
+    eyre::ensure!(
+        l1_tip.saturating_sub(first_step_tempo) > SHORT_EIP2935_HISTORY_WINDOW,
+        "test precondition not met: first configured step tempo {first_step_tempo} is only {} blocks behind L1 tip {l1_tip}",
+        l1_tip.saturating_sub(first_step_tempo),
+    );
+
+    let seq = spawn_sequencer_with_anchor_config(
+        &l1,
+        &zone,
+        portal_address,
+        l1.dev_signer(),
+        anchor_config,
+    )
+    .await;
+
+    poll_until(
+        SHORT_STEPPING_TIMEOUT,
+        Duration::from_millis(250),
+        "BatchSubmitted event after configured short L1 gap",
+        || {
+            let portal = &portal;
+            let seq = &seq;
+            async move {
+                if seq.monitor_handle.is_finished() {
+                    eyre::bail!("monitor task exited before submitting a batch");
+                }
+
+                if seq.withdrawal_handle.is_finished() {
+                    eyre::bail!("withdrawal processor exited before batch submission completed");
+                }
+
+                let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
+                if events.is_empty() {
+                    Ok(None)
+                } else {
+                    Ok(Some(events.len()))
+                }
+            }
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Verifies that a larger configured-window gap is split into multiple
+/// `submitBatch` L1 transactions before the sequencer catches up.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_configured_short_l1_gap_requires_multiple_stepping_batches() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let anchor_config =
+        BatchAnchorConfig::new(SHORT_EIP2935_HISTORY_WINDOW, SHORT_EIP2935_SAFETY_MARGIN)?;
+
+    // Start L1 with fast blocks so the configured test window ages out quickly.
+    let l1 = L1TestNode::start_with(|cfg| {
+        cfg.dev.block_time = Some(Duration::from_millis(20));
+    })
+    .await?;
+
+    let portal_address = l1.deploy_zone().await?;
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    let genesis_block = portal.genesisTempoBlockNumber().call().await?;
+    let target_block = genesis_block + SHORT_MULTI_STEP_GAP_BLOCKS;
+
+    // Mine enough L1 blocks that catching up requires several configured steps.
+    poll_until(
+        SHORT_STEPPING_TIMEOUT,
+        Duration::from_millis(50),
+        "L1 advanced far enough to require multiple configured stepping batches",
+        || {
+            let provider = l1.provider();
+            async move {
+                let current = provider.get_block_number().await?;
+                if current >= target_block {
+                    Ok(Some(current))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    )
+    .await?;
+
+    let zone =
+        ZoneTestNode::start_from_l1_portal_genesis(l1.http_url(), l1.ws_url(), portal_address)
+            .await?;
+
+    // Let the zone replay far enough to have multiple valid split boundaries.
+    let multi_step_tempo =
+        genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW * SHORT_MULTI_STEP_BATCH_COUNT;
+    zone.wait_for_tempo_block_number(multi_step_tempo, SHORT_STEPPING_TIMEOUT)
+        .await?;
+
+    // Assert the first step is genuinely outside the configured history window.
+    let first_step_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW;
+    let l1_tip = l1.provider().get_block_number().await?;
+    eyre::ensure!(
+        l1_tip.saturating_sub(first_step_tempo) > SHORT_EIP2935_HISTORY_WINDOW,
+        "test precondition not met: first configured step tempo {first_step_tempo} is only {} blocks behind L1 tip {l1_tip}",
+        l1_tip.saturating_sub(first_step_tempo),
+    );
+    eyre::ensure!(
+        multi_step_tempo < l1_tip.saturating_sub(SHORT_EIP2935_SAFETY_MARGIN),
+        "test precondition not met: multi-step tempo {multi_step_tempo} is not below the safe L1 anchor tip {l1_tip}",
+    );
+
+    // Start the sequencer only after the backlog has accumulated.
+    let seq = spawn_sequencer_with_anchor_config(
+        &l1,
+        &zone,
+        portal_address,
+        l1.dev_signer(),
+        anchor_config,
+    )
+    .await;
+
+    // Wait for the stepping loop to submit the first configured catch-up batches.
+    let calls = poll_until(
+        SHORT_STEPPING_TIMEOUT,
+        Duration::from_millis(250),
+        "multiple stepping BatchSubmitted events",
+        || {
+            let portal = &portal;
+            let seq = &seq;
+            let l1 = &l1;
+            async move {
+                if seq.monitor_handle.is_finished() {
+                    eyre::bail!("monitor task exited before submitting stepping batches");
+                }
+
+                if seq.withdrawal_handle.is_finished() {
+                    eyre::bail!("withdrawal processor exited before stepping batches completed");
+                }
+
+                let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
+                if events.len() < SHORT_MULTI_STEP_BATCH_COUNT as usize {
+                    return Ok(None);
+                }
+
+                let mut calls = Vec::with_capacity(SHORT_MULTI_STEP_BATCH_COUNT as usize);
+                for (_, log) in events.iter().take(SHORT_MULTI_STEP_BATCH_COUNT as usize) {
+                    let tx_hash = log.transaction_hash.ok_or_else(|| {
+                        eyre::eyre!("BatchSubmitted log missing transaction hash")
+                    })?;
+                    let (call, _) = fetch_submit_batch_call(l1, tx_hash).await?;
+                    calls.push(call);
+                }
+
+                Ok(Some(calls))
+            }
+        },
+    )
+    .await?;
+
+    let tempo_block_numbers = calls
+        .iter()
+        .map(|call| call.tempoBlockNumber)
+        .collect::<Vec<_>>();
+    // Each stepping submission should move the portal anchor forward.
+    eyre::ensure!(
+        tempo_block_numbers
+            .windows(2)
+            .all(|window| window[0] < window[1]),
+        "stepping submissions should advance tempoBlockNumber monotonically: {tempo_block_numbers:?}"
+    );
+    // Since these steps are still out of the short direct window, they use ancestry mode.
+    eyre::ensure!(
+        calls
+            .iter()
+            .all(|call| call.recentTempoBlockNumber > call.tempoBlockNumber),
+        "stepping catch-up submissions should use ancestry anchors: {tempo_block_numbers:?}"
+    );
+    // Proof bytes stay empty until real proof generation is wired in.
+    eyre::ensure!(
+        calls.iter().all(|call| call.proof.is_empty()),
+        "stepping catch-up submissions should keep proof bytes empty for now"
+    );
+
+    Ok(())
+}
+
+/// Verifies that the fast configured-window stepping path submits ancestry-mode
+/// calldata, not a direct `tempoBlockNumber` lookup, while proof bytes remain
+/// empty until real proof generation is implemented.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_stepping_ancestry_submission_uses_recent_anchor() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let anchor_config =
+        BatchAnchorConfig::new(SHORT_EIP2935_HISTORY_WINDOW, SHORT_EIP2935_SAFETY_MARGIN)?;
+
+    let l1 = L1TestNode::start_with(|cfg| {
+        cfg.dev.block_time = Some(Duration::from_millis(20));
+    })
+    .await?;
+
+    let portal_address = l1.deploy_zone().await?;
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    let genesis_block = portal.genesisTempoBlockNumber().call().await?;
+    let target_block = genesis_block + SHORT_EXTENDED_GAP_BLOCKS;
+
+    poll_until(
+        SHORT_STEPPING_TIMEOUT,
+        Duration::from_millis(50),
+        "L1 advanced past configured short EIP-2935 window",
+        || {
+            let provider = l1.provider();
+            async move {
+                let current = provider.get_block_number().await?;
+                if current >= target_block {
+                    Ok(Some(current))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    )
+    .await?;
+
+    let zone =
+        ZoneTestNode::start_from_l1_portal_genesis(l1.http_url(), l1.ws_url(), portal_address)
+            .await?;
+
+    let first_step_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW;
+    zone.wait_for_tempo_block_number(first_step_tempo, SHORT_STEPPING_TIMEOUT)
+        .await?;
+
+    let l1_tip = l1.provider().get_block_number().await?;
+    eyre::ensure!(
+        l1_tip.saturating_sub(first_step_tempo) > SHORT_EIP2935_HISTORY_WINDOW,
+        "test precondition not met: first configured step tempo {first_step_tempo} is only {} blocks behind L1 tip {l1_tip}",
+        l1_tip.saturating_sub(first_step_tempo),
+    );
+
+    let seq = spawn_sequencer_with_anchor_config(
+        &l1,
+        &zone,
+        portal_address,
+        l1.dev_signer(),
+        anchor_config,
+    )
+    .await;
+
+    let (call, inclusion_block) = poll_until(
+        SHORT_STEPPING_TIMEOUT,
+        Duration::from_millis(250),
+        "ancestry submitBatch calldata using recent anchor",
+        || {
+            let portal = &portal;
+            let seq = &seq;
+            let l1 = &l1;
+            async move {
+                if seq.monitor_handle.is_finished() {
+                    eyre::bail!("monitor task exited before submitting a batch");
+                }
+
+                if seq.withdrawal_handle.is_finished() {
+                    eyre::bail!("withdrawal processor exited before batch submission completed");
+                }
+
+                let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
+                for (_, log) in events {
+                    let tx_hash = log.transaction_hash.ok_or_else(|| {
+                        eyre::eyre!("BatchSubmitted log missing transaction hash")
+                    })?;
+                    let (call, inclusion_block) = fetch_submit_batch_call(l1, tx_hash).await?;
+
+                    if call.recentTempoBlockNumber != 0 {
+                        return Ok(Some((call, inclusion_block)));
+                    }
+                }
+
+                Ok(None)
+            }
+        },
+    )
+    .await?;
+
+    eyre::ensure!(
+        call.recentTempoBlockNumber > call.tempoBlockNumber,
+        "ancestry submission should use a recent anchor greater than tempoBlockNumber"
+    );
+    eyre::ensure!(
+        inclusion_block.saturating_sub(call.tempoBlockNumber) > SHORT_EIP2935_HISTORY_WINDOW,
+        "test did not submit an out-of-config-window tempo block: tempo={}, included_at={inclusion_block}",
+        call.tempoBlockNumber,
+    );
+    eyre::ensure!(
+        call.proof.is_empty(),
+        "ancestry submission should keep proof bytes empty until proof generation is implemented"
     );
 
     Ok(())

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -528,6 +528,7 @@ impl ZoneTestNode {
             zone_id: 0,
             zone_poll_interval: std::time::Duration::from_secs(1),
             batch_interval: std::time::Duration::from_secs(60),
+            batch_anchor_config: zone::BatchAnchorConfig::default(),
             withdrawal_poll_interval: std::time::Duration::from_secs(5),
         });
 
@@ -2236,6 +2237,24 @@ pub(crate) async fn spawn_sequencer(
     portal_address: Address,
     sequencer_signer: alloy_signer_local::PrivateKeySigner,
 ) -> zone::ZoneSequencerHandle {
+    spawn_sequencer_with_anchor_config(
+        l1,
+        zone,
+        portal_address,
+        sequencer_signer,
+        zone::BatchAnchorConfig::default(),
+    )
+    .await
+}
+
+/// Spawn the zone sequencer background tasks with custom EIP-2935 anchor limits.
+pub(crate) async fn spawn_sequencer_with_anchor_config(
+    l1: &L1TestNode,
+    zone: &ZoneTestNode,
+    portal_address: Address,
+    sequencer_signer: alloy_signer_local::PrivateKeySigner,
+    batch_anchor_config: zone::BatchAnchorConfig,
+) -> zone::ZoneSequencerHandle {
     use zone::abi::{TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
     let config = zone::ZoneSequencerConfig {
@@ -2249,6 +2268,7 @@ pub(crate) async fn spawn_sequencer(
         zone_rpc_url: zone.http_url().to_string(),
         zone_poll_interval: Duration::from_millis(500),
         batch_interval: Duration::from_millis(500),
+        batch_anchor_config,
     };
 
     zone::spawn_zone_sequencer(config, sequencer_signer).await


### PR DESCRIPTION
## Summary

- Add `BatchAnchorConfig` so the batch submitter can use the production EIP-2935 window by default while integration tests can shrink the window to a few blocks.
- Thread the anchor config through the sequencer, zone monitor, CLI defaults, and integration test helper.
- Keep ancestry submissions on the recent-anchor path while leaving verifier config and proof bytes empty until real proof generation is implemented.
- Keep the long ignored extended-gap test, and add fast configured-window stepping tests that verify ancestry calldata and multiple stepping batch submissions.

## Why

The existing ignored extended-gap test needs thousands of L1 blocks before it can exercise the out-of-window path. Configurable limits let the same behavior run with a 10-block test window, making the stepping and ancestry paths practical to cover in regular integration tests.