### PR TITLE
fix: Separate admin and sequencer in tests and scripts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -113,7 +113,7 @@ zone-info identifier:
     cargo run -p tempo-xtask -- zone-info {{identifier}}
 
 [group('zone')]
-[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL, PRIVATE_KEY, and SEQUENCER_KEY env vars. Set ZONE_FACTORY to override the Moderato default.')]
+[doc('Creates a new zone on L1 via ZoneFactory and generates genesis + zone.json in generated/<name>/. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL, PRIVATE_KEY, SEQUENCER_KEY, and ADMIN_KEY or ADMIN_ADDR env vars. Set ZONE_FACTORY to override the Moderato default.')]
 create-zone name token="":
     #!/bin/bash
     set -euo pipefail
@@ -133,6 +133,11 @@ create-zone name token="":
             ZONE_TOKEN_L1="0x20c0000000000000000000000000000000000002" ;;
     esac
     SEQ_KEY="${SEQUENCER_KEY:?Set SEQUENCER_KEY env var}"
+    ADMIN_ADDR="${ADMIN_ADDR:-}"
+    if [[ -z "$ADMIN_ADDR" ]]; then
+        ADMIN_KEY="${ADMIN_KEY:?Set ADMIN_KEY env var or ADMIN_ADDR env var}"
+        ADMIN_ADDR=$(cast wallet address "$ADMIN_KEY")
+    fi
     L1_RPC="${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}"
     HTTP_RPC=$(echo "$L1_RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
     SEQUENCER_ADDR=$(cast wallet address "$SEQ_KEY")
@@ -144,10 +149,13 @@ create-zone name token="":
     cargo build -p tempo-xtask
     echo "Creating zone '{{name}}' on L1 and generating genesis..."
     echo "Initial portal token: $ZONE_TOKEN_L1"
+    echo "Admin: $ADMIN_ADDR"
+    echo "Sequencer: $SEQUENCER_ADDR"
     cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
+        --admin "$ADMIN_ADDR" \
         --sequencer "$SEQUENCER_ADDR" \
         --private-key "$PK"
     echo "Zone '{{name}}' created. Artifacts in $OUTPUT/"
@@ -703,7 +711,7 @@ check-balance-private name token="0x20C0000000000000000000000000000000000000" rp
     echo "Balance of $ACCOUNT: $BALANCE"
 
 [group('zone')]
-[doc('End-to-end: generates a sequencer key, funds it on L1, creates a zone on-chain, generates genesis, and starts the zone node. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL. Set ZONE_FACTORY to override the Moderato default.')]
+[doc('End-to-end: generates admin and sequencer keys, funds them on L1, creates a zone on-chain, generates genesis, and starts the zone node. Optional second positional argument selects the initial TIP-20 enabled on the portal; defaults to pathUSD. Requires L1_RPC_URL. Set ADMIN_KEY or ADMIN_ADDR to choose the portal admin. Set ZONE_FACTORY to override the Moderato default.')]
 deploy-zone name token="":
     #!/bin/bash
     set -euo pipefail
@@ -732,18 +740,32 @@ deploy-zone name token="":
     echo "  Initial portal token: $ZONE_TOKEN_L1"
     echo ""
 
-    # Step 1: Generate a new sequencer keypair
-    echo "Step 1: Generating sequencer keypair..."
+    # Step 1: Resolve the admin key/address and generate a new sequencer keypair
+    echo "Step 1: Resolving admin and generating sequencer keypairs..."
+    ADMIN_KEY="${ADMIN_KEY:-}"
+    ADMIN_ADDR="${ADMIN_ADDR:-}"
+    if [[ -n "$ADMIN_KEY" ]]; then
+        ADMIN_ADDR=$(cast wallet address "$ADMIN_KEY")
+    elif [[ -z "$ADMIN_ADDR" ]]; then
+        ADMIN_OUTPUT=$(cast wallet new 2>/dev/null)
+        ADMIN_ADDR=$(echo "$ADMIN_OUTPUT" | grep 'Address:' | awk '{print $2}')
+        ADMIN_KEY=$(echo "$ADMIN_OUTPUT" | grep 'Private key:' | awk '{print $3}')
+    fi
     KEY_OUTPUT=$(cast wallet new 2>/dev/null)
     SEQUENCER_ADDR=$(echo "$KEY_OUTPUT" | grep 'Address:' | awk '{print $2}')
     SEQUENCER_KEY=$(echo "$KEY_OUTPUT" | grep 'Private key:' | awk '{print $3}')
+    echo "  Admin address:    $ADMIN_ADDR"
     echo "  Sequencer address: $SEQUENCER_ADDR"
     echo ""
 
-    # Step 2: Fund the sequencer on L1
-    echo "Step 2: Funding sequencer on L1 (via tempo_fundAddress)..."
+    # Step 2: Fund the admin and sequencer on L1
+    echo "Step 2: Funding admin and sequencer on L1 (via tempo_fundAddress)..."
     cast rpc tempo_fundAddress "$SEQUENCER_ADDR" --rpc-url "$HTTP_RPC" > /dev/null 2>&1
-    echo "  Funded! Check: https://explore.moderato.tempo.xyz/address/$SEQUENCER_ADDR"
+    if [[ "$(echo "$ADMIN_ADDR" | tr '[:upper:]' '[:lower:]')" != "$(echo "$SEQUENCER_ADDR" | tr '[:upper:]' '[:lower:]')" ]]; then
+        cast rpc tempo_fundAddress "$ADMIN_ADDR" --rpc-url "$HTTP_RPC" > /dev/null 2>&1
+    fi
+    echo "  Admin funded:    https://explore.moderato.tempo.xyz/address/$ADMIN_ADDR"
+    echo "  Sequencer funded: https://explore.moderato.tempo.xyz/address/$SEQUENCER_ADDR"
     echo ""
 
     # Step 3: Build Solidity specs
@@ -758,15 +780,21 @@ deploy-zone name token="":
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
+        --admin "$ADMIN_ADDR" \
         --sequencer "$SEQUENCER_ADDR" \
         --private-key "$SEQUENCER_KEY"
     echo ""
 
-    # Save generated keys into zone.json for later use. deploy-zone uses the
-    # sequencer as the portal admin unless --admin is added to create-zone.
-    jq --arg sk "$SEQUENCER_KEY" --arg sa "$SEQUENCER_ADDR" \
-        '. + {sequencerKey: $sk, sequencerAddress: $sa, adminKey: $sk, adminAddress: $sa}' "$OUTPUT/zone.json" > "$OUTPUT/zone.json.tmp" \
-        && mv "$OUTPUT/zone.json.tmp" "$OUTPUT/zone.json"
+    # Save generated keys into zone.json for later use.
+    if [[ -n "$ADMIN_KEY" ]]; then
+        jq --arg sk "$SEQUENCER_KEY" --arg sa "$SEQUENCER_ADDR" --arg ak "$ADMIN_KEY" --arg aa "$ADMIN_ADDR" \
+            '. + {sequencerKey: $sk, sequencerAddress: $sa, adminKey: $ak, adminAddress: $aa}' "$OUTPUT/zone.json" > "$OUTPUT/zone.json.tmp" \
+            && mv "$OUTPUT/zone.json.tmp" "$OUTPUT/zone.json"
+    else
+        jq --arg sk "$SEQUENCER_KEY" --arg sa "$SEQUENCER_ADDR" --arg aa "$ADMIN_ADDR" \
+            '. + {sequencerKey: $sk, sequencerAddress: $sa, adminAddress: $aa}' "$OUTPUT/zone.json" > "$OUTPUT/zone.json.tmp" \
+            && mv "$OUTPUT/zone.json.tmp" "$OUTPUT/zone.json"
+    fi
 
     PORTAL=$(jq -r '.portal' "$OUTPUT/zone.json")
     ZONE_ID=$(jq -r '.zoneId' "$OUTPUT/zone.json")
@@ -789,6 +817,7 @@ deploy-zone name token="":
     echo "  Zone Name:       {{name}}"
     echo "  Portal:          $PORTAL"
     echo "  Initial Token:   $ZONE_TOKEN_L1"
+    echo "  Admin:           $ADMIN_ADDR"
     echo "  Sequencer:       $SEQUENCER_ADDR"
     echo "  Anchor Block:    $ANCHOR_BLOCK"
     echo ""
@@ -798,6 +827,11 @@ deploy-zone name token="":
     echo ""
     echo "  Explorer:        https://explore.moderato.tempo.xyz/address/$PORTAL"
     echo ""
+    if [[ -n "$ADMIN_KEY" ]]; then
+        echo "  Admin key saved to $OUTPUT/zone.json"
+    else
+        echo "  Admin key not saved (ADMIN_ADDR was provided without ADMIN_KEY)"
+    fi
     echo "  Sequencer key saved to $OUTPUT/zone.json"
     echo ""
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export L1_RPC_URL="wss://rpc.moderato.tempo.xyz"
 just deploy-zone my-zone
 ```
 
-The `deploy-zone` command generates a sequencer keypair, funds it on L1, deploys the portal via `ZoneFactory`, generates genesis, and starts the node.
+The `deploy-zone` command generates admin and sequencer keypairs, funds them on L1, deploys the portal via `ZoneFactory`, generates genesis, and starts the node.
 
 ```bash
 # Start/restart a zone after initial deployment

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -748,6 +748,21 @@ impl L1TestNode {
         self.dev_signer().address()
     }
 
+    /// Returns the signer used as the ZonePortal admin (mnemonic index 2).
+    ///
+    /// Distinct from the dev account (which acts as the sequencer) so the test
+    /// suite exercises the admin/sequencer role separation. This account is NOT
+    /// pre-funded; [`create_zone`](Self::create_zone) funds it with pathUSD for
+    /// gas so it can make admin-only portal calls.
+    pub(crate) fn admin_signer(&self) -> alloy_signer_local::PrivateKeySigner {
+        self.signer_at(2)
+    }
+
+    /// Returns the address of the ZonePortal admin account.
+    pub(crate) fn admin_address(&self) -> Address {
+        self.admin_signer().address()
+    }
+
     /// Returns a signer for the second test account (mnemonic index 1).
     ///
     /// This account is NOT pre-funded — use [`fund_user`](Self::fund_user) to
@@ -888,6 +903,17 @@ impl L1TestNode {
     pub(crate) fn dev_provider(&self) -> alloy_provider::DynProvider {
         ProviderBuilder::new()
             .wallet(self.dev_signer())
+            .connect_http(self.http_url.clone())
+            .erased()
+    }
+
+    /// Returns an HTTP provider with the admin account wallet attached.
+    ///
+    /// Used for `onlyAdmin` portal calls so they are signed by the admin key
+    /// rather than the dev (sequencer) key.
+    pub(crate) fn admin_provider(&self) -> alloy_provider::DynProvider {
+        ProviderBuilder::new()
+            .wallet(self.admin_signer())
             .connect_http(self.http_url.clone())
             .erased()
     }
@@ -1067,15 +1093,24 @@ impl L1TestNode {
     /// Create a zone on an existing ZoneFactory and return the portal address.
     ///
     /// Captures the current L1 header as the genesis anchor, then calls
-    /// `createZone()` with pathUSD as the token and the dev account as both
-    /// explicit admin and sequencer.
+    /// `createZone()` with pathUSD as the token, a distinct [`admin_address`] as
+    /// the portal admin, and the dev account as the sequencer. This exercises the
+    /// admin/sequencer role separation. The admin account is funded with pathUSD
+    /// for gas so admin-only portal calls (e.g. `enableToken`) can be made.
+    ///
+    /// [`admin_address`]: Self::admin_address
     pub(crate) async fn create_zone(&self, factory_address: Address) -> eyre::Result<Address> {
-        self.create_zone_with_admin_and_sequencer(
-            factory_address,
-            self.dev_address(),
-            self.dev_address(),
-        )
-        .await
+        let portal = self
+            .create_zone_with_admin_and_sequencer(
+                factory_address,
+                self.admin_address(),
+                self.dev_address(),
+            )
+            .await?;
+        // The admin is not pre-funded; give it pathUSD to pay for gas on
+        // admin-only portal calls.
+        self.fund_user(self.admin_address(), 10_000_000).await?;
+        Ok(portal)
     }
 
     /// Create a zone on an existing ZoneFactory with explicit admin and sequencer addresses.
@@ -1248,7 +1283,7 @@ impl L1TestNode {
         token: Address,
     ) -> eyre::Result<()> {
         use tempo_zone_contracts::ZonePortal;
-        let provider = self.dev_provider();
+        let provider = self.admin_provider();
         let portal = ZonePortal::new(portal_address, &provider);
         let receipt = portal
             .enableToken(token)
@@ -1266,7 +1301,7 @@ impl L1TestNode {
         portal_address: Address,
         token: Address,
     ) -> eyre::Result<()> {
-        let provider = self.dev_provider();
+        let provider = self.admin_provider();
         let portal = TestZonePortalAdmin::new(portal_address, &provider);
         let receipt = portal
             .pauseDeposits(token)

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1067,16 +1067,22 @@ impl L1TestNode {
     /// Create a zone on an existing ZoneFactory and return the portal address.
     ///
     /// Captures the current L1 header as the genesis anchor, then calls
-    /// `createZone()` with pathUSD as the token and the dev account as sequencer.
+    /// `createZone()` with pathUSD as the token and the dev account as both
+    /// explicit admin and sequencer.
     pub(crate) async fn create_zone(&self, factory_address: Address) -> eyre::Result<Address> {
-        self.create_zone_with_sequencer(factory_address, self.dev_address())
-            .await
+        self.create_zone_with_admin_and_sequencer(
+            factory_address,
+            self.dev_address(),
+            self.dev_address(),
+        )
+        .await
     }
 
-    /// Create a zone on an existing ZoneFactory with a custom sequencer address.
-    pub(crate) async fn create_zone_with_sequencer(
+    /// Create a zone on an existing ZoneFactory with explicit admin and sequencer addresses.
+    pub(crate) async fn create_zone_with_admin_and_sequencer(
         &self,
         factory_address: Address,
+        admin: Address,
         sequencer: Address,
     ) -> eyre::Result<Address> {
         use tempo_precompiles::PATH_USD_ADDRESS;
@@ -1101,7 +1107,7 @@ impl L1TestNode {
         let verifier_address = factory.verifier().call().await?;
         let receipt = factory
             .createZone(ZoneFactory::CreateZoneParams {
-                admin: sequencer,
+                admin,
                 initialToken: PATH_USD_ADDRESS,
                 sequencer,
                 verifier: verifier_address,
@@ -1178,10 +1184,18 @@ impl L1TestNode {
     ) -> eyre::Result<(Address, Address, Address)> {
         let factory = self.deploy_zone_factory().await?;
         let portal_a = self
-            .create_zone_with_sequencer(factory, sequencer_a.address())
+            .create_zone_with_admin_and_sequencer(
+                factory,
+                self.dev_address(),
+                sequencer_a.address(),
+            )
             .await?;
         let portal_b = self
-            .create_zone_with_sequencer(factory, sequencer_b.address())
+            .create_zone_with_admin_and_sequencer(
+                factory,
+                self.dev_address(),
+                sequencer_b.address(),
+            )
             .await?;
         let router = self.deploy_router(factory).await?;
         Ok((portal_a, portal_b, router))

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -82,26 +82,30 @@ export L1_RPC_URL="wss://rpc.moderato.tempo.xyz"
 export L1_RPC_URL="wss://rpc.devnet.tempoxyz.dev"
 ```
 
-### 2. Generate a Sequencer Key
+### 2. Generate Admin and Sequencer Keys
 
-The sequencer is the operator that builds zone blocks, processes deposits, and submits batch proofs back to L1.
+The admin controls portal governance such as token enablement and deposit pause/resume. The sequencer is the operator that builds zone blocks, processes deposits, and submits batch proofs back to L1. The same key may be used for both roles, but pass it explicitly as both `ADMIN_KEY` and `SEQUENCER_KEY` when that is intentional.
 
 ```bash
 cast wallet new
+cast wallet new
 ```
 
-Save both the **address** and **private key**.
+Save both **addresses** and **private keys**.
 
 ```bash
+export ADMIN_KEY="0x<admin-private-key>"
 export SEQUENCER_KEY="0x<your-private-key>"
+ADMIN_ADDR=$(cast wallet address "$ADMIN_KEY")
 SEQUENCER_ADDR=$(cast wallet address "$SEQUENCER_KEY")
 ```
 
-### 3. Fund the Sequencer on L1
+### 3. Fund the Admin and Sequencer on L1
 
-The sequencer needs pathUSD on L1 to pay for the `createZone` transaction and deposit fees.
+The sequencer needs pathUSD on L1 to pay for the `createZone` transaction and deposit fees. The admin needs funds for later governance calls.
 
 ```bash
+cast rpc tempo_fundAddress "$ADMIN_ADDR" --rpc-url "$L1_RPC_URL"
 cast rpc tempo_fundAddress "$SEQUENCER_ADDR" --rpc-url "$L1_RPC_URL"
 ```
 
@@ -142,11 +146,12 @@ You can also run the xtask directly for more control:
 cargo run -p tempo-xtask -- create-zone \
   --output generated/my-zone \
   --initial-token 0x20c0000000000000000000000000000000000001 \
+  --admin "$ADMIN_ADDR" \
   --sequencer "$SEQUENCER_ADDR" \
   --private-key "$SEQUENCER_KEY"
 ```
 
-By default, `create-zone` sets the portal admin to the sequencer. To separate the cold admin role from the hot sequencer role, pass `--admin "$ADMIN_ADDR"` to the direct xtask command and keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token`, `pause-deposits`, and `resume-deposits`.
+`create-zone` requires the admin address explicitly. Keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token`, `pause-deposits`, and `resume-deposits`.
 
 ### 5. Start the Zone Node
 
@@ -607,7 +612,7 @@ Current deployment:
 | Command | Description |
 |---------|-------------|
 | `just deploy-zone <name> [<tip20>]` | One-shot: keygen → fund → create → genesis → start node |
-| `just create-zone <name> [<tip20>]` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`) |
+| `just create-zone <name> [<tip20>]` | Create zone on L1 + generate genesis (requires `PRIVATE_KEY`, `SEQUENCER_KEY`, and `ADMIN_KEY` or `ADMIN_ADDR`) |
 | `just deploy-router <name> [dex]` | Deploy `SwapAndDepositRouter` on L1 for the zone and save it to `zone.json` |
 | `just zone-up <name> [reset] [profile]` | Start the zone node. `reset=true` wipes datadir. `profile=release` for production. |
 | `just max-approve-portal [token]` | Approve portal to spend tokens on L1 |

--- a/specs/ref-impls/test/BaseTest.t.sol
+++ b/specs/ref-impls/test/BaseTest.t.sol
@@ -44,7 +44,8 @@ contract BaseTest is Test {
     bytes32 internal constant _RECEIVE_WITH_MEMO_ROLE = keccak256("RECEIVE_WITH_MEMO_ROLE");
 
     // Common test addresses
-    address public admin = address(this);
+    address public admin = address(0x500);
+    address public sequencer = address(this);
     address public alice = address(0x200);
     address public bob = address(0x300);
     address public charlie = address(0x400);
@@ -104,18 +105,9 @@ contract BaseTest is Test {
             revert MissingPrecompile("ZoneTxContext", _ZONE_TX_CONTEXT);
         }
 
-        // Set ValidatorConfig owner to admin via direct storage write
+        // Set ValidatorConfig owner to sequencer via direct storage write
         // owner is at slot 0 in ValidatorConfig
-        vm.store(_VALIDATOR_CONFIG, bytes32(uint256(0)), bytes32(uint256(uint160(admin))));
-
-        // Grant DEFAULT_ADMIN_ROLE to admin for pathUSD via direct storage write
-        bytes32 adminRoleSlot = keccak256(
-            abi.encode(
-                bytes32(0), // DEFAULT_ADMIN_ROLE
-                keccak256(abi.encode(admin, uint256(0)))
-            )
-        );
-        vm.store(_PATH_USD, adminRoleSlot, bytes32(uint256(1)));
+        vm.store(_VALIDATOR_CONFIG, bytes32(uint256(0)), bytes32(uint256(uint160(sequencer))));
 
         // Grant DEFAULT_ADMIN_ROLE to pathUSDAdmin
         bytes32 tempoAdminRoleSlot = keccak256(
@@ -127,10 +119,14 @@ contract BaseTest is Test {
         vm.store(_PATH_USD, tempoAdminRoleSlot, bytes32(uint256(1)));
 
         token1 = ITIP20Token(
-            factory.createToken("TOKEN1", "T1", "USD", ITIP20(_PATH_USD), admin, bytes32("token1"))
+            factory.createToken(
+                "TOKEN1", "T1", "USD", ITIP20(_PATH_USD), sequencer, bytes32("token1")
+            )
         );
         token2 = ITIP20Token(
-            factory.createToken("TOKEN2", "T2", "USD", ITIP20(_PATH_USD), admin, bytes32("token2"))
+            factory.createToken(
+                "TOKEN2", "T2", "USD", ITIP20(_PATH_USD), sequencer, bytes32("token2")
+            )
         );
     }
 

--- a/specs/ref-impls/test/l1/SwapAndDepositRouter.t.sol
+++ b/specs/ref-impls/test/l1/SwapAndDepositRouter.t.sol
@@ -168,12 +168,12 @@ contract SwapAndDepositRouterTest is BaseTest {
         pathUSD.mint(address(router), AMOUNT * 10);
         vm.stopPrank();
 
-        vm.prank(admin);
-        token1.grantRole(_ISSUER_ROLE, admin);
-        vm.prank(admin);
+        vm.prank(sequencer);
+        token1.grantRole(_ISSUER_ROLE, sequencer);
+        vm.prank(sequencer);
         token1.mint(address(router), AMOUNT * 10);
 
-        vm.prank(admin);
+        vm.prank(sequencer);
         token1.grantRole(_ISSUER_ROLE, address(mockDEX));
     }
 

--- a/specs/ref-impls/test/l1/ZoneBridge.t.sol
+++ b/specs/ref-impls/test/l1/ZoneBridge.t.sol
@@ -157,7 +157,7 @@ contract ZoneBridgeTest is BaseTest {
             address(l2ZoneToken), // initialToken = MockZoneToken (NOT pathUSD)
             address(messengerContract),
             admin, // admin
-            admin, // sequencer
+            sequencer, // sequencer
             l1Factory.verifier(),
             GENESIS_BLOCK_HASH,
             genesisTempoBlockNumber,
@@ -167,12 +167,13 @@ contract ZoneBridgeTest is BaseTest {
 
         // === Deploy zone contracts ===
         // TempoState mock for testing
-        l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
+        l2TempoState =
+            new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
 
         // Zone config (reads sequencer from L1 portal via Tempo state)
         l2Config = new ZoneConfig(address(l1Portal), address(l2TempoState));
         l2TempoState.setMockStorageValue(
-            address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+            address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
         );
         l2TempoState.setMockTokenEnabled(address(l1Portal), address(l2ZoneToken), true);
 
@@ -238,7 +239,7 @@ contract ZoneBridgeTest is BaseTest {
     }
 
     function _finalizeWithdrawalBatch(uint256 count) internal returns (bytes32) {
-        vm.startPrank(admin);
+        vm.startPrank(sequencer);
         bytes32 hash = l2Outbox.finalizeWithdrawalBatch(
             count, uint64(block.number), _emptyEncryptedSenders(count)
         );
@@ -300,7 +301,7 @@ contract ZoneBridgeTest is BaseTest {
 
         // Process on zone via advanceTempo (sequencer-only call)
         // Empty header since MockTempoState just advances block number
-        vm.prank(admin);
+        vm.prank(sequencer);
         l2Inbox.advanceTempo(
             "", _wrapDeposits(deposits), new DecryptionData[](0), new EnabledToken[](0)
         );
@@ -739,7 +740,7 @@ contract ZoneBridgeTest is BaseTest {
         deposits[0] = pendingDeposits[0].deposit;
 
         // Should succeed — proof validates ancestor contiguity, not exact match
-        vm.prank(admin);
+        vm.prank(sequencer);
         l2Inbox.advanceTempo(
             "", _wrapDeposits(deposits), new DecryptionData[](0), new EnabledToken[](0)
         );
@@ -1008,7 +1009,7 @@ contract ZoneBridgeTest is BaseTest {
         }
 
         // Process on zone via advanceTempo
-        vm.prank(admin);
+        vm.prank(sequencer);
         l2Inbox.advanceTempo("", queued, decs, new EnabledToken[](0));
 
         // Clear pending
@@ -1257,7 +1258,7 @@ contract ZoneBridgeTest is BaseTest {
         _setupEncryptionKeyMockOnZone(0, encKeyX, encKeyYParity);
         _setupPrecompileMocksSuccess(decryptedTo, decryptedMemo);
 
-        vm.prank(admin);
+        vm.prank(sequencer);
         l2Inbox.advanceTempo("", queued, decs, new EnabledToken[](0));
 
         // === STEP 7: Verify all balances ===
@@ -1401,7 +1402,7 @@ contract ZoneBridgeTest is BaseTest {
             abi.encode(plaintext, true)
         );
 
-        vm.prank(admin);
+        vm.prank(sequencer);
         l2Inbox.advanceTempo("", queued, decs, new EnabledToken[](0));
 
         // === STEP 7: Verify ===

--- a/specs/ref-impls/test/l1/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/l1/ZoneFactory.t.sol
@@ -31,7 +31,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -54,7 +54,7 @@ contract ZoneFactoryTest is BaseTest {
         assertTrue(info.messenger != address(0));
         assertEq(info.initialToken, address(pathUSD));
         assertEq(info.admin, admin);
-        assertEq(info.sequencer, admin);
+        assertEq(info.sequencer, sequencer);
         assertEq(info.verifier, zoneFactory.verifier());
         assertEq(info.genesisBlockHash, GENESIS_BLOCK_HASH);
         assertEq(info.genesisTempoBlockHash, GENESIS_TEMPO_BLOCK_HASH);
@@ -64,7 +64,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -92,7 +92,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params1 = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -104,10 +104,11 @@ contract ZoneFactoryTest is BaseTest {
 
         (uint32 zoneId1, address portal1) = zoneFactory.createZone(params1);
 
+        address secondSequencer = alice;
         IZoneFactory.CreateZoneParams memory params2 = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: alice,
+            sequencer: secondSequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: keccak256("genesis2"),
@@ -129,6 +130,8 @@ contract ZoneFactoryTest is BaseTest {
         // Each zone should have its own messenger
         ZoneInfo memory info1 = zoneFactory.zones(zoneId1);
         ZoneInfo memory info2 = zoneFactory.zones(zoneId2);
+        assertEq(info1.sequencer, sequencer);
+        assertEq(info2.sequencer, secondSequencer);
         assertTrue(info1.messenger != info2.messenger);
     }
 
@@ -136,7 +139,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -182,7 +185,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(0),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -203,7 +206,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: notTip20,
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -221,7 +224,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: alice, // EOA, not a contract
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -243,7 +246,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: address(0),
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -287,7 +290,7 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: address(0xdead),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -331,7 +334,7 @@ contract ZoneFactoryTest is BaseTest {
         return IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -399,12 +402,15 @@ contract ZoneFactoryTest is BaseTest {
     // later portal rotation; the portal remains the source of truth.
     function test_zones_sequencerIsSnapshot_afterRotation() public {
         (uint32 id, address portal) = zoneFactory.createZone(_defaultParams());
-        ZonePortal(portal).transferSequencer(alice);
-        vm.prank(alice);
+        address nextSequencer = alice;
+
+        vm.prank(sequencer);
+        ZonePortal(portal).transferSequencer(nextSequencer);
+        vm.prank(nextSequencer);
         ZonePortal(portal).acceptSequencer();
 
-        assertEq(ZonePortal(portal).sequencer(), alice); // portal: current
-        assertEq(zoneFactory.zones(id).sequencer, admin); // factory: snapshot at creation
+        assertEq(ZonePortal(portal).sequencer(), nextSequencer); // portal: current
+        assertEq(zoneFactory.zones(id).sequencer, sequencer); // factory: snapshot at creation
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/specs/ref-impls/test/l1/ZoneIntegration.t.sol
+++ b/specs/ref-impls/test/l1/ZoneIntegration.t.sol
@@ -101,7 +101,7 @@ contract ZoneIntegrationTest is BaseTest {
             address(l2ZoneToken),
             address(messengerContract),
             admin,
-            admin,
+            sequencer,
             l1Factory.verifier(),
             GENESIS_BLOCK_HASH,
             genesisTempoBlockNumber,
@@ -110,10 +110,11 @@ contract ZoneIntegrationTest is BaseTest {
         zoneId = 1;
 
         // L2 setup
-        l2TempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
+        l2TempoState =
+            new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
         l2Config = new ZoneConfig(address(l1Portal), address(l2TempoState));
         l2TempoState.setMockStorageValue(
-            address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(admin)))
+            address(l1Portal), bytes32(uint256(0)), bytes32(uint256(uint160(sequencer)))
         );
         l2TempoState.setMockTokenEnabled(address(l1Portal), address(l2ZoneToken), true);
         l2Inbox = new ZoneInbox(address(l2Config), address(l1Portal), address(l2TempoState));
@@ -189,7 +190,7 @@ contract ZoneIntegrationTest is BaseTest {
     }
 
     function _finalizeWithdrawalBatch(uint256 count) internal returns (bytes32) {
-        vm.startPrank(admin);
+        vm.startPrank(sequencer);
         bytes32 hash = l2Outbox.finalizeWithdrawalBatch(
             count, uint64(block.number), _emptyEncryptedSenders(count)
         );
@@ -271,7 +272,7 @@ contract ZoneIntegrationTest is BaseTest {
         uint256 supplyPre = l2ZoneToken.totalSupply();
 
         // Process on L2
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(deposits);
 
         // Verify L2 minting: each user receives their deposited amounts
@@ -310,7 +311,7 @@ contract ZoneIntegrationTest is BaseTest {
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, l2Hash1
         );
         uint256 alicePreBatch1 = l2ZoneToken.balanceOf(alice);
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(batch1);
 
         assertEq(l2ZoneToken.balanceOf(alice), alicePreBatch1 + 1000e6);
@@ -368,7 +369,7 @@ contract ZoneIntegrationTest is BaseTest {
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, l2Hash3
         );
         uint256 alicePreBatch2 = l2ZoneToken.balanceOf(alice);
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(batch2);
 
         assertEq(l2ZoneToken.balanceOf(alice), alicePreBatch2 + 5000e6);
@@ -399,7 +400,7 @@ contract ZoneIntegrationTest is BaseTest {
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
         );
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(deposits);
 
         // Alice requests withdrawal with callback
@@ -475,7 +476,7 @@ contract ZoneIntegrationTest is BaseTest {
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, depositHash
         );
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(deposits);
 
         // First batch: Alice withdraws to Bob
@@ -630,7 +631,7 @@ contract ZoneIntegrationTest is BaseTest {
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d2
         );
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(deposits1);
 
         // Phase 2: Withdrawals
@@ -685,7 +686,7 @@ contract ZoneIntegrationTest is BaseTest {
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d3
         );
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(deposits2);
 
         // Verify all L2 balances (initial 1M - deposited + minted - burned)
@@ -734,7 +735,7 @@ contract ZoneIntegrationTest is BaseTest {
         l2TempoState.setMockStorageValue(
             address(l1Portal), PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, d1
         );
-        vm.prank(admin);
+        vm.prank(sequencer);
         _advanceTempo(deposits);
 
         assertEq(l2ZoneToken.totalSupply(), initialSupply + 10_000e6);

--- a/specs/ref-impls/test/l1/ZonePortal.t.sol
+++ b/specs/ref-impls/test/l1/ZonePortal.t.sol
@@ -270,6 +270,53 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
     }
 
+    function test_sequencerGovernance_revertsIfAdmin() public {
+        // Inverse of test_tokenGovernance_revertsIfNotAdmin: the admin role must
+        // not be able to perform any sequencer-only action. Locks in the
+        // admin/sequencer separation from both directions. (onlySequencer reverts
+        // at the modifier, so the call arguments below are otherwise irrelevant.)
+        Withdrawal memory w =
+            _withdrawal(address(pathUSD), alice, bob, 500e6, bytes32(0), 0, alice, "");
+        // Read state used as call args up front so the staticcall isn't mistaken
+        // for the call expectRevert is guarding.
+        bytes32 prevBlockHash = portal.blockHash();
+
+        vm.startPrank(admin);
+
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setZoneGasRate(1);
+
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setRpcUrl("https://rpc.example");
+
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setSequencerEncryptionKey(bytes32(uint256(1)), 0x02, 27, bytes32(0), bytes32(0));
+
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.transferSequencer(alice);
+
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.submitBatch(
+            uint64(block.number),
+            0,
+            BlockTransition({ prevBlockHash: prevBlockHash, nextBlockHash: keccak256("state") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: bytes32(0),
+                prevDepositNumber: 0,
+                nextDepositNumber: 0
+            }),
+            bytes32(0),
+            "",
+            ""
+        );
+
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.processWithdrawal(w, bytes32(0));
+
+        vm.stopPrank();
+    }
+
     /*//////////////////////////////////////////////////////////////
                          DEPOSIT TESTS (L1 -> ZONE)
     //////////////////////////////////////////////////////////////*/

--- a/specs/ref-impls/test/l1/ZonePortal.t.sol
+++ b/specs/ref-impls/test/l1/ZonePortal.t.sol
@@ -153,7 +153,7 @@ contract ZonePortalTest is BaseTest {
         // Grant issuer role and mint tokens for tests
         vm.startPrank(pathUSDAdmin);
         pathUSD.grantRole(_ISSUER_ROLE, pathUSDAdmin);
-        pathUSD.mint(admin, 1_000_000e6);
+        pathUSD.mint(sequencer, 1_000_000e6);
         pathUSD.mint(alice, 100_000e6);
         pathUSD.mint(bob, 100_000e6);
         vm.stopPrank();
@@ -165,7 +165,7 @@ contract ZonePortalTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin, // admin is the sequencer for tests
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -226,7 +226,7 @@ contract ZonePortalTest is BaseTest {
     function test_zoneCreation() public view {
         assertEq(portal.zoneId(), testZoneId);
         assertTrue(portal.isTokenEnabled(address(pathUSD)));
-        assertEq(portal.sequencer(), admin);
+        assertEq(portal.sequencer(), sequencer);
         assertEq(portal.admin(), admin);
         assertEq(portal.verifier(), zoneFactory.verifier());
         assertEq(portal.blockHash(), GENESIS_BLOCK_HASH);
@@ -244,6 +244,7 @@ contract ZonePortalTest is BaseTest {
         assertEq(info.messenger, address(messenger));
         assertEq(info.initialToken, address(pathUSD));
         assertEq(info.admin, admin);
+        assertEq(info.sequencer, sequencer);
     }
 
     function test_adminCanPauseAndResumeDeposits() public {
@@ -257,7 +258,7 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_tokenGovernance_revertsIfNotAdmin() public {
-        vm.startPrank(alice);
+        vm.startPrank(sequencer);
         vm.expectRevert(IZonePortal.NotAdmin.selector);
         portal.pauseDeposits(address(pathUSD));
 
@@ -353,7 +354,7 @@ contract ZonePortalTest is BaseTest {
         senderAccounts[0] = alice;
         senderAccounts[1] = address(portal);
         uint64 senderPolicyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
         );
 
         address[] memory recipientAccounts = new address[](3);
@@ -361,13 +362,13 @@ contract ZonePortalTest is BaseTest {
         recipientAccounts[1] = address(portal);
         recipientAccounts[2] = bob;
         uint64 recipientPolicyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
         );
 
         address[] memory mintRecipientAccounts = new address[](1);
         mintRecipientAccounts[0] = charlie;
         uint64 mintRecipientPolicyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, mintRecipientAccounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, mintRecipientAccounts
         );
 
         uint64 compoundPolicyId =
@@ -389,7 +390,7 @@ contract ZonePortalTest is BaseTest {
         accounts[0] = alice;
         accounts[1] = address(portal);
         uint64 policyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, accounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, accounts
         );
         vm.prank(pathUSDAdmin);
         pathUSD.changeTransferPolicyId(policyId);
@@ -408,7 +409,7 @@ contract ZonePortalTest is BaseTest {
         senderAccounts[0] = alice;
         senderAccounts[1] = address(portal);
         uint64 senderPolicyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
         );
 
         address[] memory recipientAccounts = new address[](3);
@@ -416,13 +417,13 @@ contract ZonePortalTest is BaseTest {
         recipientAccounts[1] = address(portal);
         recipientAccounts[2] = bob;
         uint64 recipientPolicyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
         );
 
         address[] memory mintRecipientAccounts = new address[](1);
         mintRecipientAccounts[0] = bob;
         uint64 mintRecipientPolicyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, mintRecipientAccounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, mintRecipientAccounts
         );
 
         uint64 compoundPolicyId =
@@ -1030,7 +1031,7 @@ contract ZonePortalTest is BaseTest {
         );
 
         uint256 portalBalanceBefore = pathUSD.balanceOf(address(portal));
-        uint256 sequencerBalanceBefore = pathUSD.balanceOf(admin);
+        uint256 sequencerBalanceBefore = pathUSD.balanceOf(sequencer);
         uint256 bobBalanceBefore = pathUSD.balanceOf(bob);
         uint256 charlieBalanceBefore = pathUSD.balanceOf(charlie);
         uint64 depositCountBefore = portal.depositCount();
@@ -1038,14 +1039,14 @@ contract ZonePortalTest is BaseTest {
         // Blacklist the sequencer as a token recipient while leaving everyone else allowed.
         // This makes w1's fee transfer revert while leaving the user-facing transfer valid.
         address[] memory blockedAccounts = new address[](1);
-        blockedAccounts[0] = admin;
+        blockedAccounts[0] = sequencer;
         uint64 policyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.BLACKLIST, blockedAccounts
+            sequencer, ITIP403Registry.PolicyType.BLACKLIST, blockedAccounts
         );
         vm.prank(pathUSDAdmin);
         pathUSD.changeTransferPolicyId(policyId);
 
-        assertFalse(registry.isAuthorizedRecipient(policyId, admin));
+        assertFalse(registry.isAuthorizedRecipient(policyId, sequencer));
         assertTrue(registry.isAuthorizedRecipient(policyId, bob));
         assertTrue(registry.isAuthorizedRecipient(policyId, charlie));
 
@@ -1054,7 +1055,7 @@ contract ZonePortalTest is BaseTest {
         portal.processWithdrawal(w1, innerHash);
 
         assertEq(pathUSD.balanceOf(bob), bobBalanceBefore + w1.amount);
-        assertEq(pathUSD.balanceOf(admin), sequencerBalanceBefore);
+        assertEq(pathUSD.balanceOf(sequencer), sequencerBalanceBefore);
         assertEq(pathUSD.balanceOf(address(portal)), portalBalanceBefore - w1.amount);
         assertEq(portal.depositCount(), depositCountBefore);
 
@@ -1959,7 +1960,7 @@ contract ZonePortalTest is BaseTest {
 
     function test_immutableGetters() public view {
         assertEq(portal.zoneId(), testZoneId);
-        assertEq(portal.sequencer(), admin);
+        assertEq(portal.sequencer(), sequencer);
         assertEq(portal.verifier(), zoneFactory.verifier());
         assertEq(portal.genesisTempoBlockNumber(), genesisTempoBlockNumber);
     }
@@ -2266,7 +2267,7 @@ contract ZonePortalTest is BaseTest {
         uint128 depositAmount = 1000e6;
         uint128 expectedFee = uint128(100_000) * 1; // FIXED_DEPOSIT_GAS * zoneGasRate
         uint256 aliceBefore = pathUSD.balanceOf(alice);
-        uint256 seqBefore = pathUSD.balanceOf(admin);
+        uint256 seqBefore = pathUSD.balanceOf(sequencer);
         uint256 portalBefore = pathUSD.balanceOf(address(portal));
 
         vm.startPrank(alice);
@@ -2275,7 +2276,7 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
 
         assertEq(pathUSD.balanceOf(alice), aliceBefore - depositAmount);
-        assertEq(pathUSD.balanceOf(admin), seqBefore + expectedFee);
+        assertEq(pathUSD.balanceOf(sequencer), seqBefore + expectedFee);
         assertEq(pathUSD.balanceOf(address(portal)), portalBefore + depositAmount - expectedFee);
     }
 
@@ -2414,7 +2415,7 @@ contract ZonePortalTest is BaseTest {
         accounts[0] = alice;
         accounts[1] = address(portal);
         uint64 policyId = registry.createPolicyWithAccounts(
-            admin, ITIP403Registry.PolicyType.WHITELIST, accounts
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, accounts
         );
         vm.prank(pathUSDAdmin);
         pathUSD.changeTransferPolicyId(policyId);

--- a/specs/ref-impls/test/l1/ZonePortalGasLimit.t.sol
+++ b/specs/ref-impls/test/l1/ZonePortalGasLimit.t.sol
@@ -45,6 +45,7 @@ contract ZonePortalGasLimitTest is Test {
     ZonePortal public portal;
     MockPortalToken public token;
 
+    address public admin = address(0x500);
     address public fallbackRecipient = address(0x200);
     address public recipient = address(0x300);
 
@@ -54,7 +55,7 @@ contract ZonePortalGasLimitTest is Test {
             1,
             address(token),
             address(0x400),
-            address(this),
+            admin,
             address(this),
             address(0),
             keccak256("genesis"),

--- a/specs/ref-impls/test/predeploys/ZoneConfig.t.sol
+++ b/specs/ref-impls/test/predeploys/ZoneConfig.t.sol
@@ -38,7 +38,7 @@ contract ZoneConfigTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: admin,
+            sequencer: sequencer,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -50,7 +50,8 @@ contract ZoneConfigTest is BaseTest {
 
         (, address portalAddr) = zoneFactory.createZone(params);
         portal = ZonePortal(portalAddr);
-        tempoState = new MockTempoState(admin, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
+        tempoState =
+            new MockTempoState(sequencer, GENESIS_TEMPO_BLOCK_HASH, genesisTempoBlockNumber);
         config = new ZoneConfig(address(portal), address(tempoState));
 
         _syncPortalSlot(PORTAL_SEQUENCER_SLOT);
@@ -103,9 +104,9 @@ contract ZoneConfigTest is BaseTest {
         assertEq(config.sequencer(), portal.sequencer());
     }
 
-    /// @notice Verifies sequencer membership is true for admin and false otherwise.
+    /// @notice Verifies sequencer membership is true for the portal sequencer and false otherwise.
     function test_isSequencer_trueAndFalse() public view {
-        assertTrue(config.isSequencer(admin));
+        assertTrue(config.isSequencer(sequencer));
         assertFalse(config.isSequencer(alice));
     }
 
@@ -164,7 +165,7 @@ contract ZoneConfigTest is BaseTest {
 
     /// @notice Verifies the config reads the pending sequencer from portal storage.
     function test_pendingSequencer() public {
-        vm.prank(admin);
+        vm.prank(sequencer);
         portal.transferSequencer(alice);
         _syncPortalSlot(PORTAL_PENDING_SEQUENCER_SLOT);
 
@@ -173,7 +174,7 @@ contract ZoneConfigTest is BaseTest {
 
     /// @notice Verifies sequencer slot reads stay correct after sequencer rotation.
     function test_storageSlotRegression_readsSequencerAfterRotation() public {
-        vm.prank(admin);
+        vm.prank(sequencer);
         portal.transferSequencer(alice);
         vm.prank(alice);
         portal.acceptSequencer();

--- a/specs/ref-impls/test/predeploys/ZoneSymbolic.t.sol
+++ b/specs/ref-impls/test/predeploys/ZoneSymbolic.t.sol
@@ -26,7 +26,7 @@ import { Test } from "forge-std/Test.sol";
 ///         pass.
 ///
 ///         Inherits ZonePortalTest to reuse its concrete setUp (a real ZonePortal deployed via
-///         ZoneFactory, with `admin` acting as the sequencer).
+///         ZoneFactory, with separate portal admin and sequencer roles).
 contract ZonePortalSymbolic is ZonePortalTest {
 
     /// @notice Deposit fee never overflows uint128 for any rate within the enforced cap, so
@@ -34,7 +34,7 @@ contract ZonePortalSymbolic is ZonePortalTest {
     function check_depositFeeNeverOverflows(uint128 rate) external {
         vm.assume(rate <= portal.MAX_GAS_FEE_RATE());
 
-        vm.prank(admin); // admin is the sequencer in this harness
+        vm.prank(sequencer);
         portal.setZoneGasRate(rate);
 
         uint128 fee = portal.calculateDepositFee();
@@ -45,7 +45,7 @@ contract ZonePortalSymbolic is ZonePortalTest {
     ///         for any input (over-cap inputs revert and are pruned). Encodes the MAX_GAS_FEE_RATE
     ///         invariant.
     function check_gasRateAlwaysWithinCap(uint128 rate) external {
-        vm.prank(admin);
+        vm.prank(sequencer);
         try portal.setZoneGasRate(rate) {
             assertLe(uint256(portal.zoneGasRate()), uint256(portal.MAX_GAS_FEE_RATE()));
         } catch { }

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -81,9 +81,9 @@ pub(crate) struct CreateZone {
     sequencer: Address,
 
     /// Admin address that controls token enablement and deposit pause/resume.
-    /// Defaults to the sequencer address when omitted.
+    /// Pass the sequencer address explicitly when both roles should use the same key.
     #[arg(long)]
-    admin: Option<Address>,
+    admin: Address,
 
     /// Public RPC endpoint for the zone, published on-chain in the portal.
     /// Can be left empty and set later via `ZonePortal.setRpcUrl`.
@@ -131,13 +131,12 @@ impl CreateZone {
         // via --l1.genesis-block-number.
         let current_block = provider.get_block_number().await?;
 
-        let admin = self.admin.unwrap_or(self.sequencer);
-        println!("Admin: {admin}");
+        println!("Admin: {}", self.admin);
         println!("Sequencer: {}", self.sequencer);
 
         let params = CreateZoneParams {
             initialToken: self.initial_token,
-            admin,
+            admin: self.admin,
             sequencer: self.sequencer,
             verifier,
             zoneParams: ZoneParams {
@@ -209,6 +208,7 @@ impl CreateZone {
             gas_limit: self.gas_limit,
             tempo_portal: portal,
             tempo_genesis_header_rlp: header_rlp_hex,
+            admin: self.admin,
             sequencer: Some(self.sequencer),
             specs_out: self.specs_out.clone(),
             with_createx: true,
@@ -223,7 +223,7 @@ impl CreateZone {
             "chainId": chain_id,
             "portal": format!("{portal}"),
             "initialToken": format!("{}", self.initial_token),
-            "admin": format!("{admin}"),
+            "admin": format!("{}", self.admin),
             "sequencer": format!("{}", self.sequencer),
             "tempoAnchorBlock": confirm_header.inner.number,
             "zoneFactory": format!("{}", self.zone_factory),
@@ -241,7 +241,7 @@ impl CreateZone {
         println!("  Chain ID: {chain_id}");
         println!("  Portal: {portal}");
         println!("  Initial Token: {}", self.initial_token);
-        println!("  Admin: {admin}");
+        println!("  Admin: {}", self.admin);
         println!("  Sequencer: {}", self.sequencer);
         println!("  ZoneFactory: {}", self.zone_factory);
         if !self.rpc_url.is_empty() {

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -74,6 +74,9 @@ pub(crate) struct GenerateZoneGenesis {
     pub(crate) tempo_genesis_header_rlp: String,
 
     #[arg(long)]
+    pub(crate) admin: Address,
+
+    #[arg(long)]
     pub(crate) sequencer: Option<Address>,
 
     #[arg(long, default_value = "specs/ref-impls/out")]
@@ -106,6 +109,10 @@ struct BytecodeField {
 
 impl GenerateZoneGenesis {
     pub(crate) async fn run(self) -> eyre::Result<()> {
+        if self.admin == Address::ZERO {
+            return Err(eyre!("--admin must not be the zero address"));
+        }
+
         let header_rlp = const_hex::decode(&self.tempo_genesis_header_rlp)
             .wrap_err("failed to decode hex string")?;
 
@@ -127,7 +134,7 @@ impl GenerateZoneGenesis {
 
         initialize_tip403_registry(&mut evm)?;
         initialize_tip20_factory(&mut evm)?;
-        create_path_usd_token(&mut evm)?;
+        create_path_usd_token(&mut evm, self.admin)?;
         initialize_fee_manager(&mut evm)?;
         initialize_stablecoin_dex(&mut evm)?;
         initialize_nonce_manager(&mut evm)?;
@@ -298,6 +305,8 @@ impl GenerateZoneGenesis {
             genesis_alloc.entry(sequencer).or_default().balance =
                 U256::from(1_000_000_000_000_000_000_000u128);
         }
+        genesis_alloc.entry(self.admin).or_default().balance =
+            U256::from(1_000_000_000_000_000_000_000u128);
 
         let chain_config = ChainConfig {
             chain_id: self.chain_id,
@@ -503,9 +512,7 @@ fn initialize_tip20_factory(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Resul
 /// This mirrors the L1 genesis setup: the Tempo EVM handler defaults to pathUSD
 /// (`0x20C0...`) as the fee token and validates its `currency == "USD"` storage.
 /// Without this, user transactions on the zone revert with `InvalidFeeToken`.
-fn create_path_usd_token(evm: &mut TempoEvm<CacheDB<EmptyDB>>) -> eyre::Result<()> {
-    let admin = DEPLOYER;
-
+fn create_path_usd_token(evm: &mut TempoEvm<CacheDB<EmptyDB>>, admin: Address) -> eyre::Result<()> {
     let ctx = evm.ctx_mut();
     StorageCtx::enter_evm(
         &mut ctx.journaled_state,


### PR DESCRIPTION
- in the startup scripts (xtask and just scripts) make sure to accept admin, sequencer separately
- save the 2 keys in the generated configs
- Separate admin and sequencer role in tests using separate keys
- add tests to ensure admin key can't do sequencer actions and sequencer key cant do admin actions.