### PR TITLE
hotfix: bump deps to tempo v1.7.0 for T4/TIP-1031 consensus_context support (zones v0.1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -88,21 +88,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f312b60857fb4f8e0c723a17ae9c687c0e83a3c6b7940a30d4d5a26af091"
+checksum = "d8010fc7e9e8643ef4e758cdccf3eef26734594aedf88a9d5ed35e51837d42ef"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-transport",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -127,14 +127,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e56cae3909bcb2347f77c0f318ef5eb7e131ea6d0a94d31f8bfb6e4c5e3c7c7"
+checksum = "e3d64da86c616b5092ea64eea648f311bbd58630a0b384c42d699175d6f9122b"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-trie",
  "alloy-tx-macros",
  "arbitrary",
@@ -145,7 +145,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -155,24 +155,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4394690a8a64757316c57c57f2c663bf8395febb4c4baa049a058ebd122b668"
+checksum = "8fd98696ca3617d3a9ba1a6f2011880cbfd5618228dab6400c9f8bca457859a8"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "arbitrary",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa68d4b6fbbf44b9597684f27509573c5de3ef897907122376157f25b1f378e"
+checksum = "de3df0aadc569a8b277808a7d0ad0e421180654ea36a3c59e9ed2bb968c9a1cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -219,7 +219,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "crc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -247,7 +247,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "borsh",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -262,7 +262,7 @@ dependencies = [
  "arbitrary",
  "borsh",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_with",
  "thiserror 2.0.18",
@@ -270,22 +270,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arbitrary",
  "borsh",
+ "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b97433ffdb356d11b6c89b08c69a787b9f55d787cdeee733c12fdf85d465ef1"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -293,15 +295,38 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c0456f5f7a4497e9342d20f528e30f5288ddfa0d6a012bd5044afee46cd8a0"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.4",
  "arbitrary",
  "auto_impl",
  "borsh",
  "c-kzg",
  "derive_more",
  "either",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2 0.10.9",
@@ -309,12 +334,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.29.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6ba2dafd6327f78f2b59ae539bd5c39c57a01dc76763e92942619d934a7bb"
+checksum = "c1ceeea6dcbbcd4e546b27700763a6f6c3b3fee30054209884f521078b6fda4f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -322,8 +347,6 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy",
- "op-revm",
  "revm",
  "thiserror 2.0.18",
  "tracing",
@@ -331,13 +354,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6173ced325833e40ccb781bb372c720df638a966bad6ed6733682b6bff63d855"
+checksum = "a71ff8b55d2b8aa05259f474cae7dea0e4991724dc18936b81cb23ec492a0c2a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-trie",
  "borsh",
  "serde",
@@ -372,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae95062f48461967424eecb1e1ab703e493b6a7aca7f9c327cc1c06758eb6ec2"
+checksum = "19e352478b756bad5d7203148e4b461861282ea2ded3da406ba24868b52cd098"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -387,19 +410,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464d9c2c5bca3ff3f020f2ab502629043486a1b3645c5c11613c1dade4eb6f5e"
+checksum = "ed08ae169869e08370ed121612e0d3dadac33d1a256e9f2465926b23f0bd7d95"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -413,22 +436,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2158d382ef9743ae7185c9fcd33cd9a99967419fdcd5eebc83ff7c0e79cad2bc"
+checksum = "02e6c7ad28afe348a9a9c5624b67ee5b3607b8de98d5816b3056ecdfa6fa2697"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -438,31 +461,32 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "getrandom 0.4.2",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "proptest-derive",
- "rand 0.9.2",
+ "proptest-derive 0.8.0",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
+ "secp256k1 0.31.1",
  "serde",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b08405e82effb4985f7cbe83d5067730e79893c8699793c1e113043ffeac9d"
+checksum = "93a7c17472b55482d4734154c2f5ed13f72e03f6752cebb927f6a2d8b52e646c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -487,10 +511,10 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.16.3",
+ "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -502,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f39b713fb8fd7abb6ee7601d467f71d2c2541b7799dd02d3a8f9f650d1d3f6d"
+checksum = "a8d86958b02bca85103d64fa60d7b364a8b017c6e40f2b02c3f50ca22964a738"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -524,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -535,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -546,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96846729dd095dd5a87bf5bd8efea2345ca41ceab6dda212c49f5c8ca6e2a536"
+checksum = "5beb5c2fe6b960c8e8b038e69fd502a90a2e930afa4770efb748b163b0767729"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -559,7 +583,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -572,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f20059ff046049aae59f6e19d96462214ad3290cf9920394309dd7ffc284390"
+checksum = "4ee1257a278f6d293e05c5162c5940a1561b1aa85ded0028b464c81de37ebfa5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -583,15 +607,15 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3468c7d973491c4c02a373a29273cb747aa4a99cf2e54a6178b564d97462db50"
+checksum = "e2144d5b2866e651796eac0a997d3b5a056449c12e0d91be3184129e0c722885"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -601,39 +625,43 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aca954ee74bb38b24399da5bd861a2511fb76d40cca7ae700d2289ff96fb90"
+checksum = "df32156f085e74eac942b6103744be49b817c302341aaa8cb0c1c88dc29228d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b71da7e5cdd0d5ffebc459f5987888fd3380969c2f94f8cb652ad91ae51bba"
+checksum = "6a234bfbdf7a76c3d13808f729af5321852de3dedcaa6fc6d5f54787aaf54c6a"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3569433bc2cddd4f00b1dd533a38a07512b55e62d11f662fde20930b613b57"
+checksum = "296450f5e76bece0116c939b9437b0421a5da9c5d40031bf4cf9b38d3d94e475"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "serde",
  "serde_json",
  "serde_with",
@@ -644,11 +672,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d9d9a32059dff4809fe4db016db13ba1a20babf767c4cd26e97c93ee9efe4c"
+checksum = "0ab075ac1c25bcf697f133b7cd92e2fb26afe213e872ef79fdf77f0d7bcb3793"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
  "derive_more",
  "serde",
  "serde_with",
@@ -656,37 +685,37 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f083328dbf7aa5abfe5c0a7758ec9acc86a45bfbcfb45c54186c6caa78036f2a"
+checksum = "73b12366c96f4013e1aeebc96c6b56e5f33f07853c42ea2f485045c0c157a4a1"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
  "jsonwebtoken",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1641df7ef4d15cd43843d399252c90a95abf465a67e2a2b2fd76f4e93cc60e15"
+checksum = "56a282daf869eeb7383d3d5c2deb35b0b3fb45ecb329513af4090fc61245ee18"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-sol-types",
  "arbitrary",
  "itertools 0.14.0",
@@ -698,28 +727,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b6ca72affc6669e0a456af7d3c15d6b2edf75797d7906bc3900a8b1e094348"
+checksum = "7adc1243d55744a66b3a6cbbbba96436e8df5d248f2ee8186bef4238ef704ec7"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00e2d5ab1f7310c7ecd69962af8c99d2557335ff8cf1baf39c8ff6eec9c171d"
+checksum = "6184b5d14152b68b0bb8beb621339d94f0b761a37958bb365fbf7c00922125c2"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -727,21 +756,32 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154695f4a24dd749368fd46a4bdac1ec806b4376abc40112e3028018fee5b593"
+checksum = "f00b631c361e7c7baaf4f1f5a9877730f3507fed2acb9d4b34841b8184b2ec28"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "serde",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1c2c0b5f024814f1c04ae76ff71862d06c836e7d67102daf8a557e5056be68"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eada2558e921b39dfcead33c487364df9b31374f5733c1c9d2c891c4529933"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -751,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f59de30d9d3b13ce6a1b90e85270dc086e4e4733aaa12b250fb30e1eb35849"
+checksum = "41eb29f7a8adcd8941fbb8e134022a133e6f8dfd345f2e3b7109599f8a7dca08"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -766,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e64733ea58cfb393c901047638e9ff6890c0a45dc5855bfa077f8bace0f9f9"
+checksum = "bef839e7ce9b59aa60fa9a175e97986c6145c888d643b0f1fb0a3e7b8e56a2e2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -778,7 +818,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -807,11 +847,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.10.9",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -841,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -858,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9c680a7ee0879aa27ea2e347f14e3a973a262e4325964fa1ab062b8a796064"
+checksum = "3ac7a80c0bac3e44559d53d002e34c461dc2f23262b42cafec019bc70551abbe"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -881,14 +921,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9abaedb9123ebe4b1527bc88a0409d65b2727c3de89a289284ba91ad70ae99"
+checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde_json",
  "tower",
  "tracing",
@@ -897,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74911eda4fd7ef12f446b1661f11787f9fb31bde4ab4a0a68efcac9b98cfdf"
+checksum = "1075d9d30fd4d71e50000fd4afb19ed2664ceab20c2a29f3889a6e988329e02d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -917,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130762ef3e6c0fb7dc1b855d4f359eb8ea6f2df2f800f40aa52d27737bf640f1"
+checksum = "0e3bff84b2b2a46eb34cc522dc3f889a2867c70be90a377421429b662b3ec4ce"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -928,7 +968,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
  "ws_stream_wasm",
@@ -947,7 +987,7 @@ dependencies = [
  "derive_more",
  "nybbles",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.7.0",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
@@ -956,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.8.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3684226a2220bb6e84a5ab74877e66628882336ecfba97482c9d473aa2b1cc"
+checksum = "99fce0350197dcd4ba4e9a7dd43915d908c0eb0e7352755791709a705e1c76b6"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1017,7 +1057,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1028,7 +1068,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1059,6 +1099,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
@@ -1327,7 +1373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1337,7 +1383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1347,7 +1393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1374,9 +1420,9 @@ checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1463,9 +1509,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1474,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1486,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "base64 0.22.1",
@@ -1513,7 +1559,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1616,7 +1662,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1661,18 +1707,18 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -1689,16 +1735,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "zeroize",
 ]
 
@@ -1718,6 +1764,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1743,19 +1798,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1874,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
  "serde_core",
@@ -1890,7 +1946,7 @@ checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1913,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1958,7 +2014,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1968,7 +2035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -2021,7 +2088,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -2039,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2061,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2079,9 +2146,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -2119,7 +2186,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
@@ -2139,7 +2206,7 @@ dependencies = [
  "ripemd",
  "serde",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -2172,24 +2239,24 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af69c7b97ba7225a934e29fad444f35b5d365322efaaf724e1af66c99c8c6c3"
+checksum = "f06e32817f35fb517ceb6102d984f9a85fde85666c96f053638e323b8597f2f7"
 dependencies = [
  "bytes",
  "cfg-if",
  "commonware-macros",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf9bba8bf1ad51f54c57bee0824987bb397bedb60a09917d6a93509828a2dff"
+checksum = "f0f09b55dd5510c3b7613a573606a41961c2788709ffde053d4e644bec0bff2c"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -2211,7 +2278,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
@@ -2222,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8da60f9fe8357927327729fa7838b44555f4c578e4b07c12a2964664230a98"
+checksum = "4cd313d9299e13bf995999c7a0ed8cc570eef6cd0972fcffc6e2c682cfba6663"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2232,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c4e1e7a838cff536ffbe38f441c555eee99322d755aed3e06af9407c127fd3"
+checksum = "dbc385e646d91b5397c93816985421878d627839834f7cf85a8da2ac9f8b98b7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2245,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a44f73b02286843967888c7aa750a7a91a5cd3ac8b9bc48cd1d81331836bbb"
+checksum = "e5d834ed8bf601e113b9cd2ba284dd0e95adf558933dc727f52f8879434cb286"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2259,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a590a49ee5d5389a2b966008b3367275772da7f336719fdb0f046ad257f6849"
+checksum = "db29306a40279ad54d06b42c623a05fbb5333546b5003c921796bc856b423106"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2270,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06938675df074ca7749a6d531c4706bcc339e842105e73b03a76d45bd860b349"
+checksum = "8d4ae4c804d0d9c1df615b1c7846e4e5e64fdb4228685487cb67803e67388411"
 dependencies = [
  "axum",
  "bytes",
@@ -2293,7 +2360,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pin-project",
  "prometheus-client",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rayon",
  "sha2 0.10.9",
@@ -2307,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192eb390e3e0277770982e5e63de72f3c116c810873f3250318cae9ff0206560"
+checksum = "faf66d7b5c89489d71b0669bda2e014e7c9ffcdf65629ae31886efe5361b1179"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2324,7 +2391,7 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "tokio",
  "zeroize",
@@ -2346,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -2360,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concat-kdf"
@@ -2375,12 +2442,12 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -2399,11 +2466,12 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -2434,6 +2502,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -2449,19 +2527,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2477,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -2588,7 +2666,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2639,6 +2717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,7 +2750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2784,15 +2871,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2800,12 +2887,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2955,8 +3042,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -2982,9 +3079,8 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f170f4f6ed0e1df52bf43b403899f0081917ecf1500bfe312505cc3b515a8899"
+version = "0.10.4"
+source = "git+https://github.com/sigp/discv5?rev=7663c00#7663c00ee0837ea98547caaedede95d9d6736f4d"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3000,13 +3096,12 @@ dependencies = [
  "hkdf",
  "lazy_static",
  "libp2p-identity",
- "lru 0.12.5",
  "more-asserts",
  "multiaddr",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -3166,23 +3261,11 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1 0.30.0",
  "serde",
- "sha3",
+ "sha3 0.10.9",
  "zeroize",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3218,16 +3301,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "ethereum_hashing"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
+checksum = "5aa93f58bb1eb3d1e556e4f408ef1dac130bad01ac37db4e7ade45de40d1c86a"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "ring",
  "sha2 0.10.9",
 ]
@@ -3247,24 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
+checksum = "368a4a4e4273b0135111fe9464e35465067766a8f664615b5a86338b73864407"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
@@ -3277,26 +3345,25 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+checksum = "f2cd82c68120c89361e1a457245cf212f7d9f541bffaffed530c8f2d54a160b2"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
-name = "ethereum_ssz_derive"
-version = "0.10.1"
+name = "evmap"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd596f91cff004fc8d02be44c21c0f9b93140a04b66027ae052f5f8e05b48eba"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
 dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "hashbag",
+ "left-right",
+ "smallvec",
 ]
 
 [[package]]
@@ -3311,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -3365,13 +3432,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -3398,7 +3464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3587,6 +3653,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.4.1",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3633,6 +3714,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3653,7 +3735,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -3729,7 +3811,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -3748,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3758,7 +3840,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3783,6 +3865,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,9 +3887,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3810,7 +3895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3823,17 +3907,26 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3874,24 +3967,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "serde",
+ "jni 0.22.4",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3900,22 +3991,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4013,10 +4130,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4029,7 +4155,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -4037,16 +4162,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "log",
  "rustls",
- "rustls-pki-types",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -4082,7 +4207,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4114,12 +4239,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4127,9 +4253,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4140,9 +4266,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -4154,15 +4280,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -4174,15 +4300,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4218,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4234,6 +4360,31 @@ checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "imbl"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
 ]
 
 [[package]]
@@ -4294,13 +4445,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -4320,7 +4471,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -4359,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -4369,19 +4520,20 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4389,14 +4541,7 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -4435,15 +4580,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -4454,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4472,7 +4617,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -4480,10 +4625,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.0"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -4497,10 +4694,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4564,7 +4763,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4679,17 +4878,20 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -4724,18 +4926,43 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+checksum = "1766b89733097006f3a1388a02849865d6bc98c89273cb622e29fdd209922183"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
@@ -4749,11 +4976,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
 ]
 
@@ -4770,16 +4997,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "left-right"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -4835,14 +5073,11 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -4863,9 +5098,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -4875,11 +5110,11 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4906,9 +5141,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4933,19 +5168,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru"
-version = "0.12.5"
+name = "loom"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "hashbrown 0.15.5",
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4977,9 +5216,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 
 [[package]]
 name = "mach2"
@@ -5050,12 +5289,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -5071,12 +5310,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "evmap",
+ "indexmap 2.14.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -5101,17 +5341,18 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -5149,9 +5390,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -5182,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5236,13 +5477,18 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "core2",
  "unsigned-varint",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -5266,7 +5512,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -5284,7 +5530,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -5302,7 +5548,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5340,9 +5586,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -5447,7 +5693,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -5481,121 +5727,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "op-alloy"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95dd0974d5e60ffe9342a70cc0033d299244fab01cb16a958eb7352ddba1fa7"
-dependencies = [
- "op-alloy-consensus",
- "op-alloy-network",
- "op-alloy-provider",
- "op-alloy-rpc-types",
- "op-alloy-rpc-types-engine",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadcb964b0aa645d12e952d470c7585d23286d8bcf1ac41589410b6724216b68"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "derive_more",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-alloy-network"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ea44162d493219cc678aaca1253d46c3aa73aa361326dfa9d406f086dfa135"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
-]
-
-[[package]]
-name = "op-alloy-provider"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83aa8dc34bdf077c8e6d48ff75beff4ac14b428d982c9722483ccd7473c0e114"
-dependencies = [
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-engine",
- "alloy-transport",
- "async-trait",
- "op-alloy-rpc-types-engine",
-]
-
-[[package]]
-name = "op-alloy-rpc-types"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9d16ec9f7810e0623a37edc293d1c05fe9c58a5647f6973fdd93e0b4795015"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "derive_more",
- "op-alloy-consensus",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0ac5c5ddcbffadcd097d278c717d34849bcc629f6e4f8514eb000ec862def8"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "alloy-serde",
- "derive_more",
- "ethereum_ssz 0.9.1",
- "ethereum_ssz_derive 0.9.1",
- "op-alloy-consensus",
- "serde",
- "sha2 0.10.9",
- "snap",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-revm"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a98f3a512a7e02a1dcf1242b57302d83657b265a665d50ad98d0b158efaf2c"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -5638,9 +5769,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -5685,7 +5816,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5761,7 +5892,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -5863,18 +5994,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5905,15 +6036,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain_hasher"
@@ -5958,7 +6083,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5970,7 +6095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5983,18 +6108,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -6012,6 +6137,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -6101,7 +6237,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "chrono",
  "flate2",
  "procfs-core",
@@ -6114,16 +6250,16 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "chrono",
  "hex",
 ]
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
 dependencies = [
  "dtoa",
  "itoa",
@@ -6144,15 +6280,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -6176,6 +6312,17 @@ name = "proptest-derive"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6248,7 +6395,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6265,7 +6412,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6286,7 +6433,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6320,9 +6467,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6332,13 +6479,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6381,6 +6539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6404,7 +6568,7 @@ version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustversion",
 ]
 
@@ -6426,13 +6590,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.16.3",
+ "lru",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -6458,7 +6622,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -6477,14 +6641,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -6512,16 +6676,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -6599,16 +6754,22 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -6620,9 +6781,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6642,7 +6803,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6668,16 +6829,17 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "futures-core",
  "futures-util",
  "metrics",
  "reth-chain-state",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
@@ -6686,6 +6848,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-tasks",
+ "reth-trie-parallel",
  "serde",
  "tokio",
  "tracing",
@@ -6693,11 +6856,11 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
@@ -6705,7 +6868,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "reth-chainspec",
  "reth-errors",
@@ -6725,12 +6888,12 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
@@ -6745,8 +6908,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6758,12 +6921,12 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "backon",
@@ -6782,7 +6945,7 @@ dependencies = [
  "parking_lot",
  "ratatui",
  "rayon",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",
@@ -6841,8 +7004,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6851,15 +7014,15 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "cfg-if",
  "eyre",
  "libc",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
@@ -6870,12 +7033,12 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1df733d93427eb197cf80a7aaa68bff8949e1b59d34cde1ad410351a24136d"
+checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -6891,9 +7054,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14acf8feadf1eed0734d1766b55b6c19a374d4cb140bc862880f96da33e7e5a"
+checksum = "634c90f1cc0f9887680ca785b0b21aa961070b9465917bf65afaec56a6d005bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6902,8 +7065,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -6918,8 +7081,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -6931,11 +7094,11 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -6944,11 +7107,10 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-provider",
@@ -6958,9 +7120,8 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reth-node-api",
- "reth-primitives-traits",
  "reth-tracing",
  "ringbuffer",
  "serde",
@@ -6970,12 +7131,13 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
  "eyre",
+ "libc",
  "metrics",
  "page_size",
  "parking_lot",
@@ -6998,8 +7160,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7024,8 +7186,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7054,10 +7216,10 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "arbitrary",
  "bytes",
@@ -7069,8 +7231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7078,7 +7240,7 @@ dependencies = [
  "enr",
  "itertools 0.14.0",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reth-ethereum-forks",
  "reth-net-banlist",
  "reth-net-nat",
@@ -7094,8 +7256,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7105,7 +7267,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "metrics",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-metrics",
@@ -7118,8 +7280,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7142,11 +7304,11 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "async-compression",
@@ -7177,8 +7339,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7192,7 +7354,7 @@ dependencies = [
  "futures",
  "hmac",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
@@ -7205,8 +7367,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7228,11 +7390,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -7253,12 +7415,12 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -7266,6 +7428,7 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "futures",
+ "indexmap 2.14.0",
  "metrics",
  "moka",
  "parking_lot",
@@ -7309,8 +7472,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7337,29 +7500,30 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
- "ethereum_ssz 0.10.1",
- "ethereum_ssz_derive 0.10.1",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "sha2 0.10.9",
  "snap",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
  "futures-util",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reth-era",
  "reth-fs-util",
  "sha2 0.10.9",
@@ -7368,8 +7532,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7390,8 +7554,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7401,8 +7565,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7429,12 +7593,13 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.4",
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -7450,8 +7615,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -7490,8 +7655,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "clap",
  "eyre",
@@ -7513,11 +7678,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
@@ -7529,10 +7694,10 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-engine-primitives",
@@ -7545,8 +7710,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7558,11 +7723,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -7573,6 +7738,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
+ "reth-execution-cache",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -7587,11 +7753,11 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
@@ -7601,8 +7767,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7611,11 +7777,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "auto_impl",
@@ -7635,11 +7801,11 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -7655,8 +7821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -7673,8 +7839,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7686,11 +7852,11 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
@@ -7705,11 +7871,11 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "eyre",
  "futures",
@@ -7743,10 +7909,10 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "reth-chain-state",
  "reth-execution-types",
@@ -7757,8 +7923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "serde",
  "serde_json",
@@ -7767,8 +7933,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7795,8 +7961,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "bytes",
  "futures",
@@ -7815,10 +7981,10 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "crossbeam-queue",
  "dashmap",
@@ -7832,8 +7998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "bindgen",
  "cc",
@@ -7841,20 +8007,21 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "futures",
  "metrics",
  "metrics-derive",
+ "reth-primitives-traits",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -7862,12 +8029,12 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -7876,11 +8043,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
@@ -7893,8 +8060,8 @@ dependencies = [
  "metrics",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rayon",
  "reth-chainspec",
  "reth-consensus",
@@ -7924,6 +8091,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -7933,8 +8101,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7958,11 +8126,11 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -7981,8 +8149,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7996,8 +8164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8010,8 +8178,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8027,8 +8195,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8051,11 +8219,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -8119,11 +8287,11 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "clap",
@@ -8133,7 +8301,7 @@ dependencies = [
  "futures",
  "humantime",
  "ipnet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reth-chainspec",
  "reth-cli-util",
  "reth-config",
@@ -8174,10 +8342,10 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8212,8 +8380,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8229,18 +8397,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "reth-node-events"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "derive_more",
@@ -8260,8 +8428,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "bytes",
  "eyre",
@@ -8273,7 +8441,7 @@ dependencies = [
  "metrics-process",
  "metrics-util",
  "procfs",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reth-metrics",
  "reth-tasks",
  "tikv-jemalloc-ctl",
@@ -8284,8 +8452,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8296,20 +8464,23 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rpc-types",
+ "derive_more",
  "futures-util",
  "metrics",
  "reth-chain-state",
  "reth-ethereum-engine-primitives",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-trie-parallel",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -8317,8 +8488,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8329,18 +8500,16 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "auto_impl",
  "either",
- "op-alloy-rpc-types-engine",
- "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
  "reth-execution-types",
@@ -8354,8 +8523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8364,12 +8533,12 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03650bb740d1bca0d974c007248177ae7a7e38c50c9f46eb02292c5d9bc01252"
+checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -8397,11 +8566,12 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -8431,6 +8601,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-tasks",
+ "reth-tokio-util",
  "reth-trie",
  "reth-trie-db",
  "revm-database",
@@ -8443,11 +8614,11 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
@@ -8472,8 +8643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8488,10 +8659,12 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -8501,13 +8674,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-genesis",
  "alloy-network",
@@ -8523,7 +8695,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-signer",
  "alloy-signer-local",
  "async-trait",
@@ -8579,11 +8751,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eip7928",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-primitives",
@@ -8597,7 +8768,7 @@ dependencies = [
  "alloy-rpc-types-mev",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "jsonrpsee",
  "reth-chain-state",
  "reth-engine-primitives",
@@ -8610,8 +8781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8653,8 +8824,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8662,21 +8833,21 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-signer",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
  "reth-evm",
  "reth-primitives-traits",
+ "reth-rpc-traits",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-engine",
@@ -8704,12 +8875,13 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-eips",
+ "alloy-eip7928",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
@@ -8717,7 +8889,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-mev",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "async-trait",
  "auto_impl",
  "dyn-clone",
@@ -8742,17 +8914,18 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
+ "serde_json",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -8766,8 +8939,8 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "rand 0.9.2",
- "reqwest 0.13.2",
+ "rand 0.9.4",
+ "reqwest 0.13.3",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -8796,8 +8969,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -8810,10 +8983,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -8825,12 +8998,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-stages"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+name = "reth-rpc-traits"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860fe223501a76ff14aa3bf164f739f31008c2a2905ac85708bfd88f042e6151"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-stages"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -8839,7 +9027,7 @@ dependencies = [
  "num-traits",
  "page_size",
  "rayon",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "reth-chainspec",
  "reth-codecs",
  "reth-config",
@@ -8878,10 +9066,10 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "aquamarine",
  "auto_impl",
@@ -8906,8 +9094,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8920,8 +9108,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -8940,8 +9128,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -8955,11 +9143,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
@@ -8972,6 +9160,7 @@ dependencies = [
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
+ "reth-tokio-util",
  "reth-trie-common",
  "revm-database",
  "serde_json",
@@ -8979,10 +9168,10 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
@@ -8997,8 +9186,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9018,15 +9207,15 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-genesis",
  "alloy-primitives",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "secp256k1 0.30.0",
@@ -9034,8 +9223,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9044,8 +9233,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "clap",
  "eyre",
@@ -9061,8 +9250,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "clap",
  "eyre",
@@ -9078,22 +9267,23 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.11.0",
+ "bitflags",
  "futures-util",
+ "imbl",
  "metrics",
  "parking_lot",
  "paste",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reth-chain-state",
  "reth-chainspec",
  "reth-eth-wire-types",
@@ -9122,11 +9312,11 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
@@ -9148,14 +9338,14 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-trie",
  "arbitrary",
  "arrayvec",
@@ -9175,8 +9365,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9195,12 +9385,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
+ "alloy-eip7928",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
+ "crossbeam-utils",
  "derive_more",
  "itertools 0.14.0",
  "metrics",
@@ -9213,19 +9406,19 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-sparse",
+ "revm-state",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=8328732#83287322d5d15a7a72bd9419f3ee766f7ae1426a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
- "auto_impl",
  "metrics",
  "rayon",
  "reth-execution-errors",
@@ -9241,18 +9434,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be2e9bda3e45c5d87cfbe811676bfb9cb1f0e6fa82d1dd6a3e8cd996512f236"
+checksum = "c12fafa33d2f420a9d39249a3e0357b1928d09429f30758b85280409092873b2"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "36.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0abc15d09cd211e9e73410ada10134069c794d4bcdb787dfc16a1bf0939849c"
+checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -9269,9 +9462,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
+checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
  "phf",
@@ -9281,9 +9474,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "15.0.0"
+version = "16.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb1f0a76b14d684a444fc52f7bf6b7564bf882599d91ee62e76d602e7a187c7"
+checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9298,9 +9491,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "16.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc256b27743e2912ca16899568e6652a372eb5d1d573e6edb16c7836b16cf487"
+checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -9314,11 +9507,11 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "12.0.0"
+version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0a7d6da41061f2c50f99a2632571026b23684b5449ff319914151f4449b6c8"
+checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
@@ -9328,9 +9521,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd497a38a79057b94a049552cb1f925ad15078bc1a479c132aeeebd1d2ccc768"
+checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
 dependencies = [
  "auto_impl",
  "either",
@@ -9342,9 +9535,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "17.0.0"
+version = "18.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1eed729ca9b228ae98688f352235871e9b8be3d568d488e4070f64c56e9d3d"
+checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -9361,9 +9554,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf5102391706513689f91cb3cb3d97b5f13a02e8647e6e9cb7620877ef84847"
+checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
 dependencies = [
  "auto_impl",
  "either",
@@ -9379,9 +9572,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9487362b728f80dd2033ef5f4d0688453435bbe7caa721fa7e3b8fa25d89242b"
+checksum = "731b682530a732ef9c189ef831589128e2ce34d4a306c956322ae2dffe009715"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -9397,9 +9590,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "34.0.0"
+version = "35.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf22f80612bb8f58fd1f578750281f2afadb6c93835b14ae6a4d6b75ca26f445"
+checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -9410,9 +9603,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "32.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ec11f45deec71e4945e1809736bb20d454285f9167ab53c5159dae1deb603f"
+checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -9421,11 +9614,13 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
+ "aws-lc-rs",
  "blst",
  "c-kzg",
  "cfg-if",
  "k256",
  "p256",
+ "revm-context-interface",
  "revm-primitives",
  "ripemd",
  "secp256k1 0.31.1",
@@ -9434,9 +9629,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "22.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "0c99bda77d9661521ba0b4bc04558c6692074f01e65dd420fa3b893033d9b8a2"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -9446,12 +9641,12 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "10.0.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.11.0",
+ "bitflags",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -9536,9 +9731,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -9571,9 +9766,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -9589,8 +9784,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -9606,11 +9801,11 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -9634,7 +9829,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -9643,18 +9838,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9680,9 +9875,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -9694,9 +9889,9 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -9706,18 +9901,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -9726,8 +9921,8 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "webpki-root-certs 1.0.7",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9738,9 +9933,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9771,6 +9966,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -9859,7 +10063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -9871,7 +10075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -9899,8 +10103,8 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
- "core-foundation",
+ "bitflags",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -9927,9 +10131,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -9992,7 +10196,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -10013,9 +10217,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -10034,15 +10238,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -10053,9 +10258,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10080,7 +10285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10092,7 +10297,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -10104,25 +10309,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+checksum = "9f3f15d4e239ebe08413eed880e0f9b5af4b40ee0472543320efa91d488e96a7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -10186,9 +10401,25 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -10204,9 +10435,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -10247,22 +10478,12 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10277,7 +10498,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -10356,6 +10577,12 @@ name = "subtle-ng"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -10440,6 +10667,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10453,9 +10701,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -10472,23 +10720,24 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "alloy-signer-local",
+ "alloy-sol-types",
  "alloy-transport",
  "async-trait",
  "dashmap",
@@ -10509,10 +10758,10 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
@@ -10530,11 +10779,12 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
+ "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -10542,12 +10792,13 @@ dependencies = [
  "reth-primitives-traits",
  "tempo-chainspec",
  "tempo-primitives",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tempo-contracts"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10557,8 +10808,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10576,7 +10827,6 @@ dependencies = [
  "reth-revm",
  "reth-rpc-eth-api",
  "tempo-chainspec",
- "tempo-consensus",
  "tempo-contracts",
  "tempo-payload-types",
  "tempo-primitives",
@@ -10587,14 +10837,15 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
+ "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
  "async-trait",
  "clap",
  "commonware-runtime",
@@ -10602,10 +10853,12 @@ dependencies = [
  "futures",
  "jiff",
  "jsonrpsee",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
+ "reth-chainspec",
  "reth-errors",
  "reth-ethereum",
  "reth-evm",
+ "reth-network-api",
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
@@ -10614,12 +10867,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-rpc",
+ "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-tracing",
  "reth-transaction-pool",
  "serde",
+ "serde_json",
  "tempo-alloy",
  "tempo-chainspec",
  "tempo-consensus",
@@ -10638,13 +10893,12 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
- "either",
  "metrics",
  "reth-basic-payload-builder",
  "reth-chainspec",
@@ -10662,9 +10916,9 @@ dependencies = [
  "reth-transaction-pool",
  "reth-trie-common",
  "tempo-chainspec",
- "tempo-consensus",
  "tempo-evm",
  "tempo-payload-types",
+ "tempo-precompiles",
  "tempo-primitives",
  "tempo-transaction-pool",
  "tracing",
@@ -10672,10 +10926,10 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10690,8 +10944,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10703,14 +10957,15 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-precompiles-macros",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10720,18 +10975,20 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.6.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-serde 2.0.4",
+ "aws-lc-rs",
  "base64 0.22.1",
  "derive_more",
+ "ed25519-consensus",
  "modular-bitfield",
  "once_cell",
  "p256",
@@ -10749,8 +11006,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10772,11 +11029,11 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.5.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=e331e2f488a368ea9ca76c422e12fedbfb6eb3b4#e331e2f488a368ea9ca76c422e12fedbfb6eb3b4"
+version = "1.7.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=3d70f75485e684a4ed3cf23f140b60c1f7a02a19#3d70f75485e684a4ed3cf23f140b60c1f7a02a19"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-primitives",
  "alloy-sol-types",
@@ -10790,6 +11047,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-revm",
  "reth-storage-api",
  "reth-tracing",
  "reth-transaction-pool",
@@ -10810,14 +11068,14 @@ name = "tempo-xtask"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-rlp",
  "clap",
  "const-hex",
  "eyre",
  "futures",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reth-evm",
  "rustls",
  "serde",
@@ -10902,7 +11160,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210811179577da3d54eb69ab0b50490ee40491a25d95b8c6011ba40771cb721"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "libc",
  "log",
@@ -10994,9 +11252,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -11029,9 +11287,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -11039,16 +11297,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11090,8 +11348,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -11115,13 +11385,13 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -11135,45 +11405,45 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11197,9 +11467,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -11215,7 +11485,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -11228,13 +11498,13 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -11243,7 +11513,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -11254,6 +11523,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -11283,11 +11553,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.23",
@@ -11432,24 +11703,24 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
+checksum = "f7fd51aa83d2eb83b04570808430808b5d24fdbf479a4d5ac5dee4a2e2dd2be4"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
- "ethereum_ssz 0.9.1",
+ "ethereum_ssz",
  "smallvec",
  "typenum",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
+checksum = "8840ad4d852e325d3afa7fde8a50b2412f89dce47d7eb291c0cc7f87cd040f38"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11482,12 +11753,28 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11498,9 +11785,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -11552,9 +11839,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -11585,7 +11872,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -11640,9 +11927,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -11755,11 +12042,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -11768,14 +12055,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -11786,23 +12073,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11810,9 +12093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -11823,9 +12106,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -11847,7 +12130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -11871,10 +12154,10 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -11893,9 +12176,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11917,14 +12200,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs 1.0.7",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11935,16 +12218,26 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -11975,7 +12268,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12130,6 +12423,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12172,15 +12476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -12232,21 +12527,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -12308,12 +12588,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -12332,12 +12606,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -12353,12 +12621,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12392,12 +12654,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -12413,12 +12669,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -12440,12 +12690,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -12461,12 +12705,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -12490,13 +12728,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "winnow"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "memchr",
 ]
 
 [[package]]
@@ -12507,6 +12744,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -12527,7 +12770,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -12557,8 +12800,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -12577,9 +12820,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -12589,9 +12832,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -12651,9 +12894,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -12662,9 +12905,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12674,18 +12917,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12694,18 +12937,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12735,9 +12978,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -12746,9 +12989,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -12757,9 +13000,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12779,7 +13022,7 @@ dependencies = [
  "alloy",
  "alloy-consensus",
  "alloy-contract",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
@@ -12795,15 +13038,14 @@ dependencies = [
  "base64 0.22.1",
  "const-hex",
  "derive_more",
- "either",
  "eyre",
  "futures",
  "k256",
  "metrics",
  "p256",
  "parking_lot",
- "rand 0.8.5",
- "reqwest 0.13.2",
+ "rand 0.8.6",
+ "reqwest 0.13.3",
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-errors",
@@ -12833,7 +13075,6 @@ dependencies = [
  "sha2 0.10.9",
  "tempo-alloy",
  "tempo-chainspec",
- "tempo-consensus",
  "tempo-contracts",
  "tempo-evm",
  "tempo-node",
@@ -12844,7 +13085,7 @@ dependencies = [
  "tempo-transaction-pool",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
  "zone-precompiles",
@@ -12863,7 +13104,7 @@ dependencies = [
  "alloy-sol-types",
  "const-hex",
  "k256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "revm",
  "sha2 0.10.9",
  "tempo-chainspec",
@@ -12895,7 +13136,7 @@ name = "zone-rpc"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.4",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -12910,8 +13151,8 @@ dependencies = [
  "metrics",
  "p256",
  "parking_lot",
- "rand 0.8.5",
- "reqwest 0.13.2",
+ "rand 0.8.6",
+ "reqwest 0.13.3",
  "reth-metrics",
  "serde",
  "serde_json",
@@ -12921,7 +13162,7 @@ dependencies = [
  "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,23 +78,23 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false, features = ["serde"] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false, features = ["serde"] }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "e331e2f488a368ea9ca76c422e12fedbfb6eb3b4", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "3d70f75485e684a4ed3cf23f140b60c1f7a02a19", default-features = false }
 
 # zones
 zone-precompiles = { path = "crates/precompiles", default-features = false }
@@ -102,55 +102,55 @@ zone-primitives = { path = "crates/primitives", default-features = false }
 zone-rpc = { path = "crates/rpc" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-primitives-traits = { version = "0.1.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0", features = [
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-primitives-traits = { version = "0.3.1", default-features = false }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8328732", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7f4a9a0" }
-revm = { version = "36.0.0", features = ["optional_fee_charge"] }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8328732" }
+revm = { version = "38.0.0", features = ["optional_fee_charge"], default-features = false }
 
 # alloy
-alloy = { version = "1.6.1", default-features = false }
-alloy-consensus = { version = "1.6.1", default-features = false }
-alloy-contract = { version = "1.6.1", default-features = false }
-alloy-eips = { version = "1.6.1", default-features = false }
-alloy-evm = "0.29.2"
-alloy-network = { version = "1.6.1", default-features = false }
+alloy = { version = "2.0.4", default-features = false }
+alloy-consensus = { version = "2.0.4", default-features = false }
+alloy-contract = { version = "2.0.4", default-features = false }
+alloy-eips = { version = "2.0.4", default-features = false }
+alloy-evm = { version = "0.34.0", default-features = false }
+alloy-network = { version = "2.0.4", default-features = false }
 alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-provider = { version = "1.6.1", default-features = false }
-alloy-rlp = { version = "0.3.13", default-features = false }
-alloy-rpc-client = "1.6.1"
-alloy-rpc-types-engine = "1.6.1"
-alloy-rpc-types-eth = { version = "1.6.1" }
-alloy-signer = "1.6.1"
-alloy-signer-local = "1.6.1"
+alloy-provider = { version = "2.0.4", default-features = false }
+alloy-rlp = { version = "0.3.15", default-features = false }
+alloy-rpc-client = "2.0.4"
+alloy-rpc-types-engine = "2.0.4"
+alloy-rpc-types-eth = { version = "2.0.4" }
+alloy-signer = "2.0.4"
+alloy-signer-local = "2.0.4"
 alloy-sol-types = { version = "1.5.7", default-features = false }
-alloy-transport = "1.6.1"
+alloy-transport = "2.0.4"
 
 # commonware
 commonware-codec = "2026.2.0"
@@ -164,7 +164,7 @@ aes-gcm = "0.10.3"
 base64 = "0.22.1"
 clap = { version = "4.5.45", features = ["derive"] }
 const-hex = { version = "1.15.0" }
-derive_more = { version = "2.0.0" }
+derive_more = { version = "2.0.4" }
 either = "1.15.0"
 eyre = "0.6.12"
 futures = "0.3.31"

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -20,14 +20,14 @@ tempo-contracts = { workspace = true, default-features = false }
 tempo-precompiles = { workspace = true, default-features = false }
 tempo-precompiles-macros.workspace = true
 
-# alloy (direct versions for no_std — workspace versions have default-features = true)
-alloy = { version = "1.6.1", default-features = false }
-alloy-evm = { version = "0.29.2", default-features = false }
-alloy-primitives = { version = "1.5.7", default-features = false }
-alloy-sol-types = { version = "1.5.7", default-features = false }
+# alloy
+alloy = { workspace = true, default-features = false }
+alloy-evm = { workspace = true, default-features = false }
+alloy-primitives = { workspace = true, default-features = false }
+alloy-sol-types = { workspace = true, default-features = false }
 
 # revm
-revm = { version = "36.0.0", default-features = false }
+revm = { workspace = true, default-features = false }
 
 # crypto
 aes-gcm = { version = "0.10.3", default-features = false, features = ["aes", "alloc"] }

--- a/crates/precompiles/src/aes_gcm.rs
+++ b/crates/precompiles/src/aes_gcm.rs
@@ -16,7 +16,7 @@ use aes_gcm::{
 use alloy_evm::precompiles::{DynPrecompile, Precompile, PrecompileInput};
 use alloy_primitives::{Address, Bytes, address};
 use alloy_sol_types::SolCall;
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, warn};
 
 /// AES-256-GCM Decrypt precompile address on Zone L2.
@@ -57,19 +57,21 @@ impl Precompile for AesGcmDecrypt {
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResult {
         let data = input.data;
         if data.len() < 4 {
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
         if selector != decryptCall::SELECTOR {
             warn!(target: "zone::precompile", ?selector, "AesGcmDecrypt: unknown selector");
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         debug!(target: "zone::precompile", "AesGcmDecrypt: decrypt");
 
-        let call = decryptCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+        let call = match decryptCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir)),
+        };
 
         let gas = AES_GCM_BASE_GAS + AES_GCM_PER_BYTE_GAS * call.ciphertext.len() as u64;
 
@@ -86,7 +88,7 @@ impl Precompile for AesGcmDecrypt {
             valid,
         };
         let encoded = decryptCall::abi_encode_returns(&ret);
-        Ok(PrecompileOutput::new(gas, encoded.into()))
+        Ok(PrecompileOutput::new(gas, encoded.into(), input.reservoir))
     }
 }
 

--- a/crates/precompiles/src/chaum_pedersen.rs
+++ b/crates/precompiles/src/chaum_pedersen.rs
@@ -20,7 +20,7 @@ use k256::{
         sec1::{FromEncodedPoint, ToEncodedPoint},
     },
 };
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, warn};
 
 /// Chaum-Pedersen Verify precompile address on Zone L2.
@@ -73,19 +73,21 @@ impl Precompile for ChaumPedersenVerify {
     fn call(&self, input: PrecompileInput<'_>) -> PrecompileResult {
         let data = input.data;
         if data.len() < 4 {
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
         if selector != verifyProofCall::SELECTOR {
             warn!(target: "zone::precompile", ?selector, "ChaumPedersenVerify: unknown selector");
-            return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+            return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
         }
 
         debug!(target: "zone::precompile", "ChaumPedersenVerify: verifyProof");
 
-        let call = verifyProofCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+        let call = match verifyProofCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir)),
+        };
 
         let valid = verify_chaum_pedersen(
             &call.ephemeralPubX.0,
@@ -99,7 +101,11 @@ impl Precompile for ChaumPedersenVerify {
         );
 
         let encoded = verifyProofCall::abi_encode_returns(&valid);
-        Ok(PrecompileOutput::new(CP_VERIFY_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            CP_VERIFY_GAS,
+            encoded.into(),
+            input.reservoir,
+        ))
     }
 }
 

--- a/crates/precompiles/src/ecies.rs
+++ b/crates/precompiles/src/ecies.rs
@@ -93,8 +93,8 @@ pub fn compute_ecdh_proof(
     Some(EcdhProofResult {
         shared_secret: B256::from(shared_secret_x),
         shared_secret_y_parity,
-        cp_proof_s: B256::from(s.to_repr().as_ref()),
-        cp_proof_c: B256::from(c.to_repr().as_ref()),
+        cp_proof_s: B256::from_slice(s.to_repr().as_ref()),
+        cp_proof_c: B256::from_slice(c.to_repr().as_ref()),
     })
 }
 

--- a/crates/precompiles/src/tip20_factory.rs
+++ b/crates/precompiles/src/tip20_factory.rs
@@ -14,11 +14,9 @@
 //! Only [`ZONE_INBOX_ADDRESS`] may call this precompile; all other callers are
 //! reverted with `OnlyZoneInbox()`.
 
-use alloc::format;
-
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolError};
-use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
+use revm::precompile::PrecompileResult;
 use tempo_precompiles::{
     PATH_USD_ADDRESS, Precompile as TempoPrecompile, TIP20_FACTORY_ADDRESS,
     tip20::{ISSUER_ROLE, TIP20Token},
@@ -98,16 +96,19 @@ impl ZoneTokenFactory {
             PrecompileId::Custom("ZoneTokenFactory".into()),
             move |input| {
                 if !input.is_direct_call() {
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         SolError::abi_encode(&DelegateCallNotAllowed {}).into(),
+                        input.reservoir,
                     ));
                 }
 
                 let mut storage = EvmPrecompileStorageProvider::new(
                     input.internals,
                     input.gas,
+                    input.reservoir,
                     spec,
+                    false,
                     input.is_static,
                     gas_params.clone(),
                 );
@@ -120,19 +121,21 @@ impl ZoneTokenFactory {
 
 impl TempoPrecompile for ZoneTokenFactory {
     fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        let storage = tempo_precompiles::storage::StorageCtx;
+
         if msg_sender != ZONE_INBOX_ADDRESS {
-            return Ok(PrecompileOutput::new_reverted(
-                0,
-                OnlyZoneInbox {}.abi_encode().into(),
-            ));
+            return Ok(storage.revert_output(OnlyZoneInbox {}.abi_encode().into()));
         }
 
-        let call = enableTokenCall::abi_decode(calldata)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+        let call = match enableTokenCall::abi_decode(calldata) {
+            Ok(call) => call,
+            Err(_) => return Ok(storage.revert_output(Bytes::new())),
+        };
 
-        self.enable_token(call)
-            .map_err(|e| PrecompileError::other(format!("{e}")))?;
+        if let Err(err) = self.enable_token(call) {
+            return storage.error_result(err);
+        }
 
-        Ok(PrecompileOutput::new(0, Bytes::new()))
+        Ok(storage.success_output(Bytes::new()))
     }
 }

--- a/crates/precompiles/src/tip403_proxy.rs
+++ b/crates/precompiles/src/tip403_proxy.rs
@@ -105,21 +105,22 @@ impl<P: PolicyCheck + Clone + Send + Sync + 'static> ZoneTip403ProxyRegistry<P> 
             move |input| {
                 if !input.is_direct_call() {
                     warn!(target: "zone::precompile", "ZoneTip403ProxyRegistry called via DELEGATECALL — rejecting");
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         ReadOnlyRegistry {}.abi_encode().into(),
+                        input.reservoir,
                     ));
                 }
 
                 let data = input.data;
                 if data.len() < 4 {
                     warn!(target: "zone::precompile", data_len = data.len(), "ZoneTip403ProxyRegistry called with insufficient data");
-                    return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                    return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
                 }
 
                 let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
 
-                registry.dispatch(selector, data)
+                registry.dispatch(selector, data, input.reservoir)
             },
         )
     }
@@ -127,31 +128,31 @@ impl<P: PolicyCheck + Clone + Send + Sync + 'static> ZoneTip403ProxyRegistry<P> 
 
 impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
     /// Dispatch based on the 4-byte selector.
-    fn dispatch(&self, selector: [u8; 4], data: &[u8]) -> PrecompileResult {
+    fn dispatch(&self, selector: [u8; 4], data: &[u8], reservoir: u64) -> PrecompileResult {
         // View functions — served from cache/RPC
         if selector == ITIP403Registry::isAuthorizedCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::Transfer);
+            return self.handle_is_authorized(data, AuthRole::Transfer, reservoir);
         }
         if selector == ITIP403Registry::isAuthorizedSenderCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::Sender);
+            return self.handle_is_authorized(data, AuthRole::Sender, reservoir);
         }
         if selector == ITIP403Registry::isAuthorizedRecipientCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::Recipient);
+            return self.handle_is_authorized(data, AuthRole::Recipient, reservoir);
         }
         if selector == ITIP403Registry::isAuthorizedMintRecipientCall::SELECTOR {
-            return self.handle_is_authorized(data, AuthRole::MintRecipient);
+            return self.handle_is_authorized(data, AuthRole::MintRecipient, reservoir);
         }
         if selector == ITIP403Registry::policyDataCall::SELECTOR {
-            return self.handle_policy_data(data);
+            return self.handle_policy_data(data, reservoir);
         }
         if selector == ITIP403Registry::compoundPolicyDataCall::SELECTOR {
-            return self.handle_compound_policy_data(data);
+            return self.handle_compound_policy_data(data, reservoir);
         }
         if selector == ITIP403Registry::policyExistsCall::SELECTOR {
-            return self.handle_policy_exists(data);
+            return self.handle_policy_exists(data, reservoir);
         }
         if selector == ITIP403Registry::policyIdCounterCall::SELECTOR {
-            return self.handle_policy_id_counter();
+            return self.handle_policy_id_counter(reservoir);
         }
 
         // Mutating functions — all reverted on zone
@@ -163,34 +164,48 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
             || selector == ITIP403Registry::modifyPolicyBlacklistCall::SELECTOR
         {
             debug!(target: "zone::precompile", ?selector, "ZoneTip403ProxyRegistry: mutating call reverted");
-            return Ok(PrecompileOutput::new_reverted(
+            return Ok(PrecompileOutput::revert(
                 0,
                 ReadOnlyRegistry {}.abi_encode().into(),
+                reservoir,
             ));
         }
 
         // Unknown selector
         warn!(target: "zone::precompile", ?selector, "ZoneTip403ProxyRegistry: unknown selector");
-        Ok(PrecompileOutput::new_reverted(0, Bytes::new()))
+        Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir))
     }
 
     /// Handle `isAuthorized(policyId, user)` and the directional variants.
     ///
     /// All four share the same ABI shape: `(uint64 policyId, address user) → bool`.
-    fn handle_is_authorized(&self, data: &[u8], role: AuthRole) -> PrecompileResult {
-        let call = ITIP403Registry::isAuthorizedCall::abi_decode_raw(&data[4..])
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_is_authorized(
+        &self,
+        data: &[u8],
+        role: AuthRole,
+        reservoir: u64,
+    ) -> PrecompileResult {
+        let call = match ITIP403Registry::isAuthorizedCall::abi_decode_raw(&data[4..]) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let authorized = self.is_authorized(call.policyId, call.user, role)?;
 
         let encoded = ITIP403Registry::isAuthorizedCall::abi_encode_returns(&authorized);
-        Ok(PrecompileOutput::new(AUTH_CHECK_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            AUTH_CHECK_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `policyData(policyId) → (PolicyType, address admin)`.
-    fn handle_policy_data(&self, data: &[u8]) -> PrecompileResult {
-        let call = ITIP403Registry::policyDataCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_policy_data(&self, data: &[u8], reservoir: u64) -> PrecompileResult {
+        let call = match ITIP403Registry::policyDataCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         // Builtins: reject-all is an empty whitelist, allow-all is an empty blacklist
         let builtin_type = match call.policyId {
@@ -204,7 +219,11 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
                 admin: Address::ZERO,
             };
             let encoded = ITIP403Registry::policyDataCall::abi_encode_returns(&ret);
-            return Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()));
+            return Ok(PrecompileOutput::new(
+                POLICY_DATA_GAS,
+                encoded.into(),
+                reservoir,
+            ));
         }
 
         let policy_type = self.provider.policy_type_sync(call.policyId)?;
@@ -214,13 +233,19 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
             admin: Address::ZERO,
         };
         let encoded = ITIP403Registry::policyDataCall::abi_encode_returns(&ret);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `compoundPolicyData(policyId) → (uint64, uint64, uint64)`.
-    fn handle_compound_policy_data(&self, data: &[u8]) -> PrecompileResult {
-        let call = ITIP403Registry::compoundPolicyDataCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_compound_policy_data(&self, data: &[u8], reservoir: u64) -> PrecompileResult {
+        let call = match ITIP403Registry::compoundPolicyDataCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let (sender, recipient, mint_recipient) =
             self.provider.compound_policy_data(call.policyId)?;
@@ -231,29 +256,47 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
             mintRecipientPolicyId: mint_recipient,
         };
         let encoded = ITIP403Registry::compoundPolicyDataCall::abi_encode_returns(&ret);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `policyExists(policyId) → bool`.
-    fn handle_policy_exists(&self, data: &[u8]) -> PrecompileResult {
-        let call = ITIP403Registry::policyExistsCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_policy_exists(&self, data: &[u8], reservoir: u64) -> PrecompileResult {
+        let call = match ITIP403Registry::policyExistsCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         // Builtins always exist
         if matches!(call.policyId, REJECT_ALL_POLICY_ID | ALLOW_ALL_POLICY_ID) {
             let encoded = ITIP403Registry::policyExistsCall::abi_encode_returns(&true);
-            return Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()));
+            return Ok(PrecompileOutput::new(
+                POLICY_DATA_GAS,
+                encoded.into(),
+                reservoir,
+            ));
         }
 
         let exists = self.provider.policy_exists(call.policyId)?;
         let encoded = ITIP403Registry::policyExistsCall::abi_encode_returns(&exists);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle `policyIdCounter() → uint64`.
-    fn handle_policy_id_counter(&self) -> PrecompileResult {
+    fn handle_policy_id_counter(&self, reservoir: u64) -> PrecompileResult {
         let counter = self.provider.policy_id_counter();
         let encoded = ITIP403Registry::policyIdCounterCall::abi_encode_returns(&counter);
-        Ok(PrecompileOutput::new(POLICY_DATA_GAS, encoded.into()))
+        Ok(PrecompileOutput::new(
+            POLICY_DATA_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 }

--- a/crates/precompiles/src/ztip20.rs
+++ b/crates/precompiles/src/ztip20.rs
@@ -15,7 +15,9 @@ use alloc::sync::Arc;
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolError, SolInterface};
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{
+    PrecompileError, PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult,
+};
 use tempo_precompiles::{
     DelegateCallNotAllowed, Precompile as TempoPrecompile,
     storage::{StorageCtx, evm::EvmPrecompileStorageProvider},
@@ -45,7 +47,7 @@ macro_rules! decode_or_revert {
         match <$call_ty>::abi_decode_raw($args) {
             Ok(c) => c,
             Err(_) => {
-                return Some(Ok(PrecompileOutput::new_reverted(0, Bytes::new())));
+                return Some(Ok(StorageCtx::default().revert_output(Bytes::new())));
             }
         }
     };
@@ -105,7 +107,6 @@ impl<P: PolicyCheck> ZoneTip20Token<P> {
         match result {
             Ok(mut output) => {
                 output.gas_used = FIXED_TRANSFER_GAS;
-                output.gas_refunded = 0;
                 Ok(output)
             }
             Err(err) => Err(err),
@@ -313,20 +314,21 @@ impl<P: PolicyCheck> ZoneTip20Token<P> {
     }
 
     fn unauthorized_output() -> PrecompileOutput {
-        PrecompileOutput::new_reverted(0, Unauthorized {}.abi_encode().into())
+        StorageCtx::default().revert_output(Unauthorized {}.abi_encode().into())
     }
 
     fn roles_unauthorized_output() -> PrecompileOutput {
-        PrecompileOutput::new_reverted(0, RolesAuthError::unauthorized().selector().into())
+        StorageCtx::default().revert_output(RolesAuthError::unauthorized().selector().into())
     }
 
     /// Build a reverted output with the `policyForbids()` error selector.
     fn policy_forbids_output() -> PrecompileOutput {
-        PrecompileOutput::new_reverted(
+        PrecompileOutput::revert(
             AUTH_CHECK_GAS,
             tempo_contracts::precompiles::TIP20Error::policy_forbids()
                 .selector()
                 .into(),
+            StorageCtx::default().reservoir(),
         )
     }
 }
@@ -357,22 +359,28 @@ where
             PrecompileId::Custom("ZoneTip20Token".into()),
             move |input| {
                 if !input.is_direct_call() {
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         SolError::abi_encode(&DelegateCallNotAllowed {}).into(),
+                        input.reservoir,
                     ));
                 }
 
                 let selector = Self::selector(input.data);
                 let is_fixed_gas = selector.is_some_and(Self::is_fixed_gas_selector);
                 if is_fixed_gas && input.gas < FIXED_TRANSFER_GAS {
-                    return Err(PrecompileError::OutOfGas);
+                    return Ok(PrecompileOutput::halt(
+                        PrecompileHalt::OutOfGas,
+                        input.reservoir,
+                    ));
                 }
 
                 let mut storage = EvmPrecompileStorageProvider::new(
                     input.internals,
                     if is_fixed_gas { u64::MAX } else { input.gas },
+                    input.reservoir,
                     spec,
+                    false,
                     input.is_static,
                     gas_params.clone(),
                 );
@@ -406,18 +414,16 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::{
-        primitives::{Address, U256, address},
-        sol_types::SolCall,
-    };
+    use alloy::primitives::{Address, U256, address};
     use alloy_evm::{
         EvmInternals,
         precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},
     };
+    use alloy_sol_types::SolCall;
     use revm::{
         Context,
         database::{CacheDB, EmptyDB},
-        precompile::PrecompileResult,
+        precompile::{PrecompileHalt, PrecompileResult},
     };
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_precompiles::{
@@ -475,7 +481,7 @@ mod tests {
 
         fn resolve_transfer_policy_id(&self, _token: Address) -> Result<u64, PrecompileError> {
             if self.fail_policy_id_resolution {
-                return Err(PrecompileError::other("RPC unavailable"));
+                return Err(PrecompileError::Fatal("RPC unavailable".into()));
             }
             Ok(self.policy_id)
         }
@@ -616,7 +622,7 @@ mod tests {
             let gas_params = ctx.cfg.gas_params.clone();
             let internals = EvmInternals::from_context(ctx);
             let mut storage =
-                EvmPrecompileStorageProvider::new(internals, gas_limit, spec, false, gas_params);
+                EvmPrecompileStorageProvider::new(internals, gas_limit, 0, spec, false, false, gas_params);
             f(&mut storage)
         }
 
@@ -634,6 +640,7 @@ mod tests {
                     caller,
                     internals: EvmInternals::from_context(&mut self.ctx),
                     gas,
+                    reservoir: 0,
                     value: U256::ZERO,
                     is_static,
                     target_address: self.token,
@@ -683,7 +690,7 @@ mod tests {
         );
 
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -718,7 +725,7 @@ mod tests {
         );
 
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -738,7 +745,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             true,
         )?;
-        assert!(private_balance.reverted);
+        assert!(private_balance.is_revert());
         assert_eq!(
             private_balance.bytes,
             Bytes::from(Unauthorized {}.abi_encode())
@@ -755,7 +762,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             false,
         )?;
-        assert!(!transfer.reverted);
+        assert!(transfer.is_success());
         assert_eq!(transfer.gas_used, FIXED_TRANSFER_GAS);
         assert_eq!(harness.balance_of(harness.bob)?, U256::from(12_345u64));
 
@@ -777,7 +784,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!inbox_mint.reverted);
+        assert!(inbox_mint.is_success());
         assert_eq!(harness.balance_of(harness.bob)?, U256::from(50_000u64));
 
         let outbox_burn = harness.call(
@@ -790,7 +797,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!outbox_burn.reverted);
+        assert!(outbox_burn.is_success());
         assert_eq!(harness.balance_of(ZONE_OUTBOX_ADDRESS)?, U256::ZERO);
 
         let crossed_mint = harness.call(
@@ -804,7 +811,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(crossed_mint.reverted);
+        assert!(crossed_mint.is_revert());
         assert_eq!(
             crossed_mint.bytes,
             Bytes::from(RolesAuthError::unauthorized().selector().to_vec())
@@ -820,7 +827,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(crossed_burn.reverted);
+        assert!(crossed_burn.is_revert());
         assert_eq!(
             crossed_burn.bytes,
             Bytes::from(RolesAuthError::unauthorized().selector().to_vec())
@@ -837,7 +844,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!issuer_mint.reverted);
+        assert!(issuer_mint.is_success());
 
         let issuer_burn = harness.call(
             harness.issuer,
@@ -849,7 +856,7 @@ mod tests {
             100_000,
             false,
         )?;
-        assert!(!issuer_burn.reverted);
+        assert!(issuer_burn.is_success());
 
         Ok(())
     }
@@ -870,7 +877,7 @@ mod tests {
             false,
         )?;
         assert_eq!(approve.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(approve.gas_refunded, 0);
+        assert_eq!(approve.state_gas_used, 0);
 
         let approve_update = harness.call(
             harness.alice,
@@ -884,7 +891,7 @@ mod tests {
             false,
         )?;
         assert_eq!(approve_update.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(approve_update.gas_refunded, 0);
+        assert_eq!(approve_update.state_gas_used, 0);
 
         let transfer_new = harness.call(
             harness.alice,
@@ -898,7 +905,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_new.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_new.gas_refunded, 0);
+        assert_eq!(transfer_new.state_gas_used, 0);
 
         let transfer_existing = harness.call(
             harness.alice,
@@ -912,7 +919,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_existing.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_existing.gas_refunded, 0);
+        assert_eq!(transfer_existing.state_gas_used, 0);
 
         let transfer_with_memo = harness.call(
             harness.alice,
@@ -927,7 +934,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_with_memo.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_with_memo.gas_refunded, 0);
+        assert_eq!(transfer_with_memo.state_gas_used, 0);
 
         let transfer_from = harness.call(
             harness.spender,
@@ -942,7 +949,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_from.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_from.gas_refunded, 0);
+        assert_eq!(transfer_from.state_gas_used, 0);
 
         let transfer_from_with_memo = harness.call(
             harness.spender,
@@ -958,7 +965,7 @@ mod tests {
             false,
         )?;
         assert_eq!(transfer_from_with_memo.gas_used, FIXED_TRANSFER_GAS);
-        assert_eq!(transfer_from_with_memo.gas_refunded, 0);
+        assert_eq!(transfer_from_with_memo.state_gas_used, 0);
 
         Ok(())
     }
@@ -1003,10 +1010,11 @@ mod tests {
             .abi_encode()
             .into(),
         ] {
-            assert!(matches!(
-                harness.call(harness.alice, calldata, FIXED_TRANSFER_GAS - 1, false),
-                Err(PrecompileError::OutOfGas)
-            ));
+            let output = harness
+                .call(harness.alice, calldata, FIXED_TRANSFER_GAS - 1, false)
+                .expect("out of gas is returned as a halted precompile output");
+            assert!(output.is_halt());
+            assert_eq!(output.halt_reason(), Some(&PrecompileHalt::OutOfGas));
         }
 
         Ok(())
@@ -1027,7 +1035,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             false,
         )?;
-        assert!(!approve.reverted);
+        assert!(approve.is_success());
         assert_eq!(
             harness.allowance(harness.alice, harness.spender)?,
             U256::from(123_456u64)
@@ -1044,7 +1052,7 @@ mod tests {
             FIXED_TRANSFER_GAS,
             false,
         )?;
-        assert!(!transfer.reverted);
+        assert!(transfer.is_success());
         assert_eq!(harness.balance_of(harness.bob)?, U256::from(7_654u64));
 
         Ok(())
@@ -1061,15 +1069,15 @@ mod tests {
 
         // Owner can query their own reward info
         let owner = harness.call(harness.alice, calldata.clone(), 100_000, true)?;
-        assert!(!owner.reverted);
+        assert!(owner.is_success());
 
         // Sequencer can query anyone's reward info
         let sequencer = harness.call(harness.sequencer, calldata.clone(), 100_000, true)?;
-        assert!(!sequencer.reverted);
+        assert!(sequencer.is_success());
 
         // Outsider is rejected
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -1086,15 +1094,15 @@ mod tests {
 
         // Owner can query their own pending rewards
         let owner = harness.call(harness.alice, calldata.clone(), 100_000, true)?;
-        assert!(!owner.reverted);
+        assert!(owner.is_success());
 
         // Sequencer can query anyone's pending rewards
         let sequencer = harness.call(harness.sequencer, calldata.clone(), 100_000, true)?;
-        assert!(!sequencer.reverted);
+        assert!(sequencer.is_success());
 
         // Outsider is rejected
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())
@@ -1152,15 +1160,15 @@ mod tests {
 
         // Owner can query their own roles
         let owner = harness.call(harness.alice, calldata.clone(), 100_000, true)?;
-        assert!(!owner.reverted);
+        assert!(owner.is_success());
 
         // Sequencer can query anyone's roles
         let sequencer = harness.call(harness.sequencer, calldata.clone(), 100_000, true)?;
-        assert!(!sequencer.reverted);
+        assert!(sequencer.is_success());
 
         // Outsider is rejected
         let outsider = harness.call(harness.bob, calldata, 100_000, true)?;
-        assert!(outsider.reverted);
+        assert!(outsider.is_revert());
         assert_eq!(outsider.bytes, Bytes::from(Unauthorized {}.abi_encode()));
 
         Ok(())

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -273,7 +273,7 @@ async fn handle_subscribe(
             let filter = match params.unwrap_or_default() {
                 SubscriptionParams::None => Filter::default(),
                 SubscriptionParams::Logs(filter) => *filter,
-                SubscriptionParams::Bool(_) => {
+                SubscriptionParams::Bool(_) | SubscriptionParams::TransactionReceipts(_) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
                         JsonRpcError::invalid_params("eth_subscribe(logs) expects a filter object"),
@@ -295,7 +295,7 @@ async fn handle_subscribe(
             let full = match params.unwrap_or(SubscriptionParams::None) {
                 SubscriptionParams::None | SubscriptionParams::Bool(false) => false,
                 SubscriptionParams::Bool(true) => true,
-                SubscriptionParams::Logs(_) => {
+                SubscriptionParams::Logs(_) | SubscriptionParams::TransactionReceipts(_) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
                         JsonRpcError::invalid_params(
@@ -320,6 +320,12 @@ async fn handle_subscribe(
             }
         }
         SubscriptionKind::Syncing => {
+            return WsDispatchResult::response_only(JsonRpcResponse::error(
+                req.id.clone(),
+                JsonRpcError::method_disabled(),
+            ));
+        }
+        SubscriptionKind::TransactionReceipts => {
             return WsDispatchResult::response_only(JsonRpcResponse::error(
                 req.id.clone(),
                 JsonRpcError::method_disabled(),

--- a/crates/rpc/test-utils/auth_tokens.rs
+++ b/crates/rpc/test-utils/auth_tokens.rs
@@ -39,7 +39,7 @@ pub(crate) fn sign_p256_signature(
     Ok(TempoSignature::Primitive(PrimitiveSignature::P256(
         tempo_primitives::transaction::tt_signature::P256SignatureWithPreHash {
             r: B256::from_slice(&sig_bytes[0..32]),
-            s: normalize_p256_s(&sig_bytes[32..64]),
+            s: normalize_p256_s(&sig_bytes[32..64]).map_err(|err| eyre::eyre!(err))?,
             pub_key_x,
             pub_key_y,
             pre_hash: true,
@@ -73,7 +73,7 @@ pub(crate) fn sign_webauthn_signature(
         WebAuthnSignature {
             webauthn_data: Bytes::from(webauthn_data),
             r: B256::from_slice(&sig_bytes[0..32]),
-            s: normalize_p256_s(&sig_bytes[32..64]),
+            s: normalize_p256_s(&sig_bytes[32..64]).map_err(|err| eyre::eyre!(err))?,
             pub_key_x,
             pub_key_y,
         },

--- a/crates/tempo-zone/Cargo.toml
+++ b/crates/tempo-zone/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 # tempo
 tempo-chainspec.workspace = true
-tempo-consensus.workspace = true
 tempo-evm = { workspace = true, features = ["rpc", "engine"] }
 tempo-revm.workspace = true
 tempo-node.workspace = true
@@ -72,7 +71,6 @@ metrics.workspace = true
 k256.workspace = true
 url = "2"
 derive_more = { workspace = true, features = ["deref", "deref_mut"] }
-either.workspace = true
 eyre.workspace = true
 serde = { workspace = true, features = ["derive"] }
 futures.workspace = true

--- a/crates/tempo-zone/src/batch.rs
+++ b/crates/tempo-zone/src/batch.rs
@@ -309,14 +309,6 @@ impl BatchSubmitter {
             return Ok(AnchorMode::Direct);
         }
 
-        if gap > EIP2935_HISTORY_WINDOW {
-            return Err(eyre::eyre!(
-                "tempo_block_number ({tempo_block_number}) is outside the EIP-2935 history \
-                 window (gap={gap}, max={EIP2935_HISTORY_WINDOW}) — must split via stepping"
-            ));
-        }
-
-        // Within ancestry range — collect L1 headers as proof chain.
         let anchor_block = current_l1_block.saturating_sub(EIP2935_SAFETY_MARGIN);
         let ancestry_headers = self
             .fetch_ancestry_headers(tempo_block_number, anchor_block)

--- a/crates/tempo-zone/src/builder.rs
+++ b/crates/tempo-zone/src/builder.rs
@@ -15,7 +15,6 @@ use alloy_eips::eip4895::Withdrawals;
 use alloy_primitives::{B256, Bytes, U256};
 use alloy_rlp::Encodable;
 use alloy_sol_types::{SolCall, SolEvent};
-use either::Either;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
 };
@@ -38,7 +37,7 @@ use reth_transaction_pool::{
 };
 use std::{sync::Arc, time::Instant};
 use tempo_chainspec::spec::TempoChainSpec;
-use tempo_consensus::TEMPO_SHARED_GAS_DIVISOR;
+
 use tempo_evm::TempoNextBlockEnvAttributes;
 use tempo_payload_types::TempoBuiltPayload;
 use tempo_primitives::{
@@ -50,7 +49,7 @@ use tracing::{error, info, warn};
 
 use super::node::ZoneNode;
 
-use alloy_evm::block::BlockExecutor;
+use alloy_evm::block::{BlockExecutor, TxResult};
 
 #[derive(Clone)]
 struct RequestedWithdrawalContext {
@@ -112,6 +111,7 @@ where
             config,
             cancel,
             best_payload: _,
+            ..
         } = args;
         let PayloadConfig {
             parent_header,
@@ -197,7 +197,7 @@ where
         let chain_spec = self.provider.chain_spec();
 
         let block_gas_limit = parent_header.gas_limit();
-        let shared_gas_limit = block_gas_limit / TEMPO_SHARED_GAS_DIVISOR;
+        let shared_gas_limit = block_gas_limit / 10;
         let general_gas_limit = 0;
 
         let mut cumulative_gas_used = 0u64;
@@ -218,10 +218,12 @@ where
                         parent_beacon_block_root: attributes.parent_beacon_block_root(),
                         withdrawals: attributes.withdrawals().cloned().map(Withdrawals::new),
                         extra_data: attributes.extra_data(),
+                        slot_number: attributes.slot_number(),
                     },
                     general_gas_limit,
                     shared_gas_limit,
                     timestamp_millis_part: attributes.timestamp_millis_part(),
+                    consensus_context: None,
                     subblock_fee_recipients: Default::default(),
                 },
             )
@@ -237,13 +239,14 @@ where
             let advance_tx = build_advance_tempo_tx(prepared);
             let mut reverted = false;
             match builder.execute_transaction_with_result_closure(advance_tx, |result| {
-                if !result.is_success() {
-                    let revert_data = result.output().cloned().unwrap_or_default();
+                let evm_result = result.result();
+                if !evm_result.result.is_success() {
+                    let revert_data = evm_result.result.output().cloned().unwrap_or_default();
                     error!(
                         target: "zone::payload",
                         l1_block = prepared.header.inner.number,
                         deposits = total_deposits,
-                        is_halt = result.is_halt(),
+                        is_halt = evm_result.result.is_halt(),
                         revert_data = %revert_data,
                         "advanceTempo system tx reverted on-chain"
                     );
@@ -309,7 +312,7 @@ where
             let tx_hash = *pool_tx.hash();
             match builder.execute_transaction(tx_with_env) {
                 Ok(gas_used) => {
-                    cumulative_gas_used += gas_used;
+                    cumulative_gas_used += gas_used.tx_gas_used();
                     if let Some(receipt) = builder.executor().receipts().last() {
                         collect_requested_withdrawals(
                             receipt,
@@ -378,12 +381,13 @@ where
         );
         let mut finalize_reverted = false;
         match builder.execute_transaction_with_result_closure(finalize_tx, |result| {
-            if !result.is_success() {
-                let revert_data = result.output().cloned().unwrap_or_default();
+            let evm_result = result.result();
+            if !evm_result.result.is_success() {
+                let revert_data = evm_result.result.output().cloned().unwrap_or_default();
                 error!(
                     target: "zone::payload",
                     block_number,
-                    is_halt = result.is_halt(),
+                    is_halt = evm_result.result.is_halt(),
                     revert_data = %revert_data,
                     "finalizeWithdrawalBatch system tx reverted on-chain"
                 );
@@ -407,7 +411,7 @@ where
             hashed_state,
             trie_updates,
             block,
-        } = builder.finish(&state_provider)?;
+        } = builder.finish(&*state_provider, None)?;
 
         let requests = chain_spec
             .is_prague_active_at_timestamp(attributes.timestamp())
@@ -428,7 +432,7 @@ where
             "Built zone payload"
         );
 
-        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests);
+        let eth_payload = EthBuiltPayload::new(sealed_block, total_fees, requests, None);
 
         let execution_output = BlockExecutionOutput {
             result: execution_result,
@@ -438,8 +442,8 @@ where
         let executed_block = BuiltPayloadExecutedBlock {
             recovered_block: Arc::new(block),
             execution_output: Arc::new(execution_output),
-            hashed_state: Either::Left(Arc::new(hashed_state)),
-            trie_updates: Either::Left(Arc::new(trie_updates)),
+            hashed_state: Arc::new(hashed_state),
+            trie_updates: Arc::new(trie_updates),
         };
 
         let payload = TempoBuiltPayload::new(eth_payload, Some(executed_block));
@@ -464,6 +468,8 @@ where
     ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
         self.try_build(BuildArguments::new(
             Default::default(),
+            None,
+            None,
             config,
             Default::default(),
             Default::default(),

--- a/crates/tempo-zone/src/engine.rs
+++ b/crates/tempo-zone/src/engine.rs
@@ -230,6 +230,7 @@ impl ZoneEngine {
                     .chain_spec
                     .is_cancun_active_at_timestamp(timestamp_secs)
                     .then_some(B256::ZERO),
+                slot_number: None,
             },
             timestamp_millis_part,
             l1_block,

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -17,7 +17,8 @@ use crate::{
 };
 use alloy_evm::{
     Database, Evm, EvmEnv, EvmFactory,
-    block::{BlockExecutorFactory, BlockExecutorFor},
+    block::BlockExecutorFactory,
+    eth::EthTxResult,
     precompiles::PrecompilesMap,
     revm::{Inspector, inspector::NoOpInspector},
 };
@@ -44,7 +45,7 @@ use tempo_precompiles::{
     tip20::is_tip20_prefix, validator_config::ValidatorConfig,
     validator_config_v2::ValidatorConfigV2,
 };
-use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope};
+use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType};
 
 type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
 
@@ -278,6 +279,8 @@ impl BlockExecutorFactory for ZoneEvmConfig {
     type ExecutionCtx<'a> = TempoBlockExecutionCtx<'a>;
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
+    type TxExecutionResult = EthTxResult<<ZoneEvmFactory as EvmFactory>::HaltReason, TempoTxType>;
+    type Executor<'a, DB: StateDB, I: Inspector<TempoCtx<DB>>> = ZoneBlockExecutor<'a, DB, I>;
 
     fn evm_factory(&self) -> &Self::EvmFactory {
         &self.zone_factory
@@ -287,10 +290,10 @@ impl BlockExecutorFactory for ZoneEvmConfig {
         &'a self,
         evm: TempoEvm<DB, I>,
         ctx: Self::ExecutionCtx<'a>,
-    ) -> impl BlockExecutorFor<'a, Self, DB, I>
+    ) -> Self::Executor<'a, DB, I>
     where
-        DB: StateDB + 'a,
-        I: Inspector<TempoCtx<DB>> + 'a,
+        DB: StateDB,
+        I: Inspector<TempoCtx<DB>>,
     {
         ZoneBlockExecutor::new(evm, ctx, self.chain_spec())
     }
@@ -343,10 +346,12 @@ impl ConfigureEvm for ZoneEvmConfig {
                     .map(|withdrawals| Cow::Borrowed(withdrawals.as_slice())),
                 extra_data: block.header().extra_data().clone(),
                 tx_count_hint: Some(block.body().transactions.len()),
+                slot_number: None,
             },
             general_gas_limit: 0,
             shared_gas_limit: 0,
             validator_set: None,
+            consensus_context: block.header().consensus_context,
             subblock_fee_recipients: Default::default(),
         })
     }

--- a/crates/tempo-zone/src/executor.rs
+++ b/crates/tempo-zone/src/executor.rs
@@ -7,7 +7,10 @@
 use alloy_consensus::transaction::TxHashRef;
 use alloy_evm::{
     Database, Evm, RecoveredTx,
-    block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, OnStateHook},
+    block::{
+        BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, GasOutput,
+        OnStateHook,
+    },
     eth::{EthBlockExecutor, EthTxResult},
 };
 use reth_evm::block::StateDB;
@@ -25,7 +28,7 @@ use crate::tx_context;
 ///
 /// Wraps [`EthBlockExecutor`] without any subblock validation, gas-section tracking,
 /// or end-of-block metadata system transaction requirements.
-pub(crate) struct ZoneBlockExecutor<'a, DB: Database, I> {
+pub struct ZoneBlockExecutor<'a, DB: Database, I> {
     inner: EthBlockExecutor<'a, TempoEvm<DB, I>, &'a TempoChainSpec, TempoReceiptBuilder>,
 }
 
@@ -100,21 +103,11 @@ where
             .execute_transaction_without_commit((tx_env, recovered))
     }
 
-    fn commit_transaction(&mut self, output: Self::Result) -> Result<u64, BlockExecutionError> {
-        let gas_used = self.inner.commit_transaction(output)?;
-
-        // Collect revert logs (same as Tempo L1 executor).
-        let logs = self.inner.evm.take_revert_logs();
-        if !logs.is_empty() {
-            self.inner
-                .receipts
-                .last_mut()
-                .expect("receipt was just pushed")
-                .logs
-                .extend(logs);
-        }
-
-        Ok(gas_used)
+    fn commit_transaction(
+        &mut self,
+        output: Self::Result,
+    ) -> GasOutput {
+        self.inner.commit_transaction(output)
     }
 
     fn finish(
@@ -227,7 +220,7 @@ mod tests {
                 // Zone executor override: validatorTokens[sequencer] = fee_token.
                 fee_manager.validator_tokens[sequencer].write(*token)?;
 
-                fee_manager.collect_fee_pre_tx(user, *token, *max, sequencer)?;
+                fee_manager.collect_fee_pre_tx(user, *token, *max, sequencer, false)?;
                 fee_manager.collect_fee_post_tx(user, *used, *max - *used, *token, sequencer)?;
             }
 

--- a/crates/tempo-zone/src/l1_state/precompile.rs
+++ b/crates/tempo-zone/src/l1_state/precompile.rs
@@ -27,7 +27,7 @@
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolError};
-use revm::precompile::{PrecompileError, PrecompileId, PrecompileOutput, PrecompileResult};
+use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, error, warn};
 
 use super::provider::L1StateProvider;
@@ -80,29 +80,30 @@ impl TempoStateReader {
             move |input| {
                 if !input.is_direct_call() {
                     warn!(target: "zone::precompile", "TempoStateReader called via DELEGATECALL — rejecting");
-                    return Ok(PrecompileOutput::new_reverted(
+                    return Ok(PrecompileOutput::revert(
                         0,
                         DelegateCallNotAllowed {}.abi_encode().into(),
+                        input.reservoir,
                     ));
                 }
 
                 let data = input.data;
                 if data.len() < 4 {
                     warn!(target: "zone::precompile", data_len = data.len(), "TempoStateReader called with insufficient data");
-                    return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                    return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
                 }
 
                 let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
 
                 let result = if selector == readStorageAtCall::SELECTOR {
                     debug!(target: "zone::precompile", "TempoStateReader: readStorageAt");
-                    Self::handle_single_slot(&provider, data)
+                    Self::handle_single_slot(&provider, data, input.reservoir)
                 } else if selector == readStorageBatchAtCall::SELECTOR {
                     debug!(target: "zone::precompile", "TempoStateReader: readStorageBatchAt");
-                    Self::handle_multi_slot(&provider, data)
+                    Self::handle_multi_slot(&provider, data, input.reservoir)
                 } else {
                     warn!(target: "zone::precompile", selector = ?selector, "TempoStateReader: unknown selector");
-                    Ok(PrecompileOutput::new_reverted(0, Bytes::new()))
+                    Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir))
                 };
 
                 match &result {
@@ -125,9 +126,15 @@ impl TempoStateReader {
     /// Decodes the ABI calldata, performs a synchronous lookup via the provider at the specified
     /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32`
     /// value. Returns a hard [`PrecompileError`] if both the cache and RPC fallback fail.
-    fn handle_single_slot(provider: &L1StateProvider, data: &[u8]) -> PrecompileResult {
-        let call = readStorageAtCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_single_slot(
+        provider: &L1StateProvider,
+        data: &[u8],
+        reservoir: u64,
+    ) -> PrecompileResult {
+        let call = match readStorageAtCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let gas = BASE_GAS + PER_SLOT_GAS;
 
@@ -141,7 +148,7 @@ impl TempoStateReader {
             })?;
 
         let encoded = readStorageAtCall::abi_encode_returns(&value);
-        Ok(PrecompileOutput::new(gas, encoded.into()))
+        Ok(PrecompileOutput::new(gas, encoded.into(), reservoir))
     }
 
     /// Handle a `readStorageBatchAt(address, bytes32[], uint64)` call.
@@ -150,9 +157,15 @@ impl TempoStateReader {
     /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32[]`
     /// result. If **any** slot fails both cache and RPC lookup, the entire call fails with a
     /// hard [`PrecompileError`].
-    fn handle_multi_slot(provider: &L1StateProvider, data: &[u8]) -> PrecompileResult {
-        let call = readStorageBatchAtCall::abi_decode(data)
-            .map_err(|_| PrecompileError::other("ABI decode failed"))?;
+    fn handle_multi_slot(
+        provider: &L1StateProvider,
+        data: &[u8],
+        reservoir: u64,
+    ) -> PrecompileResult {
+        let call = match readStorageBatchAtCall::abi_decode(data) {
+            Ok(call) => call,
+            Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
+        };
 
         let num_slots = call.slots.len() as u64;
         let gas = BASE_GAS + PER_SLOT_GAS * num_slots;
@@ -171,6 +184,6 @@ impl TempoStateReader {
         }
 
         let encoded = readStorageBatchAtCall::abi_encode_returns(&results);
-        Ok(PrecompileOutput::new(gas, encoded.into()))
+        Ok(PrecompileOutput::new(gas, encoded.into(), reservoir))
     }
 }

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -652,7 +652,9 @@ impl PolicyCheck for PolicyProvider {
 
     fn policy_exists(&self, policy_id: u64) -> Result<bool, PrecompileError> {
         self.policy_exists_sync(policy_id).map_err(|e| {
-            PrecompileError::other(format!("policyExists failed for policy {policy_id}: {e}"))
+            zone_precompiles::zone_rpc_error(format!(
+                "policyExists failed for policy {policy_id}: {e}"
+            ))
         })
     }
 

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -34,10 +34,12 @@ use reth_transaction_pool::{
     TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
 };
+use reth_primitives_traits::SealedBlock;
 use std::sync::Arc;
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_evm::TempoEvmConfig;
+use tempo_payload_types::TempoExecutionData;
 use tempo_node::{
     DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoReceiptConverter,
 };
@@ -292,6 +294,7 @@ where
                 NoopEngineApiBuilder::default(),
                 BasicEngineValidatorBuilder::default(),
                 Identity::default(),
+                Identity::default(),
             ),
             deposit_queue,
             l1_config,
@@ -487,10 +490,14 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for ZoneNode {
     type RpcBlock =
         alloy_rpc_types_eth::Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeader>;
 
-    fn rpc_to_primitive_block(rpc_block: Self::RpcBlock) -> tempo_primitives::Block {
-        rpc_block
+    fn rpc_to_execution_data(rpc_block: Self::RpcBlock) -> TempoExecutionData {
+        let block = rpc_block
             .into_consensus_block()
-            .map_transactions(|tx| tx.into_inner())
+            .map_transactions(|tx| tx.into_inner());
+        TempoExecutionData {
+            block: Arc::new(SealedBlock::seal_slow(block)),
+            validator_set: None,
+        }
     }
 
     fn local_payload_attributes_builder(

--- a/crates/tempo-zone/src/payload.rs
+++ b/crates/tempo-zone/src/payload.rs
@@ -55,6 +55,10 @@ impl reth_node_api::PayloadAttributes for ZonePayloadAttributes {
     fn parent_beacon_block_root(&self) -> Option<B256> {
         self.inner.parent_beacon_block_root
     }
+
+    fn slot_number(&self) -> Option<u64> {
+        self.inner.slot_number
+    }
 }
 
 impl ZonePayloadAttributes {

--- a/crates/tempo-zone/src/tx_context.rs
+++ b/crates/tempo-zone/src/tx_context.rs
@@ -72,9 +72,10 @@ impl ZoneTxContext {
                     target: "zone::precompile",
                     "ZoneTxContext called via DELEGATECALL — rejecting"
                 );
-                return Ok(PrecompileOutput::new_reverted(
+                return Ok(PrecompileOutput::revert(
                     0,
                     DelegateCallNotAllowed {}.abi_encode().into(),
+                    input.reservoir,
                 ));
             }
 
@@ -85,7 +86,7 @@ impl ZoneTxContext {
                     data_len = data.len(),
                     "ZoneTxContext called with insufficient data"
                 );
-                return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
             }
 
             let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
@@ -95,14 +96,14 @@ impl ZoneTxContext {
                     ?selector,
                     "ZoneTxContext: unknown selector"
                 );
-                return Ok(PrecompileOutput::new_reverted(0, Bytes::new()));
+                return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
             }
 
             debug!(target: "zone::precompile", "ZoneTxContext: currentTxHash");
 
             let tx_hash = current_tx_hash().unwrap_or_else(|| synthetic_tx_hash(&input));
             let encoded = currentTxHashCall::abi_encode_returns(&tx_hash);
-            Ok(PrecompileOutput::new(20, encoded.into()))
+            Ok(PrecompileOutput::new(20, encoded.into(), input.reservoir))
         })
     }
 }

--- a/crates/tempo-zone/tests/advance_tempo.rs
+++ b/crates/tempo-zone/tests/advance_tempo.rs
@@ -257,7 +257,7 @@ fn advance_tempo_repro() {
     match &config_result {
         Ok(result) => {
             println!("config() result: {:?}", result.result);
-            let gas_used = result.result.gas_used();
+            let gas_used = result.result.tx_gas_used();
             match &result.result {
                 ExecutionResult::Success { output, .. } => {
                     if let Output::Call(data) = output {
@@ -285,7 +285,7 @@ fn advance_tempo_repro() {
         evm.transact_system_call(sequencer, TEMPO_STATE_ADDRESS, Bytes::from(hash_calldata));
     match &hash_result {
         Ok(result) => {
-            let gas_used = result.result.gas_used();
+            let gas_used = result.result.tx_gas_used();
             match &result.result {
                 ExecutionResult::Success { output, .. } => {
                     if let Output::Call(data) = output {
@@ -386,7 +386,7 @@ fn advance_tempo_repro() {
         evm.transact_system_call(sequencer, ZONE_INBOX_ADDRESS, Bytes::from(advance_calldata));
     match &advance_result {
         Ok(result) => {
-            let gas_used = result.result.gas_used();
+            let gas_used = result.result.tx_gas_used();
             match &result.result {
                 ExecutionResult::Success { output, .. } => {
                     if let Output::Call(data) = output {

--- a/crates/tempo-zone/tests/it/deposit.rs
+++ b/crates/tempo-zone/tests/it/deposit.rs
@@ -59,7 +59,7 @@ async fn test_l1_deposit_mints_on_zone() -> eyre::Result<()> {
 
     let factory = ITIP20Factory::new(TIP20_FACTORY_ADDRESS, zone_provider.clone());
     let receipt = factory
-        .createToken(
+        .createToken_0(
             "ZoneTest".to_string(),
             "ZTEST".to_string(),
             "USD".to_string(),

--- a/crates/tempo-zone/tests/it/stepping_e2e.rs
+++ b/crates/tempo-zone/tests/it/stepping_e2e.rs
@@ -1,38 +1,39 @@
-//! Stepping mode E2E test: verifies batch submission after extended L1 gap.
+//! Extended-gap batch submission E2E test.
 //!
-//! When a zone node goes down for longer than the EIP-2935 history window (8192 blocks),
-//! the batch submitter must split the batch into multiple direct-mode submissions.
-//! This test validates that the stepping logic correctly handles this scenario.
+//! When a zone node goes down for long enough that even the first stepping
+//! boundary is outside the EIP-2935 history window, the sequencer must still
+//! submit batches successfully once it comes back. This exercises the
+//! long-downtime ancestry path instead of the simpler direct-mode case.
 
-use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
+use crate::utils::{L1TestNode, ZoneTestNode, poll_until, spawn_sequencer};
 use alloy::providers::Provider;
 use std::time::Duration;
-use zone::abi::{ZONE_TOKEN_ADDRESS, ZonePortal};
+use zone::abi::ZonePortal;
 
-/// Extended timeout for stepping tests — the L1 needs to mine >8200 blocks
-/// and the zone must process them all.
-const STEPPING_TIMEOUT: Duration = Duration::from_secs(180);
+const EIP2935_HISTORY_WINDOW: u64 = 8192;
+const EIP2935_SAFETY_MARGIN: u64 = 360;
+const EIP2935_EFFECTIVE_WINDOW: u64 = EIP2935_HISTORY_WINDOW - EIP2935_SAFETY_MARGIN;
+const EXTENDED_GAP_BLOCKS: u64 = EIP2935_HISTORY_WINDOW + EIP2935_EFFECTIVE_WINDOW + 64;
 
-/// Timeout for L1 operations.
-const L1_TIMEOUT: Duration = Duration::from_secs(30);
+/// Extended timeout for stepping tests — the L1 needs to mine >16k blocks and
+/// the zone must replay enough history to cross the first stepping boundary.
+const STEPPING_TIMEOUT: Duration = Duration::from_secs(300);
+const BATCH_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Test that batch submission works after the zone's `tempoBlockNumber` has
-/// fallen outside the EIP-2935 history window (gap > 8192 blocks).
-///
-/// The stepping logic must split the batch into multiple direct-mode
-/// submissions, each within the EIP-2935 effective window.
+/// fallen far enough behind L1 that the first stepped sub-batch still lands
+/// outside the EIP-2935 history window.
 ///
 /// 1. Start L1 with 10ms block time to mine blocks quickly.
 /// 2. Deploy zone portal on L1.
-/// 3. Wait for L1 to advance >8200 blocks past genesis.
-/// 4. Start zone node connected to L1.
-/// 5. Wait for zone to process all L1 blocks.
-/// 6. Fund user and deposit to create non-trivial state.
-/// 7. Spawn sequencer (monitor + withdrawal processor).
-/// 8. Assert multiple BatchSubmitted events (stepping produces >=2 submissions).
-/// 9. Verify withdrawal works through stepped batches.
+/// 3. Wait for L1 to advance past `history + effective window`, so the first
+///    stepping boundary is still outside the history window.
+/// 4. Start zone node connected to L1, anchored at the portal genesis.
+/// 5. Wait for the zone to replay up to the first stepping boundary.
+/// 6. Spawn sequencer while the zone is still far behind L1.
+/// 7. Assert a `BatchSubmitted` event appears.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "slow: mines >8200 L1 blocks (~82s), run with --ignored or in nightly CI"]
+#[ignore = "slow: mines >16k L1 blocks and replays zone history, run with --ignored or in nightly CI"]
 async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -45,19 +46,17 @@ async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
     // --- Step 2: Deploy zone portal ---
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Step 3: Wait for L1 to advance past the EIP-2935 window ---
-    // The portal's genesisTempoBlockNumber is set to the current L1 block at
-    // deployment time. We need the L1 to advance >8200 blocks beyond that.
-    let genesis_block = l1.provider().get_block_number().await?;
-    let target_block = genesis_block + 8200;
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    let genesis_block = portal.genesisTempoBlockNumber().call().await?;
+    let target_block = genesis_block + EXTENDED_GAP_BLOCKS;
 
     tracing::info!(
         genesis_block,
         target_block,
-        "Waiting for L1 to advance past EIP-2935 window"
+        "Waiting for L1 to advance past the extended ancestry threshold"
     );
 
-    // Poll until L1 reaches the target — at 10ms/block this takes ~82 seconds.
+    // Poll until L1 reaches the target — at 10ms/block this takes ~160 seconds.
     let poll_start = std::time::Instant::now();
     loop {
         let current = l1.provider().get_block_number().await?;
@@ -70,7 +69,7 @@ async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
             );
             break;
         }
-        if poll_start.elapsed() > Duration::from_secs(120) {
+        if poll_start.elapsed() > STEPPING_TIMEOUT {
             return Err(eyre::eyre!(
                 "Timed out waiting for L1 to reach block {target_block} (current: {current})"
             ));
@@ -78,67 +77,61 @@ async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 
-    // --- Step 4: Start zone node connected to L1 ---
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
+    // --- Step 4: Start zone node connected to L1, anchored at the portal genesis ---
+    let zone =
+        ZoneTestNode::start_from_l1_portal_genesis(l1.http_url(), l1.ws_url(), portal_address)
+            .await?;
 
-    // --- Step 5: Wait for zone to catch up ---
-    zone.wait_for_l2_tempo_finalized(0, STEPPING_TIMEOUT)
+    // --- Step 5: Wait for the zone to replay to the first stepping boundary ---
+    let first_step_tempo = genesis_block + EIP2935_EFFECTIVE_WINDOW;
+    zone.wait_for_tempo_block_number(first_step_tempo, STEPPING_TIMEOUT)
         .await?;
 
-    // --- Step 6: Fund user and deposit ---
-    let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
-    l1.fund_user(account.address(), 2_000_000).await?;
-    account.deposit(1_000_000, L1_TIMEOUT, &zone).await?;
+    let l1_tip = l1.provider().get_block_number().await?;
+    eyre::ensure!(
+        l1_tip.saturating_sub(first_step_tempo) > EIP2935_HISTORY_WINDOW,
+        "test precondition not met: first step tempo {first_step_tempo} is only {} blocks behind L1 tip {l1_tip}",
+        l1_tip.saturating_sub(first_step_tempo),
+    );
 
-    // --- Step 7: Spawn sequencer ---
-    let _seq = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    // --- Step 6: Spawn sequencer while the zone still has a large backlog ---
+    let seq = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
-    // --- Step 8: Assert multiple BatchSubmitted events ---
-    // The gap exceeds the EIP-2935 window, so stepping must produce >=2 submitBatch calls.
-    let batch_timeout = Duration::from_secs(60);
-    let batch_start = std::time::Instant::now();
-    let portal = ZonePortal::new(portal_address, l1.provider());
+    // --- Step 7: Assert batch submission succeeds after the long gap ---
+    let batch_count = poll_until(
+        BATCH_TIMEOUT,
+        Duration::from_millis(500),
+        "BatchSubmitted event after extended L1 gap",
+        || {
+            let portal = &portal;
+            let seq = &seq;
+            async move {
+                if seq.monitor_handle.is_finished() {
+                    eyre::bail!("monitor task exited before submitting a batch");
+                }
 
-    loop {
-        let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
+                if seq.withdrawal_handle.is_finished() {
+                    eyre::bail!("withdrawal processor exited before batch submission completed");
+                }
 
-        let batch_count = events.len();
-        if batch_count >= 2 {
-            tracing::info!(
-                batch_count,
-                elapsed_secs = batch_start.elapsed().as_secs(),
-                "Stepping produced multiple batch submissions"
-            );
-            break;
-        }
-
-        if batch_start.elapsed() > batch_timeout {
-            return Err(eyre::eyre!(
-                "Expected >= 2 BatchSubmitted events from stepping, got {batch_count}"
-            ));
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-
-    // --- Step 9: Verify withdrawal works through stepped batches ---
-    let withdrawal_amount: u128 = 500_000;
-    account.withdraw(withdrawal_amount).await?;
-
-    l1.wait_for_withdrawal_on_l1(
-        portal_address,
-        account.address(),
-        withdrawal_amount,
-        STEPPING_TIMEOUT,
+                let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
+                let batch_count = events.len();
+                if batch_count >= 1 {
+                    Ok(Some(batch_count))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
     )
     .await?;
 
-    // Verify L2 balance decreased
-    let l2_balance = zone
-        .balance_of(ZONE_TOKEN_ADDRESS, account.address())
-        .await?;
-    assert!(
-        l2_balance <= alloy::primitives::U256::from(1_000_000u128 - withdrawal_amount),
-        "L2 balance should decrease by at least the withdrawal amount (got {l2_balance})"
+    tracing::info!(
+        batch_count,
+        l1_tip,
+        first_step_tempo,
+        first_step_gap = l1_tip.saturating_sub(first_step_tempo),
+        "Batch submission succeeded after extended L1 gap"
     );
 
     Ok(())

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -403,6 +403,38 @@ impl ZoneTestNode {
         .await
     }
 
+    /// Start a zone node connected to a real L1, anchoring genesis to the
+    /// portal's on-chain `genesisTempoBlockNumber`.
+    ///
+    /// Unlike [`start_from_l1`], this preserves the full replay gap between the
+    /// portal genesis and the current L1 tip, which is useful for long-downtime
+    /// catch-up tests.
+    pub(crate) async fn start_from_l1_portal_genesis(
+        l1_http_url: &url::Url,
+        l1_ws_url: &url::Url,
+        portal_address: Address,
+    ) -> eyre::Result<Self> {
+        let l1_provider =
+            ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(l1_http_url.clone());
+        let portal = zone::abi::ZonePortal::new(portal_address, &l1_provider);
+        let genesis_block_number = portal.genesisTempoBlockNumber().call().await?;
+        let (genesis, genesis_block_number) =
+            build_l1_anchored_genesis_at_block(l1_http_url, portal_address, genesis_block_number)
+                .await?;
+
+        let throwaway_key = k256::SecretKey::from_slice(&[0x01; 32]).expect("valid throwaway key");
+        Self::launch_with_genesis(
+            l1_ws_url.to_string(),
+            portal_address,
+            Some(genesis_block_number),
+            next_unique_chain_id(),
+            Some(genesis),
+            Address::ZERO,
+            throwaway_key,
+        )
+        .await
+    }
+
     /// Start a zone node connected to a real L1, with a sequencer key for ECIES decryption.
     ///
     /// Same as [`start_from_l1`] but passes the sequencer key through to `ZoneNode::new`
@@ -1542,8 +1574,6 @@ async fn build_l1_anchored_genesis(
     l1_http_url: &url::Url,
     portal_address: Address,
 ) -> eyre::Result<(Genesis, u64)> {
-    use alloy_primitives::address;
-
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(l1_http_url.clone());
 
@@ -1552,6 +1582,32 @@ async fn build_l1_anchored_genesis(
         .await?
         .ok_or_else(|| eyre::eyre!("L1 latest block not found"))?;
     let l1_header: &TempoHeader = block.header.as_ref();
+    build_l1_anchored_genesis_from_header(l1_header, portal_address)
+}
+
+/// Build a zone test genesis anchored to a specific L1 block number.
+async fn build_l1_anchored_genesis_at_block(
+    l1_http_url: &url::Url,
+    portal_address: Address,
+    block_number: u64,
+) -> eyre::Result<(Genesis, u64)> {
+    let l1_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(l1_http_url.clone());
+
+    let block = l1_provider
+        .get_block_by_number(block_number.into())
+        .await?
+        .ok_or_else(|| eyre::eyre!("L1 block {block_number} not found"))?;
+    let l1_header: &TempoHeader = block.header.as_ref();
+    build_l1_anchored_genesis_from_header(l1_header, portal_address)
+}
+
+fn build_l1_anchored_genesis_from_header(
+    l1_header: &TempoHeader,
+    portal_address: Address,
+) -> eyre::Result<(Genesis, u64)> {
+    use alloy_primitives::address;
+
     let genesis_block_number = l1_header.inner.number;
 
     let mut rlp_buf = Vec::new();

--- a/crates/tempo-zone/tests/it/utils.rs
+++ b/crates/tempo-zone/tests/it/utils.rs
@@ -1113,7 +1113,7 @@ impl L1TestNode {
         let provider = self.dev_provider();
         let factory = ITIP20Factory::new(TIP20_FACTORY_ADDRESS, &provider);
         let receipt = factory
-            .createToken(
+            .createToken_0(
                 name.to_string(),
                 symbol.to_string(),
                 "USD".to_string(),
@@ -2717,7 +2717,7 @@ impl PrivateRpcTestCtx {
             .connect_http(self.zone.http_url().clone());
         let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &provider);
         let pending = keychain
-            .authorizeKey(key_id, signature_type, expiry, false, vec![])
+            .authorizeKey_0(key_id, signature_type, expiry, false, vec![])
             .send()
             .await?;
         self.fixture.inject_empty_block(self.zone.deposit_queue());

--- a/xtask/src/demo_blacklist.rs
+++ b/xtask/src/demo_blacklist.rs
@@ -207,7 +207,7 @@ impl DemoBlacklist {
         println!("  Predicted address: {token_addr}");
 
         let receipt = factory
-            .createToken(
+            .createToken_0(
                 "DemoUSD".to_string(),
                 "DUSD".to_string(),
                 "USD".to_string(),

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -409,7 +409,7 @@ async fn create_demo_token<P: Provider<TempoNetwork>>(
         .await
         .wrap_err("failed to compute token address")?;
     let receipt = factory
-        .createToken(
+        .createToken_0(
             name.to_string(),
             symbol.to_string(),
             "USD".to_string(),

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -13,7 +13,7 @@ use alloy::{
 };
 use alloy_eips::Encodable2718;
 use eyre::{Context as _, eyre};
-use std::{collections::BTreeMap, time::Instant};
+use std::{collections::BTreeMap, num::NonZeroU64, time::Instant};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP20;
 use tempo_primitives::{
@@ -209,7 +209,9 @@ impl SpamDeposits {
                     }],
                     nonce_key,
                     nonce: 0,
-                    valid_after: Some(target_ts),
+                    valid_after: Some(
+                        NonZeroU64::new(target_ts).expect("target timestamp is always non-zero"),
+                    ),
                     ..Default::default()
                 };
 


### PR DESCRIPTION
## Problem

Zone-005/006 stalled on Moderato testnet after T4 hardfork activation. The deployed v0.1.0 binary pins tempo-primitives at rev e331e2f4 which lacks the `consensus_context` field in `TempoHeader`. Post-T4, L1 blocks include `consensus_context` in the RLP — the old binary silently drops the field on deserialize, re-encodes a shorter RLP, and commits a wrong `tempoBlockHash` to `TempoState`, permanently stalling the zone.

## Fix

Bump all deps to tempo v1.7.0 stack so `TempoHeader` includes `consensus_context` and RLP encoding is correct end-to-end.

**Branch based on v0.1.0 tag** — this is a hotfix release branch, not a normal feature PR.

### Dependency bumps
- tempo: 3d70f75485 (v1.7.0)
- reth: 8328732, alloy: 2.0.4, alloy-evm: 0.34.0, revm: 38.0.0
- alloy-sol-types pinned to 1.5.7 via lockfile (1.6.0 breaks tempo-contracts sol! macro)

### Recovery plan
After deploying the hotfix image: `tempo-zone stage unwind --datadir <path> --chain <chainspec> num-blocks 1`, then restart.