### PR TITLE
fix(withdrawals): use replace semantics when storing a portal slot

### DIFF
--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -706,14 +706,24 @@ impl ZoneMonitor {
                     if !batch_data.withdrawal_queue_hash.is_zero() {
                         if !withdrawals.is_empty() {
                             let portal_slot = self.portal_withdrawal_queue_tail;
+                            let count = withdrawals.len();
                             let mut store = self.withdrawal_store.lock();
-                            for w in &withdrawals {
-                                store.add_withdrawal(portal_slot, w.clone());
-                            }
+                            // Each portal slot is written exactly once per
+                            // successful submission and later cleared by the
+                            // withdrawal processor via `remove_batch`. Use
+                            // replace semantics so a fresh slot write can never
+                            // silently concatenate onto a stale slot — that would
+                            // corrupt the slot's withdrawal hash chain and wedge
+                            // the queue (every `processWithdrawal` would revert on
+                            // the hash mismatch).
+                            debug_assert!(
+                                !store.has_batch(portal_slot),
+                                "writing withdrawals to an already-populated portal slot {portal_slot}"
+                            );
+                            store.add_batch(portal_slot, withdrawals);
                             info!(
                                 portal_slot,
-                                count = withdrawals.len(),
-                                "Stored withdrawals for portal queue slot"
+                                count, "Stored withdrawals for portal queue slot"
                             );
                         }
                         self.portal_withdrawal_queue_tail += 1;

--- a/crates/tempo-zone/src/zonemonitor.rs
+++ b/crates/tempo-zone/src/zonemonitor.rs
@@ -708,18 +708,6 @@ impl ZoneMonitor {
                             let portal_slot = self.portal_withdrawal_queue_tail;
                             let count = withdrawals.len();
                             let mut store = self.withdrawal_store.lock();
-                            // Each portal slot is written exactly once per
-                            // successful submission and later cleared by the
-                            // withdrawal processor via `remove_batch`. Use
-                            // replace semantics so a fresh slot write can never
-                            // silently concatenate onto a stale slot — that would
-                            // corrupt the slot's withdrawal hash chain and wedge
-                            // the queue (every `processWithdrawal` would revert on
-                            // the hash mismatch).
-                            debug_assert!(
-                                !store.has_batch(portal_slot),
-                                "writing withdrawals to an already-populated portal slot {portal_slot}"
-                            );
                             store.add_batch(portal_slot, withdrawals);
                             info!(
                                 portal_slot,


### PR DESCRIPTION
# fix(withdrawals): use replace semantics when storing a portal slot

> ⚠️ **Impact:** a violated invariant here permanently wedges the withdrawal
> queue, leaving user funds stuck in L1 escrow. Low-risk fix, high-cost failure.

### Symptom (if the latent bug triggers)
Every `processWithdrawal` on the head slot reverts with a hash mismatch. The
queue head stops advancing and no further withdrawals are processed — funds
remain in escrow on L1.

### Trigger
Two batches' withdrawals end up concatenated under a single portal slot. That
can happen any time the slot at `portal_withdrawal_queue_tail` is not empty when
we write it — e.g. a submission whose receipt timed out is retried, or the tail
advances before the processor clears the prior occupant via `remove_batch`.

### Root cause
On a successful batch landing, the monitor stored withdrawals with
`WithdrawalStore::add_withdrawal`, which **appends**
(`entry(slot).or_default().push(w)`). Append is only safe under the unspoken
assumption that the slot is always empty. Once two batches share a slot, the
processor hashes the merged list, which never matches the portal slot hash —
hence the permanent revert loop above.

### Fix
A slot is written exactly once per submission and cleared afterwards by the
processor, so switching to `add_batch` (**replace**) is identical on the happy
path while making the empty-slot invariant impossible to break silently. A
`debug_assert!` pins the invariant for debug/test builds. The replace behavior
of `add_batch` is already exercised by `withdrawals::tests::store_add_batch`.
