### PR TITLE
fix(payload): charge advanceTempo gas against the block budget

### DIFF
--- a/crates/tempo-zone/src/payload/builder.rs
+++ b/crates/tempo-zone/src/payload/builder.rs
@@ -261,7 +261,19 @@ where
                         ),
                     )));
                 }
-                Ok(_) => {}
+                Ok(gas_used) => {
+                    // Charge the advanceTempo system tx against the block gas
+                    // budget. The inner block executor enforces the block gas
+                    // limit against a counter that already includes this system
+                    // tx, so the builder's own `cumulative_gas_used` must too.
+                    // Otherwise the admission check below would over-estimate the
+                    // remaining gas and let through a pool tx that the executor
+                    // then rejects with `TransactionGasLimitMoreThanAvailableBlockGas`
+                    // — an error that aborts the whole build and, because zone
+                    // blocks are deterministic, recurs on every rebuild, halting
+                    // block production.
+                    cumulative_gas_used += gas_used.tx_gas_used();
+                }
                 Err(err) => {
                     error!(
                         ?err,


### PR DESCRIPTION
# fix(payload): charge advanceTempo gas against the block budget

## What happens today (step by step)

1. `try_build` runs the `advanceTempo` system transaction. It consumes real
   gas — and more of it the more deposits / token-enables the L1 block carries.
2. `cumulative_gas_used` is initialized to `0` and is **only** bumped for pool
   transactions. The system tx's gas is dropped on the floor.
3. A user submits a transaction whose `gas_limit` sits just under the block
   limit. The builder's admission check —
   `cumulative_gas_used + pool_tx.gas_limit() > block_gas_limit` — passes,
   because `cumulative_gas_used` is missing the system-tx gas.
4. The inner block executor *does* count the system-tx gas, so for it the tx is
   over budget. It returns `TransactionGasLimitMoreThanAvailableBlockGas`.
5. That variant isn't the `InvalidTx` arm and isn't the transient-RPC arm, so it
   hits `Err(err) => return Err(PayloadBuilderError::evm(err))` and the whole
   build aborts.
6. Zone blocks are deterministic: the next rebuild replays the exact same txs
   and aborts at the exact same point. **Block production is wedged** until that
   transaction leaves the pool.

So a single near-block-limit transaction can halt the sequencer whenever
advanceTempo isn't ~free.

## The fix

Add the system tx's gas to `cumulative_gas_used` right after advanceTempo
executes, so the builder's admission check and the executor's budget agree. The
over-budget pool tx is then correctly rejected at admission (marked invalid,
skipped) instead of blowing up the build.