### PR TITLE
Emit senderTag on processed withdrawals

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -302,7 +302,7 @@ send-withdrawal amount="1000000" to="" token="0x20C00000000000000000000000000000
     echo "Waiting for withdrawal to be processed on L1 (from block $FROM_BLOCK)..."
     while true; do
         LOGS=$(cast logs --address "$PORTAL" --from-block "$FROM_BLOCK" --rpc-url "$HTTP_RPC" \
-            "WithdrawalProcessed(address indexed to, address token, uint128 amount, bool callbackSuccess)" \
+            "WithdrawalProcessed(address indexed to, bytes32 indexed senderTag, address token, uint128 amount, bool callbackSuccess)" \
             "$TO" --json 2>/dev/null || echo "[]")
         if [[ "$LOGS" != "[]" && "$LOGS" != "" && "$LOGS" != "null" ]]; then
             L1_TX=$(echo "$LOGS" | jq -r '.[-1].transactionHash')

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -100,7 +100,13 @@ crate::sol! {
             uint64 lastProcessedDepositNumber
         );
 
-        event WithdrawalProcessed(address indexed to, address token, uint128 amount, bool callbackSuccess);
+        event WithdrawalProcessed(
+            address indexed to,
+            bytes32 indexed senderTag,
+            address token,
+            uint128 amount,
+            bool callbackSuccess
+        );
 
         event WithdrawalBounceBack(
             bytes32 indexed newCurrentDepositQueueHash,

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -539,7 +539,11 @@ interface IZonePortal {
     );
 
     event WithdrawalProcessed(
-        address indexed to, address token, uint128 amount, bool callbackSuccess
+        address indexed to,
+        bytes32 indexed senderTag,
+        address token,
+        uint128 amount,
+        bool callbackSuccess
     );
 
     event WithdrawalBounceBack(

--- a/specs/ref-impls/src/l1/ZonePortal.sol
+++ b/specs/ref-impls/src/l1/ZonePortal.sol
@@ -675,7 +675,9 @@ contract ZonePortal is IZonePortal {
 
         if (withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) {
             _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
-            emit WithdrawalProcessed(withdrawal.to, _token, withdrawal.amount, false);
+            emit WithdrawalProcessed(
+                withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, false
+            );
             return;
         }
 
@@ -707,9 +709,13 @@ contract ZonePortal is IZonePortal {
         if (!success) {
             // Callback failed: bounce back to zone (only amount, not fee)
             _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
-            emit WithdrawalProcessed(withdrawal.to, _token, withdrawal.amount, false);
+            emit WithdrawalProcessed(
+                withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, false
+            );
         } else {
-            emit WithdrawalProcessed(withdrawal.to, _token, withdrawal.amount, true);
+            emit WithdrawalProcessed(
+                withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, true
+            );
         }
     }
 

--- a/specs/ref-impls/test/l1/ZonePortal.t.sol
+++ b/specs/ref-impls/test/l1/ZonePortal.t.sol
@@ -1905,8 +1905,8 @@ contract ZonePortalTest is BaseTest {
             ""
         );
 
-        vm.expectEmit(true, false, false, true);
-        emit IZonePortal.WithdrawalProcessed(bob, address(pathUSD), 500e6, true);
+        vm.expectEmit(true, true, false, true);
+        emit IZonePortal.WithdrawalProcessed(bob, w.senderTag, address(pathUSD), 500e6, true);
 
         portal.processWithdrawal(w, bytes32(0));
     }
@@ -1946,9 +1946,9 @@ contract ZonePortalTest is BaseTest {
             ""
         );
 
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(true, true, false, true);
         emit IZonePortal.WithdrawalProcessed(
-            address(gasConsumingReceiver), address(pathUSD), 500e6, false
+            address(gasConsumingReceiver), w.senderTag, address(pathUSD), 500e6, false
         );
 
         portal.processWithdrawal(w, bytes32(0));

--- a/specs/ref-impls/test/l1/ZonePortalGasLimit.t.sol
+++ b/specs/ref-impls/test/l1/ZonePortalGasLimit.t.sol
@@ -85,8 +85,8 @@ contract ZonePortalGasLimitTest is Test {
         emit IZonePortal.WithdrawalBounceBack(
             bytes32(0), fallbackRecipient, address(token), 500e6, 1
         );
-        vm.expectEmit(true, false, false, true, address(portal));
-        emit IZonePortal.WithdrawalProcessed(recipient, address(token), 500e6, false);
+        vm.expectEmit(true, true, false, true, address(portal));
+        emit IZonePortal.WithdrawalProcessed(recipient, w.senderTag, address(token), 500e6, false);
         portal.processWithdrawal(w, bytes32(0));
 
         assertEq(portal.withdrawalQueueHead(), 1);

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1602,7 +1602,13 @@ interface IZonePortal {
         bytes32 withdrawalQueueHash,
         uint64 lastProcessedDepositNumber
     );
-    event WithdrawalProcessed(address indexed to, address token, uint128 amount, bool callbackSuccess);
+    event WithdrawalProcessed(
+        address indexed to,
+        bytes32 indexed senderTag,
+        address token,
+        uint128 amount,
+        bool callbackSuccess
+    );
     event WithdrawalBounceBack(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed fallbackRecipient,


### PR DESCRIPTION
## Summary
- add indexed `senderTag` to `WithdrawalProcessed` events
- emit the withdrawal sender tag on success, callback failure, and over-cap callback bounce-back paths
- update ABI bindings, spec docs, Justfile log filter, and event expectation tests

Prompted by: @0xKitsune

## Testing
- `forge test --match-contract ZonePortal --match-test WithdrawalProcessed`
- `cargo check -p tempo-zone-contracts`
- `forge fmt --check`
- `cargo fmt --check`
- `git diff --check`