### PR TITLE
refactor(precompiles): move zone registration helper

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -16,6 +16,8 @@
 //! - **TIP-20 Factory** ([`tip20_factory`]) — zone-side TIP-20 token factory.
 //! - **TIP-403 Proxy** ([`tip403_proxy`]) — read-only TIP-403 registry proxy.
 //! - **Zone TIP-20** ([`ztip20`]) — policy-aware TIP-20 wrapper.
+//! - **TempoStateReader** ([`tempo_state_reader`]) — L1 storage reader for zone contracts.
+//! - **ZoneTxContext** ([`tx_context`]) — executing transaction hash context.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
@@ -29,14 +31,24 @@ pub mod aes_gcm;
 pub mod chaum_pedersen;
 pub mod ecies;
 pub mod policy;
+#[cfg(feature = "std")]
+pub mod registration;
+pub mod tempo_state_reader;
 pub mod tip20_factory;
 pub mod tip403_proxy;
+#[cfg(feature = "std")]
+pub mod tx_context;
 pub mod ztip20;
 
 pub use aes_gcm::{AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt};
 pub use chaum_pedersen::{CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify};
+#[cfg(feature = "std")]
+pub use registration::extend_zone_precompiles;
+pub use tempo_state_reader::{TempoStateReader, TempoStateReaderProvider};
 pub use tip20_factory::{ZONE_TIP20_FACTORY_ADDRESS, ZoneTokenFactory};
 pub use tip403_proxy::{ZONE_TIP403_PROXY_ADDRESS, ZoneTip403ProxyRegistry};
+#[cfg(feature = "std")]
+pub use tx_context::{TxHashGuard, ZoneTxContext, set_current_tx_hash};
 pub use ztip20::{SequencerExt, ZoneTip20Token};
 
 use revm::precompile::PrecompileError;

--- a/crates/precompiles/src/registration.rs
+++ b/crates/precompiles/src/registration.rs
@@ -1,0 +1,94 @@
+//! Registration helpers for the full zone precompile set.
+
+use alloc::sync::Arc;
+
+use alloy_evm::precompiles::PrecompilesMap;
+use alloy_primitives::Address;
+use revm::context::CfgEnv;
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, account_keychain::AccountKeychain, nonce::NonceManager,
+    tip_fee_manager::TipFeeManager, tip20::is_tip20_prefix,
+};
+use zone_primitives::constants::{TEMPO_STATE_READER_ADDRESS, ZONE_TX_CONTEXT_ADDRESS};
+
+use crate::{
+    AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
+    SequencerExt, TempoStateReader, TempoStateReaderProvider, ZONE_TIP20_FACTORY_ADDRESS,
+    ZONE_TIP403_PROXY_ADDRESS, ZoneTip20Token, ZoneTip403ProxyRegistry, ZoneTokenFactory,
+    ZoneTxContext, policy::PolicyCheck,
+};
+
+/// Registers zone-specific precompiles into an existing [`PrecompilesMap`].
+///
+/// This is the zone counterpart to `tempo_precompiles::extend_tempo_precompiles`: callers provide
+/// the already-created map and hardfork config, and this helper installs the zone precompile set
+/// in-place. It registers static zone addresses for TempoStateReader, ZoneTxContext,
+/// Chaum-Pedersen verification, AES-GCM decryption, the zone TIP-20 factory, and the optional
+/// TIP-403 proxy.
+///
+/// The helper also replaces the dynamic lookup with zone-aware behavior:
+///
+/// - TIP-20 token addresses are routed to [`ZoneTip20Token`] so zone policy, privacy,
+///   fixed-gas, and bridge-auth rules are enforced before delegating to vanilla TIP-20 logic.
+/// - Tempo precompiles that remain valid on zones (`TipFeeManager`, `NonceManager`, and
+///   `AccountKeychain`) are preserved.
+/// - `StablecoinDEX` is intentionally disabled because zones should not expose the L1 DEX
+///   precompile.
+///
+/// Static map entries installed by `apply_precompile` take priority over the dynamic lookup, so
+/// zone overrides such as [`ZoneTokenFactory`] and [`ZoneTip403ProxyRegistry`] win over generic
+/// TIP-20 prefix matching.
+pub fn extend_zone_precompiles<L1, P>(
+    precompiles: &mut PrecompilesMap,
+    cfg: &CfgEnv<TempoHardfork>,
+    l1_provider: L1,
+    policy_provider: Option<P>,
+) where
+    L1: TempoStateReaderProvider + SequencerExt + Clone + Send + Sync + 'static,
+    P: PolicyCheck + Clone + Send + Sync + 'static,
+{
+    precompiles.apply_precompile(&TEMPO_STATE_READER_ADDRESS, |_| {
+        Some(TempoStateReader::create(l1_provider.clone()))
+    });
+    precompiles.apply_precompile(&ZONE_TX_CONTEXT_ADDRESS, |_| Some(ZoneTxContext::create()));
+    precompiles.apply_precompile(&CHAUM_PEDERSEN_VERIFY_ADDRESS, |_| {
+        Some(ChaumPedersenVerify.into())
+    });
+    precompiles.apply_precompile(&AES_GCM_DECRYPT_ADDRESS, |_| Some(AesGcmDecrypt.into()));
+    precompiles.apply_precompile(&ZONE_TIP20_FACTORY_ADDRESS, |_| {
+        Some(ZoneTokenFactory::create(cfg))
+    });
+
+    let registry = policy_provider.clone().map(ZoneTip403ProxyRegistry::new);
+    let sequencer: Arc<dyn SequencerExt> = Arc::new(l1_provider);
+
+    if let Some(provider) = policy_provider {
+        precompiles.apply_precompile(&ZONE_TIP403_PROXY_ADDRESS, |_| {
+            Some(ZoneTip403ProxyRegistry::create(provider))
+        });
+    }
+
+    let cfg = cfg.clone();
+    precompiles.set_precompile_lookup(move |address: &Address| {
+        if is_tip20_prefix(*address) {
+            Some(ZoneTip20Token::create(
+                *address,
+                &cfg,
+                registry.clone(),
+                sequencer.clone(),
+            ))
+        } else if *address == TIP_FEE_MANAGER_ADDRESS {
+            Some(TipFeeManager::create_precompile(&cfg))
+        } else if *address == STABLECOIN_DEX_ADDRESS {
+            None
+        } else if *address == NONCE_PRECOMPILE_ADDRESS {
+            Some(NonceManager::create_precompile(&cfg))
+        } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
+            Some(AccountKeychain::create_precompile(&cfg))
+        } else {
+            None
+        }
+    });
+}

--- a/crates/precompiles/src/tempo_state_reader.rs
+++ b/crates/precompiles/src/tempo_state_reader.rs
@@ -7,30 +7,24 @@
 //!
 //! This precompile implements two functions:
 //!
-//! - `readStorageAt(address account, bytes32 slot, uint64 blockNumber) → bytes32`
-//! - `readStorageBatchAt(address account, bytes32[] slots, uint64 blockNumber) → bytes32[]`
+//! - `readStorageAt(address account, bytes32 slot, uint64 blockNumber) -> bytes32`
+//! - `readStorageBatchAt(address account, bytes32[] slots, uint64 blockNumber) -> bytes32[]`
 //!
-//! Reads are served synchronously from the [`L1StateProvider`]. The provider first checks the
-//! in-memory cache and, on miss, retries the RPC fetch (`eth_getStorageAt` at the given block
-//! number) to Tempo L1 indefinitely with exponential backoff. This means a transient L1 RPC
-//! outage will stall block production until connectivity is restored, rather than bricking the
-//! chain with an unrecoverable hard error.
-//!
-//! [`PrecompileError`]: revm::precompile::PrecompileError
+//! Reads are served synchronously from a [`TempoStateReaderProvider`]. The zone node implements
+//! that trait with a cache-first, RPC-fallback provider; prover guests can implement it with a
+//! witness-backed reader.
 //!
 //! # Gas costs
 //!
 //! Each call is charged [`BASE_GAS`] plus [`PER_SLOT_GAS`] for every slot read.
-//!
-//! [`L1StateProvider`]: super::provider::L1StateProvider
+
+use alloc::{format, vec::Vec};
 
 use alloy_evm::precompiles::DynPrecompile;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, B256, Bytes};
 use alloy_sol_types::{SolCall, SolError};
 use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, error, warn};
-
-use super::provider::L1StateProvider;
 
 alloy_sol_types::sol! {
     /// Read a single storage slot from a Tempo L1 contract at a specific block height.
@@ -43,6 +37,20 @@ alloy_sol_types::sol! {
     error DelegateCallNotAllowed();
 }
 
+/// Backend used by [`TempoStateReader`] to fetch L1 storage during EVM execution.
+pub trait TempoStateReaderProvider {
+    /// Error returned when a storage read cannot be served.
+    type Error: core::fmt::Display;
+
+    /// Read a storage slot synchronously at `block_number`.
+    fn get_storage(
+        &self,
+        address: Address,
+        slot: B256,
+        block_number: u64,
+    ) -> Result<B256, Self::Error>;
+}
+
 /// Fixed gas cost charged on every call.
 const BASE_GAS: u64 = 200;
 
@@ -53,7 +61,7 @@ const PER_SLOT_GAS: u64 = 200;
 ///
 /// The precompile is registered at a dedicated predeploy address (separate from the TempoState
 /// contract) and handles `readStorageAt` and `readStorageBatchAt` calls by reading Tempo L1
-/// contract storage via an [`L1StateProvider`].
+/// contract storage via a [`TempoStateReaderProvider`].
 ///
 /// The caller provides the L1 block number to query, making the precompile fully stateless.
 /// Zone system contracts (ZoneInbox, ZoneConfig) pass the `tempoBlockNumber` from the
@@ -62,24 +70,21 @@ const PER_SLOT_GAS: u64 = 200;
 /// # Restrictions
 ///
 /// - Only direct `CALL`s are accepted; `DELEGATECALL` reverts with [`DelegateCallNotAllowed`].
-/// - The precompile is **view-only** — it never writes to EVM state.
-/// - On cache miss the provider retries the RPC fetch indefinitely with backoff, stalling
-///   block production until L1 connectivity is restored.
+/// - The precompile is **view-only** and never writes to EVM state.
 pub struct TempoStateReader;
 
 impl TempoStateReader {
     /// Create a [`DynPrecompile`] that dispatches `readStorageAt` and
-    /// `readStorageBatchAt` calls to the given [`L1StateProvider`].
-    ///
-    /// The returned precompile captures `provider` by move and can be registered in a
-    /// [`PrecompilesMap`](alloy_evm::precompiles::PrecompilesMap) at the TempoStateReader
-    /// predeploy address.
-    pub fn create(provider: L1StateProvider) -> DynPrecompile {
+    /// `readStorageBatchAt` calls to `provider`.
+    pub fn create<P>(provider: P) -> DynPrecompile
+    where
+        P: TempoStateReaderProvider + Send + Sync + 'static,
+    {
         DynPrecompile::new_stateful(
             PrecompileId::Custom("TempoStateReader".into()),
             move |input| {
                 if !input.is_direct_call() {
-                    warn!(target: "zone::precompile", "TempoStateReader called via DELEGATECALL — rejecting");
+                    warn!(target: "zone::precompile", "TempoStateReader called via DELEGATECALL - rejecting");
                     return Ok(PrecompileOutput::revert(
                         0,
                         DelegateCallNotAllowed {}.abi_encode().into(),
@@ -124,10 +129,10 @@ impl TempoStateReader {
     /// Handle a `readStorageAt(address, bytes32, uint64)` call.
     ///
     /// Decodes the ABI calldata, performs a synchronous lookup via the provider at the specified
-    /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32`
-    /// value. Returns a hard [`PrecompileError`] if both the cache and RPC fallback fail.
-    fn handle_single_slot(
-        provider: &L1StateProvider,
+    /// L1 block number, and returns the ABI-encoded `bytes32` value. Returns a hard precompile
+    /// error if the provider cannot serve the slot.
+    fn handle_single_slot<P: TempoStateReaderProvider>(
+        provider: &P,
         data: &[u8],
         reservoir: u64,
     ) -> PrecompileResult {
@@ -136,29 +141,30 @@ impl TempoStateReader {
             Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
         };
 
-        let gas = BASE_GAS + PER_SLOT_GAS;
-
         let value = provider
             .get_storage(call.account, call.slot, call.blockNumber)
             .map_err(|e| {
-                zone_precompiles::zone_rpc_error(format!(
+                crate::zone_rpc_error(format!(
                     "L1 storage unavailable for account={} slot={} block={}: {e}",
                     call.account, call.slot, call.blockNumber
                 ))
             })?;
 
         let encoded = readStorageAtCall::abi_encode_returns(&value);
-        Ok(PrecompileOutput::new(gas, encoded.into(), reservoir))
+        Ok(PrecompileOutput::new(
+            BASE_GAS + PER_SLOT_GAS,
+            encoded.into(),
+            reservoir,
+        ))
     }
 
     /// Handle a `readStorageBatchAt(address, bytes32[], uint64)` call.
     ///
     /// Decodes the ABI calldata, performs a synchronous lookup for each slot at the specified
-    /// L1 block number (cache first, then RPC fallback), and returns the ABI-encoded `bytes32[]`
-    /// result. If **any** slot fails both cache and RPC lookup, the entire call fails with a
-    /// hard [`PrecompileError`].
-    fn handle_multi_slot(
-        provider: &L1StateProvider,
+    /// L1 block number, and returns the ABI-encoded `bytes32[]` result. If **any** slot fails,
+    /// the entire call fails with a hard precompile error.
+    fn handle_multi_slot<P: TempoStateReaderProvider>(
+        provider: &P,
         data: &[u8],
         reservoir: u64,
     ) -> PrecompileResult {
@@ -167,15 +173,12 @@ impl TempoStateReader {
             Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), reservoir)),
         };
 
-        let num_slots = call.slots.len() as u64;
-        let gas = BASE_GAS + PER_SLOT_GAS * num_slots;
-
         let mut results = Vec::with_capacity(call.slots.len());
         for slot in &call.slots {
             let value = provider
                 .get_storage(call.account, *slot, call.blockNumber)
                 .map_err(|e| {
-                    zone_precompiles::zone_rpc_error(format!(
+                    crate::zone_rpc_error(format!(
                         "L1 storage unavailable for account={} slot={} block={}: {e}",
                         call.account, slot, call.blockNumber
                     ))
@@ -184,6 +187,10 @@ impl TempoStateReader {
         }
 
         let encoded = readStorageBatchAtCall::abi_encode_returns(&results);
-        Ok(PrecompileOutput::new(gas, encoded.into(), reservoir))
+        Ok(PrecompileOutput::new(
+            BASE_GAS + PER_SLOT_GAS * call.slots.len() as u64,
+            encoded.into(),
+            reservoir,
+        ))
     }
 }

--- a/crates/precompiles/src/tx_context.rs
+++ b/crates/precompiles/src/tx_context.rs
@@ -22,8 +22,8 @@ thread_local! {
     static CURRENT_TX_HASH: RefCell<Option<B256>> = const { RefCell::new(None) };
 }
 
-/// Guard that clears the current tx hash when dropped.
-pub(crate) struct TxHashGuard;
+/// Guard that clears the current transaction hash when dropped.
+pub struct TxHashGuard;
 
 impl Drop for TxHashGuard {
     fn drop(&mut self) {
@@ -32,7 +32,7 @@ impl Drop for TxHashGuard {
 }
 
 /// Publish the current executing transaction hash for the duration of EVM execution.
-pub(crate) fn set_current_tx_hash(tx_hash: B256) -> TxHashGuard {
+pub fn set_current_tx_hash(tx_hash: B256) -> TxHashGuard {
     CURRENT_TX_HASH.with(|slot| {
         *slot.borrow_mut() = Some(tx_hash);
     });
@@ -61,16 +61,17 @@ fn synthetic_tx_hash(input: &PrecompileInput<'_>) -> B256 {
     keccak256(bytes)
 }
 
-/// `DynPrecompile` implementation that returns the currently executing zone tx hash.
-pub(crate) struct ZoneTxContext;
+/// `DynPrecompile` implementation that returns the currently executing zone transaction hash.
+pub struct ZoneTxContext;
 
 impl ZoneTxContext {
-    pub(crate) fn create() -> DynPrecompile {
+    /// Create the transaction-context precompile.
+    pub fn create() -> DynPrecompile {
         DynPrecompile::new_stateful(PrecompileId::Custom("ZoneTxContext".into()), move |input| {
             if !input.is_direct_call() {
                 warn!(
                     target: "zone::precompile",
-                    "ZoneTxContext called via DELEGATECALL — rejecting"
+                    "ZoneTxContext called via DELEGATECALL - rejecting"
                 );
                 return Ok(PrecompileOutput::revert(
                     0,

--- a/crates/tempo-zone/src/evm.rs
+++ b/crates/tempo-zone/src/evm.rs
@@ -1,19 +1,11 @@
 //! Zone-specific EVM configuration.
 //!
 //! Wraps [`TempoEvmConfig`] with a custom [`ZoneEvmFactory`] that registers the
-//! [`TempoStateReader`](crate::l1_state::TempoStateReader) precompile at
-//! [`TEMPO_STATE_READER_ADDRESS`](crate::abi::TEMPO_STATE_READER_ADDRESS).
+//! zone precompile set via [`zone_precompiles::extend_zone_precompiles`].
 
 use crate::{
-    abi::{TEMPO_STATE_READER_ADDRESS, ZONE_TX_CONTEXT_ADDRESS},
     executor::ZoneBlockExecutor,
-    l1_state::{L1StateCache, L1StateProvider, PolicyProvider, TempoStateReader},
-    precompiles::{
-        AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
-        ZONE_TIP20_FACTORY_ADDRESS, ZONE_TIP403_PROXY_ADDRESS, ZoneTip20Token,
-        ZoneTip403ProxyRegistry, ZoneTokenFactory,
-    },
-    tx_context::ZoneTxContext,
+    l1_state::{L1StateCache, L1StateProvider, PolicyProvider},
 };
 use alloy_evm::{
     Database, Evm, EvmEnv, EvmFactory,
@@ -38,19 +30,13 @@ use tempo_evm::{
     evm::{TempoEvm, TempoEvmFactory},
 };
 use tempo_payload_types::TempoExecutionData;
-use tempo_precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
-    TIP_FEE_MANAGER_ADDRESS, account_keychain::AccountKeychain, nonce::NonceManager,
-    tip_fee_manager::TipFeeManager, tip20::is_tip20_prefix,
-};
 use tempo_primitives::{
     Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType,
 };
 
 type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
 
-/// Zone EVM factory — wraps [`TempoEvmFactory`] and registers the
-/// [`TempoStateReader`] precompile for reading Tempo L1 storage from zone contracts.
+/// Zone EVM factory — wraps [`TempoEvmFactory`] and registers zone-specific precompiles.
 #[derive(Debug, Clone)]
 pub struct ZoneEvmFactory {
     l1_provider: L1StateProvider,
@@ -78,61 +64,12 @@ impl ZoneEvmFactory {
     ) -> TempoEvm<DB, I> {
         let cfg = evm.ctx().cfg.clone();
         let (_, _, precompiles) = evm.components_mut();
-        precompiles.apply_precompile(&TEMPO_STATE_READER_ADDRESS, |_| {
-            Some(TempoStateReader::create(self.l1_provider.clone()))
-        });
-        precompiles.apply_precompile(&ZONE_TX_CONTEXT_ADDRESS, |_| Some(ZoneTxContext::create()));
-        precompiles.apply_precompile(&CHAUM_PEDERSEN_VERIFY_ADDRESS, |_| {
-            Some(ChaumPedersenVerify.into())
-        });
-        precompiles.apply_precompile(&AES_GCM_DECRYPT_ADDRESS, |_| Some(AesGcmDecrypt.into()));
-        precompiles.apply_precompile(&ZONE_TIP20_FACTORY_ADDRESS, |_| {
-            Some(ZoneTokenFactory::create(&cfg))
-        });
-        let registry = self
-            .policy_provider
-            .clone()
-            .map(ZoneTip403ProxyRegistry::new);
-        let sequencer: Arc<dyn crate::precompiles::SequencerExt> =
-            Arc::new(self.l1_provider.clone());
-
-        if let Some(provider) = self.policy_provider.clone() {
-            precompiles.apply_precompile(&ZONE_TIP403_PROXY_ADDRESS, |_| {
-                Some(ZoneTip403ProxyRegistry::create(provider.clone()))
-            });
-        }
-
-        // Override the TIP-20 precompile lookup so that all TIP-20 token
-        // calls go through ZoneTip20Token. When a live policy provider is
-        // available, the wrapper also enforces TIP-403 policy checks; without
-        // one, it still applies privacy, fixed-gas, and bridge-auth rules.
-        //
-        // This replaces the upstream `extend_tempo_precompiles` lookup, so we
-        // must also handle the non-TIP-20 Tempo precompiles that are zone-relevant
-        // (FeeManager, NonceManager, AccountKeychain).
-        // Zone-specific overrides (TIP20Factory, TIP403Proxy) are in the
-        // static map via `apply_precompile` and take priority over this.
-        let zone_cfg = cfg.clone();
-        precompiles.set_precompile_lookup(move |address: &alloy_primitives::Address| {
-            if is_tip20_prefix(*address) {
-                Some(ZoneTip20Token::create(
-                    *address,
-                    &zone_cfg,
-                    registry.clone(),
-                    sequencer.clone(),
-                ))
-            } else if *address == TIP_FEE_MANAGER_ADDRESS {
-                Some(TipFeeManager::create_precompile(&zone_cfg))
-            } else if *address == STABLECOIN_DEX_ADDRESS {
-                None
-            } else if *address == NONCE_PRECOMPILE_ADDRESS {
-                Some(NonceManager::create_precompile(&zone_cfg))
-            } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
-                Some(AccountKeychain::create_precompile(&zone_cfg))
-            } else {
-                None
-            }
-        });
+        zone_precompiles::extend_zone_precompiles(
+            precompiles,
+            &cfg,
+            self.l1_provider.clone(),
+            self.policy_provider.clone(),
+        );
         evm
     }
 }

--- a/crates/tempo-zone/src/executor.rs
+++ b/crates/tempo-zone/src/executor.rs
@@ -19,8 +19,6 @@ use tempo_precompiles::{TIP_FEE_MANAGER_ADDRESS, tip_fee_manager::TipFeeManager}
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::{TempoStateAccess, evm::TempoContext};
 
-use crate::tx_context;
-
 /// Simplified block executor for zone nodes.
 ///
 /// Wraps [`EthBlockExecutor`] without any subblock validation, gas-section tracking,
@@ -95,7 +93,7 @@ where
         // transaction's resolved fee token, so the handler skips FeeAMM.
         self.override_validator_token();
 
-        let _tx_hash_guard = tx_context::set_current_tx_hash(*recovered.tx().tx_hash());
+        let _tx_hash_guard = zone_precompiles::set_current_tx_hash(*recovered.tx().tx_hash());
         self.inner
             .execute_transaction_without_commit((tx_env, recovered))
     }

--- a/crates/tempo-zone/src/l1_state/cache.rs
+++ b/crates/tempo-zone/src/l1_state/cache.rs
@@ -1,6 +1,6 @@
 //! Block-versioned in-memory cache of Tempo L1 contract storage slots.
 //!
-//! The zone's [`TempoStateReader`](super::precompile::TempoStateReader) precompile reads
+//! The zone's [`TempoStateReader`](zone_precompiles::TempoStateReader) precompile reads
 //! Tempo L1 storage at a **specific L1 block height** (the `tempoBlockNumber` the zone committed
 //! to via `TempoState.finalizeTempo()` on Zone L2). Because the L1 chain may advance several
 //! blocks ahead of the zone's committed height, the cache must be able to serve historical

--- a/crates/tempo-zone/src/l1_state/mod.rs
+++ b/crates/tempo-zone/src/l1_state/mod.rs
@@ -5,17 +5,16 @@
 //! - [`L1StateCache`] — a shared in-memory cache of L1 contract storage slots.
 //! - [`L1StateCacheInner`] — the block-versioned cache storage guarded by [`L1StateCache`].
 //! - [`L1StateProvider`] — a cache-first, RPC-fallback reader for `eth_getStorageAt`.
-//! - [`TempoStateReader`] — a standalone `DynPrecompile` that handles `readStorageAt` calls.
+//! - [`TempoStateReader`](zone_precompiles::TempoStateReader) — a standalone `DynPrecompile`
+//!   that handles `readStorageAt` calls.
 //! - [`tip403`] — TIP-403 policy cache and provider.
 
 pub mod cache;
-pub mod precompile;
 pub mod provider;
 pub mod tip403;
 pub mod versioned;
 
 pub use cache::{L1StateCache, L1StateCacheInner};
-pub use precompile::TempoStateReader;
 pub use provider::{L1StateProvider, L1StateProviderConfig};
 pub use tip403::{
     AuthRole, PolicyCache, PolicyCacheInner, PolicyEvent, PolicyProvider, PolicyTaskHandle,

--- a/crates/tempo-zone/src/l1_state/provider.rs
+++ b/crates/tempo-zone/src/l1_state/provider.rs
@@ -18,7 +18,7 @@ use alloy_transport::layers::RetryBackoffLayer;
 use eyre::Result;
 use tempo_alloy::TempoNetwork;
 use tracing::{debug, info, warn};
-use zone_precompiles::SequencerExt;
+use zone_precompiles::{SequencerExt, TempoStateReaderProvider};
 
 use super::cache::L1StateCache;
 use crate::{abi::PORTAL_SEQUENCER_SLOT, rpc::rpc_connection_config};
@@ -266,5 +266,18 @@ impl L1StateProvider {
 impl SequencerExt for L1StateProvider {
     fn latest_sequencer(&self) -> Option<Address> {
         self.get_latest_sequencer().ok()
+    }
+}
+
+impl TempoStateReaderProvider for L1StateProvider {
+    type Error = eyre::Report;
+
+    fn get_storage(
+        &self,
+        address: Address,
+        slot: B256,
+        block_number: u64,
+    ) -> std::result::Result<B256, Self::Error> {
+        Self::get_storage(self, address, slot, block_number)
     }
 }

--- a/crates/tempo-zone/src/lib.rs
+++ b/crates/tempo-zone/src/lib.rs
@@ -23,7 +23,6 @@ pub mod payload;
 pub mod precompiles;
 pub mod rpc;
 pub mod sequencer;
-mod tx_context;
 pub mod withdrawals;
 pub mod zonemonitor;
 


### PR DESCRIPTION
## Summary

Move zone-specific precompile registration into `zone-precompiles` behind a documented `extend_zone_precompiles` helper. The helper owns the static address registrations and the dynamic TIP-20/Tempo lookup override, while `ZoneEvmFactory` now only forwards the precompile map, hardfork config, L1 provider, and optional policy provider.

This also moves `TempoStateReader` and `ZoneTxContext` into `zone-precompiles`. `TempoStateReader` now depends on a small provider trait so the node keeps its concrete cache/RPC implementation without creating a crate cycle.

## Impact

Precompile wiring now lives with the precompile implementations, which makes the zone registration path mirror Tempo's map-extension pattern and keeps the node EVM factory focused on construction rather than address routing.