### PR TITLE
Move PrivateZoneToken out of ref-impls

### DIFF
--- a/specs/contracts/token/PrivateZoneToken.sol
+++ b/specs/contracts/token/PrivateZoneToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import { IZoneConfig, ZONE_INBOX, ZONE_OUTBOX } from "../interfaces/IZone.sol";
+import { IZoneConfig, ZONE_INBOX, ZONE_OUTBOX } from "src/interfaces/IZone.sol";
 
 /**
  * @title PrivateZoneToken

--- a/specs/ref-impls/foundry.toml
+++ b/specs/ref-impls/foundry.toml
@@ -9,6 +9,7 @@ libs = ["lib"]
 extra_output = ["storageLayout"]
 fs_permissions = [{ access = "read-write", path = "./" }]
 remappings = [
+    "contracts/=../contracts/",
     "tempo-std/=lib/tempo-std/src/",
     "forge-std/=lib/forge-std/src/",
 ]

--- a/specs/ref-impls/test/token/PrivateZoneToken.t.sol
+++ b/specs/ref-impls/test/token/PrivateZoneToken.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { ITempoState, IZoneConfig, ZONE_INBOX, ZONE_OUTBOX } from "../../src/interfaces/IZone.sol";
-import { PrivateZoneToken } from "../../src/token/PrivateZoneToken.sol";
+import { PrivateZoneToken } from "contracts/token/PrivateZoneToken.sol";
 import { Test } from "forge-std/Test.sol";
 
 contract MockPrivateZoneTokenConfig is IZoneConfig {


### PR DESCRIPTION
## Summary
- move `PrivateZoneToken.sol` from `specs/ref-impls/src/token` to `specs/contracts/token`
- add a Foundry remapping so ref-impl tests can import contracts outside the reference implementation tree
- update the existing token test import

## Test
- `forge test --match-path test/token/PrivateZoneToken.t.sol`

Prompted by: @0xKitsune