### PR TITLE
refactor(tempo-zone): remove rpc_client.rs, move helper into rpc

### DIFF
--- a/crates/tempo-zone/src/l1.rs
+++ b/crates/tempo-zone/src/l1.rs
@@ -150,7 +150,8 @@ impl L1Subscriber {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
 
         let url: url::Url = self.config.l1_rpc_url.parse()?;
-        let mut conn_config = crate::rpc_connection_config(self.config.retry_connection_interval);
+        let mut conn_config =
+            crate::rpc::rpc_connection_config(self.config.retry_connection_interval);
 
         if !url.username().is_empty() {
             let auth = Authorization::basic(url.username(), url.password().unwrap_or_default());

--- a/crates/tempo-zone/src/l1_state/provider.rs
+++ b/crates/tempo-zone/src/l1_state/provider.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info, warn};
 use zone_precompiles::SequencerExt;
 
 use super::cache::L1StateCache;
-use crate::abi::PORTAL_SEQUENCER_SLOT;
+use crate::{abi::PORTAL_SEQUENCER_SLOT, rpc::rpc_connection_config};
 
 /// Configuration for the [`L1StateProvider`].
 #[derive(Debug, Clone)]
@@ -98,7 +98,7 @@ impl L1StateProvider {
         let retry_layer =
             RetryBackoffLayer::new(config.max_retries, config.initial_backoff_ms, u64::MAX);
 
-        let conn_config = crate::rpc_connection_config(config.retry_connection_interval);
+        let conn_config = rpc_connection_config(config.retry_connection_interval);
 
         let client = RpcClient::builder()
             .layer(retry_layer)

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -22,7 +22,6 @@ pub mod nonce_keys;
 pub mod payload;
 pub mod precompiles;
 pub mod rpc;
-mod rpc_client;
 pub mod sequencer;
 mod tx_context;
 pub mod withdrawals;
@@ -37,7 +36,6 @@ pub use l1::{
 pub use l1_state::{L1StateCache, PolicyCache, PolicyProvider};
 pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};
 pub use payload::{ZonePayloadAttributes, ZonePayloadTypes};
-pub(crate) use rpc_client::rpc_connection_config;
 pub use sequencer::{ZoneSequencerConfig, ZoneSequencerHandle, spawn_zone_sequencer};
 pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};
 pub use zonemonitor::{ZoneMonitorConfig, spawn_zone_monitor};

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -15,8 +15,8 @@ use crate::{
         spawn_policy_resolution_task, spawn_pool_prefetch_task,
     },
     payload::{ZonePayloadAttributes, ZonePayloadFactory, ZonePayloadTypes},
-    rpc::{TempoZoneRpc, ZoneRpcApi, start_private_rpc},
-    rpc_connection_config, spawn_zone_sequencer,
+    rpc::{TempoZoneRpc, ZoneRpcApi, rpc_connection_config, start_private_rpc},
+    spawn_zone_sequencer,
 };
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider as _;

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -48,6 +48,7 @@ use tokio::{
 use crate::abi::{
     TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZoneInbox, ZonePortal,
 };
+use alloy_rpc_client::ConnectionConfig;
 use zone_rpc::{
     auth::AuthContext,
     types::{
@@ -157,7 +158,7 @@ impl<Api: EthApiTypes + 'static> TempoZoneRpc<Api> {
         let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
                 &l1_rpc_url,
-                crate::rpc_connection_config(config.retry_connection_interval),
+                rpc_connection_config(config.retry_connection_interval),
             )
             .await
             .wrap_err("failed to connect private RPC L1 provider")?
@@ -165,7 +166,7 @@ impl<Api: EthApiTypes + 'static> TempoZoneRpc<Api> {
         let zone_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
                 &zone_rpc_url,
-                crate::rpc_connection_config(config.retry_connection_interval),
+                rpc_connection_config(config.retry_connection_interval),
             )
             .await
             .wrap_err("failed to connect private RPC zone provider")?
@@ -1029,6 +1030,12 @@ fn redact_ws_header(header: &mut TempoHeaderResponse) {
 fn redact_block(block: &mut RpcBlock) {
     redact_tempo_header(&mut block.header.inner);
     block.transactions = BlockTransactions::Hashes(Vec::new());
+}
+
+pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> ConnectionConfig {
+    ConnectionConfig::new()
+        .with_max_retries(u32::MAX)
+        .with_retry_interval(retry_connection_interval)
 }
 
 #[cfg(test)]

--- a/crates/tempo-zone/src/rpc_client.rs
+++ b/crates/tempo-zone/src/rpc_client.rs
@@ -1,9 +1,0 @@
-use std::time::Duration;
-
-use alloy_rpc_client::ConnectionConfig;
-
-pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> ConnectionConfig {
-    ConnectionConfig::new()
-        .with_max_retries(u32::MAX)
-        .with_retry_interval(retry_connection_interval)
-}

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -43,6 +43,7 @@ use crate::{
         AnchorGapKind, BatchAnchorConfig, BatchData, BatchSubmitter, ZoneBlockSnapshot,
         fetch_slot_withdrawals, log_query_ranges,
     },
+    rpc::rpc_connection_config,
     withdrawals::SharedWithdrawalStore,
 };
 
@@ -154,7 +155,7 @@ impl ZoneMonitor {
             .layer(retry_layer)
             .connect_with_config(
                 &config.zone_rpc_url,
-                crate::rpc_connection_config(config.retry_connection_interval),
+                rpc_connection_config(config.retry_connection_interval),
             )
             .await
             .wrap_err_with(|| format!("failed to connect to Zone RPC at {zone_rpc_url}"))?;


### PR DESCRIPTION
This PR removes the `rpc_client.rs` module and moves `rpc_connection_config` into `rpc.rs`.