### PR TITLE
chore: update moderato zonefactory metadata

### DIFF
--- a/.codex/skills/zonefactory-deploy/SKILL.md
+++ b/.codex/skills/zonefactory-deploy/SKILL.md
@@ -27,6 +27,24 @@ forge build
 forge create --broadcast --rpc-url "$ETH_RPC_URL" --private-key "$PRIVATE_KEY" src/l1/ZoneFactory.sol:ZoneFactory
 ```
 
+## Fresh Wallet and Faucet
+
+If no deployer key is available and the factory has no deployer-owned control path, create a one-use wallet and fund it on Moderato:
+
+```bash
+export ETH_RPC_URL=https://rpc.moderato.tempo.xyz
+
+cast wallet new
+# Save the printed address and private key securely.
+export DEPLOYER_ADDRESS=0x...
+export PRIVATE_KEY=0x...
+
+cast rpc tempo_fundAddress "$DEPLOYER_ADDRESS" -r "$ETH_RPC_URL"
+cast call 0x20C0000000000000000000000000000000000000 \
+  "balanceOf(address)(uint256)" "$DEPLOYER_ADDRESS" \
+  -r "$ETH_RPC_URL"
+```
+
 For manual deployments, prefer replacing `--private-key "$PRIVATE_KEY"` with `--interactive` so the key is not written into shell history or process arguments. If the user explicitly requires a non-interactive command and has already provided `PRIVATE_KEY` through the environment, use `--private-key "$PRIVATE_KEY"` without echoing the value.
 
 After deployment:

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -524,7 +524,7 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0x3F07435187fB4B4d4A562138A93C0397D0734F2b` |
+| ZoneFactory (moderato) | `0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68` |
 
 The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` uses `zoneFactory` from `zone.json` before falling back to this address. Pass `--zone-factory` or set `ZONE_FACTORY` to override it.
 
@@ -559,10 +559,10 @@ Current deployment:
 
 | Field | Value |
 |-------|-------|
-| Address | `0x3F07435187fB4B4d4A562138A93C0397D0734F2b` |
-| Transaction | `0x97037ae1ccec2ac6e9425f1499ae0d6c08deebe07054181d2e154987907480fd` |
-| Block | `23667934` |
-| Deployed | `2026-06-24 18:27:45 UTC` |
+| Address | `0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68` |
+| Transaction | `0xb3d519f55fd6b0b349b3f118d8966edf3e20f2cc1d1ca24df60c333a23f4e1cf` |
+| Block | `24532374` |
+| Deployed | `2026-06-30 19:22:56 UTC` |
 
 ### Zone Node CLI Options
 

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -21,9 +21,9 @@ pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
 /// `create-zone`, `deploy-router`, and `zone-info` use this as their default
 /// factory unless the caller overrides `--zone-factory` or `ZONE_FACTORY`, or
 /// `zone.json` already provides a zone-specific value.
-/// Explorer: https://explore.moderato.tempo.xyz/address/0x3F07435187fB4B4d4A562138A93C0397D0734F2b
+/// Explorer: https://explore.moderato.tempo.xyz/address/0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68
 pub(crate) const MODERATO_ZONE_FACTORY: Address =
-    address!("0x3F07435187fB4B4d4A562138A93C0397D0734F2b");
+    address!("0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
     address!("0xDEc0000000000000000000000000000000000000");
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;


### PR DESCRIPTION
## Summary

- Point the built-in Moderato `ZoneFactory` default at `0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68`.
- Refresh `docs/ZONES.md` with the new factory address, transaction hash, block, and deployment timestamp.
- Add `zonefactory-deploy` skill guidance for creating a one-use wallet and funding it via `tempo_fundAddress` on Moderato.

## Why

The shared Moderato factory was redeployed after the latest ZoneFactory-related changes, and the repo metadata needs to match the live default. This follows the metadata pattern used by PR #526 and records the wallet/faucet path used when no deployer key is already available.

## Impact

`create-zone`, `zone-info`, and the `deploy-router` fallback now use the new shared Moderato factory by default. Operators also get current deployment audit metadata in the Zones docs, and future deployments have explicit instructions for creating and funding a fresh Moderato deployer wallet.