### PR TITLE
fix: Redact gasUsed, blockSize, log_index etc... that leak tx counts from zones

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -11,12 +11,12 @@ use std::{
     time::Duration,
 };
 
-use alloy_network::{ReceiptResponse, TransactionResponse};
+use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U64, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rpc_types_eth::{
-    Block, BlockId, BlockNumberOrTag, BlockTransactions, Filter, FilterChanges, FilterId,
-    TransactionRequest,
+    Block, BlockId, BlockNumberOrTag, BlockTransactions, FeeHistory, Filter, FilterChanges,
+    FilterId, TransactionRequest,
     state::{EvmOverrides, StateOverride},
 };
 use alloy_sol_types::{SolCall, SolEvent, SolEventInterface};
@@ -34,11 +34,12 @@ use tempo_alloy::{
     TempoNetwork,
     rpc::{TempoHeaderResponse, TempoTransactionRequest},
 };
+use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     account_keychain::IAccountKeychain::{self, KeyInfo, getKeyCall},
 };
-use tempo_primitives::{TempoHeader, TempoTxEnvelope};
+use tempo_primitives::TempoTxEnvelope;
 use tokio::{
     sync::Mutex,
     time::{MissedTickBehavior, interval},
@@ -476,10 +477,12 @@ where
         reward_percentiles: Option<Vec<f64>>,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            let history =
+            let mut history =
                 EthFees::fee_history(&self.eth.api, block_count, newest_block, reward_percentiles)
                     .await
                     .map_err(internal)?;
+            // Redact gas fields (like `gas_used_ratio`) that can be used to guess tx counts
+            redact_fee_history(&mut history);
             to_raw(&history)
         })
     }
@@ -566,11 +569,16 @@ where
                 .transpose()
                 .map_err(internal)?;
 
-            let Some(tx) = tx else { return Ok(raw_null()) };
+            let Some(mut tx) = tx else {
+                return Ok(raw_null());
+            };
 
             if tx.from() != auth.caller {
                 return Ok(raw_null());
             }
+
+            // transaction_index leaks how many txns were in this block, so redact
+            tx.transaction_index = Some(0);
 
             to_raw(&tx)
         })
@@ -680,6 +688,10 @@ where
     ) -> BoxFut<'_> {
         Box::pin(async move {
             self.enforce_authorized(&mut request, &auth).await?;
+
+            // Prefill the users request so the `fill_transaction` doesnt leak dynamic fee estimates via
+            // missing fee fields.
+            apply_public_fee_policy(&mut request);
 
             let result = EthTransactions::fill_transaction(&self.eth.api, request)
                 .await
@@ -823,7 +835,7 @@ where
                     futures::stream::iter(headers)
                 })
                 .map(move |mut header| {
-                    redact_ws_header(&mut header);
+                    redact_header(&mut header);
                     to_raw(&header)
                 });
             let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
@@ -857,9 +869,15 @@ where
                     futures::stream::iter(all_logs)
                 });
 
+            // Renumber `log_index` per-transaction so a log seen live over the
+            // subscription carries the same `(transactionHash, logIndex)` it would
+            // via `eth_getLogs`/`eth_getTransactionReceipt`.
+            // Logs arrive in block order grouped by tx, which is what `LogOrderingRedactor` needs.
+            let mut log_redactor = zone_rpc::filter::LogOrderingRedactor::default();
             let stream = stream.filter_map(move |log| {
                 std::future::ready(
-                    zone_rpc::filter::is_log_visible(&log, &caller).then(|| to_raw(&log)),
+                    zone_rpc::filter::is_log_visible(&log, &caller)
+                        .then(|| to_raw(&log_redactor.redact(log))),
                 )
             });
             let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
@@ -1051,18 +1069,60 @@ fn encrypted_deposit_details(
     }
 }
 
-fn redact_tempo_header(header: &mut TempoHeader) {
-    header.inner.logs_bloom = Bloom::ZERO;
+/// Clear RPC header fields that reveal private execution state from the header
+fn redact_header(header: &mut TempoHeaderResponse) {
+    header.inner.size = header.inner.size.map(|_| U256::ZERO);
+    let inner = &mut header.inner.inner.inner;
+    inner.gas_used = 0;
+    inner.logs_bloom = Bloom::ZERO;
+    inner.blob_gas_used = inner.blob_gas_used.map(|_| 0);
+    inner.excess_blob_gas = inner.excess_blob_gas.map(|_| 0);
 }
 
-fn redact_ws_header(header: &mut TempoHeaderResponse) {
-    redact_tempo_header(&mut header.inner.inner);
+/// Clear gas related fields that leak the size (and therefore tx counts)
+fn redact_fee_history(history: &mut FeeHistory) {
+    history.base_fee_per_gas.fill(u128::from(TEMPO_T0_BASE_FEE));
+    history.gas_used_ratio.fill(0.0);
+    history.base_fee_per_blob_gas.fill(0);
+    history.blob_gas_used_ratio.fill(0.0);
+    if let Some(rewards) = &mut history.reward {
+        for block_rewards in rewards {
+            block_rewards.fill(0);
+        }
+    }
+}
+
+/// Prefill missing transaction fee fields with public, deterministic values before calling reth's
+/// transaction filler, so `eth_fillTransaction` does not expose dynamic fee estimates derived from
+/// private zone activity.
+fn apply_public_fee_policy(request: &mut TempoTransactionRequest) {
+    if request.inner.has_eip4844_fields() && request.inner.max_fee_per_blob_gas.is_none() {
+        request.inner.max_fee_per_blob_gas = Some(0);
+    }
+
+    if request.gas_price().is_some() {
+        return;
+    }
+
+    if matches!(request.inner.transaction_type, Some(0 | 1)) {
+        request.set_gas_price(u128::from(TEMPO_T0_BASE_FEE));
+        return;
+    }
+
+    let priority_fee = request.max_priority_fee_per_gas().unwrap_or(0);
+    if request.max_priority_fee_per_gas().is_none() {
+        request.set_max_priority_fee_per_gas(0);
+    }
+    if request.max_fee_per_gas().is_none() {
+        request.set_max_fee_per_gas(u128::from(TEMPO_T0_BASE_FEE) + priority_fee);
+    }
 }
 
 /// Strip privacy-sensitive fields from a block for non-sequencer callers.
 fn redact_block(block: &mut RpcBlock) {
-    redact_tempo_header(&mut block.header.inner);
+    redact_header(&mut block.header);
     block.transactions = BlockTransactions::Hashes(Vec::new());
+    block.withdrawals = block.withdrawals.take().map(|_| Default::default());
 }
 
 pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> ConnectionConfig {
@@ -1124,6 +1184,117 @@ mod tests {
             err.message,
             "regular deposit event matched encrypted deposit hash"
         );
+    }
+
+    #[test]
+    fn redact_fee_history_preserves_shape_and_public_values() {
+        let mut history = FeeHistory {
+            base_fee_per_gas: vec![1, 2, 3],
+            gas_used_ratio: vec![0.25, 0.75],
+            base_fee_per_blob_gas: vec![4, 5, 6],
+            blob_gas_used_ratio: vec![0.5, 1.0],
+            oldest_block: 42,
+            reward: Some(vec![vec![7, 8], vec![9, 10]]),
+        };
+
+        redact_fee_history(&mut history);
+
+        assert_eq!(history.oldest_block, 42);
+        assert_eq!(
+            history.base_fee_per_gas,
+            vec![u128::from(TEMPO_T0_BASE_FEE); 3]
+        );
+        assert_eq!(history.gas_used_ratio, vec![0.0; 2]);
+        assert_eq!(history.base_fee_per_blob_gas, vec![0; 3]);
+        assert_eq!(history.blob_gas_used_ratio, vec![0.0; 2]);
+        assert_eq!(history.reward, Some(vec![vec![0, 0], vec![0, 0]]));
+    }
+
+    #[test]
+    fn apply_public_fee_policy_prefills_missing_fees() {
+        let mut request = TempoTransactionRequest::default();
+
+        apply_public_fee_policy(&mut request);
+
+        assert_eq!(request.gas_price(), None);
+        assert_eq!(
+            request.max_fee_per_gas(),
+            Some(u128::from(TEMPO_T0_BASE_FEE))
+        );
+        assert_eq!(request.max_priority_fee_per_gas(), Some(0));
+    }
+
+    #[test]
+    fn apply_public_fee_policy_prefills_legacy_gas_price() {
+        let mut request = TempoTransactionRequest::default();
+        request.inner.transaction_type = Some(0);
+
+        apply_public_fee_policy(&mut request);
+
+        assert_eq!(request.gas_price(), Some(u128::from(TEMPO_T0_BASE_FEE)));
+        assert_eq!(request.max_fee_per_gas(), None);
+        assert_eq!(request.max_priority_fee_per_gas(), None);
+    }
+
+    #[test]
+    fn apply_public_fee_policy_preserves_supplied_priority_fee() {
+        let mut request = TempoTransactionRequest::default();
+        request.set_max_priority_fee_per_gas(7);
+
+        apply_public_fee_policy(&mut request);
+
+        assert_eq!(request.max_priority_fee_per_gas(), Some(7));
+        assert_eq!(
+            request.max_fee_per_gas(),
+            Some(u128::from(TEMPO_T0_BASE_FEE) + 7)
+        );
+    }
+
+    #[test]
+    fn apply_public_fee_policy_prefills_blob_fee() {
+        let mut request = TempoTransactionRequest::default();
+        request.inner.blob_versioned_hashes = Some(Vec::new());
+
+        apply_public_fee_policy(&mut request);
+
+        assert_eq!(request.inner.max_fee_per_blob_gas, Some(0));
+    }
+
+    #[test]
+    fn redact_header_clears_activity_metadata() {
+        let mut header = TempoHeaderResponse {
+            inner: alloy_rpc_types_eth::Header {
+                hash: B256::with_last_byte(7),
+                inner: tempo_primitives::TempoHeader {
+                    inner: alloy_consensus::Header {
+                        gas_used: 123,
+                        state_root: B256::with_last_byte(1),
+                        transactions_root: B256::with_last_byte(2),
+                        receipts_root: B256::with_last_byte(3),
+                        extra_data: Bytes::from_static(b"private"),
+                        blob_gas_used: Some(4),
+                        excess_blob_gas: Some(5),
+                        withdrawals_root: Some(B256::with_last_byte(6)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                size: Some(U256::from(8)),
+                ..Default::default()
+            },
+            timestamp_millis: 123_000,
+        };
+
+        redact_header(&mut header);
+
+        let inner = &header.inner.inner.inner;
+        assert_eq!(header.inner.hash, B256::with_last_byte(7));
+        assert_eq!(header.inner.size, Some(U256::ZERO));
+        assert_eq!(header.timestamp_millis, 123_000);
+        assert_eq!(inner.gas_used, 0);
+        assert_eq!(inner.logs_bloom, Bloom::ZERO);
+        assert_eq!(inner.blob_gas_used, Some(0));
+        assert_eq!(inner.excess_blob_gas, Some(0));
     }
 
     #[test]

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -854,10 +854,6 @@ async fn test_block_access_control() -> eyre::Result<()> {
         );
     }
     assert_eq!(block["gasUsed"], "0x0");
-    assert_eq!(block["transactionsRoot"], format!("{:#x}", B256::ZERO));
-    assert_eq!(block["receiptsRoot"], format!("{:#x}", B256::ZERO));
-    assert_eq!(block["stateRoot"], format!("{:#x}", B256::ZERO));
-    assert_eq!(block["extraData"], "0x");
     if let Some(size) = block.get("size") {
         assert_eq!(size.as_str(), Some("0x0"));
     }
@@ -871,12 +867,6 @@ async fn test_block_access_control() -> eyre::Result<()> {
         assert!(
             withdrawals.as_array().is_some_and(|items| items.is_empty()),
             "block withdrawals should be empty when present"
-        );
-    }
-    if let Some(withdrawals_root) = block.get("withdrawalsRoot") {
-        assert_eq!(
-            withdrawals_root.as_str(),
-            Some(format!("{:#x}", B256::ZERO).as_str())
         );
     }
 

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -853,6 +853,32 @@ async fn test_block_access_control() -> eyre::Result<()> {
             "block logsBloom should be all zeros"
         );
     }
+    assert_eq!(block["gasUsed"], "0x0");
+    assert_eq!(block["transactionsRoot"], format!("{:#x}", B256::ZERO));
+    assert_eq!(block["receiptsRoot"], format!("{:#x}", B256::ZERO));
+    assert_eq!(block["stateRoot"], format!("{:#x}", B256::ZERO));
+    assert_eq!(block["extraData"], "0x");
+    if let Some(size) = block.get("size") {
+        assert_eq!(size.as_str(), Some("0x0"));
+    }
+    if let Some(blob_gas_used) = block.get("blobGasUsed") {
+        assert_eq!(blob_gas_used.as_str(), Some("0x0"));
+    }
+    if let Some(excess_blob_gas) = block.get("excessBlobGas") {
+        assert_eq!(excess_blob_gas.as_str(), Some("0x0"));
+    }
+    if let Some(withdrawals) = block.get("withdrawals") {
+        assert!(
+            withdrawals.as_array().is_some_and(|items| items.is_empty()),
+            "block withdrawals should be empty when present"
+        );
+    }
+    if let Some(withdrawals_root) = block.get("withdrawalsRoot") {
+        assert_eq!(
+            withdrawals_root.as_str(),
+            Some(format!("{:#x}", B256::ZERO).as_str())
+        );
+    }
 
     Ok(())
 }

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -83,16 +83,48 @@ pub fn is_log_visible(log: &Log, caller: &Address) -> bool {
     log.topic0().is_some_and(|t| WHITELISTED_TOPICS.contains(t)) && is_caller_eligible(log, caller)
 }
 
-/// Filters logs to only those the caller is allowed to see.
+/// Renumbers ordering fields on a sequence of logs so that
+/// `(transactionHash, logIndex)` is stable and per-tx, without leaking
+/// how many other logs preceded them.
+///
+/// `logIndex` restarts at `0` for each new tx and increments for each
+/// subsequent log within that same tx.
+/// `transactionIndex` is always zeroed to hide ordering within the block.
+#[derive(Default)]
+pub struct LogOrderingRedactor {
+    current_tx: Option<B256>,
+    next_index: u64,
+}
+
+impl LogOrderingRedactor {
+    /// Redact the ordering fields of a single already-visible log.
+    pub fn redact(&mut self, mut log: Log) -> Log {
+        if self.current_tx != log.transaction_hash {
+            self.current_tx = log.transaction_hash;
+            self.next_index = 0;
+        }
+        log.transaction_index = Some(0);
+        log.log_index = Some(self.next_index);
+        self.next_index += 1;
+        log
+    }
+}
+
+/// Filters logs to only those the caller is allowed to see, renumbering the
+/// `log_index` via [`LogOrderingRedactor`].
 pub fn filter_logs(logs: Vec<Log>, caller: &Address) -> Vec<Log> {
+    let mut redactor = LogOrderingRedactor::default();
     logs.into_iter()
         .filter(|log| is_log_visible(log, caller))
+        .map(|log| redactor.redact(log))
         .collect()
 }
 
 /// Filters a receipt's logs for its sender and recomputes `logsBloom`.
 pub fn filter_receipt_logs(mut receipt: TempoTransactionReceipt) -> TempoTransactionReceipt {
     let caller = receipt.from();
+    receipt.inner.transaction_index = Some(0);
+    receipt.inner.inner.receipt.cumulative_gas_used = receipt.inner.gas_used;
     let logs = core::mem::take(&mut receipt.inner.inner.receipt.logs);
     receipt.inner.inner.receipt.logs = filter_logs(logs, &caller);
     receipt.inner.inner.logs_bloom = receipt.inner.inner.receipt.bloom();
@@ -207,6 +239,16 @@ mod tests {
             log_index: None,
             removed: false,
         }
+    }
+
+    /// Build a test `Log` carrying real (pre-redaction) ordering metadata so
+    /// tests can assert the ordering fields are actually rewritten.
+    fn make_log_in_tx(emitter: Address, topics: Vec<B256>, tx_hash: B256, log_index: u64) -> Log {
+        let mut log = make_log(emitter, topics);
+        log.transaction_hash = Some(tx_hash);
+        log.transaction_index = Some(42);
+        log.log_index = Some(log_index);
+        log
     }
 
     fn caller_word(addr: &Address) -> B256 {
@@ -465,7 +507,10 @@ mod tests {
         let result = filter_logs(logs, &caller);
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0], eligible);
+        let mut expected = eligible;
+        expected.transaction_index = Some(0);
+        expected.log_index = Some(0);
+        assert_eq!(result[0], expected);
     }
 
     #[test]
@@ -473,6 +518,119 @@ mod tests {
         let caller = address!("0x0000000000000000000000000000000000000001");
         let result = filter_logs(vec![], &caller);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_logs_renumbers_log_index_per_transaction() {
+        let zone_token = address!("0x000000000000000000000000000000000000aaaa");
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let other = address!("0x0000000000000000000000000000000000000002");
+
+        let tx_a = B256::with_last_byte(0xaa);
+        let tx_b = B256::with_last_byte(0xbb);
+
+        // tx A: two caller-visible logs separated by one the caller can't see.
+        // Real (block-global) log indices are non-contiguous and must be erased.
+        let a_visible_0 = make_log_in_tx(
+            zone_token,
+            vec![TRANSFER_TOPIC, caller_word(&caller), caller_word(&other)],
+            tx_a,
+            7,
+        );
+        let a_hidden = make_log_in_tx(
+            zone_token,
+            vec![TRANSFER_TOPIC, caller_word(&other), caller_word(&other)],
+            tx_a,
+            8,
+        );
+        let a_visible_1 = make_log_in_tx(
+            zone_token,
+            vec![APPROVAL_TOPIC, caller_word(&caller), caller_word(&other)],
+            tx_a,
+            9,
+        );
+        // tx B: a single caller-visible log; numbering must restart at 0.
+        let b_visible_0 = make_log_in_tx(
+            zone_token,
+            vec![TRANSFER_TOPIC, caller_word(&other), caller_word(&caller)],
+            tx_b,
+            3,
+        );
+
+        let result = filter_logs(
+            vec![a_visible_0, a_hidden, a_visible_1, b_visible_0],
+            &caller,
+        );
+
+        // Only the caller's three logs survive, in order.
+        let ordering: Vec<_> = result
+            .iter()
+            .map(|log| (log.transaction_hash, log.transaction_index, log.log_index))
+            .collect();
+        assert_eq!(
+            ordering,
+            vec![
+                // tx A: renumbered 0, 1 among the caller's visible logs.
+                (Some(tx_a), Some(0), Some(0)),
+                (Some(tx_a), Some(0), Some(1)),
+                // tx B: restarts at 0.
+                (Some(tx_b), Some(0), Some(0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn log_ordering_is_consistent_between_batch_and_stream() {
+        // The same visible logs numbered once via `filter_logs` (the batch
+        // `eth_getLogs` path) and once by driving `LogOrderingRedactor` a log at a
+        // time (the `eth_subscribe("logs")` stream path) must agree, so a log's
+        // `(transactionHash, logIndex)` is identical regardless of which RPC
+        // surfaced it.
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let other = address!("0x0000000000000000000000000000000000000002");
+        let tx_a = B256::with_last_byte(0xaa);
+        let tx_b = B256::with_last_byte(0xbb);
+
+        let visible = vec![
+            make_log_in_tx(
+                Address::ZERO,
+                vec![TRANSFER_TOPIC, caller_word(&caller), caller_word(&other)],
+                tx_a,
+                5,
+            ),
+            make_log_in_tx(
+                Address::ZERO,
+                vec![APPROVAL_TOPIC, caller_word(&caller), caller_word(&other)],
+                tx_a,
+                6,
+            ),
+            make_log_in_tx(
+                Address::ZERO,
+                vec![TRANSFER_TOPIC, caller_word(&other), caller_word(&caller)],
+                tx_b,
+                9,
+            ),
+        ];
+
+        let batch = filter_logs(visible.clone(), &caller);
+
+        // Mirror the WS stream: filter, then feed survivors one at a time.
+        let mut redactor = LogOrderingRedactor::default();
+        let streamed: Vec<Log> = visible
+            .into_iter()
+            .filter(|log| is_log_visible(log, &caller))
+            .map(|log| redactor.redact(log))
+            .collect();
+
+        assert_eq!(batch, streamed);
+        let indices: Vec<_> = batch
+            .iter()
+            .map(|log| (log.transaction_index, log.log_index))
+            .collect();
+        assert_eq!(
+            indices,
+            vec![(Some(0), Some(0)), (Some(0), Some(1)), (Some(0), Some(0))]
+        );
     }
 
     #[test]
@@ -501,7 +659,19 @@ mod tests {
             ],
         ));
 
-        assert_eq!(filtered.inner.logs(), std::slice::from_ref(&visible));
+        let mut expected_visible = visible.clone();
+        expected_visible.transaction_index = Some(0);
+        expected_visible.log_index = Some(0);
+
+        assert_eq!(
+            filtered.inner.logs(),
+            std::slice::from_ref(&expected_visible)
+        );
+        assert_eq!(filtered.inner.transaction_index, Some(0));
+        assert_eq!(
+            filtered.inner.inner.receipt.cumulative_gas_used,
+            filtered.inner.gas_used
+        );
         assert_eq!(
             filtered.inner.inner.logs_bloom,
             alloy_primitives::logs_bloom(filtered.inner.logs().iter().map(|log| log.as_ref())),
@@ -509,7 +679,7 @@ mod tests {
         assert_ne!(
             filtered.inner.inner.logs_bloom,
             alloy_primitives::logs_bloom(
-                [visible, hidden_transfer, hidden_event]
+                [expected_visible, hidden_transfer, hidden_event]
                     .iter()
                     .map(|log| log.as_ref())
             ),

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -659,7 +659,7 @@ mod tests {
             ],
         ));
 
-        let mut expected_visible = visible.clone();
+        let mut expected_visible = visible;
         expected_visible.transaction_index = Some(0);
         expected_visible.log_index = Some(0);
 

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -52,13 +52,6 @@ const MAX_WS_SUBSCRIPTIONS: usize = 32;
 type NotificationTx = mpsc::Sender<String>;
 type CloseSessionTx = watch::Sender<bool>;
 
-/// Per-subscription redaction applied before sending notifications.
-#[derive(Clone, Copy)]
-enum SubscriptionRedaction {
-    None,
-    NewHeads,
-}
-
 /// Query parameters for the WebSocket upgrade endpoint.
 #[derive(serde::Deserialize, Default)]
 pub(crate) struct WsQuery {
@@ -74,7 +67,6 @@ struct ActiveSubscription {
 struct PendingSubscription {
     id: FilterId,
     stream: WsSubscriptionStream,
-    redaction: SubscriptionRedaction,
 }
 
 struct WsSession {
@@ -178,42 +170,12 @@ fn subscription_notification_raw(subscription_id: &FilterId, result: &RawValue) 
     .expect("subscription notification serialization is infallible")
 }
 
-/// Redact a subscription payload, returning `None` if redaction fails so the
-/// caller can drop the item rather than forwarding unredacted data.
-fn redacted_subscription_result(
-    result: Box<RawValue>,
-    redaction: SubscriptionRedaction,
-) -> Option<Box<RawValue>> {
-    match redaction {
-        SubscriptionRedaction::None => Some(result),
-        SubscriptionRedaction::NewHeads => redact_new_head_result(&result),
-    }
-}
-
-/// Apply block-header privacy rules to `eth_subscribe("newHeads")` payloads.
-///
-/// Fails closed: returns `None` on any parse/serialize error instead of leaking
-/// the original, potentially unredacted payload.
-fn redact_new_head_result(result: &RawValue) -> Option<Box<RawValue>> {
-    let mut header = serde_json::from_str::<Value>(result.get()).ok()?;
-    let header = header.as_object_mut()?;
-
-    header.insert(
-        "logsBloom".to_string(),
-        Value::String(format!("0x{}", "0".repeat(512))),
-    );
-    header.remove("transactions");
-
-    to_raw(header).ok()
-}
-
 /// Forward subscription stream items into the session outbound queue.
 fn spawn_subscription(
     subscription_id: FilterId,
     mut subscription: WsSubscriptionStream,
     notifications: NotificationTx,
     close_session: CloseSessionTx,
-    redaction: SubscriptionRedaction,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(item) = subscription.next().await {
@@ -228,14 +190,6 @@ fn spawn_subscription(
                     );
                     break;
                 }
-            };
-            let Some(result) = redacted_subscription_result(result, redaction) else {
-                warn!(
-                    target: "zone::rpc",
-                    subscription = ?subscription_id,
-                    "ws subscription redaction failed; closing subscription"
-                );
-                break;
             };
 
             if !try_queue_notification(
@@ -314,7 +268,7 @@ async fn handle_subscribe(
             }
 
             match state.api.ws_subscribe_new_heads(auth.clone()).await {
-                Ok(subscription) => (subscription, SubscriptionRedaction::NewHeads),
+                Ok(subscription) => subscription,
                 Err(err) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
@@ -336,7 +290,7 @@ async fn handle_subscribe(
             };
 
             match state.api.ws_subscribe_logs(filter, auth.clone()).await {
-                Ok(subscription) => (subscription, SubscriptionRedaction::None),
+                Ok(subscription) => subscription,
                 Err(err) => {
                     return WsDispatchResult::response_only(JsonRpcResponse::error(
                         req.id.clone(),
@@ -375,8 +329,7 @@ async fn handle_subscribe(
         response: success_response(req.id.clone(), &subscription_id),
         pending_subscriptions: vec![PendingSubscription {
             id: subscription_id,
-            stream: subscription.0,
-            redaction: subscription.1,
+            stream: subscription,
         }],
     }
 }
@@ -497,7 +450,6 @@ fn activate_pending_subscriptions(
             pending.stream,
             notifications.clone(),
             close_session.clone(),
-            pending.redaction,
         );
         session.activate_subscription(pending.id, task);
     }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -160,8 +160,13 @@ impl ZoneRpcApi for MockZoneRpcApi {
                 ),
                 "number": "0x42",
                 "parentHash": format!("{:#x}", alloy_primitives::B256::ZERO),
-                "logsBloom": format!("0x{}", "f".repeat(512)),
-                "transactions": ["0x1234"],
+                "logsBloom": format!("0x{}", "0".repeat(512)),
+                "gasUsed": "0x0",
+                "size": "0x0",
+                "transactionsRoot": format!("{:#x}", alloy_primitives::B256::ZERO),
+                "receiptsRoot": format!("{:#x}", alloy_primitives::B256::ZERO),
+                "stateRoot": format!("{:#x}", alloy_primitives::B256::ZERO),
+                "extraData": "0x",
             }))]);
             let stream: WsSubscriptionStream = Box::pin(stream);
             Ok(stream)

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -877,10 +877,18 @@ The RPC uses a default-deny model. Any method not explicitly listed returns `-32
 For non-sequencer callers, block responses are modified:
 
 - The `transactions` field is always an empty array, regardless of the `include_transactions` parameter.
-- The `logsBloom` field is zeroed. The Bloom filter summarizes all log topics and emitting addresses in the block, so returning the real value would allow probing whether a specific address had activity in that block.
-- All other header fields (`number`, `hash`, `parentHash`, `timestamp`, `stateRoot`, `gasUsed`, etc.) are returned normally. Aggregate activity metrics are intentionally public.
+- Header fields that reveal aggregate execution activity are zeroed or emptied: `gasUsed`, `transactionsRoot`, `receiptsRoot`, `stateRoot`, `extraData`, `logsBloom`, `size`, optional blob gas fields (`blobGasUsed`, `excessBlobGas`), and optional withdrawal fields (`withdrawals`, `withdrawalsRoot`). The Bloom filter summarizes all log topics and emitting addresses in the block, and the other redacted fields reveal transaction count, payload size, state changes, receipt/log activity, blob usage, or withdrawal activity.
+- Public block identity and timing fields such as `number`, `hash`, `parentHash`, `timestamp`, and fee metadata remain visible.
 
 The sequencer receives full block data.
+
+### Fee History
+
+`eth_feeHistory` uses the underlying node implementation for block range resolution, history limits, and reward percentile validation, then redacts activity-derived fields before returning the response to non-sequencer callers:
+
+- `baseFeePerGas` is set to the public zone T0 base fee for every returned entry.
+- `gasUsedRatio`, `baseFeePerBlobGas` and `blobGasUsedRatio` are set to `0`.
+- `reward`, when requested, is returned with the same shape but every value set to `0`.
 
 ### Event Filtering
 
@@ -896,6 +904,11 @@ All log queries are restricted to TIP-20 events where the authenticated account 
 
 All other events (system events, configuration events) are filtered out. The `address` filter parameter must be a zone token address or omitted. The RPC server injects topic filters to restrict indexed address parameters to the caller, then post-filters results as a final pass.
 
+To avoid leaking how much activity occurred in a block, some fields of returned logs are redacted:
+
+- `transactionIndex` is set to `0` on every log, so the caller cannot infer its transaction's position among, or the number of, other transactions in the block.
+- `logIndex` is renumbered per transaction rather than exposing the log's global position in the block. `(transactionHash, logIndex)` is stable and consistent for a given log across `eth_getLogs`, `eth_getFilterLogs`, `eth_getFilterChanges`, `eth_getTransactionReceipt`, and `eth_subscribe("logs")`.
+
 ### Timing Side Channels
 
 Scoped methods that fetch data before checking authorization leak existence via timing differences. The RPC server enforces a minimum response time of 100ms on `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getLogs`, `eth_getFilterLogs`, and `eth_getFilterChanges`.
@@ -906,7 +919,7 @@ Methods where authorization is checked before any data fetch (`eth_getBalance`, 
 
 WebSocket connections follow the same authorization model. The authorization token is provided during the handshake and scopes all subscriptions for that connection.
 
-- `eth_subscribe("newHeads")`: allowed, pushes block headers with `logsBloom` zeroed for non-sequencer callers.
+- `eth_subscribe("newHeads")`: allowed, pushes block headers with the same header redaction as HTTP block responses for non-sequencer callers.
 - `eth_subscribe("logs")`: scoped to the authenticated account using the same event filtering rules.
 - `eth_subscribe("newPendingTransactions")`: disabled.
 


### PR DESCRIPTION
- Redact gasUsed, blockSize, log_index and other fields from zone block headers and logs that might allow an observer to guess zone activity and allow side channel attacks
- Move redaction from ws.rs upstream, so the ws.rs is now just plumbing making it easier to maintain (i.e., all info going into ws.rs will already be redacted)
- re-order log_index so user's wallets can continue to rely on (txhash, log_index) but not leak block activity
- update spec