### PR TITLE
fix(tip403): ignore stale cache fallback writes

### DIFF
--- a/crates/tempo-zone/src/l1_state/tip403/cache.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/cache.rs
@@ -510,14 +510,39 @@ mod tests {
     }
 
     #[test]
-    fn policy_set_below_baseline_updates_directly() {
+    fn policy_set_at_or_below_baseline_is_ignored() {
         let mut set = PolicySet::default();
         set.record_status(USER_A, 10, true);
         set.advance(20);
 
-        // Set below baseline updates directly
+        // Delayed writes from finalized heights must not rewrite baseline membership.
         set.record_status(USER_A, 15, false);
-        assert!(!set.contains(USER_A, 20));
+        set.record_status(USER_A, 20, false);
+        assert!(set.contains(USER_A, 20));
+
+        // Stale writes must not mark unknown users as observed either.
+        set.record_status(USER_B, 15, false);
+        assert!(!set.is_known(&USER_B));
+
+        set.record_status(USER_A, 21, false);
+        assert!(!set.contains(USER_A, 21));
+    }
+
+    #[test]
+    fn policy_set_initial_baseline_write_is_ignored() {
+        let mut set = PolicySet::default();
+
+        set.record_status(USER_A, 0, false);
+        assert!(!set.is_known(&USER_A));
+        assert!(!set.contains(USER_A, 0));
+
+        set.record_status(USER_B, 0, true);
+        assert!(!set.is_known(&USER_B));
+        assert!(!set.contains(USER_B, 0));
+
+        set.record_status(USER_B, 1, true);
+        assert!(set.is_known(&USER_B));
+        assert!(set.contains(USER_B, 1));
     }
 
     // --- PolicyCacheInner tests: simple policies ---
@@ -529,6 +554,19 @@ mod tests {
         assert_eq!(
             cache.is_authorized(TOKEN, USER_A, 10, AuthRole::Transfer),
             Some(false)
+        );
+    }
+
+    #[test]
+    fn token_policy_seed_after_genesis_is_cached() {
+        let mut cache = PolicyCacheInner::default();
+
+        cache.set_token_policy(TOKEN, 1, 1);
+
+        assert_eq!(cache.get_token_policy(TOKEN, 1), Some(1));
+        assert_eq!(
+            cache.is_authorized(TOKEN, USER_A, 1, AuthRole::Transfer),
+            Some(true)
         );
     }
 
@@ -797,6 +835,72 @@ mod tests {
             cache.is_authorized(TOKEN, USER_A, 25, AuthRole::Transfer),
             Some(true)
         ); // unblacklisted at 20
+    }
+
+    #[test]
+    fn stale_membership_write_after_advance_cannot_poison_blacklist() {
+        let mut cache = PolicyCacheInner::default();
+        cache.set_token_policy(TOKEN, 10, 3);
+        cache.set_policy_type(3, PolicyType::BLACKLIST);
+        cache.set_policy_status(3, USER_A, 10, false);
+        cache.advance(10);
+
+        assert_eq!(
+            cache.is_authorized(TOKEN, USER_A, 10, AuthRole::Transfer),
+            Some(true)
+        );
+
+        cache.set_policy_status(3, USER_A, 12, true);
+        cache.advance(12);
+
+        assert_eq!(
+            cache.is_authorized(TOKEN, USER_A, 12, AuthRole::Transfer),
+            Some(false)
+        );
+
+        // Simulates an RPC fallback result captured before the block-12 blacklist event
+        // and returning after the engine advanced the cache baseline.
+        cache.set_policy_status(3, USER_A, 10, false);
+        cache.set_policy_status(3, USER_A, 12, false);
+
+        assert_eq!(
+            cache.is_authorized(TOKEN, USER_A, 13, AuthRole::Transfer),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn stale_membership_write_after_advance_does_not_mark_unknown_observed() {
+        let mut cache = PolicyCacheInner::default();
+        cache.set_token_policy(TOKEN, 10, 3);
+        cache.set_policy_type(3, PolicyType::BLACKLIST);
+        cache.advance(10);
+
+        cache.set_policy_status(3, USER_B, 10, false);
+
+        assert_eq!(
+            cache.is_authorized(TOKEN, USER_B, 10, AuthRole::Transfer),
+            None
+        );
+    }
+
+    #[test]
+    fn stale_token_policy_write_after_advance_cannot_revert_policy() {
+        let mut cache = PolicyCacheInner::default();
+        cache.set_token_policy(TOKEN, 10, 2);
+        cache.advance(10);
+
+        cache.set_token_policy(TOKEN, 12, 3);
+        cache.advance(12);
+
+        cache.set_token_policy(TOKEN, 10, 1);
+        cache.set_token_policy(TOKEN, 12, 1);
+
+        assert_eq!(cache.get_token_policy(TOKEN, 12), Some(3));
+        assert_eq!(cache.get_token_policy(TOKEN, 13), Some(3));
+
+        cache.set_token_policy(TOKEN, 13, 1);
+        assert_eq!(cache.get_token_policy(TOKEN, 13), Some(1));
     }
 
     #[test]

--- a/crates/tempo-zone/src/l1_state/tip403/policy_set.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/policy_set.rs
@@ -54,23 +54,23 @@ impl PolicySet {
     }
 
     /// Record a set update at the given block height.
+    ///
+    /// Updates at or below the baseline height are ignored. The baseline represents finalized
+    /// engine-consumed state and is only updated by [`advance`](Self::advance), which prevents
+    /// delayed RPC fallback results from overwriting newer event-derived membership.
     pub fn record_status(&mut self, user: Address, block_number: u64, in_set: bool) {
-        self.observed.insert(user);
         if block_number <= self.baseline_height {
-            if in_set {
-                self.baseline.insert(user);
-            } else {
-                self.baseline.remove(&user);
-            }
-        } else {
-            self.pending
-                .entry(block_number)
-                .or_default()
-                .push(PolicySetUpdate {
-                    account: user,
-                    in_set,
-                });
+            return;
         }
+
+        self.observed.insert(user);
+        self.pending
+            .entry(block_number)
+            .or_default()
+            .push(PolicySetUpdate {
+                account: user,
+                in_set,
+            });
     }
 
     /// Advance the baseline to `new_height`, folding pending deltas.

--- a/crates/tempo-zone/src/l1_state/versioned.rs
+++ b/crates/tempo-zone/src/l1_state/versioned.rs
@@ -61,14 +61,15 @@ impl<V: Copy> HeightVersioned<V> {
 
     /// Records a value at the given block height.
     ///
-    /// If `block_number` is at or below the baseline height, the baseline is updated directly.
-    /// Otherwise the value is stored in the pending map.
+    /// Values at or below the baseline height are ignored. The baseline represents finalized
+    /// engine-consumed state and is only updated by [`advance`](Self::advance), which prevents
+    /// delayed RPC fallback results from overwriting newer event-derived state.
     pub fn set(&mut self, block_number: u64, value: V) {
         if block_number <= self.baseline_height {
-            self.baseline = Some(value);
-        } else {
-            self.pending.insert(block_number, value);
+            return;
         }
+
+        self.pending.insert(block_number, value);
     }
 
     /// Advance the baseline to `new_height`, folding all pending entries up to that height.
@@ -195,14 +196,31 @@ mod tests {
     }
 
     #[test]
-    fn set_below_baseline_updates_baseline() {
+    fn set_at_or_below_baseline_is_ignored() {
         let mut v = HeightVersioned::default();
         v.set(10, 1u64);
         v.advance(20);
 
-        // Setting at or below baseline updates it directly
+        // Delayed writes from finalized heights must not rewrite the baseline.
         v.set(15, 99);
-        assert_eq!(v.get(20), Some(99));
+        v.set(20, 100);
+        assert_eq!(v.get(20), Some(1));
+
+        v.set(21, 2);
+        assert_eq!(v.get(21), Some(2));
+    }
+
+    #[test]
+    fn set_at_initial_baseline_is_ignored() {
+        let mut v = HeightVersioned::default();
+
+        v.set(0, 1u64);
+
+        assert_eq!(v.get(0), None);
+        assert_eq!(v.get(10), None);
+
+        v.set(1, 1);
+        assert_eq!(v.get(1), Some(1));
     }
 
     #[test]

--- a/crates/tempo-zone/src/payload/builder.rs
+++ b/crates/tempo-zone/src/payload/builder.rs
@@ -110,7 +110,6 @@ where
             mut cached_reads,
             config,
             cancel,
-            best_payload: _,
             ..
         } = args;
         let PayloadConfig {

--- a/crates/tempo-zone/tests/it/l1_e2e.rs
+++ b/crates/tempo-zone/tests/it/l1_e2e.rs
@@ -1069,10 +1069,7 @@ async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
         // holding a parking_lot guard across an await point.
         let l1_block = l1.provider().get_block_number().await?;
         let mut cache = policy_cache.write();
-        cache.set_token_policy(PATH_USD_ADDRESS, 0, policy_id);
         cache.set_policy_type(policy_id, PolicyType::BLACKLIST);
-        cache.set_policy_status(policy_id, blacklisted_recipient, 0, true);
-        // Also seed for current and future blocks
         cache.set_token_policy(PATH_USD_ADDRESS, l1_block, policy_id);
         cache.set_policy_status(policy_id, blacklisted_recipient, l1_block, true);
     }
@@ -1215,7 +1212,6 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
 
         let l1_block = l1.provider().get_block_number().await?;
         let mut cache = zone.policy_cache().write();
-        cache.set_token_policy(PATH_USD_ADDRESS, 0, compound_policy_id);
         cache.set_token_policy(PATH_USD_ADDRESS, l1_block, compound_policy_id);
         cache.set_policy_type(compound_policy_id, PolicyType::COMPOUND);
         cache.set_compound(
@@ -1227,7 +1223,6 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
             },
         );
         cache.set_policy_type(sender_policy_id, PolicyType::BLACKLIST);
-        cache.set_policy_status(sender_policy_id, alice, 0, true);
         cache.set_policy_status(sender_policy_id, alice, l1_block, true);
     }
 

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -129,9 +129,14 @@ const DUMMY_L1_URL: &str = "http://127.0.0.1:1";
 /// (allow all), and local tests rely on that behavior for outbox `transferFrom`
 /// flows.
 fn seed_local_policy_cache(policy_cache: &zone::PolicyCache) {
-    policy_cache
-        .write()
-        .set_token_policy(PATH_USD_ADDRESS, 0, ALLOW_ALL_POLICY_ID);
+    const LOCAL_POLICY_CACHE_SEED_BLOCK: u64 = 1;
+
+    policy_cache.set_last_l1_block(LOCAL_POLICY_CACHE_SEED_BLOCK);
+    policy_cache.write().set_token_policy(
+        PATH_USD_ADDRESS,
+        LOCAL_POLICY_CACHE_SEED_BLOCK,
+        ALLOW_ALL_POLICY_ID,
+    );
 }
 
 /// Compute the TIP-20 token address for a given sender and salt.
@@ -2263,10 +2268,7 @@ pub(crate) async fn start_local_zone_with_fixture(
 
     // Local tests have no real L1, so the RPC fallback in resolve_transfer_policy_id
     // fails. Seed pathUSD with the default allow-all policy (mirrors L1 default).
-    use tempo_precompiles::{PATH_USD_ADDRESS, tip403_registry::ALLOW_ALL_POLICY_ID};
-    zone.policy_cache()
-        .write()
-        .set_token_policy(PATH_USD_ADDRESS, 0, ALLOW_ALL_POLICY_ID);
+    seed_local_policy_cache(zone.policy_cache());
 
     fixture.seed_l1_cache(
         zone.l1_state_cache(),


### PR DESCRIPTION
## Summary

TIP-403 policy cache writes now treat the advanced baseline as finalized state. Delayed RPC fallback results at or below a versioned entry's baseline height are discarded instead of mutating the baseline, so a prefetch or synchronous fallback that started before a later L1 policy event cannot overwrite the event-derived state after the engine advances.

This applies to both token-to-policy `HeightVersioned` entries and simple policy `MembershipSet` entries. Membership stale writes are rejected before touching `observed`, which keeps future cache misses able to fall back to L1 instead of permanently trusting stale negative membership observations.

The regression coverage models stale blacklist membership and stale token-policy fallback writes returning after `advance()`, plus the lower-level versioned primitive behavior.