### PR TITLE
fix: update zone metadata and docs

### DIFF
--- a/.codex/skills/zones-deploy-debug/SKILL.md
+++ b/.codex/skills/zones-deploy-debug/SKILL.md
@@ -35,6 +35,7 @@ Use this skill for repo-local zone deployment, smoke tests, and sync debugging.
 
 - Fresh `dev` nodes can look broken because they are still compiling and replaying L1; use `release` for meaningful validation.
 - Direct deposit/withdraw validation needs both approvals: `just max-approve-portal` before depositing and `just max-approve-outbox` before withdrawing.
+- Admin-only portal calls (`enable-token`, deposit pause/resume, and demos that enable temporary tokens) need `ADMIN_KEY` or a saved `adminKey`; `SEQUENCER_KEY` only works on zones where admin equals sequencer.
 - The demo's first real wait point is token enablement on L2. If the zone is still replaying older L1 blocks, `demo-swap-and-deposit` can time out before the `TokenEnabled` event appears.
 - The current `just demo-swap-and-deposit` recipe takes optional overrides positionally, not as `amount=... tick=...`.
 - If a restarted zone crashes while seeding `transferPolicyId` for a temporary token, check `crates/tempo-zone/src/l1_state/tip403/cache.rs` and consider retesting with a fresh zone.

--- a/.codex/skills/zones-deploy-debug/references/commands.md
+++ b/.codex/skills/zones-deploy-debug/references/commands.md
@@ -12,12 +12,14 @@ Create a fresh zone when you need a clean router test:
 just deploy-zone my-zone
 ```
 
-That recipe creates the zone, stores `sequencerKey` in `generated/my-zone/zone.json`, and starts the node immediately. If you need tighter control, run:
+That recipe creates the zone, stores `sequencerKey` and `adminKey` in `generated/my-zone/zone.json`, and starts the node immediately. If you need tighter control, run:
 
 ```bash
 target/debug/tempo-xtask create-zone --output generated/my-zone --l1-rpc-url "$HTTP_RPC" --sequencer "$SEQUENCER_ADDR" --private-key "$SEQUENCER_KEY"
 target/debug/tempo-xtask set-encryption-key --l1-rpc-url "$HTTP_RPC" --portal "$PORTAL" --private-key "$SEQUENCER_KEY"
 ```
+
+`deploy-zone` also stores `adminKey` and `adminAddress` using the generated sequencer key, because that convenience flow creates zones with `admin == sequencer`. For manual `create-zone` flows, pass `--admin "$ADMIN_ADDR"` when separating the cold admin role from the hot sequencer role, and keep the matching `ADMIN_KEY` available for admin-only portal calls.
 
 ## Start a zone in release
 
@@ -37,7 +39,7 @@ cast block-number --rpc-url http://localhost:8546
 Read deployment metadata:
 
 ```bash
-jq '{zoneId, portal, tempoAnchorBlock, zoneFactory, swapAndDepositRouter, sequencerAddress}' generated/my-zone/zone.json
+jq '{zoneId, portal, tempoAnchorBlock, zoneFactory, swapAndDepositRouter, admin, sequencer, adminAddress, sequencerAddress}' generated/my-zone/zone.json
 ```
 
 ## Direct deposit + withdrawal validation
@@ -139,6 +141,7 @@ If the zone is still behind the tx block, wait longer or rerun the test with a `
 ## Known failure modes
 
 - `swapAndDepositRouter not found`: run `just deploy-router <name>` or pass `--router`.
+- `resolved admin ... is not the portal admin`: set `ADMIN_KEY` for the portal's on-chain admin, or use the saved `adminKey` from a `deploy-zone` zone. `SEQUENCER_KEY` only works when `admin == sequencer`.
 - Missing sequencer key: read `sequencerKey` from `generated/<name>/zone.json` or set `SEQUENCER_KEY`.
 - Timeout waiting for `TokenEnabled`: the zone is usually still catching up.
 - Restart crash with `failed to seed transferPolicyId ... Uninitialized`: inspect `crates/tempo-zone/src/l1_state/tip403/cache.rs` and prefer a fresh zone for smoke tests involving temporary tokens.

--- a/Justfile
+++ b/Justfile
@@ -836,9 +836,15 @@ spam-deposits total="20" per-block="10" amount="1000000" encrypted="" token="0x2
     cargo run -p tempo-xtask -- spam-deposits --private-key "$PK" $ARGS
 
 [group('zone')]
-[doc('Runs the full TIP-20 + TIP-403 blacklist demo: creates token, enables on zone, blacklists address, shows deposit bounce, unblacklists, shows deposit success, withdraws. Requires PRIVATE_KEY for the token admin/depositor, L1_PORTAL_ADDRESS, and portal admin authority via ADMIN_KEY or <zone-dir>/zone.json adminKey.')]
-demo-blacklist amount="500000" rpc=zone_rpc zone-dir="generated/z5":
-    cargo run -p tempo-xtask -- demo-blacklist --zone-rpc-url {{rpc}} --amount {{amount}} --zone-dir "{{zone-dir}}"
+[doc('Runs the full TIP-20 + TIP-403 blacklist demo: creates token, enables on zone, blacklists address, shows deposit bounce, unblacklists, shows deposit success, withdraws. Requires PRIVATE_KEY for the token admin/depositor, L1_PORTAL_ADDRESS, and portal admin authority via ADMIN_KEY or matching generated/<name>/zone.json adminKey.')]
+demo-blacklist amount="500000" rpc=zone_rpc zone-dir="":
+    #!/bin/bash
+    set -euo pipefail
+    ARGS=(--zone-rpc-url "{{rpc}}" --amount "{{amount}}")
+    if [[ -n "{{zone-dir}}" ]]; then
+        ARGS+=(--zone-dir "{{zone-dir}}")
+    fi
+    cargo run -p tempo-xtask -- demo-blacklist "${ARGS[@]}"
 
 # Docs commands
 [group('docs')]

--- a/Justfile
+++ b/Justfile
@@ -836,9 +836,9 @@ spam-deposits total="20" per-block="10" amount="1000000" encrypted="" token="0x2
     cargo run -p tempo-xtask -- spam-deposits --private-key "$PK" $ARGS
 
 [group('zone')]
-[doc('Runs the full TIP-20 + TIP-403 blacklist demo: creates token, enables on zone, blacklists address, shows deposit bounce, unblacklists, shows deposit success, withdraws. Requires PRIVATE_KEY (sequencer key) and L1_PORTAL_ADDRESS env vars.')]
-demo-blacklist amount="500000" rpc=zone_rpc:
-    cargo run -p tempo-xtask -- demo-blacklist --zone-rpc-url {{rpc}} --amount {{amount}}
+[doc('Runs the full TIP-20 + TIP-403 blacklist demo: creates token, enables on zone, blacklists address, shows deposit bounce, unblacklists, shows deposit success, withdraws. Requires PRIVATE_KEY for the token admin/depositor, L1_PORTAL_ADDRESS, and portal admin authority via ADMIN_KEY or <zone-dir>/zone.json adminKey.')]
+demo-blacklist amount="500000" rpc=zone_rpc zone-dir="generated/z5":
+    cargo run -p tempo-xtask -- demo-blacklist --zone-rpc-url {{rpc}} --amount {{amount}} --zone-dir "{{zone-dir}}"
 
 # Docs commands
 [group('docs')]

--- a/crates/tempo-zone/README.md
+++ b/crates/tempo-zone/README.md
@@ -151,7 +151,8 @@ End-to-end walkthrough for creating a TIP-20 token on L1, assigning a
 blacklist policy, enabling it on the zone, and verifying enforcement.
 
 **Prerequisites:** `L1_RPC_URL`, `PRIVATE_KEY`, `L1_PORTAL_ADDRESS`, and
-`SEQUENCER_KEY` env vars set. A running zone (`just zone-up <name>`).
+`ADMIN_KEY` env vars set. `SEQUENCER_KEY` works only for legacy zones where
+admin equals sequencer. A running zone (`just zone-up <name>`).
 
 ### 1. Create a TIP-20 token on L1
 
@@ -222,7 +223,7 @@ just enable-token $TOKEN
 just max-approve-portal
 
 # Deposit to yourself on the zone
-just send-deposit token=$TOKEN
+just send-deposit 1000000 "" $TOKEN
 ```
 
 ### 7. Test enforcement on the zone

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -445,20 +445,19 @@ This is useful for verifying that transfer-policy enforcement works end-to-end a
 ```bash
 export PRIVATE_KEY="0x<token-admin-and-depositor-private-key>"
 export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
-# For zones created by `deploy-zone`, this reads the saved portal admin key.
-# Otherwise set ADMIN_KEY to the private key for the portal's on-chain admin.
-export ADMIN_KEY=$(jq -r '.adminKey' generated/my-zone/zone.json)
+# If generated/*/zone.json does not contain the matching adminKey, set ADMIN_KEY
+# to the private key for the portal's on-chain admin.
 
 just demo-blacklist              # default deposit amount = 500,000
 just demo-blacklist 1000000      # custom deposit amount
-just demo-blacklist 500000 http://localhost:8546 generated/my-zone
+just demo-blacklist 500000 http://localhost:8546 generated/my-zone  # explicit metadata directory
 ```
 
 The demo walks through 9 steps, printing every transaction with an explorer link:
 
 1. **Create token** — deploys a fresh TIP-20 "DemoUSD" via `TIP20Factory` (random salt each run)
 2. **Configure token** — sets supply cap, grants `ISSUER_ROLE`, mints tokens, approves portal
-3. **Enable on zone** — portal admin calls `enableToken` on the portal (uses `ADMIN_KEY`, or reads `adminKey` from the selected zone directory with `sequencerKey` as a legacy fallback)
+3. **Enable on zone** — portal admin calls `enableToken` on the portal (uses `ADMIN_KEY`, or auto-discovers the matching `generated/<name>/zone.json` and reads `adminKey` with `sequencerKey` as a legacy fallback)
 4. **Deposit** — plain deposit so the `PRIVATE_KEY` wallet has L2 funds
 5. **Blacklist** — creates a TIP-403 blacklist policy, adds a fresh target wallet, assigns the policy to the token
 6. **Encrypted deposit → bounce** — sends an encrypted deposit to the blacklisted target; zone rejects it and returns funds to sender
@@ -466,7 +465,7 @@ The demo walks through 9 steps, printing every transaction with an explorer link
 8. **Encrypted deposit → success** — same encrypted deposit now goes through
 9. **Withdraw** — target withdraws tokens from zone back to L1
 
-Prerequisites: a running zone with the sequencer producing blocks, the `PRIVATE_KEY` wallet funded with pathUSD on L1, and portal admin authority available via `ADMIN_KEY` or a saved `adminKey` in the selected zone directory (the demo deposits a small amount to the target for L2 gas fees).
+Prerequisites: a running zone with the sequencer producing blocks, the `PRIVATE_KEY` wallet funded with pathUSD on L1, and portal admin authority available via `ADMIN_KEY` or a saved `adminKey` in the matching `generated/<name>/zone.json` (the demo deposits a small amount to the target for L2 gas fees).
 
 ## Architecture
 

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -27,8 +27,8 @@ This single command will:
 5. Generate the zone's `genesis.json` and `zone.json`
 6. Build and start the zone node
 
-> The sequencer key is saved in `generated/<name>/zone.json` — `zone-up` reads it automatically.
-> `zone.json` now also stores `zoneFactory`, and `just deploy-router` appends `swapAndDepositRouter`.
+> `deploy-zone` uses the generated sequencer key as the portal admin too. It saves `sequencerKey`, `sequencerAddress`, `adminKey`, and `adminAddress` in `generated/<name>/zone.json`; `zone-up` reads the sequencer key automatically.
+> `zone.json` also stores `zoneFactory`, and `just deploy-router` appends `swapAndDepositRouter`.
 
 Once running, generate a user wallet and deposit some tokens:
 
@@ -132,7 +132,7 @@ just create-zone my-zone alphausd
 
 This creates `generated/my-zone/` containing:
 - **`genesis.json`** — Zone L2 genesis state (system contracts, fee token, etc.)
-- **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block, `zoneFactory`, and optional router/sequencer metadata)
+- **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block, `zoneFactory`, public `admin` / `sequencer` addresses, and optional saved keys/router metadata)
 
 This initial token controls the first L1 TIP-20 the portal accepts and mirrors onto the zone. The zone's fee token in genesis remains `pathUSD`.
 
@@ -145,6 +145,8 @@ cargo run -p tempo-xtask -- create-zone \
   --sequencer "$SEQUENCER_ADDR" \
   --private-key "$SEQUENCER_KEY"
 ```
+
+By default, `create-zone` sets the portal admin to the sequencer. To separate the cold admin role from the hot sequencer role, pass `--admin "$ADMIN_ADDR"` to the direct xtask command and keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token`, `pause-deposits`, and `resume-deposits`.
 
 ### 5. Start the Zone Node
 
@@ -243,6 +245,7 @@ Prerequisites:
 - `L1_RPC_URL` and `PRIVATE_KEY` set
 - `generated/<name>/zone.json` present
 - `SEQUENCER_KEY` set if `zone.json` does not already contain `sequencerKey`
+- `ADMIN_KEY` set if `zone.json` does not already contain `adminKey` and the portal admin differs from the sequencer
 
 Deploy the router once for the zone:
 
@@ -440,26 +443,30 @@ just check-authorized 2 0x<address-to-block>
 This is useful for verifying that transfer-policy enforcement works end-to-end across L1 and L2, or for demoing the blacklist feature to others.
 
 ```bash
-export PRIVATE_KEY="0x<your-wallet-private-key>"
+export PRIVATE_KEY="0x<token-admin-and-depositor-private-key>"
 export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
+# For zones created by `deploy-zone`, this reads the saved portal admin key.
+# Otherwise set ADMIN_KEY to the private key for the portal's on-chain admin.
+export ADMIN_KEY=$(jq -r '.adminKey' generated/my-zone/zone.json)
 
 just demo-blacklist              # default deposit amount = 500,000
 just demo-blacklist 1000000      # custom deposit amount
+just demo-blacklist 500000 http://localhost:8546 generated/my-zone
 ```
 
 The demo walks through 9 steps, printing every transaction with an explorer link:
 
 1. **Create token** — deploys a fresh TIP-20 "DemoUSD" via `TIP20Factory` (random salt each run)
 2. **Configure token** — sets supply cap, grants `ISSUER_ROLE`, mints tokens, approves portal
-3. **Enable on zone** — portal admin calls `enableToken` on the portal (auto-reads `adminKey` from `zone.json`, with `sequencerKey` as a legacy fallback)
-4. **Deposit** — plain deposit so admin has L2 funds
+3. **Enable on zone** — portal admin calls `enableToken` on the portal (uses `ADMIN_KEY`, or reads `adminKey` from the selected zone directory with `sequencerKey` as a legacy fallback)
+4. **Deposit** — plain deposit so the `PRIVATE_KEY` wallet has L2 funds
 5. **Blacklist** — creates a TIP-403 blacklist policy, adds a fresh target wallet, assigns the policy to the token
 6. **Encrypted deposit → bounce** — sends an encrypted deposit to the blacklisted target; zone rejects it and returns funds to sender
 7. **Unblacklist** — removes the target from the blacklist on L1
 8. **Encrypted deposit → success** — same encrypted deposit now goes through
 9. **Withdraw** — target withdraws tokens from zone back to L1
 
-Prerequisites: a running zone with the sequencer producing blocks, and the admin wallet funded with pathUSD on L1 (the demo deposits a small amount to the target for L2 gas fees).
+Prerequisites: a running zone with the sequencer producing blocks, the `PRIVATE_KEY` wallet funded with pathUSD on L1, and portal admin authority available via `ADMIN_KEY` or a saved `adminKey` in the selected zone directory (the demo deposits a small amount to the target for L2 gas fees).
 
 ## Architecture
 
@@ -595,19 +602,21 @@ Current deployment:
 |---------|-------------|
 | `just deploy-zone <name> [<tip20>]` | One-shot: keygen → fund → create → genesis → start node |
 | `just create-zone <name> [<tip20>]` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`) |
-| `just deploy-router <name>` | Deploy `SwapAndDepositRouter` on L1 for the zone and save it to `zone.json` |
+| `just deploy-router <name> [dex]` | Deploy `SwapAndDepositRouter` on L1 for the zone and save it to `zone.json` |
 | `just zone-up <name> [reset] [profile]` | Start the zone node. `reset=true` wipes datadir. `profile=release` for production. |
-| `just max-approve-portal` | Approve portal to spend tokens on L1 |
-| `just send-deposit [to]` | Deposit tokens from L1 to zone (defaults to sender) |
-| `just send-deposit-encrypted [to]` | Encrypted deposit — hides recipient and memo on-chain |
+| `just max-approve-portal [token]` | Approve portal to spend tokens on L1 |
+| `just send-deposit [amount] [to] [token] [memo]` | Deposit tokens from L1 to zone (defaults to sender) |
+| `just send-deposit-encrypted [amount] [to] [memo] [token] [rpc]` | Encrypted deposit — hides recipient and memo on-chain |
 | `just enable-token <token>` | Enable a TIP-20 token on the portal for bridging (admin only) |
 | `just pause-deposits <token>` | Pause deposits for an enabled token on the portal (admin only) |
 | `just resume-deposits <token>` | Resume deposits for a paused token on the portal (admin only) |
-| `just max-approve-outbox` | Approve outbox to spend tokens on zone |
-| `just send-withdrawal [to]` | Withdraw tokens from zone to L1 (defaults to sender) |
-| `just demo-swap-and-deposit <name>` | Self-contained same-zone router demo: create tokens, seed DEX liquidity, swap on L1, deposit output back into the zone |
-| `just check-balance <addr>` | Check token balance on the zone |
+| `just list-enabled-tokens [portal]` | List TIP-20 token addresses enabled on a portal |
+| `just max-approve-outbox [token] [rpc]` | Approve outbox to spend tokens on zone |
+| `just send-withdrawal [amount] [to] [token] [memo] [gas-limit] [fallback-recipient] [data] [reveal-to] [rpc]` | Withdraw tokens from zone to L1 (defaults to sender) |
+| `just demo-swap-and-deposit <name> [amount] [tick] [rpc]` | Self-contained same-zone router demo: create tokens, seed DEX liquidity, swap on L1, deposit output back into the zone |
+| `just check-balance <addr> [token] [rpc]` | Check token balance on the zone |
 | `just zone-auth-token <name>` | Generate a signed private RPC auth token (10 min TTL) |
-| `just check-balance-private <name>` | Check balance via the private RPC (auto-generates auth token) |
+| `just check-balance-private <name> [token] [rpc]` | Check balance via the private RPC (auto-generates auth token) |
 | `just zone-info <id-or-portal>` | Fetch zone metadata from ZoneFactory |
-| `just demo-blacklist [amount]` | End-to-end TIP-20 + TIP-403 blacklist lifecycle demo |
+| `just demo-blacklist [amount] [rpc] [zone-dir]` | End-to-end TIP-20 + TIP-403 blacklist lifecycle demo |
+| `just spam-deposits [total] [per-block] [amount] [encrypted] [token] [lead-time]` | Send many deposit transactions to measure portal throughput |

--- a/xtask/src/demo_blacklist.rs
+++ b/xtask/src/demo_blacklist.rs
@@ -20,7 +20,8 @@
 //!
 //! # Prerequisites
 //!
-//! - A running zone (defaults to z5: `generated/z5/zone.json`)
+//! - A running zone. Pass `--zone-dir` if `generated/*/zone.json` auto-discovery
+//!   cannot match `L1_PORTAL_ADDRESS`.
 //! - The zone's sequencer must be actively producing blocks
 //! - An L1 account with enough funds for gas (set via `PRIVATE_KEY`)
 //! - Portal admin authority via `ADMIN_KEY`, or `adminKey` in zone.json
@@ -30,7 +31,7 @@
 //! # Usage
 //!
 //! ```sh
-//! just demo-blacklist              # defaults: zone z5, amount=500000
+//! just demo-blacklist              # default amount=500000, auto-discovers zone metadata
 //! just demo-blacklist 1000000      # custom deposit amount
 //! just demo-blacklist 500000 http://localhost:8546 generated/my-zone
 //! ```
@@ -98,8 +99,9 @@ pub(crate) struct DemoBlacklist {
     #[arg(long, env = "PRIVATE_KEY")]
     private_key: String,
 
-    /// Portal admin private key (hex). If not set, reads adminKey from zone.json,
-    /// then falls back to SEQUENCER_KEY / sequencerKey for legacy zones.
+    /// Portal admin private key (hex). If not set, reads adminKey from the
+    /// explicit or auto-discovered zone.json, then falls back to SEQUENCER_KEY /
+    /// sequencerKey for legacy zones.
     #[arg(long, env = "ADMIN_KEY")]
     admin_key: Option<String>,
 
@@ -107,9 +109,10 @@ pub(crate) struct DemoBlacklist {
     #[arg(long, env = "SEQUENCER_KEY")]
     sequencer_key: Option<String>,
 
-    /// Path to zone directory containing zone.json.
-    #[arg(long, default_value = "generated/z5")]
-    zone_dir: String,
+    /// Path to zone directory containing zone.json. If omitted, scans
+    /// generated/*/zone.json for the portal address.
+    #[arg(long)]
+    zone_dir: Option<std::path::PathBuf>,
 
     /// Zone L2 RPC URL.
     #[arg(long, env = "ZONE_RPC_URL", default_value = "http://localhost:8546")]
@@ -130,10 +133,8 @@ impl DemoBlacklist {
         let admin = signer.address();
         let wallet = EthereumWallet::from(signer);
 
-        let zone_json_path = std::path::PathBuf::from(&self.zone_dir).join("zone.json");
-        let zone_json = std::fs::read_to_string(&zone_json_path)
-            .ok()
-            .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok());
+        let (zone_json_path, zone_json) =
+            load_zone_metadata(self.zone_dir.as_deref(), self.portal)?;
         let portal_admin_key_str = self
             .admin_key
             .clone()
@@ -142,8 +143,12 @@ impl DemoBlacklist {
             .or_else(|| zone_json.as_ref()?.get("sequencerKey")?.as_str().map(str::to_owned))
             .ok_or_else(|| {
                 eyre!(
-                    "portal admin key missing. Set ADMIN_KEY or store adminKey in {}. SEQUENCER_KEY/sequencerKey only works for legacy zones where admin == sequencer.",
-                    zone_json_path.display()
+                    "portal admin key missing. Set ADMIN_KEY or store adminKey in {}. \
+                     SEQUENCER_KEY/sequencerKey only works for legacy zones where admin == sequencer.",
+                    zone_json_path
+                        .as_ref()
+                        .map(|path| path.display().to_string())
+                        .unwrap_or_else(|| "the matching generated/<name>/zone.json".to_string())
                 )
             })?;
         let portal_admin_key = portal_admin_key_str
@@ -613,6 +618,46 @@ impl DemoBlacklist {
 
         Ok(())
     }
+}
+
+fn load_zone_metadata(
+    zone_dir: Option<&std::path::Path>,
+    portal: Address,
+) -> eyre::Result<(Option<std::path::PathBuf>, Option<serde_json::Value>)> {
+    if let Some(zone_dir) = zone_dir {
+        let path = zone_dir.join("zone.json");
+        let value = read_zone_json(&path)?;
+        return Ok((Some(path), Some(value)));
+    }
+
+    let generated = std::path::Path::new("generated");
+    if !generated.is_dir() {
+        return Ok((None, None));
+    }
+
+    for entry in std::fs::read_dir(generated).wrap_err("failed reading generated/")? {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let path = entry.path().join("zone.json");
+        let Ok(value) = read_zone_json(&path) else {
+            continue;
+        };
+        let Some(json_portal) = value.get("portal").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if json_portal.parse::<Address>().ok() == Some(portal) {
+            return Ok((Some(path), Some(value)));
+        }
+    }
+
+    Ok((None, None))
+}
+
+fn read_zone_json(path: &std::path::Path) -> eyre::Result<serde_json::Value> {
+    let contents = std::fs::read_to_string(path)
+        .wrap_err_with(|| format!("failed reading {}", path.display()))?;
+    serde_json::from_str(&contents).wrap_err_with(|| format!("failed parsing {}", path.display()))
 }
 
 /// Verify a transaction receipt succeeded, returning an error with `label` context if it reverted.

--- a/xtask/src/demo_blacklist.rs
+++ b/xtask/src/demo_blacklist.rs
@@ -7,8 +7,8 @@
 //!
 //!  1. Create a fresh TIP-20 token on L1 (via `TIP20Factory`)
 //!  2. Configure the token (supply cap, ISSUER_ROLE, mint, approve)
-//!  3. Sequencer enables the token on the zone portal
-//!  4. Deposit tokens into the zone (plain deposit to admin)
+//!  3. Portal admin enables the token on the zone portal
+//!  4. Deposit tokens into the zone (plain deposit to the PRIVATE_KEY wallet)
 //!  5. Create a TIP-403 blacklist policy, blacklist a target wallet, assign it to the token
 //!  6. Encrypted deposit to the blacklisted target → zone bounces it back
 //!  7. Remove target from the blacklist on L1
@@ -23,7 +23,8 @@
 //! - A running zone (defaults to z5: `generated/z5/zone.json`)
 //! - The zone's sequencer must be actively producing blocks
 //! - An L1 account with enough funds for gas (set via `PRIVATE_KEY`)
-//! - The admin account needs a small pathUSD balance on L1 (deposited to
+//! - Portal admin authority via `ADMIN_KEY`, or `adminKey` in zone.json
+//! - The `PRIVATE_KEY` account needs a small pathUSD balance on L1 (deposited to
 //!   the target wallet for L2 gas fees)
 //!
 //! # Usage
@@ -31,6 +32,7 @@
 //! ```sh
 //! just demo-blacklist              # defaults: zone z5, amount=500000
 //! just demo-blacklist 1000000      # custom deposit amount
+//! just demo-blacklist 500000 http://localhost:8546 generated/my-zone
 //! ```
 //!
 //! Or directly via cargo:
@@ -48,8 +50,8 @@
 //!   signs portal governance calls, with `sequencerKey` retained as a legacy
 //!   fallback for zones where admin == sequencer.
 //! - TIP-403 policies are assigned directly to the token via
-//!   `changeTransferPolicyId`. The deployed L1 `TIP403Registry` does not have
-//!   `createCompoundPolicy`, so we use a simple blacklist policy.
+//!   `changeTransferPolicyId`. This demo uses a simple blacklist policy; use
+//!   `just create-compound-policy` for role-specific sender/recipient policies.
 //! - After modifying the blacklist on L1, the zone needs a few seconds to sync
 //!   the policy state via its L1 listener. We wait 6 seconds which is enough
 //!   for a couple of L1 blocks.


### PR DESCRIPTION
## Summary

- Refresh ZONES.md and the repo-local deploy-debug skill for the admin/sequencer split.
- Remove the hardcoded `generated/z5` blacklist-demo default and auto-discover matching `generated/<name>/zone.json` from `L1_PORTAL_ADDRESS`.
- Keep explicit zone metadata selection available via `just demo-blacklist ... <zone-dir>` / `--zone-dir`.
- Fix stale TIP-403 README and xtask comments, including the positional send-deposit token example.

## Why

PR 525 restored the shared Moderato ZoneFactory default after the admin-aware deployment changes, but some examples still implied sequencer authority or older command signatures. The blacklist demo also exposed a legacy `generated/z5` metadata default that does not make sense for arbitrary generated zones.

## Impact

Operators get current ADMIN_KEY/adminKey guidance and command signatures. `demo-blacklist` now uses `ADMIN_KEY` first, then explicit or auto-discovered zone metadata, instead of assuming a fixed generated zone.