### PR TITLE
fix: harden private rpc websocket access

### DIFF
--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -3,7 +3,10 @@
 //! Each handler calls the underlying EthApi via the [`ZoneRpcApi`] trait,
 //! which performs typed privacy redactions internally before serialization.
 
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use alloy_primitives::{Address, B256, Bytes, U64};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
@@ -20,6 +23,8 @@ use crate::{
         classify_method,
     },
 };
+
+const MIN_FETCH_THEN_CHECK_RESPONSE_TIME: Duration = Duration::from_millis(100);
 
 /// Interface to the underlying reth EthApi for the private zone RPC.
 ///
@@ -262,6 +267,7 @@ pub async fn dispatch(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
+    let started_at = Instant::now();
     let id = req.id.clone();
 
     let tier = match classify_method(&req.method) {
@@ -282,7 +288,7 @@ pub async fn dispatch(
     // Raw params JSON — handlers deserialize directly, no intermediate Vec<Value>.
     let raw = req.params.as_deref().map(|p| p.get()).unwrap_or("[]");
 
-    match req.method.as_str() {
+    let response = match req.method.as_str() {
         // Simple passthrough methods (no params, no auth scoping)
         "eth_blockNumber" => api_result(id, "eth_blockNumber", api.block_number().await),
         "eth_chainId" => api_result(id, "eth_chainId", api.chain_id().await),
@@ -349,6 +355,30 @@ pub async fn dispatch(
                 JsonRpcError::internal("method not yet implemented in private RPC"),
             )
         }
+    };
+
+    if requires_min_response_time(&req.method) {
+        enforce_min_response_time(started_at).await;
+    }
+
+    response
+}
+
+fn requires_min_response_time(method: &str) -> bool {
+    matches!(
+        method,
+        "eth_getTransactionByHash"
+            | "eth_getTransactionReceipt"
+            | "eth_getLogs"
+            | "eth_getFilterLogs"
+            | "eth_getFilterChanges"
+    )
+}
+
+async fn enforce_min_response_time(started_at: Instant) {
+    let elapsed = started_at.elapsed();
+    if elapsed < MIN_FETCH_THEN_CHECK_RESPONSE_TIME {
+        tokio::time::sleep(MIN_FETCH_THEN_CHECK_RESPONSE_TIME - elapsed).await;
     }
 }
 
@@ -1003,5 +1033,16 @@ mod tests {
         let err = resp.error.expect("should reject extra simulation params");
         assert_eq!(err.code, -32602);
         assert_eq!(err.message, "expected [request, block?, stateOverride?]");
+    }
+
+    #[tokio::test]
+    async fn fetch_then_check_methods_enforce_min_response_time() {
+        let api = MockZoneRpcApi::default();
+        let started_at = Instant::now();
+
+        let resp = dispatch(&request("eth_getLogs", json!([{}])), &auth(), &api).await;
+
+        assert!(resp.result.is_none());
+        assert!(started_at.elapsed() >= MIN_FETCH_THEN_CHECK_RESPONSE_TIME);
     }
 }

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -4,8 +4,9 @@
 //! a `?token=0x<hex>` query parameter (for browser clients that cannot set
 //! custom headers on the upgrade request).
 //!
-//! Auth is validated once during the HTTP upgrade handshake — individual
-//! messages are not re-authenticated since WS frames don't carry auth headers.
+//! Auth is validated during the HTTP upgrade handshake and the session is
+//! closed once that token expires. Individual messages are not re-authenticated
+//! since WS frames don't carry auth headers.
 
 use alloy_rpc_types_eth::{
     Filter, FilterId,
@@ -22,7 +23,11 @@ use axum::{
 use futures::{SinkExt, stream::StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, value::RawValue};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
@@ -219,6 +224,15 @@ fn try_queue_notification(
     }
 }
 
+fn duration_until_unix_timestamp(timestamp: u64) -> Duration {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_secs();
+
+    Duration::from_secs(timestamp.saturating_sub(now))
+}
+
 struct WsDispatchResult {
     response: JsonRpcResponse,
     pending_subscriptions: Vec<PendingSubscription>,
@@ -292,32 +306,10 @@ async fn handle_subscribe(
             }
         }
         SubscriptionKind::NewPendingTransactions => {
-            let full = match params.unwrap_or(SubscriptionParams::None) {
-                SubscriptionParams::None | SubscriptionParams::Bool(false) => false,
-                SubscriptionParams::Bool(true) => true,
-                SubscriptionParams::Logs(_) | SubscriptionParams::TransactionReceipts(_) => {
-                    return WsDispatchResult::response_only(JsonRpcResponse::error(
-                        req.id.clone(),
-                        JsonRpcError::invalid_params(
-                            "eth_subscribe(newPendingTransactions) expects an optional boolean",
-                        ),
-                    ));
-                }
-            };
-
-            match state
-                .api
-                .ws_subscribe_pending_transactions(full, auth.clone())
-                .await
-            {
-                Ok(subscription) => subscription,
-                Err(err) => {
-                    return WsDispatchResult::response_only(JsonRpcResponse::error(
-                        req.id.clone(),
-                        err,
-                    ));
-                }
-            }
+            return WsDispatchResult::response_only(JsonRpcResponse::error(
+                req.id.clone(),
+                JsonRpcError::method_disabled(),
+            ));
         }
         SubscriptionKind::Syncing => {
             return WsDispatchResult::response_only(JsonRpcResponse::error(
@@ -519,9 +511,19 @@ async fn handle_ws_session(
     });
 
     let mut session = WsSession::default();
+    let expiry = tokio::time::sleep(duration_until_unix_timestamp(auth.expires_at));
+    tokio::pin!(expiry);
 
     loop {
         let msg = tokio::select! {
+            _ = &mut expiry => {
+                warn!(
+                    target: "zone::rpc",
+                    caller = %auth.caller,
+                    "ws authorization token expired, closing session"
+                );
+                break;
+            }
             _ = close_session_rx.changed() => break,
             msg = ws_receiver.next() => match msg {
                 Some(msg) => msg,

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -292,8 +292,12 @@ impl TestContext {
     }
 
     fn build_token(&self) -> String {
+        self.build_token_with_ttl(600)
+    }
+
+    fn build_token_with_ttl(&self, ttl_secs: u64) -> String {
         let now = now_secs();
-        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
+        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + ttl_secs);
         let sig = self.signer.sign_hash_sync(&digest).expect("signing failed");
 
         let mut blob = Vec::with_capacity(65 + fields.len());
@@ -324,6 +328,16 @@ async fn connect_with_header(
     ctx: &TestContext,
 ) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
     let token = ctx.build_token();
+    connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("ws connect failed")
+}
+
+async fn connect_with_short_lived_header(
+    ctx: &TestContext,
+    ttl_secs: u64,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    let token = ctx.build_token_with_ttl(ttl_secs);
     connect_with_token(&ctx.ws_url(), ctx.addr, &token)
         .await
         .expect("ws connect failed")
@@ -438,6 +452,20 @@ async fn ws_reject_invalid_token() {
         panic!("expected HTTP error, got {err:?}");
     };
     assert_eq!(response.status(), 403);
+}
+
+#[tokio::test]
+async fn ws_closes_when_auth_token_expires() {
+    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let mut ws = connect_with_short_lived_header(&ctx, 1).await;
+
+    let close = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("ws should close after token expiry");
+    match close {
+        None | Some(Ok(tungstenite::Message::Close(_))) | Some(Err(_)) => {}
+        other => panic!("expected websocket close after token expiry, got {other:?}"),
+    }
 }
 
 #[tokio::test]
@@ -616,67 +644,24 @@ async fn ws_subscribe_logs_emits_notifications() {
 }
 
 #[tokio::test]
-async fn ws_subscribe_pending_transactions_hashes_emits_notifications() {
+async fn ws_subscribe_pending_transactions_is_disabled() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions"]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
-
-    assert_eq!(resp["id"], 1);
-    let subscription_id = resp["result"].as_str().expect("subscription id");
-
-    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+    for (id, params) in [
+        (1, json!(["newPendingTransactions"])),
+        (2, json!(["newPendingTransactions", true])),
+    ] {
+        ws.send(tungstenite::Message::Text(
+            jsonrpc_with_params("eth_subscribe", params, id).into(),
+        ))
         .await
-        .expect("timed out waiting for pending tx hash notification")
-        .unwrap()
         .unwrap();
-    let notification = parse_response(notification);
+        let resp = parse_response(ws.next().await.unwrap().unwrap());
 
-    assert_eq!(notification["method"], "eth_subscription");
-    assert_eq!(notification["params"]["subscription"], subscription_id);
-    assert_eq!(
-        notification["params"]["result"],
-        format!(
-            "{:#x}",
-            b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
-        )
-    );
-}
-
-#[tokio::test]
-async fn ws_subscribe_pending_transactions_full_emits_notifications() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
-    let mut ws = connect_with_header(&ctx).await;
-
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions", true]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
-
-    assert_eq!(resp["id"], 1);
-    let subscription_id = resp["result"].as_str().expect("subscription id");
-
-    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
-        .await
-        .expect("timed out waiting for full pending tx notification")
-        .unwrap()
-        .unwrap();
-    let notification = parse_response(notification);
-
-    assert_eq!(notification["method"], "eth_subscription");
-    assert_eq!(notification["params"]["subscription"], subscription_id);
-    assert_eq!(notification["params"]["result"]["nonce"], "0x7");
-    assert_eq!(
-        notification["params"]["result"]["from"],
-        format!("{:#x}", Address::repeat_byte(0x11))
-    );
+        assert_eq!(resp["id"], id);
+        assert_eq!(resp["error"]["code"], -32006);
+    }
 }
 
 #[tokio::test]
@@ -713,10 +698,10 @@ async fn ws_subscribe_rejects_invalid_param_shapes() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    for (id, params) in [
-        (1, json!(["newHeads", false])),
-        (2, json!(["logs", false])),
-        (3, json!(["newPendingTransactions", {}])),
+    for (id, params, code) in [
+        (1, json!(["newHeads", false]), -32602),
+        (2, json!(["logs", false]), -32602),
+        (3, json!(["newPendingTransactions", {}]), -32006),
     ] {
         ws.send(tungstenite::Message::Text(
             jsonrpc_with_params("eth_subscribe", params, id).into(),
@@ -725,7 +710,7 @@ async fn ws_subscribe_rejects_invalid_param_shapes() {
         .unwrap();
         let resp = parse_response(ws.next().await.unwrap().unwrap());
         assert_eq!(resp["id"], id);
-        assert_eq!(resp["error"]["code"], -32602);
+        assert_eq!(resp["error"]["code"], code);
     }
 }
 

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -117,18 +117,6 @@ async fn ws_subscribe(ws: &mut PrivateRpcWs, params: Value) -> eyre::Result<Stri
         .to_owned())
 }
 
-async fn ws_expect_no_message(ws: &mut PrivateRpcWs, duration: Duration) -> eyre::Result<()> {
-    match tokio::time::timeout(duration, ws.next()).await {
-        Err(_) => Ok(()),
-        Ok(Some(Ok(Message::Close(_)))) | Ok(None) => Ok(()),
-        Ok(Some(Ok(Message::Text(text)))) => {
-            eyre::bail!("unexpected websocket message: {text}")
-        }
-        Ok(Some(Ok(other))) => eyre::bail!("unexpected websocket frame: {other:?}"),
-        Ok(Some(Err(err))) => Err(err.into()),
-    }
-}
-
 async fn ws_collect_messages_until_quiet(
     ws: &mut PrivateRpcWs,
     duration: Duration,
@@ -947,78 +935,24 @@ async fn test_ws_logs_subscription_is_sender_scoped() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Pending transaction subscriptions are sender-scoped for all callers.
+/// Pending transaction subscriptions are disabled on the private RPC.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_ws_pending_transactions_are_sender_scoped_for_users() -> eyre::Result<()> {
+async fn test_ws_pending_transactions_are_disabled() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let mut ctx = start_zone_with_private_rpc().await?;
-    let owner_signer = MnemonicBuilder::<English>::default()
-        .phrase(TEST_MNEMONIC)
-        .build()?;
-    let outsider_signer = PrivateKeySigner::random();
-    let spender = PrivateKeySigner::random().address();
+    let ctx = start_zone_with_private_rpc().await?;
+    let user_signer = PrivateKeySigner::random();
+    let user_token = ctx.user_token(&user_signer);
+    let mut ws = connect_private_rpc_ws(&ctx.private_rpc_url, &user_token).await?;
 
-    ctx.inject_deposit(
-        PATH_USD_ADDRESS,
-        owner_signer.address(),
-        owner_signer.address(),
-        1_000_000,
-    )
+    ws.send(Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions"]), 1).into(),
+    ))
     .await?;
-    ctx.inject_deposit(
-        PATH_USD_ADDRESS,
-        outsider_signer.address(),
-        outsider_signer.address(),
-        1_000_000,
-    )
-    .await?;
+    let response = ws_next_json(&mut ws).await?;
 
-    let owner_token = ctx.user_token(&owner_signer);
-    let mut owner_ws = connect_private_rpc_ws(&ctx.private_rpc_url, &owner_token).await?;
-
-    let owner_subscription = ws_subscribe(&mut owner_ws, json!(["newPendingTransactions"])).await?;
-
-    let owner_provider = ProviderBuilder::new()
-        .wallet(owner_signer.clone())
-        .connect_http(ctx.zone.http_url().clone());
-    let outsider_provider = ProviderBuilder::new()
-        .wallet(outsider_signer.clone())
-        .connect_http(ctx.zone.http_url().clone());
-
-    let owner_pending = ContractTip20::new(PATH_USD_ADDRESS, &owner_provider)
-        .approve(spender, U256::from(333u64))
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(150_000)
-        .send()
-        .await?;
-    let outsider_pending = ContractTip20::new(PATH_USD_ADDRESS, &outsider_provider)
-        .approve(spender, U256::from(444u64))
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(150_000)
-        .send()
-        .await?;
-
-    let owner_hash = *owner_pending.tx_hash();
-
-    let owner_notification = ws_next_json(&mut owner_ws).await?;
-    assert_eq!(
-        owner_notification["params"]["subscription"]
-            .as_str()
-            .unwrap(),
-        owner_subscription
-    );
-    assert_eq!(
-        owner_notification["params"]["result"].as_str().unwrap(),
-        format!("{owner_hash:#x}")
-    );
-    ws_expect_no_message(&mut owner_ws, Duration::from_millis(500)).await?;
-
-    ctx.fixture.inject_empty_block(ctx.zone.deposit_queue());
-    let owner_receipt = owner_pending.get_receipt().await?;
-    let outsider_receipt = outsider_pending.get_receipt().await?;
-    assert!(owner_receipt.status(), "owner approve should succeed");
-    assert!(outsider_receipt.status(), "outsider approve should succeed");
+    assert_eq!(response["id"], 1);
+    assert_eq!(response["error"]["code"], -32006);
 
     Ok(())
 }


### PR DESCRIPTION
## What changed

- Close authenticated private RPC WebSocket sessions when the authorization token reaches `expiresAt`.
- Disable `eth_subscribe("newPendingTransactions")` on the private RPC WebSocket surface.
- Add the spec-required 100 ms minimum response time for fetch-then-check methods: transaction lookup, receipt lookup, log queries, and filter polling.
- Update RPC and zone integration tests to cover token-expiry closure, disabled pending subscriptions, and the timing guard.

## Why

The private RPC spec requires scoped data to be available only through authenticated, still-valid access and calls out pending transaction subscriptions and timing side channels as privacy risks. The previous WebSocket path authenticated only at upgrade time, allowed pending transaction subscriptions, and returned scoped fetch-then-check calls as soon as the backend responded.

## Relationship to #497

This complements #497, which hardens HTTP/filter polling by disabling `eth_newPendingTransactionFilter` and failing closed on unexpected proxy `eth_getFilterChanges` result shapes. The two branches auto-merge cleanly, and the combined RPC test suite passes.

## Impact

Expired WebSocket tokens stop granting continued RPC access, pending mempool subscriptions are unavailable on the private RPC surface, and scoped lookups are less useful as existence probes. Normal authenticated HTTP calls and allowed WebSocket `newHeads`/`logs` subscriptions continue to work.