### PR TITLE
fix(l1): use RPC-provided hash in live stream confirmation buffer

### DIFF
--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -413,8 +413,16 @@ impl L1Subscriber {
                         receipts = receipts.len(),
                         "Fetched L1 block data"
                     );
+                    // Use the RPC-provided hash instead of recomputing via
+                    // seal_slow. This ensures the hash matches the canonical
+                    // chain even if the local TempoHeader struct is missing
+                    // fields added in newer hardforks (e.g. consensus_context
+                    // from T4/TIP-1031).
+                    // TODO: once tempo dep is bumped, recalculate the hash
+                    // locally and assert it matches the RPC-provided hash.
+                    let rpc_hash = header_resp.inner.hash;
                     let header = header_resp.inner.inner;
-                    Ok::<_, eyre::Report>((header, receipts))
+                    Ok::<_, eyre::Report>((header, rpc_hash, receipts))
                 }
             })
             .buffered(concurrency);
@@ -422,12 +430,12 @@ impl L1Subscriber {
         let mut enqueued = 0u64;
         let backfill_start = std::time::Instant::now();
 
-        while let Some((header, receipts)) = fetched.try_next().await? {
+        while let Some((header, rpc_hash, receipts)) = fetched.try_next().await? {
             let block_number = header.number();
             let (events, policy_events) = self.extract_events(block_number, &receipts);
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
-            let sealed = SealedHeader::seal_slow(header);
+            let sealed = SealedHeader::new(header, rpc_hash);
             self.update_l1_state_anchor(block_number, sealed.hash(), sealed.parent_hash());
             self.apply_policy_events(block_number, &policy_events);
             self.apply_portal_state_events(block_number, &events);
@@ -508,7 +516,11 @@ impl L1Subscriber {
                 break;
             };
             let block_number = header.number();
-            let sealed = SealedHeader::seal_slow(header.inner.into_consensus());
+            // Use the RPC-provided hash — see backfill path comment for rationale.
+            // TODO: once tempo dep is bumped, recalculate the hash locally and
+            // assert it matches the RPC-provided hash.
+            let rpc_hash = header.inner.hash;
+            let sealed = SealedHeader::new(header.inner.into_consensus(), rpc_hash);
             let (events, policy_events) = self.extract_events(block_number, &receipts);
             self.record_seen_block(block_number, 0);
 


### PR DESCRIPTION
## Summary

Use the RPC-provided canonical block hash instead of recomputing it via `seal_slow()` in the L1 subscriber's live stream confirmation buffer.

## Problem

After T4 activated on Moderato (May 14, 14:00 UTC), zone-005 and zone-006 stalled. The live stream confirmation buffer (line 517) compares `sealed.parent_hash() == tip_header.hash()` — where `tip_header.hash()` is recomputed locally via `SealedHeader::seal_slow()`. Post-T4, this recomputation produces a different hash than the canonical one, causing every block to be discarded as a "reorg" and preventing any new blocks from entering the deposit queue.

## Root cause

`TempoHeader::hash_slow()` computes `keccak256(RLP(TempoHeader))`. The RLP encoding depends on the exact struct layout and field population of `TempoHeader` (including `consensus_context` added by TIP-1031 for T4). When the zone binary's dependency versions differ from the L1 validators, the RLP encoding can diverge, producing different hashes for the same logical header.

## Fix

Replace `SealedHeader::seal_slow(header.inner.into_consensus())` with `SealedHeader::new(header.inner.into_consensus(), header.inner.hash)` on the live stream path. This uses the hash provided by the L1 RPC node (which is the canonical hash computed by the block producer) instead of recomputing it locally.

This is safe because:
- The hash comes from the L1 node that produced/validated the block
- The confirmation buffer still verifies chain continuity via parent_hash linkage
- The backfill path already trusts the RPC for block data

## Testing

- All 111 unit tests pass (`cargo test -p zone --lib`)
- Integration test failures are pre-existing (missing foundry build artifacts)