### PR TITLE
fix: reuse tempo eth api for zones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10971,7 +10971,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11010,7 +11010,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11044,8 +11044,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11056,8 +11056,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11088,11 +11088,12 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy",
  "alloy-eips",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-admin",
  "alloy-rpc-types-eth",
@@ -11134,6 +11135,7 @@ dependencies = [
  "tempo-payload-types",
  "tempo-precompiles",
  "tempo-primitives",
+ "tempo-revm",
  "tempo-transaction-pool",
  "thiserror 2.0.18",
  "tokio",
@@ -11144,8 +11146,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -11183,8 +11185,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11202,8 +11204,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11223,8 +11225,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11235,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11265,8 +11267,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11288,14 +11290,15 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.9.0"
-source = "git+https://github.com/tempoxyz/tempo?tag=v1.9.0#948196c8a551c520a2e88e36e91f271cff0cd34e"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=19631ec55ccbb9e8996b3d1481332d06d1ef5803#19631ec55ccbb9e8996b3d1481332d06d1ef5803"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-sol-types",
+ "dashmap",
  "futures",
  "itertools 0.14.0",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,25 +78,25 @@ codegen-units = 1
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", tag = "v1.9.0", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "19631ec55ccbb9e8996b3d1481332d06d1ef5803", default-features = false }
 
 # zones
 zone-precompiles = { path = "crates/precompiles", default-features = false }

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -18,7 +18,7 @@ use crate::{
     rpc::{TempoZoneRpc, ZoneRpcApi, rpc_connection_config, start_private_rpc},
     spawn_zone_sequencer,
 };
-use alloy_primitives::{Address, U256};
+use alloy_primitives::Address;
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
 use k256::SecretKey;
@@ -35,17 +35,16 @@ use reth_node_builder::{
         NoopNetworkBuilder, PoolBuilder, spawn_maintenance_tasks,
     },
     rpc::{
-        BasicEngineValidatorBuilder, EngineValidatorAddOn, EthApiBuilder, EthApiCtx,
-        NoopEngineApiBuilder, PayloadValidatorBuilder, RethRpcAddOns, RpcAddOns,
+        BasicEngineValidatorBuilder, EngineValidatorAddOn, EthApiBuilder, NoopEngineApiBuilder,
+        PayloadValidatorBuilder, RethRpcAddOns, RpcAddOns,
     },
 };
 use reth_primitives_traits::{
     AlloyBlockHeader, SealedBlock, SealedHeader, transaction::error::InvalidTransactionError,
 };
 use reth_provider::ChainSpecProvider;
-use reth_rpc::DynRpcConverter;
 use reth_rpc_builder::Identity;
-use reth_rpc_eth_api::{EthApiTypes, RpcConverter};
+use reth_rpc_eth_api::EthApiTypes;
 use reth_storage_api::{BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProviderFactory};
 use reth_transaction_pool::{
     Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
@@ -56,7 +55,7 @@ use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_evm::TempoEvmConfig;
 use tempo_node::{
-    DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoReceiptConverter,
+    DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoEthApiBuilder,
 };
 use tempo_payload_types::TempoExecutionData;
 use tempo_primitives::{
@@ -238,10 +237,14 @@ impl NodeTypes for ZoneNode {
 }
 
 /// Addons for Tempo Zone nodes.
-pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>> {
+pub struct ZoneAddOns<N>
+where
+    N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>,
+    N::Pool: reth_transaction_pool::TransactionPool<Transaction = TempoPooledTransaction>,
+{
     inner: RpcAddOns<
         N,
-        ZoneEthApiBuilder,
+        TempoEthApiBuilder<N>,
         ZoneEngineValidatorBuilder,
         NoopEngineApiBuilder,
         BasicEngineValidatorBuilder<ZoneEngineValidatorBuilder>,
@@ -263,8 +266,10 @@ pub struct ZoneAddOns<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfi
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
 }
 
-impl<N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>> std::fmt::Debug
-    for ZoneAddOns<N>
+impl<N> std::fmt::Debug for ZoneAddOns<N>
+where
+    N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>,
+    N::Pool: reth_transaction_pool::TransactionPool<Transaction = TempoPooledTransaction>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ZoneAddOns").finish_non_exhaustive()
@@ -287,7 +292,7 @@ where
     ) -> Self {
         Self {
             inner: RpcAddOns::new(
-                ZoneEthApiBuilder::default(),
+                TempoEthApiBuilder::default(),
                 ZoneEngineValidatorBuilder,
                 NoopEngineApiBuilder::default(),
                 BasicEngineValidatorBuilder::default(),
@@ -311,11 +316,11 @@ where
     N::Pool: reth_transaction_pool::TransactionPool<
             Transaction = tempo_transaction_pool::transaction::TempoPooledTransaction,
         >,
-    ZoneEthApiBuilder: EthApiBuilder<N, EthApi: EthApiTypes<NetworkTypes = TempoNetwork>>,
+    TempoEthApiBuilder<N>: EthApiBuilder<N, EthApi: EthApiTypes<NetworkTypes = TempoNetwork>>,
 {
     type Handle = <RpcAddOns<
         N,
-        ZoneEthApiBuilder,
+        TempoEthApiBuilder<N>,
         ZoneEngineValidatorBuilder,
         NoopEngineApiBuilder,
         BasicEngineValidatorBuilder<ZoneEngineValidatorBuilder>,
@@ -394,7 +399,7 @@ where
     N::Pool: reth_transaction_pool::TransactionPool<
             Transaction = tempo_transaction_pool::transaction::TempoPooledTransaction,
         >,
-    ZoneEthApiBuilder: EthApiBuilder<N, EthApi: EthApiTypes<NetworkTypes = TempoNetwork>>,
+    TempoEthApiBuilder<N>: EthApiBuilder<N, EthApi: EthApiTypes<NetworkTypes = TempoNetwork>>,
 {
     /// Resolve enabled tokens and seed the policy cache.
     async fn resolve_and_seed_tokens(
@@ -614,10 +619,10 @@ where
     N::Pool: reth_transaction_pool::TransactionPool<
             Transaction = tempo_transaction_pool::transaction::TempoPooledTransaction,
         >,
-    ZoneEthApiBuilder:
+    TempoEthApiBuilder<N>:
         EthApiBuilder<N, EthApi: reth_rpc_eth_api::EthApiTypes<NetworkTypes = TempoNetwork>>,
 {
-    type EthApi = <ZoneEthApiBuilder as EthApiBuilder<N>>::EthApi;
+    type EthApi = <TempoEthApiBuilder<N> as EthApiBuilder<N>>::EthApi;
 
     fn hooks_mut(&mut self) -> &mut reth_node_builder::rpc::RpcHooks<N, Self::EthApi> {
         self.inner.hooks_mut()
@@ -630,7 +635,7 @@ where
     N::Pool: reth_transaction_pool::TransactionPool<
             Transaction = tempo_transaction_pool::transaction::TempoPooledTransaction,
         >,
-    ZoneEthApiBuilder: EthApiBuilder<N, EthApi: EthApiTypes<NetworkTypes = TempoNetwork>>,
+    TempoEthApiBuilder<N>: EthApiBuilder<N, EthApi: EthApiTypes<NetworkTypes = TempoNetwork>>,
 {
     type ValidatorBuilder = BasicEngineValidatorBuilder<ZoneEngineValidatorBuilder>;
 
@@ -902,27 +907,5 @@ where
         debug!(target: "reth::cli", "Spawned txpool maintenance task");
 
         Ok(transaction_pool)
-    }
-}
-
-/// EthApi builder for Zone
-#[derive(Debug, Default, Clone)]
-pub struct ZoneEthApiBuilder;
-
-impl<N> EthApiBuilder<N> for ZoneEthApiBuilder
-where
-    N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>,
-{
-    type EthApi = reth_rpc::EthApi<N, DynRpcConverter<ZoneEvmConfig, TempoNetwork>>;
-
-    async fn build_eth_api(self, ctx: EthApiCtx<'_, N>) -> eyre::Result<Self::EthApi> {
-        let chain_spec = ctx.components.provider().chain_spec();
-        let eth_api = ctx
-            .eth_api_builder()
-            .modify_gas_oracle_config(|config| config.default_suggested_fee = Some(U256::ZERO))
-            .map_converter(|_| RpcConverter::new(TempoReceiptConverter::new(chain_spec)).erased())
-            .build();
-
-        Ok(eth_api)
     }
 }

--- a/crates/tempo-zone/tests/it/tip403_transfers.rs
+++ b/crates/tempo-zone/tests/it/tip403_transfers.rs
@@ -10,10 +10,11 @@
 //! a block that includes it.
 
 use alloy::primitives::{B256, U256, address};
-use alloy_provider::ProviderBuilder;
+use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer_local::{MnemonicBuilder, coins_bip39::English};
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::ITIP20;
+use tempo_node::rpc::NATIVE_BALANCE_PLACEHOLDER;
 use tempo_precompiles::PATH_USD_ADDRESS;
 use zone::abi::{ZONE_OUTBOX_ADDRESS, ZoneOutbox};
 
@@ -59,10 +60,22 @@ async fn test_deposit_then_transfer() -> eyre::Result<()> {
         .connect_http(zone.http_url().clone());
     let tip20 = ITIP20::new(PATH_USD_ADDRESS, &provider);
 
+    let native_balance = provider.get_balance(dev_address).await?;
+    assert_eq!(
+        native_balance, NATIVE_BALANCE_PLACEHOLDER,
+        "zone should expose Tempo's placeholder native balance"
+    );
+
+    let estimated_gas = tip20
+        .transfer(bob, U256::from(transfer_amount))
+        .gas_price(TEMPO_T0_BASE_FEE as u128)
+        .estimate_gas()
+        .await?;
+    assert!(estimated_gas > 0, "transfer gas estimate should be nonzero");
+
     let pending = tip20
         .transfer(bob, U256::from(transfer_amount))
         .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(150_000)
         .send()
         .await?;
 


### PR DESCRIPTION
## Summary

- Move Tempo dependencies to commit `19631ec55ccbb9e8996b3d1481332d06d1ef5803`, which contains the generic `TempoEthApi`/`TempoEthApiBuilder` support needed by zones while staying on the current Reth/Alloy line.
- Replace the local zone Eth API builder with `tempo_node::rpc::TempoEthApiBuilder<N>` so zones reuse Tempo's balance, nonce-key, receipt-conversion, and fee-token gas estimation behavior.
- Add regression coverage to the deposit-then-transfer path for Tempo's placeholder native balance and successful TIP-20 transfer gas estimation before submitting without a manual gas limit.

## Why

Zone deposits credit the TIP-20 fee token balance, but the previous public Eth API path still used native-balance gas allowance semantics during estimation. That left deposited users with a zero native balance and caused ordinary in-zone transfers to fail before execution.

Tempo's Eth API already encodes the intended semantics: `eth_getBalance` returns the Tempo placeholder value and gas allowance is calculated from the configured fee token balance. Reusing the upstream builder keeps zones aligned with Tempo instead of carrying a local API implementation.

## Impact

Deposited pathUSD users can submit standard in-zone TIP-20 transfers through the public RPC without needing a separate native balance. The dependency is pinned to the untagged Tempo commit that introduced the generic builder because the current later Tempo `main` revs also require a broader Reth/Alloy bump.