### PR TITLE
feat: add forge vault accounting script and PR workflow

### DIFF
--- a/.github/workflows/forge-pr.yml
+++ b/.github/workflows/forge-pr.yml
@@ -1,0 +1,72 @@
+name: Forge PR
+
+on:
+  pull_request:
+    branches: [main, dr/validium]
+    paths:
+      - "specs/ref-impls/**"
+      - ".github/workflows/forge-pr.yml"
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  forge-test:
+    name: forge test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        with:
+          version: nightly
+
+      - name: Cache Forge artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            specs/ref-impls/cache
+            specs/ref-impls/out
+          key: forge-${{ runner.os }}-${{ hashFiles('specs/ref-impls/foundry.toml', 'specs/ref-impls/src/**/*.sol', 'specs/ref-impls/test/**/*.sol') }}
+          restore-keys: |
+            forge-${{ runner.os }}-
+
+      - name: Run Forge tests with gas report
+        working-directory: specs/ref-impls
+        run: forge test -vvv --gas-report | tee forge-gas-report.txt
+
+      - name: Upload gas report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: forge-gas-report
+          path: specs/ref-impls/forge-gas-report.txt
+          if-no-files-found: error
+
+      - name: Post gas report
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- forge-gas-report -->';
+            const report = fs.readFileSync('specs/ref-impls/forge-gas-report.txt', 'utf8');
+            const body = `${marker}\n### Forge gas report\n\n\`\`\`text\n${report.slice(-60000)}\n\`\`\``;
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.rest.issues.listComments({owner, repo, issue_number, per_page: 100});
+            const existing = comments.data.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
+            } else {
+              await github.rest.issues.createComment({owner, repo, issue_number, body});
+            }

--- a/specs/ref-impls/script/ERC4626VaultAccounting.s.sol
+++ b/specs/ref-impls/script/ERC4626VaultAccounting.s.sol
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { Script } from "forge-std/Script.sol";
+
+interface IERC20 {
+
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+
+}
+
+contract WrappedEthAsset is IERC20 {
+
+    string public constant name = "Wrapped ETH";
+    string public constant symbol = "WETH";
+    uint8 public constant decimals = 18;
+
+    uint256 public override totalSupply;
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    function deposit() external payable {
+        balanceOf[msg.sender] += msg.value;
+        totalSupply += msg.value;
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    )
+        external
+        override
+        returns (bool)
+    {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "ALLOWANCE");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "BALANCE");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+    }
+
+    }
+
+    contract Eth4626Vault is IERC20 {
+
+        string public constant name = "ETH ERC4626 Vault";
+        string public constant symbol = "vETH";
+        uint8 public constant decimals = 18;
+
+        IERC20 public immutable asset;
+        uint256 public override totalSupply;
+        mapping(address => uint256) public override balanceOf;
+        mapping(address => mapping(address => uint256)) public override allowance;
+
+        constructor(IERC20 asset_) {
+            asset = asset_;
+        }
+
+        function totalAssets() public view returns (uint256) {
+            return asset.balanceOf(address(this));
+        }
+
+        function convertToShares(uint256 assets) public view returns (uint256) {
+            uint256 supply = totalSupply;
+            return supply == 0 ? assets : (assets * supply) / totalAssets();
+        }
+
+        function convertToAssets(uint256 shares) public view returns (uint256) {
+            uint256 supply = totalSupply;
+            return supply == 0 ? shares : (shares * totalAssets()) / supply;
+        }
+
+        function previewDeposit(uint256 assets) external view returns (uint256) {
+            return convertToShares(assets);
+        }
+
+        function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+            shares = convertToShares(assets);
+            require(shares != 0, "ZERO_SHARES");
+            require(asset.transferFrom(msg.sender, address(this), assets), "TRANSFER_FROM");
+            totalSupply += shares;
+            balanceOf[receiver] += shares;
+        }
+
+        function approve(address spender, uint256 amount) external override returns (bool) {
+            allowance[msg.sender][spender] = amount;
+            return true;
+        }
+
+        function transfer(address to, uint256 amount) external override returns (bool) {
+            _transfer(msg.sender, to, amount);
+            return true;
+        }
+
+        function transferFrom(
+            address from,
+            address to,
+            uint256 amount
+        )
+            external
+            override
+            returns (bool)
+        {
+            uint256 allowed = allowance[from][msg.sender];
+            require(allowed >= amount, "ALLOWANCE");
+            if (allowed != type(uint256).max) {
+                allowance[from][msg.sender] = allowed - amount;
+            }
+            _transfer(from, to, amount);
+            return true;
+        }
+
+        function _transfer(address from, address to, uint256 amount) internal {
+            require(balanceOf[from] >= amount, "BALANCE");
+            balanceOf[from] -= amount;
+            balanceOf[to] += amount;
+        }
+
+        }
+
+        contract ERC4626VaultAccountingScript is Script {
+
+            function run() external payable {
+                uint256 deployerKey = vm.envOr("PRIVATE_KEY", uint256(0));
+                address deployer = deployerKey == 0 ? msg.sender : vm.addr(deployerKey);
+                uint256 depositAmount = vm.envOr("DEPOSIT_AMOUNT", uint256(10 ether));
+
+                if (deployerKey == 0) {
+                    vm.startBroadcast();
+                } else {
+                    vm.startBroadcast(deployerKey);
+                }
+
+                WrappedEthAsset weth = new WrappedEthAsset();
+                Eth4626Vault vault = new Eth4626Vault(IERC20(address(weth)));
+
+                weth.deposit{ value: depositAmount }();
+                require(weth.balanceOf(deployer) == depositAmount, "ETH_NOT_WRAPPED");
+
+                uint256 expectedShares = vault.previewDeposit(depositAmount);
+                require(weth.approve(address(vault), depositAmount), "APPROVE_FAILED");
+                uint256 shares = vault.deposit(depositAmount, deployer);
+
+                require(shares == expectedShares, "SHARE_PREVIEW_MISMATCH");
+                require(vault.balanceOf(deployer) == shares, "SHARE_BALANCE_MISMATCH");
+                require(vault.totalAssets() == depositAmount, "TOTAL_ASSETS_MISMATCH");
+                require(vault.convertToAssets(shares) == depositAmount, "ASSET_ACCOUNTING_MISMATCH");
+
+                vm.stopBroadcast();
+            }
+
+        }


### PR DESCRIPTION
Adds a Foundry script that deploys a minimal ERC-4626-style ETH vault flow, wraps ETH, deposits into the vault, and asserts share/accounting invariants. Also adds a PR Forge workflow with cached artifacts and an upserted gas report comment.