### PR TITLE
fix(rpc): harden zone RPC privacy and WS auth constraints

### DIFF
--- a/crates/rpc/src/auth/token.rs
+++ b/crates/rpc/src/auth/token.rs
@@ -35,6 +35,8 @@ pub struct AuthContext {
     pub caller: Address,
     /// Token expiry timestamp (unix seconds).
     pub expires_at: u64,
+    /// Keychain key used for authentication, if this is a keychain token.
+    pub keychain_key_id: Option<Address>,
 }
 
 /// Parsed authorization token fields (before signature verification).

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -10,6 +10,8 @@ use alloy_primitives::{Address, B256, b256};
 use alloy_rpc_types_eth::{Filter, FilterSet, Log};
 use tempo_alloy::rpc::TempoTransactionReceipt;
 
+use crate::types::JsonRpcError;
+
 /// `Transfer(address,address,uint256)`
 pub const TRANSFER_TOPIC: B256 =
     b256!("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
@@ -73,9 +75,6 @@ pub fn is_caller_eligible(log: &Log, caller: &Address) -> bool {
 /// A log is included only when **both** of the following hold:
 /// 1. Its topic0 is one of the [`WHITELISTED_TOPICS`].
 /// 2. The `caller` is eligible per [`is_caller_eligible`].
-///
-/// TODO: once the enabled-token registry is plumbed through, also filter
-/// by emitting contract address (only logs from enabled TIP-20 tokens).
 pub fn is_log_visible(log: &Log, caller: &Address) -> bool {
     log.topic0().is_some_and(|t| WHITELISTED_TOPICS.contains(t)) && is_caller_eligible(log, caller)
 }
@@ -96,6 +95,28 @@ pub fn filter_receipt_logs(mut receipt: TempoTransactionReceipt) -> TempoTransac
     receipt
 }
 
+/// Scopes a user-supplied filter to only match enabled zone token addresses.
+pub fn scope_filter_addresses(
+    filter: &mut Filter,
+    zone_tokens: &[Address],
+) -> Result<(), JsonRpcError> {
+    let requested_addresses: Vec<Address> = filter.address.iter().copied().collect();
+
+    if requested_addresses.is_empty() {
+        filter.address = FilterSet::from(zone_tokens.to_vec());
+        return Ok(());
+    }
+
+    if requested_addresses
+        .iter()
+        .all(|address| zone_tokens.contains(address))
+    {
+        Ok(())
+    } else {
+        Err(JsonRpcError::invalid_params("invalid filter address"))
+    }
+}
+
 /// Scopes a user-supplied filter to only match whitelisted TIP-20 event topics.
 ///
 /// Intersects the user's requested topic0 with [`WHITELISTED_TOPICS`].
@@ -104,9 +125,6 @@ pub fn filter_receipt_logs(mut receipt: TempoTransactionReceipt) -> TempoTransac
 ///
 /// The post-filter in [`filter_logs`] remains the actual privacy enforcement;
 /// this pre-filter reduces DB scan volume and timing side-channels.
-///
-/// TODO: once the enabled-token registry is plumbed through, also scope the
-/// filter's `address` field to only match enabled TIP-20 token addresses.
 pub fn scope_filter(filter: &mut Filter) {
     // --- Topic0 scoping ---
     let user_topic0: Vec<B256> = filter.topics[0].iter().copied().collect();
@@ -495,5 +513,42 @@ mod tests {
         filter.topics[0] = FilterSet::from(bogus);
         scope_filter(&mut filter);
         assert_eq!(filter.topics[0], FilterSet::from(B256::ZERO));
+    }
+
+    #[test]
+    fn scope_filter_addresses_scopes_omitted_address() {
+        let token_a = address!("0x00000000000000000000000000000000000000aa");
+        let token_b = address!("0x00000000000000000000000000000000000000bb");
+        let mut filter = Filter::default();
+
+        scope_filter_addresses(&mut filter, &[token_a, token_b]).unwrap();
+
+        assert!(filter.address.contains(&token_a));
+        assert!(filter.address.contains(&token_b));
+        assert_eq!(filter.address.len(), 2);
+    }
+
+    #[test]
+    fn scope_filter_addresses_allows_enabled_token_address() {
+        let token = address!("0x00000000000000000000000000000000000000aa");
+        let mut filter = Filter::default();
+        filter.address = FilterSet::from(token);
+
+        scope_filter_addresses(&mut filter, &[token]).unwrap();
+
+        assert_eq!(filter.address, FilterSet::from(token));
+    }
+
+    #[test]
+    fn scope_filter_addresses_rejects_non_zone_token_address() {
+        let token = address!("0x00000000000000000000000000000000000000aa");
+        let other = address!("0x00000000000000000000000000000000000000cc");
+        let mut filter = Filter::default();
+        filter.address = FilterSet::from(vec![token, other]);
+
+        let err = scope_filter_addresses(&mut filter, &[token]).unwrap_err();
+
+        assert_eq!(err.code, JsonRpcError::invalid_params("").code);
+        assert_eq!(err.message, "invalid filter address");
     }
 }

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -531,8 +531,10 @@ mod tests {
     #[test]
     fn scope_filter_addresses_allows_enabled_token_address() {
         let token = address!("0x00000000000000000000000000000000000000aa");
-        let mut filter = Filter::default();
-        filter.address = FilterSet::from(token);
+        let mut filter = Filter {
+            address: FilterSet::from(token),
+            ..Default::default()
+        };
 
         scope_filter_addresses(&mut filter, &[token]).unwrap();
 
@@ -543,8 +545,10 @@ mod tests {
     fn scope_filter_addresses_rejects_non_zone_token_address() {
         let token = address!("0x00000000000000000000000000000000000000aa");
         let other = address!("0x00000000000000000000000000000000000000cc");
-        let mut filter = Filter::default();
-        filter.address = FilterSet::from(vec![token, other]);
+        let mut filter = Filter {
+            address: FilterSet::from(vec![token, other]),
+            ..Default::default()
+        };
 
         let err = scope_filter_addresses(&mut filter, &[token]).unwrap_err();
 

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -883,6 +883,7 @@ mod tests {
         AuthContext {
             caller: Address::repeat_byte(0xaa),
             expires_at: 1_700_000_000,
+            keychain_key_id: None,
         }
     }
 

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_primitives::{Address, B256, Bytes, U64};
+use alloy_primitives::{Address, B256, Bytes, U64, keccak256};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
 use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
@@ -47,6 +47,12 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `net_version` — returns the network ID as a decimal string.
     fn net_version(&self) -> BoxFut<'_>;
+
+    /// `eth_syncing` — returns sync status from the upstream node.
+    fn syncing(&self) -> BoxFut<'_>;
+
+    /// `eth_coinbase` — returns the configured block beneficiary address.
+    fn coinbase(&self) -> BoxFut<'_>;
 
     /// `eth_gasPrice` — returns the current gas price.
     fn gas_price(&self) -> BoxFut<'_>;
@@ -290,6 +296,9 @@ pub async fn dispatch(
         ),
         "net_version" => api_result(id, "net_version", api.net_version().await),
         "net_listening" => api_result(id, "net_listening", crate::types::to_raw(&true)),
+        "eth_syncing" => api_result(id, "eth_syncing", api.syncing().await),
+        "eth_coinbase" => api_result(id, "eth_coinbase", api.coinbase().await),
+        "web3_sha3" => handle_web3_sha3(id, raw).await,
         "web3_clientVersion" => api_result(
             id,
             "web3_clientVersion",
@@ -370,6 +379,16 @@ async fn enforce_timing_floor(started_at: Option<Instant>) {
     if elapsed < TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME {
         tokio::time::sleep(TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME - elapsed).await;
     }
+}
+
+/// Handle `web3_sha3(data)` locally.
+async fn handle_web3_sha3(id: Value, raw: &str) -> JsonRpcResponse {
+    let (data,) = match parse_params::<(Bytes,)>(raw, &id, "expected [data]") {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    api_result(id, "web3_sha3", crate::types::to_raw(&keccak256(data)))
 }
 
 /// Handle `eth_getBlockByNumber`. Rejects `full=true` for non-sequencer callers.
@@ -851,6 +870,14 @@ mod tests {
             })
         }
 
+        fn syncing(&self) -> BoxFut<'_> {
+            Box::pin(async move { to_raw(&false) })
+        }
+
+        fn coinbase(&self) -> BoxFut<'_> {
+            Box::pin(async move { to_raw(&Address::repeat_byte(0xbb)) })
+        }
+
         fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
             Box::pin(async move {
                 to_raw(&json!({
@@ -915,6 +942,34 @@ mod tests {
             format!("{:#x}", Address::repeat_byte(0xaa)),
         );
         assert_eq!(body["expiresAt"], "0x6553f100");
+    }
+
+    #[tokio::test]
+    async fn dispatches_allowed_compatibility_methods() {
+        let api = MockZoneRpcApi::default();
+
+        let syncing = dispatch(&request("eth_syncing", json!([])), &auth(), &api).await;
+        assert_eq!(
+            serde_json::from_str::<Value>(syncing.result.as_ref().unwrap().get()).unwrap(),
+            false
+        );
+
+        let coinbase = dispatch(&request("eth_coinbase", json!([])), &auth(), &api).await;
+        assert_eq!(
+            serde_json::from_str::<Value>(coinbase.result.as_ref().unwrap().get()).unwrap(),
+            format!("{:#x}", Address::repeat_byte(0xbb))
+        );
+
+        let sha3 = dispatch(
+            &request("web3_sha3", json!(["0x68656c6c6f"])),
+            &auth(),
+            &api,
+        )
+        .await;
+        assert_eq!(
+            serde_json::from_str::<Value>(sha3.result.as_ref().unwrap().get()).unwrap(),
+            "0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
+        );
     }
 
     #[tokio::test]

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -883,6 +883,7 @@ mod tests {
                 to_raw(&json!({
                     "zoneId": "0x1",
                     "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
+                    "sequencer": format!("{:#x}", Address::repeat_byte(0x22)),
                     "chainId": "0x2a",
                 }))
             })
@@ -984,6 +985,10 @@ mod tests {
         assert_eq!(
             body["zoneTokens"][0],
             format!("{:#x}", Address::repeat_byte(0x11))
+        );
+        assert_eq!(
+            body["sequencer"],
+            format!("{:#x}", Address::repeat_byte(0x22))
         );
         assert_eq!(body["chainId"], "0x2a");
     }

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -3,10 +3,7 @@
 //! Each handler calls the underlying EthApi via the [`ZoneRpcApi`] trait,
 //! which performs typed privacy redactions internally before serialization.
 
-use std::{
-    str::FromStr,
-    time::{Duration, Instant},
-};
+use std::str::FromStr;
 
 use alloy_primitives::{Address, B256, Bytes, U64, keccak256};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
@@ -14,8 +11,6 @@ use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_contracts::precompiles::account_keychain::IAccountKeychain::KeyInfo;
 use tracing::warn;
-
-const TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME: Duration = Duration::from_millis(100);
 
 use crate::{
     auth::AuthContext,
@@ -264,7 +259,6 @@ pub async fn dispatch(
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
     let id = req.id.clone();
-    let timing_floor_started_at = method_needs_timing_floor(&req.method).then(Instant::now);
 
     let tier = match classify_method(&req.method) {
         Some(tier) => tier,
@@ -284,7 +278,7 @@ pub async fn dispatch(
     // Raw params JSON — handlers deserialize directly, no intermediate Vec<Value>.
     let raw = req.params.as_deref().map(|p| p.get()).unwrap_or("[]");
 
-    let response = match req.method.as_str() {
+    match req.method.as_str() {
         // Simple passthrough methods (no params, no auth scoping)
         "eth_blockNumber" => api_result(id, "eth_blockNumber", api.block_number().await),
         "eth_chainId" => api_result(id, "eth_chainId", api.chain_id().await),
@@ -354,30 +348,6 @@ pub async fn dispatch(
                 JsonRpcError::internal("method not yet implemented in private RPC"),
             )
         }
-    };
-
-    enforce_timing_floor(timing_floor_started_at).await;
-    response
-}
-
-fn method_needs_timing_floor(method: &str) -> bool {
-    matches!(
-        method,
-        "eth_getTransactionByHash"
-            | "eth_getTransactionReceipt"
-            | "eth_getLogs"
-            | "eth_getFilterLogs"
-            | "eth_getFilterChanges"
-    )
-}
-
-async fn enforce_timing_floor(started_at: Option<Instant>) {
-    let Some(started_at) = started_at else {
-        return;
-    };
-    let elapsed = started_at.elapsed();
-    if elapsed < TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME {
-        tokio::time::sleep(TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME - elapsed).await;
     }
 }
 
@@ -1085,7 +1055,6 @@ mod tests {
         assert_eq!(err.code, -32602);
         assert_eq!(err.message, "expected [request, block?, stateOverride?]");
     }
-
     #[tokio::test]
     async fn classifies_spec_disabled_and_restricted_methods() {
         let api = MockZoneRpcApi::default();
@@ -1109,21 +1078,5 @@ mod tests {
             assert_eq!(err.code, -32005);
             assert_eq!(err.message, "Sequencer only");
         }
-    }
-
-    #[tokio::test]
-    async fn enforces_timing_floor_for_fetch_then_check_methods() {
-        let api = MockZoneRpcApi::default();
-        let started_at = Instant::now();
-
-        let resp = dispatch(
-            &request("eth_getTransactionByHash", json!(["not-a-hash"])),
-            &auth(),
-            &api,
-        )
-        .await;
-
-        assert!(resp.result.is_none());
-        assert!(started_at.elapsed() >= TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME);
     }
 }

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -1082,6 +1082,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn classifies_spec_disabled_and_restricted_methods() {
+        let api = MockZoneRpcApi::default();
+
+        for method in [
+            "eth_getProof",
+            "eth_newPendingTransactionFilter",
+            "eth_getUncleByBlockNumberAndIndex",
+            "eth_getUncleByBlockHashAndIndex",
+            "eth_getWork",
+        ] {
+            let resp = dispatch(&request(method, json!([])), &auth(), &api).await;
+            let err = resp.error.expect("method should be disabled");
+            assert_eq!(err.code, -32006);
+            assert_eq!(err.message, "Method disabled");
+        }
+
+        for method in ["debug_accountRange", "txpool_contentFrom", "admin_peers"] {
+            let resp = dispatch(&request(method, json!([])), &auth(), &api).await;
+            let err = resp.error.expect("method should be sequencer-only");
+            assert_eq!(err.code, -32005);
+            assert_eq!(err.message, "Sequencer only");
+        }
+    }
+
+    #[tokio::test]
     async fn enforces_timing_floor_for_fetch_then_check_methods() {
         let api = MockZoneRpcApi::default();
         let started_at = Instant::now();

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -3,7 +3,10 @@
 //! Each handler calls the underlying EthApi via the [`ZoneRpcApi`] trait,
 //! which performs typed privacy redactions internally before serialization.
 
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use alloy_primitives::{Address, B256, Bytes, U64};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
@@ -11,6 +14,8 @@ use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_contracts::precompiles::account_keychain::IAccountKeychain::KeyInfo;
 use tracing::warn;
+
+const TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME: Duration = Duration::from_millis(100);
 
 use crate::{
     auth::AuthContext,
@@ -253,6 +258,7 @@ pub async fn dispatch(
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
     let id = req.id.clone();
+    let timing_floor_started_at = method_needs_timing_floor(&req.method).then(Instant::now);
 
     let tier = match classify_method(&req.method) {
         Some(tier) => tier,
@@ -272,7 +278,7 @@ pub async fn dispatch(
     // Raw params JSON — handlers deserialize directly, no intermediate Vec<Value>.
     let raw = req.params.as_deref().map(|p| p.get()).unwrap_or("[]");
 
-    match req.method.as_str() {
+    let response = match req.method.as_str() {
         // Simple passthrough methods (no params, no auth scoping)
         "eth_blockNumber" => api_result(id, "eth_blockNumber", api.block_number().await),
         "eth_chainId" => api_result(id, "eth_chainId", api.chain_id().await),
@@ -339,6 +345,30 @@ pub async fn dispatch(
                 JsonRpcError::internal("method not yet implemented in private RPC"),
             )
         }
+    };
+
+    enforce_timing_floor(timing_floor_started_at).await;
+    response
+}
+
+fn method_needs_timing_floor(method: &str) -> bool {
+    matches!(
+        method,
+        "eth_getTransactionByHash"
+            | "eth_getTransactionReceipt"
+            | "eth_getLogs"
+            | "eth_getFilterLogs"
+            | "eth_getFilterChanges"
+    )
+}
+
+async fn enforce_timing_floor(started_at: Option<Instant>) {
+    let Some(started_at) = started_at else {
+        return;
+    };
+    let elapsed = started_at.elapsed();
+    if elapsed < TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME {
+        tokio::time::sleep(TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME - elapsed).await;
     }
 }
 
@@ -993,5 +1023,21 @@ mod tests {
         let err = resp.error.expect("should reject extra simulation params");
         assert_eq!(err.code, -32602);
         assert_eq!(err.message, "expected [request, block?, stateOverride?]");
+    }
+
+    #[tokio::test]
+    async fn enforces_timing_floor_for_fetch_then_check_methods() {
+        let api = MockZoneRpcApi::default();
+        let started_at = Instant::now();
+
+        let resp = dispatch(
+            &request("eth_getTransactionByHash", json!(["not-a-hash"])),
+            &auth(),
+            &api,
+        )
+        .await;
+
+        assert!(resp.result.is_none());
+        assert!(started_at.elapsed() >= TIMING_SIDE_CHANNEL_MIN_RESPONSE_TIME);
     }
 }

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -164,6 +164,14 @@ impl ZoneRpcApi for ProxyZoneRpc {
         Box::pin(async move { self.forward("net_version", serde_json::json!([])).await })
     }
 
+    fn syncing(&self) -> BoxFut<'_> {
+        Box::pin(async move { self.forward("eth_syncing", serde_json::json!([])).await })
+    }
+
+    fn coinbase(&self) -> BoxFut<'_> {
+        Box::pin(async move { self.forward("eth_coinbase", serde_json::json!([])).await })
+    }
+
     fn gas_price(&self) -> BoxFut<'_> {
         Box::pin(async move { self.forward("eth_gasPrice", serde_json::json!([])).await })
     }

--- a/crates/rpc/src/proxy.rs
+++ b/crates/rpc/src/proxy.rs
@@ -619,6 +619,7 @@ mod tests {
                 AuthContext {
                     caller,
                     expires_at: u64::MAX,
+                    keychain_key_id: None,
                 },
             )
             .await

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -372,6 +372,8 @@ mod tests {
         stub!(block_number);
         stub!(chain_id);
         stub!(net_version);
+        stub!(syncing);
+        stub!(coinbase);
         stub!(gas_price);
         stub!(max_priority_fee_per_gas);
         stub!(fee_history, _a: u64, _b: alloy_rpc_types_eth::BlockNumberOrTag, _c: Option<Vec<f64>>);

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -17,7 +17,9 @@ use std::{
     sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
-use tempo_contracts::precompiles::account_keychain::IAccountKeychain::SignatureType as KeyInfoSignatureType;
+use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
+    KeyInfo, SignatureType as KeyInfoSignatureType,
+};
 use tempo_primitives::transaction::{
     SignatureType as TempoSignatureType,
     tt_signature::{KeychainSignature, TempoSignature},
@@ -234,13 +236,16 @@ pub(crate) async fn authenticate_token(
         .recover_signer(&token.digest)
         .map_err(|_| AuthError::InvalidSignature)?;
 
-    if let TempoSignature::Keychain(keychain_signature) = &signature {
-        validate_keychain_signature(api, caller, keychain_signature, &token.digest).await?;
-    }
+    let keychain_key_id = if let TempoSignature::Keychain(keychain_signature) = &signature {
+        Some(validate_keychain_signature(api, caller, keychain_signature, &token.digest).await?)
+    } else {
+        None
+    };
 
     Ok(AuthContext {
         caller,
         expires_at: token.expires_at,
+        keychain_key_id,
     })
 }
 
@@ -249,21 +254,13 @@ async fn validate_keychain_signature(
     caller: alloy_primitives::Address,
     keychain_signature: &KeychainSignature,
     digest: &alloy_primitives::B256,
-) -> Result<(), AuthenticateError> {
+) -> Result<alloy_primitives::Address, AuthenticateError> {
     let key_id = keychain_signature
         .key_id(digest)
         .map_err(|_| AuthError::InvalidSignature)?;
     let key_info = api.get_keychain_key(caller, key_id).await?;
 
-    if key_info.isRevoked {
-        return Err(AuthError::RevokedKeychainKey.into());
-    }
-    if key_info.keyId.is_zero() {
-        return Err(AuthError::UnauthorizedKeychainKey.into());
-    }
-    if key_info.expiry <= now_unix_seconds() {
-        return Err(AuthError::ExpiredKeychainKey.into());
-    }
+    validate_keychain_key_info(&key_info)?;
 
     let expected_signature_type = match keychain_signature.signature.signature_type() {
         TempoSignatureType::Secp256k1 => KeyInfoSignatureType::Secp256k1,
@@ -275,10 +272,24 @@ async fn validate_keychain_signature(
         return Err(AuthError::KeychainSignatureTypeMismatch.into());
     }
 
+    Ok(key_id)
+}
+
+pub(crate) fn validate_keychain_key_info(key_info: &KeyInfo) -> Result<(), AuthenticateError> {
+    if key_info.isRevoked {
+        return Err(AuthError::RevokedKeychainKey.into());
+    }
+    if key_info.keyId.is_zero() {
+        return Err(AuthError::UnauthorizedKeychainKey.into());
+    }
+    if key_info.expiry <= now_unix_seconds() {
+        return Err(AuthError::ExpiredKeychainKey.into());
+    }
+
     Ok(())
 }
 
-fn now_unix_seconds() -> u64 {
+pub(crate) fn now_unix_seconds() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system clock before UNIX epoch")

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -298,25 +298,30 @@ pub fn classify_method(method: &str) -> Option<MethodTier> {
         | "eth_getStorageAt"
         | "eth_getBlockReceipts"
         | "eth_sendTransaction"
-        | "debug_traceTransaction"
-        | "debug_traceBlockByNumber"
-        | "debug_traceBlockByHash"
         | "eth_createAccessList"
         | "eth_getBlockTransactionCountByNumber"
         | "eth_getBlockTransactionCountByHash"
         | "eth_getTransactionByBlockNumberAndIndex"
         | "eth_getTransactionByBlockHashAndIndex"
         | "eth_getUncleCountByBlockNumber"
-        | "eth_getUncleCountByBlockHash"
-        | "txpool_content"
-        | "txpool_status"
-        | "txpool_inspect" => Some(MethodTier::Restricted),
+        | "eth_getUncleCountByBlockHash" => Some(MethodTier::Restricted),
 
         // Disabled (mining, subscriptions not supported via HTTP proxy)
-        "eth_mining" | "eth_hashrate" | "eth_submitWork" | "eth_submitHashrate"
-        | "eth_subscribe" | "eth_unsubscribe" => Some(MethodTier::Disabled),
+        "eth_getProof"
+        | "eth_newPendingTransactionFilter"
+        | "eth_getUncleByBlockNumberAndIndex"
+        | "eth_getUncleByBlockHashAndIndex"
+        | "eth_mining"
+        | "eth_hashrate"
+        | "eth_getWork"
+        | "eth_submitWork"
+        | "eth_submitHashrate"
+        | "eth_subscribe"
+        | "eth_unsubscribe" => Some(MethodTier::Disabled),
 
         _ if method.starts_with("admin_") => Some(MethodTier::Restricted),
+        _ if method.starts_with("debug_") => Some(MethodTier::Restricted),
+        _ if method.starts_with("txpool_") => Some(MethodTier::Restricted),
         _ => None,
     }
 }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -177,6 +177,8 @@ pub struct ZoneInfoResponse {
     pub zone_id: U64,
     /// The enabled zone token contract addresses.
     pub zone_tokens: Vec<Address>,
+    /// The active sequencer address.
+    pub sequencer: Address,
     /// The zone chain ID.
     pub chain_id: U64,
 }

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -178,24 +178,25 @@ fn subscription_notification_raw(subscription_id: &FilterId, result: &RawValue) 
     .expect("subscription notification serialization is infallible")
 }
 
+/// Redact a subscription payload, returning `None` if redaction fails so the
+/// caller can drop the item rather than forwarding unredacted data.
 fn redacted_subscription_result(
     result: Box<RawValue>,
     redaction: SubscriptionRedaction,
-) -> Box<RawValue> {
+) -> Option<Box<RawValue>> {
     match redaction {
-        SubscriptionRedaction::None => result,
-        SubscriptionRedaction::NewHeads => redact_new_head_result(result),
+        SubscriptionRedaction::None => Some(result),
+        SubscriptionRedaction::NewHeads => redact_new_head_result(&result),
     }
 }
 
 /// Apply block-header privacy rules to `eth_subscribe("newHeads")` payloads.
-fn redact_new_head_result(result: Box<RawValue>) -> Box<RawValue> {
-    let Ok(mut header) = serde_json::from_str::<Value>(result.get()) else {
-        return result;
-    };
-    let Some(header) = header.as_object_mut() else {
-        return result;
-    };
+///
+/// Fails closed: returns `None` on any parse/serialize error instead of leaking
+/// the original, potentially unredacted payload.
+fn redact_new_head_result(result: &RawValue) -> Option<Box<RawValue>> {
+    let mut header = serde_json::from_str::<Value>(result.get()).ok()?;
+    let header = header.as_object_mut()?;
 
     header.insert(
         "logsBloom".to_string(),
@@ -203,7 +204,7 @@ fn redact_new_head_result(result: Box<RawValue>) -> Box<RawValue> {
     );
     header.remove("transactions");
 
-    to_raw(header).unwrap_or(result)
+    to_raw(header).ok()
 }
 
 /// Forward subscription stream items into the session outbound queue.
@@ -228,7 +229,14 @@ fn spawn_subscription(
                     break;
                 }
             };
-            let result = redacted_subscription_result(result, redaction);
+            let Some(result) = redacted_subscription_result(result, redaction) else {
+                warn!(
+                    target: "zone::rpc",
+                    subscription = ?subscription_id,
+                    "ws subscription redaction failed; closing subscription"
+                );
+                break;
+            };
 
             if !try_queue_notification(
                 &notifications,

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -49,6 +49,7 @@ const MAX_WS_SUBSCRIPTIONS: usize = 32;
 type NotificationTx = mpsc::Sender<String>;
 type CloseSessionTx = watch::Sender<bool>;
 
+/// Per-subscription redaction applied before sending notifications.
 #[derive(Clone, Copy)]
 enum SubscriptionRedaction {
     None,
@@ -66,6 +67,7 @@ struct ActiveSubscription {
     task: JoinHandle<()>,
 }
 
+/// Subscription stream accepted by RPC dispatch but not yet spawned.
 struct PendingSubscription {
     id: FilterId,
     stream: WsSubscriptionStream,
@@ -183,6 +185,7 @@ fn redacted_subscription_result(
     }
 }
 
+/// Apply block-header privacy rules to `eth_subscribe("newHeads")` payloads.
 fn redact_new_head_result(result: Box<RawValue>) -> Box<RawValue> {
     let Ok(mut header) = serde_json::from_str::<Value>(result.get()) else {
         return result;
@@ -200,6 +203,7 @@ fn redact_new_head_result(result: Box<RawValue>) -> Box<RawValue> {
     to_raw(header).unwrap_or(result)
 }
 
+/// Forward subscription stream items into the session outbound queue.
 fn spawn_subscription(
     subscription_id: FilterId,
     mut subscription: WsSubscriptionStream,
@@ -492,6 +496,7 @@ fn duration_until_unix_timestamp(timestamp: u64) -> Duration {
     Duration::from_secs(timestamp.saturating_sub(now_unix_seconds()))
 }
 
+/// Re-check keychain auth for long-lived WebSocket sessions.
 async fn keychain_auth_still_valid(auth: &AuthContext, state: &RpcState) -> bool {
     let Some(key_id) = auth.keychain_key_id else {
         return true;

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -22,7 +22,11 @@ use axum::{
 use futures::{SinkExt, stream::StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, value::RawValue};
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
@@ -32,8 +36,7 @@ use tracing::warn;
 use crate::{
     auth::{self, AuthContext, AuthError},
     server::{
-        MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request, now_unix_seconds,
-        validate_keychain_key_info,
+        MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request, validate_keychain_key_info,
     },
     subscription::WsSubscriptionStream,
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
@@ -492,8 +495,14 @@ fn activate_pending_subscriptions(
     }
 }
 
+/// Time remaining until the given unix-second deadline, using the full system
+/// clock precision (not truncated to whole seconds) so the session closes as
+/// close as possible to the exact `expires_at` boundary.
 fn duration_until_unix_timestamp(timestamp: u64) -> Duration {
-    Duration::from_secs(timestamp.saturating_sub(now_unix_seconds()))
+    let deadline = UNIX_EPOCH + Duration::from_secs(timestamp);
+    deadline
+        .duration_since(SystemTime::now())
+        .unwrap_or_default()
 }
 
 /// Re-check keychain auth for long-lived WebSocket sessions.
@@ -567,14 +576,23 @@ async fn handle_ws_session(
 
     loop {
         let msg = tokio::select! {
+            biased;
             _ = &mut token_expiry => break,
+            _ = close_session_rx.changed() => break,
             _ = keychain_recheck.tick(), if auth.keychain_key_id.is_some() => {
-                if !keychain_auth_still_valid(&auth, &state).await {
+                // Revalidation may be slow; allow token expiry / forced close to
+                // interrupt it so those deadlines are not delayed by a hung RPC.
+                let still_valid = tokio::select! {
+                    biased;
+                    _ = &mut token_expiry => false,
+                    _ = close_session_rx.changed() => false,
+                    valid = keychain_auth_still_valid(&auth, &state) => valid,
+                };
+                if !still_valid {
                     break;
                 }
                 continue;
             }
-            _ = close_session_rx.changed() => break,
             msg = ws_receiver.next() => match msg {
                 Some(msg) => msg,
                 None => break,

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -22,7 +22,7 @@ use axum::{
 use futures::{SinkExt, stream::StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, value::RawValue};
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
@@ -31,7 +31,10 @@ use tracing::warn;
 
 use crate::{
     auth::{self, AuthContext, AuthError},
-    server::{MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request},
+    server::{
+        MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request, now_unix_seconds,
+        validate_keychain_key_info,
+    },
     subscription::WsSubscriptionStream,
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
 };
@@ -45,6 +48,12 @@ const MAX_WS_SUBSCRIPTIONS: usize = 32;
 
 type NotificationTx = mpsc::Sender<String>;
 type CloseSessionTx = watch::Sender<bool>;
+
+#[derive(Clone, Copy)]
+enum SubscriptionRedaction {
+    None,
+    NewHeads,
+}
 
 /// Query parameters for the WebSocket upgrade endpoint.
 #[derive(serde::Deserialize, Default)]
@@ -60,6 +69,7 @@ struct ActiveSubscription {
 struct PendingSubscription {
     id: FilterId,
     stream: WsSubscriptionStream,
+    redaction: SubscriptionRedaction,
 }
 
 struct WsSession {
@@ -163,11 +173,39 @@ fn subscription_notification_raw(subscription_id: &FilterId, result: &RawValue) 
     .expect("subscription notification serialization is infallible")
 }
 
+fn redacted_subscription_result(
+    result: Box<RawValue>,
+    redaction: SubscriptionRedaction,
+) -> Box<RawValue> {
+    match redaction {
+        SubscriptionRedaction::None => result,
+        SubscriptionRedaction::NewHeads => redact_new_head_result(result),
+    }
+}
+
+fn redact_new_head_result(result: Box<RawValue>) -> Box<RawValue> {
+    let Ok(mut header) = serde_json::from_str::<Value>(result.get()) else {
+        return result;
+    };
+    let Some(header) = header.as_object_mut() else {
+        return result;
+    };
+
+    header.insert(
+        "logsBloom".to_string(),
+        Value::String(format!("0x{}", "0".repeat(512))),
+    );
+    header.remove("transactions");
+
+    to_raw(header).unwrap_or(result)
+}
+
 fn spawn_subscription(
     subscription_id: FilterId,
     mut subscription: WsSubscriptionStream,
     notifications: NotificationTx,
     close_session: CloseSessionTx,
+    redaction: SubscriptionRedaction,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(item) = subscription.next().await {
@@ -183,6 +221,7 @@ fn spawn_subscription(
                     break;
                 }
             };
+            let result = redacted_subscription_result(result, redaction);
 
             if !try_queue_notification(
                 &notifications,
@@ -260,7 +299,7 @@ async fn handle_subscribe(
             }
 
             match state.api.ws_subscribe_new_heads(auth.clone()).await {
-                Ok(subscription) => subscription,
+                Ok(subscription) => (subscription, SubscriptionRedaction::NewHeads),
                 Err(err) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
@@ -282,7 +321,7 @@ async fn handle_subscribe(
             };
 
             match state.api.ws_subscribe_logs(filter, auth.clone()).await {
-                Ok(subscription) => subscription,
+                Ok(subscription) => (subscription, SubscriptionRedaction::None),
                 Err(err) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
@@ -321,7 +360,8 @@ async fn handle_subscribe(
         response: success_response(req.id.clone(), &subscription_id),
         pending_subscriptions: vec![PendingSubscription {
             id: subscription_id,
-            stream: subscription,
+            stream: subscription.0,
+            redaction: subscription.1,
         }],
     }
 }
@@ -442,8 +482,27 @@ fn activate_pending_subscriptions(
             pending.stream,
             notifications.clone(),
             close_session.clone(),
+            pending.redaction,
         );
         session.activate_subscription(pending.id, task);
+    }
+}
+
+fn duration_until_unix_timestamp(timestamp: u64) -> Duration {
+    Duration::from_secs(timestamp.saturating_sub(now_unix_seconds()))
+}
+
+async fn keychain_auth_still_valid(auth: &AuthContext, state: &RpcState) -> bool {
+    let Some(key_id) = auth.keychain_key_id else {
+        return true;
+    };
+
+    match state.api.get_keychain_key(auth.caller, key_id).await {
+        Ok(key_info) => validate_keychain_key_info(&key_info).is_ok(),
+        Err(err) => {
+            warn!(target: "zone::rpc", err = %err, "ws keychain revalidation failed");
+            false
+        }
     }
 }
 
@@ -488,6 +547,9 @@ async fn handle_ws_session(
     let (mut ws_sender, mut ws_receiver) = socket.split();
     let (notifications, mut outbound) = mpsc::channel::<String>(MAX_WS_OUTBOUND_QUEUE);
     let (close_session, mut close_session_rx) = watch::channel(false);
+    let token_expiry = tokio::time::sleep(duration_until_unix_timestamp(auth.expires_at));
+    tokio::pin!(token_expiry);
+    let mut keychain_recheck = tokio::time::interval(Duration::from_secs(1));
     let writer = tokio::spawn(async move {
         while let Some(message) = outbound.recv().await {
             if ws_sender.send(Message::Text(message.into())).await.is_err() {
@@ -500,6 +562,13 @@ async fn handle_ws_session(
 
     loop {
         let msg = tokio::select! {
+            _ = &mut token_expiry => break,
+            _ = keychain_recheck.tick(), if auth.keychain_key_id.is_some() => {
+                if !keychain_auth_still_valid(&auth, &state).await {
+                    break;
+                }
+                continue;
+            }
             _ = close_session_rx.changed() => break,
             msg = ws_receiver.next() => match msg {
                 Some(msg) => msg,

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -75,6 +75,12 @@ impl MockZoneRpcApi {
             ws_subscriptions_enabled: true,
         }
     }
+
+    fn revoke_key(&self, account: Address, key_id: Address) {
+        if let Some(key_info) = self.key_infos.lock().get_mut(&(account, key_id)) {
+            key_info.isRevoked = true;
+        }
+    }
 }
 
 macro_rules! stub {
@@ -152,7 +158,8 @@ impl ZoneRpcApi for MockZoneRpcApi {
                 ),
                 "number": "0x42",
                 "parentHash": format!("{:#x}", alloy_primitives::B256::ZERO),
-                "logsBloom": format!("0x{}", "0".repeat(512)),
+                "logsBloom": format!("0x{}", "f".repeat(512)),
+                "transactions": ["0x1234"],
             }))]);
             let stream: WsSubscriptionStream = Box::pin(stream);
             Ok(stream)
@@ -244,6 +251,10 @@ struct TestContext {
 
 impl TestContext {
     async fn start(api: MockZoneRpcApi) -> Self {
+        Self::start_shared(Arc::new(api)).await
+    }
+
+    async fn start_shared(api: Arc<MockZoneRpcApi>) -> Self {
         let signer = PrivateKeySigner::random();
         let config = PrivateRpcConfig {
             listen_addr: ([127, 0, 0, 1], 0).into(),
@@ -255,13 +266,17 @@ impl TestContext {
             max_auth_token_validity: zone_rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
             zone_portal: Address::ZERO,
         };
-        let addr = start_private_rpc(config, Arc::new(api)).await.unwrap();
+        let addr = start_private_rpc(config, api).await.unwrap();
         Self { addr, signer }
     }
 
     fn build_token(&self) -> String {
         let now = now_secs();
-        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
+        self.build_token_expiring_at(now, now + 600)
+    }
+
+    fn build_token_expiring_at(&self, issued_at: u64, expires_at: u64) -> String {
+        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, issued_at, expires_at);
         let sig = self.signer.sign_hash_sync(&digest).expect("signing failed");
 
         let mut blob = Vec::with_capacity(65 + fields.len());
@@ -786,6 +801,46 @@ async fn ws_roundtrip_with_keychain_auth() {
 
     assert_eq!(resp["id"], 11);
     assert_eq!(resp["result"], "0x42");
+}
+
+#[tokio::test]
+async fn ws_closes_when_auth_token_expires() {
+    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let now = now_secs();
+    let token = ctx.build_token_expiring_at(now, now + 1);
+    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("ws connect failed");
+
+    let _closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for token-expiry close");
+}
+
+#[tokio::test]
+async fn ws_closes_when_keychain_key_is_revoked() {
+    let root_account = Address::repeat_byte(0x77);
+    let access_signer = P256SigningKey::random(&mut thread_rng());
+    let now = now_secs();
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
+    let (signature, key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)
+        .expect("keychain signing should succeed");
+    let api = Arc::new(MockZoneRpcApi::with_key(
+        root_account,
+        key_id,
+        KeyInfoSignatureType::P256,
+    ));
+    let ctx = TestContext::start_shared(api.clone()).await;
+    let token = build_token_with_signature(signature, &fields);
+    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("authorized keychain ws connect failed");
+
+    api.revoke_key(root_account, key_id);
+
+    let _closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for keychain-revocation close");
 }
 
 #[tokio::test]

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -120,6 +120,8 @@ impl ZoneRpcApi for MockZoneRpcApi {
     }
 
     stub!(net_version);
+    stub!(syncing);
+    stub!(coinbase);
     stub!(gas_price);
     stub!(max_priority_fee_per_gas);
     stub!(fee_history, _a: u64, _b: alloy_rpc_types_eth::BlockNumberOrTag, _c: Option<Vec<f64>>);

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -667,6 +667,8 @@ where
 
     fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
+            let zone_tokens = self.zone_tokens().await?;
+            zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter(&mut filter);
             let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
                 .await
@@ -678,6 +680,8 @@ where
 
     fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
+            let zone_tokens = self.zone_tokens().await?;
+            zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter(&mut filter);
             let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
                 .await
@@ -809,6 +813,8 @@ where
             let provider = self.eth.api.provider().clone();
             let caller = auth.caller;
 
+            let zone_tokens = self.zone_tokens().await?;
+            zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter(&mut filter);
 
             let stream = provider

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -435,7 +435,7 @@ where
     }
 
     fn coinbase(&self) -> BoxFut<'_> {
-        Box::pin(async move { to_raw(&Address::ZERO) })
+        Box::pin(async move { to_raw(&self.zone_sequencer().await?) })
     }
 
     fn gas_price(&self) -> BoxFut<'_> {

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -300,6 +300,18 @@ impl<Api: EthApiTypes + 'static> TempoZoneRpc<Api> {
             .map_err(internal)
     }
 
+    async fn zone_sequencer(&self) -> Result<Address, JsonRpcError> {
+        if self.config.zone_portal.is_zero() {
+            return Ok(Address::ZERO);
+        }
+
+        ZonePortal::new(self.config.zone_portal, &self.l1_provider)
+            .sequencer()
+            .call()
+            .await
+            .map_err(internal)
+    }
+
     async fn terminal_event_for_deposit(
         &self,
         deposit_hash: B256,
@@ -856,9 +868,11 @@ where
     fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
             let zone_tokens = self.zone_tokens().await?;
+            let sequencer = self.zone_sequencer().await?;
             to_raw(&ZoneInfoResponse {
                 zone_id: U64::from(self.config.zone_id),
                 zone_tokens,
+                sequencer,
                 chain_id: U64::from(self.config.chain_id),
             })
         })

--- a/crates/tempo-zone/src/rpc.rs
+++ b/crates/tempo-zone/src/rpc.rs
@@ -415,6 +415,17 @@ where
         })
     }
 
+    fn syncing(&self) -> BoxFut<'_> {
+        Box::pin(async move {
+            let status = EthApiSpec::sync_status(&self.eth.api).map_err(internal)?;
+            to_raw(&status)
+        })
+    }
+
+    fn coinbase(&self) -> BoxFut<'_> {
+        Box::pin(async move { to_raw(&Address::ZERO) })
+    }
+
     fn gas_price(&self) -> BoxFut<'_> {
         Box::pin(async move {
             let price = EthFees::gas_price(&self.eth.api).await.map_err(internal)?;


### PR DESCRIPTION
## Summary
- enforce WebSocket `newHeads` redaction in the WS notification path, failing closed if redaction errors
- close WebSocket sessions promptly when auth tokens expire or keychain auth is revoked/expired (exact-time deadline, close-priority select)
- implement allowed compatibility RPC methods: `eth_syncing`, `eth_coinbase`, and `web3_sha3`
- scope log filters to enabled zone token addresses
- classify spec-disabled and restricted RPC methods with the expected JSON-RPC errors
- return the active sequencer address from `zone_getZoneInfo`

## Test plan
- cargo build --profile profiling --bin tempo-zone --features jemalloc
- cargo clippy -p zone-rpc --all-targets --all-features -- -D warnings
- cargo test -p zone-rpc

Prompted by: @grandizzy