### PR TITLE
ci: add reproducible build verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     strategy:
       matrix:
-        binary: [tempo, tempo-bench, tempo-sidecar]
+        binary: [tempo-zone]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,0 +1,90 @@
+name: Reproducible Build
+
+# Builds and hashes the byte-deterministic `tempo-zone` binary for
+# x86_64-unknown-linux-gnu from the pinned Dockerfile.reproducible recipe.
+
+permissions: {}
+
+concurrency:
+  group: reproducible-build-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch, tag, or full SHA) to build reproducibly"
+        type: string
+        required: false
+        default: "main"
+
+jobs:
+  build:
+    name: Build & hash
+    runs-on: depot-ubuntu-latest-16
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve version + artifact name
+        id: cfg
+        run: |
+          set -euo pipefail
+          SHORT=$(git rev-parse --short=7 HEAD)
+          SHA=$(git rev-parse HEAD)
+          echo "version=sha-$SHORT" >> "$GITHUB_OUTPUT"
+          echo "artifact=reproducible-hash-${SHA}" >> "$GITHUB_OUTPUT"
+          echo "bin=tempo-zone-sha-${SHORT}-x86_64-unknown-linux-gnu" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build reproducible binary
+        env:
+          VERSION: ${{ steps.cfg.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if ./scripts/reproducible-build.sh; then
+              exit 0
+            fi
+            echo "reproducible-build.sh failed (attempt $attempt/3); retrying after backoff"
+            sleep $((attempt * 30))
+          done
+          echo "reproducible build failed after 3 attempts" >&2
+          exit 1
+
+      - name: Compute reproducible sha256
+        id: hash
+        env:
+          BIN: ${{ steps.cfg.outputs.bin }}
+        run: |
+          set -euo pipefail
+          mv out/tempo-zone "$BIN"
+          shasum -a 256 "$BIN" > "${BIN}.reproducible.sha256"
+          echo "::group::Reproducible verification result"
+          echo "ref_input         = ${{ inputs.ref }}"
+          echo "commit            = $(git rev-parse HEAD)"
+          echo "version           = ${{ steps.cfg.outputs.version }}"
+          echo "binary            = $BIN"
+          echo "SOURCE_DATE_EPOCH = $(git log -1 --pretty=%ct)"
+          cat "${BIN}.reproducible.sha256"
+          echo "::endgroup::"
+          echo "checksum=${BIN}.reproducible.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.cfg.outputs.artifact }}
+          path: ${{ steps.hash.outputs.checksum }}
+          retention-days: 7
+          if-no-files-found: error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,15 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+[profile.reproducible]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+strip = "none"
+debug = "none"
+panic = "abort"
+incremental = false
+
 [workspace.dependencies]
 # tempo (from upstream)
 tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7" }

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+#
+# Reproducible build of the `tempo-zone` binary for x86_64-unknown-linux-gnu.
+# This is verification-only for now; release.yml and docker.yml still publish
+# through the existing release paths.
+
+ARG RUST_TOOLCHAIN=1.96.0
+FROM rust:${RUST_TOOLCHAIN}-bookworm@sha256:64d9b7f60e3abb08d477cad983d0a3743acc53a19369ba4482510184c9c807e5 AS builder
+
+ARG SOURCE_DATE_EPOCH
+ARG VERSION
+ARG DEBIAN_SNAPSHOT=20260501T000000Z
+
+RUN echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bookworm main" \
+        > /etc/apt/sources.list && \
+    echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ bookworm-security main" \
+        >> /etc/apt/sources.list && \
+    echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bookworm-updates main" \
+        >> /etc/apt/sources.list && \
+    rm -f /etc/apt/sources.list.d/debian.sources
+
+RUN apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get install -y --no-install-recommends \
+        libjemalloc-dev \
+        libclang-dev \
+        clang \
+        libssl-dev \
+        pkg-config \
+        mold && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} \
+    LC_ALL=C \
+    TZ=UTC \
+    JEMALLOC_OVERRIDE=/usr/lib/x86_64-linux-gnu/libjemalloc.a \
+    RUSTFLAGS="-C symbol-mangling-version=v0 -C strip=none -C link-arg=-Wl,--build-id=none -C link-arg=-fuse-ld=mold -C metadata= --remap-path-prefix /app=. --remap-path-prefix /usr/local/cargo/registry=/registry --remap-path-prefix /usr/local/rustup=/rustup"
+
+RUN cargo build --locked --bin tempo-zone \
+        --features jemalloc \
+        --profile reproducible \
+        --target x86_64-unknown-linux-gnu
+
+FROM scratch AS artifacts
+COPY --from=builder /app/target/x86_64-unknown-linux-gnu/reproducible/tempo-zone /tempo-zone

--- a/Justfile
+++ b/Justfile
@@ -9,12 +9,12 @@ install-cross:
     cargo install cross --git https://github.com/cross-rs/cross
 
 [group('build')]
-[doc('Builds all tempo binaries in cargo release mode')]
-build-all-release extra_args="": (build-release "tempo" extra_args)
+[doc('Builds all zone binaries in cargo release mode')]
+build-all-release extra_args="": (build-release "tempo-zone" extra_args)
 
 [group('build')]
-[doc('Builds all tempo binaries')]
-build-all extra_args="": (build "tempo" extra_args)
+[doc('Builds all zone binaries')]
+build-all extra_args="": (build "tempo-zone" extra_args)
 
 build-release binary extra_args="": (build binary "-r " + extra_args)
 

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Reproducible-build wrapper. Single source of truth for producing the
+# byte-deterministic `tempo-zone` binary for x86_64-unknown-linux-gnu.
+#
+# Inputs (env):
+#   VERSION         informational version baked into audit output (default: dev)
+#   OUT_DIR         where the built binary lands (default: ./out)
+#   DEBIAN_SNAPSHOT pinned Debian apt snapshot override
+#
+# Output:
+#   $OUT_DIR/tempo-zone
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+VERSION="${VERSION:-dev}"
+OUT_DIR="${OUT_DIR:-./out}"
+DEBIAN_SNAPSHOT="${DEBIAN_SNAPSHOT:-}"
+
+SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
+COMMIT="$(git rev-parse HEAD)"
+
+echo "::group::Reproducible build inputs"
+printf '  commit              = %s\n' "$COMMIT"
+printf '  version             = %s\n' "$VERSION"
+printf '  SOURCE_DATE_EPOCH   = %s\n' "$SOURCE_DATE_EPOCH"
+printf '  Dockerfile          = Dockerfile.reproducible\n'
+printf '  out_dir             = %s\n' "$OUT_DIR"
+[[ -n "$DEBIAN_SNAPSHOT" ]] && printf '  DEBIAN_SNAPSHOT     = %s (override)\n' "$DEBIAN_SNAPSHOT"
+echo "::endgroup::"
+
+mkdir -p "$OUT_DIR"
+
+build_args=(
+  --build-arg "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
+  --build-arg "VERSION=$VERSION"
+)
+if [[ -n "$DEBIAN_SNAPSHOT" ]]; then
+  build_args+=( --build-arg "DEBIAN_SNAPSHOT=$DEBIAN_SNAPSHOT" )
+fi
+
+docker build \
+  --platform linux/amd64 \
+  "${build_args[@]}" \
+  -f Dockerfile.reproducible \
+  --target artifacts \
+  --output "type=local,dest=$OUT_DIR" \
+  .
+
+echo "Reproducible binary written to $OUT_DIR/tempo-zone"
+sha256sum "$OUT_DIR/tempo-zone"


### PR DESCRIPTION
## Summary
- add Tempo-style reproducible build verification for the `tempo-zone` Linux amd64 binary
- add a pinned Dockerfile recipe and wrapper script that emits `out/tempo-zone` plus a CI hash artifact
- clean up stale build/release references that still pointed at Tempo binaries or unsupported Tempo features

Prompted by: @grandizzy

## Validation
- `bash -n scripts/reproducible-build.sh`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo build --locked --bin tempo-zone --features jemalloc --profile reproducible --target x86_64-unknown-linux-gnu`

## Notes
- This follows Tempo's current verification-only approach; official release and Docker publishing paths are not switched to consume the reproducible build output yet.
- Existing release features `asm-keccak,otlp` were not valid for `zones`, so the release matrix now uses `jemalloc` to match `tempo-zone`.
