### PR TITLE
chore: update Moderato ZoneFactory default

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -108,13 +108,12 @@ send-deposit-encrypted amount="1000000" to="" memo="0x00000000000000000000000000
     cargo run -p tempo-xtask -- encrypted-deposit --private-key "$PK" $ARGS
 
 [group('zone')]
-[doc('Fetches and prints zone info from the ZoneFactory. Pass a zone ID (integer) or portal address (0x...). Requires ZONE_FACTORY env var.')]
+[doc('Fetches and prints zone info from the ZoneFactory. Pass a zone ID (integer) or portal address (0x...). Set ZONE_FACTORY to override the Moderato default.')]
 zone-info identifier:
-    ZONE_FACTORY="${ZONE_FACTORY:?Set ZONE_FACTORY env var}"
-    cargo run -p tempo-xtask -- zone-info {{identifier}} --zone-factory "$ZONE_FACTORY"
+    cargo run -p tempo-xtask -- zone-info {{identifier}}
 
 [group('zone')]
-[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL, PRIVATE_KEY, SEQUENCER_KEY, and ZONE_FACTORY env vars.')]
+[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars. Set ZONE_FACTORY to override the Moderato default.')]
 create-zone name token="":
     #!/bin/bash
     set -euo pipefail
@@ -134,7 +133,6 @@ create-zone name token="":
             ZONE_TOKEN_L1="0x20c0000000000000000000000000000000000002" ;;
     esac
     SEQ_KEY="${SEQUENCER_KEY:?Set SEQUENCER_KEY env var}"
-    ZONE_FACTORY="${ZONE_FACTORY:?Set ZONE_FACTORY env var}"
     L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
     HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
     SEQUENCER_ADDR=$(cast wallet address "$SEQ_KEY")
@@ -149,7 +147,6 @@ create-zone name token="":
     cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
-        --zone-factory "$ZONE_FACTORY" \
         --initial-token "$ZONE_TOKEN_L1" \
         --sequencer "$SEQUENCER_ADDR" \
         --private-key "$PK"
@@ -706,13 +703,12 @@ check-balance-private name token="0x20C0000000000000000000000000000000000000" rp
     echo "Balance of $ACCOUNT: $BALANCE"
 
 [group('zone')]
-[doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL and ZONE_FACTORY env vars.')]
+[doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL. Set ZONE_FACTORY to override the Moderato default.')]
 deploy-zone name token="":
     #!/bin/bash
     set -euo pipefail
     L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
     HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
-    ZONE_FACTORY="${ZONE_FACTORY:?Set ZONE_FACTORY env var}"
     OUTPUT="generated/{{name}}"
     ZONE_TOKEN_L1="{{token}}"
     if [[ -z "$ZONE_TOKEN_L1" ]]; then
@@ -761,7 +757,6 @@ deploy-zone name token="":
     cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
-        --zone-factory "$ZONE_FACTORY" \
         --initial-token "$ZONE_TOKEN_L1" \
         --sequencer "$SEQUENCER_ADDR" \
         --private-key "$SEQUENCER_KEY"

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -518,9 +518,9 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0xC73b446C0768bc315Be7741D60B4e494E3ebc0dC` |
+| ZoneFactory (moderato) | `0x3F07435187fB4B4d4A562138A93C0397D0734F2b` |
 
-This deployment predates the admin-aware `createZone` ABI. Until a fresh shared factory is deployed, pass a compatible factory explicitly with `--zone-factory` or `ZONE_FACTORY`; `deploy-router` reads `zoneFactory` from `zone.json` or requires `--zone-factory`.
+The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` uses `zoneFactory` from `zone.json` before falling back to this address. Pass `--zone-factory` or set `ZONE_FACTORY` to override it.
 
 ### Deploying a New ZoneFactory
 
@@ -547,16 +547,16 @@ cast call "$ZONE_FACTORY" "zoneCount()(uint32)" --rpc-url "$ETH_RPC_URL"
 cast call "$ZONE_FACTORY" "verifier()(address)" --rpc-url "$ETH_RPC_URL"
 ```
 
-`zoneCount()` should be `0` on a fresh deployment, and `verifier()` should return the verifier deployed by the factory constructor. Pass the new address via `--zone-factory` / `ZONE_FACTORY`, and update the Key Addresses table above and any other `rg` hits for the previous address.
+`zoneCount()` should be `0` on a fresh deployment, and `verifier()` should return the verifier deployed by the factory constructor. Update `MODERATO_ZONE_FACTORY` in `xtask/src/zone_utils.rs`, the Key Addresses table above, and any other `rg` hits for the previous address.
 
 Current deployment:
 
 | Field | Value |
 |-------|-------|
-| Address | `0xC73b446C0768bc315Be7741D60B4e494E3ebc0dC` |
-| Transaction | `0xd2864f54ef14553fc083cde8a42b68bd75eaea56a7e5f6928ecf2db0205f9a28` |
-| Block | `19482946` |
-| Deployed | `2026-05-27 06:29:47 UTC` |
+| Address | `0x3F07435187fB4B4d4A562138A93C0397D0734F2b` |
+| Transaction | `0x97037ae1ccec2ac6e9425f1499ae0d6c08deebe07054181d2e154987907480fd` |
+| Block | `23667934` |
+| Deployed | `2026-06-24 18:27:45 UTC` |
 
 ### Zone Node CLI Options
 
@@ -587,14 +587,14 @@ Current deployment:
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
-| `ZONE_FACTORY` | Yes for `create-zone` / `deploy-zone` / `zone-info` | ZoneFactory address matching the current `createZone` ABI |
+| `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |
 
 ## Justfile Commands Reference
 
 | Command | Description |
 |---------|-------------|
 | `just deploy-zone <name> [<tip20>]` | One-shot: keygen → fund → create → genesis → start node |
-| `just create-zone <name> [<tip20>]` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`, `ZONE_FACTORY`) |
+| `just create-zone <name> [<tip20>]` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`) |
 | `just deploy-router <name>` | Deploy `SwapAndDepositRouter` on L1 for the zone and save it to `zone.json` |
 | `just zone-up <name> [reset] [profile]` | Start the zone node. `reset=true` wipes datadir. `profile=release` for production. |
 | `just max-approve-portal` | Approve portal to spend tokens on L1 |

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -19,6 +19,8 @@ use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use zone_primitives::constants::zone_chain_id;
 
+use crate::zone_utils::MODERATO_ZONE_FACTORY;
+
 sol! {
     struct ZoneParams {
         bytes32 genesisBlockHash;
@@ -66,7 +68,7 @@ pub(crate) struct CreateZone {
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.
-    #[arg(long)]
+    #[arg(long, env = "ZONE_FACTORY", default_value_t = MODERATO_ZONE_FACTORY)]
     zone_factory: Address,
 
     /// Initial TIP-20 token address for the zone (additional tokens can be enabled later).

--- a/xtask/src/deploy_router.rs
+++ b/xtask/src/deploy_router.rs
@@ -11,7 +11,8 @@ use std::path::PathBuf;
 use tempo_alloy::TempoNetwork;
 
 use crate::zone_utils::{
-    L1_EXPLORER, STABLECOIN_DEX_ADDRESS, ZoneMetadata, check, normalize_http_rpc,
+    L1_EXPLORER, MODERATO_ZONE_FACTORY, STABLECOIN_DEX_ADDRESS, ZoneMetadata, check,
+    normalize_http_rpc,
 };
 
 #[derive(Debug, clap::Parser)]
@@ -32,8 +33,8 @@ pub(crate) struct DeployRouter {
     #[arg(long, env = "PRIVATE_KEY")]
     private_key: String,
 
-    /// ZoneFactory contract address. Falls back to `zone.json`.
-    #[arg(long)]
+    /// ZoneFactory contract address. Falls back to `zone.json`, then the shared Moderato default.
+    #[arg(long, env = "ZONE_FACTORY")]
     zone_factory: Option<Address>,
 
     /// StablecoinDEX address passed to the router constructor.
@@ -51,11 +52,7 @@ impl DeployRouter {
         let zone_factory = self
             .zone_factory
             .or(zone_metadata.get_optional_address("zoneFactory")?)
-            .ok_or_else(|| {
-                eyre!(
-                    "zone factory missing; pass --zone-factory or record zoneFactory in zone.json"
-                )
-            })?;
+            .unwrap_or(MODERATO_ZONE_FACTORY);
 
         let key_str = self
             .private_key

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -3,6 +3,8 @@ use eyre::eyre;
 use tempo_alloy::TempoNetwork;
 use zone::abi::{ZoneFactory, ZonePortal};
 
+use crate::zone_utils::MODERATO_ZONE_FACTORY;
+
 #[derive(Debug, clap::Parser)]
 pub(crate) struct ZoneInfoCmd {
     /// Zone ID (integer) or portal address (0x...) to look up.
@@ -13,7 +15,7 @@ pub(crate) struct ZoneInfoCmd {
     l1_rpc_url: String,
 
     /// ZoneFactory contract address on Tempo L1.
-    #[arg(long)]
+    #[arg(long, env = "ZONE_FACTORY", default_value_t = MODERATO_ZONE_FACTORY)]
     zone_factory: Address,
 }
 

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -16,6 +16,14 @@ use tempo_contracts::precompiles::ITIP20 as TIP20Token;
 use zone::abi::{ZoneInbox, ZonePortal};
 
 pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
+/// Shared Moderato ZoneFactory.
+///
+/// `create-zone`, `deploy-router`, and `zone-info` use this as their default
+/// factory unless the caller overrides `--zone-factory` or `ZONE_FACTORY`, or
+/// `zone.json` already provides a zone-specific value.
+/// Explorer: https://explore.moderato.tempo.xyz/address/0x3F07435187fB4B4d4A562138A93C0397D0734F2b
+pub(crate) const MODERATO_ZONE_FACTORY: Address =
+    address!("0x3F07435187fB4B4d4A562138A93C0397D0734F2b");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
     address!("0xDEc0000000000000000000000000000000000000");
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;


### PR DESCRIPTION
## Summary

- Redeploy the shared Moderato ZoneFactory and update the built-in default to `0x3F07435187fB4B4d4A562138A93C0397D0734F2b`.
- Restore the xtask/Justfile default behavior for `create-zone`, `zone-info`, and `deploy-router`, with `--zone-factory` / `ZONE_FACTORY` still available as overrides.
- Update the ZoneFactory deployment record with the new transaction, block, and deployed timestamp.

## Impact

Zone creation and lookup commands can use the admin-aware shared factory without requiring callers to pass `ZONE_FACTORY` manually.