### PR TITLE
fix(rpc): enforce auth token expiry on websocket sessions

### DIFF
--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -22,12 +22,17 @@ use axum::{
 use futures::{SinkExt, stream::StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, value::RawValue};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
+    time::{Instant, sleep_until},
 };
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{
     auth::{self, AuthContext, AuthError},
@@ -498,9 +503,25 @@ async fn handle_ws_session(
 
     let mut session = WsSession::default();
 
+    // Auth is validated only once, during the HTTP upgrade handshake. Enforce
+    // the token's expiry for the lifetime of the session so a connection opened
+    // shortly before expiry cannot keep streaming private state (logs, heads)
+    // indefinitely after the token has expired — expiry is the token's only
+    // revocation mechanism on this private chain.
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let auth_deadline =
+        Instant::now() + Duration::from_secs(auth.expires_at.saturating_sub(now_secs));
+
     loop {
         let msg = tokio::select! {
             _ = close_session_rx.changed() => break,
+            _ = sleep_until(auth_deadline) => {
+                debug!(target: "zone::rpc", "ws session auth token expired, closing");
+                break;
+            }
             msg = ws_receiver.next() => match msg {
                 Some(msg) => msg,
                 None => break,

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -260,8 +260,12 @@ impl TestContext {
     }
 
     fn build_token(&self) -> String {
+        self.build_token_expiring_in(600)
+    }
+
+    fn build_token_expiring_in(&self, ttl_secs: u64) -> String {
         let now = now_secs();
-        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
+        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + ttl_secs);
         let sig = self.signer.sign_hash_sync(&digest).expect("signing failed");
 
         let mut blob = Vec::with_capacity(65 + fields.len());
@@ -333,6 +337,34 @@ fn parse_response(msg: tungstenite::Message) -> Value {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn ws_session_closes_when_token_expires() {
+    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    // Token is valid at upgrade time but expires ~1s later.
+    let token = ctx.build_token_expiring_in(1);
+    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("ws connect should succeed before expiry");
+
+    // With no client activity, the server must close the session once the token
+    // expires. Bound the wait generously to avoid flakiness.
+    let closed = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match ws.next().await {
+                Some(Ok(tungstenite::Message::Close(_))) | None => break,
+                Some(Err(_)) => break,
+                Some(Ok(_)) => continue,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        closed.is_ok(),
+        "ws session must close itself after the auth token expires"
+    );
+}
 
 #[tokio::test]
 async fn ws_roundtrip_with_header_auth() {


### PR DESCRIPTION
# fix(rpc): enforce auth token expiry on websocket sessions

### What's the bug?
A WebSocket session keeps streaming a caller's private data **after** their auth
token has expired. Auth is checked once, at the HTTP upgrade handshake — the
session loop never looks at `expires_at` again.

### Why does that matter?
On a private chain the short-lived signed token *is* the access-control and
revocation mechanism. HTTP enforces it on every request. But over WS, a client
who connects seconds before expiry can hold the socket open and keep receiving
live `eth_subscribe("logs")` / `("newHeads")` notifications about their private
state indefinitely. Expiry stops meaning anything for long-lived connections.

### Isn't WS supposed to authenticate only once?
Once for *establishing* the session, yes — WS frames can't carry the auth
header, so per-message re-auth isn't possible. But "authenticate once" was
silently extended to "never expire", which is the actual problem. The token's
own lifetime should still bound the session.

### What's the fix?
At session start, derive a deadline from `auth.expires_at` and add a
`sleep_until(deadline)` arm to the session `select!`. When the token's lifetime
elapses, the session breaks out of its loop and `cleanup()` aborts all its
subscription tasks — same teardown path as a client-initiated close.

### How is it tested?
A new integration test (`ws_session_closes_when_token_expires`) connects with a
~1s-TTL token and asserts the server closes the connection on its own, with no
client activity, within a generous bound. Full `ws::` suite (23 tests), clippy,
and fmt all pass.