### PR TITLE
ci: update Tempo for specs workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,7 @@ permissions: {}
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - ".github/workflows/specs.yml"
   pull_request:
-    paths-ignore:
-      - ".github/workflows/specs.yml"
   merge_group:
 
 concurrency:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo
-          ref: 65185565b01bc9f406a06c522357954d75ce7cb7
+          ref: 1108cb7eedaef42fb148162b9b0b6dca3b336f7a
           path: tempo
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,7 @@ permissions: {}
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - ".github/workflows/specs.yml"
   pull_request:
-    paths-ignore:
-      - ".github/workflows/specs.yml"
   merge_group:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Update the specs workflow Tempo checkout to a current commit that supports the newer alloy-evm API
- Keep the Foundry checkout on master so CI continues testing against latest Foundry
- Remove specs-only path ignores from Lint/Test so required `lint success` and `test success` checks are created for specs workflow changes

## Testing
- uv run python workflow text check
- gh api verified pinned Tempo commit exists
- git diff --check

Prompted by: @grandizzy