### PR TITLE
fix(l1): capture same-block policy updates for newly-enabled tokens

### DIFF
--- a/crates/tempo-zone/src/l1/subscriber.rs
+++ b/crates/tempo-zone/src/l1/subscriber.rs
@@ -534,7 +534,7 @@ impl L1Subscriber {
     }
 
     /// Extract portal and policy events from pre-fetched receipts (no RPC).
-    fn extract_events(
+    pub(crate) fn extract_events(
         &mut self,
         block_number: u64,
         receipts: &[tempo_alloy::rpc::TempoTransactionReceipt],
@@ -545,6 +545,9 @@ impl L1Subscriber {
         let mut portal_events = L1PortalEvents::default();
         let mut policy_events = Vec::new();
 
+        // First pass: decode portal events (deposits, sequencer transfers, token
+        // enables) and TIP-403 registry policy events. This also grows
+        // `tracked_tokens` with every token enabled in this block.
         for receipt in receipts {
             for log in receipt.logs() {
                 let addr = log.address();
@@ -561,11 +564,24 @@ impl L1Subscriber {
                             self.tracked_tokens.push(token);
                         }
                     }
-                } else if addr == TIP403_REGISTRY_ADDRESS {
-                    if let Some(event) = PolicyEvent::decode_registry(log) {
-                        policy_events.push(event);
-                    }
-                } else if self.tracked_tokens.contains(&addr)
+                } else if addr == TIP403_REGISTRY_ADDRESS
+                    && let Some(event) = PolicyEvent::decode_registry(log)
+                {
+                    policy_events.push(event);
+                }
+            }
+        }
+
+        // Second pass: collect TIP-20 transfer-policy updates. This runs after
+        // the first pass so a token that is enabled *and* updates its transfer
+        // policy in the same L1 block is captured even when its
+        // `TransferPolicyUpdate` log precedes the portal `TokenEnabled` log.
+        // The two are emitted by different transactions, so their relative order
+        // within a block is not guaranteed; a single pass would drop the policy
+        // update because `tracked_tokens` would not yet contain the token.
+        for receipt in receipts {
+            for log in receipt.logs() {
+                if self.tracked_tokens.contains(&log.address())
                     && log.topics().first() == Some(&TransferPolicyUpdate::SIGNATURE_HASH)
                     && let Some(event) = PolicyEvent::decode_tip20(log)
                 {

--- a/crates/tempo-zone/src/l1/tests.rs
+++ b/crates/tempo-zone/src/l1/tests.rs
@@ -164,6 +164,95 @@ fn make_portal_log<E: SolEvent>(portal_address: Address, event: E) -> Log {
     }
 }
 
+/// Wrap a set of logs in a successful L1 transaction receipt.
+fn make_receipt_with_logs(logs: Vec<Log>) -> tempo_alloy::rpc::TempoTransactionReceipt {
+    use alloy_consensus::ReceiptWithBloom;
+    use alloy_primitives::TxHash;
+    use alloy_rpc_types_eth::TransactionReceipt;
+    use tempo_primitives::{TempoReceipt, TempoTxType};
+
+    let receipt = TempoReceipt {
+        tx_type: TempoTxType::Legacy,
+        success: true,
+        cumulative_gas_used: 21_000,
+        logs,
+    };
+
+    tempo_alloy::rpc::TempoTransactionReceipt {
+        inner: TransactionReceipt {
+            inner: ReceiptWithBloom::from(receipt),
+            transaction_hash: TxHash::with_last_byte(1),
+            transaction_index: Some(0),
+            block_hash: Some(B256::with_last_byte(2)),
+            block_number: Some(1),
+            gas_used: 21_000,
+            effective_gas_price: 1,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: Some(Address::ZERO),
+            contract_address: None,
+        },
+        fee_token: None,
+        fee_payer: Address::ZERO,
+    }
+}
+
+#[test]
+fn extract_events_captures_same_block_policy_update_before_token_enabled() {
+    use tempo_contracts::precompiles::ITIP20::TransferPolicyUpdate;
+
+    let mut subscriber =
+        test_subscriber(Arc::new(SequenceLocalTempoStateReader::new([0])), Some(0));
+    let portal = subscriber.config.portal_address;
+    let token = address!("0x0000000000000000000000000000000000002000");
+    let updater = address!("0x0000000000000000000000000000000000003000");
+
+    // A token can be enabled and set its transfer policy in the same L1 block.
+    // Here the token's `TransferPolicyUpdate` log is ordered *before* the portal
+    // `TokenEnabled` log — exactly the case a single-pass scan would drop.
+    let policy_log = Log {
+        inner: alloy_primitives::Log {
+            address: token,
+            data: TransferPolicyUpdate {
+                updater,
+                newPolicyId: 7,
+            }
+            .encode_log_data(),
+        },
+        block_hash: None,
+        block_number: None,
+        block_timestamp: None,
+        transaction_hash: None,
+        transaction_index: None,
+        log_index: None,
+        removed: false,
+    };
+    let enable_log = make_portal_log(
+        portal,
+        TokenEnabled {
+            token,
+            name: "Token".to_owned(),
+            symbol: "TKN".to_owned(),
+            currency: "USD".to_owned(),
+        },
+    );
+
+    let receipt = make_receipt_with_logs(vec![policy_log, enable_log]);
+    let (_portal_events, policy_events) =
+        subscriber.extract_events(1, std::slice::from_ref(&receipt));
+
+    assert!(
+        policy_events.iter().any(|event| matches!(
+            event,
+            PolicyEvent::TokenPolicyChanged { token: t, policy_id: 7 } if t == &token
+        )),
+        "policy update for a token enabled in the same block must be captured \
+         regardless of intra-block log order: {policy_events:?}"
+    );
+    assert!(subscriber.tracked_tokens.contains(&token));
+}
+
 #[tokio::test]
 async fn test_resolve_start_block_reads_live_local_state_each_time() {
     let subscriber = test_subscriber(


### PR DESCRIPTION
# fix(l1): capture same-block policy updates for newly-enabled tokens

## 1. Motivation

The L1 subscriber mirrors TIP-403 policy state into the zone by decoding events
from each L1 block's receipts. Correctness of this mirror depends on every
relevant policy event in a block being captured. This change addresses a case
in which a token's first transfer-policy update is not captured, leaving the
cache to disagree with L1 until an RPC fallback happens to repair it.

## 2. Root cause

Within `extract_events`, a TIP-20 `TransferPolicyUpdate` log is decoded only if
the emitting token already appears in `tracked_tokens` at the instant the log is
visited. `tracked_tokens` is, in turn, populated during the very same single
pass over the block's logs, as each portal `TokenEnabled` log is reached.

A token may be enabled and have its transfer policy set within one L1 block by
two distinct transactions. Because the relative order of logs from different
transactions is not constrained, the `TransferPolicyUpdate` log may precede the
`TokenEnabled` log. Under that ordering the policy update is discarded: at the
time it is visited the token is not yet tracked, and so the cache never records
the initial `TokenPolicyChanged`. Subsequent policy resolution is then forced
onto an L1 RPC round-trip, and cross-node behavior becomes a function of
intra-block log ordering.

## 3. Proposed change

Event extraction is restructured into two passes:

1. Portal events (deposits, sequencer transfers, token enables) and TIP-403
   registry policy events are decoded. As a side effect, `tracked_tokens` is
   grown to include every token enabled in the block.
2. TIP-20 transfer-policy updates are collected, by which point every token
   enabled in the block is already tracked.

Registry policy events and TIP-20 policy events are written to disjoint cache
keys; consequently, reordering the two classes of events relative to one another
preserves the resulting cache state.

## 4. Validation

| Command | Result |
| --- | --- |
| `cargo +nightly test -p zone --lib l1::tests::extract_events` | pass (new regression test) |
| `cargo +nightly test -p zone --lib l1::` | pass — 46 tests |
| `cargo +nightly clippy -p zone --lib` | no warnings |
| `cargo +nightly fmt -p zone -- --check` | no diff |

The regression test constructs a single receipt in which the
`TransferPolicyUpdate` log is ordered ahead of `TokenEnabled` and asserts that
the corresponding `TokenPolicyChanged` event is produced.