### PR TITLE
feat: tip403 checks for deposit paths

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: tempoxyz/tempo
+          ref: b78b440950a0fa31b5e55c8a2c81976131e44ba3
           path: tempo
           persist-credentials: false
 

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -145,7 +145,7 @@ crate::sol! {
         error NotSequencer();
         error InvalidProof();
         error InvalidTempoBlockNumber();
-        error DepositPolicyForbids();
+        error PolicyForbids();
         error InvalidBouncebackRecipient();
 
         // -- View functions --
@@ -293,7 +293,7 @@ impl core::fmt::Display for ZonePortal::ZonePortalErrors {
             Self::NotSequencer(_) => f.write_str("NotSequencer"),
             Self::InvalidProof(_) => f.write_str("InvalidProof"),
             Self::InvalidTempoBlockNumber(_) => f.write_str("InvalidTempoBlockNumber"),
-            Self::DepositPolicyForbids(_) => f.write_str("DepositPolicyForbids"),
+            Self::PolicyForbids(_) => f.write_str("PolicyForbids"),
             Self::InvalidBouncebackRecipient(_) => f.write_str("InvalidBouncebackRecipient"),
         }
     }

--- a/crates/tempo-zone/tests/it/l1_e2e.rs
+++ b/crates/tempo-zone/tests/it/l1_e2e.rs
@@ -1290,7 +1290,7 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
 ///  2. Create a blacklist policy, assign to pathUSD, blacklist a user.
 ///  3. Fund the blacklisted user on L1.
 ///  4. Attempt a deposit targeting the blacklisted user — should revert with
-///     `DepositPolicyForbids` on the L1 portal contract.
+///     `PolicyForbids` on the L1 portal contract.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_deposit_to_blacklisted_recipient_reverts_on_l1() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/specs/ref-impls/src/zone/IZone.sol
+++ b/specs/ref-impls/src/zone/IZone.sol
@@ -617,7 +617,6 @@ interface IZonePortal {
     error InvalidEphemeralPubkey();
     error InvalidCiphertextLength(uint256 actual, uint256 expected);
     error InvalidProofOfPossession();
-    error DepositPolicyForbids();
     error DepositTooSmall();
     error GasFeeRateTooHigh();
     error TokenNotEnabled();

--- a/specs/ref-impls/src/zone/ZonePortal.sol
+++ b/specs/ref-impls/src/zone/ZonePortal.sol
@@ -537,10 +537,13 @@ contract ZonePortal is IZonePortal {
         // token's transfer policy before accepting the deposit.
         uint64 policyId = ITIP20(_token).transferPolicyId();
         if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, to)) {
-            revert DepositPolicyForbids();
+            revert ITIP20.PolicyForbids();
         }
         if (!TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, to)) {
-            revert DepositPolicyForbids();
+            revert ITIP20.PolicyForbids();
+        }
+        if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
+            revert ITIP20.PolicyForbids();
         }
 
         // Calculate deposit fee
@@ -614,6 +617,11 @@ contract ZonePortal is IZonePortal {
         TokenConfig storage cfg = _tokenConfigs[_token];
         if (!cfg.enabled) revert TokenNotEnabled();
         if (!cfg.depositsActive) revert DepositsNotActive();
+
+        uint64 policyId = ITIP20(_token).transferPolicyId();
+        if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
+            revert ITIP20.PolicyForbids();
+        }
 
         // Validate ephemeral public key is a valid secp256k1 point
         // Prevents griefing: invalid points make Chaum-Pedersen proofs impossible,

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -351,8 +351,27 @@ contract ZonePortalTest is BaseTest {
 
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
-        vm.expectRevert(IZonePortal.DepositPolicyForbids.selector);
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
         portal.deposit(address(pathUSD), bob, depositAmount, bytes32("memo"), bob);
+        vm.stopPrank();
+    }
+
+    function test_deposit_revertsWhenBouncebackRecipientBlocked() public {
+        uint128 depositAmount = 1000e6;
+
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = address(portal);
+        uint64 policyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, accounts
+        );
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(policyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), bob);
         vm.stopPrank();
     }
 
@@ -2282,6 +2301,26 @@ contract ZonePortalTest is BaseTest {
 
         vm.expectRevert(IZonePortal.DepositTooSmall.selector);
         portal.depositEncrypted(address(pathUSD), 99_999, 0, _makeEncryptedPayload(), alice);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsWhenBouncebackRecipientBlocked() public {
+        _setEncKeyWithPoP(ENC_KEY_1);
+
+        uint128 depositAmount = 1000e6;
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = address(portal);
+        uint64 policyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, accounts
+        );
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(policyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload(), bob);
         vm.stopPrank();
     }
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -331,7 +331,7 @@ Deposits move TIP-20 tokens from Tempo into a zone. The user deposits on Tempo, 
 A user deposits by calling `deposit(token, to, amount, memo, bouncebackRecipient)` on the portal. The portal:
 
 1. Validates the token is enabled and deposits are active.
-2. Requires `bouncebackRecipient != address(0)` (reverts otherwise).
+2. Requires `bouncebackRecipient != address(0)` and authorized by the token's TIP-403 recipient policy (reverts otherwise).
 3. Snapshots the deposit fee at the current `zoneGasRate` and the bounce-back fee at the current portal-side `tempoGasRate` (see [Deposit Fees](#deposit-fees)), and requires `amount >= depositFee + bouncebackFee` (reverts `DepositTooSmall` otherwise). The bounce-back fee covers the worst-case Tempo gas of paying out a refund (including new-account creation for `bouncebackRecipient`), so it is priced in Tempo gas, not zone gas.
 4. Transfers `amount` from the user into the portal.
 5. Pays the `depositFee` to the sequencer immediately. The `bouncebackFee` is reserved on the queued entry; it is only consumed if the deposit later bounces back.
@@ -394,7 +394,7 @@ The encryption scheme is ECIES with secp256k1:
 1. The user generates an ephemeral keypair and derives a shared secret via ECDH with the sequencer's published encryption key.
 2. The user derives an AES-256 key from the shared secret using HKDF-SHA256.
 3. The user encrypts `(to || memo || padding)` with AES-256-GCM, producing ciphertext, a nonce, and an authentication tag.
-4. The user calls `depositEncrypted(token, amount, keyIndex, encryptedPayload, bouncebackRecipient)` on the portal, where `keyIndex` references which encryption key they encrypted to (see [Encryption Key Management](#encryption-key-management)), and `bouncebackRecipient` is the Tempo address that receives a refund if zone-side processing fails (see [Deposit Failures and Bounce-Back](#deposit-failures-and-bounce-back)). Like `deposit()`, `depositEncrypted` requires `bouncebackRecipient != address(0)` (reverts otherwise) and `amount >= depositFee + bouncebackFee` (reverts `DepositTooSmall` otherwise), and snapshots the bounce-back fee on the queued deposit.
+4. The user calls `depositEncrypted(token, amount, keyIndex, encryptedPayload, bouncebackRecipient)` on the portal, where `keyIndex` references which encryption key they encrypted to (see [Encryption Key Management](#encryption-key-management)), and `bouncebackRecipient` is the Tempo address that receives a refund if zone-side processing fails (see [Deposit Failures and Bounce-Back](#deposit-failures-and-bounce-back)). Like `deposit()`, `depositEncrypted` requires `bouncebackRecipient != address(0)`, requires it to be authorized by the token's TIP-403 recipient policy, requires `amount >= depositFee + bouncebackFee` (reverts `DepositTooSmall` otherwise), and snapshots the bounce-back fee on the queued deposit.
 
 The portal locks the tokens, appends the encrypted deposit to the deposit queue, and emits `EncryptedDepositMade`. The sequencer provides the ECDH shared secret and proof when processing the deposit on the zone via `advanceTempo()`; the zone decrypts `(to, memo)` from the ciphertext onchain.
 
@@ -464,7 +464,7 @@ sequenceDiagram
 
 Deposits can fail for three main reasons: a recipient blocked by the TIP-403 policy, an invalid encrypted deposit, or rejection by the sequencer. To make sure that all cases can be handled without loss of user funds, every deposit carries a `bouncebackRecipient`: a Tempo address that receives a refund if zone-side processing fails.
 
-**Validation at deposit time.** Both `deposit(...)` and `depositEncrypted(...)` require `bouncebackRecipient != address(0)` and revert otherwise (`MissingBouncebackRecipient`). The portal does **not** validate `bouncebackRecipient` against the token's TIP-403 policy at deposit time; if the on-Tempo refund transfer is later rejected by the policy, the funds are parked in a per-recipient refund registry on the portal and the recipient claims them via `claimRefund(token)` (see [Tempo-side refund](#tempo-side-refund) below).
+**Validation at deposit time.** Both `deposit(...)` and `depositEncrypted(...)` require `bouncebackRecipient != address(0)` and require it to be authorized by the token's TIP-403 recipient policy. If the on-Tempo refund transfer later reverts because policy changed, the funds are parked in a per-recipient refund registry on the portal and the recipient claims them via `claimRefund(token)` (see [Tempo-side refund](#tempo-side-refund) below).
 
 **Triggering conditions.** There are three triggering sites:
 
@@ -1584,10 +1584,10 @@ interface IZonePortal {
     /// @dev Reverts (`MissingBouncebackRecipient`) if `bouncebackRecipient == address(0)`.
     ///      Every user-initiated deposit must carry a usable refund target so that a
     ///      failed mint can be recovered without stalling the deposit queue. The portal
-    ///      does not validate the recipient against the token's TIP-403 policy at
-    ///      deposit time; if the on-Tempo refund transfer is later rejected by the
-    ///      policy, the funds are parked in the per-recipient refund registry exposed
-    ///      via `refunds(token, owner)` / `claimRefund(token)`.
+    ///      validates the refund target against the token's TIP-403 recipient policy;
+    ///      if the on-Tempo refund transfer later reverts, the funds are parked in the
+    ///      per-recipient refund registry exposed via `refunds(token, owner)` /
+    ///      `claimRefund(token)`.
     function deposit(
         address token, address to, uint128 amount, bytes32 memo, address bouncebackRecipient
     ) external returns (bytes32 newCurrentDepositQueueHash);


### PR DESCRIPTION
This PR adds TIP-403 checks for deposit paths.

For encrypted deposits, the portal now checks the `bouncebackRecipient` before depositing into the zone.

```solidity
uint64 policyId = ITIP20(_token).transferPolicyId();

if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
    revert ITIP20.PolicyForbids();
}
```

For regular deposits, the portal also checks the recipient and mint recipient before accepting the deposit.
```solidity
if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, to)) {
    revert ITIP20.PolicyForbids();
}

if (!TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, to)) {
    revert ITIP20.PolicyForbids();
}
```

If a bounce-back later fails because the policy changed, funds are parked in the portal refund registry instead of blocking the queue.

This also reuses Tempo’s existing TIP-403 errors instead of using the current zone specific error types.