### PR TITLE
feat: Allow Admin keys to be rotated

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -156,6 +156,7 @@ crate::sol! {
 
         error NotSequencer();
         error NotAdmin();
+        error NotPendingSequencer();
         error NotPendingAdmin();
         error InvalidProof();
         error InvalidTempoBlockNumber();
@@ -210,6 +211,9 @@ crate::sol! {
         function enableToken(address token) external;
         function pauseDeposits(address token) external;
         function resumeDeposits(address token) external;
+
+        function transferSequencer(address newSequencer) external;
+        function acceptSequencer() external;
 
         function transferAdmin(address newAdmin) external;
         function acceptAdmin() external;
@@ -312,6 +316,7 @@ impl core::fmt::Display for ZonePortal::ZonePortalErrors {
         match self {
             Self::NotSequencer(_) => f.write_str("NotSequencer"),
             Self::NotAdmin(_) => f.write_str("NotAdmin"),
+            Self::NotPendingSequencer(_) => f.write_str("NotPendingSequencer"),
             Self::NotPendingAdmin(_) => f.write_str("NotPendingAdmin"),
             Self::InvalidProof(_) => f.write_str("InvalidProof"),
             Self::InvalidTempoBlockNumber(_) => f.write_str("InvalidTempoBlockNumber"),

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -142,10 +142,21 @@ crate::sol! {
             address indexed newSequencer
         );
 
+        event AdminTransferStarted(
+            address indexed currentAdmin,
+            address indexed pendingAdmin
+        );
+
+        event AdminTransferred(
+            address indexed previousAdmin,
+            address indexed newAdmin
+        );
+
         // -- Errors --
 
         error NotSequencer();
         error NotAdmin();
+        error NotPendingAdmin();
         error InvalidProof();
         error InvalidTempoBlockNumber();
         error PolicyForbids();
@@ -200,6 +211,9 @@ crate::sol! {
         function pauseDeposits(address token) external;
         function resumeDeposits(address token) external;
 
+        function transferAdmin(address newAdmin) external;
+        function acceptAdmin() external;
+
         function rpcUrl() external view returns (string memory);
         function setRpcUrl(string calldata rpcUrl) external;
 
@@ -226,6 +240,7 @@ crate::sol! {
         function enabledTokenAt(uint256 index) external view returns (address);
         function zoneGasRate() external view returns (uint128);
         function pendingSequencer() external view returns (address);
+        function pendingAdmin() external view returns (address);
         function refunds(address token, address owner) external view returns (uint128);
 
         function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
@@ -297,6 +312,7 @@ impl core::fmt::Display for ZonePortal::ZonePortalErrors {
         match self {
             Self::NotSequencer(_) => f.write_str("NotSequencer"),
             Self::NotAdmin(_) => f.write_str("NotAdmin"),
+            Self::NotPendingAdmin(_) => f.write_str("NotPendingAdmin"),
             Self::InvalidProof(_) => f.write_str("InvalidProof"),
             Self::InvalidTempoBlockNumber(_) => f.write_str("InvalidTempoBlockNumber"),
             Self::PolicyForbids(_) => f.write_str("PolicyForbids"),

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -384,6 +384,7 @@ interface IZoneTxContext {
 //   slot 12: _withdrawalQueue.tail
 //   slot 13: _withdrawalQueue.slots (mapping(uint256 => bytes32))
 //   slot 14: rpcUrl (string)
+//   slot 15: pendingAdmin (address)
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via
@@ -396,6 +397,7 @@ bytes32 constant PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
 bytes32 constant PORTAL_ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
 bytes32 constant PORTAL_TOKEN_CONFIGS_SLOT = bytes32(uint256(8));
 bytes32 constant PORTAL_ENABLED_TOKENS_SLOT = bytes32(uint256(9));
+bytes32 constant PORTAL_PENDING_ADMIN_SLOT = bytes32(uint256(15));
 
 /// @title IVerifier
 /// @notice Interface for zone proof/attestation verification
@@ -554,10 +556,19 @@ interface IZonePortal {
         uint64 depositNumber
     );
 
+    /// @notice Emitted when the current sequencer nominates a new sequencer (two-step transfer).
+    /// @dev A `pendingSequencer` of address(0) signals cancellation of a pending transfer.
     event SequencerTransferStarted(
         address indexed currentSequencer, address indexed pendingSequencer
     );
+    /// @notice Emitted when a pending sequencer accepts and the sequencer role is handed over.
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+
+    /// @notice Emitted when the current admin nominates a new admin (two-step transfer).
+    /// @dev A `newAdmin` of address(0) signals cancellation of a pending transfer.
+    event AdminTransferStarted(address indexed currentAdmin, address indexed pendingAdmin);
+    /// @notice Emitted when a pending admin accepts and the admin role is handed over.
+    event AdminTransferred(address indexed previousAdmin, address indexed newAdmin);
 
     /// @notice Emitted when an encrypted deposit is made (recipient/memo not revealed)
     event EncryptedDepositMade(
@@ -612,6 +623,7 @@ interface IZonePortal {
     error NotSequencer();
     error NotAdmin();
     error NotPendingSequencer();
+    error NotPendingAdmin();
     error InvalidProof();
     error InvalidTempoBlockNumber();
     error CallbackRejected();
@@ -651,6 +663,8 @@ interface IZonePortal {
     function admin() external view returns (address);
 
     function pendingSequencer() external view returns (address);
+
+    function pendingAdmin() external view returns (address);
 
     function zoneGasRate() external view returns (uint128);
 
@@ -717,6 +731,13 @@ interface IZonePortal {
 
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
     function acceptSequencer() external;
+
+    /// @notice Start an admin transfer. Only callable by the current admin.
+    /// @param newAdmin The address that will become admin after accepting (address(0) cancels).
+    function transferAdmin(address newAdmin) external;
+
+    /// @notice Accept a pending admin transfer. Only callable by the pending admin.
+    function acceptAdmin() external;
 
     /// @notice Get the sequencer's current encryption public key for encrypted deposits
     /// @return x The X coordinate of the secp256k1 public key

--- a/specs/ref-impls/src/l1/ZonePortal.sol
+++ b/specs/ref-impls/src/l1/ZonePortal.sol
@@ -186,12 +186,11 @@ contract ZonePortal is IZonePortal {
     ///      possible to make a system tx on L1 with msg.sender == 0.
     ///      The Sequencer key can only be rotated, never renounced.
     function acceptSequencer() external {
-        address newSequencer = pendingSequencer;
-        if (newSequencer == address(0) || msg.sender != newSequencer) {
+        if (pendingSequencer == address(0) || msg.sender != pendingSequencer) {
             revert NotPendingSequencer();
         }
         address previousSequencer = sequencer;
-        sequencer = newSequencer;
+        sequencer = pendingSequencer;
         pendingSequencer = address(0);
         emit SequencerTransferred(previousSequencer, sequencer);
     }
@@ -222,14 +221,13 @@ contract ZonePortal is IZonePortal {
     }
 
     /// @notice Accept a pending admin transfer. Only callable by the pending admin.
-    /// @dev The explicit `newAdmin == address(0)` check because it is technically
+    /// @dev The explicit `pendingAdmin == address(0)` check because it is technically
     ///      possible to make a system tx on L1 with msg.sender == 0.
     ///      The Admin key can only be rotated, never renounced.
     function acceptAdmin() external {
-        address newAdmin = pendingAdmin;
-        if (newAdmin == address(0) || msg.sender != newAdmin) revert NotPendingAdmin();
+        if (pendingAdmin == address(0) || msg.sender != pendingAdmin) revert NotPendingAdmin();
         address previousAdmin = admin;
-        admin = newAdmin;
+        admin = pendingAdmin;
         pendingAdmin = address(0);
         emit AdminTransferred(previousAdmin, admin);
     }

--- a/specs/ref-impls/src/l1/ZonePortal.sol
+++ b/specs/ref-impls/src/l1/ZonePortal.sol
@@ -125,6 +125,9 @@ contract ZonePortal is IZonePortal {
     /// @notice Public RPC endpoint for the zone
     string public rpcUrl;
 
+    /// @notice Pending admin for two-step admin transfer
+    address public pendingAdmin;
+
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -179,10 +182,16 @@ contract ZonePortal is IZonePortal {
     }
 
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
+    /// @dev The explicit `pendingSequencer == address(0)` check because it is technically
+    ///      possible to make a system tx on L1 with msg.sender == 0.
+    ///      The Sequencer key can only be rotated, never renounced.
     function acceptSequencer() external {
-        if (msg.sender != pendingSequencer) revert NotPendingSequencer();
+        address newSequencer = pendingSequencer;
+        if (newSequencer == address(0) || msg.sender != newSequencer) {
+            revert NotPendingSequencer();
+        }
         address previousSequencer = sequencer;
-        sequencer = pendingSequencer;
+        sequencer = newSequencer;
         pendingSequencer = address(0);
         emit SequencerTransferred(previousSequencer, sequencer);
     }
@@ -196,6 +205,33 @@ contract ZonePortal is IZonePortal {
         if (_zoneGasRate > MAX_GAS_FEE_RATE) revert GasFeeRateTooHigh();
         zoneGasRate = _zoneGasRate;
         emit ZoneGasRateUpdated(_zoneGasRate);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             ADMIN MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Start an admin transfer. Only callable by the current admin.
+    /// @dev Two-step handoff: the new admin only takes over once it calls
+    ///      {acceptAdmin}, which prevents fat-fingered transfers.
+    ///      Passing address(0) cancels a pending transfer.
+    /// @param newAdmin The address that will become admin after accepting (address(0) cancels).
+    function transferAdmin(address newAdmin) external onlyAdmin {
+        pendingAdmin = newAdmin;
+        emit AdminTransferStarted(admin, newAdmin);
+    }
+
+    /// @notice Accept a pending admin transfer. Only callable by the pending admin.
+    /// @dev The explicit `newAdmin == address(0)` check because it is technically
+    ///      possible to make a system tx on L1 with msg.sender == 0.
+    ///      The Admin key can only be rotated, never renounced.
+    function acceptAdmin() external {
+        address newAdmin = pendingAdmin;
+        if (newAdmin == address(0) || msg.sender != newAdmin) revert NotPendingAdmin();
+        address previousAdmin = admin;
+        admin = newAdmin;
+        pendingAdmin = address(0);
+        emit AdminTransferred(previousAdmin, admin);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/specs/ref-impls/test/l1/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/l1/ZoneFactory.t.sol
@@ -407,6 +407,18 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(zoneFactory.zones(id).sequencer, admin); // factory: snapshot at creation
     }
 
+    // Factory ZoneInfo.admin is likewise a snapshot; the portal admin can rotate via the
+    // two-step transfer while the factory record still reflects the creation-time admin.
+    function test_zones_adminIsSnapshot_afterRotation() public {
+        (uint32 id, address portal) = zoneFactory.createZone(_defaultParams());
+        ZonePortal(portal).transferAdmin(alice);
+        vm.prank(alice);
+        ZonePortal(portal).acceptAdmin();
+
+        assertEq(ZonePortal(portal).admin(), alice); // portal: current
+        assertEq(zoneFactory.zones(id).admin, admin); // factory: snapshot at creation
+    }
+
     /*//////////////////////////////////////////////////////////////
                     CREATE-ADDRESS RLP BOUNDARIES
     //////////////////////////////////////////////////////////////*/

--- a/specs/ref-impls/test/l1/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/l1/ZoneFactory.t.sol
@@ -417,6 +417,7 @@ contract ZoneFactoryTest is BaseTest {
     // two-step transfer while the factory record still reflects the creation-time admin.
     function test_zones_adminIsSnapshot_afterRotation() public {
         (uint32 id, address portal) = zoneFactory.createZone(_defaultParams());
+        vm.prank(admin);
         ZonePortal(portal).transferAdmin(alice);
         vm.prank(alice);
         ZonePortal(portal).acceptAdmin();

--- a/specs/ref-impls/test/l1/ZonePortal.t.sol
+++ b/specs/ref-impls/test/l1/ZonePortal.t.sol
@@ -21,6 +21,7 @@ import {
     PORTAL_ADMIN_SLOT,
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     PORTAL_ENCRYPTION_KEYS_SLOT,
+    PORTAL_PENDING_ADMIN_SLOT,
     PORTAL_PENDING_SEQUENCER_SLOT,
     PORTAL_SEQUENCER_SLOT,
     Withdrawal,
@@ -267,6 +268,130 @@ contract ZonePortalTest is BaseTest {
         vm.expectRevert(IZonePortal.NotAdmin.selector);
         portal.enableToken(address(pathUSD));
         vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          ADMIN TRANSFER TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_transferAdmin_twoStep() public {
+        assertEq(portal.admin(), admin);
+        assertEq(portal.pendingAdmin(), address(0));
+
+        // Step 1: current admin nominates a new admin.
+        vm.expectEmit(true, true, false, true);
+        emit IZonePortal.AdminTransferStarted(admin, alice);
+        vm.prank(admin);
+        portal.transferAdmin(alice);
+
+        // Role does not move until acceptance.
+        assertEq(portal.admin(), admin);
+        assertEq(portal.pendingAdmin(), alice);
+
+        // Step 2: pending admin accepts and the role hands over.
+        vm.expectEmit(true, true, false, true);
+        emit IZonePortal.AdminTransferred(admin, alice);
+        vm.prank(alice);
+        portal.acceptAdmin();
+
+        assertEq(portal.admin(), alice);
+        assertEq(portal.pendingAdmin(), address(0));
+    }
+
+    function test_transferAdmin_movesGovernancePowers() public {
+        vm.prank(admin);
+        portal.transferAdmin(alice);
+        vm.prank(alice);
+        portal.acceptAdmin();
+
+        // New admin can exercise governance powers.
+        vm.prank(alice);
+        portal.pauseDeposits(address(pathUSD));
+        assertFalse(portal.areDepositsActive(address(pathUSD)));
+
+        // Old admin can no longer exercise them.
+        vm.prank(admin);
+        vm.expectRevert(IZonePortal.NotAdmin.selector);
+        portal.resumeDeposits(address(pathUSD));
+    }
+
+    function test_transferAdmin_revertsIfNotAdmin() public {
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotAdmin.selector);
+        portal.transferAdmin(alice);
+    }
+
+    function test_acceptAdmin_revertsIfNotPendingAdmin() public {
+        vm.prank(admin);
+        portal.transferAdmin(alice);
+
+        // Neither a random caller nor the current admin can accept.
+        vm.prank(bob);
+        vm.expectRevert(IZonePortal.NotPendingAdmin.selector);
+        portal.acceptAdmin();
+
+        vm.prank(admin);
+        vm.expectRevert(IZonePortal.NotPendingAdmin.selector);
+        portal.acceptAdmin();
+
+        assertEq(portal.admin(), admin);
+    }
+
+    function test_acceptAdmin_revertsWhenNoPendingAdmin() public {
+        // pendingAdmin defaults to address(0); acceptAdmin must never let anyone
+        // (including a zero-address caller, which is unreachable in practice) take over.
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotPendingAdmin.selector);
+        portal.acceptAdmin();
+    }
+
+    function test_transferAdmin_cancelViaZeroAddress() public {
+        vm.prank(admin);
+        portal.transferAdmin(alice);
+        assertEq(portal.pendingAdmin(), alice);
+
+        // Nominating address(0) cancels the pending transfer.
+        vm.expectEmit(true, true, false, true);
+        emit IZonePortal.AdminTransferStarted(admin, address(0));
+        vm.prank(admin);
+        portal.transferAdmin(address(0));
+        assertEq(portal.pendingAdmin(), address(0));
+
+        // The previously-pending admin can no longer accept.
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotPendingAdmin.selector);
+        portal.acceptAdmin();
+        assertEq(portal.admin(), admin);
+    }
+
+    function test_transferAdmin_renomination() public {
+        vm.prank(admin);
+        portal.transferAdmin(alice);
+
+        // Re-nominating a different address overwrites the pending admin.
+        vm.prank(admin);
+        portal.transferAdmin(bob);
+        assertEq(portal.pendingAdmin(), bob);
+
+        // The stale nominee cannot accept; the current nominee can.
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotPendingAdmin.selector);
+        portal.acceptAdmin();
+
+        vm.prank(bob);
+        portal.acceptAdmin();
+        assertEq(portal.admin(), bob);
+        assertEq(portal.pendingAdmin(), address(0));
+    }
+
+    function test_acceptSequencer_revertsWhenNoPendingSequencer() public {
+        // With no pending sequencer, acceptSequencer must always revert so the role can
+        // never be handed to (or accepted as) address(0). Guards against the theoretical
+        // zero-sender system-transaction path on the portal.
+        assertEq(portal.pendingSequencer(), address(0));
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotPendingSequencer.selector);
+        portal.acceptSequencer();
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -2588,6 +2713,17 @@ contract ZonePortalTest is BaseTest {
         // Before adding keys, length should be 0
         bytes32 slot7keys = vm.load(address(portal), PORTAL_ENCRYPTION_KEYS_SLOT);
         assertEq(uint256(slot7keys), 0, "slot 7: _encryptionKeys length should be 0 initially");
+
+        // --- Slot 15: pendingAdmin ---
+        // Nominate a new admin to get a non-zero pendingAdmin (rpcUrl at slot 14 is short,
+        // so it stays inline and pendingAdmin lands at the next slot).
+        portal.transferAdmin(bob);
+        bytes32 slot15 = vm.load(address(portal), PORTAL_PENDING_ADMIN_SLOT);
+        assertEq(
+            address(uint160(uint256(slot15))),
+            portal.pendingAdmin(),
+            "slot 15: pendingAdmin mismatch"
+        );
     }
 
     /// @notice Verify that the _encryptionKeys dynamic array uses the expected slot layout.

--- a/specs/ref-impls/test/l1/ZonePortal.t.sol
+++ b/specs/ref-impls/test/l1/ZonePortal.t.sol
@@ -2765,6 +2765,7 @@ contract ZonePortalTest is BaseTest {
         // --- Slot 15: pendingAdmin ---
         // Nominate a new admin to get a non-zero pendingAdmin (rpcUrl at slot 14 is short,
         // so it stays inline and pendingAdmin lands at the next slot).
+        vm.prank(admin);
         portal.transferAdmin(bob);
         bytes32 slot15 = vm.load(address(portal), PORTAL_PENDING_ADMIN_SLOT);
         assertEq(

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -19,6 +19,7 @@
     - [Gas Rate Configuration](#gas-rate-configuration)
     - [Encryption Key Management](#encryption-key-management)
     - [Sequencer Transfer](#sequencer-transfer)
+    - [Admin Transfer](#admin-transfer)
   - [Deposits](#deposits)
     - [Regular Deposits](#regular-deposits)
     - [Deposit Fees](#deposit-fees)
@@ -177,12 +178,15 @@ Each zone has two privileged roles registered on the [`ZonePortal`](#izoneportal
 - Holds governance powers over the zone (token enablement, deposit pause/resume).
 - Expected to be a cold key, multisig, or governance contract.
 - Set at zone creation via [`IZoneFactory.createZone`](#izonefactory).
-- Cannot be renounced. The zero address is never a valid admin.
+- Rotatable via a two-step transfer (see [Admin Transfer](#admin-transfer)), so a lost or compromised admin key can be moved to a new cold key or multisig.
+- Cannot be renounced. 
 
 **Sequencer.**
 
 - Operates the zone: collects transactions, produces blocks, advances Tempo, processes deposits and withdrawals, and submits batches with proofs.
 - Expected to be an online operational key.
+- Rotatable via a two-step transfer. (see [Sequencer Transfer](#sequencer-transfer))
+- Cannot be renounced.
 - Set at zone creation via [`IZoneFactory.createZone`](#izonefactory).
 - Holds the encryption private key used to decrypt [encrypted deposits](#encrypted-deposits).
 
@@ -197,6 +201,10 @@ The following table lists every privileged action and the role authorized to inv
 | `enableToken(token)` | [`ZonePortal`](#izoneportal) | **admin** |
 | `pauseDeposits(token)` | [`ZonePortal`](#izoneportal) | **admin** |
 | `resumeDeposits(token)` | [`ZonePortal`](#izoneportal) | **admin** |
+| `transferAdmin(newAdmin)` | [`ZonePortal`](#izoneportal) | **admin** |
+| `acceptAdmin()` | [`ZonePortal`](#izoneportal) | **pending admin** |
+| `transferSequencer(newSequencer)` | [`ZonePortal`](#izoneportal) | **sequencer** |
+| `acceptSequencer()` | [`ZonePortal`](#izoneportal) | **pending sequencer** |
 | `setZoneGasRate(rate)` | [`ZonePortal`](#izoneportal) | **sequencer** |
 | `setSequencerEncryptionKey(...)` | [`ZonePortal`](#izoneportal) | **sequencer** |
 | `setRpcUrl(url)` | [`ZonePortal`](#izoneportal) | **sequencer** |
@@ -319,10 +327,19 @@ When a new key is set, the previous key remains valid for `ENCRYPTION_KEY_GRACE_
 
 The sequencer can transfer control to a new address via a two-step process on Tempo:
 
-1. Current sequencer calls `ZonePortal.transferSequencer(newSequencer)` to nominate a new sequencer.
+1. Current sequencer calls `ZonePortal.transferSequencer(newSequencer)` to nominate a new sequencer. Calling it with `address(0)` cancels a pending transfer.
 2. New sequencer calls `ZonePortal.acceptSequencer()` to accept the transfer.
 
 Sequencer management happens exclusively on Tempo. Zone-side contracts read the sequencer address from the portal via `ZoneConfig`, so the transfer takes effect on the zone once `advanceTempo` imports the Tempo block containing the accepted transfer. The two-step pattern prevents accidental transfers to incorrect addresses.
+
+### Admin Transfer
+
+The admin can transfer the governance role to a new address via the same two-step process, allowing an operator to rotate to a new cold key or multisig after a planned governance change or a suspected key compromise:
+
+1. Current admin calls `ZonePortal.transferAdmin(newAdmin)` to nominate a new admin. Calling it with `address(0)` cancels a pending transfer.
+2. New admin calls `ZonePortal.acceptAdmin()` to accept the transfer.
+
+Until `acceptAdmin()` is called the current admin retains all governance powers, so a nomination to a wrong or unreachable address cannot strand the role. Because only a non-zero pending admin can accept, the transfer can never set the admin to `address(0)` — the admin still cannot be renounced.
 
 <br>
 
@@ -1636,6 +1653,8 @@ interface IZonePortal {
     event RefundClaimed(address indexed recipient, address indexed token, uint128 amount);
     event SequencerTransferStarted(address indexed currentSequencer, address indexed pendingSequencer);
     event SequencerTransferred(address indexed previousSequencer, address indexed newSequencer);
+    event AdminTransferStarted(address indexed currentAdmin, address indexed pendingAdmin);
+    event AdminTransferred(address indexed previousAdmin, address indexed newAdmin);
     event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity, uint256 keyIndex, uint64 activationBlock);
     event ZoneGasRateUpdated(uint128 zoneGasRate);
     event TokenEnabled(address indexed token, string name, string symbol, string currency);
@@ -1645,6 +1664,7 @@ interface IZonePortal {
     error NotSequencer();
     error NotAdmin();
     error NotPendingSequencer();
+    error NotPendingAdmin();
     error InvalidProof();
     error InvalidTempoBlockNumber();
     error CallbackRejected();
@@ -1727,6 +1747,11 @@ interface IZonePortal {
     // Sequencer management
     function transferSequencer(address newSequencer) external;
     function acceptSequencer() external;
+
+    // Admin management
+    function transferAdmin(address newAdmin) external;
+    function acceptAdmin() external;
+
     function setZoneGasRate(uint128 _zoneGasRate) external;
     function zoneGasRate() external view returns (uint128);
 
@@ -1746,6 +1771,7 @@ interface IZonePortal {
     function sequencer() external view returns (address);
     function admin() external view returns (address);
     function pendingSequencer() external view returns (address);
+    function pendingAdmin() external view returns (address);
     
     function verifier() external view returns (address);
     function blockHash() external view returns (bytes32);


### PR DESCRIPTION
- Add a two-step rotation for admin keys (mirroring sequencer key rotation)
- Tests
- Add check to make sure admin/sequencer keys can't be renounced