### PR TITLE
Require certified Tempo follower mode in zone spec

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -68,6 +68,7 @@ futures.workspace = true
 k256.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+url = "2"
 
 [dev-dependencies]
 alloy = { workspace = true, features = [
@@ -102,7 +103,6 @@ tempo-revm.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-tungstenite.workspace = true
-url = "2"
 zone-precompiles = { workspace = true, features = ["std"] }
 
 [features]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -57,6 +57,8 @@ impl ZoneCli {
         cli.run_with_components::<ZoneNode>(components, async move |mut builder, args| {
             info!(target: "reth::cli", "Launching Tempo Zone node");
 
+            validate_l1_rpc_url(&args.l1_rpc_url)?;
+
             builder.config_mut().network.discovery.disable_discovery = true;
             builder.config_mut().rpc.disable_auth_server = true;
             builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
@@ -104,7 +106,7 @@ impl ZoneCli {
 /// Tempo Zone CLI arguments.
 #[derive(Debug, Clone, Args)]
 pub struct ZoneArgs {
-    /// L1 WebSocket RPC URL for subscribing to deposit events and chain notifications.
+    /// Certified Tempo follower WebSocket RPC URL for finalized L1 state, deposit events, and chain notifications.
     #[arg(long = "l1.rpc-url", env = "L1_RPC_URL")]
     pub l1_rpc_url: String,
 
@@ -199,5 +201,34 @@ fn prepend_log_filter(filter: &mut String, directives: &str) {
         *filter = directives.to_owned();
     } else {
         *filter = format!("{directives},{filter}");
+    }
+}
+
+fn validate_l1_rpc_url(l1_rpc_url: &str) -> eyre::Result<()> {
+    let url: url::Url = l1_rpc_url
+        .parse()
+        .map_err(|err| eyre::eyre!("failed parsing --l1.rpc-url as URL: {err}"))?;
+    eyre::ensure!(
+        matches!(url.scheme(), "ws" | "wss"),
+        "--l1.rpc-url must use ws:// or wss://, got `{}`",
+        url.scheme()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_l1_rpc_url;
+
+    #[test]
+    fn l1_rpc_url_accepts_websocket_schemes() {
+        validate_l1_rpc_url("ws://localhost:8546").unwrap();
+        validate_l1_rpc_url("wss://rpc.moderato.tempo.xyz").unwrap();
+    }
+
+    #[test]
+    fn l1_rpc_url_rejects_non_websocket_schemes() {
+        assert!(validate_l1_rpc_url("http://localhost:8545").is_err());
+        assert!(validate_l1_rpc_url("https://rpc.moderato.tempo.xyz").is_err());
     }
 }

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -579,7 +579,7 @@ Current deployment:
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--l1.rpc-url` | (required) | L1 WebSocket RPC URL |
+| `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
 | `--l1.genesis-block-number` | (from zone.json) | L1 block when the zone was created |
 | `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` (mainnet) or `1424310000 + (zone_id % 723173648)` (testnet). |
@@ -597,7 +597,7 @@ Current deployment:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `L1_RPC_URL` | Yes | L1 WebSocket URL (`wss://...`) |
+| `L1_RPC_URL` | Yes | Certified Tempo follower WebSocket RPC URL (`wss://...`) |
 | `SEQUENCER_KEY` | For sequencing | Sequencer private key |
 | `ADMIN_KEY` | For portal governance | Portal admin private key for `enableToken` / deposit pause controls. `SEQUENCER_KEY` only works for legacy zones where admin == sequencer. |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -44,6 +44,7 @@
     - [Privacy Modifications](#privacy-modifications)
   - [Tempo State Reads](#tempo-state-reads)
     - [TempoState Predeploy](#tempostate-predeploy)
+    - [Tempo Follower Mode](#tempo-follower-mode)
     - [Header Finalization](#header-finalization)
     - [Storage Reads](#storage-reads)
     - [Staleness and Finality](#staleness-and-finality)
@@ -784,6 +785,12 @@ The zone reads all of its configuration from Tempo: the sequencer address, the t
 The durable onchain checkpoint is `tempoBlockHash` and `tempoBlockNumber`. The `tempoBlockHash` is always `keccak256(RLP(TempoHeader))`, committing to the complete header contents without persisting every decoded header field.
 
 Tempo headers are RLP-encoded as `rlp([general_gas_limit, shared_gas_limit, timestamp_millis_part, inner])`, where `inner` is a standard Ethereum header.
+
+### Tempo Follower Mode
+
+Zone sequencers MUST run their Tempo L1 provider in Tempo follower mode with consensus certification enabled. The follower stack syncs finalized Tempo consensus state from an upstream node and drives the execution layer from those finalized certificates.
+
+Sequencers MUST NOT use uncertified follow mode (`--follow.nocertify`) or a generic execution-only RPC as the source for `advanceTempo` headers or Tempo state reads. Certified follower mode is required so the zone only imports Tempo headers that have reached deterministic finality; this prevents zone proofs from anchoring deposits, token configuration, sequencer rotation, or TIP-403 policy reads to state that could be reorged.
 
 ### Header Finalization
 


### PR DESCRIPTION
## Summary
- Require zone sequencers to run their Tempo L1 provider in certified Tempo follower mode.
- Disallow uncertified follow mode and generic execution-only RPC sources for `advanceTempo` headers and Tempo state reads.
- Document `--l1.rpc-url` / `L1_RPC_URL` as a certified Tempo follower WebSocket RPC URL.
- Validate `--l1.rpc-url` at CLI startup so non-WebSocket schemes fail early.

## Testing
- `cargo +nightly fmt --package zone-node`
- `cargo test -p zone-node l1_rpc_url --features cli`

Prompted by: @0xalpharush