### PR TITLE
fix: restrict TempoStateReader callers

### DIFF
--- a/crates/contracts/src/precompiles/tempo_state_reader.rs
+++ b/crates/contracts/src/precompiles/tempo_state_reader.rs
@@ -2,11 +2,17 @@
 //!
 //! Separate from [`TempoState`](crate::precompiles::tempo_state::TempoState); reads Tempo L1
 //! storage at a caller-specified block.
+//!
+//! Access is restricted to the TempoState wrapper. Caller authorization is handled by that wrapper,
+//! not by this reader.
 
 crate::sol! {
     #[derive(Debug)]
     contract TempoStateReader {
+        /// Returned when the precompile is invoked via `DELEGATECALL`.
         error DelegateCallNotAllowed();
+
+        /// Returned when the caller is not TempoState.
         error Unauthorized();
 
         function readStorageAt(address account, bytes32 slot, uint64 blockNumber) external view returns (bytes32);

--- a/crates/contracts/src/precompiles/tempo_state_reader.rs
+++ b/crates/contracts/src/precompiles/tempo_state_reader.rs
@@ -7,6 +7,7 @@ crate::sol! {
     #[derive(Debug)]
     contract TempoStateReader {
         error DelegateCallNotAllowed();
+        error Unauthorized();
 
         function readStorageAt(address account, bytes32 slot, uint64 blockNumber) external view returns (bytes32);
         function readStorageBatchAt(address account, bytes32[] calldata slots, uint64 blockNumber) external view returns (bytes32[] memory);

--- a/crates/l1/src/state/precompile.rs
+++ b/crates/l1/src/state/precompile.rs
@@ -1,9 +1,10 @@
 //! `DynPrecompile` implementation for the TempoStateReader.
 //!
 //! The TempoStateReader is a **standalone precompile** (separate from the TempoState contract)
-//! that allows zone system contracts to read Tempo L1 contract storage at a specific block height
-//! during EVM execution. The caller provides the L1 block number to query, making the precompile
-//! fully stateless.
+//! that reads Tempo L1 contract storage at a specific block height during EVM execution. The
+//! normal access path is through the TempoState wrapper, which validates its caller before
+//! forwarding to this precompile with the current Tempo L1 block number. The precompile only
+//! accepts calls from the TempoState wrapper and rejects all other callers.
 //!
 //! This precompile implements two functions:
 //!
@@ -29,7 +30,7 @@ use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolError};
 use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, error, warn};
-use zone_primitives::constants::{ZONE_CONFIG_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
+use zone_primitives::constants::TEMPO_STATE_ADDRESS;
 
 use super::provider::L1StateProvider;
 
@@ -43,7 +44,7 @@ alloy_sol_types::sol! {
     /// Returned when the precompile is invoked via `DELEGATECALL` instead of `CALL`.
     error DelegateCallNotAllowed();
 
-    /// Returned when the caller is not a zone system contract.
+    /// Returned when the caller is not TempoState.
     error Unauthorized();
 }
 
@@ -60,13 +61,14 @@ const PER_SLOT_GAS: u64 = 200;
 /// contract storage via an [`L1StateProvider`].
 ///
 /// The caller provides the L1 block number to query, making the precompile fully stateless.
-/// Zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig) pass the `tempoBlockNumber` from the
-/// TempoState contract after `finalizeTempo` has been called.
+/// Contracts that need L1 state should call the TempoState wrapper, which forwards to this
+/// precompile after `finalizeTempo` has updated `tempoBlockNumber`.
 ///
 /// # Restrictions
 ///
 /// - Only direct `CALL`s are accepted; `DELEGATECALL` reverts with [`DelegateCallNotAllowed`].
-/// - Only ZoneInbox, ZoneOutbox, and ZoneConfig may call this precompile directly.
+/// - Only TempoState may call this precompile directly. Caller authorization is handled by that
+///   wrapper, not by this reader.
 /// - The precompile is **view-only** — it never writes to EVM state.
 /// - On cache miss the provider retries the RPC fetch indefinitely with backoff, stalling
 ///   block production until L1 connectivity is restored.
@@ -92,12 +94,7 @@ impl TempoStateReader {
                     ));
                 }
 
-                if !Self::is_allowed_system_caller(input.caller) {
-                    warn!(
-                        target: "zone::precompile",
-                        caller = %input.caller,
-                        "TempoStateReader called by non-system contract — rejecting"
-                    );
+                if !Self::is_allowed_caller(input.caller) {
                     return Ok(PrecompileOutput::revert(
                         0,
                         Unauthorized {}.abi_encode().into(),
@@ -139,11 +136,9 @@ impl TempoStateReader {
         )
     }
 
-    fn is_allowed_system_caller(caller: Address) -> bool {
-        matches!(
-            caller,
-            ZONE_INBOX_ADDRESS | ZONE_OUTBOX_ADDRESS | ZONE_CONFIG_ADDRESS
-        )
+    /// Only the TempoState wrapper may call this reader directly.
+    fn is_allowed_caller(caller: Address) -> bool {
+        caller == TEMPO_STATE_ADDRESS
     }
 
     /// Handle a `readStorageAt(address, bytes32, uint64)` call.
@@ -215,231 +210,24 @@ impl TempoStateReader {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    use std::collections::HashSet;
-
-    use alloy_evm::{
-        EvmInternals,
-        precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},
+    use super::TempoStateReader;
+    use alloy_primitives::{Address, address};
+    use zone_primitives::constants::{
+        TEMPO_STATE_ADDRESS, ZONE_CONFIG_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
     };
-    use alloy_primitives::{B256, U256, address};
-    use alloy_provider::{Provider, ProviderBuilder};
-    use alloy_rpc_client::RpcClient;
-    use alloy_sol_types::{SolCall, SolError};
-    use alloy_transport::mock::Asserter;
-    use revm::{
-        Context,
-        database::{CacheDB, EmptyDB},
-        precompile::{PrecompileOutput, PrecompileResult},
-    };
-    use tempo_alloy::TempoNetwork;
-    use zone_primitives::constants::TEMPO_STATE_READER_ADDRESS;
-
-    use super::super::{L1StateCache, L1StateProviderConfig};
-
-    type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
-    type TestContext = Context<
-        revm::context::BlockEnv,
-        revm::context::TxEnv,
-        revm::context::CfgEnv,
-        CacheDB<EmptyDB>,
-    >;
-
-    const BLOCK_NUMBER: u64 = 42;
-
-    fn l1_account() -> Address {
-        address!("0x0000000000000000000000000000000000001000")
-    }
 
     fn outsider() -> Address {
         address!("0x0000000000000000000000000000000000009999")
     }
 
-    fn slot_a() -> B256 {
-        B256::with_last_byte(0x01)
-    }
-
-    fn slot_b() -> B256 {
-        B256::with_last_byte(0x02)
-    }
-
-    fn value_a() -> B256 {
-        B256::with_last_byte(0xaa)
-    }
-
-    fn value_b() -> B256 {
-        B256::with_last_byte(0xbb)
-    }
-
-    fn single_slot_calldata() -> Bytes {
-        readStorageAtCall {
-            account: l1_account(),
-            slot: slot_a(),
-            blockNumber: BLOCK_NUMBER,
-        }
-        .abi_encode()
-        .into()
-    }
-
-    fn batch_calldata() -> Bytes {
-        readStorageBatchAtCall {
-            account: l1_account(),
-            slots: vec![slot_a(), slot_b()],
-            blockNumber: BLOCK_NUMBER,
-        }
-        .abi_encode()
-        .into()
-    }
-
-    struct PrecompileHarness {
-        ctx: TestContext,
-        precompile: DynPrecompile,
-        _rpc_asserter: Asserter,
-        _runtime: tokio::runtime::Runtime,
-    }
-
-    impl PrecompileHarness {
-        fn new() -> TestResult<Self> {
-            let cache = L1StateCache::new(HashSet::from([l1_account()]));
-            {
-                let mut cache = cache.write();
-                cache.set(l1_account(), slot_a(), BLOCK_NUMBER, value_a());
-                cache.set(l1_account(), slot_b(), BLOCK_NUMBER, value_b());
-            }
-
-            let rpc_asserter = Asserter::new();
-            let rpc = ProviderBuilder::new_with_network::<TempoNetwork>()
-                .connect_client(RpcClient::mocked(rpc_asserter.clone()))
-                .erased();
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()?;
-            let provider = L1StateProvider::new_raw(
-                L1StateProviderConfig::default(),
-                cache,
-                rpc,
-                runtime.handle().clone(),
-            );
-
-            Ok(Self {
-                ctx: Context::new(
-                    CacheDB::new(EmptyDB::new()),
-                    revm::primitives::hardfork::SpecId::default(),
-                ),
-                precompile: TempoStateReader::create(provider),
-                _rpc_asserter: rpc_asserter,
-                _runtime: runtime,
-            })
-        }
-
-        fn direct_call(&mut self, caller: Address, calldata: Bytes) -> PrecompileResult {
-            self.call(caller, calldata, true)
-        }
-
-        fn delegate_call(&mut self, caller: Address, calldata: Bytes) -> PrecompileResult {
-            self.call(caller, calldata, false)
-        }
-
-        fn call(
-            &mut self,
-            caller: Address,
-            calldata: Bytes,
-            is_direct_call: bool,
-        ) -> PrecompileResult {
-            let bytecode_address = if is_direct_call {
-                TEMPO_STATE_READER_ADDRESS
-            } else {
-                address!("0x000000000000000000000000000000000000dead")
-            };
-
-            AlloyEvmPrecompile::call(
-                &self.precompile,
-                PrecompileInput {
-                    data: &calldata,
-                    caller,
-                    internals: EvmInternals::from_context(&mut self.ctx),
-                    gas: 100_000,
-                    reservoir: 0,
-                    value: U256::ZERO,
-                    is_static: true,
-                    target_address: TEMPO_STATE_READER_ADDRESS,
-                    bytecode_address,
-                },
-            )
-        }
-    }
-
-    fn assert_unauthorized(output: PrecompileOutput) {
-        assert!(output.is_revert());
-        assert_eq!(output.bytes, Bytes::from(Unauthorized {}.abi_encode()));
-    }
-
-    fn assert_delegatecall_rejected(output: PrecompileOutput) {
-        assert!(output.is_revert());
-        assert_eq!(
-            output.bytes,
-            Bytes::from(DelegateCallNotAllowed {}.abi_encode())
-        );
-    }
-
     #[test]
-    fn non_system_direct_caller_cannot_read_single_slot() -> TestResult {
-        let mut harness = PrecompileHarness::new()?;
-
-        let output = harness.direct_call(outsider(), single_slot_calldata())?;
-
-        assert_unauthorized(output);
-        Ok(())
-    }
-
-    #[test]
-    fn non_system_direct_caller_cannot_read_batch() -> TestResult {
-        let mut harness = PrecompileHarness::new()?;
-
-        let output = harness.direct_call(outsider(), batch_calldata())?;
-
-        assert_unauthorized(output);
-        Ok(())
-    }
-
-    #[test]
-    fn system_callers_can_read_single_slot() -> TestResult {
-        let mut harness = PrecompileHarness::new()?;
+    fn only_tempo_state_wrapper_is_allowed() {
+        assert!(TempoStateReader::is_allowed_caller(TEMPO_STATE_ADDRESS));
 
         for caller in [ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_CONFIG_ADDRESS] {
-            let output = harness.direct_call(caller, single_slot_calldata())?;
-
-            assert!(!output.is_revert());
-            let decoded = readStorageAtCall::abi_decode_returns(&output.bytes)?;
-            assert_eq!(decoded, value_a());
+            assert!(!TempoStateReader::is_allowed_caller(caller));
         }
 
-        Ok(())
-    }
-
-    #[test]
-    fn system_callers_can_read_batch() -> TestResult {
-        let mut harness = PrecompileHarness::new()?;
-
-        for caller in [ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_CONFIG_ADDRESS] {
-            let output = harness.direct_call(caller, batch_calldata())?;
-
-            assert!(!output.is_revert());
-            let decoded = readStorageBatchAtCall::abi_decode_returns(&output.bytes)?;
-            assert_eq!(decoded, vec![value_a(), value_b()]);
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn delegatecall_rejection_is_preserved() -> TestResult {
-        let mut harness = PrecompileHarness::new()?;
-
-        let output = harness.delegate_call(outsider(), single_slot_calldata())?;
-
-        assert_delegatecall_rejected(output);
-        Ok(())
+        assert!(!TempoStateReader::is_allowed_caller(outsider()));
     }
 }

--- a/crates/l1/src/state/precompile.rs
+++ b/crates/l1/src/state/precompile.rs
@@ -25,10 +25,11 @@
 //! [`L1StateProvider`]: super::provider::L1StateProvider
 
 use alloy_evm::precompiles::DynPrecompile;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
 use alloy_sol_types::{SolCall, SolError};
 use revm::precompile::{PrecompileId, PrecompileOutput, PrecompileResult};
 use tracing::{debug, error, warn};
+use zone_primitives::constants::{ZONE_CONFIG_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
 use super::provider::L1StateProvider;
 
@@ -41,6 +42,9 @@ alloy_sol_types::sol! {
 
     /// Returned when the precompile is invoked via `DELEGATECALL` instead of `CALL`.
     error DelegateCallNotAllowed();
+
+    /// Returned when the caller is not a zone system contract.
+    error Unauthorized();
 }
 
 /// Fixed gas cost charged on every call.
@@ -56,12 +60,13 @@ const PER_SLOT_GAS: u64 = 200;
 /// contract storage via an [`L1StateProvider`].
 ///
 /// The caller provides the L1 block number to query, making the precompile fully stateless.
-/// Zone system contracts (ZoneInbox, ZoneConfig) pass the `tempoBlockNumber` from the
+/// Zone system contracts (ZoneInbox, ZoneOutbox, ZoneConfig) pass the `tempoBlockNumber` from the
 /// TempoState contract after `finalizeTempo` has been called.
 ///
 /// # Restrictions
 ///
 /// - Only direct `CALL`s are accepted; `DELEGATECALL` reverts with [`DelegateCallNotAllowed`].
+/// - Only ZoneInbox, ZoneOutbox, and ZoneConfig may call this precompile directly.
 /// - The precompile is **view-only** — it never writes to EVM state.
 /// - On cache miss the provider retries the RPC fetch indefinitely with backoff, stalling
 ///   block production until L1 connectivity is restored.
@@ -83,6 +88,19 @@ impl TempoStateReader {
                     return Ok(PrecompileOutput::revert(
                         0,
                         DelegateCallNotAllowed {}.abi_encode().into(),
+                        input.reservoir,
+                    ));
+                }
+
+                if !Self::is_allowed_system_caller(input.caller) {
+                    warn!(
+                        target: "zone::precompile",
+                        caller = %input.caller,
+                        "TempoStateReader called by non-system contract — rejecting"
+                    );
+                    return Ok(PrecompileOutput::revert(
+                        0,
+                        Unauthorized {}.abi_encode().into(),
                         input.reservoir,
                     ));
                 }
@@ -118,6 +136,13 @@ impl TempoStateReader {
 
                 result
             },
+        )
+    }
+
+    fn is_allowed_system_caller(caller: Address) -> bool {
+        matches!(
+            caller,
+            ZONE_INBOX_ADDRESS | ZONE_OUTBOX_ADDRESS | ZONE_CONFIG_ADDRESS
         )
     }
 
@@ -185,5 +210,236 @@ impl TempoStateReader {
 
         let encoded = readStorageBatchAtCall::abi_encode_returns(&results);
         Ok(PrecompileOutput::new(gas, encoded.into(), reservoir))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashSet;
+
+    use alloy_evm::{
+        EvmInternals,
+        precompiles::{Precompile as AlloyEvmPrecompile, PrecompileInput},
+    };
+    use alloy_primitives::{B256, U256, address};
+    use alloy_provider::{Provider, ProviderBuilder};
+    use alloy_rpc_client::RpcClient;
+    use alloy_sol_types::{SolCall, SolError};
+    use alloy_transport::mock::Asserter;
+    use revm::{
+        Context,
+        database::{CacheDB, EmptyDB},
+        precompile::{PrecompileOutput, PrecompileResult},
+    };
+    use tempo_alloy::TempoNetwork;
+    use zone_primitives::constants::TEMPO_STATE_READER_ADDRESS;
+
+    use super::super::{L1StateCache, L1StateProviderConfig};
+
+    type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+    type TestContext = Context<
+        revm::context::BlockEnv,
+        revm::context::TxEnv,
+        revm::context::CfgEnv,
+        CacheDB<EmptyDB>,
+    >;
+
+    const BLOCK_NUMBER: u64 = 42;
+
+    fn l1_account() -> Address {
+        address!("0x0000000000000000000000000000000000001000")
+    }
+
+    fn outsider() -> Address {
+        address!("0x0000000000000000000000000000000000009999")
+    }
+
+    fn slot_a() -> B256 {
+        B256::with_last_byte(0x01)
+    }
+
+    fn slot_b() -> B256 {
+        B256::with_last_byte(0x02)
+    }
+
+    fn value_a() -> B256 {
+        B256::with_last_byte(0xaa)
+    }
+
+    fn value_b() -> B256 {
+        B256::with_last_byte(0xbb)
+    }
+
+    fn single_slot_calldata() -> Bytes {
+        readStorageAtCall {
+            account: l1_account(),
+            slot: slot_a(),
+            blockNumber: BLOCK_NUMBER,
+        }
+        .abi_encode()
+        .into()
+    }
+
+    fn batch_calldata() -> Bytes {
+        readStorageBatchAtCall {
+            account: l1_account(),
+            slots: vec![slot_a(), slot_b()],
+            blockNumber: BLOCK_NUMBER,
+        }
+        .abi_encode()
+        .into()
+    }
+
+    struct PrecompileHarness {
+        ctx: TestContext,
+        precompile: DynPrecompile,
+        _rpc_asserter: Asserter,
+        _runtime: tokio::runtime::Runtime,
+    }
+
+    impl PrecompileHarness {
+        fn new() -> TestResult<Self> {
+            let cache = L1StateCache::new(HashSet::from([l1_account()]));
+            {
+                let mut cache = cache.write();
+                cache.set(l1_account(), slot_a(), BLOCK_NUMBER, value_a());
+                cache.set(l1_account(), slot_b(), BLOCK_NUMBER, value_b());
+            }
+
+            let rpc_asserter = Asserter::new();
+            let rpc = ProviderBuilder::new_with_network::<TempoNetwork>()
+                .connect_client(RpcClient::mocked(rpc_asserter.clone()))
+                .erased();
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            let provider = L1StateProvider::new_raw(
+                L1StateProviderConfig::default(),
+                cache,
+                rpc,
+                runtime.handle().clone(),
+            );
+
+            Ok(Self {
+                ctx: Context::new(
+                    CacheDB::new(EmptyDB::new()),
+                    revm::primitives::hardfork::SpecId::default(),
+                ),
+                precompile: TempoStateReader::create(provider),
+                _rpc_asserter: rpc_asserter,
+                _runtime: runtime,
+            })
+        }
+
+        fn direct_call(&mut self, caller: Address, calldata: Bytes) -> PrecompileResult {
+            self.call(caller, calldata, true)
+        }
+
+        fn delegate_call(&mut self, caller: Address, calldata: Bytes) -> PrecompileResult {
+            self.call(caller, calldata, false)
+        }
+
+        fn call(
+            &mut self,
+            caller: Address,
+            calldata: Bytes,
+            is_direct_call: bool,
+        ) -> PrecompileResult {
+            let bytecode_address = if is_direct_call {
+                TEMPO_STATE_READER_ADDRESS
+            } else {
+                address!("0x000000000000000000000000000000000000dead")
+            };
+
+            AlloyEvmPrecompile::call(
+                &self.precompile,
+                PrecompileInput {
+                    data: &calldata,
+                    caller,
+                    internals: EvmInternals::from_context(&mut self.ctx),
+                    gas: 100_000,
+                    reservoir: 0,
+                    value: U256::ZERO,
+                    is_static: true,
+                    target_address: TEMPO_STATE_READER_ADDRESS,
+                    bytecode_address,
+                },
+            )
+        }
+    }
+
+    fn assert_unauthorized(output: PrecompileOutput) {
+        assert!(output.is_revert());
+        assert_eq!(output.bytes, Bytes::from(Unauthorized {}.abi_encode()));
+    }
+
+    fn assert_delegatecall_rejected(output: PrecompileOutput) {
+        assert!(output.is_revert());
+        assert_eq!(
+            output.bytes,
+            Bytes::from(DelegateCallNotAllowed {}.abi_encode())
+        );
+    }
+
+    #[test]
+    fn non_system_direct_caller_cannot_read_single_slot() -> TestResult {
+        let mut harness = PrecompileHarness::new()?;
+
+        let output = harness.direct_call(outsider(), single_slot_calldata())?;
+
+        assert_unauthorized(output);
+        Ok(())
+    }
+
+    #[test]
+    fn non_system_direct_caller_cannot_read_batch() -> TestResult {
+        let mut harness = PrecompileHarness::new()?;
+
+        let output = harness.direct_call(outsider(), batch_calldata())?;
+
+        assert_unauthorized(output);
+        Ok(())
+    }
+
+    #[test]
+    fn system_callers_can_read_single_slot() -> TestResult {
+        let mut harness = PrecompileHarness::new()?;
+
+        for caller in [ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_CONFIG_ADDRESS] {
+            let output = harness.direct_call(caller, single_slot_calldata())?;
+
+            assert!(!output.is_revert());
+            let decoded = readStorageAtCall::abi_decode_returns(&output.bytes)?;
+            assert_eq!(decoded, value_a());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn system_callers_can_read_batch() -> TestResult {
+        let mut harness = PrecompileHarness::new()?;
+
+        for caller in [ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_CONFIG_ADDRESS] {
+            let output = harness.direct_call(caller, batch_calldata())?;
+
+            assert!(!output.is_revert());
+            let decoded = readStorageBatchAtCall::abi_decode_returns(&output.bytes)?;
+            assert_eq!(decoded, vec![value_a(), value_b()]);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn delegatecall_rejection_is_preserved() -> TestResult {
+        let mut harness = PrecompileHarness::new()?;
+
+        let output = harness.delegate_call(outsider(), single_slot_calldata())?;
+
+        assert_delegatecall_rejected(output);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
Restricts the standalone `TempoStateReader` precompile to the `TempoState` wrapper only. Contracts that need Tempo L1 state must read through `TempoState`, which validates its caller and forwards reads with the current `tempoBlockNumber`.

## Root Cause
The reader precompile rejected delegatecall but accepted direct calls from unauthorized EVM callers, so user transactions could bypass the wrapper-only caller check and trigger L1 storage reads with caller-selected inputs.

## Impact
Unauthorized direct callers are rejected at the precompile boundary. Legitimate wrapper-forwarded reads from `TempoState` continue to work.