### PR TITLE
chore: Remove RPC timing side channels from spec

### DIFF
--- a/specs/spec.md
+++ b/specs/spec.md
@@ -55,7 +55,6 @@
     - [Method Access Control](#method-access-control)
     - [Block Responses](#block-responses)
     - [Event Filtering](#event-filtering)
-    - [Timing Side Channels](#timing-side-channels)
     - [WebSocket Subscriptions](#websocket-subscriptions)
     - [Zone-Specific Methods](#zone-specific-methods)
     - [Error Codes](#error-codes)
@@ -909,11 +908,6 @@ To avoid leaking how much activity occurred in a block, some fields of returned 
 - `transactionIndex` is set to `0` on every log, so the caller cannot infer its transaction's position among, or the number of, other transactions in the block.
 - `logIndex` is renumbered per transaction rather than exposing the log's global position in the block. `(transactionHash, logIndex)` is stable and consistent for a given log across `eth_getLogs`, `eth_getFilterLogs`, `eth_getFilterChanges`, `eth_getTransactionReceipt`, and `eth_subscribe("logs")`.
 
-### Timing Side Channels
-
-Scoped methods that fetch data before checking authorization leak existence via timing differences. The RPC server enforces a minimum response time of 100ms on `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getLogs`, `eth_getFilterLogs`, and `eth_getFilterChanges`.
-
-Methods where authorization is checked before any data fetch (`eth_getBalance`, `eth_call`, `eth_sendRawTransaction`) do not need the speed bump.
 
 ### WebSocket Subscriptions
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -871,6 +871,8 @@ The RPC uses a default-deny model. Any method not explicitly listed returns `-32
 
 **Disabled.** Methods not available on zones. `eth_getProof` leaks trie structure. `eth_newPendingTransactionFilter` and `eth_subscribe("newPendingTransactions")` enable mempool observation. Uncle query methods (`eth_getUncleByBlockNumberAndIndex`, `eth_getUncleByBlockHashAndIndex`) and mining methods (`eth_mining`, `eth_hashrate`, `eth_getWork`, `eth_submitWork`, `eth_submitHashrate`) do not apply to zones.
 
+**Note on timing side channel attacks:** Scoped methods returning empty values could technically be timed to estimate if the values exist. However, (1) Benchmarked timing differences are very small and (2) The values like `transactionHash` etc... can't be correlated to actual user data, so any leaked signal is not material.
+
 ### Block Responses
 
 For non-sequencer callers, block responses are modified:


### PR DESCRIPTION
Delete the side channel timing from the RPC section. The differences are not meaningful enough to matter

```
- eth_getTransactionByHash
      - Missing hash: mean 0.690ms, p99 0.854ms
      - Existing hash as non-owner, still returns null: mean 0.654ms, p99 0.805ms
      - Paired delta hidden-existing minus missing: mean -0.036ms, p99 0.062ms

  - eth_getTransactionReceipt
      - Missing hash: mean 0.662ms, p99 0.744ms
      - Existing hash as non-owner, still returns null: mean 0.673ms, p99 0.757ms
      - Paired delta hidden-existing minus missing: mean 0.011ms, p99 0.086ms
```