### PR TITLE
fix: disable websocket pending subscriptions

### DIFF
--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -169,16 +169,6 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
         Box::pin(async { Err(JsonRpcError::method_disabled()) })
     }
 
-    /// `eth_subscribe("newPendingTransactions", full?)` — opens a stream of
-    /// pending transactions, returning either hashes or full transaction objects.
-    fn ws_subscribe_pending_transactions(
-        &self,
-        _full: bool,
-        _auth: AuthContext,
-    ) -> BoxWsSubscriptionFut<'_> {
-        Box::pin(async { Err(JsonRpcError::method_disabled()) })
-    }
-
     /// `zone_getAuthorizationTokenInfo()` — returns the authenticated account
     /// and token expiry.
     fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_>;

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -292,32 +292,10 @@ async fn handle_subscribe(
             }
         }
         SubscriptionKind::NewPendingTransactions => {
-            let full = match params.unwrap_or(SubscriptionParams::None) {
-                SubscriptionParams::None | SubscriptionParams::Bool(false) => false,
-                SubscriptionParams::Bool(true) => true,
-                SubscriptionParams::Logs(_) | SubscriptionParams::TransactionReceipts(_) => {
-                    return WsDispatchResult::response_only(JsonRpcResponse::error(
-                        req.id.clone(),
-                        JsonRpcError::invalid_params(
-                            "eth_subscribe(newPendingTransactions) expects an optional boolean",
-                        ),
-                    ));
-                }
-            };
-
-            match state
-                .api
-                .ws_subscribe_pending_transactions(full, auth.clone())
-                .await
-            {
-                Ok(subscription) => subscription,
-                Err(err) => {
-                    return WsDispatchResult::response_only(JsonRpcResponse::error(
-                        req.id.clone(),
-                        err,
-                    ));
-                }
-            }
+            return WsDispatchResult::response_only(JsonRpcResponse::error(
+                req.id.clone(),
+                JsonRpcError::method_disabled(),
+            ));
         }
         SubscriptionKind::Syncing => {
             return WsDispatchResult::response_only(JsonRpcResponse::error(

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -195,38 +195,6 @@ impl ZoneRpcApi for MockZoneRpcApi {
         })
     }
 
-    fn ws_subscribe_pending_transactions(
-        &self,
-        full: bool,
-        _auth: zone_rpc::auth::AuthContext,
-    ) -> BoxWsSubscriptionFut<'_> {
-        let enabled = self.ws_subscriptions_enabled;
-        Box::pin(async move {
-            if !enabled {
-                return Err(JsonRpcError::method_disabled());
-            }
-
-            let stream = if full {
-                stream::iter(vec![zone_rpc::types::to_raw(&json!({
-                    "hash": format!(
-                        "{:#x}",
-                        b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
-                    ),
-                    "from": format!("{:#x}", Address::repeat_byte(0x11)),
-                    "to": format!("{:#x}", Address::repeat_byte(0x22)),
-                    "nonce": "0x7"
-                }))])
-            } else {
-                stream::iter(vec![zone_rpc::types::to_raw(&format!(
-                    "{:#x}",
-                    b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
-                ))])
-            };
-            let stream: WsSubscriptionStream = Box::pin(stream);
-            Ok(stream)
-        })
-    }
-
     fn zone_get_authorization_token_info(&self, auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             zone_rpc::types::to_raw(&serde_json::json!({
@@ -616,67 +584,25 @@ async fn ws_subscribe_logs_emits_notifications() {
 }
 
 #[tokio::test]
-async fn ws_subscribe_pending_transactions_hashes_emits_notifications() {
+async fn ws_subscribe_pending_transactions_is_disabled() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions"]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
-
-    assert_eq!(resp["id"], 1);
-    let subscription_id = resp["result"].as_str().expect("subscription id");
-
-    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
+    for (id, params) in [
+        (1, json!(["newPendingTransactions"])),
+        (2, json!(["newPendingTransactions", true])),
+        (3, json!(["newPendingTransactions", {}])),
+    ] {
+        ws.send(tungstenite::Message::Text(
+            jsonrpc_with_params("eth_subscribe", params, id).into(),
+        ))
         .await
-        .expect("timed out waiting for pending tx hash notification")
-        .unwrap()
         .unwrap();
-    let notification = parse_response(notification);
+        let resp = parse_response(ws.next().await.unwrap().unwrap());
 
-    assert_eq!(notification["method"], "eth_subscription");
-    assert_eq!(notification["params"]["subscription"], subscription_id);
-    assert_eq!(
-        notification["params"]["result"],
-        format!(
-            "{:#x}",
-            b256!("0x5555555555555555555555555555555555555555555555555555555555555555")
-        )
-    );
-}
-
-#[tokio::test]
-async fn ws_subscribe_pending_transactions_full_emits_notifications() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
-    let mut ws = connect_with_header(&ctx).await;
-
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["newPendingTransactions", true]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
-
-    assert_eq!(resp["id"], 1);
-    let subscription_id = resp["result"].as_str().expect("subscription id");
-
-    let notification = tokio::time::timeout(Duration::from_secs(2), ws.next())
-        .await
-        .expect("timed out waiting for full pending tx notification")
-        .unwrap()
-        .unwrap();
-    let notification = parse_response(notification);
-
-    assert_eq!(notification["method"], "eth_subscription");
-    assert_eq!(notification["params"]["subscription"], subscription_id);
-    assert_eq!(notification["params"]["result"]["nonce"], "0x7");
-    assert_eq!(
-        notification["params"]["result"]["from"],
-        format!("{:#x}", Address::repeat_byte(0x11))
-    );
+        assert_eq!(resp["id"], id);
+        assert_eq!(resp["error"]["code"], -32006);
+    }
 }
 
 #[tokio::test]
@@ -713,11 +639,7 @@ async fn ws_subscribe_rejects_invalid_param_shapes() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    for (id, params) in [
-        (1, json!(["newHeads", false])),
-        (2, json!(["logs", false])),
-        (3, json!(["newPendingTransactions", {}])),
-    ] {
+    for (id, params) in [(1, json!(["newHeads", false])), (2, json!(["logs", false]))] {
         ws.send(tungstenite::Message::Text(
             jsonrpc_with_params("eth_subscribe", params, id).into(),
         ))

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -30,7 +30,6 @@ use reth_rpc_eth_api::{
     helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
 };
 use reth_rpc_eth_types::logs_utils;
-use reth_transaction_pool::TransactionPool;
 use tempo_alloy::{
     TempoNetwork,
     rpc::{TempoHeaderResponse, TempoTransactionRequest},
@@ -823,44 +822,6 @@ where
                     zone_rpc::filter::is_log_visible(&log, &caller).then(|| to_raw(&log)),
                 )
             });
-            let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
-            Ok(stream)
-        })
-    }
-
-    fn ws_subscribe_pending_transactions(
-        &self,
-        full: bool,
-        auth: AuthContext,
-    ) -> BoxWsSubscriptionFut<'_> {
-        Box::pin(async move {
-            let caller = auth.caller;
-            let pool = self.eth.api.pool().clone();
-
-            if !full {
-                let stream =
-                    pool.new_pending_pool_transactions_listener()
-                        .filter_map(move |pending_tx| {
-                            std::future::ready(
-                                (pending_tx.transaction.sender() == caller)
-                                    .then(|| to_raw(pending_tx.transaction.hash())),
-                            )
-                        });
-                let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
-                return Ok(stream);
-            }
-
-            let api = self.eth.api.clone();
-            let stream =
-                pool.new_pending_pool_transactions_listener()
-                    .filter_map(move |pending_tx| {
-                        std::future::ready((pending_tx.transaction.sender() == caller).then(|| {
-                            api.converter()
-                                .fill_pending(pending_tx.transaction.to_consensus())
-                                .map_err(internal)
-                                .and_then(|tx| to_raw(&tx))
-                        }))
-                    });
             let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
             Ok(stream)
         })

--- a/crates/tempo-zone/tests/it/private_rpc_e2e.rs
+++ b/crates/tempo-zone/tests/it/private_rpc_e2e.rs
@@ -117,18 +117,6 @@ async fn ws_subscribe(ws: &mut PrivateRpcWs, params: Value) -> eyre::Result<Stri
         .to_owned())
 }
 
-async fn ws_expect_no_message(ws: &mut PrivateRpcWs, duration: Duration) -> eyre::Result<()> {
-    match tokio::time::timeout(duration, ws.next()).await {
-        Err(_) => Ok(()),
-        Ok(Some(Ok(Message::Close(_)))) | Ok(None) => Ok(()),
-        Ok(Some(Ok(Message::Text(text)))) => {
-            eyre::bail!("unexpected websocket message: {text}")
-        }
-        Ok(Some(Ok(other))) => eyre::bail!("unexpected websocket frame: {other:?}"),
-        Ok(Some(Err(err))) => Err(err.into()),
-    }
-}
-
 async fn ws_collect_messages_until_quiet(
     ws: &mut PrivateRpcWs,
     duration: Duration,
@@ -947,78 +935,34 @@ async fn test_ws_logs_subscription_is_sender_scoped() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Pending transaction subscriptions are sender-scoped for all callers.
+/// Pending transaction subscriptions are disabled because they expose mempool activity.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_ws_pending_transactions_are_sender_scoped_for_users() -> eyre::Result<()> {
+async fn test_ws_pending_transaction_subscriptions_are_disabled() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let mut ctx = start_zone_with_private_rpc().await?;
-    let owner_signer = MnemonicBuilder::<English>::default()
-        .phrase(TEST_MNEMONIC)
-        .build()?;
-    let outsider_signer = PrivateKeySigner::random();
-    let spender = PrivateKeySigner::random().address();
+    let ctx = start_zone_with_private_rpc().await?;
+    let user_signer = PrivateKeySigner::random();
+    let user_token = ctx.user_token(&user_signer);
+    let mut user_ws = connect_private_rpc_ws(&ctx.private_rpc_url, &user_token).await?;
 
-    ctx.inject_deposit(
-        PATH_USD_ADDRESS,
-        owner_signer.address(),
-        owner_signer.address(),
-        1_000_000,
-    )
-    .await?;
-    ctx.inject_deposit(
-        PATH_USD_ADDRESS,
-        outsider_signer.address(),
-        outsider_signer.address(),
-        1_000_000,
-    )
-    .await?;
-
-    let owner_token = ctx.user_token(&owner_signer);
-    let mut owner_ws = connect_private_rpc_ws(&ctx.private_rpc_url, &owner_token).await?;
-
-    let owner_subscription = ws_subscribe(&mut owner_ws, json!(["newPendingTransactions"])).await?;
-
-    let owner_provider = ProviderBuilder::new()
-        .wallet(owner_signer.clone())
-        .connect_http(ctx.zone.http_url().clone());
-    let outsider_provider = ProviderBuilder::new()
-        .wallet(outsider_signer.clone())
-        .connect_http(ctx.zone.http_url().clone());
-
-    let owner_pending = ContractTip20::new(PATH_USD_ADDRESS, &owner_provider)
-        .approve(spender, U256::from(333u64))
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(150_000)
-        .send()
-        .await?;
-    let outsider_pending = ContractTip20::new(PATH_USD_ADDRESS, &outsider_provider)
-        .approve(spender, U256::from(444u64))
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(150_000)
-        .send()
-        .await?;
-
-    let owner_hash = *owner_pending.tx_hash();
-
-    let owner_notification = ws_next_json(&mut owner_ws).await?;
-    assert_eq!(
-        owner_notification["params"]["subscription"]
-            .as_str()
-            .unwrap(),
-        owner_subscription
-    );
-    assert_eq!(
-        owner_notification["params"]["result"].as_str().unwrap(),
-        format!("{owner_hash:#x}")
-    );
-    ws_expect_no_message(&mut owner_ws, Duration::from_millis(500)).await?;
-
-    ctx.fixture.inject_empty_block(ctx.zone.deposit_queue());
-    let owner_receipt = owner_pending.get_receipt().await?;
-    let outsider_receipt = outsider_pending.get_receipt().await?;
-    assert!(owner_receipt.status(), "owner approve should succeed");
-    assert!(outsider_receipt.status(), "outsider approve should succeed");
+    for (id, params) in [
+        (1, json!(["newPendingTransactions"])),
+        (2, json!(["newPendingTransactions", true])),
+        (3, json!(["newPendingTransactions", {}])),
+    ] {
+        user_ws
+            .send(Message::Text(
+                jsonrpc_with_params("eth_subscribe", params, id).into(),
+            ))
+            .await?;
+        let response = ws_next_json(&mut user_ws).await?;
+        assert_eq!(response["id"], id);
+        assert_eq!(
+            response["error"]["code"].as_i64().unwrap(),
+            -32006,
+            "newPendingTransactions should be disabled"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Disables `eth_subscribe("newPendingTransactions")` in the private RPC WebSocket dispatcher so the implementation follows the existing spec.

Removes the pending transaction subscription hook from the RPC trait, mock API, and zone-backed API implementation so there is no backend path left for pending transaction streams.

Replaces the previous pending subscription success coverage with unit and e2e assertions that hash-only, `full=true`, and object-shaped pending transaction subscription requests all return the disabled-method error.

## Root Cause

The WebSocket implementation still exposed sender-scoped pending transaction subscriptions even though the spec marks `eth_subscribe("newPendingTransactions")` disabled because pending transaction observation leaks mempool activity.