### PR TITLE
chore: update Moderato ZoneFactory metadata

### DIFF
--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -535,7 +535,7 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68` |
+| ZoneFactory (moderato) | `0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5` |
 
 The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` uses `zoneFactory` from `zone.json` before falling back to this address. Pass `--zone-factory` or set `ZONE_FACTORY` to override it.
 
@@ -570,10 +570,10 @@ Current deployment:
 
 | Field | Value |
 |-------|-------|
-| Address | `0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68` |
-| Transaction | `0xb3d519f55fd6b0b349b3f118d8966edf3e20f2cc1d1ca24df60c333a23f4e1cf` |
-| Block | `24532374` |
-| Deployed | `2026-06-30 19:22:56 UTC` |
+| Address | `0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5` |
+| Transaction | `0x3d3f0f4ec21084d8fda0c315cfe19c92568df3320c20a56679a12935547c2c4c` |
+| Block | `25403236` |
+| Deployed | `2026-07-06 20:41:32 UTC` |
 
 ### Zone Node CLI Options
 

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -21,9 +21,9 @@ pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
 /// `create-zone`, `deploy-router`, and `zone-info` use this as their default
 /// factory unless the caller overrides `--zone-factory` or `ZONE_FACTORY`, or
 /// `zone.json` already provides a zone-specific value.
-/// Explorer: https://explore.moderato.tempo.xyz/address/0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68
+/// Explorer: https://explore.moderato.tempo.xyz/address/0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5
 pub(crate) const MODERATO_ZONE_FACTORY: Address =
-    address!("0xcDf1101C60B34Cc5205BB27C88F02Db36A373C68");
+    address!("0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
     address!("0xDEc0000000000000000000000000000000000000");
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;


### PR DESCRIPTION
## What changed

Updates the shared Moderato ZoneFactory default to `0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5` in `xtask` and `docs/ZONES.md`.

Records the new deployment transaction `0x3d3f0f4ec21084d8fda0c315cfe19c92568df3320c20a56679a12935547c2c4c`, block `25403236`, and deployment time `2026-07-06 20:41:32 UTC`.

## Why

The previous shared factory embedded older `ZonePortal` creation bytecode. A fresh factory is needed so newly created zones use the current portal implementation, including admin rotation support.

## Impact

New `create-zone`, `zone-info`, and router workflows will default to the new shared Moderato factory. Existing generated zone metadata remains unchanged so historical zones still point to the factory that created them.