### PR TITLE
chore: remove extra sequencer vars from zone node

### DIFF
--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -33,8 +33,6 @@ pub const DEFAULT_MAX_AUTH_TOKEN_VALIDITY: Duration =
 pub struct AuthContext {
     /// The authenticated account address.
     pub caller: Address,
-    /// Whether this caller is the sequencer.
-    pub is_sequencer: bool,
     /// Token expiry timestamp (unix seconds).
     pub expires_at: u64,
 }

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,6 +1,5 @@
 //! Configuration for the private zone RPC server.
 
-use alloy_primitives::Address;
 use std::{net::SocketAddr, time::Duration};
 
 /// Configuration for the private zone RPC server.
@@ -24,7 +23,5 @@ pub struct PrivateRpcConfig {
     /// policy, but it must not exceed the protocol maximum.
     pub max_auth_token_validity: Duration,
     /// The ZonePortal contract address on L1 (used for querying deposits, not for auth tokens).
-    pub zone_portal: Address,
-    /// The sequencer address — callers matching this get unredacted responses.
-    pub sequencer: Address,
+    pub zone_portal: alloy_primitives::Address,
 }

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -255,9 +255,8 @@ fn api_result(
 /// Dispatch a single JSON-RPC request through the private zone RPC pipeline.
 ///
 /// Enforces a strict whitelist of allowed methods (see [`classify_method`]) and
-/// rejects anything unknown or disabled. Restricted methods are gated on
-/// [`AuthContext::is_sequencer`]. Individual handlers may apply additional
-/// per-method access checks (e.g. `full` block requests are sequencer-only).
+/// rejects anything unknown or disabled. Individual handlers may apply
+/// additional per-method access checks.
 pub async fn dispatch(
     req: &JsonRpcRequest,
     auth: &AuthContext,
@@ -274,7 +273,7 @@ pub async fn dispatch(
         MethodTier::Disabled => {
             return JsonRpcResponse::error(id, JsonRpcError::method_disabled());
         }
-        MethodTier::Restricted if !auth.is_sequencer => {
+        MethodTier::Restricted => {
             return JsonRpcResponse::error(id, JsonRpcError::sequencer_only());
         }
         _ => {}
@@ -370,7 +369,7 @@ async fn handle_get_block_by_number(
     };
     let number = normalize_block_number(number);
 
-    if full && !auth.is_sequencer {
+    if full {
         return JsonRpcResponse::error(id, JsonRpcError::sequencer_only());
     }
 
@@ -381,7 +380,7 @@ async fn handle_get_block_by_number(
     )
 }
 
-/// Handle `eth_getBlockByHash`. Rejects `full=true` for non-sequencer callers.
+/// Handle `eth_getBlockByHash`. Rejects `full=true`.
 async fn handle_get_block_by_hash(
     id: Value,
     raw: &str,
@@ -393,7 +392,7 @@ async fn handle_get_block_by_hash(
         Err(resp) => return resp,
     };
 
-    if full && !auth.is_sequencer {
+    if full {
         return JsonRpcResponse::error(id, JsonRpcError::sequencer_only());
     }
 
@@ -456,7 +455,7 @@ async fn handle_call(
             Err(resp) => return resp,
         };
 
-    if !auth.is_sequencer && state_override.is_some() {
+    if state_override.is_some() {
         return JsonRpcResponse::error(
             id,
             JsonRpcError::invalid_params("state overrides not allowed"),
@@ -471,7 +470,7 @@ async fn handle_call(
 }
 
 /// Handle `eth_estimateGas`. Same `from`-enforcement as `eth_call`.
-/// Rejects state overrides for non-sequencer callers.
+/// Rejects state overrides.
 async fn handle_estimate_gas(
     id: Value,
     raw: &str,
@@ -484,7 +483,7 @@ async fn handle_estimate_gas(
             Err(resp) => return resp,
         };
 
-    if !auth.is_sequencer && state_override.is_some() {
+    if state_override.is_some() {
         return JsonRpcResponse::error(
             id,
             JsonRpcError::invalid_params("state overrides not allowed"),
@@ -832,12 +831,11 @@ mod tests {
             })
         }
 
-        fn zone_get_zone_info(&self, auth: AuthContext) -> BoxFut<'_> {
+        fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
             Box::pin(async move {
                 to_raw(&json!({
                     "zoneId": "0x1",
                     "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
-                    "sequencer": format!("{:#x}", auth.caller),
                     "chainId": "0x2a",
                 }))
             })
@@ -864,15 +862,6 @@ mod tests {
     fn auth() -> AuthContext {
         AuthContext {
             caller: Address::repeat_byte(0xaa),
-            is_sequencer: false,
-            expires_at: 1_700_000_000,
-        }
-    }
-
-    fn sequencer_auth() -> AuthContext {
-        AuthContext {
-            caller: Address::repeat_byte(0xbb),
-            is_sequencer: true,
             expires_at: 1_700_000_000,
         }
     }
@@ -947,7 +936,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_state_override_for_non_sequencer_eth_call() {
+    async fn rejects_state_override_for_eth_call() {
         let api = MockZoneRpcApi::default();
         let resp = dispatch(
             &request(
@@ -970,30 +959,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn allows_state_override_for_sequencer_eth_call() {
-        let api = MockZoneRpcApi::default();
-        let resp = dispatch(
-            &request(
-                "eth_call",
-                json!([
-                    {"to": format!("{:#x}", Address::repeat_byte(0x11)), "data": "0x"},
-                    "latest",
-                    {}
-                ]),
-            ),
-            &sequencer_auth(),
-            &api,
-        )
-        .await;
-
-        assert!(resp.result.is_none());
-        let err = resp.error.expect("sequencer request should reach the API");
-        assert_eq!(err.code, -32603);
-        assert_eq!(err.message, "not implemented");
-    }
-
-    #[tokio::test]
-    async fn rejects_state_override_for_non_sequencer_estimate_gas() {
+    async fn rejects_state_override_for_estimate_gas() {
         let api = MockZoneRpcApi::default();
         let resp = dispatch(
             &request(
@@ -1013,29 +979,6 @@ mod tests {
         let err = resp.error.expect("should reject state overrides");
         assert_eq!(err.code, -32602);
         assert_eq!(err.message, "state overrides not allowed");
-    }
-
-    #[tokio::test]
-    async fn allows_state_override_for_sequencer_estimate_gas() {
-        let api = MockZoneRpcApi::default();
-        let resp = dispatch(
-            &request(
-                "eth_estimateGas",
-                json!([
-                    {"to": format!("{:#x}", Address::repeat_byte(0x11)), "data": "0x"},
-                    "latest",
-                    {}
-                ]),
-            ),
-            &sequencer_auth(),
-            &api,
-        )
-        .await;
-
-        assert!(resp.result.is_none());
-        let err = resp.error.expect("sequencer request should reach the API");
-        assert_eq!(err.code, -32603);
-        assert_eq!(err.message, "not implemented");
     }
 
     #[tokio::test]

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -97,9 +97,6 @@ impl ProxyZoneRpc {
         id: &FilterId,
         auth: &AuthContext,
     ) -> Result<(), JsonRpcError> {
-        if auth.is_sequencer {
-            return Ok(());
-        }
         let owners = self.filter_owners.lock().await;
         match owners.get(id) {
             Some(owner) if *owner == auth.caller => Ok(()),
@@ -200,7 +197,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer && address != auth.caller {
+            if address != auth.caller {
                 return Ok(raw_zero());
             }
             self.forward("eth_getBalance", serde_json::json!([address, block]))
@@ -215,7 +212,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer && address != auth.caller {
+            if address != auth.caller {
                 return Ok(raw_zero());
             }
             self.forward(
@@ -230,16 +227,12 @@ impl ZoneRpcApi for ProxyZoneRpc {
         &self,
         number: BlockNumberOrTag,
         full: bool,
-        auth: AuthContext,
+        _auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
             let result = self
                 .forward("eth_getBlockByNumber", serde_json::json!([number, full]))
                 .await?;
-
-            if auth.is_sequencer {
-                return Ok(result);
-            }
 
             let mut block: serde_json::Value =
                 serde_json::from_str(result.get()).map_err(internal)?;
@@ -257,16 +250,12 @@ impl ZoneRpcApi for ProxyZoneRpc {
         &self,
         hash: alloy_primitives::B256,
         full: bool,
-        auth: AuthContext,
+        _auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
             let result = self
                 .forward("eth_getBlockByHash", serde_json::json!([hash, full]))
                 .await?;
-
-            if auth.is_sequencer {
-                return Ok(result);
-            }
 
             let mut block: serde_json::Value =
                 serde_json::from_str(result.get()).map_err(internal)?;
@@ -292,7 +281,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
                 return Ok(result);
             }
 
-            if !auth.is_sequencer && json_from(&tx) != Some(auth.caller) {
+            if json_from(&tx) != Some(auth.caller) {
                 return Ok(raw_null());
             }
 
@@ -313,10 +302,6 @@ impl ZoneRpcApi for ProxyZoneRpc {
                 return Ok(result);
             };
 
-            if auth.is_sequencer {
-                return Ok(result);
-            }
-
             if receipt.from() != auth.caller {
                 return Ok(raw_null());
             }
@@ -333,14 +318,11 @@ impl ZoneRpcApi for ProxyZoneRpc {
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer && state_override.is_some() {
+            if state_override.is_some() {
                 return Err(JsonRpcError::invalid_params("state overrides not allowed"));
             }
 
-            if !auth.is_sequencer {
-                policy::enforce_from(&mut request, &auth)?;
-            }
-
+            policy::enforce_from(&mut request, &auth)?;
             policy::enforce_no_contract_creation(&request)?;
 
             self.forward(
@@ -359,14 +341,11 @@ impl ZoneRpcApi for ProxyZoneRpc {
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer && state_override.is_some() {
+            if state_override.is_some() {
                 return Err(JsonRpcError::invalid_params("state overrides not allowed"));
             }
 
-            if !auth.is_sequencer {
-                policy::enforce_from(&mut request, &auth)?;
-            }
-
+            policy::enforce_from(&mut request, &auth)?;
             policy::enforce_no_contract_creation(&request)?;
 
             self.forward(
@@ -379,9 +358,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
 
     fn send_raw_transaction(&self, data: Bytes, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                policy::verify_raw_tx_sender(&data, &auth)?;
-            }
+            policy::verify_raw_tx_sender(&data, &auth)?;
 
             self.forward("eth_sendRawTransaction", serde_json::json!([data]))
                 .await
@@ -390,17 +367,11 @@ impl ZoneRpcApi for ProxyZoneRpc {
 
     fn send_raw_transaction_sync(&self, data: Bytes, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                policy::verify_raw_tx_sender(&data, &auth)?;
-            }
+            policy::verify_raw_tx_sender(&data, &auth)?;
 
             let result = self
                 .forward("eth_sendRawTransactionSync", serde_json::json!([data]))
                 .await?;
-
-            if auth.is_sequencer {
-                return Ok(result);
-            }
 
             let receipt: TempoTransactionReceipt =
                 serde_json::from_str(result.get()).map_err(internal)?;
@@ -414,9 +385,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                policy::enforce_from(&mut request, &auth)?;
-            }
+            policy::enforce_from(&mut request, &auth)?;
 
             policy::enforce_no_contract_creation(&request)?;
 
@@ -427,12 +396,6 @@ impl ZoneRpcApi for ProxyZoneRpc {
 
     fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if auth.is_sequencer {
-                return self
-                    .forward("eth_getLogs", serde_json::json!([filter]))
-                    .await;
-            }
-
             filter::scope_filter(&mut filter);
             let result = self
                 .forward("eth_getLogs", serde_json::json!([filter]))
@@ -445,9 +408,7 @@ impl ZoneRpcApi for ProxyZoneRpc {
 
     fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                filter::scope_filter(&mut filter);
-            }
+            filter::scope_filter(&mut filter);
             let result = self
                 .forward("eth_newFilter", serde_json::json!([filter]))
                 .await?;
@@ -465,10 +426,6 @@ impl ZoneRpcApi for ProxyZoneRpc {
                 .forward("eth_getFilterLogs", serde_json::json!([id]))
                 .await?;
 
-            if auth.is_sequencer {
-                return Ok(result);
-            }
-
             let logs: Vec<Log> = serde_json::from_str(result.get()).map_err(internal)?;
             let filtered = filter::filter_logs(logs, &auth.caller);
             to_raw(&filtered)
@@ -482,10 +439,6 @@ impl ZoneRpcApi for ProxyZoneRpc {
             let result = self
                 .forward("eth_getFilterChanges", serde_json::json!([id]))
                 .await?;
-
-            if auth.is_sequencer {
-                return Ok(result);
-            }
 
             // Try to parse as logs for filtering. If the result is block hashes
             // (from a block filter) or empty, the parse will fail and we pass through.
@@ -635,7 +588,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transaction_receipt_filters_logs_for_non_sequencer() {
+    async fn transaction_receipt_filters_logs() {
         let caller = address!("0x0000000000000000000000000000000000000001");
         let other = address!("0x0000000000000000000000000000000000000002");
         let third = address!("0x0000000000000000000000000000000000000003");
@@ -665,7 +618,6 @@ mod tests {
                 TxHash::with_last_byte(1),
                 AuthContext {
                     caller,
-                    is_sequencer: false,
                     expires_at: u64::MAX,
                 },
             )

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -238,11 +238,8 @@ pub(crate) async fn authenticate_token(
         validate_keychain_signature(api, caller, keychain_signature, &token.digest).await?;
     }
 
-    let is_sequencer = caller == config.sequencer;
-
     Ok(AuthContext {
         caller,
-        is_sequencer,
         expires_at: token.expires_at,
     })
 }
@@ -399,7 +396,6 @@ mod tests {
             chain_id: CHAIN_ID,
             max_auth_token_validity: crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
             zone_portal: PORTAL,
-            sequencer: Address::ZERO,
         }
     }
 

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -177,8 +177,6 @@ pub struct ZoneInfoResponse {
     pub zone_id: U64,
     /// The enabled zone token contract addresses.
     pub zone_tokens: Vec<Address>,
-    /// The configured sequencer account.
-    pub sequencer: Address,
     /// The zone chain ID.
     pub chain_id: U64,
 }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -241,7 +241,6 @@ impl ZoneRpcApi for MockZoneRpcApi {
             zone_rpc::types::to_raw(&serde_json::json!({
                 "zoneId": "0x1",
                 "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
-                "sequencer": format!("{:#x}", Address::repeat_byte(0x22)),
                 "chainId": "0x2a",
             }))
         })
@@ -287,7 +286,6 @@ impl TestContext {
             chain_id: CHAIN_ID,
             max_auth_token_validity: zone_rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
             zone_portal: Address::ZERO,
-            sequencer: signer.address(),
         };
         let addr = start_private_rpc(config, Arc::new(api)).await.unwrap();
         Self { addr, signer }

--- a/crates/tempo-zone/src/cli.rs
+++ b/crates/tempo-zone/src/cli.rs
@@ -59,14 +59,10 @@ impl ZoneCli {
             builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
             builder.config_mut().rpc.rpc_max_blocks_per_filter = MAX_BLOCKS_PER_FILTER.into();
 
-            let sequencer_signer = args.sequencer_key.parse::<PrivateKeySigner>()?;
-
             let mut node = ZoneNode::new(
                 args.l1_rpc_url,
                 args.portal_address,
                 args.l1_genesis_block_number,
-                sequencer_signer.address(),
-                sequencer_signer.credential().into(),
                 args.l1_fetch_concurrency,
                 Duration::from_millis(args.l1_retry_connection_interval_ms),
             )
@@ -79,6 +75,8 @@ impl ZoneCli {
             });
 
             if args.enable_sequencer {
+                let sequencer_signer: PrivateKeySigner =
+                    args.sequencer_key.parse().expect("invalid sequencer private key");
                 node = node.with_sequencer(ZoneSequencerAddOnsConfig {
                     sequencer_signer,
                     zone_id: args.zone_id,

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -114,10 +114,6 @@ pub struct ZoneNode {
     /// Shared TIP-403 policy cache, populated by the unified [`L1Subscriber`](crate::l1::L1Subscriber)
     /// and read by the precompile during block building.
     policy_cache: SharedPolicyCache,
-    /// Address of the zone sequencer (fee recipient, authorized block producer).
-    sequencer: Address,
-    /// Sequencer's secp256k1 secret key for ECIES decryption of encrypted deposits.
-    sequencer_key: SecretKey,
     /// Address of the L1 deposit portal contract.
     portal_address: Address,
     /// Optional pre-configured list of enabled token addresses. When set, the
@@ -135,8 +131,6 @@ impl ZoneNode {
         l1_rpc_url: String,
         portal_address: Address,
         genesis_tempo_block_number: Option<u64>,
-        sequencer: Address,
-        sequencer_key: SecretKey,
         l1_fetch_concurrency: usize,
         retry_connection_interval: Duration,
     ) -> Self {
@@ -167,8 +161,6 @@ impl ZoneNode {
             l1_state_provider_config,
             l1_state_cache,
             policy_cache,
-            sequencer,
-            sequencer_key,
             portal_address,
             initial_tokens: None,
             private_rpc_config: ZonePrivateRpcConfig::default(),
@@ -256,12 +248,8 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     deposit_queue: DepositQueue,
     /// Configuration for the L1 event subscriber
     l1_config: L1SubscriberConfig,
-    /// Receiver address for zone block fees
-    fee_recipient: Address,
     /// TIP-403 policy cache
     policy_cache: SharedPolicyCache,
-    /// Sequencer's secp256k1 secret key for ECIES decryption of encrypted deposits.
-    sequencer_key: SecretKey,
     /// ZonePortal address on L1.
     portal_address: Address,
     /// Pre-configured list of initial tokens.
@@ -288,9 +276,7 @@ where
     pub fn new(
         deposit_queue: DepositQueue,
         l1_config: L1SubscriberConfig,
-        fee_recipient: Address,
         policy_cache: SharedPolicyCache,
-        sequencer_key: SecretKey,
         portal_address: Address,
         initial_tokens: Option<Vec<Address>>,
         private_rpc_config: ZonePrivateRpcConfig,
@@ -306,9 +292,7 @@ where
             ),
             deposit_queue,
             l1_config,
-            fee_recipient,
             policy_cache,
-            sequencer_key,
             portal_address,
             initial_tokens,
             private_rpc_config,
@@ -351,7 +335,12 @@ where
         self.resolve_and_seed_tokens(&l1_provider).await?;
         self.spawn_l1_subscriber(&ctx);
         self.spawn_policy_tasks(&l1_provider, &ctx);
-        self.spawn_zone_engine(l1_provider, &ctx)?;
+
+        if let Some(ref config) = self.sequencer_config {
+            let sequencer_addr = config.sequencer_signer.address();
+            let sequencer_key = SecretKey::from(config.sequencer_signer.credential());
+            self.spawn_zone_engine(l1_provider, &ctx, sequencer_addr, sequencer_key)?;
+        }
 
         let task_executor = ctx.node.task_executor().clone();
 
@@ -365,18 +354,20 @@ where
             .chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
-        Self::launch_private_rpc(
-            self.private_rpc_config,
-            &handle,
-            self.l1_config.l1_rpc_url.clone(),
-            self.l1_config.retry_connection_interval,
-            self.l1_config.portal_address,
-            self.fee_recipient,
-            chain_id,
-        )
-        .await?;
-
         if let Some(config) = self.sequencer_config.take() {
+            let sequencer_addr = config.sequencer_signer.address();
+
+            Self::launch_private_rpc(
+                self.private_rpc_config,
+                &handle,
+                self.l1_config.l1_rpc_url.clone(),
+                self.l1_config.retry_connection_interval,
+                self.l1_config.portal_address,
+                sequencer_addr,
+                chain_id,
+            )
+            .await?;
+
             Self::launch_sequencer_tasks(
                 config,
                 &handle,
@@ -384,7 +375,7 @@ where
                 self.l1_config.l1_rpc_url,
                 self.l1_config.portal_address,
                 self.l1_config.retry_connection_interval,
-                self.fee_recipient,
+                sequencer_addr,
                 chain_id,
             )
             .await?;
@@ -460,9 +451,11 @@ where
 
     /// Spawn the [`ZoneEngine`] for L1-event-driven block production.
     fn spawn_zone_engine(
-        &mut self,
+        &self,
         l1_provider: alloy_provider::DynProvider<TempoNetwork>,
         ctx: &AddOnsContext<'_, N>,
+        fee_recipient: Address,
+        sequencer_key: SecretKey,
     ) -> eyre::Result<()> {
         let policy_provider = PolicyProvider::new(
             self.policy_cache.clone(),
@@ -479,8 +472,8 @@ where
             ctx.node.payload_builder_handle().clone(),
             self.deposit_queue.clone(),
             last_header,
-            self.fee_recipient,
-            self.sequencer_key.clone(),
+            fee_recipient,
+            sequencer_key,
             self.portal_address,
             policy_provider,
         );
@@ -671,9 +664,7 @@ where
         ZoneAddOns::new(
             self.deposit_queue.clone(),
             self.l1_config.clone(),
-            self.sequencer,
             self.policy_cache.clone(),
-            self.sequencer_key.clone(),
             self.portal_address,
             self.initial_tokens.clone(),
             self.private_rpc_config.clone(),

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -354,19 +354,18 @@ where
             .chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
+        Self::launch_private_rpc(
+            self.private_rpc_config,
+            &handle,
+            self.l1_config.l1_rpc_url.clone(),
+            self.l1_config.retry_connection_interval,
+            self.l1_config.portal_address,
+            chain_id,
+        )
+        .await?;
+
         if let Some(config) = self.sequencer_config.take() {
             let sequencer_addr = config.sequencer_signer.address();
-
-            Self::launch_private_rpc(
-                self.private_rpc_config,
-                &handle,
-                self.l1_config.l1_rpc_url.clone(),
-                self.l1_config.retry_connection_interval,
-                self.l1_config.portal_address,
-                sequencer_addr,
-                chain_id,
-            )
-            .await?;
 
             Self::launch_sequencer_tasks(
                 config,
@@ -491,7 +490,6 @@ where
         l1_rpc_url: String,
         retry_connection_interval: Duration,
         portal_address: Address,
-        sequencer_addr: Address,
         chain_id: u64,
     ) -> eyre::Result<()> {
         if config.zone_id != 0 {
@@ -521,7 +519,6 @@ where
             chain_id,
             max_auth_token_validity: config.max_auth_token_validity,
             zone_portal: portal_address,
-            sequencer: sequencer_addr,
         };
         let api: Arc<dyn ZoneRpcApi> =
             Arc::new(TempoZoneRpc::new(eth_handlers, private_rpc_config.clone()).await?);

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -224,9 +224,6 @@ impl<Api: EthApiTypes + 'static> TempoZoneRpc<Api> {
         id: &FilterId,
         auth: &AuthContext,
     ) -> Result<(), JsonRpcError> {
-        if auth.is_sequencer {
-            return Ok(());
-        }
         let owner_matches = {
             let owners = self.filter_owners.lock().await;
             matches!(owners.get(id), Some(owner) if *owner == auth.caller)
@@ -441,7 +438,7 @@ where
     ) -> BoxFut<'_> {
         Box::pin(async move {
             // Silent dummy: non-caller addresses get "0x0" to avoid leaking account existence.
-            if !auth.is_sequencer && address != auth.caller {
+            if address != auth.caller {
                 return Ok(raw_zero());
             }
             let balance = EthState::balance(&self.eth.api, address, block)
@@ -459,7 +456,7 @@ where
     ) -> BoxFut<'_> {
         Box::pin(async move {
             // Silent dummy: non-caller addresses get "0x0" to avoid leaking account existence.
-            if !auth.is_sequencer && address != auth.caller {
+            if address != auth.caller {
                 return Ok(raw_zero());
             }
             let count = EthState::transaction_count(&self.eth.api, address, block)
@@ -473,7 +470,7 @@ where
         &self,
         number: BlockNumberOrTag,
         full: bool,
-        auth: AuthContext,
+        _auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
             let block = EthBlocks::rpc_block(&self.eth.api, number.into(), full)
@@ -484,15 +481,13 @@ where
                 return Ok(raw_null());
             };
 
-            if !auth.is_sequencer {
-                redact_block(&mut block);
-            }
+            redact_block(&mut block);
 
             to_raw(&block)
         })
     }
 
-    fn block_by_hash(&self, hash: B256, full: bool, auth: AuthContext) -> BoxFut<'_> {
+    fn block_by_hash(&self, hash: B256, full: bool, _auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             let block = EthBlocks::rpc_block(&self.eth.api, hash.into(), full)
                 .await
@@ -502,9 +497,7 @@ where
                 return Ok(raw_null());
             };
 
-            if !auth.is_sequencer {
-                redact_block(&mut block);
-            }
+            redact_block(&mut block);
 
             to_raw(&block)
         })
@@ -521,7 +514,7 @@ where
 
             let Some(tx) = tx else { return Ok(raw_null()) };
 
-            if !auth.is_sequencer && tx.from() != auth.caller {
+            if tx.from() != auth.caller {
                 return Ok(raw_null());
             }
 
@@ -539,13 +532,11 @@ where
                 return Ok(raw_null());
             };
 
-            if !auth.is_sequencer {
-                if receipt.from() != auth.caller {
-                    return Ok(raw_null());
-                }
-
-                receipt = zone_rpc::filter::filter_receipt_logs(receipt);
+            if receipt.from() != auth.caller {
+                return Ok(raw_null());
             }
+
+            receipt = zone_rpc::filter::filter_receipt_logs(receipt);
 
             to_raw(&receipt)
         })
@@ -559,16 +550,11 @@ where
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            // Defense-in-depth: handlers.rs also rejects this for non-sequencers,
-            // but enforce here too.
-            if !auth.is_sequencer && state_override.is_some() {
+            if state_override.is_some() {
                 return Err(JsonRpcError::invalid_params("state overrides not allowed"));
             }
 
-            if !auth.is_sequencer {
-                zone_rpc::policy::enforce_from(&mut request, &auth)?;
-            }
-
+            zone_rpc::policy::enforce_from(&mut request, &auth)?;
             zone_rpc::policy::enforce_no_contract_creation(&request)?;
 
             let result = EthCall::call(
@@ -591,15 +577,11 @@ where
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            // Defense-in-depth: handlers.rs also rejects this for non-sequencers,
-            // but enforce here too.
-            if !auth.is_sequencer && state_override.is_some() {
+            if state_override.is_some() {
                 return Err(JsonRpcError::invalid_params("state overrides not allowed"));
             }
 
-            if !auth.is_sequencer {
-                zone_rpc::policy::enforce_from(&mut request, &auth)?;
-            }
+            zone_rpc::policy::enforce_from(&mut request, &auth)?;
 
             zone_rpc::policy::enforce_no_contract_creation(&request)?;
 
@@ -617,9 +599,7 @@ where
 
     fn send_raw_transaction(&self, data: Bytes, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                zone_rpc::policy::verify_raw_tx_sender(&data, &auth)?;
-            }
+            zone_rpc::policy::verify_raw_tx_sender(&data, &auth)?;
 
             let hash = EthTransactions::send_raw_transaction(&self.eth.api, data)
                 .await
@@ -630,17 +610,13 @@ where
 
     fn send_raw_transaction_sync(&self, data: Bytes, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                zone_rpc::policy::verify_raw_tx_sender(&data, &auth)?;
-            }
+            zone_rpc::policy::verify_raw_tx_sender(&data, &auth)?;
 
             let mut receipt = EthTransactions::send_raw_transaction_sync(&self.eth.api, data)
                 .await
                 .map_err(internal)?;
 
-            if !auth.is_sequencer {
-                receipt = zone_rpc::filter::filter_receipt_logs(receipt);
-            }
+            receipt = zone_rpc::filter::filter_receipt_logs(receipt);
 
             to_raw(&receipt)
         })
@@ -652,10 +628,7 @@ where
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                zone_rpc::policy::enforce_from(&mut request, &auth)?;
-            }
-
+            zone_rpc::policy::enforce_from(&mut request, &auth)?;
             zone_rpc::policy::enforce_no_contract_creation(&request)?;
 
             let result = EthTransactions::fill_transaction(&self.eth.api, request)
@@ -667,13 +640,6 @@ where
 
     fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if auth.is_sequencer {
-                let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
-                    .await
-                    .map_err(internal)?;
-                return to_raw(&logs);
-            }
-
             zone_rpc::filter::scope_filter(&mut filter);
             let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
                 .await
@@ -685,9 +651,7 @@ where
 
     fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            if !auth.is_sequencer {
-                zone_rpc::filter::scope_filter(&mut filter);
-            }
+            zone_rpc::filter::scope_filter(&mut filter);
             let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
                 .await
                 .map_err(internal)?;
@@ -709,10 +673,6 @@ where
                 .await
                 .map_err(map_eth_filter_error)?;
 
-            if auth.is_sequencer {
-                return to_raw(&logs);
-            }
-
             let filtered = zone_rpc::filter::filter_logs(logs, &auth.caller);
             to_raw(&filtered)
         })
@@ -727,10 +687,6 @@ where
                 .filter_changes(id)
                 .await
                 .map_err(map_eth_filter_error)?;
-
-            if auth.is_sequencer {
-                return to_raw(&changes);
-            }
 
             match changes {
                 FilterChanges::Logs(logs) => {
@@ -782,9 +738,8 @@ where
         })
     }
 
-    fn ws_subscribe_new_heads(&self, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+    fn ws_subscribe_new_heads(&self, _auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
         Box::pin(async move {
-            let redact_logs_bloom = !auth.is_sequencer;
             let api = self.eth.api.clone();
             let provider = self.eth.api.provider().clone();
             let stream = provider
@@ -814,9 +769,7 @@ where
                     futures::stream::iter(headers)
                 })
                 .map(move |mut header| {
-                    if redact_logs_bloom {
-                        redact_ws_header(&mut header);
-                    }
+                    redact_ws_header(&mut header);
                     to_raw(&header)
                 });
             let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
@@ -829,9 +782,7 @@ where
             let provider = self.eth.api.provider().clone();
             let caller = auth.caller;
 
-            if !auth.is_sequencer {
-                zone_rpc::filter::scope_filter(&mut filter);
-            }
+            zone_rpc::filter::scope_filter(&mut filter);
 
             let stream = provider
                 .canonical_state_stream()
@@ -850,12 +801,6 @@ where
                     futures::stream::iter(all_logs)
                 });
 
-            if auth.is_sequencer {
-                let stream = stream.map(|log| to_raw(&log));
-                let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
-                return Ok(stream);
-            }
-
             let stream = stream.filter_map(move |log| {
                 std::future::ready(
                     zone_rpc::filter::is_log_visible(&log, &caller).then(|| to_raw(&log)),
@@ -872,34 +817,6 @@ where
         auth: AuthContext,
     ) -> BoxWsSubscriptionFut<'_> {
         Box::pin(async move {
-            if auth.is_sequencer {
-                if !full {
-                    let pool = self.eth.api.pool().clone();
-                    // Sequencers can use the direct hash listener because no sender scoping is
-                    // required; non-sequencers must source full tx events to filter by sender.
-                    let stream = futures::stream::unfold(
-                        pool.pending_transactions_listener(),
-                        |mut rx| async move { rx.recv().await.map(|hash| (hash, rx)) },
-                    )
-                    .map(|hash| to_raw(&hash));
-                    let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
-                    return Ok(stream);
-                }
-
-                let api = self.eth.api.clone();
-                let pool = self.eth.api.pool().clone();
-                let stream = pool
-                    .new_pending_pool_transactions_listener()
-                    .map(move |pending_tx| {
-                        api.converter()
-                            .fill_pending(pending_tx.transaction.to_consensus())
-                            .map_err(internal)
-                            .and_then(|tx| to_raw(&tx))
-                    });
-                let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
-                return Ok(stream);
-            }
-
             let caller = auth.caller;
             let pool = self.eth.api.pool().clone();
 
@@ -947,7 +864,6 @@ where
             to_raw(&ZoneInfoResponse {
                 zone_id: U64::from(self.config.zone_id),
                 zone_tokens,
-                sequencer: self.config.sequencer,
                 chain_id: U64::from(self.config.chain_id),
             })
         })

--- a/crates/tempo-zone/tests/it/l1_e2e.rs
+++ b/crates/tempo-zone/tests/it/l1_e2e.rs
@@ -874,11 +874,11 @@ async fn test_encrypted_deposit_and_withdrawal() -> eyre::Result<()> {
     // Must start the zone BEFORE registering the encryption key, so the zone's
     // genesis anchor captures the current L1 block. The encryption key registration
     // and deposit happen in subsequent L1 blocks that the zone processes naturally.
-    let zone = ZoneTestNode::start_from_l1_with_sequencer_key(
+    let zone = ZoneTestNode::start_from_l1_with_sequencer_signer(
         l1.http_url(),
         l1.ws_url(),
         portal_address,
-        encryption_key.clone(),
+        alloy_signer_local::PrivateKeySigner::from_signing_key(encryption_key.clone().into()),
     )
     .await?;
 
@@ -1045,11 +1045,11 @@ async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
     );
 
     // --- Step 3: Start zone with sequencer key ---
-    let zone = ZoneTestNode::start_from_l1_with_sequencer_key(
+    let zone = ZoneTestNode::start_from_l1_with_sequencer_signer(
         l1.http_url(),
         l1.ws_url(),
         portal_address,
-        encryption_key.clone(),
+        alloy_signer_local::PrivateKeySigner::from_signing_key(encryption_key.clone().into()),
     )
     .await?;
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -620,7 +620,7 @@ async fn test_tip20_eth_call_privacy() -> eyre::Result<()> {
             "eth_call",
             serde_json::json!([
                 {
-                    "from": format!("{:#x}", ctx.config.sequencer),
+                    "from": format!("{:#x}", ctx.sequencer_signer.address()),
                     "to": format!("{PATH_USD_ADDRESS:#x}"),
                     "data": format!("0x{}", hex::encode(balance_call.abi_encode())),
                 },
@@ -644,7 +644,7 @@ async fn test_tip20_eth_call_privacy() -> eyre::Result<()> {
             "eth_call",
             serde_json::json!([
                 {
-                    "from": format!("{:#x}", ctx.config.sequencer),
+                    "from": format!("{:#x}", ctx.sequencer_signer.address()),
                     "to": format!("{PATH_USD_ADDRESS:#x}"),
                     "data": format!("0x{}", hex::encode(allowance_call.abi_encode())),
                 },
@@ -727,7 +727,7 @@ async fn test_simulation_validation_rejects_create_and_overrides() -> eyre::Resu
                 method,
                 json!([
                     {
-                        "from": format!("{:#x}", ctx.config.sequencer),
+                        "from": format!("{:#x}", ctx.sequencer_signer.address()),
                         "to": simulation_target.clone(),
                         "data": "0x"
                     },
@@ -867,7 +867,7 @@ async fn test_method_tiers() -> eyre::Result<()> {
     let resp = ctx
         .call_as_sequencer(
             "eth_getCode",
-            serde_json::json!([format!("{:#x}", ctx.config.sequencer), "latest"]),
+            serde_json::json!([format!("{:#x}", ctx.sequencer_signer.address()), "latest"]),
         )
         .await?;
     if let Some(error) = resp.get("error") {
@@ -1173,10 +1173,6 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
             .map(|token| token.as_str().unwrap())
             .collect::<Vec<_>>(),
         vec!["0x20c0000000000000000000000000000000000000"],
-    );
-    assert_eq!(
-        zone_info["result"]["sequencer"].as_str().unwrap(),
-        format!("{:#x}", ctx.config.sequencer),
     );
     assert_eq!(
         zone_info["result"]["chainId"].as_str().unwrap(),

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -374,7 +374,6 @@ impl ZoneTestNode {
             portal_address,
             None,
             next_unique_chain_id(),
-            Address::ZERO,
         )
         .await
     }
@@ -392,14 +391,14 @@ impl ZoneTestNode {
             build_l1_anchored_genesis(l1_http_url, portal_address).await?;
 
         let throwaway_key = k256::SecretKey::from_slice(&[0x01; 32]).expect("valid throwaway key");
+        let signer = alloy_signer_local::PrivateKeySigner::from_signing_key(throwaway_key.into());
         Self::launch_with_genesis(
             l1_ws_url.to_string(),
             portal_address,
             Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
-            Address::ZERO,
-            throwaway_key,
+            signer,
         )
         .await
     }
@@ -424,27 +423,27 @@ impl ZoneTestNode {
                 .await?;
 
         let throwaway_key = k256::SecretKey::from_slice(&[0x01; 32]).expect("valid throwaway key");
+        let signer = alloy_signer_local::PrivateKeySigner::from_signing_key(throwaway_key.into());
         Self::launch_with_genesis(
             l1_ws_url.to_string(),
             portal_address,
             Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
-            Address::ZERO,
-            throwaway_key,
+            signer,
         )
         .await
     }
 
     /// Start a zone node connected to a real L1, with a sequencer key for ECIES decryption.
     ///
-    /// Same as [`start_from_l1`] but passes the sequencer key through to `ZoneNode::new`
+    /// Same as [`start_from_l1`] but passes the sequencer signer through
     /// so the payload builder can decrypt encrypted deposits.
-    pub(crate) async fn start_from_l1_with_sequencer_key(
+    pub(crate) async fn start_from_l1_with_sequencer_signer(
         l1_http_url: &url::Url,
         l1_ws_url: &url::Url,
         portal_address: Address,
-        sequencer_key: k256::SecretKey,
+        sequencer_signer: alloy_signer_local::PrivateKeySigner,
     ) -> eyre::Result<Self> {
         let (genesis, genesis_block_number) =
             build_l1_anchored_genesis(l1_http_url, portal_address).await?;
@@ -455,8 +454,7 @@ impl ZoneTestNode {
             Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
-            Address::ZERO,
-            sequencer_key,
+            sequencer_signer,
         )
         .await
     }
@@ -473,7 +471,6 @@ impl ZoneTestNode {
             Address::ZERO,
             None,
             next_unique_chain_id(),
-            Address::ZERO,
         )
         .await
     }
@@ -488,7 +485,6 @@ impl ZoneTestNode {
             Address::ZERO,
             None,
             chain_id,
-            Address::ZERO,
         )
         .await
     }
@@ -498,18 +494,17 @@ impl ZoneTestNode {
         portal_address: Address,
         genesis_tempo_block_number: Option<u64>,
         chain_id: u64,
-        sequencer: Address,
     ) -> eyre::Result<Self> {
-        // Generate a throwaway key for tests that don't use encrypted deposits.
+        // Generate a throwaway signer for tests that don't use encrypted deposits.
         let throwaway_key = k256::SecretKey::from_slice(&[0x01; 32]).expect("valid throwaway key");
+        let signer = alloy_signer_local::PrivateKeySigner::from_signing_key(throwaway_key.into());
         Self::launch_with_genesis(
             l1_ws_url,
             portal_address,
             genesis_tempo_block_number,
             chain_id,
             None,
-            sequencer,
-            throwaway_key,
+            signer,
         )
         .await
     }
@@ -520,8 +515,7 @@ impl ZoneTestNode {
         genesis_tempo_block_number: Option<u64>,
         chain_id: u64,
         custom_genesis: Option<Genesis>,
-        sequencer: Address,
-        sequencer_key: k256::SecretKey,
+        sequencer_signer: alloy_signer_local::PrivateKeySigner,
     ) -> eyre::Result<Self> {
         let tasks = Runtime::test();
         let is_local_dummy_l1 = l1_ws_url == DUMMY_L1_URL;
@@ -537,12 +531,17 @@ impl ZoneTestNode {
             l1_ws_url,
             portal_address,
             genesis_tempo_block_number,
-            sequencer,
-            sequencer_key,
             4,
             std::time::Duration::from_millis(100),
         )
-        .with_initial_tokens(vec![]);
+        .with_initial_tokens(vec![])
+        .with_sequencer(zone::ZoneSequencerAddOnsConfig {
+            sequencer_signer,
+            zone_id: 0,
+            zone_poll_interval: std::time::Duration::from_secs(1),
+            batch_interval: std::time::Duration::from_secs(60),
+            withdrawal_poll_interval: std::time::Duration::from_secs(5),
+        });
 
         // Don't use .dev() — it spawns a LocalMiner that conflicts with ZoneEngine.
         // The ZoneEngine is the sole block producer; it advances the chain when L1
@@ -2809,7 +2808,6 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
         Address::ZERO,
         None,
         next_unique_chain_id(),
-        sequencer_address,
     )
     .await?;
     let fixture = L1Fixture::new();
@@ -2865,11 +2863,11 @@ async fn start_zone_with_private_rpc_l1_inner(
     let portal_address = l1.deploy_zone().await?;
 
     let zone = if let Some(key) = encryption_key.clone() {
-        ZoneTestNode::start_from_l1_with_sequencer_key(
+        ZoneTestNode::start_from_l1_with_sequencer_signer(
             l1.http_url(),
             l1.ws_url(),
             portal_address,
-            key,
+            alloy_signer_local::PrivateKeySigner::from_signing_key(key.into()),
         )
         .await?
     } else {

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -2825,7 +2825,6 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
         chain_id,
         max_auth_token_validity: zone::rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
         zone_portal: Address::ZERO,
-        sequencer: sequencer_address,
     };
 
     let private_rpc_url = start_private_rpc_url(&zone, config.clone()).await?;
@@ -2891,7 +2890,6 @@ async fn start_zone_with_private_rpc_l1_inner(
         chain_id,
         max_auth_token_validity: zone::rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
         zone_portal: portal_address,
-        sequencer: l1.dev_address(),
     };
 
     let private_rpc_url = start_private_rpc_url(&zone, config.clone()).await?;


### PR DESCRIPTION
This PR remove the `sequencer_key` and `sequencer` address from `ZoneNode` and derives them from `sequencer_config` when the sequencer is enabled. 