### PR TITLE
fix: meter AES-GCM AAD gas

### DIFF
--- a/crates/precompiles/src/aes_gcm.rs
+++ b/crates/precompiles/src/aes_gcm.rs
@@ -25,7 +25,7 @@ pub const AES_GCM_DECRYPT_ADDRESS: Address = address!("0x1C000000000000000000000
 /// Base gas cost for AES-GCM decryption.
 const AES_GCM_BASE_GAS: u64 = 1_000;
 
-/// Additional gas per byte of ciphertext.
+/// Additional gas per byte of authenticated AES-GCM input.
 const AES_GCM_PER_BYTE_GAS: u64 = 3;
 
 /// Precompile identifier.
@@ -73,7 +73,8 @@ impl Precompile for AesGcmDecrypt {
             Err(_) => return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir)),
         };
 
-        let gas = AES_GCM_BASE_GAS + AES_GCM_PER_BYTE_GAS * call.ciphertext.len() as u64;
+        let gas = AES_GCM_BASE_GAS
+            + AES_GCM_PER_BYTE_GAS * (call.ciphertext.len() + call.aad.len()) as u64;
 
         let (plaintext, valid) = decrypt_aes_gcm(
             &call.key.0,
@@ -141,6 +142,68 @@ pub fn decrypt_aes_gcm(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_evm::EvmInternals;
+    use alloy_primitives::U256;
+    use revm::{
+        Context,
+        database::{CacheDB, EmptyDB},
+        precompile::PrecompileOutput,
+    };
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    type TestContext = Context<
+        revm::context::BlockEnv,
+        revm::context::TxEnv,
+        revm::context::CfgEnv<TempoHardfork>,
+        CacheDB<EmptyDB>,
+    >;
+
+    fn test_context() -> TestContext {
+        Context::new(CacheDB::new(EmptyDB::new()), TempoHardfork::default())
+    }
+
+    fn encrypt(plaintext: &[u8], aad: &[u8]) -> decryptCall {
+        let key = [0x42u8; 32];
+        let nonce_bytes = [0x01u8; 12];
+        let cipher = Aes256Gcm::new((&key).into());
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let encrypted = cipher
+            .encrypt(
+                nonce,
+                Payload {
+                    msg: plaintext,
+                    aad,
+                },
+            )
+            .expect("encrypt");
+        let ct = &encrypted[..encrypted.len() - 16];
+        let tag: [u8; 16] = encrypted[encrypted.len() - 16..].try_into().unwrap();
+
+        decryptCall {
+            key: key.into(),
+            nonce: nonce_bytes.into(),
+            ciphertext: Bytes::copy_from_slice(ct),
+            aad: Bytes::copy_from_slice(aad),
+            tag: tag.into(),
+        }
+    }
+
+    fn call_precompile(calldata: Bytes) -> PrecompileOutput {
+        let mut ctx = test_context();
+        AesGcmDecrypt
+            .call(PrecompileInput {
+                data: &calldata,
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: AES_GCM_DECRYPT_ADDRESS,
+                is_static: true,
+                bytecode_address: AES_GCM_DECRYPT_ADDRESS,
+                internals: EvmInternals::from_context(&mut ctx),
+            })
+            .expect("precompile call succeeds")
+    }
 
     #[test]
     fn test_aes_gcm_roundtrip() {
@@ -203,6 +266,42 @@ mod tests {
         let (decrypted, valid) = decrypt_aes_gcm(&key, &nonce_bytes, ct, aad, &tag);
         assert!(valid);
         assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn precompile_gas_charges_aad_bytes() {
+        let plaintext = b"";
+        let aad = vec![0xA5; 128];
+        let call = encrypt(plaintext, &aad);
+        let ciphertext_len = call.ciphertext.len();
+        let aad_len = call.aad.len();
+
+        let output = call_precompile(call.abi_encode().into());
+        let decoded = decryptCall::abi_decode_returns(&output.bytes).expect("decode return");
+
+        assert!(decoded.valid);
+        assert_eq!(decoded.plaintext, Bytes::copy_from_slice(plaintext));
+        assert_eq!(
+            output.gas_used,
+            AES_GCM_BASE_GAS + AES_GCM_PER_BYTE_GAS * (ciphertext_len + aad_len) as u64
+        );
+    }
+
+    #[test]
+    fn precompile_decrypts_without_aad_and_reports_ciphertext_gas() {
+        let plaintext = b"normal precompile path";
+        let call = encrypt(plaintext, &[]);
+        let ciphertext_len = call.ciphertext.len();
+
+        let output = call_precompile(call.abi_encode().into());
+        let decoded = decryptCall::abi_decode_returns(&output.bytes).expect("decode return");
+
+        assert!(decoded.valid);
+        assert_eq!(decoded.plaintext, Bytes::copy_from_slice(plaintext));
+        assert_eq!(
+            output.gas_used,
+            AES_GCM_BASE_GAS + AES_GCM_PER_BYTE_GAS * ciphertext_len as u64
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Charges AES-GCM precompile gas for both ciphertext bytes and authenticated associated data bytes.

## Root Cause
The precompile decoded caller-controlled `aad` and passed it into AES-GCM authentication, but gas accounting only used `ciphertext.len()`. A caller could therefore make AAD arbitrarily larger without paying the existing per-byte precompile charge for that authenticated input.

## Impact
Calls with large AAD now scale gas with the amount of authenticated data processed, while normal no-AAD and ciphertext-only paths keep their existing gas behavior.