### PR TITLE
feat: add private zone RPC skill

### DIFF
--- a/.codex/skills/private-zone-rpc/SKILL.md
+++ b/.codex/skills/private-zone-rpc/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: private-zone-rpc
+description: Interact with authenticated private Tempo Zone RPC endpoints, derive X-Authorization-Token zone auth tokens, identify zone IDs and chain IDs from ZoneFactory or repo metadata, and debug 401/403 auth failures. Use when calling rpc-zone-*-private endpoints, web3_clientVersion, eth_chainId, zone_getZoneInfo, or any private zone JSON-RPC method that needs a zone auth token.
+---
+
+# Private Zone RPC
+
+Use this skill for private Tempo Zone JSON-RPC endpoints that require
+`X-Authorization-Token`.
+
+## Auth Model
+
+Private zone RPC authenticates every request before method dispatch, including
+public methods like `web3_clientVersion`.
+
+The token header is:
+
+```text
+X-Authorization-Token: <hex token>
+```
+
+The token is:
+
+```text
+<signature><version:1><zoneId:4><chainId:8><issuedAt:8><expiresAt:8>
+```
+
+Build the signing digest as:
+
+```text
+keccak256("TempoZoneRPC" padded with zeros to 32 bytes || token fields)
+```
+
+Sign that digest with `cast wallet sign --no-hash`. Do not use Ethereum signed
+message prefixing.
+
+## Quick Call
+
+For zones created by the current repo tooling, prefer the built-in token helper
+because it reads generated metadata:
+
+```bash
+export PRIVATE_KEY=<zone-wallet-private-key>
+TOKEN=$(just zone-auth-token my-zone)
+cast rpc web3_clientVersion \
+  --rpc-url https://private-zone-rpc.example.com \
+  --rpc-headers "X-Authorization-Token: $TOKEN"
+```
+
+When only the endpoint tuple is known, set `PRIVATE_KEY` in the environment and
+use the helper script for one-off calls:
+
+```bash
+.codex/skills/private-zone-rpc/scripts/private_rpc_call.sh \
+  https://private-zone-rpc.example.com \
+  71 \
+  421700071 \
+  web3_clientVersion
+```
+
+The helper prints the JSON-RPC body on success and keeps the token out of logs.
+
+## Finding Zone ID And Chain ID
+
+Prefer exact metadata:
+
+1. Read `generated/<name>/zone.json` for `zoneId`.
+2. Read `generated/<name>/genesis.json` for `.config.chainId`; `zone.json` may
+   also mirror the same value as `chainId`.
+3. Resolve the ZoneFactory address from `generated/<name>/zone.json`,
+   `ZONE_FACTORY`, or the repo default. In this repo, the default lives
+   in `xtask/src/zone_utils.rs` as `MODERATO_ZONE_FACTORY`, and `docs/ZONES.md`
+   mirrors it.
+4. For this repo, derive missing chain IDs with
+   `zone_primitives::constants::zone_chain_id`:
+
+```text
+chain_id = 421700000 + (zone_id % 1002610000)
+```
+
+`xtask create-zone` writes this value, and the node validates it at startup
+when `--zone.id` is nonzero.
+
+Query the factory counter:
+
+```bash
+cast call "$ZONE_FACTORY" \
+  'zoneCount()(uint32)' \
+  --rpc-url https://rpc.moderato.tempo.xyz
+```
+
+`zoneCount()` returns created zones. The internal next-zone counter is
+`zoneCount + 1`.
+
+## Debugging Status Codes
+
+- `401` with empty body usually means the auth header is missing or the header
+  name is wrong.
+- `403` with empty body means a token was present but failed validation:
+  malformed signature, wrong `zoneId`, wrong `chainId`, expired token, or token
+  validity window too large.
+- If `X-Authorization-Token` gives `403` but `zone-auth-token` or
+  `Authorization: Bearer` gives `401`, the endpoint is using the expected
+  header name and the tuple/signature is wrong.

--- a/.codex/skills/private-zone-rpc/agents/openai.yaml
+++ b/.codex/skills/private-zone-rpc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Private Zone RPC"
+  short_description: "Authenticate private Tempo Zone RPC endpoints"
+  default_prompt: "Use $private-zone-rpc to call web3_clientVersion on a private Tempo Zone RPC endpoint."

--- a/.codex/skills/private-zone-rpc/scripts/private_rpc_call.sh
+++ b/.codex/skills/private-zone-rpc/scripts/private_rpc_call.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  PRIVATE_KEY=0x... private_rpc_call.sh RPC_URL ZONE_ID CHAIN_ID METHOD [PARAMS_JSON]
+
+Examples:
+  PRIVATE_KEY=0x... private_rpc_call.sh \
+    https://private-zone-rpc.example.com \
+    71 \
+    421700071 \
+    web3_clientVersion
+
+  PRIVATE_KEY=0x... private_rpc_call.sh \
+    https://private-zone-rpc.example.com \
+    71 \
+    421700071 \
+    eth_getBalance \
+    '["0x0000000000000000000000000000000000000000","latest"]'
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -lt 4 || $# -gt 5 ]]; then
+  usage >&2
+  exit 2
+fi
+
+rpc_url="$1"
+zone_id="$2"
+chain_id="$3"
+method="$4"
+params="${5:-[]}"
+private_key="${PRIVATE_KEY:-}"
+
+if [[ -z "$private_key" ]]; then
+  echo "PRIVATE_KEY is required" >&2
+  exit 2
+fi
+if ! command -v cast >/dev/null 2>&1; then
+  echo "cast is required" >&2
+  exit 127
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 127
+fi
+
+now=$(date +%s)
+expires=$((now + 600))
+magic="54656d706f5a6f6e655250430000000000000000000000000000000000000000"
+fields="00$(printf '%08x' "$zone_id")$(printf '%016x' "$chain_id")$(printf '%016x' "$now")$(printf '%016x' "$expires")"
+digest=$(cast keccak "0x${magic}${fields}")
+signature=$(cast wallet sign --no-hash "$digest" --private-key "$private_key")
+token="${signature#0x}${fields}"
+payload=$(printf '{"jsonrpc":"2.0","method":"%s","params":%s,"id":1}' "$method" "$params")
+
+body=$(mktemp)
+trap 'rm -f "$body"' EXIT
+
+status=$(curl -sS -o "$body" -w '%{http_code}' \
+  -H 'Content-Type: application/json' \
+  -H "X-Authorization-Token: ${token}" \
+  --data "$payload" \
+  "$rpc_url")
+
+cat "$body"
+if [[ "$status" != 2* ]]; then
+  printf '\nHTTP %s\n' "$status" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a `private-zone-rpc` Codex skill for working with authenticated private Tempo Zone RPC endpoints.

The skill documents how to derive `X-Authorization-Token` values, how to identify zone IDs and chain IDs from generated metadata or the v0.1.0 ZoneFactory, and how to interpret 401/403 failures. It also includes a small `private_rpc_call.sh` helper that signs the token with `cast wallet sign --no-hash` and sends JSON-RPC requests without printing the token.

## Impact

Future debugging sessions can reproduce the private RPC auth flow without rediscovering the token format or release-specific chain-id derivation.