### PR TITLE
chore: bump tempo dep to v1.7.0 for T4 activation timestamps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,23 +78,23 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false, features = ["serde"] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false, features = ["serde"] }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "bb08bb905b6ee13fafe046aa9531aea2cdf60651", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
 
 # zones
 zone-precompiles = { path = "crates/precompiles", default-features = false }
@@ -186,3 +186,5 @@ axum = "0.8"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 tokio-tungstenite = "0.28"
 tracing = "0.1.41"
+
+


### PR DESCRIPTION
## Summary

Bump tempo dependency from `bb08bb905b` to `3d70f75` (v1.7.0) to include T4 activation timestamps for Moderato testnet.

## Motivation

Zone-005 and zone-006 stalled after T4 activated on Moderato (May 14, 14:00 UTC). The zones' pinned tempo rev predates the T4 chainspec scheduling commit (`99a6c05bb`), so the zone binary doesn't know T4 is active. This likely contributes to the L1 subscriber's confirmation buffer failing on every post-T4 block.

## Changes
- Bump `tempo-*` deps to v1.7.0 rev (`3d70f75485e684a4ed3cf23f140b60c1f7a02a19`)

## ⚠️ Build note
The reth dep also needs bumping to `8328732` (matching v1.7.0) along with a `roaring` crate patch — `roaring 0.11.3` removed the `Eq` derive that `reth-db-api` requires. The v1.7.0 tempo CI likely resolved this via lockfile pinning. Daniel to complete the dep alignment.