### PR TITLE
chore: rename `PolicyCache`

### DIFF
--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -53,7 +53,7 @@ pub struct L1SubscriberConfig {
     /// Shared TIP-403 policy cache. The subscriber applies policy events
     /// extracted from L1 receipts directly into this cache before enqueuing
     /// blocks.
-    pub policy_cache: crate::l1_state::tip403::SharedPolicyCache,
+    pub policy_cache: crate::l1_state::tip403::PolicyCache,
     /// Shared L1 state cache. The subscriber updates the cache anchor on each
     /// confirmed block and clears it on reorgs.
     pub l1_state_cache: crate::l1_state::cache::SharedL1StateCache,
@@ -1823,7 +1823,7 @@ mod tests {
                 l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
                 portal_address,
                 genesis_tempo_block_number,
-                policy_cache: crate::SharedPolicyCache::default(),
+                policy_cache: crate::PolicyCache::default(),
                 l1_state_cache: crate::SharedL1StateCache::new(HashSet::from([portal_address])),
                 l1_fetch_concurrency: 1,
                 retry_connection_interval: Duration::from_secs(1),

--- a/crates/tempo-zone/src/l1_state/mod.rs
+++ b/crates/tempo-zone/src/l1_state/mod.rs
@@ -17,6 +17,6 @@ pub use cache::{L1StateCache, SharedL1StateCache};
 pub use precompile::TempoStateReader;
 pub use provider::{L1StateProvider, L1StateProviderConfig};
 pub use tip403::{
-    AuthRole, PolicyCacheInner, PolicyEvent, PolicyProvider, PolicyTaskHandle, PolicyTaskMessage,
-    PolicyCache, Tip403Metrics, spawn_policy_resolution_task, spawn_pool_prefetch_task,
+    AuthRole, PolicyCache, PolicyCacheInner, PolicyEvent, PolicyProvider, PolicyTaskHandle,
+    PolicyTaskMessage, Tip403Metrics, spawn_policy_resolution_task, spawn_pool_prefetch_task,
 };

--- a/crates/tempo-zone/src/l1_state/mod.rs
+++ b/crates/tempo-zone/src/l1_state/mod.rs
@@ -17,6 +17,6 @@ pub use cache::{L1StateCache, SharedL1StateCache};
 pub use precompile::TempoStateReader;
 pub use provider::{L1StateProvider, L1StateProviderConfig};
 pub use tip403::{
-    AuthRole, PolicyCache, PolicyEvent, PolicyProvider, PolicyTaskHandle, PolicyTaskMessage,
-    SharedPolicyCache, Tip403Metrics, spawn_policy_resolution_task, spawn_pool_prefetch_task,
+    AuthRole, PolicyCacheInner, PolicyEvent, PolicyProvider, PolicyTaskHandle, PolicyTaskMessage,
+    PolicyCache, Tip403Metrics, spawn_policy_resolution_task, spawn_pool_prefetch_task,
 };

--- a/crates/tempo-zone/src/l1_state/tip403/cache.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/cache.rs
@@ -17,7 +17,7 @@
 //! ## Special policies
 //!
 //! Policy ID `0` always rejects, policy ID `1` always allows. These are handled inline by
-//! [`PolicyCache::is_authorized`] without any storage lookups.
+//! [`PolicyCacheInner::is_authorized`] without any storage lookups.
 //!
 //! ## Default membership
 //!
@@ -29,12 +29,12 @@
 //! ## Compound policies (TIP-1015)
 //!
 //! A compound policy delegates authorization to sub-policies based on the user's role
-//! (sender, recipient, or mint recipient). The [`is_authorized`](PolicyCache::is_authorized)
+//! (sender, recipient, or mint recipient). The [`is_authorized`](PolicyCacheInner::is_authorized)
 //! method accepts an [`AuthRole`] to resolve the correct sub-policy.
 //!
 //! ## Reorg handling
 //!
-//! On reorgs the caller is expected to [`PolicyCache::clear`] the entire cache. There is no
+//! On reorgs the caller is expected to [`PolicyCacheInner::clear`] the entire cache. There is no
 //! per-block rollback.
 
 use alloy_primitives::Address;
@@ -54,6 +54,81 @@ use super::builtin_authorization;
 
 use crate::l1_state::versioned::HeightVersioned;
 
+/// Thread-safe TIP-403 policy cache backed by an `Arc<RwLock<PolicyCacheInner>>`.
+#[derive(Debug, Clone, Deref, Default)]
+pub struct PolicyCache {
+    #[deref]
+    inner: Arc<RwLock<PolicyCacheInner>>,
+}
+
+impl PolicyCache {
+    /// Returns the last L1 block number tracked by the cache.
+    pub fn last_l1_block(&self) -> u64 {
+        self.read().last_l1_block()
+    }
+
+    /// Seeds the cache with the initial L1 block height so RPC fallback queries
+    /// target the correct block before the subscriber has processed any events.
+    pub fn set_last_l1_block(&self, block_number: u64) {
+        self.write().set_last_l1_block(block_number);
+    }
+
+    /// Collapse versioned entries up to `block_number`.
+    ///
+    /// Called by the engine after successfully processing an L1 block. Only the
+    /// engine should drive this — the subscriber must not advance past blocks the
+    /// engine hasn't consumed yet.
+    pub fn advance(&self, block_number: u64) {
+        self.write().advance(block_number);
+    }
+
+    /// Query the current `transferPolicyId` for each tracked token and seed it
+    /// into the cache. This ensures the cache knows about tokens that have never
+    /// had a `TransferPolicyUpdate` event (i.e. still using the default policy).
+    ///
+    /// Fails if any token's `transferPolicyId` cannot be resolved — all enabled
+    /// tokens must be seeded for the zone to enforce policies correctly.
+    pub async fn seed_token_policies(
+        &self,
+        portal_address: Address,
+        tracked_tokens: &[Address],
+        provider: &DynProvider<TempoNetwork>,
+    ) -> eyre::Result<()> {
+        use tempo_contracts::precompiles::ITIP20;
+
+        let block_number = self.last_l1_block();
+
+        let seeded = futures::future::join_all(tracked_tokens.iter().map(|token| {
+            let tip20 = ITIP20::new(*token, provider);
+            async move {
+                let policy_id = tip20
+                    .transferPolicyId()
+                    .block(alloy_rpc_types_eth::BlockId::number(block_number))
+                    .call()
+                    .await
+                    .map_err(|e| {
+                        eyre::eyre!(
+                            "failed to seed transferPolicyId for token {token} \
+                             (portal {portal_address}): {e}"
+                        )
+                    })?;
+                Ok::<_, eyre::Report>((*token, policy_id))
+            }
+        }))
+        .await
+        .into_iter()
+        .collect::<eyre::Result<Vec<_>>>()?;
+
+        let mut w = self.write();
+        for (token, policy_id) in seeded {
+            info!(%token, policy_id, block_number, "Seeded token policy from L1");
+            w.set_token_policy(token, block_number, policy_id);
+        }
+
+        Ok(())
+    }
+}
+
 /// Block-versioned cache of TIP-403 policy state from Tempo L1.
 ///
 /// Mirrors the on-chain `TIP403Registry` storage layout with:
@@ -62,7 +137,7 @@ use crate::l1_state::versioned::HeightVersioned;
 ///
 /// This allows the zone sequencer to evaluate transfer authorization without RPC round-trips.
 #[derive(Debug, Default)]
-pub struct PolicyCache {
+pub struct PolicyCacheInner {
     /// Per-token transfer policy ID.
     tokens: HashMap<Address, HeightVersioned<u64>>,
     /// Per-policy-ID records (type, membership, compound data).
@@ -84,7 +159,7 @@ pub struct PolicyCache {
     last_l1_block: u64,
 }
 
-impl PolicyCache {
+impl PolicyCacheInner {
     /// Returns the `transferPolicyId` for a token at the given block, or `None` if not cached.
     pub fn get_token_policy(&self, token: Address, block_number: u64) -> Option<u64> {
         self.tokens.get(&token)?.get(block_number)
@@ -352,89 +427,11 @@ impl PolicyCache {
     }
 }
 
-/// Shared handle to the policy cache.
-#[derive(Debug, Clone, Deref)]
-pub struct SharedPolicyCache(Arc<RwLock<PolicyCache>>);
-
-impl Default for SharedPolicyCache {
-    fn default() -> Self {
-        Self(Arc::new(RwLock::new(PolicyCache::default())))
-    }
-}
-
-impl SharedPolicyCache {
-    /// Returns the last L1 block number tracked by the cache.
-    pub fn last_l1_block(&self) -> u64 {
-        self.read().last_l1_block()
-    }
-
-    /// Seeds the cache with the initial L1 block height so RPC fallback queries
-    /// target the correct block before the subscriber has processed any events.
-    pub fn set_last_l1_block(&self, block_number: u64) {
-        self.write().set_last_l1_block(block_number);
-    }
-
-    /// Collapse versioned entries up to `block_number`.
-    ///
-    /// Called by the engine after successfully processing an L1 block. Only the
-    /// engine should drive this — the subscriber must not advance past blocks the
-    /// engine hasn't consumed yet.
-    pub fn advance(&self, block_number: u64) {
-        self.write().advance(block_number);
-    }
-
-    /// Query the current `transferPolicyId` for each tracked token and seed it
-    /// into the cache. This ensures the cache knows about tokens that have never
-    /// had a `TransferPolicyUpdate` event (i.e. still using the default policy).
-    ///
-    /// Fails if any token's `transferPolicyId` cannot be resolved — all enabled
-    /// tokens must be seeded for the zone to enforce policies correctly.
-    pub async fn seed_token_policies(
-        &self,
-        portal_address: Address,
-        tracked_tokens: &[Address],
-        provider: &DynProvider<TempoNetwork>,
-    ) -> eyre::Result<()> {
-        use tempo_contracts::precompiles::ITIP20;
-
-        let block_number = self.last_l1_block();
-
-        let seeded = futures::future::join_all(tracked_tokens.iter().map(|token| {
-            let tip20 = ITIP20::new(*token, provider);
-            async move {
-                let policy_id = tip20
-                    .transferPolicyId()
-                    .block(alloy_rpc_types_eth::BlockId::number(block_number))
-                    .call()
-                    .await
-                    .map_err(|e| {
-                        eyre::eyre!(
-                            "failed to seed transferPolicyId for token {token} \
-                             (portal {portal_address}): {e}"
-                        )
-                    })?;
-                Ok::<_, eyre::Report>((*token, policy_id))
-            }
-        }))
-        .await
-        .into_iter()
-        .collect::<eyre::Result<Vec<_>>>()?;
-
-        let mut w = self.write();
-        for (token, policy_id) in seeded {
-            info!(%token, policy_id, block_number, "Seeded token policy from L1");
-            w.set_token_policy(token, block_number, policy_id);
-        }
-
-        Ok(())
-    }
-}
-
 /// A decoded L1 policy event ready to be applied to the cache.
 ///
 /// The [`L1Subscriber`](crate::l1::L1Subscriber) decodes raw logs into these events
 /// outside the cache write lock, then applies them in batch via
-/// [`PolicyCache::apply_events`].
+/// [`PolicyCacheInner::apply_events`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum PolicyEvent {
@@ -833,11 +830,11 @@ mod tests {
         assert!(!set.is_member(USER_A, 20));
     }
 
-    // --- PolicyCache tests: simple policies ---
+    // --- PolicyCacheInner tests: simple policies ---
 
     #[test]
     fn special_policy_always_reject() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 0);
         assert_eq!(
             cache.is_authorized(TOKEN, USER_A, 10, AuthRole::Transfer),
@@ -847,7 +844,7 @@ mod tests {
 
     #[test]
     fn special_policy_always_allow() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 1);
         assert_eq!(
             cache.is_authorized(TOKEN, USER_A, 10, AuthRole::Transfer),
@@ -857,7 +854,7 @@ mod tests {
 
     #[test]
     fn whitelist_authorized_when_in_set() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
@@ -875,7 +872,7 @@ mod tests {
 
     #[test]
     fn blacklist_authorized_when_not_in_set() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 3);
         cache.set_policy_type(3, PolicyType::BLACKLIST);
         cache.set_member(3, USER_A, 10, true);
@@ -893,7 +890,7 @@ mod tests {
 
     #[test]
     fn blacklist_unknown_user_returns_none() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 3);
         cache.set_policy_type(3, PolicyType::BLACKLIST);
 
@@ -906,7 +903,7 @@ mod tests {
 
     #[test]
     fn whitelist_unknown_user_returns_none() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
 
@@ -919,7 +916,7 @@ mod tests {
 
     #[test]
     fn returns_none_on_missing_token_policy() {
-        let cache = PolicyCache::default();
+        let cache = PolicyCacheInner::default();
         assert_eq!(
             cache.is_authorized(TOKEN, USER_A, 10, AuthRole::Transfer),
             None
@@ -928,7 +925,7 @@ mod tests {
 
     #[test]
     fn returns_none_on_missing_policy_type() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 5);
         assert_eq!(
             cache.is_authorized(TOKEN, USER_A, 10, AuthRole::Transfer),
@@ -938,7 +935,7 @@ mod tests {
 
     #[test]
     fn block_versioned_policy_change() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 1);
         cache.set_token_policy(TOKEN, 20, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
@@ -968,7 +965,7 @@ mod tests {
 
     #[test]
     fn block_versioned_membership_change() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, false);
@@ -986,7 +983,7 @@ mod tests {
 
     #[test]
     fn clear_removes_all_data() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
@@ -1001,7 +998,7 @@ mod tests {
 
     #[test]
     fn flatten_keeps_baseline() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 5, 1);
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_token_policy(TOKEN, 20, 3);
@@ -1017,7 +1014,7 @@ mod tests {
 
     #[test]
     fn shared_policy_across_tokens() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         let token2: Address = address!("0x20C0000000000000000000000000000000000001");
 
         // Two tokens share policy 2
@@ -1039,7 +1036,7 @@ mod tests {
 
     #[test]
     fn shared_blacklist_across_tokens() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         let token2: Address = address!("0x20C0000000000000000000000000000000000001");
 
         cache.set_token_policy(TOKEN, 10, 2);
@@ -1069,7 +1066,7 @@ mod tests {
 
     #[test]
     fn tokens_with_different_policies() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         let token2: Address = address!("0x20C0000000000000000000000000000000000001");
 
         cache.set_token_policy(TOKEN, 10, 2);
@@ -1093,7 +1090,7 @@ mod tests {
 
     #[test]
     fn advance_then_lookup() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::BLACKLIST);
         cache.set_member(2, USER_A, 10, true);
@@ -1114,7 +1111,7 @@ mod tests {
 
     #[test]
     fn flatten_preserves_token_entries() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         let token2: Address = address!("0x20C0000000000000000000000000000000000001");
 
         cache.set_token_policy(TOKEN, 10, 2);
@@ -1129,7 +1126,7 @@ mod tests {
 
     #[test]
     fn policy_change_mid_block_range() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
 
         // Start with whitelist at block 10, switch to blacklist policy at block 20
         cache.set_token_policy(TOKEN, 10, 2);
@@ -1155,7 +1152,7 @@ mod tests {
 
     #[test]
     fn compound_policy_sender_check() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         // Simple sub-policies
         cache.set_policy_type(2, PolicyType::BLACKLIST); // sender policy
         cache.set_policy_type(3, PolicyType::WHITELIST); // recipient policy
@@ -1189,7 +1186,7 @@ mod tests {
 
     #[test]
     fn compound_policy_transfer_checks_both() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_policy_type(2, PolicyType::WHITELIST); // sender
         cache.set_policy_type(3, PolicyType::WHITELIST); // recipient
 
@@ -1226,7 +1223,7 @@ mod tests {
 
     #[test]
     fn compound_policy_with_builtin_sub_policies() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         // Compound: sender=allow(1), recipient=reject(0), mint=allow(1)
         cache.set_compound(
             5,
@@ -1259,7 +1256,7 @@ mod tests {
 
     #[test]
     fn compound_returns_none_when_sub_policy_missing() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         // Compound references sub-policy 99 which doesn't exist
         cache.set_compound(
             5,
@@ -1279,7 +1276,7 @@ mod tests {
 
     #[test]
     fn compound_returns_none_when_compound_data_missing() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         // Policy 5 has COMPOUND type but no compound data set
         cache.set_policy_type(5, PolicyType::COMPOUND);
         cache.set_token_policy(TOKEN, 10, 5);
@@ -1292,7 +1289,7 @@ mod tests {
 
     #[test]
     fn apply_events_with_policy_created() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         let events = vec![
             PolicyEvent::PolicyCreated {
                 policy_id: 2,
@@ -1326,7 +1323,7 @@ mod tests {
 
     #[test]
     fn observed_survives_advance() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
@@ -1355,7 +1352,7 @@ mod tests {
 
     #[test]
     fn observed_survives_advance_for_removed_member() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
 
@@ -1375,7 +1372,7 @@ mod tests {
 
     #[test]
     fn observed_survives_advance_blacklist() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::BLACKLIST);
         cache.set_member(2, USER_A, 10, true); // blacklisted
@@ -1397,7 +1394,7 @@ mod tests {
 
     #[test]
     fn clear_resets_observed() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 10, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
         cache.set_member(2, USER_A, 10, true);
@@ -1444,7 +1441,7 @@ mod tests {
 
     #[test]
     fn multiple_advances_preserve_observed() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         cache.set_token_policy(TOKEN, 5, 2);
         cache.set_policy_type(2, PolicyType::WHITELIST);
 
@@ -1477,7 +1474,7 @@ mod tests {
 
     #[test]
     fn apply_events_with_compound_policy() {
-        let mut cache = PolicyCache::default();
+        let mut cache = PolicyCacheInner::default();
         // Pre-populate simple sub-policies
         cache.set_policy_type(2, PolicyType::BLACKLIST);
         cache.set_policy_type(3, PolicyType::WHITELIST);

--- a/crates/tempo-zone/src/l1_state/tip403/mod.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/mod.rs
@@ -69,7 +69,7 @@ pub mod provider;
 pub mod task;
 
 pub use cache::{
-    CachedPolicy, CompoundData, MembershipSet, PolicyCacheInner, PolicyEvent, PolicyCache,
+    CachedPolicy, CompoundData, MembershipSet, PolicyCache, PolicyCacheInner, PolicyEvent,
 };
 use tempo_precompiles::tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID};
 pub use zone_primitives::policy::AuthRole;

--- a/crates/tempo-zone/src/l1_state/tip403/mod.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module tracks TIP-403 transfer policy state from Tempo L1:
 //!
-//! - [`PolicyCache`] — block-versioned in-memory cache of policy data.
+//! - [`PolicyCacheInner`] — block-versioned in-memory cache of policy data.
 //! - [`PolicyProvider`] — cache-first, RPC-fallback authorization provider.
 //! - [`PolicyResolutionTask`] — background task for pre-fetching authorization data.
 //!
@@ -18,7 +18,7 @@
 //!                  |              |          |
 //!            write |         read |          |
 //!                  v              |          |
-//!           SharedPolicyCache-----+     engine + EVM
+//!           PolicyCache-----+     engine + EVM
 //!                  ^                        ^
 //!                  |                        | pre-fetch
 //!             seed (startup)    pool_prefetch + ResolutionTask
@@ -26,20 +26,20 @@
 //!
 //! The [`L1Subscriber`](crate::l1::L1Subscriber) extracts policy events from
 //! `eth_getBlockReceipts` and applies them (creates, membership updates,
-//! compound configs) to the [`SharedPolicyCache`].
+//! compound configs) to the [`PolicyCache`].
 //! [`PolicyProvider`] serves authorization queries from cache, falling back to L1
 //! RPC on miss and writing the result back for future lookups.
 //!
 //! # Startup sequence
 //!
-//! 1. [`SharedPolicyCache::seed_token_policies`] — bulk-fetch current policy state from L1 for all
+//! 1. [`PolicyCache::seed_token_policies`] — bulk-fetch current policy state from L1 for all
 //!    tracked tokens and populate the cache baseline.
 //! 2. [`spawn_policy_resolution_task`] — start the background resolution task
 //!    (processes pre-fetch requests from the pool and other callers).
 //! 3. [`spawn_pool_prefetch_task`] — watch incoming pool transactions and submit
 //!    sender/recipient addresses for cache warming.
 //! 4. Create [`PolicyProvider`] instances — one for the engine payload builder,
-//!    one for the EVM precompile, both backed by the same [`SharedPolicyCache`].
+//!    one for the EVM precompile, both backed by the same [`PolicyCache`].
 //!
 //! # Cache miss resolution
 //!
@@ -59,7 +59,7 @@
 //!
 //! - **Only the engine drives `advance()`**: the L1Subscriber writes events via
 //!   `apply_events` but never advances the cache baseline. The engine calls
-//!   `SharedPolicyCache::advance()` after processing each L1 block, ensuring the
+//!   `PolicyCache::advance()` after processing each L1 block, ensuring the
 //!   cache never runs ahead of the engine's view.
 
 mod cache;
@@ -69,7 +69,7 @@ pub mod provider;
 pub mod task;
 
 pub use cache::{
-    CachedPolicy, CompoundData, MembershipSet, PolicyCache, PolicyEvent, SharedPolicyCache,
+    CachedPolicy, CompoundData, MembershipSet, PolicyCacheInner, PolicyEvent, PolicyCache,
 };
 use tempo_precompiles::tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID};
 pub use zone_primitives::policy::AuthRole;

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -1,6 +1,6 @@
 //! Cache-first, RPC-fallback provider for TIP-403 policy authorization.
 //!
-//! [`PolicyProvider`] wraps a [`SharedPolicyCache`] and an L1 HTTP provider. Authorization
+//! [`PolicyProvider`] wraps a [`PolicyCache`] and an L1 HTTP provider. Authorization
 //! checks are served from the in-memory cache when possible. On cache miss the provider
 //! falls back to `isAuthorized(policyId, user)` via the L1 RPC and writes the result back
 //! into the cache so subsequent lookups are instant.
@@ -22,11 +22,11 @@ use zone_precompiles::policy::PolicyCheck;
 
 use super::builtin_authorization;
 
-use super::{AuthRole, CompoundData, SharedPolicyCache, metrics::Tip403Metrics};
+use super::{AuthRole, CompoundData, PolicyCache, metrics::Tip403Metrics};
 
 /// Cache-first, RPC-fallback provider for TIP-403 policy authorization.
 ///
-/// Wraps a [`SharedPolicyCache`] (populated by the [`L1Subscriber`](crate::l1::L1Subscriber))
+/// Wraps a [`PolicyCache`] (populated by the [`L1Subscriber`](crate::l1::L1Subscriber))
 /// and an L1 HTTP provider. When the cache cannot resolve an authorization query (e.g. the
 /// policy existed before the subscriber started), the provider falls back to L1 RPC calls and
 /// caches the result for future lookups.
@@ -39,7 +39,7 @@ use super::{AuthRole, CompoundData, SharedPolicyCache, metrics::Tip403Metrics};
 #[derive(Debug, Clone)]
 pub struct PolicyProvider {
     /// Shared in-memory policy cache, populated by the subscriber and RPC fallback.
-    cache: SharedPolicyCache,
+    cache: PolicyCache,
     /// L1 HTTP provider for RPC fallback on cache miss.
     provider: DynProvider<TempoNetwork>,
     /// Tokio runtime handle for `block_in_place` + `block_on` in sync call sites.
@@ -51,7 +51,7 @@ pub struct PolicyProvider {
 impl PolicyProvider {
     /// Create a new provider from components.
     pub fn new(
-        cache: SharedPolicyCache,
+        cache: PolicyCache,
         provider: DynProvider<TempoNetwork>,
         runtime_handle: tokio::runtime::Handle,
     ) -> Self {
@@ -64,7 +64,7 @@ impl PolicyProvider {
     }
 
     /// Returns a reference to the underlying shared policy cache.
-    pub fn cache(&self) -> &SharedPolicyCache {
+    pub fn cache(&self) -> &PolicyCache {
         &self.cache
     }
 

--- a/crates/tempo-zone/src/l1_state/tip403/task.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/task.rs
@@ -3,7 +3,7 @@
 //! The [`PolicyResolutionTask`] receives [`PolicyTaskMessage`]s via a channel and resolves
 //! them concurrently using [`FuturesUnordered`]. Each request triggers a
 //! [`PolicyProvider::is_authorized_async`] call which will populate the
-//! [`SharedPolicyCache`] on cache miss, ensuring the payload builder hits the cache
+//! [`PolicyCache`] on cache miss, ensuring the payload builder hits the cache
 //! at block-building time.
 //!
 //! Typical producers are the transaction pool (mempool) validation layer, which can
@@ -16,7 +16,7 @@ use tempo_alloy::TempoNetwork;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
-use super::{AuthRole, SharedPolicyCache, metrics::Tip403Metrics};
+use super::{AuthRole, PolicyCache, metrics::Tip403Metrics};
 use crate::l1_state::PolicyProvider;
 
 /// Background task that processes [`PolicyTaskMessage`]s concurrently.
@@ -168,7 +168,7 @@ impl PolicyTaskHandle {
 ///
 /// Returns a [`PolicyTaskHandle`] for sending pre-fetch requests.
 pub fn spawn_policy_resolution_task(
-    cache: SharedPolicyCache,
+    cache: PolicyCache,
     l1_provider: DynProvider<TempoNetwork>,
     max_concurrent: usize,
     channel_capacity: usize,

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -33,7 +33,7 @@ pub use l1::{
     Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1BlockDeposits, L1Deposit,
     L1PortalEvents, L1SequencerEvent, L1Subscriber, L1SubscriberConfig,
 };
-pub use l1_state::{PolicyProvider, SharedL1StateCache, PolicyCache};
+pub use l1_state::{PolicyCache, PolicyProvider, SharedL1StateCache};
 pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};
 pub use payload::{ZonePayloadAttributes, ZonePayloadTypes};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -33,7 +33,7 @@ pub use l1::{
     Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1BlockDeposits, L1Deposit,
     L1PortalEvents, L1SequencerEvent, L1Subscriber, L1SubscriberConfig,
 };
-pub use l1_state::{PolicyProvider, SharedL1StateCache, SharedPolicyCache};
+pub use l1_state::{PolicyProvider, SharedL1StateCache, PolicyCache};
 pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};
 pub use payload::{ZonePayloadAttributes, ZonePayloadTypes};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -4,7 +4,7 @@
 //! It reuses Tempo's EVM, primitives, and pool, but with noop consensus/network/payload.
 
 use crate::{
-    DepositQueue, L1SubscriberConfig, SharedPolicyCache, ZoneEngine, ZoneSequencerConfig,
+    DepositQueue, L1SubscriberConfig, PolicyCache, ZoneEngine, ZoneSequencerConfig,
     abi::{TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal},
     builder::ZonePayloadFactory,
     evm::ZoneEvmConfig,
@@ -113,7 +113,7 @@ pub struct ZoneNode {
     l1_state_cache: SharedL1StateCache,
     /// Shared TIP-403 policy cache, populated by the unified [`L1Subscriber`](crate::l1::L1Subscriber)
     /// and read by the precompile during block building.
-    policy_cache: SharedPolicyCache,
+    policy_cache: PolicyCache,
     /// Address of the L1 deposit portal contract.
     portal_address: Address,
     /// Optional pre-configured list of enabled token addresses. When set, the
@@ -136,7 +136,7 @@ impl ZoneNode {
     ) -> Self {
         let deposit_queue = DepositQueue::default();
 
-        let policy_cache = SharedPolicyCache::default();
+        let policy_cache = PolicyCache::default();
         let l1_state_cache = SharedL1StateCache::new(HashSet::from([portal_address]));
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
@@ -199,7 +199,7 @@ impl ZoneNode {
     }
 
     /// Returns the current TIP-403 policy cache
-    pub fn policy_cache(&self) -> SharedPolicyCache {
+    pub fn policy_cache(&self) -> PolicyCache {
         self.policy_cache.clone()
     }
 
@@ -249,7 +249,7 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     /// Configuration for the L1 event subscriber
     l1_config: L1SubscriberConfig,
     /// TIP-403 policy cache
-    policy_cache: SharedPolicyCache,
+    policy_cache: PolicyCache,
     /// ZonePortal address on L1.
     portal_address: Address,
     /// Pre-configured list of initial tokens.
@@ -276,7 +276,7 @@ where
     pub fn new(
         deposit_queue: DepositQueue,
         l1_config: L1SubscriberConfig,
-        policy_cache: SharedPolicyCache,
+        policy_cache: PolicyCache,
         portal_address: Address,
         initial_tokens: Option<Vec<Address>>,
         private_rpc_config: ZonePrivateRpcConfig,
@@ -711,7 +711,7 @@ impl PayloadAttributesBuilder<ZonePayloadAttributes, TempoHeader> for ZonePayloa
 pub struct ZoneExecutorBuilder {
     l1_state_provider_config: L1StateProviderConfig,
     l1_state_cache: SharedL1StateCache,
-    policy_cache: SharedPolicyCache,
+    policy_cache: PolicyCache,
 }
 
 impl ZoneExecutorBuilder {
@@ -719,7 +719,7 @@ impl ZoneExecutorBuilder {
     pub fn new(
         l1_state_provider_config: L1StateProviderConfig,
         l1_state_cache: SharedL1StateCache,
-        policy_cache: SharedPolicyCache,
+        policy_cache: PolicyCache,
     ) -> Self {
         Self {
             l1_state_provider_config,

--- a/crates/tempo-zone/tests/it/l1_e2e.rs
+++ b/crates/tempo-zone/tests/it/l1_e2e.rs
@@ -1059,7 +1059,7 @@ async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
         .await?;
 
     // --- Step 5: Pre-populate zone's policy cache ---
-    // The builder checks PolicyCache during encrypted deposit processing.
+    // The builder checks PolicyCacheInner during encrypted deposit processing.
     // Since the L1 subscriber may not have caught up yet, seed it manually.
     {
         use tempo_contracts::precompiles::ITIP403Registry::PolicyType;

--- a/crates/tempo-zone/tests/it/tip403_policy.rs
+++ b/crates/tempo-zone/tests/it/tip403_policy.rs
@@ -1,7 +1,7 @@
 //! E2E tests for the TIP-403 policy proxy precompile on the zone.
 //!
 //! These tests verify that the `ZoneTip403ProxyRegistry` precompile correctly
-//! serves authorization queries from the `SharedPolicyCache` and rejects
+//! serves authorization queries from the `PolicyCache` and rejects
 //! mutating calls. The cache is populated directly in tests (no L1 subscriber).
 
 use alloy::primitives::{U256, address};

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -128,7 +128,7 @@ const DUMMY_L1_URL: &str = "http://127.0.0.1:1";
 /// token's `transferPolicyId` via RPC. pathUSD defaults to builtin policy `1`
 /// (allow all), and local tests rely on that behavior for outbox `transferFrom`
 /// flows.
-fn seed_local_policy_cache(policy_cache: &zone::SharedPolicyCache) {
+fn seed_local_policy_cache(policy_cache: &zone::PolicyCache) {
     policy_cache
         .write()
         .set_token_policy(PATH_USD_ADDRESS, 0, ALLOW_ALL_POLICY_ID);
@@ -194,7 +194,7 @@ pub(crate) struct ZoneTestNode {
     http_url: url::Url,
     deposit_queue: DepositQueue,
     l1_state_cache: SharedL1StateCache,
-    policy_cache: zone::SharedPolicyCache,
+    policy_cache: zone::PolicyCache,
     rpc_api_factory: Arc<RpcApiFactory>,
     node_handle: Box<dyn TestNodeHandle>,
     _tasks: Runtime,
@@ -224,7 +224,7 @@ impl ZoneTestNode {
     }
 
     /// Returns a handle to the policy cache for TIP-403 authorization.
-    pub(crate) fn policy_cache(&self) -> &zone::SharedPolicyCache {
+    pub(crate) fn policy_cache(&self) -> &zone::PolicyCache {
         &self.policy_cache
     }
 


### PR DESCRIPTION
Rename `SharedPolicyCache` to `PolicyCache` and `PolicyCache`to `PolicyCacheInner` to match reth's inner `Arc<Inner>` convention.