### PR TITLE
fix: update moderato zonefactory default

### DIFF
--- a/.codex/skills/zonefactory-deploy/SKILL.md
+++ b/.codex/skills/zonefactory-deploy/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: zonefactory-deploy
+description: Deploy a fresh ZoneFactory contract to Moderato Tempo L1 after ABI or implementation-breaking changes, verify the deployment, and update repo constants and docs.
+---
+
+# ZoneFactory Deploy
+
+Use this skill when a shared Moderato `ZoneFactory` must be redeployed because the factory, portal, messenger, verifier, or related ABI changed.
+
+## Workflow
+
+1. Read `xtask/src/zone_utils.rs` and `docs/ZONES.md` to confirm the current `MODERATO_ZONE_FACTORY` address and docs table entry.
+2. Build the Foundry reference contracts from `specs/ref-impls`.
+3. Deploy `src/zone/ZoneFactory.sol:ZoneFactory` to Moderato.
+4. Verify the new factory has code, `zoneCount()` returns `0`, and `verifier()` returns a non-zero address.
+5. Update `MODERATO_ZONE_FACTORY`, its explorer comment, `docs/ZONES.md`, and any other `rg` hits for the old address.
+6. Run Rust formatting/checks that cover the changed constants.
+
+## Commands
+
+```bash
+cd specs/ref-impls
+export ETH_RPC_URL=https://rpc.moderato.tempo.xyz
+export PRIVATE_KEY=<deployer_private_key>
+
+forge build
+forge create --broadcast --rpc-url "$ETH_RPC_URL" --private-key "$PRIVATE_KEY" src/zone/ZoneFactory.sol:ZoneFactory
+```
+
+For manual deployments, prefer replacing `--private-key "$PRIVATE_KEY"` with `--interactive` so the key is not written into shell history or process arguments. If the user explicitly requires a non-interactive command and has already provided `PRIVATE_KEY` through the environment, use `--private-key "$PRIVATE_KEY"` without echoing the value.
+
+After deployment:
+
+```bash
+export ZONE_FACTORY=0x...
+
+cast code "$ZONE_FACTORY" --rpc-url "$ETH_RPC_URL"
+cast call "$ZONE_FACTORY" "zoneCount()(uint32)" --rpc-url "$ETH_RPC_URL"
+cast call "$ZONE_FACTORY" "verifier()(address)" --rpc-url "$ETH_RPC_URL"
+```
+
+Record the deployed address, transaction hash, and block number in the docs section for future audits.

--- a/.codex/skills/zonefactory-deploy/agents/openai.yaml
+++ b/.codex/skills/zonefactory-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "ZoneFactory Deploy"
+  short_description: "Deploy and update the shared ZoneFactory"
+  default_prompt: "Use $zonefactory-deploy to deploy a fresh Moderato ZoneFactory and update the repo defaults."

--- a/.codex/skills/zones-deploy-debug/references/commands.md
+++ b/.codex/skills/zones-deploy-debug/references/commands.md
@@ -25,6 +25,9 @@ target/debug/tempo-xtask set-encryption-key --l1-rpc-url "$HTTP_RPC" --portal "$
 RUST_LOG=warn just zone-up my-zone false release
 ```
 
+The `zone-up` recipe starts `tempo-zone` with both `--sequencer` and
+`--sequencer-key`; block production will not advance with the key alone.
+
 Health check:
 
 ```bash

--- a/Justfile
+++ b/Justfile
@@ -242,6 +242,7 @@ zone-up name reset="false" profile="dev" args="":
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \
+                      --sequencer \
                       --sequencer-key "$SEQ_KEY" \
                       {{args}}
 
@@ -573,7 +574,7 @@ token-policy token rpc="":
 [group('zone')]
 [doc('Checks TIP-20 token balance for an account on the zone (port 8546)')]
 check-balance account token="0x20C0000000000000000000000000000000000000" rpc=zone_rpc:
-    @printf "Balance of {{account}}: " && cast call "{{token}}" "balanceOf(address)(uint256)" "{{account}}" --rpc-url "{{rpc}}"
+    @printf "Balance of {{account}}: " && cast call "{{token}}" "balanceOf(address)(uint256)" "{{account}}" --from "{{account}}" --rpc-url "{{rpc}}"
 
 [group('zone')]
 [doc('Generates a signed auth token for the private zone RPC. Requires PRIVATE_KEY env var. Reads zone metadata from generated/<name>/zone.json.')]
@@ -747,6 +748,7 @@ deploy-zone name token="":
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \
+                      --sequencer \
                       --sequencer-key "$SEQUENCER_KEY"
 
 [group('zone')]

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -511,9 +511,45 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0x7Cc496Dc634b718289c192b59CF90262C5228545` |
+| ZoneFactory (moderato) | `0xC73b446C0768bc315Be7741D60B4e494E3ebc0dC` |
 
 The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` falls back to it when `zone.json` does not already record `zoneFactory`.
+
+### Deploying a New ZoneFactory
+
+Deploy a fresh shared factory when the Solidity `ZoneFactory`, `ZonePortal`, `ZoneMessenger`, or verifier ABI changes in a way that existing factory deployments cannot serve.
+
+```bash
+cd specs/ref-impls
+export ETH_RPC_URL=https://rpc.moderato.tempo.xyz
+export PRIVATE_KEY=<deployer_private_key>
+
+forge build
+forge create --broadcast --rpc-url "$ETH_RPC_URL" --private-key "$PRIVATE_KEY" src/zone/ZoneFactory.sol:ZoneFactory
+```
+
+The `--private-key "$PRIVATE_KEY"` form is useful for controlled non-interactive deployments. For manual deployments, prefer replacing it with `--interactive` and paste the key at Foundry's prompt so the key is not written into shell history or process arguments.
+
+After deployment, capture the `Deployed to` address and transaction hash, then verify the contract:
+
+```bash
+export ZONE_FACTORY=0x...
+
+cast code "$ZONE_FACTORY" --rpc-url "$ETH_RPC_URL"
+cast call "$ZONE_FACTORY" "zoneCount()(uint32)" --rpc-url "$ETH_RPC_URL"
+cast call "$ZONE_FACTORY" "verifier()(address)" --rpc-url "$ETH_RPC_URL"
+```
+
+`zoneCount()` should be `0` on a fresh deployment, and `verifier()` should return the verifier deployed by the factory constructor. Update `MODERATO_ZONE_FACTORY` in `xtask/src/zone_utils.rs`, the Key Addresses table above, and any other `rg` hits for the previous address.
+
+Current deployment:
+
+| Field | Value |
+|-------|-------|
+| Address | `0xC73b446C0768bc315Be7741D60B4e494E3ebc0dC` |
+| Transaction | `0xd2864f54ef14553fc083cde8a42b68bd75eaea56a7e5f6928ecf2db0205f9a28` |
+| Block | `19482946` |
+| Deployed | `2026-05-27 06:29:47 UTC` |
 
 ### Zone Node CLI Options
 

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -559,7 +559,8 @@ Current deployment:
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
 | `--l1.genesis-block-number` | (from zone.json) | L1 block when the zone was created |
 | `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` (mainnet) or `1424310000 + (zone_id % 723173648)` (testnet). |
-| `--sequencer-key` | (optional) | Sequencer private key for block production |
+| `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
+| `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled |
 | `--block.interval-ms` | 250 | Block building interval |
 | `--zone.batch-interval-secs` | 60 | Max seconds to accumulate zone blocks before submitting a batch to L1 |
 | `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -20,9 +20,9 @@ pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
 /// `create-zone`, `deploy-router`, and `zone-info` use this as their default
 /// factory unless the caller overrides `--zone-factory` or `zone.json` already
 /// provides a zone-specific value.
-/// Explorer: https://explore.moderato.tempo.xyz/address/0x7Cc496Dc634b718289c192b59CF90262C5228545
+/// Explorer: https://explore.moderato.tempo.xyz/address/0xC73b446C0768bc315Be7741D60B4e494E3ebc0dC
 pub(crate) const MODERATO_ZONE_FACTORY: Address =
-    address!("0x7Cc496Dc634b718289c192b59CF90262C5228545");
+    address!("0xC73b446C0768bc315Be7741D60B4e494E3ebc0dC");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
     address!("0xDEc0000000000000000000000000000000000000");
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;


### PR DESCRIPTION
## Summary

Updates the built-in Moderato `ZoneFactory` default to the freshly deployed contract at `0xC73b446C0768bc315Be7741D60B4e494E3ebc0dC`.

## Why

Recent ABI-breaking contract changes mean new zone deployments need to use a fresh shared factory instance. The previous default pointed at an older factory deployment that no longer matches the current reference implementation.

## Impact

`create-zone`, `zone-info`, and router deployment fallback behavior now target the new factory by default. The zone docs record the deployment metadata and include the repeatable factory deployment steps, and a dedicated Codex skill captures the operational workflow for future redeploys.

The zone example recipes now also start `tempo-zone` in explicit sequencer mode and `just check-balance` sets the caller address for privacy-aware balance reads, so the documented bridge and router smoke commands work against newly created zones.