### PR TITLE
[codex] add zone RPC URL metadata

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -112,7 +112,7 @@ zone-info identifier:
     cargo run -p tempo-xtask -- zone-info {{identifier}}
 
 [group('zone')]
-[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars.')]
+[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Set ZONE_RPC_URL to publish an HTTPS zone RPC URL. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars.')]
 create-zone name token="":
     #!/bin/bash
     set -euo pipefail
@@ -133,6 +133,7 @@ create-zone name token="":
     esac
     SEQ_KEY="${SEQUENCER_KEY:?Set SEQUENCER_KEY env var}"
     L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
+    ZONE_RPC_METADATA="${ZONE_RPC_URL:-}"
     HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
     SEQUENCER_ADDR=$(cast wallet address "$SEQ_KEY")
     OUTPUT="generated/{{name}}"
@@ -148,6 +149,7 @@ create-zone name token="":
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
         --sequencer "$SEQUENCER_ADDR" \
+        --zone-rpc-url "$ZONE_RPC_METADATA" \
         --private-key "$PK"
     echo "Zone '{{name}}' created. Artifacts in $OUTPUT/"
 
@@ -312,6 +314,21 @@ send-withdrawal amount="1000000" to="" token="0x20C00000000000000000000000000000
         fi
         sleep 0.25
     done
+
+[group('zone')]
+[doc('Updates the public Zone RPC URL stored on the ZonePortal. Pass an HTTPS URL, or "" to clear. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and SEQUENCER_KEY env vars.')]
+set-zone-rpc-url url:
+    #!/bin/bash
+    set -euo pipefail
+    RPC="${L1_RPC_URL:?Set L1_RPC_URL env var}"
+    PK="${SEQUENCER_KEY:?Set SEQUENCER_KEY env var (only the sequencer can update zone RPC URL)}"
+    PORTAL="${L1_PORTAL_ADDRESS:?Set L1_PORTAL_ADDRESS env var}"
+    HTTP_RPC=$(echo "$RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
+    cargo run -p tempo-xtask -- set-zone-rpc-url \
+        --l1-rpc-url "$HTTP_RPC" \
+        --portal "$PORTAL" \
+        --private-key "$PK" \
+        --zone-rpc-url "{{url}}"
 
 [group('zone')]
 [doc('Enables a TIP-20 token on the ZonePortal for bridging. Token can be an address or alias (pathusd, alphausd, betausd). Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and SEQUENCER_KEY env vars.')]
@@ -631,13 +648,14 @@ check-balance-private name token="0x20C0000000000000000000000000000000000000" rp
     echo "Balance of $ACCOUNT: $BALANCE"
 
 [group('zone')]
-[doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL env var.')]
+[doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Set ZONE_RPC_URL to publish an HTTPS zone RPC URL. Requires L1_RPC_URL env var.')]
 deploy-zone name token="":
     #!/bin/bash
     set -euo pipefail
     L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
     HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
     OUTPUT="generated/{{name}}"
+    ZONE_RPC_METADATA="${ZONE_RPC_URL:-}"
     ZONE_TOKEN_L1="{{token}}"
     if [[ -z "$ZONE_TOKEN_L1" ]]; then
         ZONE_TOKEN_L1="${ZONE_TOKEN:-0x20C0000000000000000000000000000000000000}"
@@ -687,6 +705,7 @@ deploy-zone name token="":
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
         --sequencer "$SEQUENCER_ADDR" \
+        --zone-rpc-url "$ZONE_RPC_METADATA" \
         --private-key "$SEQUENCER_KEY"
     echo ""
 
@@ -717,6 +736,7 @@ deploy-zone name token="":
     echo "  Portal:          $PORTAL"
     echo "  Initial Token:   $ZONE_TOKEN_L1"
     echo "  Sequencer:       $SEQUENCER_ADDR"
+    echo "  Zone RPC URL:    ${ZONE_RPC_METADATA:-<unset>}"
     echo "  Anchor Block:    $ANCHOR_BLOCK"
     echo ""
     echo "  Artifacts:       $OUTPUT/"

--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ Prerequisites: [Rust](https://rustup.rs/), [Foundry](https://book.getfoundry.sh/
 ```bash
 # Deploy and start a zone on Moderato testnet
 export L1_RPC_URL="wss://rpc.moderato.tempo.xyz"
+# Optional: publish a public HTTPS RPC URL in the zone's on-chain metadata
+export ZONE_RPC_URL="https://rpc.my-zone.example"
 just deploy-zone my-zone
 ```
 
-The `deploy-zone` command generates a sequencer keypair, funds it on L1, deploys the portal via `ZoneFactory`, generates genesis, and starts the node.
+The `deploy-zone` command generates a sequencer keypair, funds it on L1, deploys the portal via `ZoneFactory`, stores the optional zone RPC URL, generates genesis, and starts the node.
 
 ```bash
 # Start/restart a zone after initial deployment

--- a/crates/primitives/src/abi.rs
+++ b/crates/primitives/src/abi.rs
@@ -180,6 +180,9 @@ macro_rules! define_abi {
                     address indexed newSequencer
                 );
 
+                #[derive(Debug)]
+                event ZoneRpcUrlUpdated(address indexed updater, string newZoneRpcUrl);
+
                 // -- Errors --
 
                 #[derive(Debug)]
@@ -190,13 +193,19 @@ macro_rules! define_abi {
                 error InvalidTempoBlockNumber();
                 #[derive(Debug)]
                 error DepositPolicyForbids();
+                #[derive(Debug)]
+                error ZoneRpcUrlTooLong();
+                #[derive(Debug)]
+                error InvalidZoneRpcUrl();
 
                 // -- View functions --
 
                 function zoneId() external view returns (uint32);
                 function sequencer() external view returns (address);
+                function zoneRpcUrl() external view returns (string memory);
                 function verifier() external view returns (address);
                 function sequencerPubkey() external view returns (bytes32);
+                function MAX_ZONE_RPC_URL_BYTES() external view returns (uint256);
                 function withdrawalBatchIndex() external view returns (uint64);
                 function blockHash() external view returns (bytes32);
                 function currentDepositQueueHash() external view returns (bytes32);
@@ -229,6 +238,8 @@ macro_rules! define_abi {
                 ) external;
 
                 function enableToken(address token) external;
+
+                function setZoneRpcUrl(string calldata newZoneRpcUrl) external;
 
                 function depositEncrypted(
                     address token,
@@ -408,6 +419,7 @@ macro_rules! define_abi {
                 bytes32 genesisBlockHash;
                 bytes32 genesisTempoBlockHash;
                 uint64 genesisTempoBlockNumber;
+                string zoneRpcUrl;
             }
 
             $($rpc_attr)*
@@ -422,6 +434,7 @@ macro_rules! define_abi {
                     address sequencer;
                     address verifier;
                     ZoneParams zoneParams;
+                    string zoneRpcUrl;
                 }
                 #[derive(Debug)]
                 event ZoneCreated(
@@ -433,7 +446,8 @@ macro_rules! define_abi {
                     address verifier,
                     bytes32 genesisBlockHash,
                     bytes32 genesisTempoBlockHash,
-                    uint64 genesisTempoBlockNumber
+                    uint64 genesisTempoBlockNumber,
+                    string zoneRpcUrl
                 );
                 function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
                 function verifier() external view returns (address);
@@ -667,6 +681,8 @@ impl core::fmt::Display for ZonePortal::ZonePortalErrors {
             Self::InvalidProof(_) => f.write_str("InvalidProof"),
             Self::InvalidTempoBlockNumber(_) => f.write_str("InvalidTempoBlockNumber"),
             Self::DepositPolicyForbids(_) => f.write_str("DepositPolicyForbids"),
+            Self::ZoneRpcUrlTooLong(_) => f.write_str("ZoneRpcUrlTooLong"),
+            Self::InvalidZoneRpcUrl(_) => f.write_str("InvalidZoneRpcUrl"),
         }
     }
 }

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -1009,6 +1009,7 @@ impl L1TestNode {
                     genesisTempoBlockHash: genesis_tempo_block_hash,
                     genesisTempoBlockNumber: l1_header.inner.number,
                 },
+                zoneRpcUrl: String::new(),
             })
             .send()
             .await?

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -130,9 +130,17 @@ To choose the initial TIP-20 enabled on the portal, pass it as the second positi
 just create-zone my-zone alphausd
 ```
 
+To publish a public RPC endpoint in the on-chain zone metadata at deploy time, set
+`ZONE_RPC_URL` to an HTTPS URL before creating the zone. Empty is allowed and means unset.
+
+```bash
+export ZONE_RPC_URL="https://rpc.my-zone.example"
+just create-zone my-zone
+```
+
 This creates `generated/my-zone/` containing:
 - **`genesis.json`** — Zone L2 genesis state (system contracts, fee token, etc.)
-- **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block, `zoneFactory`, and optional router/sequencer metadata)
+- **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block, `zoneFactory`, `zoneRpcUrl`, and optional router/sequencer metadata)
 
 This initial token controls the first L1 TIP-20 the portal accepts and mirrors onto the zone. The zone's fee token in genesis remains `pathUSD`.
 
@@ -143,7 +151,14 @@ cargo run -p tempo-xtask -- create-zone \
   --output generated/my-zone \
   --initial-token 0x20c0000000000000000000000000000000000001 \
   --sequencer "$SEQUENCER_ADDR" \
+  --zone-rpc-url "https://rpc.my-zone.example" \
   --private-key "$SEQUENCER_KEY"
+```
+
+The current sequencer can update the on-chain RPC URL later:
+
+```bash
+just set-zone-rpc-url "https://rpc.my-zone.example/v2"
 ```
 
 ### 5. Start the Zone Node
@@ -209,7 +224,7 @@ just send-deposit-encrypted 1000000                       # to your own address
 just send-deposit-encrypted 1000000 <recipient-address>   # to a specific address
 ```
 
-Set `ZONE_RPC_URL` to poll the zone for processing confirmation:
+For local polling helpers, set `ZONE_RPC_URL` to the running zone node:
 
 ```bash
 export ZONE_RPC_URL="http://localhost:8546"
@@ -368,7 +383,7 @@ just enable-token pathusd
 just enable-token alphausd
 ```
 
-If `ZONE_RPC_URL` is set (defaults to `http://localhost:8546`), the command waits for the zone to process the L1 block and confirms the token is available on L2.
+If `ZONE_RPC_URL` is set for local polling (defaults to `http://localhost:8546`), the command waits for the zone to process the L1 block and confirms the token is available on L2.
 
 Once the token is enabled, approve the portal and deposit as usual — just pass the token address:
 
@@ -542,6 +557,7 @@ The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zo
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
+| `ZONE_RPC_URL` | No | Public HTTPS zone RPC URL to publish on `ZonePortal` during `just create-zone` / `just deploy-zone`; helper commands also use it as the local zone-node URL |
 
 ## Justfile Commands Reference
 
@@ -555,6 +571,7 @@ The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zo
 | `just send-deposit [to]` | Deposit tokens from L1 to zone (defaults to sender) |
 | `just send-deposit-encrypted [to]` | Encrypted deposit — hides recipient and memo on-chain |
 | `just enable-token <token>` | Enable a TIP-20 token on the portal for bridging (sequencer only) |
+| `just set-zone-rpc-url <url>` | Update the public zone RPC URL stored on the portal (sequencer only; pass `""` to clear) |
 | `just max-approve-outbox` | Approve outbox to spend tokens on zone |
 | `just send-withdrawal [to]` | Withdraw tokens from zone to L1 (defaults to sender) |
 | `just demo-swap-and-deposit <name>` | Self-contained same-zone router demo: create tokens, seed DEX liquidity, swap on L1, deposit output back into the zone |

--- a/specs/ref-impls/src/zone/IZone.sol
+++ b/specs/ref-impls/src/zone/IZone.sol
@@ -24,6 +24,7 @@ struct ZoneInfo {
     bytes32 genesisBlockHash;
     bytes32 genesisTempoBlockHash;
     uint64 genesisTempoBlockNumber;
+    string zoneRpcUrl;
 }
 
 /// @notice Zone creation parameters stored in genesis
@@ -363,6 +364,10 @@ interface IZoneTxContext {
 //   slot 6: _encryptionKeys (EncryptionKeyEntry[])
 //   slot 7: _tokenConfigs (mapping(address => TokenConfig))
 //   slot 8: _enabledTokens (address[])
+//   slot 9: _withdrawalQueue.head (uint256)
+//   slot 10: _withdrawalQueue.tail (uint256)
+//   slot 11: _withdrawalQueue.slots (mapping(uint256 => bytes32))
+//   slot 12: zoneRpcUrl (string)
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via
@@ -426,6 +431,7 @@ interface IZoneFactory {
         address sequencer;
         address verifier;
         ZoneParams zoneParams;
+        string zoneRpcUrl;
     }
 
     event ZoneCreated(
@@ -437,7 +443,8 @@ interface IZoneFactory {
         address verifier,
         bytes32 genesisBlockHash,
         bytes32 genesisTempoBlockHash,
-        uint64 genesisTempoBlockNumber
+        uint64 genesisTempoBlockNumber,
+        string zoneRpcUrl
     );
 
     error InvalidToken();
@@ -445,6 +452,8 @@ interface IZoneFactory {
     error InvalidVerifier();
     error InsufficientGas();
     error ZoneIdOverflow();
+    error ZoneRpcUrlTooLong();
+    error InvalidZoneRpcUrl();
 
     /// @notice Returns whether a verifier contract is approved for zone creation.
     /// @param verifier The verifier contract address to check.
@@ -553,6 +562,7 @@ interface IZonePortal {
         bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock
     );
     event ZoneGasRateUpdated(uint128 zoneGasRate);
+    event ZoneRpcUrlUpdated(address indexed updater, string newZoneRpcUrl);
 
     /// @notice Emitted when sequencer enables a new TIP-20 token for bridging
     event TokenEnabled(address indexed token, string name, string symbol, string currency);
@@ -581,6 +591,8 @@ interface IZonePortal {
     error TokenNotEnabled();
     error DepositsNotActive();
     error TokenAlreadyEnabled();
+    error ZoneRpcUrlTooLong();
+    error InvalidZoneRpcUrl();
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
@@ -588,10 +600,14 @@ interface IZonePortal {
     /// @notice Maximum allowed gas fee rate (1e18)
     function MAX_GAS_FEE_RATE() external view returns (uint128);
 
+    /// @notice Maximum allowed byte length of the zone RPC URL.
+    function MAX_ZONE_RPC_URL_BYTES() external view returns (uint256);
+
     function zoneId() external view returns (uint32);
     function messenger() external view returns (address);
     function sequencer() external view returns (address);
     function pendingSequencer() external view returns (address);
+    function zoneRpcUrl() external view returns (string memory);
     function zoneGasRate() external view returns (uint128);
     function verifier() external view returns (address);
     function withdrawalBatchIndex() external view returns (uint64);
@@ -686,6 +702,12 @@ interface IZonePortal {
     /// @notice Set zone gas rate. Only callable by sequencer.
     /// @param _zoneGasRate Zone token units per gas unit on the zone
     function setZoneGasRate(uint128 _zoneGasRate) external;
+
+    /// @notice Set the zone's public RPC URL metadata. Only callable by sequencer.
+    /// @dev Empty strings are valid and clear the URL. Non-empty URLs must use
+    ///      the `https` scheme and be at most 256 bytes.
+    /// @param newZoneRpcUrl The new zone RPC URL metadata value.
+    function setZoneRpcUrl(string calldata newZoneRpcUrl) external;
 
     /// @notice Calculate the fee for a deposit
     function calculateDepositFee() external view returns (uint128 fee);

--- a/specs/ref-impls/src/zone/ZoneFactory.sol
+++ b/specs/ref-impls/src/zone/ZoneFactory.sol
@@ -5,6 +5,7 @@ import { IZoneFactory, ZoneInfo } from "./IZone.sol";
 import { Verifier } from "./Verifier.sol";
 import { ZoneMessenger } from "./ZoneMessenger.sol";
 import { ZonePortal } from "./ZonePortal.sol";
+import { ZoneRpcUrlLib } from "./ZoneRpcUrlLib.sol";
 import { StdPrecompiles } from "tempo-std/StdPrecompiles.sol";
 import { ITIP20Factory } from "tempo-std/interfaces/ITIP20Factory.sol";
 
@@ -59,6 +60,7 @@ contract ZoneFactory is IZoneFactory {
         }
         if (params.sequencer == address(0)) revert InvalidSequencer();
         if (!_validVerifiers[params.verifier]) revert InvalidVerifier();
+        ZoneRpcUrlLib.validate(params.zoneRpcUrl);
         if (gasleft() < ZONE_CREATION_GAS) revert InsufficientGas();
 
         zoneId = _nextZoneId;
@@ -94,7 +96,8 @@ contract ZoneFactory is IZoneFactory {
             params.sequencer,
             params.verifier,
             params.zoneParams.genesisBlockHash,
-            params.zoneParams.genesisTempoBlockNumber
+            params.zoneParams.genesisTempoBlockNumber,
+            params.zoneRpcUrl
         );
         portal = address(portalContract);
 
@@ -111,7 +114,8 @@ contract ZoneFactory is IZoneFactory {
             verifier: params.verifier,
             genesisBlockHash: params.zoneParams.genesisBlockHash,
             genesisTempoBlockHash: params.zoneParams.genesisTempoBlockHash,
-            genesisTempoBlockNumber: params.zoneParams.genesisTempoBlockNumber
+            genesisTempoBlockNumber: params.zoneParams.genesisTempoBlockNumber,
+            zoneRpcUrl: params.zoneRpcUrl
         });
 
         _isZonePortal[portal] = true;
@@ -126,7 +130,8 @@ contract ZoneFactory is IZoneFactory {
             params.verifier,
             params.zoneParams.genesisBlockHash,
             params.zoneParams.genesisTempoBlockHash,
-            params.zoneParams.genesisTempoBlockNumber
+            params.zoneParams.genesisTempoBlockNumber,
+            params.zoneRpcUrl
         );
     }
 

--- a/specs/ref-impls/src/zone/ZonePortal.sol
+++ b/specs/ref-impls/src/zone/ZonePortal.sol
@@ -21,6 +21,7 @@ import {
     Withdrawal
 } from "./IZone.sol";
 import { WithdrawalQueue, WithdrawalQueueLib } from "./WithdrawalQueueLib.sol";
+import { ZoneRpcUrlLib } from "./ZoneRpcUrlLib.sol";
 import { StdPrecompiles } from "tempo-std/StdPrecompiles.sol";
 import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 import { ITIP20Factory } from "tempo-std/interfaces/ITIP20Factory.sol";
@@ -48,6 +49,9 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Maximum allowed gas fee rate to prevent overflows
     uint128 public constant MAX_GAS_FEE_RATE = 1e18;
+
+    /// @notice Maximum allowed byte length of the zone RPC URL.
+    uint256 public constant MAX_ZONE_RPC_URL_BYTES = ZoneRpcUrlLib.MAX_ZONE_RPC_URL_BYTES;
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -103,6 +107,10 @@ contract ZonePortal is IZonePortal {
     /// @notice Withdrawal queue (zone→Tempo): fixed-size ring buffer
     WithdrawalQueue internal _withdrawalQueue;
 
+    /// @notice Public RPC URL metadata for this zone.
+    /// @dev Empty string means unset.
+    string public zoneRpcUrl;
+
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -114,14 +122,18 @@ contract ZonePortal is IZonePortal {
         address _sequencer,
         address _verifier,
         bytes32 _genesisBlockHash,
-        uint64 _genesisTempoBlockNumber
+        uint64 _genesisTempoBlockNumber,
+        string memory _zoneRpcUrl
     ) {
+        ZoneRpcUrlLib.validate(_zoneRpcUrl);
+
         zoneId = _zoneId;
         messenger = _messenger;
         sequencer = _sequencer;
         verifier = _verifier;
         blockHash = _genesisBlockHash;
         genesisTempoBlockNumber = _genesisTempoBlockNumber;
+        zoneRpcUrl = _zoneRpcUrl;
 
         // Enable the initial token
         _enableTokenInternal(_initialToken);
@@ -165,6 +177,15 @@ contract ZonePortal is IZonePortal {
         if (_zoneGasRate > MAX_GAS_FEE_RATE) revert GasFeeRateTooHigh();
         zoneGasRate = _zoneGasRate;
         emit ZoneGasRateUpdated(_zoneGasRate);
+    }
+
+    /// @notice Set the zone's public RPC URL metadata. Only callable by sequencer.
+    /// @dev Empty strings are valid and clear the URL. Non-empty URLs must use
+    ///      the `https` scheme and be at most 256 bytes.
+    function setZoneRpcUrl(string calldata newZoneRpcUrl) external onlySequencer {
+        ZoneRpcUrlLib.validate(newZoneRpcUrl);
+        zoneRpcUrl = newZoneRpcUrl;
+        emit ZoneRpcUrlUpdated(msg.sender, newZoneRpcUrl);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/specs/ref-impls/src/zone/ZoneRpcUrlLib.sol
+++ b/specs/ref-impls/src/zone/ZoneRpcUrlLib.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title ZoneRpcUrlLib
+/// @notice Validation helpers for zone RPC URL metadata.
+library ZoneRpcUrlLib {
+
+    /// @notice Maximum allowed byte length of a zone RPC URL.
+    uint256 internal constant MAX_ZONE_RPC_URL_BYTES = 256;
+
+    bytes1 private constant COLON = 0x3a;
+
+    error ZoneRpcUrlTooLong();
+    error InvalidZoneRpcUrl();
+
+    /// @notice Validate a zone RPC URL.
+    /// @dev Empty strings are valid and clear the URL. Non-empty URLs must have an
+    ///      `https` scheme, compared ASCII-case-insensitively. The URI body after
+    ///      the first `:` is intentionally not validated.
+    function validate(string memory url) internal pure {
+        bytes memory uri = bytes(url);
+        if (uri.length > MAX_ZONE_RPC_URL_BYTES) revert ZoneRpcUrlTooLong();
+        if (uri.length == 0) return;
+        if (!_hasHttpsScheme(uri)) revert InvalidZoneRpcUrl();
+    }
+
+    function _hasHttpsScheme(bytes memory uri) private pure returns (bool) {
+        for (uint256 i = 0; i < uri.length; i++) {
+            if (uri[i] == COLON) {
+                return i == 5 && _eqAsciiCaseInsensitive(uri[0], 0x68)
+                    && _eqAsciiCaseInsensitive(uri[1], 0x74)
+                    && _eqAsciiCaseInsensitive(uri[2], 0x74)
+                    && _eqAsciiCaseInsensitive(uri[3], 0x70)
+                    && _eqAsciiCaseInsensitive(uri[4], 0x73);
+            }
+        }
+        return false;
+    }
+
+    function _eqAsciiCaseInsensitive(bytes1 value, uint8 lower) private pure returns (bool) {
+        uint8 c = uint8(value);
+        return c == lower || c == lower - 32;
+    }
+
+}

--- a/specs/ref-impls/test/zone/ZoneBridge.t.sol
+++ b/specs/ref-impls/test/zone/ZoneBridge.t.sol
@@ -157,7 +157,8 @@ contract ZoneBridgeTest is BaseTest {
             admin, // sequencer
             l1Factory.verifier(),
             GENESIS_BLOCK_HASH,
-            genesisTempoBlockNumber
+            genesisTempoBlockNumber,
+            "https://rpc.zone.example"
         );
         zoneId = 1;
 

--- a/specs/ref-impls/test/zone/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/zone/ZoneFactory.t.sol
@@ -17,6 +17,7 @@ contract ZoneFactoryTest is BaseTest {
 
     bytes32 constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
+    string constant ZONE_RPC_URL = "https://rpc.zone.example:8545/path";
 
     function setUp() public override {
         super.setUp();
@@ -36,7 +37,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         (uint32 zoneId, address portal) = zoneFactory.createZone(params);
@@ -55,6 +57,8 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(info.verifier, zoneFactory.verifier());
         assertEq(info.genesisBlockHash, GENESIS_BLOCK_HASH);
         assertEq(info.genesisTempoBlockHash, GENESIS_TEMPO_BLOCK_HASH);
+        assertEq(info.zoneRpcUrl, ZONE_RPC_URL);
+        assertEq(ZonePortal(portal).zoneRpcUrl(), ZONE_RPC_URL);
     }
 
     function test_createZone_deploysMessenger() public {
@@ -66,7 +70,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         (uint32 zoneId, address portal) = zoneFactory.createZone(params);
@@ -92,7 +97,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         (uint32 zoneId1, address portal1) = zoneFactory.createZone(params1);
@@ -105,7 +111,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: keccak256("genesis2"),
                 genesisTempoBlockHash: keccak256("tempoGenesis2"),
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: "HTTPS://rpc2.zone.example:443"
         });
 
         (uint32 zoneId2, address portal2) = zoneFactory.createZone(params2);
@@ -132,7 +139,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         // Record logs and verify ZoneCreated event was emitted
@@ -146,7 +154,7 @@ contract ZoneFactoryTest is BaseTest {
             if (
                 logs[i].topics[0]
                     == keccak256(
-                        "ZoneCreated(uint32,address,address,address,address,address,bytes32,bytes32,uint64)"
+                        "ZoneCreated(uint32,address,address,address,address,address,bytes32,bytes32,uint64,string)"
                     )
             ) {
                 found = true;
@@ -176,7 +184,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         vm.expectRevert(IZoneFactory.InvalidToken.selector);
@@ -195,7 +204,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         vm.expectRevert(IZoneFactory.InvalidToken.selector);
@@ -211,7 +221,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         vm.expectRevert(IZoneFactory.InvalidToken.selector);
@@ -231,7 +242,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         vm.expectRevert(IZoneFactory.InvalidSequencer.selector);
@@ -251,10 +263,57 @@ contract ZoneFactoryTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         vm.expectRevert(IZoneFactory.InvalidVerifier.selector);
+        zoneFactory.createZone(params);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                       ZONE RPC URL VALIDATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_createZone_allowsEmptyZoneRpcUrl() public {
+        IZoneFactory.CreateZoneParams memory params = _validCreateZoneParams("");
+
+        (uint32 zoneId, address portal) = zoneFactory.createZone(params);
+
+        assertEq(zoneFactory.zones(zoneId).zoneRpcUrl, "");
+        assertEq(ZonePortal(portal).zoneRpcUrl(), "");
+    }
+
+    function test_createZone_allowsHttpsSchemeOnlyValidation() public {
+        IZoneFactory.CreateZoneParams memory params = _validCreateZoneParams("HTTPS:foo:bar");
+
+        (, address portal) = zoneFactory.createZone(params);
+
+        assertEq(ZonePortal(portal).zoneRpcUrl(), "HTTPS:foo:bar");
+    }
+
+    function test_createZone_allowsMaxLengthZoneRpcUrl() public {
+        IZoneFactory.CreateZoneParams memory params = _validCreateZoneParams(_httpsUrlOfLength(256));
+
+        (, address portal) = zoneFactory.createZone(params);
+
+        assertEq(bytes(ZonePortal(portal).zoneRpcUrl()).length, 256);
+    }
+
+    function test_createZone_revertsOnInvalidZoneRpcUrl() public {
+        string[6] memory invalidUrls = _invalidZoneRpcUrls();
+        for (uint256 i = 0; i < invalidUrls.length; i++) {
+            IZoneFactory.CreateZoneParams memory params = _validCreateZoneParams(invalidUrls[i]);
+
+            vm.expectRevert(IZoneFactory.InvalidZoneRpcUrl.selector);
+            zoneFactory.createZone(params);
+        }
+    }
+
+    function test_createZone_revertsOnZoneRpcUrlTooLong() public {
+        IZoneFactory.CreateZoneParams memory params = _validCreateZoneParams(_httpsUrlOfLength(257));
+
+        vm.expectRevert(IZoneFactory.ZoneRpcUrlTooLong.selector);
         zoneFactory.createZone(params);
     }
 
@@ -278,6 +337,44 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(info.portal, address(0));
         assertEq(info.messenger, address(0));
         assertEq(info.initialToken, address(0));
+    }
+
+    function _validCreateZoneParams(string memory zoneRpcUrl)
+        internal
+        view
+        returns (IZoneFactory.CreateZoneParams memory)
+    {
+        return IZoneFactory.CreateZoneParams({
+            initialToken: address(pathUSD),
+            sequencer: admin,
+            verifier: zoneFactory.verifier(),
+            zoneParams: ZoneParams({
+                genesisBlockHash: GENESIS_BLOCK_HASH,
+                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
+                genesisTempoBlockNumber: uint64(block.number)
+            }),
+            zoneRpcUrl: zoneRpcUrl
+        });
+    }
+
+    function _invalidZoneRpcUrls() internal pure returns (string[6] memory) {
+        return [
+            "http://rpc.zone.example",
+            "javascript:alert(1)",
+            "no-scheme-here",
+            "://missing-scheme.example",
+            "1https://digit-leading.example",
+            " https://leading-space.example"
+        ];
+    }
+
+    function _httpsUrlOfLength(uint256 len) internal pure returns (string memory) {
+        bytes memory prefix = bytes("https://example.com/");
+        bytes memory out = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            out[i] = i < prefix.length ? prefix[i] : bytes1("a");
+        }
+        return string(out);
     }
 
 }

--- a/specs/ref-impls/test/zone/ZoneIntegration.t.sol
+++ b/specs/ref-impls/test/zone/ZoneIntegration.t.sol
@@ -103,7 +103,8 @@ contract ZoneIntegrationTest is BaseTest {
             admin,
             l1Factory.verifier(),
             GENESIS_BLOCK_HASH,
-            genesisTempoBlockNumber
+            genesisTempoBlockNumber,
+            "https://rpc.zone.example"
         );
         zoneId = 1;
 

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -137,6 +137,7 @@ contract ZonePortalTest is BaseTest {
     uint32 public testZoneId;
     bytes32 public constant GENESIS_BLOCK_HASH = keccak256("genesis");
     bytes32 public constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
+    string public constant ZONE_RPC_URL = "https://rpc.zone.example:8545/path";
     uint64 public genesisTempoBlockNumber;
 
     function setUp() public override {
@@ -168,7 +169,8 @@ contract ZonePortalTest is BaseTest {
                 genesisBlockHash: GENESIS_BLOCK_HASH,
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: genesisTempoBlockNumber
-            })
+            }),
+            zoneRpcUrl: ZONE_RPC_URL
         });
 
         address portalAddr;
@@ -215,6 +217,26 @@ contract ZonePortalTest is BaseTest {
         });
     }
 
+    function _invalidZoneRpcUrls() internal pure returns (string[6] memory) {
+        return [
+            "http://rpc.zone.example",
+            "javascript:alert(1)",
+            "no-scheme-here",
+            "://missing-scheme.example",
+            "1https://digit-leading.example",
+            " https://leading-space.example"
+        ];
+    }
+
+    function _httpsUrlOfLength(uint256 len) internal pure returns (string memory) {
+        bytes memory prefix = bytes("https://example.com/");
+        bytes memory out = new bytes(len);
+        for (uint256 i = 0; i < len; i++) {
+            out[i] = i < prefix.length ? prefix[i] : bytes1("a");
+        }
+        return string(out);
+    }
+
     /*//////////////////////////////////////////////////////////////
                             ZONE CREATION TESTS
     //////////////////////////////////////////////////////////////*/
@@ -227,6 +249,56 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.blockHash(), GENESIS_BLOCK_HASH);
         assertEq(portal.withdrawalBatchIndex(), 0);
         assertEq(portal.messenger(), address(messenger));
+        assertEq(portal.zoneRpcUrl(), ZONE_RPC_URL);
+    }
+
+    function test_setZoneRpcUrl_success() public {
+        string memory newUrl = "HTTPS://rpc2.zone.example:443/path?x=1";
+
+        vm.expectEmit(true, false, false, true);
+        emit IZonePortal.ZoneRpcUrlUpdated(admin, newUrl);
+        portal.setZoneRpcUrl(newUrl);
+
+        assertEq(portal.zoneRpcUrl(), newUrl);
+    }
+
+    function test_setZoneRpcUrl_allowsEmptyString() public {
+        portal.setZoneRpcUrl("");
+
+        assertEq(portal.zoneRpcUrl(), "");
+    }
+
+    function test_setZoneRpcUrl_allowsHttpsSchemeOnlyValidation() public {
+        portal.setZoneRpcUrl("https:foo:bar");
+
+        assertEq(portal.zoneRpcUrl(), "https:foo:bar");
+    }
+
+    function test_setZoneRpcUrl_allowsMaxLength() public {
+        string memory atLimit = _httpsUrlOfLength(portal.MAX_ZONE_RPC_URL_BYTES());
+
+        portal.setZoneRpcUrl(atLimit);
+
+        assertEq(portal.zoneRpcUrl(), atLimit);
+    }
+
+    function test_setZoneRpcUrl_revertsForNonSequencer() public {
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setZoneRpcUrl("https://rpc.zone.example");
+    }
+
+    function test_setZoneRpcUrl_revertsOnInvalidZoneRpcUrl() public {
+        string[6] memory invalidUrls = _invalidZoneRpcUrls();
+        for (uint256 i = 0; i < invalidUrls.length; i++) {
+            vm.expectRevert(IZonePortal.InvalidZoneRpcUrl.selector);
+            portal.setZoneRpcUrl(invalidUrls[i]);
+        }
+    }
+
+    function test_setZoneRpcUrl_revertsOnZoneRpcUrlTooLong() public {
+        vm.expectRevert(IZonePortal.ZoneRpcUrlTooLong.selector);
+        portal.setZoneRpcUrl(_httpsUrlOfLength(257));
     }
 
     function test_zoneFactoryTracksZones() public view {
@@ -2339,6 +2411,7 @@ contract ZonePortalTest is BaseTest {
     ///        slot 4: currentDepositQueueHash (bytes32)
     ///        slot 5: lastSyncedTempoBlockNumber (uint64)
     ///        slot 6: _encryptionKeys.length (EncryptionKeyEntry[])
+    ///        slot 12: zoneRpcUrl (string)
     function test_storageLayout_slotPositions() public {
         // --- Slot 0: sequencer ---
         bytes32 slot0 = vm.load(address(portal), bytes32(uint256(0)));

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -197,6 +197,7 @@ The following table lists every privileged action and the role authorized to inv
 | `resumeDeposits(token)` | [`ZonePortal`](#izoneportal) | **admin** |
 | `setZoneGasRate(rate)` | [`ZonePortal`](#izoneportal) | **sequencer** |
 | `setTempoGasRate(rate)` | [`ZonePortal`](#izoneportal) | **sequencer** |
+| `setZoneRpcUrl(url)` | [`ZonePortal`](#izoneportal) | **sequencer** |
 | `setSequencerEncryptionKey(...)` | [`ZonePortal`](#izoneportal) | **sequencer** |
 | `submitBatch(...)` | [`ZonePortal`](#izoneportal) | **sequencer** |
 | `processWithdrawal(...)` | [`ZonePortal`](#izoneportal) | **sequencer** |
@@ -223,8 +224,11 @@ A zone is created via `ZoneFactory.createZone(...)` on Tempo with the following 
 | `sequencer` | The address that will operate the zone (block production, batch submission, withdrawal processing). |
 | `verifier` | The `IVerifier` contract used to validate batch proofs. |
 | `zoneParams` | Genesis configuration: genesis block hash, genesis Tempo block hash, and genesis Tempo block number. |
+| `zoneRpcUrl` | Public zone RPC URL metadata stored on the `ZonePortal`. Empty string means unset; non-empty values must be at most 256 bytes and use the `https` scheme. |
 
-The factory assigns a unique `zoneId`, deploys a [`ZonePortal`](#izoneportal) and a [`ZoneMessenger`](#izonemessenger), and enables the initial token. The [`ZoneCreated`](#izonefactory) event emits all deployment parameters.
+The factory assigns a unique `zoneId`, deploys a [`ZonePortal`](#izoneportal) and a [`ZoneMessenger`](#izonemessenger), stores the initial zone RPC URL, and enables the initial token. The [`ZoneCreated`](#izonefactory) event emits all deployment parameters.
+
+`zoneRpcUrl` is mutable metadata. Empty string is valid and means unset. Non-empty values MUST be at most 256 bytes and MUST have an `https` scheme, compared ASCII-case-insensitively. The protocol validates only the scheme before the first `:` and does not validate the URI body, so values like `https:` and `https:foo` are accepted.
 
 ### Chain ID
 
@@ -1478,6 +1482,7 @@ struct ZoneInfo {
     bytes32 genesisBlockHash;
     bytes32 genesisTempoBlockHash;
     uint64 genesisTempoBlockNumber;
+    string zoneRpcUrl;
 }
 
 struct ZoneParams {
@@ -1501,12 +1506,14 @@ interface IZoneFactory {
         address sequencer;
         address verifier;
         ZoneParams zoneParams;
+        string zoneRpcUrl;
     }
 
     event ZoneCreated(
         uint32 indexed zoneId, address indexed portal, address indexed messenger,
         address initialToken, address sequencer, address verifier,
-        bytes32 genesisBlockHash, bytes32 genesisTempoBlockHash, uint64 genesisTempoBlockNumber
+        bytes32 genesisBlockHash, bytes32 genesisTempoBlockHash, uint64 genesisTempoBlockNumber,
+        string zoneRpcUrl
     );
 
     function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
@@ -1555,6 +1562,7 @@ interface IZonePortal {
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
     event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock);
     event ZoneGasRateUpdated(uint128 zoneGasRate);
+    event ZoneRpcUrlUpdated(address indexed updater, string newZoneRpcUrl);
     event TempoGasRateUpdated(uint128 tempoGasRate);
     event TokenEnabled(address indexed token, string name, string symbol, string currency);
     event DepositsPaused(address indexed token);
@@ -1568,6 +1576,8 @@ interface IZonePortal {
     function areDepositsActive(address token) external view returns (bool);
     function enabledTokenCount() external view returns (uint256);
     function enabledTokenAt(uint256 index) external view returns (address);
+    function zoneRpcUrl() external view returns (string memory);
+    function setZoneRpcUrl(string calldata newZoneRpcUrl) external;
 
     // Deposits
     /// @dev Reverts (`MissingBouncebackRecipient`) if `bouncebackRecipient == address(0)`.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -6,3 +6,4 @@ Subcommands currently supported:
 
 + `create-zone`: creates a new zone on Tempo L1 via the ZoneFactory contract.
 + `generate-zone-genesis`: generates a zone L2 genesis file.
++ `set-zone-rpc-url`: updates the public RPC URL metadata on a ZonePortal.

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -29,6 +29,7 @@ sol! {
         address sequencer;
         address verifier;
         ZoneParams zoneParams;
+        string zoneRpcUrl;
     }
 
     #[sol(rpc)]
@@ -42,7 +43,8 @@ sol! {
             address verifier,
             bytes32 genesisBlockHash,
             bytes32 genesisTempoBlockHash,
-            uint64 genesisTempoBlockNumber
+            uint64 genesisTempoBlockNumber,
+            string zoneRpcUrl
         );
 
         function verifier() external view returns (address);
@@ -73,6 +75,10 @@ pub(crate) struct CreateZone {
     /// Sequencer address that will operate the zone.
     #[arg(long)]
     sequencer: Address,
+
+    /// Public HTTPS RPC URL metadata to store on the ZonePortal. Empty clears/unsets it.
+    #[arg(long, default_value = "")]
+    zone_rpc_url: String,
 
     /// Private key (hex) for signing the createZone transaction on L1.
     #[arg(long)]
@@ -124,6 +130,7 @@ impl CreateZone {
                 genesisTempoBlockHash: B256::ZERO,
                 genesisTempoBlockNumber: current_block,
             },
+            zoneRpcUrl: self.zone_rpc_url.clone(),
         };
 
         println!(
@@ -202,6 +209,7 @@ impl CreateZone {
             "portal": format!("{portal}"),
             "initialToken": format!("{}", self.initial_token),
             "sequencer": format!("{}", self.sequencer),
+            "zoneRpcUrl": self.zone_rpc_url,
             "tempoAnchorBlock": confirm_header.inner.number,
             "zoneFactory": format!("{}", self.zone_factory),
         });
@@ -218,6 +226,10 @@ impl CreateZone {
         println!("  Portal: {portal}");
         println!("  Initial Token: {}", self.initial_token);
         println!("  Sequencer: {}", self.sequencer);
+        println!(
+            "  Zone RPC URL: {}",
+            zone_json["zoneRpcUrl"].as_str().unwrap_or("")
+        );
         println!("  ZoneFactory: {}", self.zone_factory);
         println!("  Tempo anchor block: {}", confirm_header.inner.number);
         println!(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,7 +3,8 @@ use crate::{
     create_zone::CreateZone, demo_blacklist::DemoBlacklist,
     demo_swap_and_deposit::DemoSwapAndDeposit, deploy_router::DeployRouter,
     encrypted_deposit::EncryptedDeposit, generate_zone_genesis::GenerateZoneGenesis,
-    set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
+    set_encryption_key::SetEncryptionKey, set_zone_rpc_url::SetZoneRpcUrl,
+    spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;
@@ -15,6 +16,7 @@ mod deploy_router;
 mod encrypted_deposit;
 mod generate_zone_genesis;
 mod set_encryption_key;
+mod set_zone_rpc_url;
 mod spam_deposits;
 mod zone_info;
 mod zone_utils;
@@ -42,6 +44,7 @@ async fn main() -> eyre::Result<()> {
             args.run().await.wrap_err("failed to generate zone genesis")
         }
         Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
+        Action::SetZoneRpcUrl(args) => args.run().await.wrap_err("failed to set zone RPC URL"),
         Action::SpamDeposits(args) => args.run().await.wrap_err("failed to spam deposits"),
         Action::ZoneInfo(args) => args.run().await.wrap_err("failed to fetch zone info"),
     }
@@ -66,6 +69,7 @@ enum Action {
     EncryptedDeposit(EncryptedDeposit),
     GenerateZoneGenesis(GenerateZoneGenesis),
     SetEncryptionKey(SetEncryptionKey),
+    SetZoneRpcUrl(SetZoneRpcUrl),
     SpamDeposits(SpamDeposits),
     ZoneInfo(ZoneInfoCmd),
 }

--- a/xtask/src/set_zone_rpc_url.rs
+++ b/xtask/src/set_zone_rpc_url.rs
@@ -1,0 +1,63 @@
+//! Updates the public RPC URL metadata stored on a ZonePortal.
+
+use alloy::{
+    network::{EthereumWallet, primitives::ReceiptResponse},
+    primitives::Address,
+    providers::ProviderBuilder,
+    signers::local::PrivateKeySigner,
+};
+use eyre::{WrapErr as _, eyre};
+use tempo_alloy::TempoNetwork;
+use zone::abi::ZonePortal;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SetZoneRpcUrl {
+    /// Tempo L1 RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, env = "L1_PORTAL_ADDRESS")]
+    portal: Address,
+
+    /// Sequencer private key (hex) for the ZonePortal update transaction.
+    #[arg(long, env = "SEQUENCER_KEY")]
+    private_key: String,
+
+    /// New public zone RPC URL. Empty string clears/unsets the URL.
+    #[arg(long, default_value = "")]
+    zone_rpc_url: String,
+}
+
+impl SetZoneRpcUrl {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let key_str = self
+            .private_key
+            .strip_prefix("0x")
+            .unwrap_or(&self.private_key);
+        let signer: PrivateKeySigner = key_str.parse()?;
+        let wallet = EthereumWallet::from(signer);
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(wallet)
+            .connect(&self.l1_rpc_url)
+            .await?;
+
+        println!("Sending setZoneRpcUrl to portal {}...", self.portal);
+        let portal = ZonePortal::new(self.portal, &provider);
+        let receipt = portal
+            .setZoneRpcUrl(self.zone_rpc_url.clone())
+            .send_sync()
+            .await
+            .wrap_err("failed to send setZoneRpcUrl")?;
+
+        let tx_hash = receipt.transaction_hash;
+        if !receipt.status() {
+            return Err(eyre!("setZoneRpcUrl reverted (tx: {tx_hash})"));
+        }
+
+        println!("Zone RPC URL updated: {}", self.zone_rpc_url);
+        println!("Explorer: https://explore.moderato.tempo.xyz/tx/{tx_hash}");
+
+        Ok(())
+    }
+}

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -62,6 +62,7 @@ impl ZoneInfoCmd {
         println!("  Genesis Block Hash:    {}", info.genesisBlockHash);
         println!("  Genesis Tempo Hash:    {}", info.genesisTempoBlockHash);
         println!("  Genesis Tempo Block:   {}", info.genesisTempoBlockNumber);
+        println!("  Zone RPC URL:          {}", info.zoneRpcUrl);
 
         // Query live portal state
         let portal = ZonePortal::new(info.portal, &provider);
@@ -69,6 +70,7 @@ impl ZoneInfoCmd {
         let sequencer = portal.sequencer().call().await?;
         let pending = portal.pendingSequencer().call().await?;
         let gas_rate = portal.zoneGasRate().call().await?;
+        let zone_rpc_url = portal.zoneRpcUrl().call().await?;
         let batch_index = portal.withdrawalBatchIndex().call().await?;
         let block_hash = portal.blockHash().call().await?;
         let deposit_queue = portal.currentDepositQueueHash().call().await?;
@@ -80,6 +82,7 @@ impl ZoneInfoCmd {
             println!("  Pending Sequencer:     {pending}");
         }
         println!("  Zone Gas Rate:         {gas_rate}");
+        println!("  Zone RPC URL (live):   {zone_rpc_url}");
         println!("  Withdrawal Batch:      {batch_index}");
         println!("  Block Hash:            {block_hash}");
         println!("  Deposit Queue Hash:    {deposit_queue}");


### PR DESCRIPTION
## Summary
- add ZonePortal `zoneRpcUrl` storage plus `setZoneRpcUrl(string)` with `ZoneRpcUrlUpdated(address indexed updater, string newZoneRpcUrl)`
- allow empty strings, cap URLs at 256 bytes, require an ASCII-case-insensitive `https` scheme, and intentionally do not validate after the first `:` to mirror the TIP-1026 scheme-validation style
- thread the URL through `ZoneFactory.createZone`, `ZoneCreated`, `ZoneInfo`, Rust ABI bindings, `create-zone`, `zone-info`, and a new `set-zone-rpc-url` xtask/Just recipe

## Validation
- `cargo check -p zone-primitives -p tempo-xtask`
- `forge build --skip test`
- `forge test --match-path 'test/zone/Zone{Factory,Portal}.t.sol'` currently compiles, then fails in local test setup because this machine’s `forge` does not recognize the repo’s Tempo hardfork/precompile config: `MissingPrecompile("AccountKeychain", 0xaAAAaaAA00000000000000000000000000000000)`.
