### PR TITLE
feat(zone): skip txpool during L1 catch-up

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -152,6 +152,8 @@ pub struct ZoneArgs {
     pub withdrawal_poll_interval_secs: u64,
 
     /// Maximum L1 timestamp drift before catch-up blocks skip txpool transactions.
+    ///
+    /// Set to zero to disable the catch-up no-txpool heuristic.
     #[arg(
         long = "zone.no-tx-pool-drift-threshold-secs",
         env = "ZONE_NO_TX_POOL_DRIFT_THRESHOLD_SECS",

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -13,7 +13,7 @@ use zone_evm::ZoneEvmConfig;
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL;
 
 use crate::{
-    ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig,
+    DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig,
     rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 use zone_sequencer::BatchAnchorConfig;
@@ -92,6 +92,9 @@ impl ZoneCli {
                     withdrawal_poll_interval: Duration::from_secs(
                         args.withdrawal_poll_interval_secs,
                     ),
+                    no_tx_pool_drift_threshold: Duration::from_secs(
+                        args.no_tx_pool_drift_threshold_secs,
+                    ),
                 });
             }
 
@@ -147,6 +150,14 @@ pub struct ZoneArgs {
         default_value_t = 5
     )]
     pub withdrawal_poll_interval_secs: u64,
+
+    /// Maximum L1 timestamp drift before catch-up blocks skip txpool transactions.
+    #[arg(
+        long = "zone.no-tx-pool-drift-threshold-secs",
+        env = "ZONE_NO_TX_POOL_DRIFT_THRESHOLD_SECS",
+        default_value_t = DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD.as_secs()
+    )]
+    pub no_tx_pool_drift_threshold_secs: u64,
 
     /// Genesis Tempo L1 block number override.
     #[arg(long = "l1.genesis-block-number", env = "L1_GENESIS_BLOCK_NUMBER")]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -52,7 +52,7 @@ use std::{
 };
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_primitives::TempoHeader;
-use tracing::{error, info, warn};
+use tracing::{error, warn};
 
 use zone_l1::{DepositQueue, L1BlockDeposits, PolicyProvider, PreparedL1Block};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
@@ -92,8 +92,6 @@ pub struct ZoneEngine {
     policy_provider: PolicyProvider,
     /// Maximum L1 timestamp drift before catch-up blocks skip txpool transactions.
     no_tx_pool_drift_threshold: Duration,
-    /// Consecutive blocks built without txpool transactions due to L1 catch-up drift.
-    no_tx_pool_skip_streak: u64,
 }
 
 impl ZoneEngine {
@@ -120,7 +118,6 @@ impl ZoneEngine {
             portal_address,
             policy_provider,
             no_tx_pool_drift_threshold,
-            no_tx_pool_skip_streak: 0,
         }
     }
 
@@ -219,32 +216,11 @@ impl ZoneEngine {
         // two chains stay in lockstep.
         let timestamp_secs = l1_block.header.timestamp();
         let timestamp_millis_part = l1_block.header.timestamp_millis_part;
-        let no_tx_pool_drift = tx_pool_skip_drift(
+        let no_tx_pool = tx_pool_skip_drift(
             l1_block.header.header().timestamp_millis(),
             SystemTime::now(),
             self.no_tx_pool_drift_threshold,
         );
-        if let Some(drift_ms) = no_tx_pool_drift {
-            self.no_tx_pool_skip_streak = self.no_tx_pool_skip_streak.saturating_add(1);
-            if self.no_tx_pool_skip_streak == 1 || self.no_tx_pool_skip_streak.is_multiple_of(100) {
-                warn!(
-                    target: "zone::engine",
-                    l1_block = l1_num_hash.number,
-                    l1_hash = %l1_num_hash.hash,
-                    skipped_blocks = self.no_tx_pool_skip_streak,
-                    drift_ms = %drift_ms,
-                    threshold_ms = %self.no_tx_pool_drift_threshold.as_millis(),
-                    "skipping txpool transactions while catching up to L1"
-                );
-            }
-        } else if self.no_tx_pool_skip_streak > 0 {
-            info!(
-                target: "zone::engine",
-                skipped_blocks = self.no_tx_pool_skip_streak,
-                "resuming txpool transactions after L1 catch-up"
-            );
-            self.no_tx_pool_skip_streak = 0;
-        }
 
         let l1_block = self.prepare_l1_block(l1_block).await?;
 
@@ -266,7 +242,7 @@ impl ZoneEngine {
             },
             timestamp_millis_part,
             l1_block,
-            no_tx_pool: no_tx_pool_drift.is_some(),
+            no_tx_pool,
         };
 
         // Send FCU with payload attributes through the engine API to trigger
@@ -327,7 +303,7 @@ impl ZoneEngine {
     }
 }
 
-/// Returns the wall-clock drift in milliseconds that should disable txpool inclusion, if any.
+/// Returns whether wall-clock drift should disable txpool inclusion.
 ///
 /// A zero threshold disables the no-txpool catch-up heuristic. The comparison
 /// expects a full Tempo L1 timestamp in milliseconds, so sub-second blocks are
@@ -336,14 +312,20 @@ fn tx_pool_skip_drift(
     l1_timestamp_millis: u64,
     now: SystemTime,
     no_tx_pool_drift_threshold: Duration,
-) -> Option<u128> {
+) -> bool {
     if no_tx_pool_drift_threshold.is_zero() {
-        return None;
+        return false;
     }
 
-    let now_millis = now.duration_since(UNIX_EPOCH).ok()?.as_millis();
-    let drift_millis = now_millis.checked_sub(u128::from(l1_timestamp_millis))?;
-    (drift_millis > no_tx_pool_drift_threshold.as_millis()).then_some(drift_millis)
+    let Some(drift_millis) = now
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|now| now.as_millis().checked_sub(u128::from(l1_timestamp_millis)))
+    else {
+        return false;
+    };
+
+    drift_millis > no_tx_pool_drift_threshold.as_millis()
 }
 
 #[cfg(test)]
@@ -366,19 +348,21 @@ mod tests {
             + Duration::from_millis(header.timestamp_millis())
             + Duration::from_millis(900);
 
-        assert_eq!(
-            tx_pool_skip_drift(header.timestamp_millis(), now, threshold),
-            None
-        );
-        assert_eq!(
-            tx_pool_skip_drift(header.inner.timestamp * 1000, now, threshold),
-            Some(1400)
-        );
+        assert!(!tx_pool_skip_drift(
+            header.timestamp_millis(),
+            now,
+            threshold
+        ));
+        assert!(tx_pool_skip_drift(
+            header.inner.timestamp * 1000,
+            now,
+            threshold
+        ));
     }
 
     #[test]
     fn tx_pool_skip_drift_zero_threshold_disables_skip() {
         let now = UNIX_EPOCH + Duration::from_secs(1);
-        assert_eq!(tx_pool_skip_drift(0, now, Duration::ZERO), None);
+        assert!(!tx_pool_skip_drift(0, now, Duration::ZERO));
     }
 }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -46,13 +46,26 @@ use reth_node_builder::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{BuiltPayload, PayloadKind, PayloadTypes};
 use reth_primitives_traits::SealedHeader;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_primitives::TempoHeader;
 use tracing::{error, warn};
 
 use zone_l1::{DepositQueue, L1BlockDeposits, PolicyProvider, PreparedL1Block};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
+
+fn should_skip_tx_pool(
+    l1_timestamp_secs: u64,
+    now: SystemTime,
+    no_tx_pool_drift_threshold: Duration,
+) -> bool {
+    let l1_timestamp = UNIX_EPOCH + Duration::from_secs(l1_timestamp_secs);
+    now.duration_since(l1_timestamp)
+        .is_ok_and(|drift| drift > no_tx_pool_drift_threshold)
+}
 
 /// Engine that drives L2 block production from L1 events.
 ///
@@ -87,6 +100,8 @@ pub struct ZoneEngine {
     /// Cache-first, RPC-fallback TIP-403 policy provider for authorization checks
     /// on encrypted deposit recipients during preparation.
     policy_provider: PolicyProvider,
+    /// Maximum L1 timestamp drift before catch-up blocks skip txpool transactions.
+    no_tx_pool_drift_threshold: Duration,
 }
 
 impl ZoneEngine {
@@ -100,6 +115,7 @@ impl ZoneEngine {
         sequencer_key: k256::SecretKey,
         portal_address: Address,
         policy_provider: PolicyProvider,
+        no_tx_pool_drift_threshold: Duration,
     ) -> Self {
         Self {
             chain_spec,
@@ -111,6 +127,7 @@ impl ZoneEngine {
             sequencer_key,
             portal_address,
             policy_provider,
+            no_tx_pool_drift_threshold,
         }
     }
 
@@ -209,6 +226,11 @@ impl ZoneEngine {
         // two chains stay in lockstep.
         let timestamp_secs = l1_block.header.timestamp();
         let timestamp_millis_part = l1_block.header.timestamp_millis_part;
+        let no_tx_pool = should_skip_tx_pool(
+            timestamp_secs,
+            SystemTime::now(),
+            self.no_tx_pool_drift_threshold,
+        );
 
         let l1_block = self.prepare_l1_block(l1_block).await?;
 
@@ -230,6 +252,7 @@ impl ZoneEngine {
             },
             timestamp_millis_part,
             l1_block,
+            no_tx_pool,
         };
 
         // Send FCU with payload attributes through the engine API to trigger

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -57,14 +57,39 @@ use tracing::{error, warn};
 use zone_l1::{DepositQueue, L1BlockDeposits, PolicyProvider, PreparedL1Block};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 
-fn should_skip_tx_pool(
+fn tx_pool_skip_drift(
     l1_timestamp_secs: u64,
+    l1_timestamp_millis_part: u64,
     now: SystemTime,
     no_tx_pool_drift_threshold: Duration,
-) -> bool {
-    let l1_timestamp = UNIX_EPOCH + Duration::from_secs(l1_timestamp_secs);
+) -> Option<Duration> {
+    let l1_timestamp = UNIX_EPOCH
+        + Duration::from_secs(l1_timestamp_secs)
+        + Duration::from_millis(l1_timestamp_millis_part);
     now.duration_since(l1_timestamp)
-        .is_ok_and(|drift| drift > no_tx_pool_drift_threshold)
+        .ok()
+        .filter(|drift| *drift > no_tx_pool_drift_threshold)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tx_pool_skip_drift_uses_millisecond_timestamp_part() {
+        let timestamp_secs = 1_700_000_000;
+        let threshold = Duration::from_secs(1);
+        let now = UNIX_EPOCH + Duration::from_secs(timestamp_secs) + Duration::from_millis(1400);
+
+        assert_eq!(
+            tx_pool_skip_drift(timestamp_secs, 500, now, threshold),
+            None
+        );
+        assert_eq!(
+            tx_pool_skip_drift(timestamp_secs, 0, now, threshold),
+            Some(Duration::from_millis(1400))
+        );
+    }
 }
 
 /// Engine that drives L2 block production from L1 events.
@@ -226,11 +251,28 @@ impl ZoneEngine {
         // two chains stay in lockstep.
         let timestamp_secs = l1_block.header.timestamp();
         let timestamp_millis_part = l1_block.header.timestamp_millis_part;
-        let no_tx_pool = should_skip_tx_pool(
+        let no_tx_pool_drift = tx_pool_skip_drift(
             timestamp_secs,
+            timestamp_millis_part,
             SystemTime::now(),
             self.no_tx_pool_drift_threshold,
         );
+        let no_tx_pool = no_tx_pool_drift.is_some();
+        if let Some(drift) = no_tx_pool_drift {
+            let drift_ms = drift.as_millis().min(u128::from(u64::MAX)) as u64;
+            let threshold_ms = self
+                .no_tx_pool_drift_threshold
+                .as_millis()
+                .min(u128::from(u64::MAX)) as u64;
+            warn!(
+                target: "zone::engine",
+                l1_block = l1_num_hash.number,
+                l1_hash = %l1_num_hash.hash,
+                drift_ms,
+                threshold_ms,
+                "skipping txpool transactions while catching up to L1"
+            );
+        }
 
         let l1_block = self.prepare_l1_block(l1_block).await?;
 

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -52,49 +52,10 @@ use std::{
 };
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_primitives::TempoHeader;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use zone_l1::{DepositQueue, L1BlockDeposits, PolicyProvider, PreparedL1Block};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
-
-/// Returns the wall-clock drift that should disable txpool inclusion, if any.
-///
-/// The comparison uses the full Tempo L1 block timestamp, including its millisecond
-/// part, so live sub-second blocks are not treated as older than they are.
-fn tx_pool_skip_drift(
-    l1_timestamp_secs: u64,
-    l1_timestamp_millis_part: u64,
-    now: SystemTime,
-    no_tx_pool_drift_threshold: Duration,
-) -> Option<Duration> {
-    let l1_timestamp = UNIX_EPOCH
-        + Duration::from_secs(l1_timestamp_secs)
-        + Duration::from_millis(l1_timestamp_millis_part);
-    now.duration_since(l1_timestamp)
-        .ok()
-        .filter(|drift| *drift > no_tx_pool_drift_threshold)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tx_pool_skip_drift_uses_millisecond_timestamp_part() {
-        let timestamp_secs = 1_700_000_000;
-        let threshold = Duration::from_secs(1);
-        let now = UNIX_EPOCH + Duration::from_secs(timestamp_secs) + Duration::from_millis(1400);
-
-        assert_eq!(
-            tx_pool_skip_drift(timestamp_secs, 500, now, threshold),
-            None
-        );
-        assert_eq!(
-            tx_pool_skip_drift(timestamp_secs, 0, now, threshold),
-            Some(Duration::from_millis(1400))
-        );
-    }
-}
 
 /// Engine that drives L2 block production from L1 events.
 ///
@@ -131,6 +92,8 @@ pub struct ZoneEngine {
     policy_provider: PolicyProvider,
     /// Maximum L1 timestamp drift before catch-up blocks skip txpool transactions.
     no_tx_pool_drift_threshold: Duration,
+    /// Consecutive blocks built without txpool transactions due to L1 catch-up drift.
+    no_tx_pool_skip_streak: u64,
 }
 
 impl ZoneEngine {
@@ -157,6 +120,7 @@ impl ZoneEngine {
             portal_address,
             policy_provider,
             no_tx_pool_drift_threshold,
+            no_tx_pool_skip_streak: 0,
         }
     }
 
@@ -256,26 +220,30 @@ impl ZoneEngine {
         let timestamp_secs = l1_block.header.timestamp();
         let timestamp_millis_part = l1_block.header.timestamp_millis_part;
         let no_tx_pool_drift = tx_pool_skip_drift(
-            timestamp_secs,
-            timestamp_millis_part,
+            l1_block.header.header().timestamp_millis(),
             SystemTime::now(),
             self.no_tx_pool_drift_threshold,
         );
-        let no_tx_pool = no_tx_pool_drift.is_some();
-        if let Some(drift) = no_tx_pool_drift {
-            let drift_ms = drift.as_millis().min(u128::from(u64::MAX)) as u64;
-            let threshold_ms = self
-                .no_tx_pool_drift_threshold
-                .as_millis()
-                .min(u128::from(u64::MAX)) as u64;
-            warn!(
+        if let Some(drift_ms) = no_tx_pool_drift {
+            self.no_tx_pool_skip_streak = self.no_tx_pool_skip_streak.saturating_add(1);
+            if self.no_tx_pool_skip_streak == 1 || self.no_tx_pool_skip_streak.is_multiple_of(100) {
+                warn!(
+                    target: "zone::engine",
+                    l1_block = l1_num_hash.number,
+                    l1_hash = %l1_num_hash.hash,
+                    skipped_blocks = self.no_tx_pool_skip_streak,
+                    drift_ms = %drift_ms,
+                    threshold_ms = %self.no_tx_pool_drift_threshold.as_millis(),
+                    "skipping txpool transactions while catching up to L1"
+                );
+            }
+        } else if self.no_tx_pool_skip_streak > 0 {
+            info!(
                 target: "zone::engine",
-                l1_block = l1_num_hash.number,
-                l1_hash = %l1_num_hash.hash,
-                drift_ms,
-                threshold_ms,
-                "skipping txpool transactions while catching up to L1"
+                skipped_blocks = self.no_tx_pool_skip_streak,
+                "resuming txpool transactions after L1 catch-up"
             );
+            self.no_tx_pool_skip_streak = 0;
         }
 
         let l1_block = self.prepare_l1_block(l1_block).await?;
@@ -298,7 +266,7 @@ impl ZoneEngine {
             },
             timestamp_millis_part,
             l1_block,
-            no_tx_pool,
+            no_tx_pool: no_tx_pool_drift.is_some(),
         };
 
         // Send FCU with payload attributes through the engine API to trigger
@@ -356,5 +324,61 @@ impl ZoneEngine {
         }
 
         Ok(())
+    }
+}
+
+/// Returns the wall-clock drift in milliseconds that should disable txpool inclusion, if any.
+///
+/// A zero threshold disables the no-txpool catch-up heuristic. The comparison
+/// expects a full Tempo L1 timestamp in milliseconds, so sub-second blocks are
+/// not treated as older than they are.
+fn tx_pool_skip_drift(
+    l1_timestamp_millis: u64,
+    now: SystemTime,
+    no_tx_pool_drift_threshold: Duration,
+) -> Option<u128> {
+    if no_tx_pool_drift_threshold.is_zero() {
+        return None;
+    }
+
+    let now_millis = now.duration_since(UNIX_EPOCH).ok()?.as_millis();
+    let drift_millis = now_millis.checked_sub(u128::from(l1_timestamp_millis))?;
+    (drift_millis > no_tx_pool_drift_threshold.as_millis()).then_some(drift_millis)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+
+    #[test]
+    fn tx_pool_skip_drift_uses_millisecond_timestamp() {
+        let header = TempoHeader {
+            timestamp_millis_part: 500,
+            inner: Header {
+                timestamp: 1_700_000_000,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let threshold = Duration::from_secs(1);
+        let now = UNIX_EPOCH
+            + Duration::from_millis(header.timestamp_millis())
+            + Duration::from_millis(900);
+
+        assert_eq!(
+            tx_pool_skip_drift(header.timestamp_millis(), now, threshold),
+            None
+        );
+        assert_eq!(
+            tx_pool_skip_drift(header.inner.timestamp * 1000, now, threshold),
+            Some(1400)
+        );
+    }
+
+    #[test]
+    fn tx_pool_skip_drift_zero_threshold_disables_skip() {
+        let now = UNIX_EPOCH + Duration::from_secs(1);
+        assert_eq!(tx_pool_skip_drift(0, now, Duration::ZERO), None);
     }
 }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -57,6 +57,10 @@ use tracing::{error, warn};
 use zone_l1::{DepositQueue, L1BlockDeposits, PolicyProvider, PreparedL1Block};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 
+/// Returns the wall-clock drift that should disable txpool inclusion, if any.
+///
+/// The comparison uses the full Tempo L1 block timestamp, including its millisecond
+/// part, so live sub-second blocks are not treated as older than they are.
 fn tx_pool_skip_drift(
     l1_timestamp_secs: u64,
     l1_timestamp_millis_part: u64,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -13,4 +13,7 @@ pub mod node;
 pub mod rpc;
 
 pub use engine::ZoneEngine;
-pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};
+pub use node::{
+    DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD, ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig,
+    ZoneSequencerAddOnsConfig,
+};

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -73,6 +73,9 @@ use zone_sequencer::{BatchAnchorConfig, ZoneSequencerConfig, spawn_zone_sequence
 /// Network primitives for Zone Nodes
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
+/// Default L1 timestamp drift before catch-up blocks skip txpool transactions.
+pub const DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD: Duration = Duration::from_secs(1);
+
 /// Configuration for the sequencer background tasks
 #[derive(Debug, Clone)]
 pub struct ZoneSequencerAddOnsConfig {
@@ -88,6 +91,8 @@ pub struct ZoneSequencerAddOnsConfig {
     pub batch_anchor_config: BatchAnchorConfig,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: Duration,
+    /// Maximum L1 timestamp drift before the engine skips txpool transactions.
+    pub no_tx_pool_drift_threshold: Duration,
 }
 
 /// Configuration for the Zone private RPC server extension.
@@ -375,7 +380,13 @@ where
         if let Some(ref config) = self.sequencer_config {
             let sequencer_addr = config.sequencer_signer.address();
             let sequencer_key = SecretKey::from(config.sequencer_signer.credential());
-            self.spawn_zone_engine(l1_provider, &ctx, sequencer_addr, sequencer_key)?;
+            self.spawn_zone_engine(
+                l1_provider,
+                &ctx,
+                sequencer_addr,
+                sequencer_key,
+                config.no_tx_pool_drift_threshold,
+            )?;
         }
 
         let task_executor = ctx.node.task_executor().clone();
@@ -491,6 +502,7 @@ where
         ctx: &AddOnsContext<'_, N>,
         fee_recipient: Address,
         sequencer_key: SecretKey,
+        no_tx_pool_drift_threshold: Duration,
     ) -> eyre::Result<()> {
         let policy_provider = PolicyProvider::new(
             self.policy_cache.clone(),
@@ -511,6 +523,7 @@ where
             sequencer_key,
             self.portal_address,
             policy_provider,
+            no_tx_pool_drift_threshold,
         );
         ctx.node
             .task_executor()

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -74,7 +74,7 @@ use zone_sequencer::{BatchAnchorConfig, ZoneSequencerConfig, spawn_zone_sequence
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
 /// Default L1 timestamp drift before catch-up blocks skip txpool transactions.
-pub const DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD: Duration = Duration::from_secs(1800);
+pub const DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD: Duration = Duration::from_secs(24);
 
 /// Configuration for the sequencer background tasks
 #[derive(Debug, Clone)]
@@ -92,6 +92,8 @@ pub struct ZoneSequencerAddOnsConfig {
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: Duration,
     /// Maximum L1 timestamp drift before the engine skips txpool transactions.
+    ///
+    /// Set to zero to disable the catch-up no-txpool heuristic.
     pub no_tx_pool_drift_threshold: Duration,
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -74,7 +74,7 @@ use zone_sequencer::{BatchAnchorConfig, ZoneSequencerConfig, spawn_zone_sequence
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
 /// Default L1 timestamp drift before catch-up blocks skip txpool transactions.
-pub const DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD: Duration = Duration::from_secs(1);
+pub const DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD: Duration = Duration::from_secs(1800);
 
 /// Configuration for the sequencer background tasks
 #[derive(Debug, Clone)]

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -654,6 +654,7 @@ impl ZoneTestNode {
             SecretKey::from(sequencer_signer.credential()),
             portal_address,
             policy_provider,
+            zone_node::DEFAULT_NO_TX_POOL_DRIFT_THRESHOLD,
         );
         node_handle
             .node

--- a/crates/payload/src/attrs.rs
+++ b/crates/payload/src/attrs.rs
@@ -38,6 +38,9 @@ pub struct ZonePayloadAttributes {
     /// processes exactly one L1 block via `advanceTempo`. Decryption and
     /// TIP-403 policy checks have already been performed by the engine.
     pub l1_block: PreparedL1Block,
+
+    /// Whether to skip user txpool transactions while building this payload.
+    pub no_tx_pool: bool,
 }
 
 impl reth_node_api::PayloadAttributes for ZonePayloadAttributes {

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -346,72 +346,74 @@ where
             }
         }
 
-        // Execute pool transactions
-        // TODO: Use gas accounting from TempoPayloadBuilder (payment vs non-payment limits, etc.)
-        let mut best_txs = self
-            .pool
-            .best_transactions_with_attributes(BestTransactionsAttributes::new(base_fee, None));
+        if !attributes.no_tx_pool {
+            // Execute pool transactions
+            // TODO: Use gas accounting from TempoPayloadBuilder (payment vs non-payment limits, etc.)
+            let mut best_txs = self
+                .pool
+                .best_transactions_with_attributes(BestTransactionsAttributes::new(base_fee, None));
 
-        while let Some(pool_tx) = best_txs.next() {
-            // Contract creation (CREATE) transactions are not allowed on zones
-            if pool_tx.transaction.is_create() {
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    InvalidPoolTransactionError::Consensus(
-                        reth_primitives_traits::transaction::error::InvalidTransactionError::TxTypeNotSupported,
-                    ),
-                );
-                continue;
-            }
-            let gas_limit_left = block_gas_limit;
-            if cumulative_gas_used + pool_tx.gas_limit() > gas_limit_left {
-                best_txs.mark_invalid(
-                    &pool_tx,
-                    InvalidPoolTransactionError::ExceedsGasLimit(
-                        pool_tx.gas_limit(),
-                        gas_limit_left.saturating_sub(cumulative_gas_used),
-                    ),
-                );
-                continue;
-            }
-
-            if cancel.is_cancelled() {
-                return Ok(BuildOutcome::Cancelled);
-            }
-
-            let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
-            let tx_hash = *pool_tx.hash();
-            match builder.execute_transaction(tx_with_env) {
-                Ok(gas_used) => {
-                    cumulative_gas_used += gas_used.tx_gas_used();
-                    if let Some(receipt) = builder.executor().receipts().last() {
-                        collect_requested_withdrawals(
-                            receipt,
-                            tx_hash,
-                            &mut requested_withdrawals,
-                        )?;
-                    }
-                }
-                Err(reth_evm::block::BlockExecutionError::Validation(
-                    reth_evm::block::BlockValidationError::InvalidTx { error, .. },
-                )) => {
-                    if !error.is_nonce_too_low() {
-                        best_txs.mark_invalid(
-                            &pool_tx,
-                            InvalidPoolTransactionError::Consensus(
-                                reth_primitives_traits::transaction::error::InvalidTransactionError::TxTypeNotSupported,
-                            ),
-                        );
-                    }
+            while let Some(pool_tx) = best_txs.next() {
+                // Contract creation (CREATE) transactions are not allowed on zones
+                if pool_tx.transaction.is_create() {
+                    best_txs.mark_invalid(
+                        &pool_tx,
+                        InvalidPoolTransactionError::Consensus(
+                            reth_primitives_traits::transaction::error::InvalidTransactionError::TxTypeNotSupported,
+                        ),
+                    );
                     continue;
                 }
-                Err(reth_evm::block::BlockExecutionError::Internal(
-                    reth_evm::block::InternalBlockExecutionError::EVM { ref error, .. },
-                )) if zone_precompiles::is_zone_rpc_error(&error.to_string()) => {
-                    warn!(target: "zone::payload", %error, ?pool_tx, "skipping pool tx due to transient RPC error");
+                let gas_limit_left = block_gas_limit;
+                if cumulative_gas_used + pool_tx.gas_limit() > gas_limit_left {
+                    best_txs.mark_invalid(
+                        &pool_tx,
+                        InvalidPoolTransactionError::ExceedsGasLimit(
+                            pool_tx.gas_limit(),
+                            gas_limit_left.saturating_sub(cumulative_gas_used),
+                        ),
+                    );
                     continue;
                 }
-                Err(err) => return Err(PayloadBuilderError::evm(err)),
+
+                if cancel.is_cancelled() {
+                    return Ok(BuildOutcome::Cancelled);
+                }
+
+                let tx_with_env = pool_tx.transaction.clone().into_with_tx_env();
+                let tx_hash = *pool_tx.hash();
+                match builder.execute_transaction(tx_with_env) {
+                    Ok(gas_used) => {
+                        cumulative_gas_used += gas_used.tx_gas_used();
+                        if let Some(receipt) = builder.executor().receipts().last() {
+                            collect_requested_withdrawals(
+                                receipt,
+                                tx_hash,
+                                &mut requested_withdrawals,
+                            )?;
+                        }
+                    }
+                    Err(reth_evm::block::BlockExecutionError::Validation(
+                        reth_evm::block::BlockValidationError::InvalidTx { error, .. },
+                    )) => {
+                        if !error.is_nonce_too_low() {
+                            best_txs.mark_invalid(
+                                &pool_tx,
+                                InvalidPoolTransactionError::Consensus(
+                                    reth_primitives_traits::transaction::error::InvalidTransactionError::TxTypeNotSupported,
+                                ),
+                            );
+                        }
+                        continue;
+                    }
+                    Err(reth_evm::block::BlockExecutionError::Internal(
+                        reth_evm::block::InternalBlockExecutionError::EVM { ref error, .. },
+                    )) if zone_precompiles::is_zone_rpc_error(&error.to_string()) => {
+                        warn!(target: "zone::payload", %error, ?pool_tx, "skipping pool tx due to transient RPC error");
+                        continue;
+                    }
+                    Err(err) => return Err(PayloadBuilderError::evm(err)),
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add a `no_tx_pool` payload attribute for stale L1 catch-up blocks
- skip user txpool transactions when L1 wall-clock drift exceeds the configured threshold
- derive drift from `TempoHeader::timestamp_millis()` so sub-second L1 timestamps are preserved
- default the drift threshold to 24 seconds for Tempo L1 catch-up; set it to 0 to disable the heuristic

Fixes #214

## Root Cause
During L1 backfill, zone payload building still attempted user txpool inclusion against stale L1 precompile state, so pool transactions could fail repeatedly and slow catch-up.