### PR TITLE
Enforce TIP-403 policy on zone withdrawals

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -518,6 +518,10 @@ interface IZonePortal {
         uint64 depositNumber
     );
 
+    event WithdrawalBounceBackPending(
+        address indexed fallbackRecipient, address indexed token, uint128 amount
+    );
+
     /// @notice Emitted when the current sequencer nominates a new sequencer (two-step transfer).
     /// @dev A `pendingSequencer` of address(0) signals cancellation of a pending transfer.
     event SequencerTransferStarted(

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -524,6 +524,10 @@ contract ZonePortal is IZonePortal {
         }
     }
 
+    function _validateBounceBackPolicy(address _token, address fallbackRecipient) internal view {
+        _validateDepositPolicy(_token, address(this), fallbackRecipient, fallbackRecipient);
+    }
+
     function _isAuthorizedWithdrawalRecipient(
         address _token,
         address to
@@ -838,6 +842,8 @@ contract ZonePortal is IZonePortal {
     )
         internal
     {
+        _validateBounceBackPolicy(_token, fallbackRecipient);
+
         Deposit memory depositData = Deposit({
             token: _token,
             sender: address(this),

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -485,6 +485,7 @@ contract ZonePortal is IZonePortal {
 
     function _validateDepositPolicy(
         address _token,
+        address from,
         address to,
         address bouncebackRecipient
     )
@@ -492,10 +493,30 @@ contract ZonePortal is IZonePortal {
         view
     {
         uint64 policyId = ITIP20(_token).transferPolicyId();
+        if (!TIP403_REGISTRY.isAuthorizedSender(policyId, from)) {
+            revert ITIP20.PolicyForbids();
+        }
         if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, to)) {
             revert ITIP20.PolicyForbids();
         }
         if (!TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, to)) {
+            revert ITIP20.PolicyForbids();
+        }
+        if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
+            revert ITIP20.PolicyForbids();
+        }
+    }
+
+    function _validateEncryptedDepositPolicy(
+        address _token,
+        address from,
+        address bouncebackRecipient
+    )
+        internal
+        view
+    {
+        uint64 policyId = ITIP20(_token).transferPolicyId();
+        if (!TIP403_REGISTRY.isAuthorizedSender(policyId, from)) {
             revert ITIP20.PolicyForbids();
         }
         if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
@@ -563,7 +584,7 @@ contract ZonePortal is IZonePortal {
         if (bouncebackRecipient == address(0)) revert InvalidBouncebackRecipient();
 
         _validateDepositsActive(_token);
-        _validateDepositPolicy(_token, to, bouncebackRecipient);
+        _validateDepositPolicy(_token, msg.sender, to, bouncebackRecipient);
         (uint128 fee, uint128 netAmount) = _collectDepositFunds(_token, amount);
 
         // Build deposit struct with net amount (fee already paid to sequencer on Tempo)
@@ -616,11 +637,7 @@ contract ZonePortal is IZonePortal {
         if (bouncebackRecipient == address(0)) revert InvalidBouncebackRecipient();
 
         _validateDepositsActive(_token);
-
-        uint64 policyId = ITIP20(_token).transferPolicyId();
-        if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
-            revert ITIP20.PolicyForbids();
-        }
+        _validateEncryptedDepositPolicy(_token, msg.sender, bouncebackRecipient);
 
         // Validate ephemeral public key is a valid secp256k1 point
         // Prevents griefing: invalid points make Chaum-Pedersen proofs impossible,

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -503,6 +503,18 @@ contract ZonePortal is IZonePortal {
         }
     }
 
+    function _isAuthorizedWithdrawalRecipient(
+        address _token,
+        address to
+    )
+        internal
+        view
+        returns (bool)
+    {
+        uint64 policyId = ITIP20(_token).transferPolicyId();
+        return TIP403_REGISTRY.isAuthorizedRecipient(policyId, to);
+    }
+
     function _collectDepositFunds(
         address _token,
         uint128 amount
@@ -714,7 +726,9 @@ contract ZonePortal is IZonePortal {
         }
 
         bool success;
-        if (withdrawal.gasLimit == 0) {
+        if (!_isAuthorizedWithdrawalRecipient(_token, withdrawal.to)) {
+            success = false;
+        } else if (withdrawal.gasLimit == 0) {
             success = _tryTransfer(_token, withdrawal.to, withdrawal.amount);
         } else {
             try IZoneMessenger(messenger)

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -55,6 +55,10 @@ contract ZonePortal is IZonePortal {
     /// @notice Scale factor from 18-decimal Tempo gas prices to 6-decimal TIP-20 units
     uint256 internal constant TEMPO_BASE_FEE_SCALE = 1e12;
 
+    uint8 internal constant POLICY_ROLE_SENDER = 0;
+    uint8 internal constant POLICY_ROLE_RECIPIENT = 1;
+    uint8 internal constant POLICY_ROLE_MINT_RECIPIENT = 2;
+
     /// @notice Maximum gas a withdrawal callback may request
     /// @dev Over-cap legacy withdrawals are dequeued and bounced back in `processWithdrawal`.
     uint64 public constant MAX_WITHDRAWAL_GAS_LIMIT = MAX_WITHDRAWAL_CALLBACK_GAS;
@@ -493,9 +497,6 @@ contract ZonePortal is IZonePortal {
         view
     {
         uint64 policyId = ITIP20(_token).transferPolicyId();
-        if (!TIP403_REGISTRY.isAuthorizedSender(policyId, from)) {
-            revert ITIP20.PolicyForbids();
-        }
         if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, to)) {
             revert ITIP20.PolicyForbids();
         }
@@ -505,6 +506,11 @@ contract ZonePortal is IZonePortal {
         if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
             revert ITIP20.PolicyForbids();
         }
+
+        _validateOtherEnabledTokenPolicies(_token, from, POLICY_ROLE_SENDER);
+        _validateOtherEnabledTokenPolicies(_token, to, POLICY_ROLE_RECIPIENT);
+        _validateOtherEnabledTokenPolicies(_token, to, POLICY_ROLE_MINT_RECIPIENT);
+        _validateOtherEnabledTokenPolicies(_token, bouncebackRecipient, POLICY_ROLE_RECIPIENT);
     }
 
     function _validateEncryptedDepositPolicy(
@@ -516,12 +522,12 @@ contract ZonePortal is IZonePortal {
         view
     {
         uint64 policyId = ITIP20(_token).transferPolicyId();
-        if (!TIP403_REGISTRY.isAuthorizedSender(policyId, from)) {
-            revert ITIP20.PolicyForbids();
-        }
         if (!TIP403_REGISTRY.isAuthorizedRecipient(policyId, bouncebackRecipient)) {
             revert ITIP20.PolicyForbids();
         }
+
+        _validateOtherEnabledTokenPolicies(_token, from, POLICY_ROLE_SENDER);
+        _validateOtherEnabledTokenPolicies(_token, bouncebackRecipient, POLICY_ROLE_RECIPIENT);
     }
 
     function _validateBounceBackPolicy(address _token, address fallbackRecipient) internal view {
@@ -536,7 +542,14 @@ contract ZonePortal is IZonePortal {
         uint64 policyId = ITIP20(_token).transferPolicyId();
         return TIP403_REGISTRY.isAuthorizedSender(policyId, address(this))
             && TIP403_REGISTRY.isAuthorizedRecipient(policyId, fallbackRecipient)
-            && TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, fallbackRecipient);
+            && TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, fallbackRecipient)
+            && _authorizedByOtherEnabledTokenPolicies(_token, address(this), POLICY_ROLE_SENDER)
+            && _authorizedByOtherEnabledTokenPolicies(
+            _token, fallbackRecipient, POLICY_ROLE_RECIPIENT
+        )
+            && _authorizedByOtherEnabledTokenPolicies(
+            _token, fallbackRecipient, POLICY_ROLE_MINT_RECIPIENT
+        );
     }
 
     function _isAuthorizedWithdrawalRecipient(
@@ -547,8 +560,79 @@ contract ZonePortal is IZonePortal {
         view
         returns (bool)
     {
-        uint64 policyId = ITIP20(_token).transferPolicyId();
-        return TIP403_REGISTRY.isAuthorizedRecipient(policyId, to);
+        return _authorizedByOtherEnabledTokenPolicies(_token, to, POLICY_ROLE_RECIPIENT);
+    }
+
+    function _validateOtherEnabledTokenPolicies(
+        address _token,
+        address account,
+        uint8 role
+    )
+        internal
+        view
+    {
+        if (!_authorizedByOtherEnabledTokenPolicies(_token, account, role)) {
+            revert ITIP20.PolicyForbids();
+        }
+    }
+
+    function _authorizedByOtherEnabledTokenPolicies(
+        address _token,
+        address account,
+        uint8 role
+    )
+        internal
+        view
+        returns (bool)
+    {
+        uint64 basePolicyId = ITIP20(_token).transferPolicyId();
+        uint64[] memory checkedPolicyIds = new uint64[](_enabledTokens.length);
+        uint256 checkedPolicyCount;
+
+        for (uint256 i = 0; i < _enabledTokens.length; i++) {
+            uint64 policyId = ITIP20(_enabledTokens[i]).transferPolicyId();
+            if (policyId == basePolicyId) continue;
+            if (_containsPolicyId(checkedPolicyIds, checkedPolicyCount, policyId)) continue;
+
+            if (!_isAuthorizedForRole(policyId, account, role)) return false;
+            checkedPolicyIds[checkedPolicyCount] = policyId;
+            checkedPolicyCount++;
+        }
+
+        return true;
+    }
+
+    function _containsPolicyId(
+        uint64[] memory policyIds,
+        uint256 policyCount,
+        uint64 policyId
+    )
+        internal
+        pure
+        returns (bool)
+    {
+        for (uint256 i = 0; i < policyCount; i++) {
+            if (policyIds[i] == policyId) return true;
+        }
+        return false;
+    }
+
+    function _isAuthorizedForRole(
+        uint64 policyId,
+        address account,
+        uint8 role
+    )
+        internal
+        view
+        returns (bool)
+    {
+        if (role == POLICY_ROLE_SENDER) {
+            return TIP403_REGISTRY.isAuthorizedSender(policyId, account);
+        }
+        if (role == POLICY_ROLE_RECIPIENT) {
+            return TIP403_REGISTRY.isAuthorizedRecipient(policyId, account);
+        }
+        return TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, account);
     }
 
     function _collectDepositFunds(

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -528,6 +528,17 @@ contract ZonePortal is IZonePortal {
         _validateDepositPolicy(_token, address(this), fallbackRecipient, fallbackRecipient);
     }
 
+    function _canBounceBack(address _token, address fallbackRecipient)
+        internal
+        view
+        returns (bool)
+    {
+        uint64 policyId = ITIP20(_token).transferPolicyId();
+        return TIP403_REGISTRY.isAuthorizedSender(policyId, address(this))
+            && TIP403_REGISTRY.isAuthorizedRecipient(policyId, fallbackRecipient)
+            && TIP403_REGISTRY.isAuthorizedMintRecipient(policyId, fallbackRecipient);
+    }
+
     function _isAuthorizedWithdrawalRecipient(
         address _token,
         address to
@@ -739,7 +750,7 @@ contract ZonePortal is IZonePortal {
         }
 
         if (withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) {
-            _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
+            _bounceBackOrParkRefund(_token, withdrawal.amount, withdrawal.fallbackRecipient);
             emit WithdrawalProcessed(
                 withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, false
             );
@@ -769,7 +780,7 @@ contract ZonePortal is IZonePortal {
 
         if (!success) {
             // Callback failed: bounce back to zone (only amount, not fee)
-            _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
+            _bounceBackOrParkRefund(_token, withdrawal.amount, withdrawal.fallbackRecipient);
         }
         emit WithdrawalProcessed(
             withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, success
@@ -835,14 +846,18 @@ contract ZonePortal is IZonePortal {
     /// @param _token The token from the failed withdrawal
     /// @param amount The amount to bounce back
     /// @param fallbackRecipient The zone address to receive the bounce-back
-    function _enqueueBounceBack(
+    function _bounceBackOrParkRefund(
         address _token,
         uint128 amount,
         address fallbackRecipient
     )
         internal
     {
-        _validateBounceBackPolicy(_token, fallbackRecipient);
+        if (!_canBounceBack(_token, fallbackRecipient)) {
+            refunds[_token][fallbackRecipient] += amount;
+            emit WithdrawalBounceBackPending(fallbackRecipient, _token, amount);
+            return;
+        }
 
         Deposit memory depositData = Deposit({
             token: _token,

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -865,7 +865,7 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.withdrawalQueueHead(), 1);
     }
 
-    function test_withdrawalQueue_revertsWhenPolicyBlocksRecipientAndFallback() public {
+    function test_withdrawalQueue_parksRefundWhenPolicyBlocksRecipientAndFallback() public {
         uint128 depositAmount = 1000e6;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
@@ -905,13 +905,17 @@ contract ZonePortalTest is BaseTest {
             ""
         );
 
-        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        vm.expectEmit(true, true, false, true);
+        emit IZonePortal.WithdrawalBounceBackPending(charlie, address(pathUSD), 500e6);
+        vm.expectEmit(true, true, true, true);
+        emit IZonePortal.WithdrawalProcessed(bob, _senderTag(alice), address(pathUSD), 500e6, false);
         portal.processWithdrawal(w, bytes32(0));
 
         assertEq(pathUSD.balanceOf(bob), 100_000e6);
         assertEq(portal.currentDepositQueueHash(), depositHashBefore);
-        assertEq(portal.withdrawalQueueSlot(0), wHash);
-        assertEq(portal.withdrawalQueueHead(), 0);
+        assertEq(portal.refunds(address(pathUSD), charlie), 500e6);
+        assertEq(portal.withdrawalQueueSlot(0), EMPTY_SENTINEL);
+        assertEq(portal.withdrawalQueueHead(), 1);
     }
 
     function test_withdrawalQueue_multipleWithdrawalsInBatch() public {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -865,6 +865,55 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.withdrawalQueueHead(), 1);
     }
 
+    function test_withdrawalQueue_revertsWhenPolicyBlocksRecipientAndFallback() public {
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), alice);
+        vm.stopPrank();
+
+        bytes32 depositHashBefore = portal.currentDepositQueueHash();
+
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = address(portal);
+        uint64 policyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, accounts
+        );
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(policyId);
+
+        Withdrawal memory w =
+            _withdrawal(address(pathUSD), alice, bob, 500e6, bytes32(0), 0, charlie, "");
+        bytes32 wHash = keccak256(abi.encode(w, EMPTY_SENTINEL));
+
+        vm.roll(block.number + 1);
+        portal.submitBatch(
+            uint64(block.number - 1),
+            0,
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: depositHashBefore,
+                    prevDepositNumber: 0,
+                    nextDepositNumber: 0
+                }),
+            wHash,
+            "",
+            ""
+        );
+
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        portal.processWithdrawal(w, bytes32(0));
+
+        assertEq(pathUSD.balanceOf(bob), 100_000e6);
+        assertEq(portal.currentDepositQueueHash(), depositHashBefore);
+        assertEq(portal.withdrawalQueueSlot(0), wHash);
+        assertEq(portal.withdrawalQueueHead(), 0);
+    }
+
     function test_withdrawalQueue_multipleWithdrawalsInBatch() public {
         // Setup: deposit funds
         uint128 depositAmount = 2000e6;

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -574,6 +574,35 @@ contract ZonePortalTest is BaseTest {
         vm.stopPrank();
     }
 
+    function test_deposit_revertsWhenSenderBlocked() public {
+        uint128 depositAmount = 1000e6;
+
+        address[] memory senderAccounts = new address[](2);
+        senderAccounts[0] = bob;
+        senderAccounts[1] = address(portal);
+        uint64 senderPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+        );
+
+        address[] memory recipientAccounts = new address[](2);
+        recipientAccounts[0] = alice;
+        recipientAccounts[1] = address(portal);
+        uint64 recipientPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+        );
+
+        uint64 compoundPolicyId =
+            registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, recipientPolicyId);
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(compoundPolicyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), alice);
+        vm.stopPrank();
+    }
+
     function test_deposit_allowsCompoundPolicyMintRecipient() public {
         uint128 depositAmount = 1000e6;
 
@@ -2647,6 +2676,37 @@ contract ZonePortalTest is BaseTest {
         pathUSD.approve(address(portal), depositAmount);
         vm.expectRevert(ITIP20.PolicyForbids.selector);
         portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload(), bob);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsWhenSenderBlocked() public {
+        _setEncKeyWithPoP(ENC_KEY_1);
+
+        uint128 depositAmount = 1000e6;
+
+        address[] memory senderAccounts = new address[](2);
+        senderAccounts[0] = bob;
+        senderAccounts[1] = address(portal);
+        uint64 senderPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+        );
+
+        address[] memory recipientAccounts = new address[](2);
+        recipientAccounts[0] = alice;
+        recipientAccounts[1] = address(portal);
+        uint64 recipientPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+        );
+
+        uint64 compoundPolicyId =
+            registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, recipientPolicyId);
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(compoundPolicyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload(), alice);
         vm.stopPrank();
     }
 

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -785,6 +785,57 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.withdrawalQueueHead(), 1);
     }
 
+    function test_withdrawalQueue_bouncesBackWhenPolicyBlocksRecipient() public {
+        uint128 depositAmount = 1000e6;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), alice);
+        vm.stopPrank();
+
+        bytes32 depositHashBefore = portal.currentDepositQueueHash();
+        uint256 bobBalanceBefore = pathUSD.balanceOf(bob);
+
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = address(portal);
+        uint64 policyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, accounts
+        );
+        vm.prank(pathUSDAdmin);
+        pathUSD.changeTransferPolicyId(policyId);
+
+        Withdrawal memory w =
+            _withdrawal(address(pathUSD), alice, bob, 500e6, bytes32(0), 0, alice, "");
+        bytes32 wHash = keccak256(abi.encode(w, EMPTY_SENTINEL));
+
+        vm.roll(block.number + 1);
+        portal.submitBatch(
+            uint64(block.number - 1),
+            0,
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("state")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: depositHashBefore,
+                    prevDepositNumber: 0,
+                    nextDepositNumber: 0
+                }),
+            wHash,
+            "",
+            ""
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit IZonePortal.WithdrawalProcessed(bob, _senderTag(alice), address(pathUSD), 500e6, false);
+        portal.processWithdrawal(w, bytes32(0));
+
+        assertEq(pathUSD.balanceOf(bob), bobBalanceBefore);
+        assertTrue(portal.currentDepositQueueHash() != depositHashBefore);
+        assertEq(portal.withdrawalQueueSlot(0), EMPTY_SENTINEL);
+        assertEq(portal.withdrawalQueueHead(), 1);
+    }
+
     function test_withdrawalQueue_multipleWithdrawalsInBatch() public {
         // Setup: deposit funds
         uint128 depositAmount = 2000e6;

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -564,8 +564,11 @@ contract ZonePortalTest is BaseTest {
         uint64 policyId = registry.createPolicyWithAccounts(
             sequencer, ITIP403Registry.PolicyType.WHITELIST, accounts
         );
-        vm.prank(pathUSDAdmin);
-        pathUSD.changeTransferPolicyId(policyId);
+        vm.prank(sequencer);
+        token1.changeTransferPolicyId(policyId);
+
+        vm.prank(admin);
+        portal.enableToken(address(token1));
 
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
@@ -595,6 +598,38 @@ contract ZonePortalTest is BaseTest {
             registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, recipientPolicyId);
         vm.prank(pathUSDAdmin);
         pathUSD.changeTransferPolicyId(compoundPolicyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        portal.deposit(address(pathUSD), alice, depositAmount, bytes32("memo"), alice);
+        vm.stopPrank();
+    }
+
+    function test_deposit_revertsWhenDifferentEnabledTokenPolicyBlocksSender() public {
+        uint128 depositAmount = 1000e6;
+
+        address[] memory senderAccounts = new address[](2);
+        senderAccounts[0] = bob;
+        senderAccounts[1] = address(portal);
+        uint64 senderPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+        );
+
+        address[] memory recipientAccounts = new address[](2);
+        recipientAccounts[0] = alice;
+        recipientAccounts[1] = address(portal);
+        uint64 recipientPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+        );
+
+        uint64 compoundPolicyId =
+            registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, recipientPolicyId);
+        vm.prank(sequencer);
+        token1.changeTransferPolicyId(compoundPolicyId);
+
+        vm.prank(admin);
+        portal.enableToken(address(token1));
 
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);
@@ -830,8 +865,11 @@ contract ZonePortalTest is BaseTest {
         uint64 policyId = registry.createPolicyWithAccounts(
             sequencer, ITIP403Registry.PolicyType.WHITELIST, accounts
         );
-        vm.prank(pathUSDAdmin);
-        pathUSD.changeTransferPolicyId(policyId);
+        vm.prank(sequencer);
+        token1.changeTransferPolicyId(policyId);
+
+        vm.prank(admin);
+        portal.enableToken(address(token1));
 
         Withdrawal memory w =
             _withdrawal(address(pathUSD), alice, bob, 500e6, bytes32(0), 0, alice, "");
@@ -880,8 +918,11 @@ contract ZonePortalTest is BaseTest {
         uint64 policyId = registry.createPolicyWithAccounts(
             sequencer, ITIP403Registry.PolicyType.WHITELIST, accounts
         );
-        vm.prank(pathUSDAdmin);
-        pathUSD.changeTransferPolicyId(policyId);
+        vm.prank(sequencer);
+        token1.changeTransferPolicyId(policyId);
+
+        vm.prank(admin);
+        portal.enableToken(address(token1));
 
         Withdrawal memory w =
             _withdrawal(address(pathUSD), alice, bob, 500e6, bytes32(0), 0, charlie, "");
@@ -2755,6 +2796,40 @@ contract ZonePortalTest is BaseTest {
             registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, recipientPolicyId);
         vm.prank(pathUSDAdmin);
         pathUSD.changeTransferPolicyId(compoundPolicyId);
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), depositAmount);
+        vm.expectRevert(ITIP20.PolicyForbids.selector);
+        portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload(), alice);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsWhenDifferentEnabledTokenPolicyBlocksSender() public {
+        _setEncKeyWithPoP(ENC_KEY_1);
+
+        uint128 depositAmount = 1000e6;
+
+        address[] memory senderAccounts = new address[](2);
+        senderAccounts[0] = bob;
+        senderAccounts[1] = address(portal);
+        uint64 senderPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, senderAccounts
+        );
+
+        address[] memory recipientAccounts = new address[](2);
+        recipientAccounts[0] = alice;
+        recipientAccounts[1] = address(portal);
+        uint64 recipientPolicyId = registry.createPolicyWithAccounts(
+            sequencer, ITIP403Registry.PolicyType.WHITELIST, recipientAccounts
+        );
+
+        uint64 compoundPolicyId =
+            registry.createCompoundPolicy(senderPolicyId, recipientPolicyId, recipientPolicyId);
+        vm.prank(sequencer);
+        token1.changeTransferPolicyId(compoundPolicyId);
+
+        vm.prank(admin);
+        portal.enableToken(address(token1));
 
         vm.startPrank(alice);
         pathUSD.approve(address(portal), depositAmount);


### PR DESCRIPTION
## Summary
- rely on TIP20 for the active token's own transfer-policy enforcement
- add explicit ZonePortal guardrails only for other enabled tokens whose `transferPolicyId` differs from the active token policy
- apply those distinct-policy checks to plaintext deposits, encrypted deposits, withdrawal payouts, and withdrawal bounce-back fallback recipients
- if withdrawal payout and fallback are blocked by distinct enabled-token policy checks, park the amount in portal refunds for the fallback recipient and advance the withdrawal queue instead of reverting
- add regression tests for distinct enabled-token policies blocking deposit senders, withdrawal recipients, and withdrawal fallback recipients

## Testing
- `forge build --root specs/ref-impls --skip test`
- `forge test --root specs/ref-impls --match-contract ZonePortalTest --match-test test_withdrawalQueue_bouncesBackWhenPolicyBlocksRecipient -vvv` *(fails in this sandbox at `setUp()` because standard forge is missing the Tempo `BlockHashHistory` precompile; the test compiles before runtime setup)*

Prompted by: @0xalpharush