### PR TITLE
feat: Wire tempoGasRate and maxWithdrawalsPerBlock to config

### DIFF
--- a/crates/contracts/src/precompiles/zone_outbox.rs
+++ b/crates/contracts/src/precompiles/zone_outbox.rs
@@ -44,9 +44,21 @@ crate::sol! {
 
         event BatchFinalized(bytes32 indexed withdrawalQueueHash, uint64 withdrawalBatchIndex);
 
+        event TempoGasRateUpdated(uint128 tempoGasRate);
+
+        event MaxWithdrawalsPerBlockUpdated(uint256 maxWithdrawalsPerBlock);
+
         // -- Errors --
 
+        error InvalidFallbackRecipient();
+        error CallbackDataTooLarge();
+        error GasFeeRateTooHigh();
+        error TransferFailed();
         error OnlySequencer();
+        error InvalidBlockNumber();
+        error TooManyWithdrawalsThisBlock();
+        error InvalidRevealTo();
+        error InvalidCurrentTxHash();
         error GasLimitTooHigh();
         error OnlyZoneInbox();
         error InvalidWithdrawalCount(uint256 actual, uint256 expected);
@@ -63,6 +75,8 @@ crate::sol! {
         function getPendingWithdrawals() external view returns (PendingWithdrawal[] memory);
         function calculateWithdrawalFee(uint64 gasLimit) external view returns (uint128 fee);
         function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);
+        function tempoGasRate() external view returns (uint128);
+        function maxWithdrawalsPerBlock() external view returns (uint256);
 
         // -- State-changing functions --
 
@@ -82,5 +96,7 @@ crate::sol! {
             address bouncebackRecipient
         ) external;
         function finalizeWithdrawalBatch(uint256 count, uint64 blockNumber, bytes[] calldata encryptedSenders) external returns (bytes32 withdrawalQueueHash);
+        function setTempoGasRate(uint128 tempoGasRate) external;
+        function setMaxWithdrawalsPerBlock(uint256 maxWithdrawalsPerBlock) external;
     }
 }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -70,6 +70,10 @@ impl ZoneCli {
                 Duration::from_millis(args.l1_retry_connection_interval_ms),
             )
             .with_withdrawal_batch_interval(Duration::from_secs(args.zone_batch_interval_secs))
+            .with_outbox_fee_config(zone_payload::OutboxFeeConfig {
+                tempo_gas_rate: args.tempo_gas_rate,
+                max_withdrawals_per_block: args.max_withdrawals_per_block,
+            })
             .with_private_rpc(ZonePrivateRpcConfig {
                 private_rpc_port: args.private_rpc_port,
                 zone_id: args.zone_id,
@@ -192,6 +196,22 @@ pub struct ZoneArgs {
     /// withdrawal batches.
     #[arg(long = "sequencer", env = "SEQUENCER")]
     pub enable_sequencer: bool,
+
+    /// ZoneOutbox withdrawal gas rate (zone token units per Tempo gas unit).
+    /// When set, the payload builder keeps the on-chain `tempoGasRate` synced
+    /// to this value via system transactions. Unset leaves the on-chain value
+    /// untouched (zero at genesis = free withdrawals).
+    #[arg(long = "zone.tempo-gas-rate", env = "ZONE_TEMPO_GAS_RATE")]
+    pub tempo_gas_rate: Option<u128>,
+
+    /// Maximum withdrawal requests per zone block (0 = unlimited). When set,
+    /// the payload builder keeps the on-chain `maxWithdrawalsPerBlock` synced
+    /// to this value via system transactions.
+    #[arg(
+        long = "zone.max-withdrawals-per-block",
+        env = "ZONE_MAX_WITHDRAWALS_PER_BLOCK"
+    )]
+    pub max_withdrawals_per_block: Option<u64>,
 }
 
 fn prepend_log_filter(filter: &mut String, directives: &str) {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -66,7 +66,8 @@ use zone_l1::{
     },
 };
 use zone_payload::{
-    DEFAULT_WITHDRAWAL_BATCH_INTERVAL, ZonePayloadAttributes, ZonePayloadFactory, ZonePayloadTypes,
+    DEFAULT_WITHDRAWAL_BATCH_INTERVAL, OutboxFeeConfig, ZonePayloadAttributes, ZonePayloadFactory,
+    ZonePayloadTypes,
 };
 use zone_sequencer::{BatchAnchorConfig, ZoneSequencerConfig, spawn_zone_sequencer};
 
@@ -123,6 +124,8 @@ pub struct ZoneNode {
     initial_tokens: Option<Vec<Address>>,
     /// Maximum chain-time duration between withdrawal batch finalizations.
     withdrawal_batch_interval: Duration,
+    /// ZoneOutbox fee parameters the payload builder keeps synced on-chain.
+    outbox_fee_config: OutboxFeeConfig,
     /// Private RPC config.
     private_rpc_config: ZonePrivateRpcConfig,
     /// Optional sequencer config. When set, sequencer tasks are spawned.
@@ -168,6 +171,7 @@ impl ZoneNode {
             portal_address,
             initial_tokens: None,
             withdrawal_batch_interval: DEFAULT_WITHDRAWAL_BATCH_INTERVAL,
+            outbox_fee_config: OutboxFeeConfig::default(),
             private_rpc_config: ZonePrivateRpcConfig::default(),
             sequencer_config: None,
         }
@@ -197,6 +201,12 @@ impl ZoneNode {
     /// withdrawal batch finalization.
     pub fn with_withdrawal_batch_interval(mut self, interval: Duration) -> Self {
         self.withdrawal_batch_interval = interval;
+        self
+    }
+
+    /// Set the ZoneOutbox fee parameters the payload builder keeps synced on-chain.
+    pub fn with_outbox_fee_config(mut self, config: OutboxFeeConfig) -> Self {
+        self.outbox_fee_config = config;
         self
     }
 
@@ -722,7 +732,8 @@ where
             self.l1_state_cache.clone(),
             self.policy_cache.clone(),
         );
-        let payload_factory = ZonePayloadFactory::new(self.withdrawal_batch_interval);
+        let payload_factory = ZonePayloadFactory::new(self.withdrawal_batch_interval)
+            .with_outbox_fee_config(self.outbox_fee_config);
         Self::components_with_payload_factory(executor_builder, payload_factory)
     }
 

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -23,6 +23,60 @@ use crate::utils::{
     local_dev_zone_account, poll_until, seed_fixture_for_zone, start_local_zone_with_fixture,
 };
 
+/// Verify the payload builder syncs configured ZoneOutbox fee parameters
+/// on-chain via system transactions.
+///
+/// The outbox's `tempoGasRate` and `maxWithdrawalsPerBlock` are zero at zone
+/// genesis. With an [`zone_payload::OutboxFeeConfig`] configured, the first
+/// built block must inject `setTempoGasRate` and `setMaxWithdrawalsPerBlock`
+/// system txs so withdrawal fees become live.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_outbox_fee_config_synced_via_system_txs() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let fee_config = zone_payload::OutboxFeeConfig {
+        tempo_gas_rate: Some(25),
+        max_withdrawals_per_block: Some(64),
+    };
+    let zone = ZoneTestNode::start_local_with_outbox_fee_config(fee_config).await?;
+    let mut fixture = L1Fixture::new();
+    seed_fixture_for_zone(&fixture, &zone, 10);
+
+    let outbox = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, zone.provider());
+    assert_eq!(
+        outbox.tempoGasRate().call().await?,
+        0,
+        "genesis rate is zero"
+    );
+
+    // The first built block injects the setter system txs.
+    fixture.inject_empty_block(zone.deposit_queue());
+    poll_until(
+        DEFAULT_TIMEOUT,
+        DEFAULT_POLL,
+        "outbox fee config synced",
+        || {
+            let outbox = &outbox;
+            async move {
+                let rate = outbox.tempoGasRate().call().await?;
+                let cap = outbox.maxWithdrawalsPerBlock().call().await?;
+                if rate == 25 && cap == U256::from(64) {
+                    Ok(Some(()))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    )
+    .await?;
+
+    // fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate.
+    let fee = outbox.calculateWithdrawalFee(0).call().await?;
+    assert_eq!(fee, 50_000u128 * 25);
+
+    Ok(())
+}
+
 /// Self-contained test: inject a deposit via the queue and verify the zone
 /// mints the corresponding pathUSD balance on L2.
 ///

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -479,6 +479,7 @@ impl ZoneTestNode {
             signer,
             Duration::from_secs(4),
             initial_tokens,
+            Default::default(),
         )
         .await
     }
@@ -502,6 +503,7 @@ impl ZoneTestNode {
             signer,
             withdrawal_batch_interval,
             Some(vec![]),
+            Default::default(),
         )
         .await
     }
@@ -561,6 +563,26 @@ impl ZoneTestNode {
         Self::launch(DUMMY_L1_URL.to_string(), Address::ZERO, None, chain_id).await
     }
 
+    /// Start a self-contained zone node with configured ZoneOutbox fee.
+    pub(crate) async fn start_local_with_outbox_fee_config(
+        outbox_fee_config: zone_payload::OutboxFeeConfig,
+    ) -> eyre::Result<Self> {
+        let throwaway_key = k256::SecretKey::from_slice(&[0x01; 32]).expect("valid throwaway key");
+        let signer = alloy_signer_local::PrivateKeySigner::from_signing_key(throwaway_key.into());
+        Self::launch_with_genesis_and_withdrawal_batch_interval(
+            DUMMY_L1_URL.to_string(),
+            Address::ZERO,
+            None,
+            next_unique_chain_id(),
+            None,
+            signer,
+            Duration::from_secs(4),
+            Some(vec![]),
+            outbox_fee_config,
+        )
+        .await
+    }
+
     async fn launch(
         l1_ws_url: String,
         portal_address: Address,
@@ -598,6 +620,7 @@ impl ZoneTestNode {
             sequencer_signer,
             Duration::from_secs(4),
             Some(vec![]),
+            Default::default(),
         )
         .await
     }
@@ -612,6 +635,7 @@ impl ZoneTestNode {
         sequencer_signer: alloy_signer_local::PrivateKeySigner,
         withdrawal_batch_interval: Duration,
         initial_tokens: Option<Vec<Address>>,
+        outbox_fee_config: zone_payload::OutboxFeeConfig,
     ) -> eyre::Result<Self> {
         let tasks = Runtime::test();
         let is_local_dummy_l1 = l1_ws_url == DUMMY_L1_URL;
@@ -631,7 +655,8 @@ impl ZoneTestNode {
             4,
             std::time::Duration::from_millis(100),
         )
-        .with_withdrawal_batch_interval(withdrawal_batch_interval);
+        .with_withdrawal_batch_interval(withdrawal_batch_interval)
+        .with_outbox_fee_config(outbox_fee_config);
         if let Some(initial_tokens) = initial_tokens {
             zone_node = zone_node.with_initial_tokens(initial_tokens);
         }

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -53,18 +53,49 @@ use crate::{ZonePayloadAttributes, ZonePayloadTypes};
 
 pub const DEFAULT_WITHDRAWAL_BATCH_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Sequencer-configured `ZoneOutbox` fee parameters, applied on-chain via
+/// system transactions during block building.
+///
+/// The outbox's `tempoGasRate` and `maxWithdrawalsPerBlock` are zero at zone
+/// genesis (withdrawals are free). When configured, the payload
+/// builder compares the on-chain values at the start of each block and injects
+/// setter system txs to ensure they match.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OutboxFeeConfig {
+    /// Desired `ZoneOutbox.tempoGasRate` (zone token units per Tempo gas unit).
+    /// `None` leaves the on-chain value untouched.
+    pub tempo_gas_rate: Option<u128>,
+    /// Desired `ZoneOutbox.maxWithdrawalsPerBlock` (`0` = unlimited).
+    /// `None` leaves the on-chain value untouched.
+    pub max_withdrawals_per_block: Option<u64>,
+}
+
+impl OutboxFeeConfig {
+    pub fn is_empty(&self) -> bool {
+        self.tempo_gas_rate.is_none() && self.max_withdrawals_per_block.is_none()
+    }
+}
+
 /// Factory for constructing the zone payload builder.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ZonePayloadFactory {
     withdrawal_batch_interval: Duration,
+    outbox_fee_config: OutboxFeeConfig,
 }
 
 impl ZonePayloadFactory {
     pub fn new(withdrawal_batch_interval: Duration) -> Self {
         Self {
             withdrawal_batch_interval,
+            outbox_fee_config: OutboxFeeConfig::default(),
         }
+    }
+
+    /// Set the `ZoneOutbox` fee parameters the builder keeps synced on-chain.
+    pub fn with_outbox_fee_config(mut self, config: OutboxFeeConfig) -> Self {
+        self.outbox_fee_config = config;
+        self
     }
 }
 
@@ -104,6 +135,7 @@ where
             provider: ctx.provider().clone(),
             evm_config,
             withdrawal_batch_interval: self.withdrawal_batch_interval,
+            outbox_fee_config: self.outbox_fee_config,
         })
     }
 }
@@ -119,6 +151,8 @@ pub struct ZonePayloadBuilder<Provider, EvmConfig> {
     evm_config: EvmConfig,
     /// Maximum chain-time duration between withdrawal batch finalizations.
     withdrawal_batch_interval: Duration,
+    /// Configured `ZoneOutbox` fee parameters to keep synced on-chain.
+    outbox_fee_config: OutboxFeeConfig,
 }
 
 impl<Provider, EvmConfig> PayloadBuilder for ZonePayloadBuilder<Provider, EvmConfig>
@@ -329,6 +363,10 @@ where
             }
         }
 
+        // Keep configured ZoneOutbox fee parameters synced on-chain before
+        // pool txs, so withdrawals in this block pay the configured fee.
+        self.sync_outbox_fee_config(&mut builder, block_gas_limit, block_number)?;
+
         // Execute pool transactions
         // TODO: Use gas accounting from TempoPayloadBuilder (payment vs non-payment limits, etc.)
         let mut best_txs = self
@@ -535,6 +573,154 @@ where
         ))?
         .into_payload()
         .ok_or_else(|| PayloadBuilderError::MissingPayload)
+    }
+}
+
+impl<Provider, EvmConfig> ZonePayloadBuilder<Provider, EvmConfig> {
+    /// Compare on-chain `ZoneOutbox` fee parameters with the configured values
+    /// and inject setter system txs for any that differ.
+    fn sync_outbox_fee_config<B>(
+        &self,
+        builder: &mut B,
+        gas_limit: u64,
+        block_number: u64,
+    ) -> Result<(), PayloadBuilderError>
+    where
+        B: BlockBuilder<Primitives = tempo_primitives::TempoPrimitives>,
+    {
+        if self.outbox_fee_config.is_empty() {
+            return Ok(());
+        }
+
+        // Sync `tempoGasRate` if needed
+        if let Some(tempo_gas_rate) = self.outbox_fee_config.tempo_gas_rate {
+            let calldata = abi::ZoneOutbox::tempoGasRateCall {}.abi_encode();
+            let output = execute_outbox_view_call(
+                builder,
+                calldata.into(),
+                gas_limit,
+                block_number,
+                "tempoGasRate",
+            )?;
+            let current =
+                abi::ZoneOutbox::tempoGasRateCall::abi_decode_returns(&output).map_err(|err| {
+                    PayloadBuilderError::Internal(reth_errors::RethError::msg(format!(
+                        "failed to decode tempoGasRate return data: {err}"
+                    )))
+                })?;
+
+            if current != tempo_gas_rate {
+                info!(
+                    target: "zone::payload",
+                    block_number,
+                    current_tempo_gas_rate = current,
+                    configured_tempo_gas_rate = tempo_gas_rate,
+                    "Injecting setTempoGasRate system tx"
+                );
+                let calldata = abi::ZoneOutbox::setTempoGasRateCall {
+                    tempoGasRate: tempo_gas_rate,
+                }
+                .abi_encode();
+                execute_outbox_system_tx(
+                    builder,
+                    calldata.into(),
+                    block_number,
+                    "setTempoGasRate",
+                )?;
+            }
+        }
+
+        // Sync `maxWithdrawalsPerBlock` if needed
+        if let Some(max_withdrawals) = self.outbox_fee_config.max_withdrawals_per_block {
+            let calldata = abi::ZoneOutbox::maxWithdrawalsPerBlockCall {}.abi_encode();
+            let output = execute_outbox_view_call(
+                builder,
+                calldata.into(),
+                gas_limit,
+                block_number,
+                "maxWithdrawalsPerBlock",
+            )?;
+            let current = abi::ZoneOutbox::maxWithdrawalsPerBlockCall::abi_decode_returns(&output)
+                .map_err(|err| {
+                    PayloadBuilderError::Internal(reth_errors::RethError::msg(format!(
+                        "failed to decode maxWithdrawalsPerBlock return data: {err}"
+                    )))
+                })?;
+
+            if current != U256::from(max_withdrawals) {
+                info!(
+                    target: "zone::payload",
+                    block_number,
+                    current_max_withdrawals_per_block = %current,
+                    configured_max_withdrawals_per_block = max_withdrawals,
+                    "Injecting setMaxWithdrawalsPerBlock system tx"
+                );
+                let calldata = abi::ZoneOutbox::setMaxWithdrawalsPerBlockCall {
+                    maxWithdrawalsPerBlock: U256::from(max_withdrawals),
+                }
+                .abi_encode();
+                execute_outbox_system_tx(
+                    builder,
+                    calldata.into(),
+                    block_number,
+                    "setMaxWithdrawalsPerBlock",
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Execute a `ZoneOutbox` system transaction from `address(0)`, treating a
+/// revert as a hard error.
+fn execute_outbox_system_tx<B>(
+    builder: &mut B,
+    calldata: Bytes,
+    block_number: u64,
+    label: &str,
+) -> Result<(), PayloadBuilderError>
+where
+    B: BlockBuilder<Primitives = tempo_primitives::TempoPrimitives>,
+{
+    let tx = TxLegacy {
+        chain_id: None,
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 0,
+        to: ZONE_OUTBOX_ADDRESS.into(),
+        value: U256::ZERO,
+        input: calldata,
+    };
+    let tx = Recovered::new_unchecked(
+        TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, TEMPO_SYSTEM_TX_SIGNATURE)),
+        TEMPO_SYSTEM_TX_SENDER,
+    );
+
+    let mut reverted = false;
+    match builder.execute_transaction_with_result_closure(tx, |result| {
+        let evm_result = result.result();
+        if !evm_result.result.is_success() {
+            let revert_data = evm_result.result.output().cloned().unwrap_or_default();
+            error!(
+                target: "zone::payload",
+                block_number,
+                label,
+                is_halt = evm_result.result.is_halt(),
+                revert_data = %revert_data,
+                "ZoneOutbox system tx reverted on-chain"
+            );
+            reverted = true;
+        }
+    }) {
+        Ok(_) if reverted => Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
+            format!("ZoneOutbox {label} system tx reverted at zone block {block_number}"),
+        ))),
+        Ok(_) => Ok(()),
+        Err(err) => {
+            error!(?err, label, "ZoneOutbox system tx failed");
+            Err(PayloadBuilderError::evm(err))
+        }
     }
 }
 

--- a/crates/payload/src/lib.rs
+++ b/crates/payload/src/lib.rs
@@ -12,6 +12,6 @@ mod builder;
 
 pub use attrs::{ZonePayloadAttributes, ZonePayloadTypes};
 pub use builder::{
-    DEFAULT_WITHDRAWAL_BATCH_INTERVAL, ZonePayloadBuilder, ZonePayloadFactory,
+    DEFAULT_WITHDRAWAL_BATCH_INTERVAL, OutboxFeeConfig, ZonePayloadBuilder, ZonePayloadFactory,
     build_advance_tempo_tx,
 };

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -587,6 +587,8 @@ Current deployment:
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled |
 | `--block.interval-ms` | 250 | Block building interval |
 | `--zone.batch-interval-secs` | 60 | Max seconds to accumulate zone blocks before submitting a batch to L1 |
+| `--zone.tempo-gas-rate` | unset | ZoneOutbox withdrawal gas rate, in zone token units per Tempo gas unit. Unset leaves the on-chain value untouched (`0` at genesis = free withdrawals). |
+| `--zone.max-withdrawals-per-block` | unset | Maximum withdrawal requests accepted per zone block (`0` = unlimited). Unset leaves the on-chain value untouched (`0` at genesis). |
 | `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
@@ -604,6 +606,8 @@ Current deployment:
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
 | `ROUTER_BOUNCEBACK_RECIPIENT` | No | Optional controlled burner/stealth address for `demo-swap-and-deposit` routed deposit refunds |
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
+| `ZONE_TEMPO_GAS_RATE` | No | Sets `--zone.tempo-gas-rate`; unset leaves withdrawal fees unchanged. |
+| `ZONE_MAX_WITHDRAWALS_PER_BLOCK` | No | Sets `--zone.max-withdrawals-per-block`; unset leaves the on-chain per-block withdrawal cap unchanged. |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 | `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |
 


### PR DESCRIPTION
Allow setting the zone gas rate and max withdrawals (`--zone.tempo-gas-rate` and `--zone.max-withdrawals-per-block`) and sync them to the ZoneOutbox during block building by injecting system txns in the zone block. 

Linear Issue: https://linear.app/tempoxyz/issue/CHAIN-952/wire-depositwithdrawal-fee-configuration-into-deployment

Note: This PR doesn't change defaults, which is 0 fee (free withdrawals) set at genesis.