### PR TITLE
fix: Handle fee transfer failure during processWithdrawal

### DIFF
--- a/specs/ref-impls/src/zone/ZonePortal.sol
+++ b/specs/ref-impls/src/zone/ZonePortal.sol
@@ -726,9 +726,13 @@ contract ZonePortal is IZonePortal {
             return;
         }
 
-        // Transfer fee to sequencer (always, regardless of withdrawal success)
+        // Transfer fee to sequencer.
         if (withdrawal.fee > 0) {
-            ITIP20(_token).transfer(sequencer, withdrawal.fee);
+            try ITIP20(_token).transfer(sequencer, withdrawal.fee) returns (bool) { }
+                catch {
+                // Fee transfer can fail for eg. TIP-403 blacklist, in which case the sequencer
+                // will forgo the fee so as to not stall withdrawals.
+            }
         }
 
         if (withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) {

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -1034,18 +1034,19 @@ contract ZonePortalTest is BaseTest {
         uint256 charlieBalanceBefore = pathUSD.balanceOf(charlie);
         uint64 depositCountBefore = portal.depositCount();
 
-        // The portal can send to withdrawal recipients, but the sequencer cannot receive fees.
+        // Blacklist the sequencer as a token recipient while leaving everyone else allowed.
         // This makes w1's fee transfer revert while leaving the user-facing transfer valid.
-        address[] memory allowedAccounts = new address[](3);
-        allowedAccounts[0] = address(portal);
-        allowedAccounts[1] = bob;
-        allowedAccounts[2] = charlie;
-        // No admin in allowedAccounts so the fee transfer will fail
+        address[] memory blockedAccounts = new address[](1);
+        blockedAccounts[0] = admin;
         uint64 policyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, allowedAccounts
+            admin, ITIP403Registry.PolicyType.BLACKLIST, blockedAccounts
         );
         vm.prank(pathUSDAdmin);
         pathUSD.changeTransferPolicyId(policyId);
+
+        assertFalse(registry.isAuthorizedRecipient(policyId, admin));
+        assertTrue(registry.isAuthorizedRecipient(policyId, bob));
+        assertTrue(registry.isAuthorizedRecipient(policyId, charlie));
 
         // Process w1. The fee is forgiven, bob receives the withdrawal amount, and no
         // bounce-back deposit is created

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -989,6 +989,88 @@ contract ZonePortalTest is BaseTest {
         assertTrue(portal.currentDepositQueueHash() != depositHashBefore);
     }
 
+    function test_withdrawal_feeTransferFailureForgoesFeeAndAdvancesQueue() public {
+        // Fund portal
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), alice);
+        vm.stopPrank();
+
+        bytes32 depositHash = portal.currentDepositQueueHash();
+
+        // Create two withdrawals in the same queue slot. The first has a fee that will fail
+        // to transfer; the second proves the queue can still keep moving afterward.
+        Withdrawal memory w1 =
+            _withdrawal(address(pathUSD), alice, bob, 300e6, bytes32(0), 0, alice, "");
+        w1.fee = 25e6;
+        Withdrawal memory w2 =
+            _withdrawal(address(pathUSD), alice, charlie, 400e6, bytes32(0), 0, alice, "");
+
+        // Build queue: w1 is oldest, w2 remains as the inner queue after w1 is processed.
+        bytes32 innerHash = keccak256(abi.encode(w2, EMPTY_SENTINEL));
+        bytes32 batchQueueHash = keccak256(abi.encode(w1, innerHash));
+
+        // Submit batch adding both withdrawals to slot 0.
+        vm.roll(block.number + 1);
+        portal.submitBatch(
+            uint64(block.number - 1),
+            0,
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: depositHash,
+                prevDepositNumber: 0,
+                nextDepositNumber: 0
+            }),
+            batchQueueHash,
+            "",
+            ""
+        );
+
+        uint256 portalBalanceBefore = pathUSD.balanceOf(address(portal));
+        uint256 sequencerBalanceBefore = pathUSD.balanceOf(admin);
+        uint256 bobBalanceBefore = pathUSD.balanceOf(bob);
+        uint256 charlieBalanceBefore = pathUSD.balanceOf(charlie);
+        uint64 depositCountBefore = portal.depositCount();
+
+        // The portal can send to withdrawal recipients, but the sequencer cannot receive fees.
+        // This makes w1's fee transfer revert while leaving the user-facing transfer valid.
+        address[] memory allowedAccounts = new address[](3);
+        allowedAccounts[0] = address(portal);
+        allowedAccounts[1] = bob;
+        allowedAccounts[2] = charlie;
+        // No admin in allowedAccounts so the fee transfer will fail
+        uint64 policyId = registry.createPolicyWithAccounts(
+            admin, ITIP403Registry.PolicyType.WHITELIST, allowedAccounts
+        );
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(policyId);
+
+        // Process w1. The fee is forgiven, bob receives the withdrawal amount, and no
+        // bounce-back deposit is created
+        portal.processWithdrawal(w1, innerHash);
+
+        assertEq(pathUSD.balanceOf(bob), bobBalanceBefore + w1.amount);
+        assertEq(pathUSD.balanceOf(admin), sequencerBalanceBefore);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBalanceBefore - w1.amount);
+        assertEq(portal.depositCount(), depositCountBefore);
+
+        // Slot 0 should now contain only w2, with the head still on the same slot.
+        assertEq(portal.withdrawalQueueSlot(0), innerHash);
+        assertEq(portal.withdrawalQueueHead(), 0);
+
+        // Process w2 to prove the failed fee transfer did not block later withdrawals.
+        portal.processWithdrawal(w2, bytes32(0));
+
+        assertEq(pathUSD.balanceOf(charlie), charlieBalanceBefore + w2.amount);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBalanceBefore - w1.amount - w2.amount);
+
+        // Slot 0 is exhausted, so it is cleared and the queue head advances.
+        assertEq(portal.withdrawalQueueSlot(0), EMPTY_SENTINEL);
+        assertEq(portal.withdrawalQueueHead(), 1);
+    }
+
     /*//////////////////////////////////////////////////////////////
                      INVALID WITHDRAWAL TESTS
     //////////////////////////////////////////////////////////////*/

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -585,7 +585,7 @@ fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
     = (50,000 + gasLimit) * tempoGasRate
 ```
 
-`WITHDRAWAL_BASE_GAS` (50,000) covers the fixed overhead of processing a withdrawal on Tempo (queue dequeue, transfer, event emission). The user specifies `gasLimit` covering any additional Tempo L1 callback gas. `gasLimit` must be less than or equal to `MAX_WITHDRAWAL_GAS_LIMIT` (10,000,000), which keeps the outer `processWithdrawal` transaction below the Tempo L1 block gas limit after portal overhead and the EIP-150 cushion are added. For simple withdrawals with no callback, use `gasLimit = 0`. The fee is paid in the same token being withdrawn. On success, `amount` goes to the recipient and `fee` goes to the sequencer. On failure (bounce-back), only `amount` is re-deposited to `fallbackRecipient`. The sequencer keeps the fee regardless of outcome.
+`WITHDRAWAL_BASE_GAS` (50,000) covers the fixed overhead of processing a withdrawal on Tempo (queue dequeue, transfer, event emission). The user specifies `gasLimit` covering any additional Tempo L1 callback gas. `gasLimit` must be less than or equal to `MAX_WITHDRAWAL_GAS_LIMIT` (10,000,000), which keeps the outer `processWithdrawal` transaction below the Tempo L1 block gas limit after portal overhead and the EIP-150 cushion are added. For simple withdrawals with no callback, use `gasLimit = 0`. The fee is paid in the same token being withdrawn. `processWithdrawal` attempts to pay `fee` to the sequencer on Tempo, but if fee payment fails, the withdrawal processing continues and the unpaid fee remains in the portal. On success, `amount` goes to the recipient. On failure (bounce-back), only `amount` is re-deposited to `fallbackRecipient`. The sequencer keeps the fee only if the Tempo-side fee transfer succeeds.
 
 `tempoGasRate` lives on the zone-side `ZoneOutbox` (see [Gas Rate Configuration](#gas-rate-configuration)). The outbox reads it at request time and snapshots it onto the queued withdrawal.
 
@@ -635,6 +635,8 @@ Withdrawals can fail on the Tempo side for several reasons:
 - The token is paused
 - The callback reverts (out of gas, logic error)
 - The receiver returns the wrong selector
+
+Sequencer fee-transfer failure is not treated as a withdrawal failure. The portal forgoes the failed fee transfer and continues with the normal withdrawal path so as to not stall withdrawals.
 
 To make sure that all of these cases can be handled without loss of user funds, every withdrawal carries a `fallbackRecipient`: a zone address that receives a refund mint if Tempo-side processing fails.
 


### PR DESCRIPTION
During `processWithdrawal`, if the fee transfer to the sequencer's L1 wallet fails (for eg TIP-403 blacklist), then the withdrawal will revert and will stall the entire withdrawal queue. Handle this `catch`ing the exception and forgoing the fee in case this happens so as to not stall withdrawals