### PR TITLE
fix: Make RPC calls take constant time

### DIFF
--- a/crates/node/tests/it/private_rpc.rs
+++ b/crates/node/tests/it/private_rpc.rs
@@ -315,7 +315,7 @@ fn classify_public_methods() {
         "zone_getDepositStatus",
     ] {
         assert_eq!(
-            classify_method(method),
+            classify_method(method).map(|policy| policy.tier),
             Some(MethodTier::Public),
             "expected {method} to be Public"
         );
@@ -344,7 +344,7 @@ fn classify_restricted_methods() {
         "txpool_inspect",
     ] {
         assert_eq!(
-            classify_method(method),
+            classify_method(method).map(|policy| policy.tier),
             Some(MethodTier::Restricted),
             "expected {method} to be Restricted"
         );
@@ -363,7 +363,7 @@ fn classify_disabled_methods() {
         "eth_unsubscribe",
     ] {
         assert_eq!(
-            classify_method(method),
+            classify_method(method).map(|policy| policy.tier),
             Some(MethodTier::Disabled),
             "expected {method} to be Disabled"
         );
@@ -379,7 +379,7 @@ fn classify_admin_wildcard() {
         "admin_peers",
     ] {
         assert_eq!(
-            classify_method(method),
+            classify_method(method).map(|policy| policy.tier),
             Some(MethodTier::Restricted),
             "expected {method} to be Restricted (admin_* wildcard)"
         );

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -260,12 +260,11 @@ pub async fn dispatch(
 ) -> JsonRpcResponse {
     let id = req.id.clone();
 
-    let tier = match classify_method(&req.method) {
-        Some(tier) => tier,
-        None => return JsonRpcResponse::error(id, JsonRpcError::method_not_found()),
+    let Some(policy) = classify_method(&req.method) else {
+        return JsonRpcResponse::error(id, JsonRpcError::method_not_found());
     };
 
-    match tier {
+    match policy.tier {
         MethodTier::Disabled => {
             return JsonRpcResponse::error(id, JsonRpcError::method_disabled());
         }

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -32,7 +32,7 @@ use crate::{
     error::{AuthError, AuthenticateError},
     handlers::{self, ZoneRpcApi},
     metrics::{PrivateRpcAuthMetrics, PrivateRpcCallMetrics},
-    types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse},
+    types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, classify_method},
     ws::handle_ws_upgrade,
 };
 
@@ -156,6 +156,7 @@ pub(crate) async fn dispatch_request(
 
     metrics.started_total.increment(1);
     let response = handlers::dispatch(req, auth, api).await;
+    enforce_timing_side_channel_floor(&req.method, started_at).await;
     metrics
         .time_seconds
         .record(started_at.elapsed().as_secs_f64());
@@ -167,6 +168,17 @@ pub(crate) async fn dispatch_request(
     }
 
     response
+}
+
+/// Ensure methods that have `MethodTimingFloor::Required` take the minimum amount of time
+/// to prevent timing attacks
+async fn enforce_timing_side_channel_floor(method: &str, started_at: Instant) {
+    if let Some(timing_floor) =
+        classify_method(method).and_then(|policy| policy.timing_floor.required_duration())
+        && let Some(remaining) = timing_floor.checked_sub(started_at.elapsed())
+    {
+        tokio::time::sleep(remaining).await;
+    }
 }
 
 /// Main HTTP RPC handler — authenticates, dispatches, returns response.
@@ -298,20 +310,26 @@ pub(crate) fn now_unix_seconds() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::authenticate_token;
+    use super::{authenticate_token, dispatch_request};
     use crate::{
         PrivateRpcConfig,
-        auth::build_token_fields,
+        auth::{AuthContext, build_token_fields},
         error::AuthenticateError,
         handlers::ZoneRpcApi,
-        types::{BoxEyreFut, BoxFut, JsonRpcError},
+        types::{
+            BoxEyreFut, BoxFut, JsonRpcError, JsonRpcRequest, MethodTimingFloor, classify_method,
+        },
     };
-    use alloy_primitives::{Address, Bytes};
+    use alloy_primitives::{Address, B256, Bytes};
     use axum::http::StatusCode;
     use p256::ecdsa::SigningKey as P256SigningKey;
     use parking_lot::Mutex;
     use rand::thread_rng;
-    use std::collections::HashMap;
+    use serde_json::{Value, json};
+    use std::{
+        collections::HashMap,
+        time::{Duration, Instant},
+    };
     use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
         KeyInfo, SignatureType as KeyInfoSignatureType,
     };
@@ -329,6 +347,13 @@ mod tests {
     const ZONE_ID: u32 = 7;
     const CHAIN_ID: u64 = 99;
     const PORTAL: Address = Address::repeat_byte(0x22);
+    const TIMING_SIDE_CHANNEL_FLOOR_METHODS: &[&str] = &[
+        "eth_getTransactionByHash",
+        "eth_getTransactionReceipt",
+        "eth_getLogs",
+        "eth_getFilterLogs",
+        "eth_getFilterChanges",
+    ];
 
     struct TestApi {
         key_infos: Mutex<HashMap<(Address, Address), KeyInfo>>,
@@ -345,6 +370,11 @@ mod tests {
     }
 
     macro_rules! stub {
+        ($method:ident => $result:expr $(, $arg:ident : $ty:ty)*) => {
+            fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
+                Box::pin(async { $result })
+            }
+        };
         ($method:ident $(, $arg:ident : $ty:ty)*) => {
             fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
                 Box::pin(async { Err(JsonRpcError::internal("not implemented")) })
@@ -381,17 +411,17 @@ mod tests {
         stub!(get_transaction_count, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: crate::auth::AuthContext);
         stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _b: bool, _c: crate::auth::AuthContext);
         stub!(block_by_hash, _a: alloy_primitives::B256, _b: bool, _c: crate::auth::AuthContext);
-        stub!(transaction_by_hash, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
-        stub!(transaction_receipt, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
+        stub!(transaction_by_hash => Ok(crate::types::raw_null()), _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
+        stub!(transaction_receipt => Ok(crate::types::raw_null()), _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
         stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
         stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
         stub!(send_raw_transaction, _a: Bytes, _c: crate::auth::AuthContext);
         stub!(send_raw_transaction_sync, _a: Bytes, _c: crate::auth::AuthContext);
         stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: crate::auth::AuthContext);
-        stub!(get_logs, _a: alloy_rpc_types_eth::Filter, _c: crate::auth::AuthContext);
+        stub!(get_logs => crate::types::to_raw(&Vec::<Value>::new()), _a: alloy_rpc_types_eth::Filter, _c: crate::auth::AuthContext);
         stub!(new_filter, _a: alloy_rpc_types_eth::Filter, _c: crate::auth::AuthContext);
-        stub!(get_filter_logs, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
-        stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
+        stub!(get_filter_logs => crate::types::to_raw(&Vec::<Value>::new()), _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
+        stub!(get_filter_changes => crate::types::to_raw(&Vec::<Value>::new()), _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
         stub!(new_block_filter, _c: crate::auth::AuthContext);
         stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
         stub!(zone_get_authorization_token_info, _c: crate::auth::AuthContext);
@@ -412,6 +442,100 @@ mod tests {
         }
     }
 
+    fn test_api() -> TestApi {
+        TestApi {
+            key_infos: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn test_auth() -> AuthContext {
+        AuthContext {
+            caller: Address::repeat_byte(0x11),
+            expires_at: now_secs() + 600,
+            keychain_key_id: None,
+        }
+    }
+
+    fn request(method: &str, params: Value) -> JsonRpcRequest {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1,
+        }))
+        .expect("valid JSON-RPC request")
+    }
+
+    fn timing_sensitive_request(method: &str) -> JsonRpcRequest {
+        let hash = format!("{:#x}", B256::ZERO);
+        let params = match method {
+            "eth_getTransactionByHash" | "eth_getTransactionReceipt" => json!([hash]),
+            "eth_getLogs" => json!([{}]),
+            "eth_getFilterLogs" | "eth_getFilterChanges" => json!(["0x1"]),
+            method => panic!("missing timing-sensitive params for {method}"),
+        };
+        request(method, params)
+    }
+
+    #[test]
+    fn timing_side_channel_floor_matches_spec_methods() {
+        for method in TIMING_SIDE_CHANNEL_FLOOR_METHODS {
+            assert_eq!(
+                classify_method(method)
+                    .expect("timing-sensitive method should be classified")
+                    .timing_floor,
+                MethodTimingFloor::Required(Duration::from_millis(100)),
+                "{method} should have the 100ms response floor"
+            );
+        }
+
+        for method in [
+            "eth_getBalance",
+            "eth_call",
+            "eth_sendRawTransaction",
+            "eth_newFilter",
+        ] {
+            assert_eq!(
+                classify_method(method)
+                    .expect("non-timing-floor method should be classified")
+                    .timing_floor,
+                MethodTimingFloor::NotRequired,
+                "{method} should not have the timing floor"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn timing_sensitive_methods_have_minimum_response_time() {
+        let api = test_api();
+        let auth = test_auth();
+
+        for method in TIMING_SIDE_CHANNEL_FLOOR_METHODS {
+            let minimum = classify_method(method)
+                .expect("timing-sensitive method should be classified")
+                .timing_floor
+                .required_duration()
+                .expect("timing-sensitive method should require a floor")
+                - Duration::from_millis(10); // safety margin for tests
+            let req = timing_sensitive_request(method);
+            let started_at = Instant::now();
+            let response = dispatch_request(&req, &auth, &api).await;
+            let elapsed = started_at.elapsed();
+
+            assert!(
+                response.error.is_none(),
+                "{} should succeed, got {:?}",
+                req.method,
+                response.error
+            );
+            assert!(
+                elapsed >= minimum,
+                "{} returned in {elapsed:?}, below the 100ms response floor",
+                req.method
+            );
+        }
+    }
+
     #[tokio::test]
     async fn configured_auth_token_validity_limit_is_enforced() {
         let mut config = test_config();
@@ -422,9 +546,7 @@ mod tests {
         let mut blob = vec![0u8; 65];
         blob.extend_from_slice(&fields);
         let token = alloy_primitives::hex::encode(blob);
-        let api = TestApi {
-            key_infos: Mutex::new(HashMap::new()),
-        };
+        let api = test_api();
 
         let err = authenticate_token(&token, &config, &api)
             .await
@@ -452,9 +574,7 @@ mod tests {
         let mut blob = vec![0u8; 65];
         blob.extend_from_slice(&fields);
         let token = alloy_primitives::hex::encode(blob);
-        let api = TestApi {
-            key_infos: Mutex::new(HashMap::new()),
-        };
+        let api = test_api();
 
         let err = authenticate_token(&token, &config, &api)
             .await

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -1,6 +1,6 @@
 //! JSON-RPC types for the private zone RPC.
 
-use std::{future::Future, pin::Pin};
+use std::{future::Future, pin::Pin, time::Duration};
 
 use alloy_primitives::{Address, B256, U64, U256};
 use serde::{Deserialize, Serialize};
@@ -252,10 +252,54 @@ pub enum MethodTier {
     Disabled,
 }
 
-/// Classify a JSON-RPC method into its access tier.
+/// Timing-floor policy for a JSON-RPC method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MethodTimingFloor {
+    /// The method must take at least this duration before it returns.
+    Required(Duration),
+    /// The method can return as soon as dispatch completes.
+    NotRequired,
+}
+
+impl MethodTimingFloor {
+    /// The required timing floor, if any.
+    pub fn required_duration(self) -> Option<Duration> {
+        match self {
+            Self::Required(duration) => Some(duration),
+            Self::NotRequired => None,
+        }
+    }
+}
+
+/// Complete private RPC policy for a JSON-RPC method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MethodPolicy {
+    /// Access tier enforced before dispatch.
+    pub tier: MethodTier,
+    /// Timing-floor behavior enforced after dispatch.
+    pub timing_floor: MethodTimingFloor,
+}
+
+impl MethodPolicy {
+    const fn new(tier: MethodTier) -> Self {
+        Self {
+            tier,
+            timing_floor: MethodTimingFloor::NotRequired,
+        }
+    }
+
+    const fn new_with_timing_floor(tier: MethodTier, timing_floor: Duration) -> Self {
+        Self {
+            tier,
+            timing_floor: MethodTimingFloor::Required(timing_floor),
+        }
+    }
+}
+
+/// Classify a JSON-RPC method into its private RPC policy.
 ///
 /// Returns `None` if the method is unknown.
-pub fn classify_method(method: &str) -> Option<MethodTier> {
+pub fn classify_method(method: &str) -> Option<MethodPolicy> {
     match method {
         // Public read methods — no privacy redaction needed
         "eth_blockNumber"
@@ -277,23 +321,33 @@ pub fn classify_method(method: &str) -> Option<MethodTier> {
         | "web3_sha3"
         | "zone_getAuthorizationTokenInfo"
         | "zone_getZoneInfo"
-        | "zone_getDepositStatus" => Some(MethodTier::Public),
+        | "zone_getDepositStatus" => Some(MethodPolicy::new(MethodTier::Public)),
 
         // Fetch-then-check: public but redacted based on caller identity
         "eth_getTransactionByHash"
         | "eth_getTransactionReceipt"
         | "eth_getLogs"
         | "eth_getFilterLogs"
-        | "eth_getFilterChanges"
-        | "eth_newFilter"
-        | "eth_newBlockFilter"
-        | "eth_uninstallFilter" => Some(MethodTier::Public),
+        | "eth_getFilterChanges" => {
+            // These methods will take a minimum of 100ms to return, to prevent timing attacks
+            Some(MethodPolicy::new_with_timing_floor(
+                MethodTier::Public,
+                Duration::from_millis(100),
+            ))
+        }
+
+        // Filter lifecycle methods are scoped but do not fetch before auth checks.
+        "eth_newFilter" | "eth_newBlockFilter" | "eth_uninstallFilter" => {
+            Some(MethodPolicy::new(MethodTier::Public))
+        }
 
         // Transaction preparation: public (scoped to caller's account)
-        "eth_fillTransaction" => Some(MethodTier::Public),
+        "eth_fillTransaction" => Some(MethodPolicy::new(MethodTier::Public)),
 
         // Transaction submission: public (caller sends their own txs)
-        "eth_sendRawTransaction" | "eth_sendRawTransactionSync" => Some(MethodTier::Public),
+        "eth_sendRawTransaction" | "eth_sendRawTransactionSync" => {
+            Some(MethodPolicy::new(MethodTier::Public))
+        }
 
         // Sequencer-only — raw state inspection and full block data bypass privacy scoping
         "eth_getCode"
@@ -306,7 +360,7 @@ pub fn classify_method(method: &str) -> Option<MethodTier> {
         | "eth_getTransactionByBlockNumberAndIndex"
         | "eth_getTransactionByBlockHashAndIndex"
         | "eth_getUncleCountByBlockNumber"
-        | "eth_getUncleCountByBlockHash" => Some(MethodTier::Restricted),
+        | "eth_getUncleCountByBlockHash" => Some(MethodPolicy::new(MethodTier::Restricted)),
 
         // Disabled (mempool observation, mining, subscriptions not supported via HTTP)
         "eth_getProof"
@@ -319,11 +373,11 @@ pub fn classify_method(method: &str) -> Option<MethodTier> {
         | "eth_submitWork"
         | "eth_submitHashrate"
         | "eth_subscribe"
-        | "eth_unsubscribe" => Some(MethodTier::Disabled),
+        | "eth_unsubscribe" => Some(MethodPolicy::new(MethodTier::Disabled)),
 
-        _ if method.starts_with("admin_") => Some(MethodTier::Restricted),
-        _ if method.starts_with("debug_") => Some(MethodTier::Restricted),
-        _ if method.starts_with("txpool_") => Some(MethodTier::Restricted),
+        _ if method.starts_with("admin_") => Some(MethodPolicy::new(MethodTier::Restricted)),
+        _ if method.starts_with("debug_") => Some(MethodPolicy::new(MethodTier::Restricted)),
+        _ if method.starts_with("txpool_") => Some(MethodPolicy::new(MethodTier::Restricted)),
         _ => None,
     }
 }


### PR DESCRIPTION
- To prevent timing attacks the following methods should take at least 100ms (already defined in the spec)

```
 "eth_getTransactionByHash"
        | "eth_getTransactionReceipt"
        | "eth_getLogs"
        | "eth_getFilterLogs"
        | "eth_getFilterChanges"
```