### PR TITLE
chore(l1-subscriber): update policy cache inner

### DIFF
--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -7,7 +7,7 @@
 use crate::{
     abi::{TEMPO_STATE_READER_ADDRESS, ZONE_TX_CONTEXT_ADDRESS},
     executor::ZoneBlockExecutor,
-    l1_state::{L1StateProvider, PolicyProvider, SharedL1StateCache, TempoStateReader},
+    l1_state::{L1StateCache, L1StateProvider, PolicyProvider, TempoStateReader},
     precompiles::{
         AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
         ZONE_TIP20_FACTORY_ADDRESS, ZONE_TIP403_PROXY_ADDRESS, ZoneTip20Token,
@@ -243,7 +243,7 @@ impl ZoneEvmConfig {
     /// portal address defaults to the zero address in this mode, so sequencer
     /// reads are treated as unavailable.
     pub fn new_without_l1(chain_spec: Arc<TempoChainSpec>) -> Self {
-        let cache = SharedL1StateCache::default();
+        let cache = L1StateCache::default();
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_http("http://127.0.0.1:1".parse().expect("valid fallback URL"))
             .erased();

--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -33,7 +33,7 @@ use crate::{
         },
     },
     ext::TempoStateExt,
-    l1_state::{cache::L1StateCache, tip403::PolicyEvent},
+    l1_state::{cache::L1StateCacheInner, tip403::PolicyEvent},
 };
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
@@ -56,7 +56,7 @@ pub struct L1SubscriberConfig {
     pub policy_cache: crate::l1_state::tip403::PolicyCache,
     /// Shared L1 state cache. The subscriber updates the cache anchor on each
     /// confirmed block and clears it on reorgs.
-    pub l1_state_cache: crate::l1_state::cache::SharedL1StateCache,
+    pub l1_state_cache: crate::l1_state::cache::L1StateCache,
     /// Maximum number of concurrent L1 RPC receipt fetches. Used directly for
     /// the live stream and halved for backfill (which sends 2 requests per block).
     pub l1_fetch_concurrency: usize,
@@ -723,7 +723,7 @@ impl L1Subscriber {
 }
 
 fn apply_sequencer_events_to_cache(
-    cache: &mut L1StateCache,
+    cache: &mut L1StateCacheInner,
     portal_address: Address,
     block_number: u64,
     sequencer_events: &[L1SequencerEvent],
@@ -1824,7 +1824,7 @@ mod tests {
                 portal_address,
                 genesis_tempo_block_number,
                 policy_cache: crate::PolicyCache::default(),
-                l1_state_cache: crate::SharedL1StateCache::new(HashSet::from([portal_address])),
+                l1_state_cache: crate::L1StateCache::new(HashSet::from([portal_address])),
                 l1_fetch_concurrency: 1,
                 retry_connection_interval: Duration::from_secs(1),
             },
@@ -2085,7 +2085,7 @@ mod tests {
         let portal_address = address!("0x0000000000000000000000000000000000000ABC");
         let current_sequencer = address!("0x00000000000000000000000000000000000000A1");
         let pending_sequencer = address!("0x00000000000000000000000000000000000000B2");
-        let mut cache = L1StateCache::new(HashSet::from([portal_address]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([portal_address]));
 
         apply_sequencer_events_to_cache(
             &mut cache,
@@ -2112,7 +2112,7 @@ mod tests {
         let portal_address = address!("0x0000000000000000000000000000000000000ABC");
         let previous_sequencer = address!("0x00000000000000000000000000000000000000A1");
         let new_sequencer = address!("0x00000000000000000000000000000000000000B2");
-        let mut cache = L1StateCache::new(HashSet::from([portal_address]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([portal_address]));
 
         apply_sequencer_events_to_cache(
             &mut cache,
@@ -2140,7 +2140,7 @@ mod tests {
         let sequencer_a = address!("0x00000000000000000000000000000000000000A1");
         let sequencer_b = address!("0x00000000000000000000000000000000000000B2");
         let sequencer_c = address!("0x00000000000000000000000000000000000000C3");
-        let mut cache = L1StateCache::new(HashSet::from([portal_address]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([portal_address]));
 
         apply_sequencer_events_to_cache(
             &mut cache,

--- a/crates/tempo-zone/src/l1_state/cache.rs
+++ b/crates/tempo-zone/src/l1_state/cache.rs
@@ -21,17 +21,33 @@
 //!
 //! ## Reorg handling
 //!
-//! On reorgs the caller is expected to [`L1StateCache::clear`] the entire cache and re-populate
-//! from the new canonical chain segment. There is no per-block rollback.
+//! On reorgs the caller is expected to [`L1StateCacheInner::clear`] the entire cache and
+//! re-populate from the new canonical chain segment. There is no per-block rollback.
 
 use alloy_eips::NumHash;
 use alloy_primitives::{Address, B256};
-use derive_more::{Deref, DerefMut};
+use derive_more::Deref;
 use parking_lot::RwLock;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
+
+/// Thread-safe L1 state cache backed by an `Arc<RwLock<L1StateCacheInner>>`.
+#[derive(Debug, Clone, Deref, Default)]
+pub struct L1StateCache {
+    #[deref]
+    inner: Arc<RwLock<L1StateCacheInner>>,
+}
+
+impl L1StateCache {
+    /// Create a new cache tracking the given contract addresses.
+    pub fn new(tracked_contracts: HashSet<Address>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(L1StateCacheInner::new(tracked_contracts))),
+        }
+    }
+}
 
 /// Block-versioned cache of Tempo L1 contract storage slots.
 ///
@@ -43,7 +59,7 @@ use std::{
 /// The anchor tracks the latest L1 block the cache has received data for, used by the
 /// [`L1Subscriber`](crate::l1::L1Subscriber) for reorg detection.
 #[derive(Debug, Default)]
-pub struct L1StateCache {
+pub struct L1StateCacheInner {
     tracked_contracts: HashSet<Address>,
     /// Per-slot value history: `(address, slot) → { block_number → value }`.
     /// The `BTreeMap` enables efficient range lookups for "latest value at or before block N".
@@ -52,7 +68,7 @@ pub struct L1StateCache {
     anchor: NumHash,
 }
 
-impl L1StateCache {
+impl L1StateCacheInner {
     /// Create a new cache tracking the given contract addresses.
     pub fn new(tracked_contracts: HashSet<Address>) -> Self {
         Self {
@@ -120,22 +136,6 @@ impl L1StateCache {
     }
 }
 
-/// Shared handle to the L1 state cache.
-#[derive(Debug, Clone, Deref, DerefMut)]
-pub struct SharedL1StateCache(Arc<RwLock<L1StateCache>>);
-
-impl Default for SharedL1StateCache {
-    fn default() -> Self {
-        Self(Arc::new(RwLock::new(L1StateCache::default())))
-    }
-}
-
-impl SharedL1StateCache {
-    pub fn new(tracked_contracts: HashSet<Address>) -> Self {
-        Self(Arc::new(RwLock::new(L1StateCache::new(tracked_contracts))))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,13 +145,13 @@ mod tests {
 
     #[test]
     fn get_returns_none_for_missing_slot() {
-        let cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         assert_eq!(cache.get(PORTAL, B256::ZERO, 100), None);
     }
 
     #[test]
     fn set_and_get_at_same_block() {
-        let mut cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let slot = B256::with_last_byte(1);
         let value = B256::with_last_byte(0xff);
 
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn get_returns_latest_value_at_or_before_requested_block() {
-        let mut cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn get_returns_none_before_earliest_entry() {
-        let mut cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0xff));
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn clear_removes_slots_and_resets_anchor() {
-        let mut cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
 
         cache.set(PORTAL, B256::ZERO, 100, B256::with_last_byte(1));
         cache.update_anchor(NumHash {
@@ -212,13 +212,13 @@ mod tests {
 
     #[test]
     fn anchor_defaults_to_zero() {
-        let cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         assert_eq!(cache.anchor(), NumHash::default());
     }
 
     #[test]
     fn update_anchor() {
-        let mut cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let hash = B256::with_last_byte(0xbe);
         cache.update_anchor(NumHash { number: 42, hash });
         assert_eq!(cache.anchor(), NumHash { number: 42, hash });
@@ -226,19 +226,19 @@ mod tests {
 
     #[test]
     fn is_tracked_returns_true_for_portal() {
-        let cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         assert!(cache.is_tracked(&PORTAL));
     }
 
     #[test]
     fn is_tracked_returns_false_for_unknown_address() {
-        let cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         assert!(!cache.is_tracked(&address!("0x0000000000000000000000000000000000000001")));
     }
 
     #[test]
     fn different_addresses_same_slot_are_independent() {
-        let mut cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let addr_b = address!("0x0000000000000000000000000000000000004343");
         let slot = B256::with_last_byte(1);
 
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn prune_keeps_baseline_entry() {
-        let mut cache = L1StateCache::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 5, B256::with_last_byte(0x05));

--- a/crates/tempo-zone/src/l1_state/mod.rs
+++ b/crates/tempo-zone/src/l1_state/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! This module provides:
 //!
-//! - [`L1StateCache`] — an in-memory cache of L1 contract storage slots, anchored by block hash.
+//! - [`L1StateCache`] — a shared in-memory cache of L1 contract storage slots.
+//! - [`L1StateCacheInner`] — the block-versioned cache storage guarded by [`L1StateCache`].
 //! - [`L1StateProvider`] — a cache-first, RPC-fallback reader for `eth_getStorageAt`.
 //! - [`TempoStateReader`] — a standalone `DynPrecompile` that handles `readStorageAt` calls.
 //! - [`tip403`] — TIP-403 policy cache and provider.
@@ -13,7 +14,7 @@ pub mod provider;
 pub mod tip403;
 pub mod versioned;
 
-pub use cache::{L1StateCache, SharedL1StateCache};
+pub use cache::{L1StateCache, L1StateCacheInner};
 pub use precompile::TempoStateReader;
 pub use provider::{L1StateProvider, L1StateProviderConfig};
 pub use tip403::{

--- a/crates/tempo-zone/src/l1_state/provider.rs
+++ b/crates/tempo-zone/src/l1_state/provider.rs
@@ -1,6 +1,6 @@
 //! Cache-first, RPC-fallback provider for reading L1 contract storage slots.
 //!
-//! [`L1StateProvider`] wraps a [`SharedL1StateCache`] and a [`DynProvider<TempoNetwork>`] backed by an
+//! [`L1StateProvider`] wraps a [`L1StateCache`] and a [`DynProvider<TempoNetwork>`] backed by an
 //! HTTP transport. Reads are served from the in-memory cache when possible. On cache miss the
 //! provider falls back to `eth_getStorageAt` via the shared HTTP provider and writes the result
 //! back into the cache.
@@ -20,7 +20,7 @@ use tempo_alloy::TempoNetwork;
 use tracing::{debug, info, warn};
 use zone_precompiles::SequencerExt;
 
-use super::cache::SharedL1StateCache;
+use super::cache::L1StateCache;
 use crate::abi::PORTAL_SEQUENCER_SLOT;
 
 /// Configuration for the [`L1StateProvider`].
@@ -58,7 +58,7 @@ impl Default for L1StateProviderConfig {
 /// `L1StateProvider` is the core bridge between synchronous EVM execution (precompiles) and the
 /// asynchronous L1 RPC layer. It holds:
 ///
-/// - A [`SharedL1StateCache`] for fast in-memory lookups.
+/// - A [`L1StateCache`] for fast in-memory lookups.
 /// - A [`DynProvider<TempoNetwork>`] (alloy HTTP provider) created once and reused across calls.
 /// - A [`tokio::runtime::Handle`] used by the synchronous [`get_storage`](Self::get_storage)
 ///   method to dispatch async work from a blocking context.
@@ -72,7 +72,7 @@ impl Default for L1StateProviderConfig {
 #[derive(Debug, Clone)]
 pub struct L1StateProvider {
     /// In-memory cache of L1 contract storage slots, checked before any RPC call.
-    cache: SharedL1StateCache,
+    cache: L1StateCache,
     /// Zone portal address on Tempo L1 used for sequencer lookups.
     portal_address: Address,
     /// HTTP provider pointed at **Tempo L1**, used as a fallback when the cache misses.
@@ -92,7 +92,7 @@ impl L1StateProvider {
     /// [`get_storage`](Self::get_storage) method.
     pub async fn new(
         config: L1StateProviderConfig,
-        cache: SharedL1StateCache,
+        cache: L1StateCache,
         runtime_handle: tokio::runtime::Handle,
     ) -> Result<Self> {
         let retry_layer =
@@ -129,7 +129,7 @@ impl L1StateProvider {
     /// to build a fallback provider that won't panic on an empty RPC URL.
     pub fn new_raw(
         config: L1StateProviderConfig,
-        cache: SharedL1StateCache,
+        cache: L1StateCache,
         provider: DynProvider<TempoNetwork>,
         runtime_handle: tokio::runtime::Handle,
     ) -> Self {
@@ -244,7 +244,7 @@ impl L1StateProvider {
     }
 
     /// Expose the shared cache handle for external use (e.g. the engine).
-    pub fn cache(&self) -> &SharedL1StateCache {
+    pub fn cache(&self) -> &L1StateCache {
         &self.cache
     }
 

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -34,7 +34,7 @@ pub use l1::{
     Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1BlockDeposits, L1Deposit,
     L1PortalEvents, L1SequencerEvent, L1Subscriber, L1SubscriberConfig,
 };
-pub use l1_state::{PolicyCache, PolicyProvider, SharedL1StateCache};
+pub use l1_state::{L1StateCache, PolicyCache, PolicyProvider};
 pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};
 pub use payload::{ZonePayloadAttributes, ZonePayloadTypes};
 pub(crate) use rpc_client::rpc_connection_config;

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -10,7 +10,7 @@ use crate::{
     ext::TempoStateExt,
     l1::L1Subscriber,
     l1_state::{
-        L1StateProvider, L1StateProviderConfig, PolicyProvider, SharedL1StateCache,
+        L1StateCache, L1StateProvider, L1StateProviderConfig, PolicyProvider,
         spawn_policy_resolution_task, spawn_pool_prefetch_task,
     },
     payload::{ZonePayloadAttributes, ZonePayloadFactory, ZonePayloadTypes},
@@ -109,7 +109,7 @@ pub struct ZoneNode {
     /// Configuration for the L1 state provider (contract addresses, query parameters).
     l1_state_provider_config: L1StateProviderConfig,
     /// Shared L1 state cache (enabled tokens, zone metadata, etc.).
-    l1_state_cache: SharedL1StateCache,
+    l1_state_cache: L1StateCache,
     /// Shared TIP-403 policy cache, populated by the unified [`L1Subscriber`](crate::l1::L1Subscriber)
     /// and read by the precompile during block building.
     policy_cache: PolicyCache,
@@ -136,7 +136,7 @@ impl ZoneNode {
         let deposit_queue = DepositQueue::default();
 
         let policy_cache = PolicyCache::default();
-        let l1_state_cache = SharedL1StateCache::new(HashSet::from([portal_address]));
+        let l1_state_cache = L1StateCache::new(HashSet::from([portal_address]));
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
             portal_address,
@@ -193,7 +193,7 @@ impl ZoneNode {
     }
 
     /// Returns the current l1 state cache
-    pub fn l1_state_cache(&self) -> SharedL1StateCache {
+    pub fn l1_state_cache(&self) -> L1StateCache {
         self.l1_state_cache.clone()
     }
 
@@ -709,7 +709,7 @@ impl PayloadAttributesBuilder<ZonePayloadAttributes, TempoHeader> for ZonePayloa
 #[non_exhaustive]
 pub struct ZoneExecutorBuilder {
     l1_state_provider_config: L1StateProviderConfig,
-    l1_state_cache: SharedL1StateCache,
+    l1_state_cache: L1StateCache,
     policy_cache: PolicyCache,
 }
 
@@ -717,7 +717,7 @@ impl ZoneExecutorBuilder {
     /// Create a zone executor builder with the shared L1 state/policy caches.
     pub fn new(
         l1_state_provider_config: L1StateProviderConfig,
-        l1_state_cache: SharedL1StateCache,
+        l1_state_cache: L1StateCache,
         policy_cache: PolicyCache,
     ) -> Self {
         Self {

--- a/crates/tempo-zone/tests/it/README.md
+++ b/crates/tempo-zone/tests/it/README.md
@@ -42,7 +42,7 @@ The harness provides two independent testing paths:
 ### Injection Path (`e2e.rs`)
 
 Uses `L1Fixture` to manually construct `TempoHeader` and `Deposit` objects,
-push them into the `DepositQueue`, and seed the `SharedL1StateCache` for
+push them into the `DepositQueue`, and seed the `L1StateCache` for
 `TempoStateReader` precompile reads. Fast (~1s per test) and deterministic.
 
 ```rust

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -31,8 +31,8 @@ use tempo_contracts::precompiles::{
 };
 use tempo_primitives::{TempoHeader, transaction::tt_signature::TempoSignature};
 use zone::{
-    Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1Deposit, L1PortalEvents,
-    SharedL1StateCache, ZoneNode,
+    Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1Deposit, L1PortalEvents, L1StateCache,
+    ZoneNode,
 };
 
 use alloy_provider::{Provider, ProviderBuilder};
@@ -177,7 +177,7 @@ where
 /// Wraps an in-process reth node configured as a Zone, providing:
 /// - An HTTP RPC endpoint for provider connections
 /// - A [`DepositQueue`] handle for injecting synthetic L1 blocks
-/// - A [`SharedL1StateCache`] for seeding TempoStateReader precompile data
+/// - A [`L1StateCache`] for seeding TempoStateReader precompile data
 ///
 /// # Construction
 ///
@@ -193,7 +193,7 @@ type RpcApiFactory = dyn Fn(zone::rpc::PrivateRpcConfig) -> RpcApiFuture + Send 
 pub(crate) struct ZoneTestNode {
     http_url: url::Url,
     deposit_queue: DepositQueue,
-    l1_state_cache: SharedL1StateCache,
+    l1_state_cache: L1StateCache,
     policy_cache: zone::PolicyCache,
     rpc_api_factory: Arc<RpcApiFactory>,
     node_handle: Box<dyn TestNodeHandle>,
@@ -219,7 +219,7 @@ impl ZoneTestNode {
     }
 
     /// Returns a handle to the L1 state cache for seeding precompile data.
-    pub(crate) fn l1_state_cache(&self) -> &SharedL1StateCache {
+    pub(crate) fn l1_state_cache(&self) -> &L1StateCache {
         &self.l1_state_cache
     }
 
@@ -2941,7 +2941,7 @@ impl L1Fixture {
     /// for each block we plan to inject.
     pub(crate) fn seed_l1_cache(
         &self,
-        cache: &SharedL1StateCache,
+        cache: &L1StateCache,
         portal_address: Address,
         sequencer: Address,
         num_blocks: u64,

--- a/crates/tempo-zone/tests/l1_state_reader.rs
+++ b/crates/tempo-zone/tests/l1_state_reader.rs
@@ -9,7 +9,7 @@ use std::collections::HashSet;
 use alloy_primitives::{Address, B256, address};
 use alloy_provider::{Provider, ProviderBuilder};
 use tempo_alloy::TempoNetwork;
-use zone::l1_state::{L1StateProvider, L1StateProviderConfig, SharedL1StateCache};
+use zone::l1_state::{L1StateCache, L1StateProvider, L1StateProviderConfig};
 
 /// ZonePortal address on Tempo L1 moderato.
 const ZONE_PORTAL: Address = address!("0x1bc99e6a8c4689f1884527152ba542f012316149");
@@ -24,7 +24,7 @@ async fn make_provider() -> L1StateProvider {
         portal_address: ZONE_PORTAL,
         ..Default::default()
     };
-    let cache = SharedL1StateCache::new(HashSet::from([ZONE_PORTAL]));
+    let cache = L1StateCache::new(HashSet::from([ZONE_PORTAL]));
     let rt = tokio::runtime::Handle::current();
     L1StateProvider::new(config, cache, rt)
         .await


### PR DESCRIPTION
Refactors the L1 state cache to match the existing policy cache pattern. `L1StateCache` is now the shared handle, with storage moved into `L1StateCacheInner`.