### PR TITLE
fix: pass router deposit bounceback recipients

### DIFF
--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -207,6 +207,7 @@ mod tests {
             token_out: address!("0x0000000000000000000000000000000000001001"),
             target_portal: address!("0x0000000000000000000000000000000000002001"),
             recipient: address!("0x0000000000000000000000000000000000003001"),
+            bounceback_recipient: address!("0x0000000000000000000000000000000000004001"),
             memo: B256::from([0x11; 32]),
             min_amount_out: 1234,
         };
@@ -216,6 +217,7 @@ mod tests {
             callback.token_out,
             callback.target_portal,
             callback.recipient,
+            callback.bounceback_recipient,
             callback.memo,
             callback.min_amount_out,
         )
@@ -252,6 +254,7 @@ mod tests {
             target_portal: address!("0x0000000000000000000000000000000000002002"),
             key_index: U256::from(7),
             encrypted: encrypted.clone(),
+            bounceback_recipient: address!("0x0000000000000000000000000000000000004002"),
             min_amount_out: 5678,
         };
 
@@ -261,6 +264,7 @@ mod tests {
             callback.target_portal,
             callback.key_index,
             encrypted,
+            callback.bounceback_recipient,
             callback.min_amount_out,
         )
             .abi_encode_params();

--- a/crates/contracts/src/precompiles/swap_and_deposit_router.rs
+++ b/crates/contracts/src/precompiles/swap_and_deposit_router.rs
@@ -29,6 +29,8 @@ pub struct SwapAndDepositRouterPlaintextCallback {
     pub target_portal: Address,
     /// Zone recipient for the downstream plaintext deposit.
     pub recipient: Address,
+    /// Tempo refund recipient if the downstream zone deposit later bounces.
+    pub bounceback_recipient: Address,
     /// Memo recorded on the downstream plaintext deposit.
     pub memo: B256,
     /// Minimum acceptable output from the optional swap.
@@ -45,6 +47,7 @@ impl SwapAndDepositRouterPlaintextCallback {
             self.token_out,
             self.target_portal,
             self.recipient,
+            self.bounceback_recipient,
             self.memo,
             self.min_amount_out,
         )
@@ -67,6 +70,8 @@ pub struct SwapAndDepositRouterEncryptedCallback {
     pub key_index: U256,
     /// ECIES-encrypted `(recipient, memo)` payload for `depositEncrypted`.
     pub encrypted: EncryptedDepositPayload,
+    /// Tempo refund recipient if the downstream encrypted deposit later bounces.
+    pub bounceback_recipient: Address,
     /// Minimum acceptable output from the optional swap.
     ///
     /// Ignored when `tokenIn == token_out` and the router can deposit directly.
@@ -82,6 +87,7 @@ impl SwapAndDepositRouterEncryptedCallback {
             self.target_portal,
             self.key_index,
             self.encrypted.clone(),
+            self.bounceback_recipient,
             self.min_amount_out,
         )
             .abi_encode_params()

--- a/crates/node/tests/it/demo_cross_zone.rs
+++ b/crates/node/tests/it/demo_cross_zone.rs
@@ -42,6 +42,7 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
     // Bob is a separate user (mnemonic index 4)
     let bob_signer = l1.signer_at(4);
     let bob_address = bob_signer.address();
+    let refund_burner = l1.signer_at(5).address();
 
     // --- Step 2: Deploy L1 infrastructure ---
     let (portal_a, portal_b, router) = l1
@@ -82,7 +83,8 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
         router,
         portal_b,
         PATH_USD_ADDRESS,
-        bob_address, // recipient on zone_b is Bob
+        bob_address,   // recipient on zone_b is Bob
+        refund_burner, // Tempo refund target if Zone B later bounces the deposit
     );
     alice.withdraw_with(args).await?;
 

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -5,7 +5,8 @@
 //! subscriber naturally receives blocks and deposits — no synthetic injection.
 
 use crate::utils::{
-    L1TestNode, STABLECOIN_DEX_ADDRESS, WithdrawalArgs, ZoneAccount, ZoneTestNode, spawn_sequencer,
+    EncryptedRouterCallbackArgs, L1TestNode, PlaintextRouterCallbackArgs, STABLECOIN_DEX_ADDRESS,
+    WithdrawalArgs, ZoneAccount, ZoneTestNode, spawn_sequencer,
 };
 use alloy::{
     primitives::{Address, B256, U256},
@@ -436,16 +437,16 @@ async fn test_cross_zone_encrypted_router_bounceback_recipient() -> eyre::Result
     let refund_before = l1.balance_of(PATH_USD_ADDRESS, refund_burner).await?;
     let router_before = l1.balance_of(PATH_USD_ADDRESS, router).await?;
 
-    let args = WithdrawalArgs::swap_and_deposit_encrypted_via_router(
-        cross_amount,
+    let args = WithdrawalArgs::swap_and_deposit_encrypted_via_router(EncryptedRouterCallbackArgs {
+        amount: cross_amount,
         router,
-        PATH_USD_ADDRESS,
-        portal_b,
+        token_out: PATH_USD_ADDRESS,
+        target_portal: portal_b,
         key_index,
         encrypted,
-        refund_burner,
-        0,
-    );
+        bounceback_recipient: refund_burner,
+        min_amount_out: 0,
+    });
     alice.withdraw_with(args).await?;
 
     let refund_after = l1
@@ -523,16 +524,16 @@ async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
     )
     .await;
 
-    let args = WithdrawalArgs::swap_and_deposit_via_router(
-        fixture.swap_amount,
-        fixture.router,
-        fixture.beta,
-        fixture.portal_address,
-        fixture.account.address(),
-        fixture.l1.signer_at(5).address(),
-        B256::ZERO,
-        expected_beta,
-    );
+    let args = WithdrawalArgs::swap_and_deposit_via_router(PlaintextRouterCallbackArgs {
+        amount: fixture.swap_amount,
+        router: fixture.router,
+        token_out: fixture.beta,
+        target_portal: fixture.portal_address,
+        recipient: fixture.account.address(),
+        bounceback_recipient: fixture.l1.signer_at(5).address(),
+        memo: B256::ZERO,
+        min_amount_out: expected_beta,
+    });
     fixture
         .account
         .withdraw_token_with(fixture.alpha, args)
@@ -621,16 +622,16 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
     )
     .await;
 
-    let args = WithdrawalArgs::swap_and_deposit_via_router(
-        fixture.swap_amount,
-        fixture.router,
-        fixture.beta,
-        fixture.portal_address,
-        fixture.account.address(),
-        fixture.l1.signer_at(5).address(),
-        B256::ZERO,
-        expected_beta,
-    );
+    let args = WithdrawalArgs::swap_and_deposit_via_router(PlaintextRouterCallbackArgs {
+        amount: fixture.swap_amount,
+        router: fixture.router,
+        token_out: fixture.beta,
+        target_portal: fixture.portal_address,
+        recipient: fixture.account.address(),
+        bounceback_recipient: fixture.l1.signer_at(5).address(),
+        memo: B256::ZERO,
+        min_amount_out: expected_beta,
+    });
     fixture
         .account
         .withdraw_token_with(fixture.alpha, args)
@@ -739,16 +740,16 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_
     )
     .await;
 
-    let args = WithdrawalArgs::swap_and_deposit_encrypted_via_router(
-        fixture.swap_amount,
-        fixture.router,
-        fixture.beta,
-        fixture.portal_address,
+    let args = WithdrawalArgs::swap_and_deposit_encrypted_via_router(EncryptedRouterCallbackArgs {
+        amount: fixture.swap_amount,
+        router: fixture.router,
+        token_out: fixture.beta,
+        target_portal: fixture.portal_address,
         key_index,
         encrypted,
-        fixture.l1.signer_at(5).address(),
-        expected_beta,
-    );
+        bounceback_recipient: fixture.l1.signer_at(5).address(),
+        min_amount_out: expected_beta,
+    });
     fixture
         .account
         .withdraw_token_with(fixture.alpha, args)

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -285,12 +285,14 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
 
     // --- Step 5: Cross-zone withdrawal: zone_a → router → zone_b ---
     let cross_amount: u128 = 400_000; // 0.4 pathUSD
+    let refund_burner_a_to_b = l1.signer_at(5).address();
     let args_a_to_b = WithdrawalArgs::cross_zone_via_router(
         cross_amount,
         router,
         portal_b,
         PATH_USD_ADDRESS,
         account_a.address(),
+        refund_burner_a_to_b,
     );
     account_a.withdraw_with(args_a_to_b).await?;
 
@@ -326,12 +328,14 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     // --- Step 7: Cross-zone withdrawal: zone_b → router → zone_a ---
     let mut account_b = ZoneAccount::from_l1_and_zone(&l1, &zone_b, portal_b);
     let reverse_amount: u128 = 200_000; // 0.2 pathUSD
+    let refund_burner_b_to_a = l1.signer_at(6).address();
     let args_b_to_a = WithdrawalArgs::cross_zone_via_router(
         reverse_amount,
         router,
         portal_a,
         PATH_USD_ADDRESS,
         account_b.address(),
+        refund_burner_b_to_a,
     );
     account_b.withdraw_with(args_b_to_a).await?;
 
@@ -361,6 +365,125 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
         final_zone_b < U256::from(cross_amount),
         "zone_b balance should decrease by at least the reverse amount (got {final_zone_b})"
     );
+
+    Ok(())
+}
+
+/// Cross-zone encrypted router deposit where Zone B accepts the L1 deposit but
+/// later bounces it because the decrypted recipient violates policy.
+///
+/// The refund must go to the bounceback recipient encoded in the router payload,
+/// not to the encrypted recipient and not to the router contract.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cross_zone_encrypted_router_bounceback_recipient() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let l1 = L1TestNode::start().await?;
+    let seq_a_signer = l1.signer_at(2);
+    let seq_b_signer = l1.signer_at(3);
+    let blacklisted_recipient = l1.signer_at(4).address();
+    let refund_burner = l1.signer_at(5).address();
+
+    let (portal_a, portal_b, router) = l1
+        .deploy_two_zones_with_sequencers(seq_a_signer.clone(), seq_b_signer.clone())
+        .await?;
+
+    let policy_id = l1.create_blacklist_policy().await?;
+    l1.change_transfer_policy_id(PATH_USD_ADDRESS, policy_id)
+        .await?;
+    l1.blacklist_address(policy_id, blacklisted_recipient)
+        .await?;
+    assert!(
+        !l1.is_authorized(policy_id, blacklisted_recipient).await?,
+        "recipient should be blacklisted on L1"
+    );
+
+    let zone_a = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_a).await?;
+    let zone_b = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_b).await?;
+
+    zone_a.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    zone_b.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+
+    let encryption_key = k256::SecretKey::from(seq_b_signer.credential());
+    l1.set_sequencer_encryption_key_with_signer(portal_b, &encryption_key, seq_b_signer.clone())
+        .await?;
+
+    {
+        use tempo_contracts::precompiles::ITIP403Registry::PolicyType;
+
+        let l1_block = l1.provider().get_block_number().await?;
+        for policy_cache in [zone_a.policy_cache(), zone_b.policy_cache()] {
+            let mut cache = policy_cache.write();
+            cache.set_policy_type(policy_id, PolicyType::BLACKLIST);
+            cache.set_token_policy(PATH_USD_ADDRESS, l1_block, policy_id);
+            cache.set_policy_status(policy_id, blacklisted_recipient, l1_block, true);
+        }
+    }
+
+    let mut alice = ZoneAccount::from_l1_and_zone(&l1, &zone_a, portal_a);
+    let deposit_amount: u128 = 2_000_000;
+    let cross_amount: u128 = 1_000_000;
+    l1.fund_user(alice.address(), deposit_amount * 2).await?;
+    alice.deposit(deposit_amount, L1_TIMEOUT, &zone_a).await?;
+
+    let _seq_a = spawn_sequencer(&l1, &zone_a, portal_a, seq_a_signer.clone()).await;
+    let _seq_b = spawn_sequencer(&l1, &zone_b, portal_b, seq_b_signer.clone()).await;
+
+    let (key_index, encrypted) = l1
+        .encrypt_deposit_for_portal(portal_b, blacklisted_recipient, B256::ZERO)
+        .await?;
+
+    let refund_before = l1.balance_of(PATH_USD_ADDRESS, refund_burner).await?;
+    let router_before = l1.balance_of(PATH_USD_ADDRESS, router).await?;
+
+    let args = WithdrawalArgs::swap_and_deposit_encrypted_via_router(
+        cross_amount,
+        router,
+        PATH_USD_ADDRESS,
+        portal_b,
+        key_index,
+        encrypted,
+        refund_burner,
+        0,
+    );
+    alice.withdraw_with(args).await?;
+
+    let refund_after = l1
+        .wait_for_balance(
+            PATH_USD_ADDRESS,
+            refund_burner,
+            refund_before + U256::from(1u64),
+            Duration::from_secs(90),
+        )
+        .await?;
+    assert!(
+        refund_after > refund_before,
+        "refund burner should receive the Zone B deposit bounce-back"
+    );
+
+    let router_after = l1.balance_of(PATH_USD_ADDRESS, router).await?;
+    assert_eq!(
+        router_after, router_before,
+        "router should not retain the bounced encrypted deposit refund"
+    );
+
+    let recipient_balance = zone_b
+        .balance_of(ZONE_TOKEN_ADDRESS, blacklisted_recipient)
+        .await?;
+    assert_eq!(
+        recipient_balance,
+        U256::ZERO,
+        "blacklisted recipient should not be minted on Zone B"
+    );
+
+    l1.assert_withdrawal_processed_with_status(
+        portal_a,
+        router,
+        PATH_USD_ADDRESS,
+        cross_amount,
+        true,
+    )
+    .await?;
 
     Ok(())
 }
@@ -406,6 +529,7 @@ async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
         fixture.beta,
         fixture.portal_address,
         fixture.account.address(),
+        fixture.l1.signer_at(5).address(),
         B256::ZERO,
         expected_beta,
     );
@@ -503,6 +627,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
         fixture.beta,
         fixture.portal_address,
         fixture.account.address(),
+        fixture.l1.signer_at(5).address(),
         B256::ZERO,
         expected_beta,
     );
@@ -621,6 +746,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_
         fixture.portal_address,
         key_index,
         encrypted,
+        fixture.l1.signer_at(5).address(),
         expected_beta,
     );
     fixture

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1200,6 +1200,21 @@ impl L1TestNode {
         portal_address: Address,
         encryption_key: &k256::SecretKey,
     ) -> eyre::Result<()> {
+        self.set_sequencer_encryption_key_with_signer(
+            portal_address,
+            encryption_key,
+            self.dev_signer(),
+        )
+        .await
+    }
+
+    /// Set the sequencer encryption key using an explicit portal sequencer signer.
+    pub(crate) async fn set_sequencer_encryption_key_with_signer(
+        &self,
+        portal_address: Address,
+        encryption_key: &k256::SecretKey,
+        sequencer_signer: alloy_signer_local::PrivateKeySigner,
+    ) -> eyre::Result<()> {
         use alloy_signer::SignerSync;
         use k256::{AffinePoint, ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
         use tempo_zone_contracts::ZonePortal;
@@ -1225,9 +1240,10 @@ impl L1TestNode {
         let pop_r = B256::from(sig.r().to_be_bytes::<32>());
         let pop_s = B256::from(sig.s().to_be_bytes::<32>());
 
-        // Call setSequencerEncryptionKey as the sequencer (dev account)
-        let dev_provider = self.dev_provider();
-        let portal = ZonePortal::new(portal_address, &dev_provider);
+        let sequencer_provider = ProviderBuilder::new()
+            .wallet(sequencer_signer)
+            .connect_http(self.http_url.clone());
+        let portal = ZonePortal::new(portal_address, &sequencer_provider);
         let receipt = portal
             .setSequencerEncryptionKey(x, y_parity, pop_v, pop_r, pop_s)
             .send()
@@ -1769,6 +1785,7 @@ impl WithdrawalArgs {
         token_out: Address,
         target_portal: Address,
         recipient: Address,
+        bounceback_recipient: Address,
         memo: B256,
         min_amount_out: u128,
     ) -> Self {
@@ -1778,6 +1795,7 @@ impl WithdrawalArgs {
             token_out,
             target_portal,
             recipient,
+            bounceback_recipient,
             memo,
             min_amount_out,
         }
@@ -1802,6 +1820,7 @@ impl WithdrawalArgs {
         target_portal: Address,
         key_index: U256,
         encrypted: tempo_zone_contracts::EncryptedDepositPayload,
+        bounceback_recipient: Address,
         min_amount_out: u128,
     ) -> Self {
         let callback_data = tempo_zone_contracts::SwapAndDepositRouterEncryptedCallback {
@@ -1809,6 +1828,7 @@ impl WithdrawalArgs {
             target_portal,
             key_index,
             encrypted,
+            bounceback_recipient,
             min_amount_out,
         }
         .abi_encode();
@@ -1835,6 +1855,7 @@ impl WithdrawalArgs {
         target_portal: Address,
         token: Address,
         recipient: Address,
+        bounceback_recipient: Address,
     ) -> Self {
         Self::swap_and_deposit_via_router(
             amount,
@@ -1842,6 +1863,7 @@ impl WithdrawalArgs {
             token,
             target_portal,
             recipient,
+            bounceback_recipient,
             B256::ZERO,
             0,
         )

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1764,6 +1764,28 @@ pub(crate) struct WithdrawalArgs {
     pub reveal_to: alloy_primitives::Bytes,
 }
 
+pub(crate) struct PlaintextRouterCallbackArgs {
+    pub amount: u128,
+    pub router: Address,
+    pub token_out: Address,
+    pub target_portal: Address,
+    pub recipient: Address,
+    pub bounceback_recipient: Address,
+    pub memo: B256,
+    pub min_amount_out: u128,
+}
+
+pub(crate) struct EncryptedRouterCallbackArgs {
+    pub amount: u128,
+    pub router: Address,
+    pub token_out: Address,
+    pub target_portal: Address,
+    pub key_index: U256,
+    pub encrypted: tempo_zone_contracts::EncryptedDepositPayload,
+    pub bounceback_recipient: Address,
+    pub min_amount_out: u128,
+}
+
 impl WithdrawalArgs {
     /// Simple withdrawal: send `amount` back to self with no callback.
     pub(crate) fn new(amount: u128) -> Self {
@@ -1779,32 +1801,23 @@ impl WithdrawalArgs {
     }
 
     /// Plaintext router callback: optionally swap, then deposit into `target_portal`.
-    pub(crate) fn swap_and_deposit_via_router(
-        amount: u128,
-        router: Address,
-        token_out: Address,
-        target_portal: Address,
-        recipient: Address,
-        bounceback_recipient: Address,
-        memo: B256,
-        min_amount_out: u128,
-    ) -> Self {
+    pub(crate) fn swap_and_deposit_via_router(args: PlaintextRouterCallbackArgs) -> Self {
         use tempo_zone_contracts::SwapAndDepositRouterPlaintextCallback;
 
         let callback_data = SwapAndDepositRouterPlaintextCallback {
-            token_out,
-            target_portal,
-            recipient,
-            bounceback_recipient,
-            memo,
-            min_amount_out,
+            token_out: args.token_out,
+            target_portal: args.target_portal,
+            recipient: args.recipient,
+            bounceback_recipient: args.bounceback_recipient,
+            memo: args.memo,
+            min_amount_out: args.min_amount_out,
         }
         .abi_encode();
 
         Self {
-            amount,
-            to: Some(router),
-            memo,
+            amount: args.amount,
+            to: Some(args.router),
+            memo: args.memo,
             gas_limit: 2_000_000,
             fallback_recipient: None, // defaults to self
             data: alloy_primitives::Bytes::from(callback_data),
@@ -1813,29 +1826,20 @@ impl WithdrawalArgs {
     }
 
     /// Encrypted router callback: optionally swap, then deposit encrypted into `target_portal`.
-    pub(crate) fn swap_and_deposit_encrypted_via_router(
-        amount: u128,
-        router: Address,
-        token_out: Address,
-        target_portal: Address,
-        key_index: U256,
-        encrypted: tempo_zone_contracts::EncryptedDepositPayload,
-        bounceback_recipient: Address,
-        min_amount_out: u128,
-    ) -> Self {
+    pub(crate) fn swap_and_deposit_encrypted_via_router(args: EncryptedRouterCallbackArgs) -> Self {
         let callback_data = tempo_zone_contracts::SwapAndDepositRouterEncryptedCallback {
-            token_out,
-            target_portal,
-            key_index,
-            encrypted,
-            bounceback_recipient,
-            min_amount_out,
+            token_out: args.token_out,
+            target_portal: args.target_portal,
+            key_index: args.key_index,
+            encrypted: args.encrypted,
+            bounceback_recipient: args.bounceback_recipient,
+            min_amount_out: args.min_amount_out,
         }
         .abi_encode();
 
         Self {
-            amount,
-            to: Some(router),
+            amount: args.amount,
+            to: Some(args.router),
             memo: B256::ZERO,
             gas_limit: 2_000_000,
             fallback_recipient: None, // defaults to self
@@ -1857,16 +1861,16 @@ impl WithdrawalArgs {
         recipient: Address,
         bounceback_recipient: Address,
     ) -> Self {
-        Self::swap_and_deposit_via_router(
+        Self::swap_and_deposit_via_router(PlaintextRouterCallbackArgs {
             amount,
             router,
-            token,
+            token_out: token,
             target_portal,
             recipient,
             bounceback_recipient,
-            B256::ZERO,
-            0,
-        )
+            memo: B256::ZERO,
+            min_amount_out: 0,
+        })
     }
 }
 

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -238,7 +238,7 @@ The sequencer includes the withdrawal in the next batch submission to L1 and pro
 
 #### Router Swap + Deposit Demo (Same Zone)
 
-This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone via an encrypted deposit. If the portal does not already have the current sequencer encryption key registered, the demo registers it automatically before building the routed callback payload.
+This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone via an encrypted deposit. The routed callback payload includes a public `bouncebackRecipient` for the downstream portal deposit; set `ROUTER_BOUNCEBACK_RECIPIENT` to a refund-specific burner or stealth address you control if you do not want a later refund to point at the encrypted zone recipient. If the portal does not already have the current sequencer encryption key registered, the demo registers it automatically before building the routed callback payload.
 
 Prerequisites:
 - A running zone with an active sequencer
@@ -259,6 +259,12 @@ Run the demo:
 
 ```bash
 just demo-swap-and-deposit my-zone
+```
+
+Run with a dedicated routed-deposit refund address:
+
+```bash
+ROUTER_BOUNCEBACK_RECIPIENT=0xYourControlledBurnerAddress just demo-swap-and-deposit my-zone
 ```
 
 Optional parameters:
@@ -591,6 +597,7 @@ Current deployment:
 | `ADMIN_KEY` | For portal governance | Portal admin private key for `enableToken` / deposit pause controls. `SEQUENCER_KEY` only works for legacy zones where admin == sequencer. |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
+| `ROUTER_BOUNCEBACK_RECIPIENT` | No | Optional controlled burner/stealth address for `demo-swap-and-deposit` routed deposit refunds |
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 | `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |
@@ -612,7 +619,7 @@ Current deployment:
 | `just list-enabled-tokens [portal]` | List TIP-20 token addresses enabled on a portal |
 | `just max-approve-outbox [token] [rpc]` | Approve outbox to spend tokens on zone |
 | `just send-withdrawal [amount] [to] [token] [memo] [gas-limit] [fallback-recipient] [data] [reveal-to] [rpc]` | Withdraw tokens from zone to L1 (defaults to sender) |
-| `just demo-swap-and-deposit <name> [amount] [tick] [rpc]` | Self-contained same-zone router demo: create tokens, seed DEX liquidity, swap on L1, deposit output back into the zone |
+| `just demo-swap-and-deposit <name> [amount] [tick] [rpc]` | Self-contained same-zone router demo: create tokens, seed DEX liquidity, swap on L1, deposit output back into the zone; set `ROUTER_BOUNCEBACK_RECIPIENT` for routed deposit refunds |
 | `just check-balance <addr> [token] [rpc]` | Check token balance on the zone |
 | `just zone-auth-token <name>` | Generate a signed private RPC auth token (10 min TTL) |
 | `just check-balance-private <name> [token] [rpc]` | Check balance via the private RPC (auto-generates auth token) |

--- a/specs/ref-impls/src/l1/SwapAndDepositRouter.sol
+++ b/specs/ref-impls/src/l1/SwapAndDepositRouter.sol
@@ -56,8 +56,8 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     /// @param data ABI-encoded callbackData (see format below)
     /// @return selector The function selector to confirm successful handling
     ///
-    /// Plaintext format: (bool isEncrypted=false, address tokenOut, address targetPortal, address recipient, bytes32 memo, uint128 minAmountOut)
-    /// Encrypted format: (bool isEncrypted=true, address tokenOut, address targetPortal, uint256 keyIndex, EncryptedDepositPayload encrypted, uint128 minAmountOut)
+    /// Plaintext format: (bool isEncrypted=false, address tokenOut, address targetPortal, address recipient, address bouncebackRecipient, bytes32 memo, uint128 minAmountOut)
+    /// Encrypted format: (bool isEncrypted=true, address tokenOut, address targetPortal, uint256 keyIndex, EncryptedDepositPayload encrypted, address bouncebackRecipient, uint128 minAmountOut)
     ///
     /// Note: minAmountOut is ignored for same-token transfers (no swap)
     function onWithdrawalReceived(
@@ -81,9 +81,10 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
                 address targetPortal,
                 uint256 keyIndex,
                 EncryptedDepositPayload memory encrypted,
+                address bouncebackRecipient,
                 uint128 minAmountOut
             ) = abi.decode(
-                data, (bool, address, address, uint256, EncryptedDepositPayload, uint128)
+                data, (bool, address, address, uint256, EncryptedDepositPayload, address, uint128)
             );
 
             _validateTarget(targetPortal, tokenOut);
@@ -91,25 +92,25 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
             uint128 amountOut = _swapIfNeeded(tokenIn, tokenOut, amount, minAmountOut);
 
             ITIP20(tokenOut).approve(targetPortal, amountOut);
-            // Encrypted deposits have no plaintext recipient; route any bounce-back refund
-            // back to this router.
             IZonePortal(targetPortal)
-                .depositEncrypted(tokenOut, amountOut, keyIndex, encrypted, address(this));
+                .depositEncrypted(tokenOut, amountOut, keyIndex, encrypted, bouncebackRecipient);
         } else {
             (, // skip isEncrypted
                 address tokenOut,
                 address targetPortal,
                 address recipient,
+                address bouncebackRecipient,
                 bytes32 memo,
                 uint128 minAmountOut
-            ) = abi.decode(data, (bool, address, address, address, bytes32, uint128));
+            ) = abi.decode(data, (bool, address, address, address, address, bytes32, uint128));
 
             _validateTarget(targetPortal, tokenOut);
 
             uint128 amountOut = _swapIfNeeded(tokenIn, tokenOut, amount, minAmountOut);
 
             ITIP20(tokenOut).approve(targetPortal, amountOut);
-            IZonePortal(targetPortal).deposit(tokenOut, recipient, amountOut, memo, recipient);
+            IZonePortal(targetPortal)
+                .deposit(tokenOut, recipient, amountOut, memo, bouncebackRecipient);
         }
 
         return IWithdrawalReceiver.onWithdrawalReceived.selector;

--- a/specs/ref-impls/test/BaseTest.t.sol
+++ b/specs/ref-impls/test/BaseTest.t.sol
@@ -89,11 +89,11 @@ contract BaseTest is Test {
             revert MissingPrecompile("ValidatorConfig", _VALIDATOR_CONFIG);
         }
 
-        // Install EIP-2935 mock when absent so zone tests can still run
-        if (_BLOCKHASH_HISTORY.code.length == 0) {
-            MockEIP2935 mock2935 = new MockEIP2935();
-            vm.etch(_BLOCKHASH_HISTORY, address(mock2935).code);
-        }
+        // Install the deterministic EIP-2935 mock for every test run. Some
+        // forge builds provide native code at this address, but the spec tests
+        // assert the mock's deterministic block hash values.
+        MockEIP2935 mock2935 = new MockEIP2935();
+        vm.etch(_BLOCKHASH_HISTORY, address(mock2935).code);
         if (_BLOCKHASH_HISTORY.code.length == 0) {
             revert MissingPrecompile("BlockHashHistory", _BLOCKHASH_HISTORY);
         }

--- a/specs/ref-impls/test/l1/SwapAndDepositRouter.t.sol
+++ b/specs/ref-impls/test/l1/SwapAndDepositRouter.t.sol
@@ -142,6 +142,7 @@ contract SwapAndDepositRouterTest is BaseTest {
     MockZonePortalForRouter public mockPortal2;
 
     bytes32 public senderTag = keccak256(abi.encodePacked(address(0x500)));
+    address public refundBurner = address(0xb000000000000000000000000000000000000123);
     uint128 public constant AMOUNT = 1000e6;
 
     function setUp() public override {
@@ -180,6 +181,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         address tokenOut,
         address targetPortal,
         address recipient,
+        address bouncebackRecipient,
         bytes32 memo,
         uint128 minAmountOut
     )
@@ -187,7 +189,9 @@ contract SwapAndDepositRouterTest is BaseTest {
         pure
         returns (bytes memory)
     {
-        return abi.encode(false, tokenOut, targetPortal, recipient, memo, minAmountOut);
+        return abi.encode(
+            false, tokenOut, targetPortal, recipient, bouncebackRecipient, memo, minAmountOut
+        );
     }
 
     function _buildEncryptedData(
@@ -195,13 +199,16 @@ contract SwapAndDepositRouterTest is BaseTest {
         address targetPortal,
         uint256 keyIndex,
         EncryptedDepositPayload memory encrypted,
+        address bouncebackRecipient,
         uint128 minAmountOut
     )
         internal
         pure
         returns (bytes memory)
     {
-        return abi.encode(true, tokenOut, targetPortal, keyIndex, encrypted, minAmountOut);
+        return abi.encode(
+            true, tokenOut, targetPortal, keyIndex, encrypted, bouncebackRecipient, minAmountOut
+        );
     }
 
     function _defaultEncryptedPayload() internal pure returns (EncryptedDepositPayload memory) {
@@ -215,8 +222,9 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_revertUnauthorizedMessenger() public {
-        bytes memory data =
-            _buildPlaintextData(address(pathUSD), address(mockPortal), alice, bytes32("memo"), 0);
+        bytes memory data = _buildPlaintextData(
+            address(pathUSD), address(mockPortal), alice, refundBurner, bytes32("memo"), 0
+        );
 
         vm.prank(alice);
         vm.expectRevert(SwapAndDepositRouter.UnauthorizedMessenger.selector);
@@ -225,8 +233,9 @@ contract SwapAndDepositRouterTest is BaseTest {
 
     function test_revertInvalidTargetPortal() public {
         address fakePortal = address(0xFAFAFA);
-        bytes memory data =
-            _buildPlaintextData(address(pathUSD), fakePortal, alice, bytes32("memo"), 0);
+        bytes memory data = _buildPlaintextData(
+            address(pathUSD), fakePortal, alice, refundBurner, bytes32("memo"), 0
+        );
 
         vm.prank(address(mockMessenger));
         vm.expectRevert(SwapAndDepositRouter.InvalidTargetPortal.selector);
@@ -234,8 +243,9 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_revertInvalidToken() public {
-        bytes memory data =
-            _buildPlaintextData(address(token1), address(mockPortal), alice, bytes32("memo"), 0);
+        bytes memory data = _buildPlaintextData(
+            address(token1), address(mockPortal), alice, refundBurner, bytes32("memo"), 0
+        );
 
         vm.prank(address(mockMessenger));
         vm.expectRevert(SwapAndDepositRouter.InvalidToken.selector);
@@ -243,8 +253,9 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_plaintextDeposit_sameToken() public {
-        bytes memory data =
-            _buildPlaintextData(address(pathUSD), address(mockPortal), alice, bytes32("hello"), 0);
+        bytes memory data = _buildPlaintextData(
+            address(pathUSD), address(mockPortal), alice, refundBurner, bytes32("hello"), 0
+        );
 
         vm.prank(address(mockMessenger));
         bytes4 ret = router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
@@ -252,7 +263,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
         assertTrue(mockPortal.depositCalled());
         assertEq(mockPortal.lastDepositRecipient(), alice);
-        assertEq(mockPortal.lastDepositBouncebackRecipient(), alice);
+        assertEq(mockPortal.lastDepositBouncebackRecipient(), refundBurner);
         assertEq(mockPortal.lastDepositAmount(), AMOUNT);
         assertEq(mockPortal.lastDepositMemo(), bytes32("hello"));
     }
@@ -262,7 +273,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         mockDEX.setNextAmountOut(swapOut);
 
         bytes memory data = _buildPlaintextData(
-            address(token1), address(mockPortal2), alice, bytes32("swap"), 900e6
+            address(token1), address(mockPortal2), alice, refundBurner, bytes32("swap"), 900e6
         );
 
         vm.prank(address(mockMessenger));
@@ -271,7 +282,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
         assertTrue(mockPortal2.depositCalled());
         assertEq(mockPortal2.lastDepositRecipient(), alice);
-        assertEq(mockPortal2.lastDepositBouncebackRecipient(), alice);
+        assertEq(mockPortal2.lastDepositBouncebackRecipient(), refundBurner);
         assertEq(mockPortal2.lastDepositAmount(), swapOut);
         assertEq(mockPortal2.lastDepositMemo(), bytes32("swap"));
     }
@@ -279,7 +290,7 @@ contract SwapAndDepositRouterTest is BaseTest {
     function test_encryptedDeposit_sameToken() public {
         EncryptedDepositPayload memory payload = _defaultEncryptedPayload();
         bytes memory data =
-            _buildEncryptedData(address(pathUSD), address(mockPortal), 0, payload, 0);
+            _buildEncryptedData(address(pathUSD), address(mockPortal), 0, payload, refundBurner, 0);
 
         vm.prank(address(mockMessenger));
         bytes4 ret = router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
@@ -288,7 +299,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         assertTrue(mockPortal.encryptedDepositCalled());
         assertEq(mockPortal.lastEncryptedAmount(), AMOUNT);
         assertEq(mockPortal.lastEncryptedKeyIndex(), 0);
-        assertEq(mockPortal.lastEncryptedBouncebackRecipient(), address(router));
+        assertEq(mockPortal.lastEncryptedBouncebackRecipient(), refundBurner);
     }
 
     function test_encryptedDeposit_withSwap() public {
@@ -296,8 +307,9 @@ contract SwapAndDepositRouterTest is BaseTest {
         mockDEX.setNextAmountOut(swapOut);
 
         EncryptedDepositPayload memory payload = _defaultEncryptedPayload();
-        bytes memory data =
-            _buildEncryptedData(address(token1), address(mockPortal2), 1, payload, 900e6);
+        bytes memory data = _buildEncryptedData(
+            address(token1), address(mockPortal2), 1, payload, refundBurner, 900e6
+        );
 
         vm.prank(address(mockMessenger));
         bytes4 ret = router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
@@ -306,14 +318,14 @@ contract SwapAndDepositRouterTest is BaseTest {
         assertTrue(mockPortal2.encryptedDepositCalled());
         assertEq(mockPortal2.lastEncryptedAmount(), swapOut);
         assertEq(mockPortal2.lastEncryptedKeyIndex(), 1);
-        assertEq(mockPortal2.lastEncryptedBouncebackRecipient(), address(router));
+        assertEq(mockPortal2.lastEncryptedBouncebackRecipient(), refundBurner);
     }
 
     function test_swapSlippageReverts() public {
         mockDEX.setNextAmountOut(800e6);
 
         bytes memory data = _buildPlaintextData(
-            address(token1), address(mockPortal2), alice, bytes32("slip"), 900e6
+            address(token1), address(mockPortal2), alice, refundBurner, bytes32("slip"), 900e6
         );
 
         vm.prank(address(mockMessenger));

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -641,6 +641,15 @@ Receiving contracts must implement `IWithdrawalReceiver` and return `onWithdrawa
 
 This enables composable withdrawals where funds flow directly into Tempo contracts (DEX swaps, staking, cross-zone deposits).
 
+#### SwapAndDepositRouter Callback Payloads
+
+`SwapAndDepositRouter` callback data explicitly carries the refund target for the downstream zone deposit:
+
+- Plaintext: `abi.encode(false, tokenOut, targetPortal, recipient, bouncebackRecipient, memo, minAmountOut)`
+- Encrypted: `abi.encode(true, tokenOut, targetPortal, keyIndex, encryptedPayload, bouncebackRecipient, minAmountOut)`
+
+The router validates the target portal and token, optionally swaps on Tempo, and then passes `bouncebackRecipient` through to `ZonePortal.deposit(...)` or `ZonePortal.depositEncrypted(...)`. For encrypted deposits this field is public, matching native `depositEncrypted`; callers that do not want a later Tempo-side refund to identify the encrypted zone recipient should use a controlled refund-specific or stealth address.
+
 ### Withdrawal Failures and Bounce-Back
 
 Withdrawals can fail on the Tempo side for several reasons:

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -345,13 +345,15 @@ impl DemoSwapAndDeposit {
         let portal_contract_seq = ZonePortal::new(portal, &l1_seq);
         let callback_data = build_encrypted_router_callback(
             &portal_contract_seq,
-            portal,
-            beta,
-            operator,
-            bounceback_recipient,
-            B256::ZERO,
-            expected_beta,
-            &sequencer_key,
+            EncryptedRouterCallbackRequest {
+                target_portal: portal,
+                token_out: beta,
+                recipient: operator,
+                bounceback_recipient,
+                memo: B256::ZERO,
+                min_amount_out: expected_beta,
+                sequencer_private_key: &sequencer_key,
+            },
         )
         .await?;
         let l1_from_block = l1.get_block_number().await.unwrap_or(0);
@@ -585,18 +587,26 @@ fn parse_private_key(private_key: &str) -> eyre::Result<PrivateKeySigner> {
         .wrap_err("invalid private key")
 }
 
-async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
-    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
-    portal_address: Address,
+struct EncryptedRouterCallbackRequest<'a> {
+    target_portal: Address,
     token_out: Address,
     recipient: Address,
     bounceback_recipient: Address,
     memo: B256,
     min_amount_out: u128,
-    sequencer_private_key: &str,
+    sequencer_private_key: &'a str,
+}
+
+async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
+    portal: &ZonePortal::ZonePortalInstance<&P, TempoNetwork>,
+    request: EncryptedRouterCallbackRequest<'_>,
 ) -> eyre::Result<Bytes> {
-    let (key, key_index) =
-        ensure_sequencer_encryption_key(portal, portal_address, sequencer_private_key).await?;
+    let (key, key_index) = ensure_sequencer_encryption_key(
+        portal,
+        request.target_portal,
+        request.sequencer_private_key,
+    )
+    .await?;
     let y_parity = key.normalized_y_parity().ok_or_else(|| {
         eyre!(
             "unexpected yParity {:#x}, expected 0/1 or 0x02/0x03",
@@ -604,13 +614,19 @@ async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
         )
     })?;
 
-    let encrypted =
-        encrypt_deposit(&key.x, y_parity, recipient, memo, portal_address, key_index)
-            .ok_or_else(|| eyre!("ECIES encryption failed — invalid sequencer public key?"))?;
+    let encrypted = encrypt_deposit(
+        &key.x,
+        y_parity,
+        request.recipient,
+        request.memo,
+        request.target_portal,
+        key_index,
+    )
+    .ok_or_else(|| eyre!("ECIES encryption failed — invalid sequencer public key?"))?;
 
     let callback = SwapAndDepositRouterEncryptedCallback {
-        token_out,
-        target_portal: portal_address,
+        token_out: request.token_out,
+        target_portal: request.target_portal,
         key_index,
         encrypted: EncryptedDepositPayload {
             ephemeralPubkeyX: encrypted.eph_pub_x,
@@ -619,8 +635,8 @@ async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
             nonce: encrypted.nonce.into(),
             tag: encrypted.tag.into(),
         },
-        bounceback_recipient,
-        min_amount_out,
+        bounceback_recipient: request.bounceback_recipient,
+        min_amount_out: request.min_amount_out,
     };
 
     Ok(Bytes::from(callback.abi_encode()))

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -77,6 +77,12 @@ pub(crate) struct DemoSwapAndDeposit {
     #[arg(long)]
     router: Option<Address>,
 
+    /// Tempo refund recipient for the routed ZonePortal.depositEncrypted call.
+    /// Defaults to the operator. Use a controlled burner or stealth address when
+    /// the zone recipient should stay unlinkable from a later bounce-back.
+    #[arg(long, env = "ROUTER_BOUNCEBACK_RECIPIENT")]
+    bounceback_recipient: Option<Address>,
+
     /// Demo swap amount in token base units (6 decimals for the demo tokens).
     #[arg(long, default_value_t = 100_000_000)]
     amount: u128,
@@ -115,6 +121,7 @@ impl DemoSwapAndDeposit {
 
         let operator_signer = parse_private_key(&self.private_key)?;
         let operator = operator_signer.address();
+        let bounceback_recipient = self.bounceback_recipient.unwrap_or(operator);
         let sequencer_signer = parse_private_key(&sequencer_key)?;
         let sequencer = sequencer_signer.address();
         let admin_signer = parse_private_key(&admin_key)?;
@@ -188,6 +195,7 @@ impl DemoSwapAndDeposit {
         println!("  Operator:         {operator}");
         println!("  Sequencer:        {sequencer}");
         println!("  Portal admin:     {portal_admin}");
+        println!("  Refund recipient: {bounceback_recipient}");
         println!("  Portal:           {portal}");
         println!("  Router:           {router}");
         println!("  L1 RPC:           {http_rpc}");
@@ -340,6 +348,7 @@ impl DemoSwapAndDeposit {
             portal,
             beta,
             operator,
+            bounceback_recipient,
             B256::ZERO,
             expected_beta,
             &sequencer_key,
@@ -581,6 +590,7 @@ async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
     portal_address: Address,
     token_out: Address,
     recipient: Address,
+    bounceback_recipient: Address,
     memo: B256,
     min_amount_out: u128,
     sequencer_private_key: &str,
@@ -609,6 +619,7 @@ async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
             nonce: encrypted.nonce.into(),
             tag: encrypted.tag.into(),
         },
+        bounceback_recipient,
         min_amount_out,
     };
 


### PR DESCRIPTION
## Summary

- Add an explicit downstream `bouncebackRecipient` to plaintext and encrypted `SwapAndDepositRouter` callback payloads.
- Pass that refund target through to `ZonePortal.deposit(...)` and `ZonePortal.depositEncrypted(...)` instead of deriving it from the recipient or router address.
- Update Rust callback encoders, router examples, docs, spec text, and tests to use a distinct controlled burner/refund address.
- Add an e2e for Zone A -> router -> Zone B encrypted deposit where Zone B later rejects the decrypted recipient and the L1 refund goes to the encoded refund target.

## Root Cause

The router encoded destination deposit data without an explicit downstream refund target. Plaintext routing reused the zone recipient, so a later Zone B bounce could refund Bob even when Alice funded the withdrawal. Encrypted routing sent refunds to the router contract, leaving bounced funds parked without an Alice-specific recovery path.

## Impact

Routed deposits now mirror native portal deposits: callers choose the Tempo refund recipient explicitly. Encrypted routed deposits keep recipient and memo private while exposing only the public refund address, allowing privacy-sensitive callers to provide a controlled burner or stealth address.
