### PR TITLE
Make zone IDs deterministic

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -113,7 +113,7 @@ zone-info identifier:
     cargo run -p tempo-xtask -- zone-info {{identifier}}
 
 [group('zone')]
-[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars. Set ZONE_FACTORY to override the Moderato default.')]
+[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Set ZONE_SALT for a deterministic nonzero salt. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars. Set ZONE_FACTORY to override the Moderato default.')]
 create-zone name token="":
     #!/bin/bash
     set -euo pipefail
@@ -144,12 +144,17 @@ create-zone name token="":
     cargo build -p tempo-xtask
     echo "Creating zone '{{name}}' on L1 and generating genesis..."
     echo "Initial portal token: $ZONE_TOKEN_L1"
+    ZONE_SALT_ARG=()
+    if [[ -n "${ZONE_SALT:-}" ]]; then
+        ZONE_SALT_ARG=(--salt "$ZONE_SALT")
+    fi
     cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
         --sequencer "$SEQUENCER_ADDR" \
-        --private-key "$PK"
+        --private-key "$PK" \
+        "${ZONE_SALT_ARG[@]}"
     echo "Zone '{{name}}' created. Artifacts in $OUTPUT/"
 
 [group('zone')]

--- a/Justfile
+++ b/Justfile
@@ -113,7 +113,7 @@ zone-info identifier:
     cargo run -p tempo-xtask -- zone-info {{identifier}}
 
 [group('zone')]
-[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Set ZONE_SALT for a deterministic nonzero salt. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars. Set ZONE_FACTORY to override the Moderato default.')]
+[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Set ZONE_SALT for a deterministic nonzero salt and ZONE_ADMIN_SIGNATURE for delegated deployment. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars. Set ZONE_FACTORY to override the Moderato default.')]
 create-zone name token="":
     #!/bin/bash
     set -euo pipefail
@@ -148,13 +148,18 @@ create-zone name token="":
     if [[ -n "${ZONE_SALT:-}" ]]; then
         ZONE_SALT_ARG=(--salt "$ZONE_SALT")
     fi
+    ZONE_ADMIN_SIGNATURE_ARG=()
+    if [[ -n "${ZONE_ADMIN_SIGNATURE:-}" ]]; then
+        ZONE_ADMIN_SIGNATURE_ARG=(--admin-signature "$ZONE_ADMIN_SIGNATURE")
+    fi
     cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
         --sequencer "$SEQUENCER_ADDR" \
         --private-key "$PK" \
-        "${ZONE_SALT_ARG[@]}"
+        "${ZONE_SALT_ARG[@]}" \
+        "${ZONE_ADMIN_SIGNATURE_ARG[@]}"
     echo "Zone '{{name}}' created. Artifacts in $OUTPUT/"
 
 [group('zone')]

--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -24,6 +24,7 @@ crate::sol! {
             uint64 genesisTempoBlockNumber;
         }
         struct CreateZoneParams {
+            bytes32 salt;
             address initialToken;
             address admin;
             address sequencer;
@@ -44,6 +45,7 @@ crate::sol! {
             uint64 genesisTempoBlockNumber
         );
         function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
+        function computeZoneId(address admin, bytes32 salt) external pure returns (uint32);
         function verifier() external view returns (address);
         function zones(uint32 zoneId) external view returns (ZoneInfo memory);
         function zoneCount() external view returns (uint32);

--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -31,6 +31,7 @@ crate::sol! {
             address verifier;
             ZoneParams zoneParams;
             string rpcUrl;
+            bytes adminSignature;
         }
         event ZoneCreated(
             uint32 indexed zoneId,
@@ -46,6 +47,7 @@ crate::sol! {
         );
         function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
         function computeZoneId(address admin, bytes32 salt) external pure returns (uint32);
+        function zoneCreationDigest(CreateZoneParams calldata params, address caller) external view returns (bytes32);
         function verifier() external view returns (address);
         function zones(uint32 zoneId) external view returns (ZoneInfo memory);
         function zoneCount() external view returns (uint32);

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1034,6 +1034,7 @@ impl L1TestNode {
                     genesisTempoBlockNumber: l1_header.inner.number,
                 },
                 rpcUrl: String::new(),
+                adminSignature: Default::default(),
             })
             .send()
             .await?

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1023,6 +1023,7 @@ impl L1TestNode {
         let verifier_address = factory.verifier().call().await?;
         let receipt = factory
             .createZone(ZoneFactory::CreateZoneParams {
+                salt: B256::ZERO,
                 admin: sequencer,
                 initialToken: PATH_USD_ADDRESS,
                 sequencer,

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -156,6 +156,8 @@ cargo run -p tempo-xtask -- create-zone \
 
 By default, `create-zone` sets the portal admin to the sequencer. To separate the cold admin role from the hot sequencer role, pass `--admin "$ADMIN_ADDR"` to the direct xtask command and keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token`, `pause-deposits`, and `resume-deposits`. Zone IDs are derived from `(admin, salt)`, so changing the admin also changes the derived zone ID for the same salt.
 
+If the L1 transaction signer is not the admin, pass `--admin-signature 0x...`. The signature must be produced by the admin over `ZoneFactory.zoneCreationDigest(params, caller)`, where `caller` is the relayer/deployer address that will submit `createZone`. Contract admins can authorize delegated deployment with EIP-1271 `isValidSignature`.
+
 ### 5. Start the Zone Node
 
 ```bash
@@ -603,6 +605,7 @@ Current deployment:
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 | `ZONE_SALT` | No | Optional 32-byte salt for deterministic zone ID derivation in `just create-zone`; defaults to zero |
+| `ZONE_ADMIN_SIGNATURE` | No | Optional admin authorization signature for delegated `just create-zone` deployments |
 | `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |
 
 ## Justfile Commands Reference

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -136,6 +136,13 @@ This creates `generated/my-zone/` containing:
 
 This initial token controls the first L1 TIP-20 the portal accepts and mirrors onto the zone. The zone's fee token in genesis remains `pathUSD`.
 
+`create-zone` defaults to a zero salt. To reserve a deterministic zone ID before deployment, choose a 32-byte salt and pass it through `ZONE_SALT`:
+
+```bash
+export ZONE_SALT=0x0000000000000000000000000000000000000000000000000000000000000001
+just create-zone my-zone
+```
+
 You can also run the xtask directly for more control:
 
 ```bash
@@ -143,10 +150,11 @@ cargo run -p tempo-xtask -- create-zone \
   --output generated/my-zone \
   --initial-token 0x20c0000000000000000000000000000000000001 \
   --sequencer "$SEQUENCER_ADDR" \
+  --salt "$ZONE_SALT" \
   --private-key "$SEQUENCER_KEY"
 ```
 
-By default, `create-zone` sets the portal admin to the sequencer. To separate the cold admin role from the hot sequencer role, pass `--admin "$ADMIN_ADDR"` to the direct xtask command and keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token`, `pause-deposits`, and `resume-deposits`.
+By default, `create-zone` sets the portal admin to the sequencer. To separate the cold admin role from the hot sequencer role, pass `--admin "$ADMIN_ADDR"` to the direct xtask command and keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token`, `pause-deposits`, and `resume-deposits`. Zone IDs are derived from `(admin, salt)`, so changing the admin also changes the derived zone ID for the same salt.
 
 ### 5. Start the Zone Node
 
@@ -551,9 +559,10 @@ export ZONE_FACTORY=0x...
 cast code "$ZONE_FACTORY" --rpc-url "$ETH_RPC_URL"
 cast call "$ZONE_FACTORY" "zoneCount()(uint32)" --rpc-url "$ETH_RPC_URL"
 cast call "$ZONE_FACTORY" "verifier()(address)" --rpc-url "$ETH_RPC_URL"
+cast call "$ZONE_FACTORY" "computeZoneId(address,bytes32)(uint32)" "$ADMIN_ADDR" "$ZONE_SALT" --rpc-url "$ETH_RPC_URL"
 ```
 
-`zoneCount()` should be `0` on a fresh deployment, and `verifier()` should return the verifier deployed by the factory constructor. Update `MODERATO_ZONE_FACTORY` in `xtask/src/zone_utils.rs`, the Key Addresses table above, and any other `rg` hits for the previous address.
+`zoneCount()` should be `0` on a fresh deployment, `verifier()` should return the verifier deployed by the factory constructor, and `computeZoneId(admin, salt)` should be usable to precompute a zone ID before calling `createZone`. Update `MODERATO_ZONE_FACTORY` in `xtask/src/zone_utils.rs`, the Key Addresses table above, and any other `rg` hits for the previous address.
 
 Current deployment:
 
@@ -593,6 +602,7 @@ Current deployment:
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
+| `ZONE_SALT` | No | Optional 32-byte salt for deterministic zone ID derivation in `just create-zone`; defaults to zero |
 | `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |
 
 ## Justfile Commands Reference

--- a/specs/ref-impls/src/zone/IZone.sol
+++ b/specs/ref-impls/src/zone/IZone.sol
@@ -451,6 +451,7 @@ interface IZoneFactory {
         address verifier;
         ZoneParams zoneParams;
         string rpcUrl;
+        bytes adminSignature;
     }
 
     event ZoneCreated(
@@ -472,6 +473,7 @@ interface IZoneFactory {
     error InvalidVerifier();
     error InsufficientGas();
     error ZoneAlreadyExists();
+    error InvalidAdminSignature();
 
     /// @notice Returns whether a verifier contract is approved for zone creation.
     /// @param verifier The verifier contract address to check.
@@ -488,6 +490,15 @@ interface IZoneFactory {
 
     /// @notice Returns the deterministic zone ID for an admin/salt pair.
     function computeZoneId(address admin, bytes32 salt) external pure returns (uint32);
+
+    /// @notice Returns the digest that `admin` must sign to authorize `caller`.
+    function zoneCreationDigest(
+        CreateZoneParams calldata params,
+        address caller
+    )
+        external
+        view
+        returns (bytes32);
 
     /// @notice Returns the number of zones created so far.
     /// @return count The total number of created zones, excluding reserved zone ID 0.

--- a/specs/ref-impls/src/zone/IZone.sol
+++ b/specs/ref-impls/src/zone/IZone.sol
@@ -444,7 +444,8 @@ interface IVerifier {
 interface IZoneFactory {
 
     struct CreateZoneParams {
-        address initialToken; // first TIP-20 to enable (sequencer can enable more later)
+        bytes32 salt;
+        address initialToken; // first TIP-20 to enable (admin can enable more later)
         address admin;
         address sequencer;
         address verifier;
@@ -470,7 +471,7 @@ interface IZoneFactory {
     error InvalidSequencer();
     error InvalidVerifier();
     error InsufficientGas();
-    error ZoneIdOverflow();
+    error ZoneAlreadyExists();
 
     /// @notice Returns whether a verifier contract is approved for zone creation.
     /// @param verifier The verifier contract address to check.
@@ -478,12 +479,15 @@ interface IZoneFactory {
     function isValidVerifier(address verifier) external view returns (bool);
 
     /// @notice Creates a new zone and deploys its portal and messenger contracts.
-    /// @param params The initial token, sequencer, verifier, and genesis parameters for the zone.
-    /// @return zoneId The newly assigned zone ID.
+    /// @param params The salt, initial token, admin, sequencer, verifier, and genesis parameters for the zone.
+    /// @return zoneId The deterministic zone ID derived from the admin and salt.
     /// @return portal The deployed portal address for the new zone.
     function createZone(CreateZoneParams calldata params)
         external
         returns (uint32 zoneId, address portal);
+
+    /// @notice Returns the deterministic zone ID for an admin/salt pair.
+    function computeZoneId(address admin, bytes32 salt) external pure returns (uint32);
 
     /// @notice Returns the number of zones created so far.
     /// @return count The total number of created zones, excluding reserved zone ID 0.

--- a/specs/ref-impls/src/zone/ZoneFactory.sol
+++ b/specs/ref-impls/src/zone/ZoneFactory.sol
@@ -20,20 +20,18 @@ contract ZoneFactory is IZoneFactory {
     /// @dev Prevents low-cost zone spam. The caller must supply at least this much gas.
     uint256 public constant ZONE_CREATION_GAS = 15_000_000;
 
-    /// @notice Next zone ID to be assigned
-    /// @dev Starts at 1, reserving zone ID 0 for potential future use (e.g., mainnet as zone 0)
-    uint32 internal _nextZoneId = 1;
+    uint32 internal _zoneCount;
+
+    /// @notice Tracks deployment count for CREATE address prediction
+    /// @dev Contracts start with nonce 1, not 0. Nonce 1 is used by the Verifier deployment
+    ///      in the constructor, so zone deployments start at nonce 2.
+    uint256 internal _deploymentNonce = 2;
 
     mapping(uint32 => ZoneInfo) internal _zones;
     mapping(address => bool) internal _isZonePortal;
     mapping(address => bool) internal _isZoneMessenger;
     mapping(address => bool) internal _validVerifiers;
     address internal _verifier;
-
-    /// @notice Tracks deployment count for CREATE address prediction
-    /// @dev Contracts start with nonce 1, not 0. Nonce 1 is used by the Verifier deployment
-    ///      in the constructor, so zone deployments start at nonce 2.
-    uint256 internal _deploymentNonce = 2;
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
@@ -62,9 +60,8 @@ contract ZoneFactory is IZoneFactory {
         if (!_validVerifiers[params.verifier]) revert InvalidVerifier();
         if (gasleft() < ZONE_CREATION_GAS) revert InsufficientGas();
 
-        zoneId = _nextZoneId;
-        if (zoneId == type(uint32).max) revert ZoneIdOverflow();
-        _nextZoneId = zoneId + 1;
+        zoneId = computeZoneId(params.admin, params.salt);
+        if (zoneId == 0 || _zones[zoneId].portal != address(0)) revert ZoneAlreadyExists();
 
         // We deploy messenger first, then portal.
         // Messenger needs portal's address at construction (immutable).
@@ -75,11 +72,9 @@ contract ZoneFactory is IZoneFactory {
         // - portal will be at nonce N+1
         //
         // We track our own nonce since contract nonce isn't accessible.
-
         uint256 currentNonce = _deploymentNonce;
         _deploymentNonce += 2; // We'll deploy 2 contracts
 
-        // Compute portal's address (will be deployed at nonce+1)
         address predictedPortal = _computeCreateAddress(address(this), currentNonce + 1);
 
         // Deploy messenger with predicted portal address (no token needed -- portal grants approval per-token)
@@ -121,6 +116,7 @@ contract ZoneFactory is IZoneFactory {
 
         _isZonePortal[portal] = true;
         _isZoneMessenger[messengerAddress] = true;
+        _zoneCount++;
 
         emit ZoneCreated(
             zoneId,
@@ -134,6 +130,10 @@ contract ZoneFactory is IZoneFactory {
             params.zoneParams.genesisTempoBlockHash,
             params.zoneParams.genesisTempoBlockNumber
         );
+    }
+
+    function computeZoneId(address admin, bytes32 salt) public pure returns (uint32) {
+        return uint32(uint256(keccak256(abi.encode(admin, salt))));
     }
 
     /// @notice Compute the address of a contract deployed with CREATE
@@ -170,7 +170,7 @@ contract ZoneFactory is IZoneFactory {
 
     /// @notice Returns the number of zones created (not including reserved zone 0)
     function zoneCount() external view returns (uint32) {
-        return _nextZoneId - 1;
+        return _zoneCount;
     }
 
     function zones(uint32 zoneId) external view returns (ZoneInfo memory) {

--- a/specs/ref-impls/src/zone/ZoneFactory.sol
+++ b/specs/ref-impls/src/zone/ZoneFactory.sol
@@ -12,6 +12,8 @@ import { ITIP20Factory } from "tempo-std/interfaces/ITIP20Factory.sol";
 /// @notice Creates zones and registers parameters
 contract ZoneFactory is IZoneFactory {
 
+    bytes4 internal constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
+
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -59,6 +61,7 @@ contract ZoneFactory is IZoneFactory {
         if (params.sequencer == address(0)) revert InvalidSequencer();
         if (!_validVerifiers[params.verifier]) revert InvalidVerifier();
         if (gasleft() < ZONE_CREATION_GAS) revert InsufficientGas();
+        _validateAdminAuthorization(params);
 
         zoneId = computeZoneId(params.admin, params.salt);
         if (zoneId == 0 || _zones[zoneId].portal != address(0)) revert ZoneAlreadyExists();
@@ -134,6 +137,68 @@ contract ZoneFactory is IZoneFactory {
 
     function computeZoneId(address admin, bytes32 salt) public pure returns (uint32) {
         return uint32(uint256(keccak256(abi.encode(admin, salt))));
+    }
+
+    function zoneCreationDigest(
+        CreateZoneParams calldata params,
+        address caller
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        bytes32 authorizationHash = keccak256(
+            abi.encode(
+                "TempoZoneFactory.createZone",
+                block.chainid,
+                address(this),
+                caller,
+                params.salt,
+                params.initialToken,
+                params.admin,
+                params.sequencer,
+                params.verifier,
+                params.zoneParams.genesisBlockHash,
+                params.zoneParams.genesisTempoBlockHash,
+                params.zoneParams.genesisTempoBlockNumber,
+                keccak256(bytes(params.rpcUrl))
+            )
+        );
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", authorizationHash));
+    }
+
+    function _validateAdminAuthorization(CreateZoneParams calldata params) internal view {
+        if (msg.sender == params.admin) {
+            if (params.adminSignature.length != 0) revert InvalidAdminSignature();
+            return;
+        }
+
+        bytes32 digest = zoneCreationDigest(params, msg.sender);
+        if (params.admin.code.length != 0) {
+            (bool ok, bytes memory result) = params.admin
+                .staticcall(
+                    abi.encodeWithSignature(
+                        "isValidSignature(bytes32,bytes)", digest, params.adminSignature
+                    )
+                );
+            if (!ok || result.length < 32 || bytes4(result) != EIP1271_MAGIC_VALUE) {
+                revert InvalidAdminSignature();
+            }
+            return;
+        }
+
+        if (params.adminSignature.length != 65) revert InvalidAdminSignature();
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        bytes calldata signature = params.adminSignature;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 32))
+            v := byte(0, calldataload(add(signature.offset, 64)))
+        }
+        if (v < 27) v += 27;
+        if (ecrecover(digest, v, r, s) != params.admin) revert InvalidAdminSignature();
     }
 
     /// @notice Compute the address of a contract deployed with CREATE

--- a/specs/ref-impls/test/zone/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/zone/ZoneFactory.t.sol
@@ -29,6 +29,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_success() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: admin,
@@ -43,13 +44,13 @@ contract ZoneFactoryTest is BaseTest {
 
         (uint32 zoneId, address portal) = zoneFactory.createZone(params);
 
-        assertEq(zoneId, 1);
+        assertEq(zoneId, zoneFactory.computeZoneId(admin, bytes32(0)));
         assertTrue(portal != address(0));
         assertEq(zoneFactory.zoneCount(), 1);
         assertTrue(zoneFactory.isZonePortal(portal));
 
         ZoneInfo memory info = zoneFactory.zones(zoneId);
-        assertEq(info.zoneId, 1);
+        assertEq(info.zoneId, zoneId);
         assertEq(info.portal, portal);
         assertTrue(info.messenger != address(0));
         assertEq(info.initialToken, address(pathUSD));
@@ -62,6 +63,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_deploysMessenger() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: admin,
@@ -90,6 +92,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_multipleZones() public {
         IZoneFactory.CreateZoneParams memory params1 = IZoneFactory.CreateZoneParams({
+            salt: bytes32(uint256(1)),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: admin,
@@ -105,6 +108,7 @@ contract ZoneFactoryTest is BaseTest {
         (uint32 zoneId1, address portal1) = zoneFactory.createZone(params1);
 
         IZoneFactory.CreateZoneParams memory params2 = IZoneFactory.CreateZoneParams({
+            salt: bytes32(uint256(2)),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: alice,
@@ -119,8 +123,8 @@ contract ZoneFactoryTest is BaseTest {
 
         (uint32 zoneId2, address portal2) = zoneFactory.createZone(params2);
 
-        assertEq(zoneId1, 1);
-        assertEq(zoneId2, 2);
+        assertEq(zoneId1, zoneFactory.computeZoneId(admin, bytes32(uint256(1))));
+        assertEq(zoneId2, zoneFactory.computeZoneId(admin, bytes32(uint256(2))));
         assertTrue(portal1 != portal2);
         assertEq(zoneFactory.zoneCount(), 2);
         assertTrue(zoneFactory.isZonePortal(portal1));
@@ -132,8 +136,30 @@ contract ZoneFactoryTest is BaseTest {
         assertTrue(info1.messenger != info2.messenger);
     }
 
+    function test_createZone_revertsOnDuplicateAdminSalt() public {
+        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32("same-salt"),
+            initialToken: address(pathUSD),
+            admin: admin,
+            sequencer: admin,
+            verifier: zoneFactory.verifier(),
+            zoneParams: ZoneParams({
+                genesisBlockHash: GENESIS_BLOCK_HASH,
+                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
+                genesisTempoBlockNumber: uint64(block.number)
+            }),
+            rpcUrl: ""
+        });
+
+        zoneFactory.createZone(params);
+
+        vm.expectRevert(IZoneFactory.ZoneAlreadyExists.selector);
+        zoneFactory.createZone(params);
+    }
+
     function test_createZone_emitsEvent() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: admin,
@@ -180,6 +206,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidToken_zeroAddress() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(0),
             admin: admin,
             sequencer: admin,
@@ -201,6 +228,7 @@ contract ZoneFactoryTest is BaseTest {
         address notTip20 = address(new NotATIP20());
 
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: notTip20,
             admin: admin,
             sequencer: admin,
@@ -219,6 +247,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidToken_eoa() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: alice, // EOA, not a contract
             admin: admin,
             sequencer: admin,
@@ -241,6 +270,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidAdmin_zeroAddress() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(pathUSD),
             admin: address(0),
             sequencer: admin,
@@ -263,6 +293,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidSequencer_zeroAddress() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: address(0),
@@ -285,6 +316,7 @@ contract ZoneFactoryTest is BaseTest {
 
     function test_createZone_revertsOnInvalidVerifier() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: admin,

--- a/specs/ref-impls/test/zone/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/zone/ZoneFactory.t.sol
@@ -39,7 +39,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         (uint32 zoneId, address portal) = zoneFactory.createZone(params);
@@ -73,7 +74,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         (uint32 zoneId, address portal) = zoneFactory.createZone(params);
@@ -102,7 +104,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         (uint32 zoneId1, address portal1) = zoneFactory.createZone(params1);
@@ -118,7 +121,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: keccak256("tempoGenesis2"),
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         (uint32 zoneId2, address portal2) = zoneFactory.createZone(params2);
@@ -148,12 +152,64 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         zoneFactory.createZone(params);
 
         vm.expectRevert(IZoneFactory.ZoneAlreadyExists.selector);
+        zoneFactory.createZone(params);
+    }
+
+    function test_createZone_allowsDelegatedDeploymentWithAdminSignature() public {
+        uint256 adminKey = 0xA11CE;
+        address coldAdmin = vm.addr(adminKey);
+        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32("delegated"),
+            initialToken: address(pathUSD),
+            admin: coldAdmin,
+            sequencer: admin,
+            verifier: zoneFactory.verifier(),
+            zoneParams: ZoneParams({
+                genesisBlockHash: GENESIS_BLOCK_HASH,
+                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
+                genesisTempoBlockNumber: uint64(block.number)
+            }),
+            rpcUrl: "https://rpc.delegated.example",
+            adminSignature: ""
+        });
+        params.adminSignature = _signCreateZone(adminKey, params, alice);
+
+        vm.prank(alice);
+        (uint32 zoneId, address portal) = zoneFactory.createZone(params);
+
+        ZoneInfo memory info = zoneFactory.zones(zoneId);
+        assertEq(info.portal, portal);
+        assertEq(info.admin, coldAdmin);
+        assertEq(info.sequencer, admin);
+    }
+
+    function test_createZone_revertsWhenSignatureCopiedByDifferentCaller() public {
+        uint256 adminKey = 0xB0B;
+        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32("copied"),
+            initialToken: address(pathUSD),
+            admin: vm.addr(adminKey),
+            sequencer: admin,
+            verifier: zoneFactory.verifier(),
+            zoneParams: ZoneParams({
+                genesisBlockHash: GENESIS_BLOCK_HASH,
+                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
+                genesisTempoBlockNumber: uint64(block.number)
+            }),
+            rpcUrl: "https://rpc.delegated.example",
+            adminSignature: ""
+        });
+        params.adminSignature = _signCreateZone(adminKey, params, alice);
+
+        vm.prank(bob);
+        vm.expectRevert(IZoneFactory.InvalidAdminSignature.selector);
         zoneFactory.createZone(params);
     }
 
@@ -169,7 +225,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         // Record logs and verify ZoneCreated event was emitted
@@ -216,7 +273,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         vm.expectRevert(IZoneFactory.InvalidToken.selector);
@@ -238,7 +296,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         vm.expectRevert(IZoneFactory.InvalidToken.selector);
@@ -257,7 +316,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         vm.expectRevert(IZoneFactory.InvalidToken.selector);
@@ -280,7 +340,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         vm.expectRevert(IZoneFactory.InvalidAdmin.selector);
@@ -303,7 +364,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         vm.expectRevert(IZoneFactory.InvalidSequencer.selector);
@@ -326,7 +388,8 @@ contract ZoneFactoryTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: uint64(block.number)
             }),
-            rpcUrl: ""
+            rpcUrl: "",
+            adminSignature: ""
         });
 
         vm.expectRevert(IZoneFactory.InvalidVerifier.selector);
@@ -353,6 +416,20 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(info.portal, address(0));
         assertEq(info.messenger, address(0));
         assertEq(info.initialToken, address(0));
+    }
+
+    function _signCreateZone(
+        uint256 privateKey,
+        IZoneFactory.CreateZoneParams memory params,
+        address caller
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 digest = zoneFactory.zoneCreationDigest(params, caller);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return bytes.concat(r, s, bytes1(v));
     }
 
 }

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -162,6 +162,7 @@ contract ZonePortalTest is BaseTest {
 
         // Create a zone
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            salt: bytes32(0),
             initialToken: address(pathUSD),
             admin: admin,
             sequencer: admin, // admin is the sequencer for tests

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -172,7 +172,8 @@ contract ZonePortalTest is BaseTest {
                 genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
                 genesisTempoBlockNumber: genesisTempoBlockNumber
             }),
-            rpcUrl: "https://rpc.test-zone.example"
+            rpcUrl: "https://rpc.test-zone.example",
+            adminSignature: ""
         });
 
         address portalAddr;

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -803,7 +803,7 @@ Every RPC request must include an authorization token in the `X-Authorization-To
 
 The signed message is `keccak256` of a packed encoding containing a `"TempoZoneRPC"` magic prefix, a version byte (currently `0`), the `zoneId`, `chainId`, `issuedAt`, and `expiresAt` timestamps. The wire format concatenates the signature and the 29-byte token fields, with the token fields always at the end.
 
-A `zoneId` of `0` indicates an unscoped token valid for any zone. Zone IDs start at 1, so `0` is never a valid zone ID. The maximum validity window is 30 days (`expiresAt - issuedAt <= 2592000`). A clock skew tolerance of 60 seconds is allowed for `issuedAt`.
+A `zoneId` of `0` indicates an unscoped token valid for any zone. Zone creation rejects a derived `zoneId` of `0`, so `0` is never a valid zone ID. The maximum validity window is 30 days (`expiresAt - issuedAt <= 2592000`). A clock skew tolerance of 60 seconds is allowed for `issuedAt`.
 
 The RPC server rejects authorization tokens where:
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -170,6 +170,8 @@ sequenceDiagram
 
 Each zone has two privileged roles registered on the [`ZonePortal`](#izoneportal): an **admin** and a **sequencer**. The roles are intentionally separated so that mission-critical governance powers can be held in a cold key (or multisig) while day-to-day block production runs from a hot operational key. The two roles MAY be held by the same address; the protocol does not enforce separation.
 
+Zone creation is permissionless. Any account MAY call [`IZoneFactory.createZone`](#izonefactory), and the caller does not receive any implicit authority unless it is also specified as `admin` or `sequencer`. This allows delegated deployment by relayers or deployment tooling while keeping zone authority bound to the explicit role parameters.
+
 ### Roles
 
 **Admin.**
@@ -221,13 +223,14 @@ A zone is created via `ZoneFactory.createZone(...)` on Tempo with the following 
 
 | Parameter | Description |
 |-----------|-------------|
+| `salt` | Admin-scoped salt used to derive the zone ID. |
 | `initialToken` | The first TIP-20 token to enable. The admin can enable additional tokens later. |
 | `admin` | The address that holds the admin role for the zone (token enablement, deposit pause/resume). MUST NOT be the zero address. May be the same as `sequencer`. See [Access Control](#access-control). |
 | `sequencer` | The address that will operate the zone (block production, batch submission, withdrawal processing). |
 | `verifier` | The `IVerifier` contract used to validate batch proofs. |
 | `zoneParams` | Genesis configuration: genesis block hash, genesis Tempo block hash, and genesis Tempo block number. |
 
-The factory assigns a unique `zoneId`, deploys a [`ZonePortal`](#izoneportal) and a [`ZoneMessenger`](#izonemessenger), and enables the initial token. The [`ZoneCreated`](#izonefactory) event emits all deployment parameters.
+The factory derives `zoneId = uint32(uint256(keccak256(abi.encode(admin, salt))))`, deploys a [`ZonePortal`](#izoneportal) and a [`ZoneMessenger`](#izonemessenger), and enables the initial token. If the derived ID is zero or already exists, creation reverts. Binding the ID to `admin` prevents a third party from front-running a deployment and consuming the intended zone ID or chain ID; callers can still deploy on behalf of the admin by using the admin's chosen salt. Portal and messenger addresses are emitted by [`ZoneCreated`](#izonefactory) and MUST be consumed from the event rather than assumed before confirmation.
 
 ### Chain ID
 
@@ -1503,19 +1506,23 @@ struct LastBatch {
 ```solidity
 interface IZoneFactory {
     struct CreateZoneParams {
+        bytes32 salt;
         address initialToken;
+        address admin;
         address sequencer;
         address verifier;
         ZoneParams zoneParams;
+        string rpcUrl;
     }
 
     event ZoneCreated(
         uint32 indexed zoneId, address indexed portal, address indexed messenger,
-        address initialToken, address sequencer, address verifier,
+        address initialToken, address admin, address sequencer, address verifier,
         bytes32 genesisBlockHash, bytes32 genesisTempoBlockHash, uint64 genesisTempoBlockNumber
     );
 
     function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
+    function computeZoneId(address admin, bytes32 salt) external pure returns (uint32);
     function zoneCount() external view returns (uint32);
     function zones(uint32 zoneId) external view returns (ZoneInfo memory);
     function isZonePortal(address portal) external view returns (bool);

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -170,7 +170,7 @@ sequenceDiagram
 
 Each zone has two privileged roles registered on the [`ZonePortal`](#izoneportal): an **admin** and a **sequencer**. The roles are intentionally separated so that mission-critical governance powers can be held in a cold key (or multisig) while day-to-day block production runs from a hot operational key. The two roles MAY be held by the same address; the protocol does not enforce separation.
 
-Zone creation is permissionless. Any account MAY call [`IZoneFactory.createZone`](#izonefactory), and the caller does not receive any implicit authority unless it is also specified as `admin` or `sequencer`. This allows delegated deployment by relayers or deployment tooling while keeping zone authority bound to the explicit role parameters.
+Zone creation supports both direct and delegated deployment. The admin MAY call [`IZoneFactory.createZone`](#izonefactory) directly, or any relayer MAY call it with an admin authorization signature over the full creation payload and the relayer address. The caller does not receive any implicit authority unless it is also specified as `admin` or `sequencer`. This allows relayers and deployment tooling to pay gas while keeping zone authority bound to the explicit role parameters.
 
 ### Roles
 
@@ -229,8 +229,9 @@ A zone is created via `ZoneFactory.createZone(...)` on Tempo with the following 
 | `sequencer` | The address that will operate the zone (block production, batch submission, withdrawal processing). |
 | `verifier` | The `IVerifier` contract used to validate batch proofs. |
 | `zoneParams` | Genesis configuration: genesis block hash, genesis Tempo block hash, and genesis Tempo block number. |
+| `adminSignature` | Empty when `msg.sender == admin`; otherwise an EOA signature or EIP-1271 contract signature from `admin` authorizing the exact creation payload and caller. |
 
-The factory derives `zoneId = uint32(uint256(keccak256(abi.encode(admin, salt))))`, deploys a [`ZonePortal`](#izoneportal) and a [`ZoneMessenger`](#izonemessenger), and enables the initial token. If the derived ID is zero or already exists, creation reverts. Binding the ID to `admin` prevents a third party from front-running a deployment and consuming the intended zone ID or chain ID; callers can still deploy on behalf of the admin by using the admin's chosen salt. Portal and messenger addresses are emitted by [`ZoneCreated`](#izonefactory) and MUST be consumed from the event rather than assumed before confirmation.
+The factory derives `zoneId = uint32(uint256(keccak256(abi.encode(admin, salt))))`, deploys a [`ZonePortal`](#izoneportal) and a [`ZoneMessenger`](#izonemessenger), and enables the initial token. If the derived ID is zero or already exists, creation reverts. Binding the ID to `admin` prevents a third party from front-running a deployment and consuming the intended zone ID or chain ID with its own admin. Binding the admin signature to the exact `msg.sender` prevents another relayer from copying the salt and signature to consume the admin's intended ID with different deployment parameters. Portal and messenger addresses are emitted by [`ZoneCreated`](#izonefactory) and MUST be consumed from the event rather than assumed before confirmation.
 
 ### Chain ID
 
@@ -1513,6 +1514,7 @@ interface IZoneFactory {
         address verifier;
         ZoneParams zoneParams;
         string rpcUrl;
+        bytes adminSignature;
     }
 
     event ZoneCreated(
@@ -1523,6 +1525,7 @@ interface IZoneFactory {
 
     function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
     function computeZoneId(address admin, bytes32 salt) external pure returns (uint32);
+    function zoneCreationDigest(CreateZoneParams calldata params, address caller) external view returns (bytes32);
     function zoneCount() external view returns (uint32);
     function zones(uint32 zoneId) external view returns (ZoneInfo memory);
     function isZonePortal(address portal) external view returns (bool);

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -7,7 +7,7 @@ use alloy::{
         EthereumWallet,
         primitives::{HeaderResponse, ReceiptResponse},
     },
-    primitives::{Address, B256, address},
+    primitives::{Address, B256, Bytes, address},
     providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
     sol,
@@ -36,6 +36,7 @@ sol! {
         address verifier;
         ZoneParams zoneParams;
         string rpcUrl;
+        bytes adminSignature;
     }
 
     #[sol(rpc)]
@@ -55,6 +56,7 @@ sol! {
 
         function verifier() external view returns (address);
         function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
+        function zoneCreationDigest(CreateZoneParams calldata params, address caller) external view returns (bytes32);
     }
 }
 
@@ -89,6 +91,11 @@ pub(crate) struct CreateZone {
     /// Admin-scoped salt for deterministic zone ID derivation.
     #[arg(long, default_value_t = B256::ZERO)]
     salt: B256,
+
+    /// Admin authorization signature for delegated deployment.
+    /// Required when the transaction signer is not the admin.
+    #[arg(long)]
+    admin_signature: Option<Bytes>,
 
     /// Public RPC endpoint for the zone, published on-chain in the portal.
     /// Can be left empty and set later via `ZonePortal.setRpcUrl`.
@@ -152,6 +159,7 @@ impl CreateZone {
                 genesisTempoBlockNumber: current_block,
             },
             rpcUrl: self.rpc_url.clone(),
+            adminSignature: self.admin_signature.unwrap_or_default(),
         };
 
         println!(

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -86,6 +86,10 @@ pub(crate) struct CreateZone {
     #[arg(long)]
     admin: Option<Address>,
 
+    /// Admin-scoped salt for deterministic zone ID derivation.
+    #[arg(long, default_value_t = B256::ZERO)]
+    salt: B256,
+
     /// Public RPC endpoint for the zone, published on-chain in the portal.
     /// Can be left empty and set later via `ZonePortal.setRpcUrl`.
     #[arg(long, default_value = "")]
@@ -137,7 +141,7 @@ impl CreateZone {
         println!("Sequencer: {}", self.sequencer);
 
         let params = CreateZoneParams {
-            salt: B256::ZERO,
+            salt: self.salt,
             initialToken: self.initial_token,
             admin,
             sequencer: self.sequencer,

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -29,6 +29,7 @@ sol! {
     }
 
     struct CreateZoneParams {
+        bytes32 salt;
         address initialToken;
         address admin;
         address sequencer;
@@ -136,6 +137,7 @@ impl CreateZone {
         println!("Sequencer: {}", self.sequencer);
 
         let params = CreateZoneParams {
+            salt: B256::ZERO,
             initialToken: self.initial_token,
             admin,
             sequencer: self.sequencer,


### PR DESCRIPTION
## Summary
- derive zone IDs from admin and salt instead of factory order
- keep delegated deployment via admin authorization signatures bound to the caller and full create payload
- update docs, scripts, bindings, and tests for salt/signature flow

## Tests
- forge test --match-contract ZoneFactoryTest
- cargo check -p tempo-zone-contracts
- cargo check -p tempo-xtask

Prompted by: @grandizzy