### PR TITLE
ci: harden supply chain checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - "A-dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 7
     groups:
@@ -16,6 +21,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - "A-dependencies"
+      - "A-ci"
+    commit-message:
+      prefix: "chore(ci)"
+    open-pull-requests-limit: 1
     cooldown:
       default-days: 7
     groups:
@@ -23,3 +34,15 @@ updates:
         applies-to: "version-updates"
         patterns: ["*"]
         update-types: ["minor", "patch"]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - "A-dependencies"
+    commit-message:
+      prefix: "chore(docker)"
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - uses: taiki-e/install-action@c802b5ed6fc0b87c8c603a600ac1d864e6dc1cbe # just
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: just
       - name: Build
-        run: just build ${{ matrix.binary }} "--profile ${{ inputs.profile || 'dev' }}"
+        env:
+          BINARY: ${{ matrix.binary }}
+          PROFILE: ${{ inputs.profile || 'dev' }}
+        run: just build "$BINARY" "--profile $PROFILE"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: binary_upload
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,6 +80,22 @@ jobs:
           persist-credentials: false
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
 
+  supply-chain:
+    name: supply chain
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: cargo-deny@0.19.1
+      - run: cargo deny check advisories sources bans
+
   lint-success:
     name: lint success
     runs-on: ubuntu-latest
@@ -89,6 +105,7 @@ jobs:
       - clippy
       - fmt
       - typos
+      - supply-chain
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,21 +80,10 @@ jobs:
           persist-credentials: false
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
 
-  supply-chain:
-    name: supply chain
-    runs-on: depot-ubuntu-latest
-    timeout-minutes: 30
+  deny:
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
-        with:
-          tool: cargo-deny@0.19.1
-      - run: cargo deny check advisories sources bans
+    uses: tempoxyz/ci/.github/workflows/deny.yml@f7b868401133161610784f840fbf8ba5c45fdd4e # main
 
   lint-success:
     name: lint success
@@ -105,7 +94,7 @@ jobs:
       - clippy
       - fmt
       - typos
-      - supply-chain
+      - deny
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -12,16 +12,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && (github.event.label.name == 'cyclops' || github.event.label.name == 'agentic-audit')
+    environment: pr-audit
+    permissions: {}
     steps:
       - name: Publish event
+        env:
+          EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
+          EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
+          EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          echo "${{ secrets.EVENTS_KEY }}" > ${{ runner.temp }}/key
-          echo "${{ secrets.EVENTS_CERT }}" > ${{ runner.temp }}/cert
+          echo "$EVENTS_KEY" > "${{ runner.temp }}/key"
+          echo "$EVENTS_CERT" > "${{ runner.temp }}/cert"
 
           # EVENTS_ARGS may contain additional curl arguments, not just a URL.
-          curl -sf -o /dev/null -X POST ${{ secrets.EVENTS_ARGS }} \
+          curl -sf -o /dev/null -X POST $EVENTS_ARGS \
             -H "Content-Type: application/json" \
             --key "${{ runner.temp }}/key" \
             --cert "${{ runner.temp }}/cert" \
@@ -29,8 +37,8 @@ jobs:
               "repository": "${{ github.repository }}",
               "event": "pr_audit",
               "data": {
-                "pr_number": ${{ github.event.pull_request.number }},
-                "sha": "${{ github.event.pull_request.head.sha }}"
+                "pr_number": '"$PR_NUMBER"',
+                "sha": "'"$PR_SHA"'"
               }
             }'
 
@@ -48,6 +56,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+    environment: pr-audit
     steps:
       - name: Check org membership
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -253,16 +262,19 @@ jobs:
         id: publish
         continue-on-error: true
         env:
+          EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
+          EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
+          EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
           PAYLOAD_B64: ${{ steps.args.outputs.payload-b64 }}
         run: |
           set -euo pipefail
 
-          printf '%s' '${{ secrets.EVENTS_KEY }}' > "${RUNNER_TEMP}/key"
-          printf '%s' '${{ secrets.EVENTS_CERT }}' > "${RUNNER_TEMP}/cert"
+          printf '%s' "$EVENTS_KEY" > "${RUNNER_TEMP}/key"
+          printf '%s' "$EVENTS_CERT" > "${RUNNER_TEMP}/cert"
           printf '%s' "$PAYLOAD_B64" | base64 --decode > "${RUNNER_TEMP}/pr-audit-event.json"
 
           # EVENTS_ARGS may contain additional curl arguments, not just a URL.
-          curl -sf -o /dev/null -X POST ${{ secrets.EVENTS_ARGS }} \
+          curl -sf -o /dev/null -X POST $EVENTS_ARGS \
             -H "Content-Type: application/json" \
             --key "${RUNNER_TEMP}/key" \
             --cert "${RUNNER_TEMP}/cert" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,13 @@ jobs:
     steps:
       - name: Get version from tag
         id: get_version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "version=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
   check-version:
     name: check version
@@ -60,8 +62,10 @@ jobs:
       - name: Verify crate version matches tag
         # Check that the Cargo version starts with the tag,
         # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
+        env:
+          VERSION: ${{ needs.get-version.outputs.version }}
         run: |
-          tag="${{ needs.get-version.outputs.version }}"
+          tag="$VERSION"
           tag=${tag#v}
           cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn’t match the Cargo version $cargo_ver"; exit 1; }
@@ -100,33 +104,43 @@ jobs:
 
       - name: Get build profile
         id: profile
+        env:
+          INPUT_PROFILE: ${{ inputs.profile }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "profile=${{ inputs.profile }}" >> $GITHUB_OUTPUT
+            echo "profile=${INPUT_PROFILE}" >> "$GITHUB_OUTPUT"
           else
-            echo "profile=maxperf" >> $GITHUB_OUTPUT
+            echo "profile=maxperf" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
 
       - name: Build binary
-        run: cargo build --bin ${{ matrix.binary.name }} --features "${{ matrix.binary.features }}" --profile ${{ steps.profile.outputs.profile }} --target ${{ matrix.platform.target }}
         env:
           CARGO_TARGET_DIR: target
+          BINARY_NAME: ${{ matrix.binary.name }}
+          FEATURES: ${{ matrix.binary.features }}
+          PROFILE: ${{ steps.profile.outputs.profile }}
+          TARGET: ${{ matrix.platform.target }}
+        run: cargo build --bin "$BINARY_NAME" --features "$FEATURES" --profile "$PROFILE" --target "$TARGET"
 
       - name: Prepare binary
         id: prepare
         shell: bash
+        env:
+          BINARY: ${{ matrix.binary.name }}
+          TARGET: ${{ matrix.platform.target }}
+          PROFILE: ${{ steps.profile.outputs.profile }}
+          VERSION: ${{ needs.get-version.outputs.version }}
         run: |
-          PROFILE="${{ steps.profile.outputs.profile }}"
           if [ "$PROFILE" = "dev" ]; then
             PROFILE_DIR="debug"
           else
             PROFILE_DIR="$PROFILE"
           fi
 
-          BINARY_PATH="target/${{ matrix.platform.target }}/${PROFILE_DIR}/${{ matrix.binary.name }}"
-          BINARY_NAME="${{ matrix.binary.name }}-${{ needs.get-version.outputs.version }}-${{ matrix.platform.target }}"
-          ARCHIVE_NAME="${{ matrix.binary.name }}-${{ needs.get-version.outputs.version }}-${{ matrix.platform.target }}.tar.gz"
+          BINARY_PATH="target/${TARGET}/${PROFILE_DIR}/${BINARY}"
+          BINARY_NAME="${BINARY}-${VERSION}-${TARGET}"
+          ARCHIVE_NAME="${BINARY}-${VERSION}-${TARGET}.tar.gz"
 
           cp "$BINARY_PATH" "$BINARY_NAME"
           tar czf "$ARCHIVE_NAME" "$BINARY_NAME"
@@ -136,8 +150,11 @@ jobs:
 
       - name: Generate checksums
         shell: bash
+        env:
+          ARCHIVE_PATH: ${{ steps.prepare.outputs.archive_path }}
+          ARCHIVE_NAME: ${{ steps.prepare.outputs.archive_name }}
         run: |
-          shasum -a 256 "${{ steps.prepare.outputs.archive_path }}" > "${{ steps.prepare.outputs.archive_name }}.sha256"
+          shasum -a 256 "$ARCHIVE_PATH" > "${ARCHIVE_NAME}.sha256"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: foundry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - uses: taiki-e/install-action@80e6af7a2ec7f280fffe2d0a9d3a12a9d11d86e9 # v2.75.1
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: nextest@0.9.124
       - name: Install Foundry

--- a/deny.toml
+++ b/deny.toml
@@ -65,9 +65,10 @@ allow = [
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-  { allow = [
-    "MPL-2.0",
-  ], name = "option-ext" },
+  { allow = ["MPL-2.0"], name = "option-ext" },
+  { allow = ["MPL-2.0"], name = "bitmaps" },
+  { allow = ["MPL-2.0"], name = "imbl" },
+  { allow = ["MPL-2.0"], name = "imbl-sized-chunks" },
 ]
 
 [[licenses.clarify]]

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,9 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+  # and is pulled in transitively by upstream crates with no safe upgrade available.
+  "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -82,9 +85,12 @@ unknown-registry = "warn"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
+unused-allowed-source = "allow"
 allow-git = [
   "https://github.com/commonwarexyz/monorepo",
   "https://github.com/foundry-rs/foundry",
   "https://github.com/paradigmxyz/reth",
   "https://github.com/rustyhorde/vergen",
+  "https://github.com/sigp/discv5",
+  "https://github.com/tempoxyz/tempo",
 ]


### PR DESCRIPTION
## Summary
- harden release/build shell steps by moving GitHub expression values into env vars before use
- refresh pinned GitHub Action refs with pinact and fix mismatched action comments/refs
- align cargo-deny source/advisory policy with Tempo/Reth patterns and enforce it through the shared `deny` workflow
- move pr-audit secret usage into env vars and gate secret-using jobs behind the pr-audit environment
- align Dependabot config with Tempo/Reth: dependency labels, commit prefixes, PR limits, cooldowns, grouped updates, and Docker updates

## Validation
- `cargo deny check advisories sources bans`
- `pinact run --diff --check --update --min-age 7`
- `zizmor --min-severity high --min-confidence high .github/workflows/`
- `uv run --with pyyaml python - <<'PY' ...` workflow/dependabot YAML parse check
- `git diff --check`

Prompted by: @grandizzy
