### PR TITLE
fix(tip403): cache policy id counter

### DIFF
--- a/crates/precompiles/src/policy.rs
+++ b/crates/precompiles/src/policy.rs
@@ -41,5 +41,5 @@ pub trait PolicyCheck {
     fn policy_exists(&self, policy_id: u64) -> Result<bool, PrecompileError>;
 
     /// Return the highest known policy ID counter.
-    fn policy_id_counter(&self) -> u64;
+    fn policy_id_counter(&self) -> Result<u64, PrecompileError>;
 }

--- a/crates/precompiles/src/tip403_proxy.rs
+++ b/crates/precompiles/src/tip403_proxy.rs
@@ -291,7 +291,7 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
 
     /// Handle `policyIdCounter() → uint64`.
     fn handle_policy_id_counter(&self, reservoir: u64) -> PrecompileResult {
-        let counter = self.provider.policy_id_counter();
+        let counter = self.provider.policy_id_counter()?;
         let encoded = ITIP403Registry::policyIdCounterCall::abi_encode_returns(&counter);
         Ok(PrecompileOutput::new(
             POLICY_DATA_GAS,

--- a/crates/precompiles/src/ztip20.rs
+++ b/crates/precompiles/src/ztip20.rs
@@ -506,8 +506,8 @@ mod tests {
             Ok(true)
         }
 
-        fn policy_id_counter(&self) -> u64 {
-            self.policy_id
+        fn policy_id_counter(&self) -> Result<u64, PrecompileError> {
+            Ok(self.policy_id)
         }
     }
 

--- a/crates/tempo-zone/src/l1_state/tip403/cache.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/cache.rs
@@ -44,11 +44,14 @@ use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP403Registry::PolicyType;
+use tempo_precompiles::tip403_registry::ALLOW_ALL_POLICY_ID;
 use tracing::info;
 
 use super::{builtin_authorization, events::PolicyEvent, policy_set::PolicySet};
 
 use crate::l1_state::versioned::HeightVersioned;
+
+const INITIAL_POLICY_ID_COUNTER: u64 = ALLOW_ALL_POLICY_ID + 1;
 
 /// Thread-safe TIP-403 policy cache backed by an `Arc<RwLock<PolicyCacheInner>>`.
 #[derive(Debug, Clone, Deref, Default)]
@@ -76,6 +79,32 @@ impl PolicyCache {
     /// engine hasn't consumed yet.
     pub fn advance(&self, block_number: u64) {
         self.write().advance(block_number);
+    }
+
+    /// Query and seed the authoritative TIP-403 `policyIdCounter` from L1.
+    pub async fn seed_policy_id_counter(
+        &self,
+        provider: &DynProvider<TempoNetwork>,
+    ) -> eyre::Result<()> {
+        use tempo_contracts::precompiles::{ITIP403Registry, TIP403_REGISTRY_ADDRESS};
+
+        let block_number = self.last_l1_block();
+        let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider);
+        let counter = registry
+            .policyIdCounter()
+            .block(alloy_rpc_types_eth::BlockId::number(block_number))
+            .call()
+            .await
+            .map_err(|e| {
+                eyre::eyre!("failed to seed policyIdCounter at block {block_number}: {e}")
+            })?;
+
+        self.write().set_policy_id_counter(counter);
+        info!(
+            counter,
+            block_number, "Seeded TIP-403 policy ID counter from L1"
+        );
+        Ok(())
     }
 
     /// Query the current `transferPolicyId` for each tracked token and seed it
@@ -132,7 +161,7 @@ impl PolicyCache {
 /// - Policy ID → policy record (type, policy set, compound data).
 ///
 /// This allows the zone sequencer to evaluate transfer authorization without RPC round-trips.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PolicyCacheInner {
     /// Per-token transfer policy ID.
     tokens: HashMap<Address, HeightVersioned<u64>>,
@@ -153,6 +182,23 @@ pub struct PolicyCacheInner {
     /// [`PolicyResolutionTask`](super::PolicyResolutionTask) reads this to
     /// query L1 at the correct block height for cache-miss RPC fallback.
     last_l1_block: u64,
+    /// Next TIP-403 policy ID, mirroring L1 `policyIdCounter`.
+    ///
+    /// Seeded from L1 during startup or provider cache-miss fallback. The zone precompile serves
+    /// `policyIdCounter()` from this local value, never by doing RPC in the EVM
+    /// execution path.
+    policy_id_counter: Option<u64>,
+}
+
+impl Default for PolicyCacheInner {
+    fn default() -> Self {
+        Self {
+            tokens: HashMap::default(),
+            policies: HashMap::default(),
+            last_l1_block: 0,
+            policy_id_counter: None,
+        }
+    }
 }
 
 impl PolicyCacheInner {
@@ -197,6 +243,20 @@ impl PolicyCacheInner {
     /// Returns a reference to the per-policy-ID records for direct inspection.
     pub fn policies(&self) -> &HashMap<u64, CachedPolicy> {
         &self.policies
+    }
+
+    /// Returns the cached next TIP-403 policy ID.
+    pub fn policy_id_counter(&self) -> Option<u64> {
+        self.policy_id_counter
+    }
+
+    /// Sets the cached TIP-403 policy ID counter from an authoritative L1 read.
+    pub fn set_policy_id_counter(&mut self, counter: u64) {
+        let counter = counter.max(INITIAL_POLICY_ID_COUNTER);
+        self.policy_id_counter = Some(
+            self.policy_id_counter
+                .map_or(counter, |current| current.max(counter)),
+        );
     }
 
     /// Returns all token addresses currently tracked by the cache.
@@ -387,8 +447,11 @@ impl PolicyCacheInner {
         }
     }
 
-    /// Clears all cached policy data. `last_l1_block` is preserved — the engine
-    /// will advance it when it reprocesses blocks after a reorg.
+    /// Clears cached token and policy records.
+    ///
+    /// `last_l1_block` and `policy_id_counter` are preserved: clear paths do
+    /// not synchronously reseed from L1, so dropping the seeded counter would
+    /// make `policyIdCounter()` temporarily undercount after a resync.
     pub fn clear(&mut self) {
         self.tokens.clear();
         self.policies.clear();
@@ -455,11 +518,17 @@ pub struct CompoundData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::address;
+    use alloy_primitives::{Bytes, U256, address};
+    use alloy_provider::{Provider, ProviderBuilder};
+    use alloy_transport::mock::Asserter;
 
     const TOKEN: Address = address!("0x20C0000000000000000000000000000000000000");
     const USER_A: Address = address!("0x0000000000000000000000000000000000000001");
     const USER_B: Address = address!("0x0000000000000000000000000000000000000002");
+
+    fn abi_encode_u64(value: u64) -> Bytes {
+        Bytes::copy_from_slice(&U256::from(value).to_be_bytes::<32>())
+    }
 
     // --- PolicySet tests ---
 
@@ -546,6 +615,67 @@ mod tests {
     }
 
     // --- PolicyCacheInner tests: simple policies ---
+
+    #[test]
+    fn policy_id_counter_defaults_to_unknown() {
+        let cache = PolicyCacheInner::default();
+        assert_eq!(cache.policy_id_counter(), None);
+    }
+
+    #[test]
+    fn policy_id_counter_ignores_learned_policies_before_seed() {
+        let mut cache = PolicyCacheInner::default();
+
+        cache.set_policy_type(5, PolicyType::WHITELIST);
+        assert_eq!(cache.policy_id_counter(), None);
+    }
+
+    #[test]
+    fn policy_id_counter_ignores_learned_policies_after_seed() {
+        let mut cache = PolicyCacheInner::default();
+
+        cache.set_policy_id_counter(10);
+        cache.set_policy_type(5, PolicyType::WHITELIST);
+        assert_eq!(cache.policy_id_counter(), Some(10));
+
+        cache.set_policy_type(3, PolicyType::BLACKLIST);
+        assert_eq!(cache.policy_id_counter(), Some(10));
+    }
+
+    #[test]
+    fn policy_id_counter_is_preserved_when_policy_cache_is_cleared() {
+        let mut cache = PolicyCacheInner::default();
+        cache.set_policy_id_counter(10);
+        cache.set_policy_type(5, PolicyType::WHITELIST);
+
+        cache.clear();
+
+        assert_eq!(cache.policy_id_counter(), Some(10));
+    }
+
+    #[test]
+    fn policy_id_counter_seed_does_not_regress_newer_cached_value() {
+        let mut cache = PolicyCacheInner::default();
+
+        cache.set_policy_id_counter(21);
+        cache.set_policy_id_counter(10);
+
+        assert_eq!(cache.policy_id_counter(), Some(21));
+    }
+
+    #[tokio::test]
+    async fn seed_policy_id_counter_reads_authoritative_value_from_l1() {
+        let asserter = Asserter::new();
+        asserter.push_success(&abi_encode_u64(42));
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_mocked_client(asserter)
+            .erased();
+        let cache = PolicyCache::default();
+
+        cache.seed_policy_id_counter(&provider).await.unwrap();
+
+        assert_eq!(cache.read().policy_id_counter(), Some(42));
+    }
 
     #[test]
     fn special_policy_always_reject() {

--- a/crates/tempo-zone/src/l1_state/tip403/provider.rs
+++ b/crates/tempo-zone/src/l1_state/tip403/provider.rs
@@ -583,6 +583,41 @@ impl PolicyProvider {
         })
     }
 
+    /// Cache-first, RPC-fallback `policyIdCounter` resolution (sync).
+    ///
+    /// Falls back to L1 only when the counter has not been seeded into the
+    /// cache yet. The fetched authoritative value is stored locally so future
+    /// precompile calls do not perform network IO.
+    pub fn policy_id_counter_sync(&self) -> Result<u64> {
+        if let Some(counter) = self.cache.read().policy_id_counter() {
+            return Ok(counter);
+        }
+
+        let block_number = self.cache.read().last_l1_block();
+        debug!(
+            block_number,
+            "Policy ID counter cache miss, fetching from L1 RPC"
+        );
+        let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &self.provider);
+        let counter = tokio::task::block_in_place(|| {
+            self.runtime_handle.block_on(async {
+                registry
+                    .policyIdCounter()
+                    .block(BlockId::number(block_number))
+                    .call()
+                    .await
+                    .map_err(|e| {
+                        self.metrics.rpc_errors.increment(1);
+                        warn!(block_number, %e, "policyIdCounter RPC failed");
+                        eyre::eyre!("policyIdCounter RPC failed at block {block_number}: {e}")
+                    })
+            })
+        })?;
+
+        self.cache.write().set_policy_id_counter(counter);
+        Ok(counter)
+    }
+
     /// Call `isAuthorized(policyId, user)` on the TIP403Registry via L1 RPC.
     async fn rpc_is_authorized(
         &self,
@@ -658,8 +693,48 @@ impl PolicyCheck for PolicyProvider {
         })
     }
 
-    fn policy_id_counter(&self) -> u64 {
-        let cache = self.cache.read();
-        cache.policies().keys().max().map_or(2, |max| max + 1)
+    fn policy_id_counter(&self) -> Result<u64, PrecompileError> {
+        self.policy_id_counter_sync().map_err(|e| {
+            zone_precompiles::zone_rpc_error(format!("failed to resolve policyIdCounter: {e}"))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, U256};
+    use alloy_provider::{Provider, ProviderBuilder};
+    use alloy_transport::mock::Asserter;
+
+    fn abi_encode_u64(value: u64) -> Bytes {
+        Bytes::copy_from_slice(&U256::from(value).to_be_bytes::<32>())
+    }
+
+    fn provider_with(asserter: Asserter, cache: PolicyCache) -> PolicyProvider {
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_mocked_client(asserter)
+            .erased();
+        PolicyProvider::new(cache, provider, tokio::runtime::Handle::current())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn policy_id_counter_fetches_l1_once_when_cache_is_unknown() {
+        let asserter = Asserter::new();
+        asserter.push_success(&abi_encode_u64(42));
+        let cache = PolicyCache::default();
+        let provider = provider_with(asserter, cache.clone());
+
+        let counters = tokio::task::spawn_blocking(move || {
+            let first = provider.policy_id_counter()?;
+            let second = provider.policy_id_counter()?;
+            Ok::<_, PrecompileError>((first, second))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(counters, (42, 42));
+        assert_eq!(cache.read().policy_id_counter(), Some(42));
     }
 }

--- a/crates/tempo-zone/src/node.rs
+++ b/crates/tempo-zone/src/node.rs
@@ -419,6 +419,11 @@ where
         };
 
         self.policy_cache
+            .seed_policy_id_counter(l1_provider)
+            .await?;
+        info!(target: "reth::cli", "Seeded TIP-403 policy ID counter from L1");
+
+        self.policy_cache
             .seed_token_policies(portal, &tracked_tokens, l1_provider)
             .await?;
         info!(target: "reth::cli", "Seeded token policies from L1");


### PR DESCRIPTION
## Summary

- Seed the TIP-403 `policyIdCounter` into `PolicyCache` during node startup.
- Store the cached counter as `Option<u64>` so an unseeded cache remains explicitly unknown.
- On `policyIdCounter()` cache miss, fetch the authoritative value from L1 at `last_l1_block`, cache it, and return it.
- Keep policy record observations separate from counter updates so cached policy IDs do not become a lower-bound counter substitute.
- Prevent delayed seed/RPC results from regressing a newer cached counter.
- Serve subsequent `PolicyCheck::policy_id_counter()` calls from local cache state.

## Root Cause

The previous implementation derived `policyIdCounter()` from `max(cached policy id) + 1`, but the policy cache can be missing policies that exist on L1. That makes the derived value only a lower bound. Keeping the authoritative value in the cache fixes the undercount without putting an L1 RPC call on every zone precompile invocation.

## Impact

Contracts calling the zone TIP-403 proxy get a locally served counter after startup seeding or the first cache-miss fallback. If the counter is genuinely unknown, the proxy fetches it once from L1 and stores it for future calls instead of fabricating `2` or performing network IO every time.