### PR TITLE
fix: expose ZonePortal deposit counter ABI

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -662,6 +662,10 @@ interface IZonePortal {
 
     function currentDepositQueueHash() external view returns (bytes32);
 
+    function depositCount() external view returns (uint64);
+
+    function lastProcessedDepositNumber() external view returns (uint64);
+
     function lastSyncedTempoBlockNumber() external view returns (uint64);
 
     function withdrawalQueueHead() external view returns (uint256);

--- a/specs/ref-impls/test/BaseTest.t.sol
+++ b/specs/ref-impls/test/BaseTest.t.sol
@@ -89,11 +89,10 @@ contract BaseTest is Test {
             revert MissingPrecompile("ValidatorConfig", _VALIDATOR_CONFIG);
         }
 
-        // Install EIP-2935 mock when absent so zone tests can still run
-        if (_BLOCKHASH_HISTORY.code.length == 0) {
-            MockEIP2935 mock2935 = new MockEIP2935();
-            vm.etch(_BLOCKHASH_HISTORY, address(mock2935).code);
-        }
+        // Always install the deterministic EIP-2935 mock. Some Forge builds expose
+        // native EIP-2935 code here, but the spec tests assert against mock hashes.
+        MockEIP2935 mock2935 = new MockEIP2935();
+        vm.etch(_BLOCKHASH_HISTORY, address(mock2935).code);
         if (_BLOCKHASH_HISTORY.code.length == 0) {
             revert MissingPrecompile("BlockHashHistory", _BLOCKHASH_HISTORY);
         }

--- a/specs/ref-impls/test/l1/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/l1/ZoneFactory.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { IZoneFactory, ZoneInfo, ZoneParams } from "../../src/interfaces/IZone.sol";
+import { IZoneFactory, IZonePortal, ZoneInfo, ZoneParams } from "../../src/interfaces/IZone.sol";
 import { ZoneFactory } from "../../src/l1/ZoneFactory.sol";
 import { ZoneMessenger } from "../../src/l1/ZoneMessenger.sol";
 import { ZonePortal } from "../../src/l1/ZonePortal.sol";
@@ -453,6 +453,49 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(info.genesisTempoBlockNumber, tbn);
         assertTrue(zoneFactory.isZonePortal(portal));
         assertEq(zoneFactory.zoneCount(), 1);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      PORTAL ABI REGRESSION (#355)
+    //////////////////////////////////////////////////////////////*/
+
+    // Verify the factory deploys the post-#355 ZonePortal: depositCount and
+    // lastProcessedDepositNumber must exist on the interface and initialize to zero.
+    function test_createZone_deployedPortalExposes_depositCounters() public {
+        (, address portal) = zoneFactory.createZone(_defaultParams());
+        IZonePortal portalInterface = IZonePortal(portal);
+
+        assertEq(portalInterface.depositCount(), 0);
+        assertEq(portalInterface.lastProcessedDepositNumber(), 0);
+    }
+
+    // Verify the factory-deployed portal emits DepositMade with the new 9-arg
+    // signature that includes uint64 depositNumber as its last field.
+    function test_createZone_deployedPortalEmits_depositMadeWithDepositNumber() public {
+        (, address portal) = zoneFactory.createZone(_defaultParams());
+        ZonePortal portalContract = ZonePortal(portal);
+
+        vm.startPrank(pathUSDAdmin);
+        pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
+        pathUSD.mint(alice, 100_000e6);
+        vm.stopPrank();
+
+        uint128 depositAmount = 1000e6;
+
+        vm.startPrank(alice);
+        pathUSD.approve(portal, depositAmount);
+
+        // vm.expectEmit checks topic[0] (event signature) always, plus topic[2] (sender).
+        // The 9-arg signature proves depositNumber is present in the ABI.
+        vm.expectEmit(false, true, false, false);
+        emit IZonePortal.DepositMade(
+            bytes32(0), alice, address(0), address(0), 0, 0, bytes32(0), address(0), 1
+        );
+
+        portalContract.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), alice);
+        vm.stopPrank();
+
+        assertEq(portalContract.depositCount(), 1);
     }
 
 }


### PR DESCRIPTION
## Summary

- Adds `depositCount()` and `lastProcessedDepositNumber()` to the `IZonePortal` interface so generated clients expose the post-#355 portal counter ABI.
- Ports the regression coverage onto the current ref-impl layout after the Solidity files moved from `src/zone` to `src/interfaces` and `src/l1`.
- Verifies a factory-deployed portal exposes the counters through `IZonePortal` and emits the current 9-field `DepositMade` event with `depositNumber`.

## Root Cause

`ZonePortal` already implemented these counter getters as public state variables, but `IZonePortal` did not declare them. The original regression test also cast to concrete `ZonePortal`, so it did not actually protect the interface ABI.

## Impact

Clients generated from `IZonePortal` can call the deposit counter getters and rely on the current deposit event ABI when interacting with newly deployed portals.

Closes https://github.com/tempoxyz/zones/issues/464
