### PR TITLE
test(zone): expand unit, fuzz & symex coverage with CI gate

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -129,7 +129,7 @@ jobs:
         working-directory: specs/ref-impls
         run: |
           "$GITHUB_WORKSPACE/foundry/target/release/forge" coverage \
-            --ir-minimum --match-path "test/zone/**" --report summary | tee coverage.txt
+            --ir-minimum --match-path "test/zone/**" --exclude-tests --report summary | tee coverage.txt
           {
             echo '### Zone spec coverage'
             echo '```'

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -24,7 +24,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build:
@@ -67,8 +66,12 @@ jobs:
         run: forge fmt --check src test
 
   test:
-    name: Forge Test
+    name: Forge Test & Coverage
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      MIN_LINES: "85"
+      MIN_BRANCHES: "58"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -107,10 +110,62 @@ jobs:
         working-directory: foundry
         run: cargo build --bin forge --profile release --no-default-features
 
+      - name: Install z3 (symbolic solver)
+        run: sudo apt-get update && sudo apt-get install -y z3
+
       - name: Run Forge tests (zone-only)
         working-directory: specs/ref-impls
         run: |
           "$GITHUB_WORKSPACE/foundry/target/release/forge" test -vvv --match-path "test/zone/**"
+
+      - name: Run symbolic (symex) property tests
+        working-directory: specs/ref-impls
+        run: |
+          "$GITHUB_WORKSPACE/foundry/target/release/forge" test \
+            --symbolic --match-test "check_" \
+            --symbolic-solver z3 --symbolic-timeout 180 -vvv
+
+      - name: Forge coverage (zone)
+        working-directory: specs/ref-impls
+        run: |
+          "$GITHUB_WORKSPACE/foundry/target/release/forge" coverage \
+            --ir-minimum --match-path "test/zone/**" --report summary | tee coverage.txt
+          {
+            echo '### Zone spec coverage'
+            echo '```'
+            cat coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Coverage gate (production src/zone)
+        working-directory: specs/ref-impls
+        run: |
+          python3 - <<'PY'
+          import os, re, sys
+          ln = ld = bn = bd = 0
+          for line in open("coverage.txt"):
+              if "| src/zone/" in line:
+                  c = line.split("|")
+                  lm = re.search(r"\((\d+)/(\d+)\)", c[2])
+                  bm = re.search(r"\((\d+)/(\d+)\)", c[4])
+                  if lm:
+                      ln += int(lm.group(1)); ld += int(lm.group(2))
+                  if bm:
+                      bn += int(bm.group(1)); bd += int(bm.group(2))
+          lines = 100 * ln / ld
+          branches = 100 * bn / bd
+          min_l = float(os.environ["MIN_LINES"])
+          min_b = float(os.environ["MIN_BRANCHES"])
+          print(f"src/zone: lines={lines:.2f}% (min {min_l}), branches={branches:.2f}% (min {min_b})")
+          failed = []
+          if lines < min_l:
+              failed.append(f"lines {lines:.2f}% < {min_l}%")
+          if branches < min_b:
+              failed.append(f"branches {branches:.2f}% < {min_b}%")
+          if failed:
+              sys.exit("Coverage gate failed: " + "; ".join(failed))
+          print("Coverage gate passed.")
+          PY
 
   specs-success:
     name: specs success

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -70,8 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"
-      MIN_LINES: "85"
-      MIN_BRANCHES: "58"
+      MIN_LINES: "88"
+      MIN_BRANCHES: "60"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/specs/ref-impls/test/zone/BlockHashHistory.t.sol
+++ b/specs/ref-impls/test/zone/BlockHashHistory.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { BLOCKHASH_HISTORY_WINDOW, getBlockHash } from "../../src/zone/BlockHashHistory.sol";
+import { BaseTest } from "../BaseTest.t.sol";
+
+contract BlockHashHistoryTest is BaseTest {
+
+    /// @notice Verifies recent block numbers return the expected block hash.
+    function test_getBlockHash_returnsInWindowHash() public {
+        vm.roll(10_000);
+        uint256 blockNumber = block.number - 1;
+
+        bytes32 hash = getBlockHash(blockNumber);
+
+        assertEq(hash, keccak256(abi.encode(blockNumber)));
+    }
+
+    /// @notice Verifies blocks older than the history window return zero.
+    function test_getBlockHash_returnsZeroForOutOfWindowBlock() public {
+        vm.roll(20_000);
+        uint256 blockNumber = block.number - BLOCKHASH_HISTORY_WINDOW - 1;
+
+        assertEq(getBlockHash(blockNumber), bytes32(0));
+    }
+
+    /// @notice Verifies genesis, current, and future unknown blocks return zero.
+    function test_getBlockHash_returnsZeroForUnknownBlocks() public {
+        vm.roll(10_000);
+
+        assertEq(getBlockHash(0), bytes32(0));
+        assertEq(getBlockHash(block.number), bytes32(0));
+        assertEq(getBlockHash(block.number + 1), bytes32(0));
+    }
+
+}

--- a/specs/ref-impls/test/zone/DepositQueueLib.t.sol
+++ b/specs/ref-impls/test/zone/DepositQueueLib.t.sol
@@ -315,6 +315,70 @@ contract DepositQueueLibTest is Test {
         assertTrue(regularHash != encryptedHash);
     }
 
+    /// @notice Regular deposit hash chains are deterministic across replays.
+    function testFuzz_enqueue_hashChainDeterminism(uint8 rawCount, bytes32 seed) public pure {
+        uint256 count = (uint256(rawCount) % 32) + 1;
+        bytes32 firstRun = bytes32(0);
+        bytes32 secondRun = bytes32(0);
+
+        for (uint256 i = 0; i < count; i++) {
+            Deposit memory d = _makeDeposit(seed, i);
+            bytes32 prevHash = firstRun;
+            firstRun = DepositQueueLib.enqueue(firstRun, d);
+            secondRun = DepositQueueLib.enqueue(secondRun, d);
+
+            assertEq(firstRun, secondRun);
+            assertEq(firstRun, keccak256(abi.encode(DepositType.Regular, d, prevHash)));
+        }
+
+        bytes32 replay = bytes32(0);
+        for (uint256 i = 0; i < count; i++) {
+            replay = DepositQueueLib.enqueue(replay, _makeDeposit(seed, i));
+        }
+
+        assertEq(firstRun, replay);
+    }
+
+    /// @notice Regular and encrypted discriminators produce distinct queue hashes.
+    function testFuzz_enqueue_discriminatorsSeparateRegularAndEncrypted(
+        bytes32 prevHash,
+        bytes32 seed,
+        uint128 amount
+    )
+        public
+        pure
+    {
+        Deposit memory d = Deposit({
+            token: address(0x1000),
+            sender: address(0x200),
+            to: address(uint160(uint256(seed))),
+            amount: amount,
+            bouncebackRecipient: address(0x300),
+            memo: seed
+        });
+        EncryptedDeposit memory ed = EncryptedDeposit({
+            token: d.token,
+            sender: d.sender,
+            amount: d.amount,
+            bouncebackRecipient: d.bouncebackRecipient,
+            keyIndex: uint256(seed),
+            encrypted: EncryptedDepositPayload({
+                ephemeralPubkeyX: seed,
+                ephemeralPubkeyYParity: 0x02,
+                ciphertext: abi.encodePacked(seed, seed),
+                nonce: bytes12(seed),
+                tag: bytes16(seed)
+            })
+        });
+
+        bytes32 regularHash = DepositQueueLib.enqueue(prevHash, d);
+        bytes32 encryptedHash = DepositQueueLib.enqueueEncrypted(prevHash, ed);
+
+        assertEq(regularHash, keccak256(abi.encode(DepositType.Regular, d, prevHash)));
+        assertEq(encryptedHash, keccak256(abi.encode(DepositType.Encrypted, ed, prevHash)));
+        assertTrue(regularHash != encryptedHash);
+    }
+
     /*//////////////////////////////////////////////////////////////
                     PLAINTEXT ENCODE / DECODE TESTS
     //////////////////////////////////////////////////////////////*/
@@ -456,6 +520,19 @@ contract DepositQueueLibTest is Test {
         assembly {
             value := mload(add(raw, 32))
         }
+    }
+
+    function _makeDeposit(bytes32 seed, uint256 index) internal pure returns (Deposit memory) {
+        return Deposit({
+            token: address(uint160(uint256(keccak256(abi.encode(seed, "token", index))))),
+            sender: address(uint160(uint256(keccak256(abi.encode(seed, "sender", index))))),
+            to: address(uint160(uint256(keccak256(abi.encode(seed, "to", index))))),
+            amount: uint128(uint256(keccak256(abi.encode(seed, "amount", index)))),
+            bouncebackRecipient: address(
+                uint160(uint256(keccak256(abi.encode(seed, "bounceback", index))))
+            ),
+            memo: keccak256(abi.encode(seed, "memo", index))
+        });
     }
 
 }

--- a/specs/ref-impls/test/zone/EncryptedDeposit.t.sol
+++ b/specs/ref-impls/test/zone/EncryptedDeposit.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {
+    ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE,
+    EncryptedDepositLib
+} from "../../src/zone/EncryptedDeposit.sol";
+import { DepositType, EncryptedDeposit, EncryptedDepositPayload } from "../../src/zone/IZone.sol";
+import { Test } from "forge-std/Test.sol";
+
+contract EncryptedDepositHarness {
+
+    function encodePlaintext(address to, bytes32 memo) external pure returns (bytes memory) {
+        return EncryptedDepositLib.encodePlaintext(to, memo);
+    }
+
+    function decodePlaintext(bytes memory plaintext)
+        external
+        pure
+        returns (address to, bytes32 memo)
+    {
+        return EncryptedDepositLib.decodePlaintext(plaintext);
+    }
+
+    function queueHash(
+        EncryptedDeposit memory deposit,
+        bytes32 prevHash
+    )
+        external
+        pure
+        returns (bytes32)
+    {
+        return EncryptedDepositLib.queueHash(deposit, prevHash);
+    }
+
+}
+
+contract EncryptedDepositLibTest is Test {
+
+    EncryptedDepositHarness internal harness;
+
+    function setUp() public {
+        harness = new EncryptedDepositHarness();
+    }
+
+    /// @notice Verifies plaintext encoding round-trips a recipient and memo.
+    function test_encodeDecode_roundtrip() public view {
+        address to = address(0x1234567890AbcdEF1234567890aBcdef12345678);
+        bytes32 memo = bytes32("memo");
+
+        bytes memory plaintext = harness.encodePlaintext(to, memo);
+        (address decodedTo, bytes32 decodedMemo) = harness.decodePlaintext(plaintext);
+
+        assertEq(plaintext.length, ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE);
+        assertEq(decodedTo, to);
+        assertEq(decodedMemo, memo);
+    }
+
+    /// @notice Verifies decoding rejects plaintext with the wrong byte length.
+    function test_decodePlaintext_revertsOnWrongLength() public {
+        bytes memory plaintext = new bytes(63);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                EncryptedDepositLib.InvalidPlaintextLength.selector,
+                uint256(63),
+                ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE
+            )
+        );
+        harness.decodePlaintext(plaintext);
+    }
+
+    /// @notice Verifies deposit queue hashing matches the typed ABI encoding.
+    function test_queueHash_matchesTypedEncoding() public view {
+        EncryptedDeposit memory deposit = _makeEncryptedDeposit(100e6, bytes32("ciphertext"));
+        bytes32 prevHash = keccak256("previous");
+
+        bytes32 actual = harness.queueHash(deposit, prevHash);
+        bytes32 expected = keccak256(abi.encode(DepositType.Encrypted, deposit, prevHash));
+
+        assertEq(actual, expected);
+    }
+
+    /// @notice Verifies plaintext encoding round-trips any recipient and memo.
+    function testFuzz_encodeDecode_roundtrip(address to, bytes32 memo) public view {
+        bytes memory plaintext = harness.encodePlaintext(to, memo);
+        (address decodedTo, bytes32 decodedMemo) = harness.decodePlaintext(plaintext);
+
+        assertEq(plaintext.length, ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE);
+        assertEq(decodedTo, to);
+        assertEq(decodedMemo, memo);
+    }
+
+    function _makeEncryptedDeposit(
+        uint128 amount,
+        bytes32 seed
+    )
+        internal
+        pure
+        returns (EncryptedDeposit memory)
+    {
+        bytes memory ciphertext = new bytes(64);
+        for (uint256 i = 0; i < ciphertext.length; i++) {
+            ciphertext[i] = bytes1(uint8(uint256(keccak256(abi.encode(seed, i)))));
+        }
+
+        return EncryptedDeposit({
+            token: address(0x1000),
+            sender: address(0x200),
+            amount: amount,
+            bouncebackRecipient: address(0x300),
+            keyIndex: 1,
+            encrypted: EncryptedDepositPayload({
+                ephemeralPubkeyX: seed,
+                ephemeralPubkeyYParity: 0x02,
+                ciphertext: ciphertext,
+                nonce: bytes12(seed),
+                tag: bytes16(seed)
+            })
+        });
+    }
+
+}

--- a/specs/ref-impls/test/zone/PrivateZoneToken.t.sol
+++ b/specs/ref-impls/test/zone/PrivateZoneToken.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { ITempoState, IZoneConfig, ZONE_INBOX, ZONE_OUTBOX } from "../../src/zone/IZone.sol";
+import { PrivateZoneToken } from "../../src/zone/PrivateZoneToken.sol";
+import { Test } from "forge-std/Test.sol";
+
+contract MockPrivateZoneTokenConfig is IZoneConfig {
+
+    address public currentSequencer;
+
+    constructor(address sequencer_) {
+        currentSequencer = sequencer_;
+    }
+
+    function setSequencer(address sequencer_) external {
+        currentSequencer = sequencer_;
+    }
+
+    function tempoPortal() external pure returns (address) {
+        return address(0x400);
+    }
+
+    function tempoState() external pure returns (ITempoState) {
+        return ITempoState(address(0x401));
+    }
+
+    function sequencer() external view returns (address) {
+        return currentSequencer;
+    }
+
+    function pendingSequencer() external pure returns (address) {
+        return address(0);
+    }
+
+    function sequencerEncryptionKey() external pure returns (bytes32, uint8) {
+        return (bytes32(0), 0);
+    }
+
+    function isSequencer(address account) external view returns (bool) {
+        return account == currentSequencer;
+    }
+
+    function isEnabledToken(address) external pure returns (bool) {
+        return false;
+    }
+
+}
+
+contract PrivateZoneTokenHarness is PrivateZoneToken {
+
+    constructor(IZoneConfig config_) {
+        config = config_;
+    }
+
+}
+
+contract PrivateZoneTokenTest is Test {
+
+    PrivateZoneTokenHarness public token;
+    MockPrivateZoneTokenConfig public config;
+    address public sequencer = address(0x100);
+    address public alice = address(0x200);
+    address public bob = address(0x300);
+    address public charlie = address(0x400);
+
+    function setUp() public {
+        config = new MockPrivateZoneTokenConfig(sequencer);
+        token = new PrivateZoneTokenHarness(config);
+    }
+
+    /// @notice Verifies the fixed transfer gas constant is 100,000.
+    function test_fixedTransferGasConstant() public view {
+        assertEq(token.FIXED_TRANSFER_GAS(), 100_000);
+    }
+
+    /// @notice Verifies non-owner non-sequencer balance reads are unauthorized.
+    function test_balanceOf_revertsUnauthorizedForNonOwnerNonSequencer() public {
+        vm.prank(charlie);
+        vm.expectRevert(PrivateZoneToken.Unauthorized.selector);
+        token.balanceOf(alice);
+    }
+
+    /// @notice Verifies unrelated callers cannot read allowances.
+    function test_allowance_revertsUnauthorizedForUnrelatedCaller() public {
+        vm.prank(charlie);
+        vm.expectRevert(PrivateZoneToken.Unauthorized.selector);
+        token.allowance(alice, bob);
+    }
+
+    /// @notice Verifies minting is restricted to the zone inbox caller.
+    function test_mint_revertsUnauthorizedForNonInbox() public {
+        vm.prank(alice);
+        vm.expectRevert(PrivateZoneToken.Unauthorized.selector);
+        token.mint(alice, 1);
+    }
+
+    /// @notice Verifies burning is restricted to the zone outbox caller.
+    function test_burn_revertsUnauthorizedForNonOutbox() public {
+        vm.prank(alice);
+        vm.expectRevert(PrivateZoneToken.Unauthorized.selector);
+        token.burn(alice, 1);
+    }
+
+    /// @notice Verifies authorized privacy reads reach the precompile stub.
+    function test_authorizedPrivacyReadsReachPrecompileStub() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        token.balanceOf(alice);
+
+        vm.prank(sequencer);
+        vm.expectRevert();
+        token.allowance(alice, bob);
+    }
+
+    /// @notice Verifies inbox mint and outbox burn calls reach the precompile stub.
+    function test_systemMintBurnCallersReachPrecompileStub() public {
+        vm.prank(ZONE_INBOX);
+        vm.expectRevert();
+        token.mint(alice, 1);
+
+        vm.prank(ZONE_OUTBOX);
+        vm.expectRevert();
+        token.burn(alice, 1);
+    }
+
+}

--- a/specs/ref-impls/test/zone/Secp256k1Lib.t.sol
+++ b/specs/ref-impls/test/zone/Secp256k1Lib.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { Secp256k1Lib } from "../../src/zone/Secp256k1Lib.sol";
+import { Test } from "forge-std/Test.sol";
+
+contract Secp256k1LibHarness {
+
+    function isValidX(bytes32 x) external view returns (bool) {
+        return Secp256k1Lib.isValidX(x);
+    }
+
+    function isCompressedYParity(uint8 yParity) external pure returns (bool) {
+        return Secp256k1Lib.isCompressedYParity(yParity);
+    }
+
+    function deriveAddress(bytes32 x, uint8 yParity) external view returns (address) {
+        return Secp256k1Lib.deriveAddress(x, yParity);
+    }
+
+}
+
+contract Secp256k1LibTest is Test {
+
+    uint256 internal constant SECP256K1_P =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
+    bytes32 internal constant GENERATOR_X =
+        0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;
+    address internal constant PRIVATE_KEY_ONE_ADDRESS = 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf;
+
+    Secp256k1LibHarness internal harness;
+
+    function setUp() public {
+        harness = new Secp256k1LibHarness();
+    }
+
+    /// @notice Verifies the generator x-coordinate is accepted as valid.
+    function test_isValidX_acceptsGeneratorX() public view {
+        assertTrue(harness.isValidX(GENERATOR_X));
+    }
+
+    /// @notice Verifies zero is rejected as an invalid x-coordinate.
+    function test_isValidX_rejectsZero() public view {
+        assertFalse(harness.isValidX(bytes32(0)));
+    }
+
+    /// @notice Verifies x-coordinates at or above the field modulus are invalid.
+    function test_isValidX_rejectsFieldModulusAndAbove() public view {
+        assertFalse(harness.isValidX(bytes32(SECP256K1_P)));
+        assertFalse(harness.isValidX(bytes32(SECP256K1_P + 1)));
+    }
+
+    /// @notice Verifies compressed y-parity prefixes 0x02 and 0x03 are accepted.
+    function test_isCompressedYParity_acceptsCompressedPrefixes() public view {
+        assertTrue(harness.isCompressedYParity(0x02));
+        assertTrue(harness.isCompressedYParity(0x03));
+    }
+
+    /// @notice Verifies non-compressed y-parity prefix values are rejected.
+    function test_isCompressedYParity_rejectsOtherValues() public view {
+        assertFalse(harness.isCompressedYParity(0x00));
+        assertFalse(harness.isCompressedYParity(0x01));
+        assertFalse(harness.isCompressedYParity(0x04));
+        assertFalse(harness.isCompressedYParity(type(uint8).max));
+    }
+
+    /// @notice Verifies the generator point derives the known private-key-one address.
+    function test_deriveAddress_matchesKnownGeneratorAddress() public view {
+        assertEq(harness.deriveAddress(GENERATOR_X, 0x02), PRIVATE_KEY_ONE_ADDRESS);
+    }
+
+    /// @notice Verifies changing y parity changes the derived address.
+    function test_deriveAddress_parityChangesAddress() public view {
+        address evenAddress = harness.deriveAddress(GENERATOR_X, 0x02);
+        address oddAddress = harness.deriveAddress(GENERATOR_X, 0x03);
+
+        assertEq(evenAddress, PRIVATE_KEY_ONE_ADDRESS);
+        assertTrue(oddAddress != evenAddress);
+    }
+
+    /// @notice Verifies isValidX is deterministic and never reverts for any input.
+    function testFuzz_isValidX_neverRevertsAndConsistent(bytes32 x) public view {
+        bool first = harness.isValidX(x);
+        bool second = harness.isValidX(x);
+        assertEq(first, second);
+    }
+
+    /// @notice Verifies only compressed y-parity prefixes pass for any byte value.
+    function testFuzz_isCompressedYParity(uint8 yParity) public view {
+        assertEq(harness.isCompressedYParity(yParity), yParity == 0x02 || yParity == 0x03);
+    }
+
+}

--- a/specs/ref-impls/test/zone/TempoState.t.sol
+++ b/specs/ref-impls/test/zone/TempoState.t.sol
@@ -348,21 +348,30 @@ contract TempoStateTest is Test {
         // 4: transactionsRoot, 5: receiptsRoot, 6: logsBloom, 7: difficulty,
         // 8: number, 9: gasLimit, 10: gasUsed, 11: timestamp, 12+: extra fields
 
-        bytes memory content = abi.encodePacked(
+        // Encoded in three chunks (instead of one 19-argument abi.encodePacked) so the field
+        // encodings are not all live on the stack at once. abi.encodePacked is plain
+        // concatenation, so the resulting bytes are identical to a single packed call; this only
+        // keeps the function within the stack limit when compiled under coverage's minimum-
+        // optimization viaIR pipeline.
+        bytes memory head = abi.encodePacked(
             _encodeBytes32(parentHash), // 0: parentHash
             _encodeBytes32(keccak256("ommersHash")), // 1: ommersHash
             _encodeAddress(beneficiary), // 2: beneficiary
             _encodeBytes32(stateRoot), // 3: stateRoot
             _encodeBytes32(transactionsRoot), // 4: transactionsRoot
             _encodeBytes32(receiptsRoot), // 5: receiptsRoot
-            _encodeBloom(), // 6: logsBloom (256 bytes)
+            _encodeBloom() // 6: logsBloom (256 bytes)
+        );
+        bytes memory mid = abi.encodePacked(
             _encodeUint64(0), // 7: difficulty
             _encodeUint64(number), // 8: number
             _encodeUint64(30_000_000), // 9: gasLimit
             _encodeUint64(0), // 10: gasUsed
             _encodeUint64(timestamp), // 11: timestamp
             _encodeBytes(bytes("")), // 12: extraData
-            _encodeBytes32(bytes32(0)), // 13: mixHash
+            _encodeBytes32(bytes32(0)) // 13: mixHash
+        );
+        bytes memory tail = abi.encodePacked(
             _encodeBytes8(bytes8(0)), // 14: nonce
             _encodeUint64(1_000_000_000), // 15: baseFeePerGas
             _encodeBytes32(bytes32(0)), // 16: withdrawalsRoot
@@ -370,7 +379,7 @@ contract TempoStateTest is Test {
             _encodeUint64(0) // 18: excessBlobGas
         );
 
-        return _encodeList(content);
+        return _encodeList(abi.encodePacked(head, mid, tail));
     }
 
     function _encodeBytes32(bytes32 value) internal pure returns (bytes memory) {

--- a/specs/ref-impls/test/zone/TempoState.t.sol
+++ b/specs/ref-impls/test/zone/TempoState.t.sol
@@ -464,4 +464,71 @@ contract TempoStateTest is Test {
         new TempoState(malformedHeader);
     }
 
+    /// @notice Finalization rejects a later header with the wrong parent hash.
+    function test_finalizeTempo_revertsOnWrongParentHashAfterAdvance() public {
+        bytes memory header1 = _buildTempoHeader(
+            genesisBlockHash,
+            keccak256("stateRoot1"),
+            keccak256("receiptsRoot1"),
+            keccak256("txRoot1"),
+            address(0x1),
+            GENESIS_BLOCK_NUMBER + 1,
+            GENESIS_TIMESTAMP + 12
+        );
+
+        vm.prank(zoneInbox);
+        tempoState.finalizeTempo(header1);
+
+        bytes memory header2 = _buildTempoHeader(
+            genesisBlockHash,
+            keccak256("stateRoot2"),
+            keccak256("receiptsRoot2"),
+            keccak256("txRoot2"),
+            address(0x2),
+            GENESIS_BLOCK_NUMBER + 2,
+            GENESIS_TIMESTAMP + 24
+        );
+
+        vm.prank(zoneInbox);
+        vm.expectRevert(ITempoState.InvalidParentHash.selector);
+        tempoState.finalizeTempo(header2);
+    }
+
+    /// @notice Finalization rejects a later header with a skipped block number.
+    function test_finalizeTempo_revertsOnNonSequentialBlockNumberAfterAdvance() public {
+        bytes memory header1 = _buildTempoHeader(
+            genesisBlockHash,
+            keccak256("stateRoot1"),
+            keccak256("receiptsRoot1"),
+            keccak256("txRoot1"),
+            address(0x1),
+            GENESIS_BLOCK_NUMBER + 1,
+            GENESIS_TIMESTAMP + 12
+        );
+
+        vm.prank(zoneInbox);
+        tempoState.finalizeTempo(header1);
+
+        bytes memory header2 = _buildTempoHeader(
+            keccak256(header1),
+            keccak256("stateRoot2"),
+            keccak256("receiptsRoot2"),
+            keccak256("txRoot2"),
+            address(0x2),
+            GENESIS_BLOCK_NUMBER + 3,
+            GENESIS_TIMESTAMP + 24
+        );
+
+        vm.prank(zoneInbox);
+        vm.expectRevert(ITempoState.InvalidBlockNumber.selector);
+        tempoState.finalizeTempo(header2);
+    }
+
+    /// @notice Access control is enforced before malformed header decoding.
+    function test_finalizeTempo_revertsOnAccessControlBeforeDecodingHeader() public {
+        vm.prank(notZoneInbox);
+        vm.expectRevert(ITempoState.OnlyZoneInbox.selector);
+        tempoState.finalizeTempo(hex"01");
+    }
+
 }

--- a/specs/ref-impls/test/zone/Verifier.t.sol
+++ b/specs/ref-impls/test/zone/Verifier.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { BlockTransition, DepositQueueTransition } from "../../src/zone/IZone.sol";
+import { Verifier } from "../../src/zone/Verifier.sol";
+import { Test } from "forge-std/Test.sol";
+
+contract VerifierTest is Test {
+
+    /// @notice Verifies the stub verifier accepts arbitrary transition inputs.
+    function test_verify_returnsTrue() public {
+        // WIP stub: the reference verifier accepts all inputs while proof verification is defined.
+        Verifier verifier = new Verifier();
+
+        bool ok = verifier.verify(
+            1,
+            1,
+            bytes32("anchor"),
+            1,
+            address(0x1234),
+            BlockTransition({ prevBlockHash: bytes32("prev"), nextBlockHash: bytes32("next") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: bytes32("deposits"),
+                prevDepositNumber: 0,
+                nextDepositNumber: 0
+            }),
+            bytes32("withdrawals"),
+            "config",
+            "proof"
+        );
+
+        assertTrue(ok);
+    }
+
+}

--- a/specs/ref-impls/test/zone/WithdrawalQueueLib.t.sol
+++ b/specs/ref-impls/test/zone/WithdrawalQueueLib.t.sol
@@ -324,6 +324,73 @@ contract WithdrawalQueueLibTest is Test {
         assertEq(harness.length(), WITHDRAWAL_QUEUE_CAPACITY);
     }
 
+    /// @notice A full queue dequeues every withdrawal in FIFO order and empties.
+    function test_enqueueDequeue_fullCapacityInFifoOrder() public {
+        Withdrawal[] memory withdrawals = new Withdrawal[](WITHDRAWAL_QUEUE_CAPACITY);
+
+        for (uint256 i = 0; i < WITHDRAWAL_QUEUE_CAPACITY; i++) {
+            withdrawals[i] = _makeWithdrawal(alice, bob, uint128(i + 1));
+            harness.enqueue(keccak256(abi.encode(withdrawals[i], EMPTY_SENTINEL)));
+            assertEq(harness.length(), i + 1);
+        }
+
+        assertEq(harness.length(), WITHDRAWAL_QUEUE_CAPACITY);
+
+        for (uint256 i = 0; i < WITHDRAWAL_QUEUE_CAPACITY; i++) {
+            harness.dequeue(withdrawals[i], bytes32(0));
+            assertEq(harness.length(), WITHDRAWAL_QUEUE_CAPACITY - i - 1);
+        }
+
+        assertFalse(harness.hasWithdrawals());
+        assertEq(harness.head(), WITHDRAWAL_QUEUE_CAPACITY);
+        assertEq(harness.tail(), WITHDRAWAL_QUEUE_CAPACITY);
+    }
+
+    /// @notice Dequeuing the last item marks the exhausted slot empty.
+    function test_dequeue_setsEmptySentinelWhenSlotExhausted() public {
+        Withdrawal memory w = _makeWithdrawal(alice, bob, 100e6);
+
+        harness.enqueue(keccak256(abi.encode(w, EMPTY_SENTINEL)));
+        harness.dequeue(w, bytes32(0));
+
+        assertEq(harness.slots(0), EMPTY_SENTINEL);
+        assertEq(harness.head(), 1);
+        assertEq(harness.length(), 0);
+    }
+
+    /// @notice Fuzzed enqueues and dequeues preserve FIFO position and length.
+    function testFuzz_enqueueDequeue_preservesFifoAndLength(bytes32 seed) public {
+        uint256 count = (uint256(seed) % WITHDRAWAL_QUEUE_CAPACITY) + 1;
+        Withdrawal[] memory withdrawals = new Withdrawal[](count);
+
+        for (uint256 i = 0; i < count; i++) {
+            uint128 amount = uint128(uint256(keccak256(abi.encode(seed, "amount", i))));
+            if (amount == 0) amount = 1;
+            withdrawals[i] = _makeWithdrawal(
+                address(uint160(uint256(keccak256(abi.encode(seed, "sender", i))))),
+                address(uint160(uint256(keccak256(abi.encode(seed, "to", i))))),
+                amount
+            );
+            harness.enqueue(keccak256(abi.encode(withdrawals[i], EMPTY_SENTINEL)));
+            assertEq(harness.length(), i + 1);
+        }
+
+        uint256 dequeues = uint256(keccak256(abi.encode(seed, "dequeues"))) % (count + 1);
+        for (uint256 i = 0; i < dequeues; i++) {
+            harness.dequeue(withdrawals[i], bytes32(0));
+            assertEq(harness.length(), count - i - 1);
+            assertEq(harness.head(), i + 1);
+        }
+
+        if (dequeues == count) {
+            assertFalse(harness.hasWithdrawals());
+        } else {
+            assertTrue(harness.hasWithdrawals());
+            assertEq(harness.head(), dequeues);
+            assertEq(harness.tail(), count);
+        }
+    }
+
     /*//////////////////////////////////////////////////////////////
                         LENGTH & HAS WITHDRAWALS
     //////////////////////////////////////////////////////////////*/

--- a/specs/ref-impls/test/zone/ZoneConfig.t.sol
+++ b/specs/ref-impls/test/zone/ZoneConfig.t.sol
@@ -87,6 +87,17 @@ contract ZoneConfigTest is BaseTest {
         portal.setSequencerEncryptionKey(x, yParity, v, r, s);
     }
 
+    /// @dev Finds the first private key >= `start` whose public key has the requested
+    ///      y-parity (0x02 even / 0x03 odd), so a test can pin distinct parities per entry.
+    function _pkWithParity(uint8 wantParity, uint256 start) internal returns (uint256) {
+        for (uint256 pk = start; pk < start + 100; pk++) {
+            Vm.Wallet memory w = vm.createWallet(pk);
+            uint8 p = w.publicKeyY % 2 == 0 ? 0x02 : 0x03;
+            if (p == wantParity) return pk;
+        }
+        revert("no key with requested parity");
+    }
+
     /// @notice Verifies the config reads the current sequencer from the portal.
     function test_sequencer_returnsPortalSequencer() public view {
         assertEq(config.sequencer(), portal.sequencer());
@@ -120,6 +131,35 @@ contract ZoneConfigTest is BaseTest {
         (bytes32 storedX, uint8 storedYParity) = config.sequencerEncryptionKey();
         assertEq(storedX, x);
         assertEq(storedYParity, yParity);
+    }
+
+    /// @notice Verifies the latest entry is read from the correct array slots with 3+ keys.
+    /// @dev With only two entries `length - 1` equals `length >> 1`, so the last-index math
+    ///      goes untested; three entries force index 2 and expose off-by-one / shift mutants.
+    ///      The last two entries are pinned to different y-parities so reading the wrong meta
+    ///      slot (slotX - 1 instead of slotX + 1) returns the wrong parity.
+    function test_sequencerEncryptionKey_threeKeys_readsLastEntry() public {
+        _setEncKeyWithPoP(_pkWithParity(0x02, 1));
+        vm.roll(block.number + 1);
+        _setEncKeyWithPoP(_pkWithParity(0x03, 2));
+        // Roll far ahead so the last entry's activationBlock differs from its y-parity,
+        // which kills the `metaSlot & 0xff -> metaSlot / 0xff` extraction mutant.
+        vm.roll(block.number + 100);
+        (bytes32 x, uint8 yParity) = _setEncKeyWithPoP(_pkWithParity(0x02, 3));
+        assertEq(yParity, 0x02);
+        _syncEncryptionKeys(3);
+
+        (bytes32 storedX, uint8 storedYParity) = config.sequencerEncryptionKey();
+        assertEq(storedX, x);
+        assertEq(storedYParity, yParity);
+    }
+
+    /// @notice Verifies membership is false for an address strictly greater than the sequencer.
+    /// @dev Guards the `==` check against `>=`/`>` mutants: the max address compares greater
+    ///      than any real sequencer, so an ordering operator would wrongly report membership.
+    function test_isSequencer_falseForAddressAboveSequencer() public view {
+        assertTrue(uint160(address(type(uint160).max)) > uint160(config.sequencer()));
+        assertFalse(config.isSequencer(address(type(uint160).max)));
     }
 
     /// @notice Verifies the config reads the pending sequencer from portal storage.

--- a/specs/ref-impls/test/zone/ZoneConfig.t.sol
+++ b/specs/ref-impls/test/zone/ZoneConfig.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {
+    IZoneConfig,
+    IZoneFactory,
+    IZonePortal,
+    PORTAL_ENCRYPTION_KEYS_SLOT,
+    PORTAL_PENDING_SEQUENCER_SLOT,
+    PORTAL_SEQUENCER_SLOT,
+    PORTAL_TOKEN_CONFIGS_SLOT,
+    ZoneParams
+} from "../../src/zone/IZone.sol";
+import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
+import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
+import { ZonePortal } from "../../src/zone/ZonePortal.sol";
+import { BaseTest } from "../BaseTest.t.sol";
+import { MockTempoState } from "./mocks/MockTempoState.sol";
+import { Vm } from "forge-std/Vm.sol";
+
+contract ZoneConfigTest is BaseTest {
+
+    ZoneFactory public zoneFactory;
+    ZonePortal public portal;
+    ZoneConfig public config;
+    MockTempoState public tempoState;
+
+    bytes32 public constant GENESIS_BLOCK_HASH = keccak256("genesis");
+    bytes32 public constant GENESIS_TEMPO_BLOCK_HASH = keccak256("tempoGenesis");
+    uint64 public genesisTempoBlockNumber;
+
+    function setUp() public override {
+        super.setUp();
+
+        zoneFactory = new ZoneFactory();
+        genesisTempoBlockNumber = uint64(block.number);
+
+        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            initialToken: address(pathUSD),
+            admin: admin,
+            sequencer: admin,
+            verifier: zoneFactory.verifier(),
+            zoneParams: ZoneParams({
+                genesisBlockHash: GENESIS_BLOCK_HASH,
+                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
+                genesisTempoBlockNumber: genesisTempoBlockNumber
+            }),
+            rpcUrl: "https://rpc.test-zone.example"
+        });
+
+        (, address portalAddr) = zoneFactory.createZone(params);
+        portal = ZonePortal(portalAddr);
+        tempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
+        config = new ZoneConfig(address(portal), address(tempoState));
+
+        _syncPortalSlot(PORTAL_SEQUENCER_SLOT);
+        _syncPortalSlot(PORTAL_PENDING_SEQUENCER_SLOT);
+        _syncTokenConfig(address(pathUSD));
+    }
+
+    function _syncPortalSlot(bytes32 slot) internal {
+        tempoState.setMockStorageValue(address(portal), slot, vm.load(address(portal), slot));
+    }
+
+    function _syncTokenConfig(address token) internal {
+        bytes32 slot = keccak256(abi.encode(token, PORTAL_TOKEN_CONFIGS_SLOT));
+        tempoState.setMockStorageValue(address(portal), slot, vm.load(address(portal), slot));
+    }
+
+    function _syncEncryptionKeys(uint256 count) internal {
+        _syncPortalSlot(PORTAL_ENCRYPTION_KEYS_SLOT);
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
+        for (uint256 i = 0; i < count; i++) {
+            bytes32 slotX = bytes32(base + (i * 2));
+            bytes32 slotMeta = bytes32(base + (i * 2) + 1);
+            _syncPortalSlot(slotX);
+            _syncPortalSlot(slotMeta);
+        }
+    }
+
+    function _setEncKeyWithPoP(uint256 privateKey) internal returns (bytes32 x, uint8 yParity) {
+        Vm.Wallet memory w = vm.createWallet(privateKey);
+        x = bytes32(w.publicKeyX);
+        yParity = w.publicKeyY % 2 == 0 ? 0x02 : 0x03;
+        bytes32 message = keccak256(abi.encode(address(portal), x, yParity));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(w.privateKey, message);
+        portal.setSequencerEncryptionKey(x, yParity, v, r, s);
+    }
+
+    /// @notice Verifies the config reads the current sequencer from the portal.
+    function test_sequencer_returnsPortalSequencer() public view {
+        assertEq(config.sequencer(), portal.sequencer());
+    }
+
+    /// @notice Verifies sequencer membership is true for admin and false otherwise.
+    function test_isSequencer_trueAndFalse() public view {
+        assertTrue(config.isSequencer(admin));
+        assertFalse(config.isSequencer(alice));
+    }
+
+    /// @notice Verifies enabled token status is true for the initial token only.
+    function test_isEnabledToken_trueAndFalse() public view {
+        assertTrue(config.isEnabledToken(address(pathUSD)));
+        assertFalse(config.isEnabledToken(address(token1)));
+    }
+
+    /// @notice Verifies reading the sequencer encryption key reverts before any key is set.
+    function test_sequencerEncryptionKey_revertsWhenNoneSet() public {
+        vm.expectRevert(IZoneConfig.NoEncryptionKeySet.selector);
+        config.sequencerEncryptionKey();
+    }
+
+    /// @notice Verifies the config returns the latest sequencer encryption key.
+    function test_sequencerEncryptionKey_returnsLatestKey() public {
+        _setEncKeyWithPoP(1);
+        vm.roll(block.number + 1);
+        (bytes32 x, uint8 yParity) = _setEncKeyWithPoP(2);
+        _syncEncryptionKeys(2);
+
+        (bytes32 storedX, uint8 storedYParity) = config.sequencerEncryptionKey();
+        assertEq(storedX, x);
+        assertEq(storedYParity, yParity);
+    }
+
+    /// @notice Verifies the config reads the pending sequencer from portal storage.
+    function test_pendingSequencer() public {
+        vm.prank(admin);
+        portal.transferSequencer(alice);
+        _syncPortalSlot(PORTAL_PENDING_SEQUENCER_SLOT);
+
+        assertEq(config.pendingSequencer(), alice);
+    }
+
+    /// @notice Verifies sequencer slot reads stay correct after sequencer rotation.
+    function test_storageSlotRegression_readsSequencerAfterRotation() public {
+        vm.prank(admin);
+        portal.transferSequencer(alice);
+        vm.prank(alice);
+        portal.acceptSequencer();
+        _syncPortalSlot(PORTAL_SEQUENCER_SLOT);
+        _syncPortalSlot(PORTAL_PENDING_SEQUENCER_SLOT);
+
+        assertEq(portal.sequencer(), alice);
+        assertEq(config.sequencer(), portal.sequencer());
+        assertEq(config.pendingSequencer(), address(0));
+    }
+
+}

--- a/specs/ref-impls/test/zone/ZoneInbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneInbox.t.sol
@@ -14,11 +14,13 @@ import {
     EncryptedDepositPayload,
     IAesGcmDecrypt,
     IChaumPedersenVerify,
+    ITIP20ZoneFactory,
     IZoneConfig,
     IZoneInbox,
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     PORTAL_ENCRYPTION_KEYS_SLOT,
     QueuedDeposit,
+    TIP20_FACTORY_ADDRESS,
     ZONE_OUTBOX
 } from "../../src/zone/IZone.sol";
 import { ZoneConfig } from "../../src/zone/ZoneConfig.sol";
@@ -988,6 +990,156 @@ contract ZoneInboxTest is Test {
         // Deposit should succeed — minted to the decrypted recipient
         assertEq(zoneToken.balanceOf(recipient), 1000e6, "recipient should receive funds");
         assertEq(zoneToken.balanceOf(alice), 0, "sender should get nothing (successful deposit)");
+    }
+
+    function _advanceTempoQueued(
+        QueuedDeposit[] memory deposits,
+        DecryptionData[] memory decryptions,
+        EnabledToken[] memory enabledTokens
+    )
+        internal
+    {
+        inbox.advanceTempo("", deposits, decryptions, enabledTokens);
+    }
+
+    /// @notice Advancing accepts an enabled token even if the portal has not enabled it.
+    function test_advanceTempo_enabledTokenNotPortalEnabled_accepts() public {
+        address token = address(0x777);
+        vm.etch(TIP20_FACTORY_ADDRESS, hex"00");
+        vm.mockCall(
+            TIP20_FACTORY_ADDRESS,
+            abi.encodeWithSelector(ITIP20ZoneFactory.enableToken.selector),
+            abi.encode()
+        );
+
+        EnabledToken[] memory enabledTokens = new EnabledToken[](1);
+        enabledTokens[0] =
+            EnabledToken({ token: token, name: "Token", symbol: "TOK", currency: "USD" });
+
+        vm.prank(sequencer);
+        _advanceTempoQueued(new QueuedDeposit[](0), new DecryptionData[](0), enabledTokens);
+    }
+
+    /// @notice Advancing accepts duplicate enabled token entries.
+    function test_advanceTempo_duplicateEnabledToken_accepts() public {
+        address token = address(0x777);
+        vm.etch(TIP20_FACTORY_ADDRESS, hex"00");
+        vm.mockCall(
+            TIP20_FACTORY_ADDRESS,
+            abi.encodeWithSelector(ITIP20ZoneFactory.enableToken.selector),
+            abi.encode()
+        );
+
+        EnabledToken[] memory enabledTokens = new EnabledToken[](2);
+        enabledTokens[0] =
+            EnabledToken({ token: token, name: "Token", symbol: "TOK", currency: "USD" });
+        enabledTokens[1] = enabledTokens[0];
+
+        vm.prank(sequencer);
+        _advanceTempoQueued(new QueuedDeposit[](0), new DecryptionData[](0), enabledTokens);
+    }
+
+    /// @notice Claiming with no refund returns zero and mints nothing.
+    function test_claimRefund_zeroAmount() public {
+        vm.prank(alice);
+        uint128 amount = inbox.claimRefund(address(zoneToken));
+
+        assertEq(amount, 0);
+        assertEq(zoneToken.balanceOf(alice), 0);
+    }
+
+    /// @notice Claiming pays a parked mint refund and clears it.
+    function test_claimRefund_success() public {
+        zoneToken.setMinter(address(inbox), false);
+        Deposit[] memory deposits = new Deposit[](1);
+        deposits[0] = Deposit({
+            token: address(zoneToken),
+            sender: alice,
+            to: bob,
+            amount: 100e6,
+            bouncebackRecipient: address(0),
+            memo: bytes32(0)
+        });
+        tempoState.setMockStorageValue(
+            mockPortal,
+            PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
+            keccak256(abi.encode(DepositType.Regular, deposits[0], bytes32(0)))
+        );
+
+        vm.prank(sequencer);
+        _advanceTempo(deposits);
+        assertEq(inbox.refunds(address(zoneToken), bob), 100e6);
+
+        zoneToken.setMinter(address(inbox), true);
+        vm.prank(bob);
+        uint128 amount = inbox.claimRefund(address(zoneToken));
+
+        assertEq(amount, 100e6);
+        assertEq(inbox.refunds(address(zoneToken), bob), 0);
+        assertEq(zoneToken.balanceOf(bob), 100e6);
+    }
+
+    /// @notice Credited supply plus parked refunds equals processed deposit value.
+    function testFuzz_advanceTempo_zoneSupplyInvariant(
+        uint8 rawRegular,
+        uint8 rawEncrypted
+    )
+        public
+    {
+        uint256 regularCount = bound(rawRegular, 0, 4);
+        uint256 encryptedCount = bound(rawEncrypted, 0, 4);
+        uint256 totalCount = regularCount + encryptedCount;
+        vm.assume(totalCount > 0);
+
+        address encryptedRecipient = address(0x500);
+        _setupEncryptionKeyMock(0, keccak256("seq-key"), 0x03);
+        _setupPrecompileMocks(encryptedRecipient, bytes32("memo"));
+
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](totalCount);
+        DecryptionData[] memory decs = new DecryptionData[](encryptedCount);
+        uint128 netCredited;
+        bytes32 currentHash;
+
+        for (uint256 i = 0; i < regularCount; i++) {
+            Deposit memory d = Deposit({
+                token: address(zoneToken),
+                sender: alice,
+                to: bob,
+                amount: uint128((i + 1) * 10e6),
+                bouncebackRecipient: bob,
+                memo: bytes32(i)
+            });
+            deposits[i] = QueuedDeposit({
+                depositType: DepositType.Regular, depositData: abi.encode(d), rejected: false
+            });
+            currentHash = keccak256(abi.encode(DepositType.Regular, d, currentHash));
+            netCredited += d.amount;
+        }
+
+        for (uint256 i = 0; i < encryptedCount; i++) {
+            uint128 amount = uint128((i + 1) * 20e6);
+            (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
+                _makeEncryptedDeposit(alice, amount, 0);
+            deposits[regularCount + i] = qd;
+            decs[i] = DecryptionData({
+                sharedSecret: bytes32(uint256(i + 1)),
+                sharedSecretYParity: 0x02,
+                cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
+            });
+            currentHash = keccak256(abi.encode(DepositType.Encrypted, ed, currentHash));
+            netCredited += amount;
+        }
+
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, currentHash
+        );
+
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs, new EnabledToken[](0));
+
+        uint256 parkedRefunds = inbox.refunds(address(zoneToken), bob)
+            + inbox.refunds(address(zoneToken), encryptedRecipient);
+        assertEq(zoneToken.totalSupply() + parkedRefunds, netCredited);
     }
 
 }

--- a/specs/ref-impls/test/zone/ZoneInbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneInbox.t.sol
@@ -29,6 +29,24 @@ import { MockTempoState } from "./mocks/MockTempoState.sol";
 import { MockZoneToken } from "./mocks/MockZoneToken.sol";
 import { Test } from "forge-std/Test.sol";
 
+/// @dev Exposes ZoneInbox's internal helpers for direct unit testing. The encrypted-deposit
+///      suite reaches them only through the mocked AES-GCM precompile, so their outputs are
+///      otherwise unobserved. `_hmacSha256` only uses the SHA256 precompile (collaborator
+///      addresses irrelevant); `_readEncryptionKey` reads portal storage via TempoState.
+contract ZoneInboxHarness is ZoneInbox {
+
+    constructor(address portal, address state) ZoneInbox(address(0), portal, state) { }
+
+    function hmacSha256(bytes memory key, bytes memory message) external view returns (bytes32) {
+        return _hmacSha256(key, message);
+    }
+
+    function readEncryptionKey(uint256 keyIndex) external view returns (bytes32 x, uint8 yParity) {
+        return _readEncryptionKey(keyIndex);
+    }
+
+}
+
 /// @title ZoneInboxTest
 /// @notice Tests for ZoneInbox covering edge cases
 contract ZoneInboxTest is Test {
@@ -470,6 +488,87 @@ contract ZoneInboxTest is Test {
         uint256 slotMeta = slotX + 1;
         tempoState.setMockStorageValue(mockPortal, bytes32(slotX), keyX);
         tempoState.setMockStorageValue(mockPortal, bytes32(slotMeta), bytes32(uint256(keyYParity)));
+    }
+
+    function _rep(bytes1 b, uint256 n) internal pure returns (bytes memory out) {
+        out = new bytes(n);
+        for (uint256 i = 0; i < n; i++) {
+            out[i] = b;
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      INTERNAL HELPER UNIT TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Known-answer tests for the internal word-level HMAC-SHA256.
+    /// @dev The encrypted-deposit suite mocks the AES-GCM precompile, so the HMAC output is
+    ///      never observed there. These golden vectors (RFC 4231 cases 1-2 plus offline-computed
+    ///      cases) exercise every key-length branch: < 32 bytes (first-word masking), == 32,
+    ///      32-64 (second-word masking), == 64, and > 64 (key is hashed first).
+    function test_hmac_knownAnswerVectors() public {
+        ZoneInboxHarness h = new ZoneInboxHarness(mockPortal, address(tempoState));
+
+        assertEq(
+            h.hmacSha256(hex"4a656665", "what do ya want for nothing?"),
+            0x5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843
+        );
+        assertEq(
+            h.hmacSha256(_rep(0x0b, 20), "Hi There"),
+            0xb0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+        );
+        assertEq(
+            h.hmacSha256(_rep(0xaa, 32), "msg-32byte-key"),
+            0xf7a62f1ceb146c3e9f1562ed8133a36fb13c7f4c3e2ad8e3d5df5ebbd72e520e
+        );
+        assertEq(
+            h.hmacSha256(_rep(0xbb, 48), "msg-48byte-key"),
+            0x827ae58dc9bf44ebb5ee7a2375b84a947400c0833665104c46d2879a4c91cf30
+        );
+        assertEq(
+            h.hmacSha256(_rep(0xcc, 63), "msg-63byte-key"),
+            0xb2b5e90568a216eb95fe94169e69fc4a18897e15e0b5922d41c5d5183c7c8afe
+        );
+        assertEq(
+            h.hmacSha256(_rep(0xdd, 64), "msg-64byte-key"),
+            0x84ff5b758d4d9e4eebc0a4f611e464a1afd7845c0fd0cb2b517a930faeb2ddaa
+        );
+        assertEq(
+            h.hmacSha256(_rep(0xee, 65), "msg-65byte-key"),
+            0x7265d8f20eba414e2ca620c3135b691818b2864ebfa513c801682e32fabc2884
+        );
+    }
+
+    /// @notice Reads the encryption key at a high index to exercise the per-entry slot math.
+    /// @dev base + index*2 for x and +1 for the meta word; a large activationBlock packed
+    ///      above the y-parity ensures the low-byte parity extraction is exercised correctly.
+    ///      Index 3 (not 0/1) exposes index*2 vs index/2/shift mutants.
+    function test_readEncryptionKey_highIndex_readsCorrectSlots() public {
+        ZoneInboxHarness h = new ZoneInboxHarness(mockPortal, address(tempoState));
+
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
+        uint256 slotX = base + (3 * 2);
+        bytes32 keyX = keccak256("key-at-index-3");
+        bytes32 meta = bytes32(uint256(0x02) | (uint256(123_456) << 8));
+        tempoState.setMockStorageValue(mockPortal, bytes32(slotX), keyX);
+        tempoState.setMockStorageValue(mockPortal, bytes32(slotX + 1), meta);
+
+        (bytes32 readX, uint8 readYParity) = h.readEncryptionKey(3);
+        assertEq(readX, keyX);
+        assertEq(readYParity, 0x02);
+    }
+
+    /// @notice An empty x slot reverts even when the meta slot is populated, proving x is read
+    ///         from base + index*2 (not the meta slot at +1).
+    function test_readEncryptionKey_emptyXSlot_reverts() public {
+        ZoneInboxHarness h = new ZoneInboxHarness(mockPortal, address(tempoState));
+
+        uint256 base = uint256(keccak256(abi.encode(uint256(PORTAL_ENCRYPTION_KEYS_SLOT))));
+        uint256 slotX = base + (2 * 2);
+        tempoState.setMockStorageValue(mockPortal, bytes32(slotX + 1), bytes32(uint256(0x03)));
+
+        vm.expectRevert();
+        h.readEncryptionKey(2);
     }
 
     /// @notice Build an EncryptedDeposit and its QueuedDeposit wrapper

--- a/specs/ref-impls/test/zone/ZoneMessenger.t.sol
+++ b/specs/ref-impls/test/zone/ZoneMessenger.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { IWithdrawalReceiver } from "../../src/zone/IZone.sol";
+import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
+import { BaseTest } from "../BaseTest.t.sol";
+import { MockZoneToken } from "./mocks/MockZoneToken.sol";
+import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
+
+contract AcceptingWithdrawalReceiver is IWithdrawalReceiver {
+
+    function onWithdrawalReceived(
+        bytes32,
+        address,
+        uint128,
+        bytes calldata
+    )
+        external
+        pure
+        returns (bytes4)
+    {
+        return IWithdrawalReceiver.onWithdrawalReceived.selector;
+    }
+
+}
+
+contract RejectingWithdrawalReceiver is IWithdrawalReceiver {
+
+    function onWithdrawalReceived(
+        bytes32,
+        address,
+        uint128,
+        bytes calldata
+    )
+        external
+        pure
+        returns (bytes4)
+    {
+        return bytes4(0xdeadbeef);
+    }
+
+}
+
+contract ZoneMessengerTest is BaseTest {
+
+    ZoneMessenger public messenger;
+    MockZoneToken public zoneToken;
+    address public portal = address(0x700);
+    address public token = address(0x701);
+
+    function setUp() public override {
+        super.setUp();
+        messenger = new ZoneMessenger(portal);
+        zoneToken = new MockZoneToken("Zone USD", "zUSD");
+        zoneToken.setMinter(address(this), true);
+    }
+
+    function _mockTransferFrom(address target, uint128 amount, bool result) internal {
+        vm.mockCall(
+            token,
+            abi.encodeWithSelector(ITIP20.transferFrom.selector, portal, target, amount),
+            abi.encode(result)
+        );
+    }
+
+    /// @notice Verifies the messenger stores the portal address immutably.
+    function test_portalImmutable() public view {
+        assertEq(messenger.portal(), portal);
+    }
+
+    /// @notice Verifies only the portal can relay withdrawal messages.
+    function test_relayMessage_revertsOnlyPortalForNonPortalCaller() public {
+        vm.expectRevert(ZoneMessenger.OnlyPortal.selector);
+        messenger.relayMessage(token, bytes32("sender"), alice, 1, 50_000, "");
+    }
+
+    /// @notice Verifies relay reverts when token transferFrom returns false.
+    function test_relayMessage_revertsTransferFailedWhenTransferFromReturnsFalse() public {
+        AcceptingWithdrawalReceiver receiver = new AcceptingWithdrawalReceiver();
+        _mockTransferFrom(address(receiver), 1, false);
+
+        vm.prank(portal);
+        vm.expectRevert(ZoneMessenger.TransferFailed.selector);
+        messenger.relayMessage(token, bytes32("sender"), address(receiver), 1, 50_000, "");
+    }
+
+    /// @notice Verifies relay reverts when the receiver returns the wrong selector.
+    function test_relayMessage_revertsCallbackRejectedForWrongSelector() public {
+        RejectingWithdrawalReceiver receiver = new RejectingWithdrawalReceiver();
+        _mockTransferFrom(address(receiver), 1, true);
+
+        vm.prank(portal);
+        vm.expectRevert(ZoneMessenger.CallbackRejected.selector);
+        messenger.relayMessage(token, bytes32("sender"), address(receiver), 1, 50_000, "");
+    }
+
+    /// @notice Verifies relay to an EOA target reverts after transfer succeeds.
+    function test_relayMessage_revertsForEoaTarget() public {
+        _mockTransferFrom(alice, 1, true);
+
+        vm.prank(portal);
+        vm.expectRevert();
+        messenger.relayMessage(token, bytes32("sender"), alice, 1, 50_000, "");
+    }
+
+    /// @notice Verifies a valid relay transfers tokens to an accepting receiver.
+    function test_relayMessage_success() public {
+        AcceptingWithdrawalReceiver receiver = new AcceptingWithdrawalReceiver();
+        bytes32 senderTag = keccak256("sender");
+        bytes memory data = hex"1234";
+        zoneToken.mint(portal, 123);
+        vm.prank(portal);
+        zoneToken.approve(address(messenger), 123);
+
+        vm.prank(portal);
+        messenger.relayMessage(
+            address(zoneToken), senderTag, address(receiver), 123, 1_000_000, data
+        );
+
+        assertEq(zoneToken.balanceOf(address(receiver)), 123);
+    }
+
+    /// @notice Verifies valid relays transfer any bounded amount to the receiver.
+    function testFuzz_relayMessage_success(
+        uint128 amount,
+        uint64 gasLimit,
+        bytes calldata data
+    )
+        public
+    {
+        vm.assume(gasLimit >= 500_000);
+        amount = uint128(bound(amount, 0, 1_000_000_000e6));
+        AcceptingWithdrawalReceiver receiver = new AcceptingWithdrawalReceiver();
+        bytes32 senderTag = keccak256(abi.encode(amount, gasLimit, data));
+        zoneToken.mint(portal, amount);
+        vm.prank(portal);
+        zoneToken.approve(address(messenger), amount);
+
+        vm.prank(portal);
+        messenger.relayMessage(
+            address(zoneToken), senderTag, address(receiver), amount, gasLimit, data
+        );
+
+        assertEq(zoneToken.balanceOf(address(receiver)), amount);
+    }
+
+}

--- a/specs/ref-impls/test/zone/ZoneOutbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneOutbox.t.sol
@@ -991,4 +991,98 @@ contract ZoneOutboxTest is Test {
         vm.stopPrank();
     }
 
+    /// @notice Sequencer updates the Tempo gas rate and emits the new value.
+    function test_setTempoGasRate_sequencerCanSetAndEmit() public {
+        uint128 rate = 7;
+
+        vm.prank(sequencer);
+        vm.expectEmit(false, false, false, true);
+        emit IZoneOutbox.TempoGasRateUpdated(rate);
+        outbox.setTempoGasRate(rate);
+
+        assertEq(outbox.tempoGasRate(), rate);
+    }
+
+    /// @notice Only the sequencer can update the Tempo gas rate.
+    function test_setTempoGasRate_onlySequencer() public {
+        vm.prank(alice);
+        vm.expectRevert(ZoneOutbox.OnlySequencer.selector);
+        outbox.setTempoGasRate(1);
+    }
+
+    /// @notice Withdrawal fee matches base plus callback gas times Tempo gas rate.
+    function testFuzz_calculateWithdrawalFee(uint64 gasLimit, uint128 tempoGasRate) public {
+        tempoGasRate = uint128(bound(tempoGasRate, 0, outbox.MAX_GAS_FEE_RATE()));
+        uint64 maxGasLimit = outbox.MAX_WITHDRAWAL_GAS_LIMIT();
+
+        vm.prank(sequencer);
+        outbox.setTempoGasRate(tempoGasRate);
+
+        if (gasLimit > maxGasLimit) {
+            vm.expectRevert(ZoneOutbox.GasLimitTooHigh.selector);
+            outbox.calculateWithdrawalFee(gasLimit);
+        } else {
+            uint128 expected = uint128(outbox.WITHDRAWAL_BASE_GAS() + gasLimit) * tempoGasRate;
+            assertEq(outbox.calculateWithdrawalFee(gasLimit), expected);
+        }
+    }
+
+    /// @notice Zero-count finalization advances the batch index without dequeuing.
+    function test_finalizeWithdrawalBatch_zeroCountWithPending_advancesBatchOnly() public {
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 500e6);
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
+        vm.stopPrank();
+
+        bytes32 hash = _finalizeWithdrawalBatch(0);
+        LastBatch memory batch = outbox.lastBatch();
+
+        assertEq(hash, bytes32(0));
+        assertEq(outbox.pendingWithdrawalsCount(), 1);
+        assertEq(outbox.withdrawalBatchIndex(), 1);
+        assertEq(batch.withdrawalQueueHash, bytes32(0));
+        assertEq(batch.withdrawalBatchIndex, 1);
+    }
+
+    /// @notice Zero gas limit withdrawals still store callback data in the hash.
+    function test_requestWithdrawal_zeroGasLimitStoresCallbackData() public {
+        bytes memory data = "simple-with-data";
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 500e6);
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32("memo"), 0, alice, data);
+        vm.stopPrank();
+
+        Withdrawal memory w = _withdrawal(1, alice, bob, 500e6, bytes32("memo"), 0, alice, data);
+        assertEq(_finalizeWithdrawalBatch(1), keccak256(abi.encode(w, EMPTY_SENTINEL)));
+    }
+
+    /// @notice Finalized withdrawal hashes chain in reverse dequeue order.
+    function testFuzz_finalizeWithdrawalBatch_hashChainOrder(uint8 rawCount) public {
+        uint256 count = bound(rawCount, 1, 8);
+        address[3] memory senders = [alice, bob, charlie];
+        Withdrawal[] memory withdrawals = new Withdrawal[](count);
+
+        for (uint256 i = 0; i < count; i++) {
+            address sender = senders[i % senders.length];
+            uint128 amount = uint128((i + 1) * 10e6);
+            bytes32 memo = bytes32(i + 1);
+
+            vm.startPrank(sender);
+            zoneToken.approve(address(outbox), amount);
+            outbox.requestWithdrawal(address(zoneToken), sender, amount, memo, 0, alice, "");
+            vm.stopPrank();
+
+            withdrawals[i] = _withdrawal(i + 1, sender, sender, amount, memo, 0, alice, "");
+        }
+
+        bytes32 expectedHash = EMPTY_SENTINEL;
+        for (uint256 i = count; i > 0; i--) {
+            expectedHash = keccak256(abi.encode(withdrawals[i - 1], expectedHash));
+        }
+
+        assertEq(_finalizeWithdrawalBatch(count), expectedHash);
+        assertEq(outbox.pendingWithdrawalsCount(), 0);
+    }
+
 }

--- a/specs/ref-impls/test/zone/ZoneOutbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneOutbox.t.sol
@@ -497,6 +497,83 @@ contract ZoneOutboxTest is Test {
                       TOKEN TRANSFER TESTS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Verifies the sender is debited `amount + fee` when a gas rate is configured.
+    /// @dev With the default zero gas rate the fee is always zero, so `amount + fee` reads
+    ///      the same as `amount`; a non-zero rate and gas limit make the fee observable.
+    ///      The expected fee hardcodes WITHDRAWAL_BASE_GAS (50_000) so a mutated base-gas
+    ///      constant is also caught.
+    function test_requestWithdrawal_burnsAmountPlusFee() public {
+        uint128 rate = 3;
+        uint64 gasLimit = 100_000;
+        vm.prank(sequencer);
+        outbox.setTempoGasRate(rate);
+
+        uint128 amount = 500e6;
+        uint128 expectedFee = uint128(50_000 + gasLimit) * rate;
+        assertGt(expectedFee, 0);
+
+        uint256 aliceBefore = zoneToken.balanceOf(alice);
+        uint256 supplyBefore = zoneToken.totalSupply();
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), amount + expectedFee);
+        outbox.requestWithdrawal(address(zoneToken), bob, amount, bytes32(0), gasLimit, alice, "");
+        vm.stopPrank();
+
+        assertEq(zoneToken.balanceOf(alice), aliceBefore - amount - expectedFee);
+        assertEq(zoneToken.totalSupply(), supplyBefore - amount - expectedFee);
+    }
+
+    /// @notice Callback data exactly at the maximum size is accepted (boundary is inclusive).
+    /// @dev Guards `data.length > MAX` against `>=`/`==` mutants, which would reject MAX bytes.
+    function test_requestWithdrawal_callbackDataAtMaxSize_succeeds() public {
+        bytes memory data = new bytes(outbox.MAX_CALLBACK_DATA_SIZE());
+
+        uint256 supplyBefore = zoneToken.totalSupply();
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 500e6);
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, data);
+        vm.stopPrank();
+
+        assertEq(zoneToken.totalSupply(), supplyBefore - 500e6);
+    }
+
+    /// @notice Callback data one byte over the maximum reverts.
+    function test_requestWithdrawal_callbackDataAboveMax_reverts() public {
+        bytes memory data = new bytes(outbox.MAX_CALLBACK_DATA_SIZE() + 1);
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 500e6);
+        vm.expectRevert(ZoneOutbox.CallbackDataTooLarge.selector);
+        outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, data);
+        vm.stopPrank();
+    }
+
+    /// @notice Finalizing with a count above the true pending count clamps via length - head.
+    /// @dev After the queue head advances, pending must subtract the head. `+`/`^`/`|` mutants
+    ///      over-report pending, so an over-large count would escape clamping and the
+    ///      encrypted-sender length check would mismatch and revert.
+    function test_finalizeWithdrawalBatch_clampsUsingLengthMinusHead() public {
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 4 * 500e6);
+        for (uint256 i = 0; i < 4; i++) {
+            outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
+        }
+        vm.stopPrank();
+
+        // Finalize the first two, advancing the head to 2 (two remain pending).
+        _finalizeWithdrawalBatch(2);
+        assertEq(outbox.pendingWithdrawalsCount(), 2);
+
+        // Request count = 4 (> real pending 2) but supply only the 2 valid encrypted senders.
+        // Correct code clamps to 2 and succeeds; an additive-head mutant expects 4 and reverts.
+        // Build the senders array before the prank: the getter call would consume it otherwise.
+        bytes[] memory senders = _emptyEncryptedSenders(4);
+        vm.prank(sequencer);
+        outbox.finalizeWithdrawalBatch(4, uint64(block.number), senders);
+        assertEq(outbox.pendingWithdrawalsCount(), 0);
+    }
+
     function test_requestWithdrawal_transfersFromSender() public {
         uint256 aliceBalanceBefore = zoneToken.balanceOf(alice);
 

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -5,6 +5,7 @@ import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 import { ITIP403Registry } from "tempo-std/interfaces/ITIP403Registry.sol";
 
 import { BLOCKHASH_HISTORY_WINDOW } from "../../src/zone/BlockHashHistory.sol";
+import { DepositQueueLib } from "../../src/zone/DepositQueueLib.sol";
 import {
     BlockTransition,
     Deposit,
@@ -29,6 +30,7 @@ import {
     ZoneParams
 } from "../../src/zone/IZone.sol";
 import { EMPTY_SENTINEL, WithdrawalQueueLib } from "../../src/zone/WithdrawalQueueLib.sol";
+import { WITHDRAWAL_QUEUE_CAPACITY } from "../../src/zone/WithdrawalQueueLib.sol";
 import { ZoneFactory } from "../../src/zone/ZoneFactory.sol";
 import { ZoneMessenger } from "../../src/zone/ZoneMessenger.sol";
 import { ZonePortal } from "../../src/zone/ZonePortal.sol";
@@ -2699,6 +2701,284 @@ contract ZonePortalTest is BaseTest {
             entry.yParity,
             "vm.load yParity != encryptionKeyAt(0).yParity"
         );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         ADDITIONAL COVERAGE TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Records that false token transferFrom returns do not block deposits.
+    function test_deposit_tokenTransferFromReturnsFalse_currentlyNotChecked() public {
+        vm.fee(0);
+        uint128 amount = 500e6;
+
+        vm.mockCall(
+            address(pathUSD),
+            abi.encodeWithSelector(ITIP20.transferFrom.selector, alice, address(portal), amount),
+            abi.encode(false)
+        );
+
+        // Records current behavior: a false TIP-20 return value is not checked.
+        vm.prank(alice);
+        bytes32 depositHash = portal.deposit(address(pathUSD), bob, amount, bytes32("memo"), bob);
+
+        assertEq(portal.depositCount(), 1);
+        assertEq(portal.currentDepositQueueHash(), depositHash);
+    }
+
+    /// @notice Sequencer updates the zone gas rate and emits the new value.
+    function test_setZoneGasRate_updatesRateAndEmits() public {
+        uint128 newRate = 42;
+
+        vm.expectEmit(false, false, false, true, address(portal));
+        emit IZonePortal.ZoneGasRateUpdated(newRate);
+        portal.setZoneGasRate(newRate);
+
+        assertEq(portal.zoneGasRate(), newRate);
+    }
+
+    /// @notice Rejects zone gas rates above the configured maximum.
+    function test_setZoneGasRate_revertsWhenTooHigh() public {
+        uint128 tooHigh = uint128(1e18) + 1;
+
+        vm.expectRevert(IZonePortal.GasFeeRateTooHigh.selector);
+        portal.setZoneGasRate(tooHigh);
+    }
+
+    /// @notice Only the sequencer can update the zone gas rate.
+    function test_setZoneGasRate_revertsIfNotSequencer() public {
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setZoneGasRate(1);
+    }
+
+    /// @notice Claiming with no refund emits and returns zero without changing state.
+    function test_claimRefund_zeroAmount() public {
+        vm.expectEmit(true, true, false, true, address(portal));
+        emit IZonePortal.RefundClaimed(alice, address(pathUSD), 0);
+
+        vm.prank(alice);
+        uint128 amount = portal.claimRefund(address(pathUSD));
+
+        assertEq(amount, 0);
+        assertEq(portal.refunds(address(pathUSD), alice), 0);
+    }
+
+    /// @notice Claiming pays out a refund parked by a failed bounced withdrawal.
+    function test_claimRefund_successAfterDepositBounceBackPending() public {
+        vm.fee(0);
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), alice);
+        vm.stopPrank();
+
+        Withdrawal memory w =
+            _withdrawal(address(pathUSD), alice, bob, 250e6, bytes32(0), 0, address(0), "");
+        bytes32 wHash = keccak256(abi.encode(w, EMPTY_SENTINEL));
+
+        vm.roll(block.number + 1);
+        portal.submitBatch(
+            uint64(block.number - 1),
+            0,
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("refund")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash(),
+                    prevDepositNumber: 0,
+                    nextDepositNumber: 0
+                }),
+            wHash,
+            "",
+            ""
+        );
+
+        vm.mockCall(
+            address(pathUSD),
+            abi.encodeWithSelector(ITIP20.transfer.selector, bob, w.amount),
+            abi.encode(false)
+        );
+        portal.processWithdrawal(w, bytes32(0));
+
+        assertEq(portal.refunds(address(pathUSD), bob), w.amount);
+
+        vm.clearMockedCalls();
+        uint256 bobBalanceBefore = pathUSD.balanceOf(bob);
+
+        vm.prank(bob);
+        uint128 claimed = portal.claimRefund(address(pathUSD));
+
+        assertEq(claimed, w.amount);
+        assertEq(portal.refunds(address(pathUSD), bob), 0);
+        assertEq(pathUSD.balanceOf(bob), bobBalanceBefore + w.amount);
+    }
+
+    /// @notice Submitting a batch reverts once the withdrawal queue is full.
+    function test_withdrawalQueue_revertsWhenFull() public {
+        vm.roll(genesisTempoBlockNumber + 1);
+        uint256 i;
+        while (
+            portal.withdrawalQueueTail() - portal.withdrawalQueueHead() < WITHDRAWAL_QUEUE_CAPACITY
+        ) {
+            portal.submitBatch(
+                genesisTempoBlockNumber,
+                0,
+                BlockTransition({
+                    prevBlockHash: portal.blockHash(), nextBlockHash: keccak256(abi.encode("s", i))
+                }),
+                DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash(),
+                    prevDepositNumber: 0,
+                    nextDepositNumber: 0
+                }),
+                keccak256(abi.encode("w", i)),
+                "",
+                ""
+            );
+            i++;
+            assertLe(i, WITHDRAWAL_QUEUE_CAPACITY);
+        }
+        assertEq(
+            portal.withdrawalQueueTail() - portal.withdrawalQueueHead(), WITHDRAWAL_QUEUE_CAPACITY
+        );
+
+        bytes32 prevBlockHash = portal.blockHash();
+        bytes32 depositQueueHash = portal.currentDepositQueueHash();
+        vm.expectRevert(WithdrawalQueueLib.WithdrawalQueueFull.selector);
+        portal.submitBatch(
+            genesisTempoBlockNumber,
+            0,
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("full") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: depositQueueHash,
+                prevDepositNumber: 0,
+                nextDepositNumber: 0
+            }),
+            keccak256("overflow"),
+            "",
+            ""
+        );
+    }
+
+    /// @notice Deposit fee equals fixed deposit gas multiplied by zone gas rate.
+    function testFuzz_calculateDepositFee(uint128 zoneGasRate) public {
+        zoneGasRate = uint128(bound(zoneGasRate, 0, portal.MAX_GAS_FEE_RATE()));
+
+        portal.setZoneGasRate(zoneGasRate);
+
+        uint128 fee = portal.calculateDepositFee();
+
+        assertEq(fee, uint128(100_000) * zoneGasRate);
+    }
+
+    /// @notice Bounceback fee rounds basefee gas cost up to token units.
+    function testFuzz_calculateBouncebackFee(uint256 basefee) public {
+        basefee = bound(basefee, 0, 1e18);
+        vm.fee(basefee);
+
+        uint256 expected = (uint256(300_000) * basefee + 1e12 - 1) / 1e12;
+        uint128 fee = portal.calculateBouncebackFee();
+
+        assertEq(fee, uint128(expected));
+    }
+
+    /// @notice Deposits below fees revert and valid amounts enqueue the net amount.
+    function testFuzz_deposit_amountBoundary(uint128 amount) public {
+        amount = uint128(bound(amount, 0, 1000e6));
+        vm.fee(1e12);
+        portal.setZoneGasRate(1);
+        uint128 minimum = portal.calculateDepositFee() + portal.calculateBouncebackFee();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), amount);
+        if (amount < minimum) {
+            vm.expectRevert(IZonePortal.DepositTooSmall.selector);
+            portal.deposit(address(pathUSD), bob, amount, bytes32("memo"), bob);
+        } else {
+            bytes32 depositHash =
+                portal.deposit(address(pathUSD), bob, amount, bytes32("memo"), bob);
+            Deposit memory depositData = Deposit({
+                token: address(pathUSD),
+                sender: alice,
+                to: bob,
+                amount: amount - portal.calculateDepositFee(),
+                bouncebackRecipient: bob,
+                memo: bytes32("memo")
+            });
+            assertEq(depositHash, DepositQueueLib.enqueue(bytes32(0), depositData));
+        }
+        vm.stopPrank();
+    }
+
+    /// @notice Multiple deposits update the queue hash chain and count in order.
+    function testFuzz_deposit_hashChain(uint8 depositIterations) public {
+        uint256 iterations = bound(depositIterations, 1, 10);
+        uint128 amount = 1000e6;
+        bytes32 expectedHash;
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), amount * iterations);
+        for (uint256 i = 0; i < iterations; i++) {
+            bytes32 memo = bytes32(i);
+            bytes32 actualHash = portal.deposit(address(pathUSD), bob, amount, memo, bob);
+            Deposit memory depositData = Deposit({
+                token: address(pathUSD),
+                sender: alice,
+                to: bob,
+                amount: amount - portal.calculateDepositFee(),
+                bouncebackRecipient: bob,
+                memo: memo
+            });
+            expectedHash = DepositQueueLib.enqueue(expectedHash, depositData);
+            assertEq(actualHash, expectedHash);
+        }
+        vm.stopPrank();
+
+        assertEq(portal.currentDepositQueueHash(), expectedHash);
+        assertEq(portal.depositCount(), iterations);
+    }
+
+    /// @notice Key lookup returns the latest encryption key active at the query block.
+    function testFuzz_encryptionKeyAtBlock(
+        uint16 gap1,
+        uint16 gap2,
+        uint16 gap3,
+        uint16 queryOffset
+    )
+        public
+    {
+        uint64[3] memory activationBlocks;
+        bytes32[3] memory xs;
+        uint8[3] memory yParities;
+
+        activationBlocks[0] = uint64(bound(gap1, 1, 100));
+        vm.roll(activationBlocks[0]);
+        (xs[0], yParities[0]) = _setEncKeyWithPoP(ENC_KEY_1);
+
+        activationBlocks[1] = activationBlocks[0] + uint64(bound(gap2, 1, 100));
+        vm.roll(activationBlocks[1]);
+        (xs[1], yParities[1]) = _setEncKeyWithPoP(ENC_KEY_2);
+
+        activationBlocks[2] = activationBlocks[1] + uint64(bound(gap3, 1, 100));
+        vm.roll(activationBlocks[2]);
+        (xs[2], yParities[2]) = _setEncKeyWithPoP(ENC_KEY_3);
+
+        uint64 queryBlock = activationBlocks[0] + uint64(bound(queryOffset, 0, 300));
+        uint256 expectedIndex;
+        for (uint256 i = 0; i < activationBlocks.length; i++) {
+            if (activationBlocks[i] <= queryBlock) {
+                expectedIndex = i;
+            }
+        }
+
+        (bytes32 x, uint8 yParity, uint256 keyIndex) = portal.encryptionKeyAtBlock(queryBlock);
+        assertEq(x, xs[expectedIndex]);
+        assertEq(yParity, yParities[expectedIndex]);
+        assertEq(keyIndex, expectedIndex);
     }
 
 }

--- a/specs/ref-impls/test/zone/ZonePortal.t.sol
+++ b/specs/ref-impls/test/zone/ZonePortal.t.sol
@@ -2053,6 +2053,17 @@ contract ZonePortalTest is BaseTest {
         portal.encryptionKeyAt(0);
     }
 
+    /// @notice Reverts with InvalidEncryptionKeyIndex when the index is strictly past the end.
+    /// @dev With one key set, the empty-array test cannot tell `index >= length` from
+    ///      `index == length`. Querying index 2 (length 1) distinguishes them: the `==` mutant
+    ///      would fall through to an out-of-bounds array access (a panic, not this revert).
+    function test_encryptionKeyAt_revertsWhenIndexAboveLength() public {
+        _setEncKeyWithPoP(ENC_KEY_1);
+
+        vm.expectRevert(abi.encodeWithSelector(IZonePortal.InvalidEncryptionKeyIndex.selector, 2));
+        portal.encryptionKeyAt(2);
+    }
+
     function test_encryptionKeyAtBlock_binarySearch() public {
         // Set key1 at block 10
         vm.roll(10);
@@ -2743,6 +2754,15 @@ contract ZonePortalTest is BaseTest {
 
         vm.expectRevert(IZonePortal.GasFeeRateTooHigh.selector);
         portal.setZoneGasRate(tooHigh);
+    }
+
+    /// @notice A gas rate exactly at the maximum is accepted (the bound is inclusive).
+    /// @dev Guards `_zoneGasRate > MAX` against a `>=` mutant, which would reject the maximum.
+    function test_setZoneGasRate_acceptsExactMaximum() public {
+        uint128 maxRate = portal.MAX_GAS_FEE_RATE();
+
+        portal.setZoneGasRate(maxRate);
+        assertEq(portal.zoneGasRate(), maxRate);
     }
 
     /// @notice Only the sequencer can update the zone gas rate.

--- a/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
+++ b/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { EncryptedDepositLib } from "../../src/zone/EncryptedDeposit.sol";
+import {
+    WITHDRAWAL_QUEUE_CAPACITY,
+    WithdrawalQueue,
+    WithdrawalQueueLib
+} from "../../src/zone/WithdrawalQueueLib.sol";
+import { ZoneOutboxTest } from "./ZoneOutbox.t.sol";
+import { ZonePortalTest } from "./ZonePortal.t.sol";
+import { Test } from "forge-std/Test.sol";
+
+/// @title ZonePortal symbolic properties
+/// @notice Curated symbolic (`check_*`) properties for the arithmetic-heavy parts of the zone
+///         contracts. These complement the unit/fuzz suites: each `check_*` is explored over the
+///         full symbolic input space (within configured bounds) rather than sampled.
+///
+///         Run with the symbolic-capable forge build:
+///           forge test --symbolic --match-contract ZonePortalSymbolic
+///           forge test --symbolic --match-contract WithdrawalQueueSymbolic
+///
+///         Guidance: prefer inequality / overflow-freedom / revert-freedom properties. Exact
+///         equalities involving multiplication tend to return `incomplete` (the engine's
+///         nonlinear "hard arithmetic" gap), which means "not established" — never treat it as a
+///         pass.
+///
+///         Inherits ZonePortalTest to reuse its concrete setUp (a real ZonePortal deployed via
+///         ZoneFactory, with `admin` acting as the sequencer).
+contract ZonePortalSymbolic is ZonePortalTest {
+
+    /// @notice Deposit fee never overflows uint128 for any rate within the enforced cap, so
+    ///         `calculateDepositFee` cannot revert. Proven over all 2^128 rate values.
+    function check_depositFeeNeverOverflows(uint128 rate) external {
+        vm.assume(rate <= portal.MAX_GAS_FEE_RATE());
+
+        vm.prank(admin); // admin is the sequencer in this harness
+        portal.setZoneGasRate(rate);
+
+        uint128 fee = portal.calculateDepositFee();
+        assertLe(uint256(fee), uint256(type(uint128).max));
+    }
+
+    /// @notice The stored gas rate is always within the cap whenever `setZoneGasRate` succeeds,
+    ///         for any input (over-cap inputs revert and are pruned). Encodes the MAX_GAS_FEE_RATE
+    ///         invariant.
+    function check_gasRateAlwaysWithinCap(uint128 rate) external {
+        vm.prank(admin);
+        try portal.setZoneGasRate(rate) {
+            assertLe(uint256(portal.zoneGasRate()), uint256(portal.MAX_GAS_FEE_RATE()));
+        } catch { }
+    }
+
+}
+
+/// @notice Harness exposing the WithdrawalQueueLib ring-buffer over a storage queue so its
+///         index arithmetic can be explored symbolically.
+contract WithdrawalQueueHarness {
+
+    using WithdrawalQueueLib for WithdrawalQueue;
+
+    WithdrawalQueue internal q;
+
+    function setHeadTail(uint256 _head, uint256 _tail) external {
+        q.head = _head;
+        q.tail = _tail;
+    }
+
+    function head() external view returns (uint256) {
+        return q.head;
+    }
+
+    function tail() external view returns (uint256) {
+        return q.tail;
+    }
+
+    function length() external view returns (uint256) {
+        return q.length();
+    }
+
+    function isFull() external view returns (bool) {
+        return q.isFull();
+    }
+
+    function hasWithdrawals() external view returns (bool) {
+        return q.hasWithdrawals();
+    }
+
+    function enqueue(bytes32 h) external {
+        q.enqueue(h);
+    }
+
+    function capacity() external pure returns (uint256) {
+        return WITHDRAWAL_QUEUE_CAPACITY;
+    }
+
+}
+
+/// @title WithdrawalQueueLib symbolic properties
+/// @notice Symbolic checks for the withdrawal ring-buffer's pure index arithmetic
+///         (head/tail). The dequeue hash-chain path is intentionally excluded because it relies
+///         on keccak injectivity, which the symbolic engine does not model.
+contract WithdrawalQueueSymbolic is Test {
+
+    WithdrawalQueueHarness internal qh;
+
+    function setUp() public {
+        qh = new WithdrawalQueueHarness();
+    }
+
+    /// @notice For any valid queue state (head <= tail, length <= capacity),
+    ///         isFull() <=> length() == capacity.
+    function check_isFullIffLengthEqualsCapacity(uint256 _head, uint256 _tail) external {
+        vm.assume(_tail >= _head);
+        vm.assume(_tail - _head <= qh.capacity());
+
+        qh.setHeadTail(_head, _tail);
+
+        assertEq(qh.isFull(), qh.length() == qh.capacity());
+    }
+
+    /// @notice For any valid queue state, hasWithdrawals() <=> length() != 0.
+    function check_hasWithdrawalsIffNonEmpty(uint256 _head, uint256 _tail) external {
+        vm.assume(_tail >= _head);
+        vm.assume(_tail - _head <= qh.capacity());
+
+        qh.setHeadTail(_head, _tail);
+
+        assertEq(qh.hasWithdrawals(), qh.length() != 0);
+    }
+
+    /// @notice A non-empty enqueue on a non-full queue advances tail by exactly one and never
+    ///         pushes length past capacity.
+    function check_enqueueAdvancesTailAndRespectsCapacity(
+        uint256 _head,
+        uint256 _tail,
+        bytes32 h
+    )
+        external
+    {
+        vm.assume(h != bytes32(0));
+        vm.assume(_tail >= _head);
+        vm.assume(_tail - _head < qh.capacity()); // not full
+        vm.assume(_tail < type(uint256).max); // tail + 1 cannot overflow
+
+        qh.setHeadTail(_head, _tail);
+        uint256 lenBefore = qh.length();
+
+        qh.enqueue(h);
+
+        assertEq(qh.tail(), _tail + 1);
+        assertEq(qh.length(), lenBefore + 1);
+        assertLe(qh.length(), qh.capacity());
+    }
+
+    /// @notice Enqueuing the zero hash (a batch with no withdrawals) is a no-op: head and tail
+    ///         are unchanged, for any starting state.
+    function check_enqueueZeroIsNoop(uint256 _head, uint256 _tail) external {
+        qh.setHeadTail(_head, _tail);
+
+        qh.enqueue(bytes32(0));
+
+        assertEq(qh.head(), _head);
+        assertEq(qh.tail(), _tail);
+    }
+
+    /// @notice A non-empty enqueue on a full queue always reverts, for any full state.
+    function check_enqueueRevertsWhenFull(uint256 _head, uint256 _tail, bytes32 h) external {
+        vm.assume(h != bytes32(0));
+        vm.assume(_tail >= _head);
+        vm.assume(_tail - _head == qh.capacity()); // full
+
+        qh.setHeadTail(_head, _tail);
+
+        vm.expectRevert(WithdrawalQueueLib.WithdrawalQueueFull.selector);
+        qh.enqueue(h);
+    }
+
+}
+
+/// @title ZoneOutbox symbolic properties
+/// @notice Symbolic checks for the zone→Tempo withdrawal fee arithmetic. Inherits ZoneOutboxTest
+///         to reuse its concrete setUp (real ZoneOutbox + ZoneConfig, `sequencer` authorized).
+contract ZoneOutboxSymbolic is ZoneOutboxTest {
+
+    /// @notice The withdrawal fee `(WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate` never
+    ///         overflows uint128, so `calculateWithdrawalFee` cannot revert. Verifies the
+    ///         overflow-safety invariant the contract documents, explored over all 2^64 gas
+    ///         limits.
+    /// @dev The rate is pinned to its maximum (MAX_GAS_FEE_RATE) because the fee is monotonic in
+    ///      the rate, so the cap is the worst case for overflow: proving no overflow here proves
+    ///      it for every rate <= cap. Pinning the rate also keeps the multiplication linear
+    ///      (constant * symbolic); leaving both operands symbolic hits the engine's nonlinear
+    ///      "hard arithmetic" gap and returns `incomplete`.
+    function check_withdrawalFeeNeverOverflows(uint64 gasLimit) external {
+        vm.assume(gasLimit <= outbox.MAX_WITHDRAWAL_GAS_LIMIT());
+
+        uint128 cap = outbox.MAX_GAS_FEE_RATE();
+        vm.prank(sequencer);
+        outbox.setTempoGasRate(cap);
+
+        uint128 fee = outbox.calculateWithdrawalFee(gasLimit);
+        assertLe(uint256(fee), uint256(type(uint128).max));
+    }
+
+    /// @notice The stored Tempo gas rate is always within the cap whenever `setTempoGasRate`
+    ///         succeeds, for any input (over-cap inputs revert and are pruned).
+    function check_tempoGasRateAlwaysWithinCap(uint128 rate) external {
+        vm.prank(sequencer);
+        try outbox.setTempoGasRate(rate) {
+            assertLe(uint256(outbox.tempoGasRate()), uint256(outbox.MAX_GAS_FEE_RATE()));
+        } catch { }
+    }
+
+    /// @notice `calculateWithdrawalFee` rejects any gas limit above MAX_WITHDRAWAL_GAS_LIMIT,
+    ///         for every over-cap value.
+    function check_withdrawalFeeRejectsOverCapGasLimit(uint64 gasLimit) external {
+        vm.assume(gasLimit > outbox.MAX_WITHDRAWAL_GAS_LIMIT());
+
+        try outbox.calculateWithdrawalFee(gasLimit) returns (uint128) {
+            fail(); // an over-cap gas limit must never produce a fee
+        } catch { }
+    }
+
+}
+
+/// @notice Harness exposing the EncryptedDepositLib plaintext packing helpers so the
+///         encode/decode assembly can be explored symbolically.
+contract EncryptedDepositHarness {
+
+    function roundtrip(address to, bytes32 memo) external pure returns (address, bytes32) {
+        return EncryptedDepositLib.decodePlaintext(EncryptedDepositLib.encodePlaintext(to, memo));
+    }
+
+}
+
+/// @title EncryptedDeposit symbolic properties
+/// @notice Symbolic check for the (to, memo) plaintext packing round-trip. Pure byte manipulation
+///         (no keccak, no external calls) — a clean symbolic-execution target.
+contract EncryptedDepositSymbolic is Test {
+
+    EncryptedDepositHarness internal h;
+
+    function setUp() public {
+        h = new EncryptedDepositHarness();
+    }
+
+    /// @notice decode(encode(to, memo)) == (to, memo) for every address and memo. Catches any
+    ///         offset/packing bug in the assembly layout.
+    function check_plaintextRoundTrip(address to, bytes32 memo) external view {
+        (address gotTo, bytes32 gotMemo) = h.roundtrip(to, memo);
+        assertEq(gotTo, to);
+        assertEq(gotMemo, memo);
+    }
+
+}


### PR DESCRIPTION
## What

Strengthens the Solidity test suite for the zone implementation and wires it into CI with a coverage gate.

### Tests
- Expands unit + fuzz tests across the zone contracts: `ZonePortal`, `ZoneInbox`, `ZoneOutbox`, `ZoneMessenger`, `ZoneConfig`, `TempoState`, `BlockHashHistory`, `DepositQueueLib`, `WithdrawalQueueLib`, `Secp256k1Lib`, `EncryptedDeposit`, `PrivateZoneToken`, `Verifier`.
- Adds native symbolic (symex) property tests in `ZoneSymbolic.t.sol` (11 `check_*` properties across 4 contracts).
- Adds mutation-guided tests (driven by `forge --mutate`) that close real gaps line/branch coverage cannot see — boundaries, storage-slot math, and accounting — rather than equivalent or cross-contract mutants:
  - `ZoneConfig`: 3-entry encryption-key read + above-sequencer membership check (73.7% -> 81.2% mutation score).
  - `ZoneInbox`: HMAC-SHA256 known-answer test (RFC 4231 + golden vectors across every key-length branch) and direct `_readEncryptionKey` tests via a harness exposing the internal helpers the encrypted-deposit suite only reaches through the mocked AES-GCM path (49.5% -> 78.2%).
  - `ZoneOutbox`: amount + fee burn accounting, callback-data size boundary, and the `length - head` pending clamp (80.1% -> 84.1%).
  - `ZonePortal`: gas-rate exact-maximum and encryption-key index-past-end boundaries.
  - `TempoState`: already scores 100%, no changes.
- Splits `TempoState` header encoding in the test so `forge coverage --ir-minimum` no longer overflows the stack.

### CI (`specs.yml`)
- Builds the Tempo-capable `forge` once and reuses it for unit/fuzz, symex, and coverage in a single job.
- Installs `z3` and runs the `--symbolic check_*` property suite after the unit/fuzz tests.
- Runs `forge coverage --exclude-tests` (so the summary lists only production `src/zone` contracts) and fails the build if `src/zone` drops below 88% lines / 60% branches.

## Coverage
`src/zone`: 89.86% lines (771/858), 64.53% branches (151/234).
