### PR TITLE
spec: portal deposit TIP-403 policy + escrow on block

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -279,9 +279,10 @@ A user deposits by calling `deposit(token, to, amount, memo, bouncebackRecipient
 2. Requires `bouncebackRecipient != address(0)` (reverts otherwise).
 3. Snapshots the deposit fee at the current `zoneGasRate` and the bounce-back fee at the current portal-side `tempoGasRate` (see [Deposit Fees](#deposit-fees)), and requires `amount >= depositFee + bouncebackFee` (reverts `DepositTooSmall` otherwise). The bounce-back fee covers the worst-case Tempo gas of paying out a refund (including new-account creation for `bouncebackRecipient`), so it is priced in Tempo gas, not zone gas.
 4. Transfers `amount` from the user into the portal.
-5. Pays the `depositFee` to the sequencer immediately. The `bouncebackFee` is reserved on the queued entry; it is only consumed if the deposit later bounces back.
-6. Appends the deposit to the deposit queue hash chain with the net amount (`amount - depositFee`), `bouncebackRecipient`, and the snapshotted `bouncebackFee`.
-7. Emits `DepositMade`.
+5. Enforces the portal's deposit-side TIP-403 policy on `msg.sender` via `isAuthorizedSender(depositPolicyId, msg.sender)` (see [Policy Enforcement on Zones](#policy-enforcement-on-zones)). If the depositor is blocked the portal does **not** revert: it credits `amount` to `_refunds[token][bouncebackRecipient]`, emits `DepositBlocked`, and returns. No fee is charged, the deposit is not enqueued, and `bouncebackRecipient` can later pull the funds via `claimRefund(token)`. This keeps `deposit(...)` callable from contracts that rely on it returning success (analogous to TIP-1028's escrow path for receiver-side blocks). See [Deposit Failures and Bounce-Back](#deposit-failures-and-bounce-back) for the full refund-registry semantics.
+6. Pays the `depositFee` to the sequencer immediately. The `bouncebackFee` is reserved on the queued entry; it is only consumed if the deposit later bounces back.
+7. Appends the deposit to the deposit queue hash chain with the net amount (`amount - depositFee`), `bouncebackRecipient`, and the snapshotted `bouncebackFee`.
+8. Emits `DepositMade`.
 
 The sequencer observes `DepositMade` events and relays deposits to the zone via `ZoneInbox.advanceTempo()`. This function processes deposits in order, minting the zone-side TIP-20 token to each recipient: `mint(deposit.to, deposit.amount)`.
 
@@ -409,12 +410,13 @@ sequenceDiagram
 
 ### Deposit Failures and Bounce-Back
 
-Deposits can fail for three main reasons: a recipient blocked by the TIP-403 policy, an invalid encrypted deposit, or rejection by the sequencer. To make sure that all cases can be handled without loss of user funds, every deposit carries a `bouncebackRecipient`: a Tempo address that receives a refund if zone-side processing fails.
+Deposits can fail for four main reasons: the portal's `depositPolicyId` blocks the depositor at deposit time, the zone-side mint reverts (e.g. the recipient is blocked by the token's TIP-403 policy), an invalid encrypted deposit, or rejection by the sequencer. To make sure that all cases can be handled without loss of user funds, every deposit carries a `bouncebackRecipient`: a Tempo address that owns the refund slot for any of these failure modes.
 
 **Validation at deposit time.** Both `deposit(...)` and `depositEncrypted(...)` require `bouncebackRecipient != address(0)` and revert otherwise (`MissingBouncebackRecipient`). The portal does **not** validate `bouncebackRecipient` against the token's TIP-403 policy at deposit time; if the on-Tempo refund transfer is later rejected by the policy, the funds are parked in a per-recipient refund registry on the portal and the recipient claims them via `claimRefund(token)` (see [Tempo-side refund](#tempo-side-refund) below).
 
-**Triggering conditions.** There are three triggering sites:
+**Triggering conditions.** There are four triggering sites:
 
+- **Deposit-time portal policy block.** `ZonePortal.deposit(...)` and `ZonePortal.depositEncrypted(...)` enforce `isAuthorizedSender(depositPolicyId, msg.sender)` after pulling the funds from the depositor (see [Portal deposit policy](#portal-deposit-policy)). On a block the portal does **not** revert: it credits `_refunds[token][bouncebackRecipient] += amount`, emits `DepositBlocked`, and returns. No fee is charged, no zone-side processing happens, and the deposit is never enqueued — the funds are recoverable from Tempo directly via `claimRefund(token)`. This is the only failure path that doesn't round-trip through the zone.
 - **Regular deposit, mint reverts.** `ZoneInbox.advanceTempo` calls `TIP20.mint(deposit.to, deposit.amount)`. If that mint reverts the deposit bounces back to the user-supplied `bouncebackRecipient`. The user-facing `deposit(...)` entry point ensures `bouncebackRecipient != address(0)`, so the queue can always advance past a failed mint.
 - **Encrypted deposit.** Two failure modes, both of which unconditionally bounce back (no zone-side mint is attempted as a fallback):
   - **Invalid encryption.** The Chaum-Pedersen proof, AES-GCM tag, or plaintext comparison fails during [Onchain Decryption Verification](#onchain-decryption-verification). There is no well-defined recipient on the zone in this case, so the zone does not try to mint to the depositor; it bounces back immediately.
@@ -725,6 +727,12 @@ Zones inherit compliance policies from Tempo automatically. Token issuers set tr
 The zone has a `TIP403Registry` deployed at the same address as on Tempo. This contract is read-only and does not support writing policies. Its `isAuthorized` function reads policy state from Tempo via `TempoState.readTempoStorageSlot()`.
 
 Zone-side TIP-20 transfers check `isAuthorized(policyId, from)` and `isAuthorized(policyId, to)` before executing. If either check fails, the transfer reverts.
+
+#### Portal deposit policy
+
+The portal applies an additional sequencer-controlled TIP-403 policy to depositors. The sequencer sets `ZonePortal.depositPolicyId` via `setDepositPolicyId(uint64)` (emitting `DepositPolicyUpdated`); both `deposit(...)` and `depositEncrypted(...)` always enforce it via `TIP403Registry.isAuthorizedSender(depositPolicyId, msg.sender)`. The default at zone genesis is policy 1, the TIP-403 registry's built-in empty BLACKLIST that authorizes every sender, so deposits work out of the box. The sequencer can switch to any other policy id (including policy 0, the built-in empty WHITELIST, to halt all deposits) without redeploying. This is independent of the per-token TIP-403 transfer policy that `transferFrom` already enforces.
+
+Unlike a token-level TIP-403 rejection, a depositor blocked by `depositPolicyId` does **not** cause `deposit()` / `depositEncrypted()` to revert. The funds are pulled into the portal as for a normal deposit, then credited to `_refunds[token][bouncebackRecipient]` and surfaced via the `DepositBlocked` event; `bouncebackRecipient` recovers them via `claimRefund(token)`. The escrow path follows TIP-1028's design philosophy: don't break callers (especially contracts) that rely on `deposit()` returning success — give them an event-driven recovery path instead. The trade-off is that the portal's deposit policy provides liveness, not asset confiscation: a blocked depositor can name any unblocked address as `bouncebackRecipient` and pull the funds straight back. Sanctions-style asset freeze on the portal is out of scope for this mechanism.
 
 ### Policy Inheritance
 
@@ -1509,6 +1517,10 @@ interface IZonePortal {
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
     event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock);
     event ZoneGasRateUpdated(uint128 zoneGasRate);
+    event DepositPolicyUpdated(uint64 depositPolicyId);
+    event DepositBlocked(
+        address indexed token, address indexed sender, uint128 amount, uint64 depositPolicyId
+    );
     event TempoGasRateUpdated(uint128 tempoGasRate);
     event TokenEnabled(address indexed token, string name, string symbol, string currency);
     event DepositsPaused(address indexed token);
@@ -1568,6 +1580,11 @@ interface IZonePortal {
     function transferSequencer(address newSequencer) external;
     function acceptSequencer() external;
     function setZoneGasRate(uint128 _zoneGasRate) external;
+    /// @notice Sequencer-controlled TIP-403 policy applied to every depositor.
+    ///         Defaults to policy 1 (built-in allow-all); set policy 0 (built-in
+    ///         empty WHITELIST) to halt all deposits, or any custom policy id.
+    function setDepositPolicyId(uint64 _depositPolicyId) external;
+    function depositPolicyId() external view returns (uint64);
     /// @notice Set the canonical Tempo gas rate. Used to price both deposit-bounce-back
     ///         fees on Tempo and withdrawal fees on Tempo (the latter is read by the
     ///         zone via the TempoState predeploy).


### PR DESCRIPTION
## Summary

Spec-only change. Adds a sequencer-controlled, portal-level TIP-403 policy that is enforced on the **depositor** (`msg.sender`) of every `ZonePortal.deposit` / `depositEncrypted` call, with a TIP-1028-style escrow path on block instead of a revert.

Stacked on #428 (deposit-bounceback spec) and shares its refund registry. The Solidity / Rust implementation lives in #429, which is the common implementation PR for both this policy and the bounceback spec from #428.

## Design

- **`depositPolicyId`** — sequencer-controlled `uint64` on `ZonePortal`, set via `setDepositPolicyId(uint64)` (emits `DepositPolicyUpdated`).
- **Default = policy 1** — the TIP-403 registry's built-in empty BLACKLIST (allow-all), so deposits work out of the box without the sequencer doing anything.
- **Policy 0 halts deposits** — built-in empty WHITELIST (reject-all). Independent of the per-token `pauseDeposits` flag, which remains for token-specific control.
- **Always enforced** — both `deposit` and `depositEncrypted` call `TIP403Registry.isAuthorizedSender(depositPolicyId, msg.sender)` after pulling the funds.
- **Escrow on block (no revert).** When the sender fails the policy:
  - Funds stay in the portal and are credited to `_refunds[token][bouncebackRecipient]` (the same registry from #428).
  - `DepositBlocked(token, sender, amount, depositPolicyId)` is emitted.
  - No fee is charged, the deposit is not enqueued, and `bouncebackRecipient` recovers via `claimRefund(token)`.
- This keeps `deposit(...)` callable from contracts that rely on it returning success (analogous to TIP-1028's escrow path for receiver-side blocks). The trade-off is documented: the portal policy provides liveness, not asset confiscation — a blocked depositor can name any unblocked address as `bouncebackRecipient` and pull the funds back.

## Spec changes (`specs/spec.md`)

- **Regular Deposits** flow: new step 5 describing the sender check, escrow on block, and `DepositBlocked` emission. Remaining steps renumbered.
- **Deposit Failures and Bounce-Back**: extends the failure catalogue from three to four modes; new bullet for the deposit-time portal policy block (the only failure path that doesn't round-trip through the zone).
- **Policy Enforcement on Zones**: new *Portal deposit policy* subsection covering the setter, the policy-1 / policy-0 sentinels, and the liveness-not-confiscation trade-off vs. token-level TIP-403.
- **`IZonePortal` stub**: adds `event DepositPolicyUpdated`, `event DepositBlocked`, `setDepositPolicyId`, `depositPolicyId()`. Reuses `refunds` / `claimRefund` / `RefundClaimed` from #428.

No Solidity, Rust, or test changes here — those go in #429.

## Test plan

- [ ] CI on `dankrad/deposit-policy-check` (markdown lint / link check / typos).
- [ ] Implementation + tests land on #429.
