### PR TITLE
chore: move payload logic into dedicated mod

### DIFF
--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -11,7 +11,6 @@ pub mod cli;
 pub mod ext;
 pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub mod batch;
-pub mod builder;
 pub mod engine;
 pub mod evm;
 mod executor;

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -6,7 +6,6 @@
 use crate::{
     DepositQueue, L1SubscriberConfig, PolicyCache, ZoneEngine, ZoneSequencerConfig,
     abi::{TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal},
-    builder::ZonePayloadFactory,
     evm::ZoneEvmConfig,
     ext::TempoStateExt,
     l1::L1Subscriber,
@@ -14,7 +13,7 @@ use crate::{
         L1StateProvider, L1StateProviderConfig, PolicyProvider, SharedL1StateCache,
         spawn_policy_resolution_task, spawn_pool_prefetch_task,
     },
-    payload::{ZonePayloadAttributes, ZonePayloadTypes},
+    payload::{ZonePayloadAttributes, ZonePayloadFactory, ZonePayloadTypes},
     rpc::{TempoZoneRpc, ZoneRpcApi, start_private_rpc},
     rpc_connection_config, spawn_zone_sequencer,
 };

--- a/crates/tempo-zone/src/payload/builder.rs
+++ b/crates/tempo-zone/src/payload/builder.rs
@@ -47,7 +47,7 @@ use tempo_primitives::{
 use tempo_transaction_pool::TempoTransactionPool;
 use tracing::{error, info, warn};
 
-use super::node::ZoneNode;
+use crate::node::ZoneNode;
 
 use alloy_evm::block::{BlockExecutor, TxResult};
 

--- a/crates/tempo-zone/src/payload/mod.rs
+++ b/crates/tempo-zone/src/payload/mod.rs
@@ -1,9 +1,13 @@
-//! Zone-specific payload types.
+//! Zone payload types and builder.
 //!
 //! Owns the full payload attribute types for the zone, wrapping Ethereum
 //! payload attributes and adding L1 block data plus the millisecond timestamp
 //! portion. This avoids pulling in Tempo-specific concepts the zone doesn't
 //! use (interrupts, subblocks, DKG extra-data).
+
+mod builder;
+
+pub use builder::{ZonePayloadBuilder, ZonePayloadFactory, build_advance_tempo_tx};
 
 use std::sync::Arc;
 


### PR DESCRIPTION
This PR moves the payload builder and related logic into a dedicated mod to match tempo/reth conventions.