### PR TITLE
fix: seed zone token policies at local l1 height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11427,6 +11427,7 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
+ "alloy-rpc-types-eth",
  "alloy-sol-types",
  "const-hex",
  "futures",

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -20,6 +20,7 @@ alloy-sol-types = { workspace = true, default-features = false }
 alloy-contract = { workspace = true, optional = true }
 alloy-network = { workspace = true, optional = true }
 alloy-provider = { workspace = true, optional = true }
+alloy-rpc-types-eth = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -40,6 +41,7 @@ rpc = [
     "dep:alloy-contract",
     "dep:alloy-network",
     "dep:alloy-provider",
+    "dep:alloy-rpc-types-eth",
     "dep:futures",
     "dep:tokio",
 ]

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -246,10 +246,24 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
     pub async fn enabled_tokens(
         &self,
     ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
-        let count = self.enabledTokenCount().call().await?;
+        self.enabled_tokens_at(alloy_rpc_types_eth::BlockId::latest())
+            .await
+    }
+
+    /// Returns all token addresses enabled for bridging at `block_id`.
+    ///
+    /// Callers that pair the returned token list with other historical L1 reads
+    /// should use this instead of [`enabled_tokens`](Self::enabled_tokens), so
+    /// future `TokenEnabled` events are not mixed into older state snapshots.
+    pub async fn enabled_tokens_at(
+        &self,
+        block_id: alloy_rpc_types_eth::BlockId,
+    ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
+        let count = self.enabledTokenCount().block(block_id).call().await?;
         let futs: alloc::vec::Vec<_> = (0..count.to::<u64>())
             .map(|i| async move {
                 self.enabledTokenAt(alloy_primitives::U256::from(i))
+                    .block(block_id)
                     .call()
                     .await
             })

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -56,7 +56,7 @@ use tempo_transaction_pool::{
 use tempo_zone_contracts::{
     TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
     DepositQueue, L1Subscriber, L1SubscriberConfig, PolicyCache, TempoStateExt,
@@ -438,16 +438,47 @@ where
             info!(target: "reth::cli", count = tokens.len(), ?tokens, "Using pre-configured initial tokens");
             tokens
         } else {
-            let tokens = ZonePortal::new(portal, l1_provider)
-                .enabled_tokens()
-                .await?;
-            info!(target: "reth::cli", count = tokens.len(), ?tokens, "Discovered enabled tokens from L1");
+            let block_number = self.policy_cache.last_l1_block();
+            let tokens = match ZonePortal::new(portal, l1_provider)
+                .enabled_tokens_at(alloy_rpc_types_eth::BlockId::number(block_number))
+                .await
+            {
+                Ok(tokens) => tokens,
+                Err(err) => {
+                    warn!(
+                        target: "reth::cli",
+                        %err,
+                        block_number,
+                        %portal,
+                        "Failed to discover enabled tokens from L1 for policy cache seeding; continuing without initial token policy seed"
+                    );
+                    return Ok(());
+                }
+            };
+            info!(
+                target: "reth::cli",
+                count = tokens.len(),
+                ?tokens,
+                block_number,
+                "Discovered enabled tokens from L1"
+            );
             tokens
         };
 
-        self.policy_cache
+        if let Err(err) = self
+            .policy_cache
             .seed_token_policies(portal, &tracked_tokens, l1_provider)
-            .await?;
+            .await
+        {
+            warn!(
+                target: "reth::cli",
+                %err,
+                count = tracked_tokens.len(),
+                %portal,
+                "Failed to seed token policies from L1; continuing with RPC fallback"
+            );
+            return Ok(());
+        }
         info!(target: "reth::cli", "Seeded token policies from L1");
         Ok(())
     }

--- a/crates/node/tests/it/enable_token.rs
+++ b/crates/node/tests/it/enable_token.rs
@@ -12,7 +12,12 @@ use crate::utils::{DEFAULT_TIMEOUT, L1Fixture, start_local_zone_with_fixture};
 // Imports for real-L1 tests
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
 use alloy::primitives::B256;
-use alloy_provider::Provider;
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types_eth::BlockId;
+use tempo_alloy::TempoNetwork;
+use tempo_precompiles::PATH_USD_ADDRESS;
+use tempo_zone_contracts::ZonePortal;
+use zone_l1::PolicyCache;
 
 /// Enable a new token (AlphaUSD) via a `TokenEnabled` event, then deposit it
 /// and verify the recipient receives the minted balance.
@@ -112,6 +117,92 @@ async fn test_enable_token_and_deposit_same_block() -> eyre::Result<()> {
 /// Longer timeout for real L1 tests — the L1 dev node produces blocks every
 /// 500ms and the L1Subscriber needs to connect, backfill, and subscribe.
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_startup_discovers_enabled_tokens_at_local_l1_height() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let l1 = L1TestNode::start().await?;
+    let portal_address = l1.deploy_zone().await?;
+    let seed_block = l1.provider().get_block_number().await?;
+
+    let future_salt = B256::new([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 42,
+    ]);
+    let future_token = l1.create_tip20("FutureUSD", "fUSD", future_salt).await?;
+    l1.enable_token_on_portal(portal_address, future_token)
+        .await?;
+
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    let latest_tokens = portal.enabled_tokens().await?;
+    assert!(
+        latest_tokens.contains(&future_token),
+        "latest portal state should include the newly-enabled token"
+    );
+
+    let historical_tokens = portal
+        .enabled_tokens_at(BlockId::number(seed_block))
+        .await?;
+    assert_eq!(
+        historical_tokens,
+        vec![PATH_USD_ADDRESS],
+        "startup should discover only tokens enabled at the local L1 height"
+    );
+
+    let tempo_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_http(l1.http_url().clone())
+        .erased();
+
+    let latest_seed_cache = PolicyCache::default();
+    latest_seed_cache.set_last_l1_block(seed_block);
+    let err = latest_seed_cache
+        .seed_token_policies(portal_address, &latest_tokens, &tempo_provider)
+        .await
+        .expect_err("latest token discovery should include a future uninitialized token");
+    assert!(
+        err.to_string().contains("Uninitialized"),
+        "expected uninitialized future token error, got {err}"
+    );
+
+    let historical_seed_cache = PolicyCache::default();
+    historical_seed_cache.set_last_l1_block(seed_block);
+    historical_seed_cache
+        .seed_token_policies(portal_address, &historical_tokens, &tempo_provider)
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_startup_policy_seed_errors_do_not_abort_launch() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let l1 = L1TestNode::start().await?;
+    let portal_address = l1.deploy_zone().await?;
+    let seed_block = l1.provider().get_block_number().await?;
+
+    let future_salt = B256::new([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 43,
+    ]);
+    let future_token = l1
+        .create_tip20("FutureSeedUSD", "fsUSD", future_salt)
+        .await?;
+    l1.enable_token_on_portal(portal_address, future_token)
+        .await?;
+
+    let _zone = ZoneTestNode::start_from_l1_at_block_with_initial_tokens(
+        l1.http_url(),
+        l1.ws_url(),
+        portal_address,
+        seed_block,
+        Some(vec![future_token]),
+    )
+    .await?;
+
+    Ok(())
+}
 
 /// Full TokenEnabled pipeline with a real in-process L1 node:
 ///

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -455,6 +455,33 @@ impl ZoneTestNode {
         .await
     }
 
+    /// Start a zone node connected to a real L1, anchoring genesis to a specific
+    /// L1 block and optionally overriding the initial token list used for
+    /// startup policy cache seeding.
+    pub(crate) async fn start_from_l1_at_block_with_initial_tokens(
+        l1_http_url: &url::Url,
+        l1_ws_url: &url::Url,
+        portal_address: Address,
+        block_number: u64,
+        initial_tokens: Option<Vec<Address>>,
+    ) -> eyre::Result<Self> {
+        let (genesis, genesis_block_number) =
+            build_l1_anchored_genesis_at_block(l1_http_url, portal_address, block_number).await?;
+
+        let signer = l1_dev_signer();
+        Self::launch_with_genesis_and_withdrawal_batch_interval(
+            l1_ws_url.to_string(),
+            portal_address,
+            Some(genesis_block_number),
+            next_unique_chain_id(),
+            Some(genesis),
+            signer,
+            Duration::from_secs(4),
+            initial_tokens,
+        )
+        .await
+    }
+
     pub(crate) async fn start_from_l1_with_withdrawal_batch_interval(
         l1_http_url: &url::Url,
         l1_ws_url: &url::Url,
@@ -473,6 +500,7 @@ impl ZoneTestNode {
             Some(genesis),
             signer,
             withdrawal_batch_interval,
+            Some(vec![]),
         )
         .await
     }
@@ -568,6 +596,7 @@ impl ZoneTestNode {
             custom_genesis,
             sequencer_signer,
             Duration::from_secs(4),
+            Some(vec![]),
         )
         .await
     }
@@ -580,6 +609,7 @@ impl ZoneTestNode {
         custom_genesis: Option<Genesis>,
         sequencer_signer: alloy_signer_local::PrivateKeySigner,
         withdrawal_batch_interval: Duration,
+        initial_tokens: Option<Vec<Address>>,
     ) -> eyre::Result<Self> {
         let tasks = Runtime::test();
         let is_local_dummy_l1 = l1_ws_url == DUMMY_L1_URL;
@@ -592,15 +622,17 @@ impl ZoneTestNode {
         genesis.config.chain_id = chain_id;
         let chain_spec = TempoChainSpec::from_genesis(genesis);
 
-        let zone_node = ZoneNode::new(
+        let mut zone_node = ZoneNode::new(
             l1_ws_url,
             portal_address,
             genesis_tempo_block_number,
             4,
             std::time::Duration::from_millis(100),
         )
-        .with_withdrawal_batch_interval(withdrawal_batch_interval)
-        .with_initial_tokens(vec![]);
+        .with_withdrawal_batch_interval(withdrawal_batch_interval);
+        if let Some(initial_tokens) = initial_tokens {
+            zone_node = zone_node.with_initial_tokens(initial_tokens);
+        }
 
         // Don't use .dev() — it spawns a LocalMiner that conflicts with ZoneEngine.
         // The ZoneEngine is the sole block producer; it advances the chain when L1

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -601,6 +601,7 @@ impl ZoneTestNode {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn launch_with_genesis_and_withdrawal_batch_interval(
         l1_ws_url: String,
         portal_address: Address,


### PR DESCRIPTION
## What changed
- Added `ZonePortal::enabled_tokens_at` so callers can resolve enabled tokens against a specific L1 block.
- Updated zone startup token discovery to read the portal at `policy_cache.last_l1_block()`, matching the block used by `seed_token_policies`.
- Made startup policy-cache seeding best-effort: discovery or seed failures now log a warning and continue instead of aborting node launch.
- Added regressions for stale-height token discovery and for startup continuing when policy seeding hits an uninitialized future token.

## Root cause
Startup discovered enabled portal tokens from latest L1 state, then seeded each token's `transferPolicyId()` at the node's persisted local L1 height. If a token had been enabled after that local height, the latest portal list included a future token whose TIP20 state was still uninitialized at the historical block, causing the node to shut down during policy seeding.

## Impact
A zone node with stale local L1 progress can restart without mixing future portal state into historical policy cache seeding. If the startup seed cannot be populated, the node logs the failure and continues; policy resolution can still fall back to L1 RPC on demand.
