### PR TITLE
Add runtime solvency circuit breaker

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -379,9 +379,9 @@ enable-token token:
         sleep 0.5
     done
 
-# Shared implementation for admin-only portal calls that take a single token
-# argument (pauseDeposits / resumeDeposits). Resolves the token alias, signs with
-# ADMIN_KEY (SEQUENCER_KEY fallback only when it is the on-chain admin).
+# Shared implementation for privileged portal calls that take a single token
+# argument. pauseDeposits accepts admin or sequencer; resumeDeposits remains
+# admin-only.
 [private]
 _portal-admin-token-call action token:
     #!/bin/bash
@@ -394,12 +394,19 @@ _portal-admin-token-call action token:
     fi
     PORTAL="${L1_PORTAL_ADDRESS:?Set L1_PORTAL_ADDRESS env var}"
     HTTP_RPC=$(echo "$RPC" | sed 's|^wss://|https://|' | sed 's|^ws://|http://|')
-    # {{action}} is onlyAdmin: reject the sequencer fallback unless it is the admin.
     SIGNER_ADDR=$(cast wallet address "$PK" | tr '[:upper:]' '[:lower:]')
     ONCHAIN_ADMIN=$(cast call "$PORTAL" "admin()(address)" --rpc-url "$HTTP_RPC" | tr '[:upper:]' '[:lower:]')
-    if [[ "$SIGNER_ADDR" != "$ONCHAIN_ADMIN" ]]; then
-        echo "Signer $SIGNER_ADDR is not the portal admin $ONCHAIN_ADMIN. Set ADMIN_KEY for this zone (SEQUENCER_KEY only works when admin == sequencer)." >&2
-        exit 1
+    if [[ "{{action}}" == "pauseDeposits" ]]; then
+        ONCHAIN_SEQUENCER=$(cast call "$PORTAL" "sequencer()(address)" --rpc-url "$HTTP_RPC" | tr '[:upper:]' '[:lower:]')
+        if [[ "$SIGNER_ADDR" != "$ONCHAIN_ADMIN" && "$SIGNER_ADDR" != "$ONCHAIN_SEQUENCER" ]]; then
+            echo "Signer $SIGNER_ADDR is neither portal admin $ONCHAIN_ADMIN nor sequencer $ONCHAIN_SEQUENCER. Set ADMIN_KEY or SEQUENCER_KEY for this zone." >&2
+            exit 1
+        fi
+    else
+        if [[ "$SIGNER_ADDR" != "$ONCHAIN_ADMIN" ]]; then
+            echo "Signer $SIGNER_ADDR is not the portal admin $ONCHAIN_ADMIN. Set ADMIN_KEY for this zone (SEQUENCER_KEY only works when admin == sequencer)." >&2
+            exit 1
+        fi
     fi
     TOKEN="{{token}}"
     TOKEN_LOWER=$(echo "$TOKEN" | tr '[:upper:]' '[:lower:]')
@@ -419,7 +426,7 @@ _portal-admin-token-call action token:
     echo "Explorer: https://explore.moderato.tempo.xyz/tx/$TX_HASH"
 
 [group('zone')]
-[doc('Pauses deposits for an enabled TIP-20 on the ZonePortal (withdrawals unaffected). Token can be an address or alias. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY env vars.')]
+[doc('Pauses deposits for an enabled TIP-20 on the ZonePortal (withdrawals unaffected). Token can be an address or alias. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY or SEQUENCER_KEY env vars.')]
 pause-deposits token:
     just _portal-admin-token-call pauseDeposits {{token}}
 

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -183,6 +183,7 @@ crate::sol! {
         function depositCount() external view returns (uint64);
         function lastProcessedDepositNumber() external view returns (uint64);
         function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);
+        function accountedBalance(address token) external view returns (uint256);
 
         // -- State-changing functions --
 

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -65,6 +65,18 @@ pub(crate) struct ZoneMonitorMetrics {
     /// Failed batch submissions after exhausting retries.
     pub batch_submit_failure_total: Counter,
 
+    /// Failed portal-accounted funds ledger checks before batch submission.
+    pub funds_ledger_check_failure_total: Counter,
+
+    /// Runtime solvency circuit breaker trips that halt settlement.
+    pub circuit_breaker_tripped_total: Counter,
+
+    /// Successful automatic deposit pauses after a circuit breaker trip.
+    pub auto_pause_success_total: Counter,
+
+    /// Failed automatic deposit pause attempts after a circuit breaker trip.
+    pub auto_pause_failure_total: Counter,
+
     /// Retry attempts for batch submissions.
     pub batch_submit_retry_total: Counter,
 

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -21,9 +21,9 @@
 //! number that IS within the EIP-2935 window, and the proof must include a
 //! block header chain linking that anchor back to `tempoBlockNumber`.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, error::Error, fmt, sync::Arc, time::Duration};
 
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
 use alloy_transport::layers::RetryBackoffLayer;
@@ -38,8 +38,8 @@ use crate::{
     abi::{self, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
     rpc::rpc_connection_config,
     settlement::{
-        BatchAnchorConfig, BatchData, BatchSubmitter, ZoneBlockSnapshot, fetch_finalized_batch,
-        fetch_finalized_batch_boundaries, log_query_ranges,
+        BatchAnchorConfig, BatchData, BatchSubmitter, LOG_QUERY_BLOCK_CHUNK, ZoneBlockSnapshot,
+        fetch_finalized_batch, fetch_finalized_batch_boundaries, log_query_ranges,
     },
     withdrawals::SharedWithdrawalStore,
 };
@@ -49,6 +49,115 @@ const MAX_RETRIES: u32 = 3;
 
 /// Initial delay between retries (doubles on each attempt).
 const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Default)]
+struct FundsLedger {
+    tokens: BTreeMap<Address, TokenFunds>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct TokenFunds {
+    unprocessed_deposits: U256,
+    pending_refunds: U256,
+    pending_withdrawals: U256,
+}
+
+#[derive(Debug, Clone)]
+struct FundsInvariantViolation {
+    token: Address,
+    accounted_balance: U256,
+    required_liability: U256,
+    funds: TokenFunds,
+}
+
+#[derive(Debug)]
+struct CircuitBreakerTripped {
+    reason: String,
+}
+
+impl fmt::Display for CircuitBreakerTripped {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.reason)
+    }
+}
+
+impl Error for CircuitBreakerTripped {}
+
+impl FundsLedger {
+    fn add_unprocessed_deposit(&mut self, token: Address, amount: u128) -> Result<()> {
+        Self::add_amount(
+            &mut self.entry_mut(token).unprocessed_deposits,
+            U256::from(amount),
+            "unprocessed deposit liability overflow",
+        )
+    }
+
+    fn add_pending_refund(&mut self, token: Address, amount: u128) -> Result<()> {
+        Self::add_amount(
+            &mut self.entry_mut(token).pending_refunds,
+            U256::from(amount),
+            "pending refund liability overflow",
+        )
+    }
+
+    fn claim_refund(&mut self, token: Address, amount: u128) -> Result<()> {
+        let funds = self.entry_mut(token);
+        let amount = U256::from(amount);
+        let next = funds.pending_refunds.checked_sub(amount).ok_or_else(|| {
+            eyre::eyre!(
+                "portal refund claims exceed pending refunds for token {token}: claim={amount}, pending={}",
+                funds.pending_refunds
+            )
+        })?;
+        funds.pending_refunds = next;
+        Ok(())
+    }
+
+    fn add_withdrawals(&mut self, withdrawals: &[abi::Withdrawal]) -> Result<()> {
+        for withdrawal in withdrawals {
+            let amount = U256::from(withdrawal.amount);
+            let fee = U256::from(withdrawal.fee);
+            let liability = amount.checked_add(fee).ok_or_else(|| {
+                eyre::eyre!(
+                    "withdrawal liability overflow for token {}",
+                    withdrawal.token
+                )
+            })?;
+            Self::add_amount(
+                &mut self.entry_mut(withdrawal.token).pending_withdrawals,
+                liability,
+                "pending withdrawal liability overflow",
+            )?;
+        }
+        Ok(())
+    }
+
+    fn liability(funds: &TokenFunds) -> Result<U256> {
+        let deposits_and_refunds = funds
+            .unprocessed_deposits
+            .checked_add(funds.pending_refunds)
+            .ok_or_else(|| eyre::eyre!("token funds liability overflow"))?;
+        deposits_and_refunds
+            .checked_add(funds.pending_withdrawals)
+            .ok_or_else(|| eyre::eyre!("token funds liability overflow"))
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Address, &TokenFunds)> {
+        self.tokens.iter()
+    }
+
+    fn entry_mut(&mut self, token: Address) -> &mut TokenFunds {
+        self.tokens.entry(token).or_default()
+    }
+
+    fn add_amount(field: &mut U256, amount: U256, context: &'static str) -> Result<()> {
+        let next = (*field)
+            .checked_add(amount)
+            .ok_or_else(|| eyre::eyre!(context))?;
+        *field = next;
+        Ok(())
+    }
+}
 
 /// Configuration for the [`ZoneMonitor`].
 #[derive(Debug, Clone)]
@@ -310,6 +419,15 @@ impl ZoneMonitor {
                 }
                 Ok(false) => {}
                 Err(e) => {
+                    if e.downcast_ref::<CircuitBreakerTripped>().is_some() {
+                        error!(
+                            from,
+                            to = latest_zone_block,
+                            error = %e,
+                            "Zone monitor halted by runtime solvency circuit breaker"
+                        );
+                        return Err(e);
+                    }
                     error!(from, to = latest_zone_block, error = %e, "Failed to process zone block range");
                     continue;
                 }
@@ -551,6 +669,219 @@ impl ZoneMonitor {
         })
     }
 
+    async fn verify_funds_ledger(
+        &self,
+        next_processed_deposit_number: u64,
+        current_batch_withdrawals: &[abi::Withdrawal],
+    ) -> Result<()> {
+        let violations = self
+            .funds_invariant_violations(next_processed_deposit_number, current_batch_withdrawals)
+            .await?;
+        if violations.is_empty() {
+            return Ok(());
+        }
+
+        self.trip_funds_circuit_breaker(violations).await
+    }
+
+    async fn funds_invariant_violations(
+        &self,
+        next_processed_deposit_number: u64,
+        current_batch_withdrawals: &[abi::Withdrawal],
+    ) -> Result<Vec<FundsInvariantViolation>> {
+        let ledger = self
+            .build_funds_ledger(next_processed_deposit_number, current_batch_withdrawals)
+            .await?;
+        let portal = ZonePortal::new(
+            self.config.portal_address,
+            self.batch_submitter.l1_provider().clone(),
+        );
+        let mut violations = Vec::new();
+
+        for (token, funds) in ledger.iter() {
+            let liability = FundsLedger::liability(funds)?;
+            if liability.is_zero() {
+                continue;
+            }
+
+            let accounted_balance = portal.accountedBalance(*token).call().await?;
+            if accounted_balance < liability {
+                violations.push(FundsInvariantViolation {
+                    token: *token,
+                    accounted_balance,
+                    required_liability: liability,
+                    funds: funds.clone(),
+                });
+                continue;
+            }
+
+            info!(
+                token = %token,
+                accounted_balance = %accounted_balance,
+                required_liability = %liability,
+                unprocessed_deposits = %funds.unprocessed_deposits,
+                pending_refunds = %funds.pending_refunds,
+                pending_withdrawals = %funds.pending_withdrawals,
+                "Portal accounted funds invariant passed"
+            );
+        }
+
+        Ok(violations)
+    }
+
+    async fn build_funds_ledger(
+        &self,
+        next_processed_deposit_number: u64,
+        current_batch_withdrawals: &[abi::Withdrawal],
+    ) -> Result<FundsLedger> {
+        let mut ledger = FundsLedger::default();
+
+        let pending = self
+            .batch_submitter
+            .fetch_pending_withdrawals(&self.provider, self.config.outbox_address)
+            .await?;
+        for withdrawals in pending.values() {
+            ledger.add_withdrawals(withdrawals)?;
+        }
+        ledger.add_withdrawals(current_batch_withdrawals)?;
+
+        let portal = ZonePortal::new(
+            self.config.portal_address,
+            self.batch_submitter.l1_provider().clone(),
+        );
+        let genesis_tempo_block_number = self
+            .batch_submitter
+            .read_genesis_tempo_block_number()
+            .await?;
+        let l1_tip = self
+            .batch_submitter
+            .l1_provider()
+            .get_block_number()
+            .await?;
+
+        let regular_deposits = portal
+            .DepositMade_filter()
+            .from_block(genesis_tempo_block_number)
+            .to_block(l1_tip)
+            .chunked()
+            .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+            .concurrent(2)
+            .query()
+            .await?;
+        for (event, _) in regular_deposits {
+            if event.depositNumber > next_processed_deposit_number {
+                ledger.add_unprocessed_deposit(event.token, event.netAmount)?;
+            }
+        }
+
+        let encrypted_deposits = portal
+            .EncryptedDepositMade_filter()
+            .from_block(genesis_tempo_block_number)
+            .to_block(l1_tip)
+            .chunked()
+            .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+            .concurrent(2)
+            .query()
+            .await?;
+        for (event, _) in encrypted_deposits {
+            if event.depositNumber > next_processed_deposit_number {
+                ledger.add_unprocessed_deposit(event.token, event.netAmount)?;
+            }
+        }
+
+        let withdrawal_bouncebacks = portal
+            .WithdrawalBounceBack_filter()
+            .from_block(genesis_tempo_block_number)
+            .to_block(l1_tip)
+            .chunked()
+            .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+            .concurrent(2)
+            .query()
+            .await?;
+        for (event, _) in withdrawal_bouncebacks {
+            if event.depositNumber > next_processed_deposit_number {
+                ledger.add_unprocessed_deposit(event.token, event.amount)?;
+            }
+        }
+
+        let pending_refunds = portal
+            .DepositBounceBackPending_filter()
+            .from_block(genesis_tempo_block_number)
+            .to_block(l1_tip)
+            .chunked()
+            .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+            .concurrent(2)
+            .query()
+            .await?;
+        for (event, _) in pending_refunds {
+            ledger.add_pending_refund(event.token, event.amount)?;
+        }
+
+        let claimed_refunds = portal
+            .RefundClaimed_filter()
+            .from_block(genesis_tempo_block_number)
+            .to_block(l1_tip)
+            .chunked()
+            .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+            .concurrent(2)
+            .query()
+            .await?;
+        for (event, _) in claimed_refunds {
+            ledger.claim_refund(event.token, event.amount)?;
+        }
+
+        Ok(ledger)
+    }
+
+    async fn trip_funds_circuit_breaker(
+        &self,
+        violations: Vec<FundsInvariantViolation>,
+    ) -> Result<()> {
+        self.metrics.funds_ledger_check_failure_total.increment(1);
+        self.metrics.circuit_breaker_tripped_total.increment(1);
+
+        let mut pause_failures = Vec::new();
+        for violation in &violations {
+            match self.batch_submitter.pause_deposits(violation.token).await {
+                Ok(tx_hash) => {
+                    self.metrics.auto_pause_success_total.increment(1);
+                    error!(
+                        token = %violation.token,
+                        %tx_hash,
+                        accounted_balance = %violation.accounted_balance,
+                        required_liability = %violation.required_liability,
+                        "Auto-paused deposits after portal solvency invariant failure"
+                    );
+                }
+                Err(err) => {
+                    self.metrics.auto_pause_failure_total.increment(1);
+                    let message = format!("{}: {err}", violation.token);
+                    pause_failures.push(message);
+                    error!(
+                        token = %violation.token,
+                        error = %err,
+                        "Failed to auto-pause deposits after portal solvency invariant failure"
+                    );
+                }
+            }
+        }
+
+        let summary = summarize_violations(&violations);
+        let reason = if pause_failures.is_empty() {
+            format!(
+                "runtime solvency circuit breaker tripped; deposits auto-paused and settlement halted: {summary}"
+            )
+        } else {
+            format!(
+                "runtime solvency circuit breaker tripped; settlement halted: {summary}; auto-pause failures: {}",
+                pause_failures.join(", ")
+            )
+        };
+
+        error!(reason = %reason, "Runtime solvency circuit breaker tripped");
+        Err(CircuitBreakerTripped { reason }.into())
+    }
+
     /// Submit a `submitBatch` transaction to the ZonePortal on L1 with exponential
     /// backoff retry.
     ///
@@ -587,6 +918,9 @@ impl ZoneMonitor {
             }
             _ => {}
         }
+
+        self.verify_funds_ledger(batch_data.next_deposit_number, &withdrawals)
+            .await?;
 
         let mut delay = INITIAL_RETRY_DELAY;
 
@@ -867,6 +1201,24 @@ impl ZoneMonitor {
     }
 }
 
+fn summarize_violations(violations: &[FundsInvariantViolation]) -> String {
+    violations
+        .iter()
+        .map(|violation| {
+            format!(
+                "token {} accounted_balance={} required_liability={} unprocessed_deposits={} pending_refunds={} pending_withdrawals={}",
+                violation.token,
+                violation.accounted_balance,
+                violation.required_liability,
+                violation.funds.unprocessed_deposits,
+                violation.funds.pending_refunds,
+                violation.funds.pending_withdrawals,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 /// Spawn the zone monitor as a background task.
 ///
 /// The monitor polls the Zone L2 for finalized batch boundaries and submits
@@ -902,6 +1254,13 @@ pub fn spawn_zone_monitor(
 
         loop {
             if let Err(e) = monitor.run().await {
+                if e.downcast_ref::<CircuitBreakerTripped>().is_some() {
+                    error!(
+                        error = %e,
+                        "Zone monitor halted by runtime solvency circuit breaker; not restarting"
+                    );
+                    return;
+                }
                 error!(error = %e, "Zone monitor failed, restarting in 5s");
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }
@@ -998,6 +1357,67 @@ mod tests {
             portal_withdrawal_queue_tail: 3,
             latest_observed_zone_block: 50,
         }
+    }
+
+    #[test]
+    fn funds_ledger_tracks_withdrawal_amount_and_fee() {
+        let token = Address::repeat_byte(0x10);
+        let mut ledger = FundsLedger::default();
+        ledger
+            .add_withdrawals(&[abi::Withdrawal {
+                token,
+                senderTag: B256::repeat_byte(0x11),
+                to: Address::repeat_byte(0x12),
+                amount: 100,
+                fee: 7,
+                memo: B256::ZERO,
+                gasLimit: 0,
+                fallbackRecipient: Address::repeat_byte(0x12),
+                callbackData: Default::default(),
+                encryptedSender: Default::default(),
+            }])
+            .unwrap();
+
+        let funds = ledger.tokens.get(&token).unwrap();
+        assert_eq!(funds.pending_withdrawals, U256::from(107));
+        assert_eq!(FundsLedger::liability(funds).unwrap(), U256::from(107));
+    }
+
+    #[test]
+    fn funds_ledger_sums_independent_liability_buckets() {
+        let token = Address::repeat_byte(0x10);
+        let mut ledger = FundsLedger::default();
+        ledger.add_unprocessed_deposit(token, 100).unwrap();
+        ledger.add_pending_refund(token, 25).unwrap();
+        ledger
+            .add_withdrawals(&[abi::Withdrawal {
+                token,
+                senderTag: B256::ZERO,
+                to: Address::repeat_byte(0x12),
+                amount: 50,
+                fee: 5,
+                memo: B256::ZERO,
+                gasLimit: 0,
+                fallbackRecipient: Address::repeat_byte(0x12),
+                callbackData: Default::default(),
+                encryptedSender: Default::default(),
+            }])
+            .unwrap();
+
+        let funds = ledger.tokens.get(&token).unwrap();
+        assert_eq!(FundsLedger::liability(funds).unwrap(), U256::from(180));
+    }
+
+    #[test]
+    fn funds_ledger_rejects_refund_claims_without_pending_refunds() {
+        let token = Address::repeat_byte(0x10);
+        let mut ledger = FundsLedger::default();
+
+        let err = ledger.claim_refund(token, 1).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("portal refund claims exceed pending refunds")
+        );
     }
 
     #[tokio::test]

--- a/crates/sequencer/src/nonce_keys.rs
+++ b/crates/sequencer/src/nonce_keys.rs
@@ -17,7 +17,7 @@ pub const SUBMIT_BATCH_NONCE_KEY: U256 = uint!(1_U256);
 /// Nonce key for `processWithdrawal` calls (high throughput, N per batch).
 pub const PROCESS_WITHDRAWAL_NONCE_KEY: U256 = uint!(2_U256);
 
-/// Nonce key for admin operations (`enableToken`, `setZoneGasRate`,
-/// `setSequencerEncryptionKey`, `pauseDeposits`, `resumeDeposits`,
-/// `transferSequencer`). Low frequency, shared key.
+/// Nonce key for low-frequency privileged operations (`enableToken`,
+/// `setZoneGasRate`, `setSequencerEncryptionKey`, `pauseDeposits`,
+/// `resumeDeposits`, `transferSequencer`). Low frequency, shared key.
 pub const ADMIN_OPS_NONCE_KEY: U256 = uint!(3_U256);

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -38,7 +38,7 @@ use futures::{StreamExt, TryStreamExt};
 use tempo_alloy::{TempoNetwork, rpc::TempoCallBuilderExt};
 use tracing::{info, instrument, warn};
 
-use crate::nonce_keys::SUBMIT_BATCH_NONCE_KEY;
+use crate::nonce_keys::{ADMIN_OPS_NONCE_KEY, SUBMIT_BATCH_NONCE_KEY};
 
 /// EIP-2935 stores the last 8192 block hashes, so the usable window is 8191 blocks.
 const DEFAULT_EIP2935_HISTORY_WINDOW: u64 = 8192 - 1;
@@ -450,6 +450,48 @@ impl BatchSubmitter {
     /// Read the portal's `genesisTempoBlockNumber` from L1.
     pub async fn read_genesis_tempo_block_number(&self) -> Result<u64> {
         Ok(self.portal.genesisTempoBlockNumber().call().await?)
+    }
+
+    /// Return the shared L1 provider backing portal reads.
+    pub(crate) fn l1_provider(&self) -> &DynProvider<TempoNetwork> {
+        &self.l1_provider
+    }
+
+    /// Pause new deposits for `token` through the ZonePortal.
+    ///
+    /// The portal permits both admin and sequencer to close deposits; reopening
+    /// remains admin-only. The sequencer uses this as the runtime circuit
+    /// breaker's first containment action before settlement halts.
+    pub async fn pause_deposits(&self, token: Address) -> Result<B256> {
+        let pending = self
+            .portal
+            .pauseDeposits(token)
+            .nonce_key(ADMIN_OPS_NONCE_KEY)
+            .send()
+            .await?;
+
+        let tx_hash = *pending.tx_hash();
+        info!(
+            %tx_hash,
+            %token,
+            timeout_secs = 30,
+            required_confirmations = 1,
+            "pauseDeposits tx accepted by RPC; waiting for confirmation"
+        );
+
+        let receipt = pending
+            .with_required_confirmations(1)
+            .with_timeout(Some(std::time::Duration::from_secs(30)))
+            .get_receipt()
+            .await?;
+
+        if !receipt.status() {
+            return Err(eyre::eyre!(
+                "pauseDeposits tx {tx_hash} for token {token} was included but reverted on L1"
+            ));
+        }
+
+        Ok(tx_hash)
     }
 
     /// Read the current `blockHash` from the ZonePortal on L1.

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -84,7 +84,7 @@ export L1_RPC_URL="wss://rpc.devnet.tempoxyz.dev"
 
 ### 2. Generate Admin and Sequencer Keys
 
-The admin controls portal governance such as token enablement and deposit pause/resume. The sequencer is the operator that builds zone blocks, processes deposits, and submits batch proofs back to L1. The same key may be used for both roles, but pass it explicitly as both `ADMIN_KEY` and `SEQUENCER_KEY` when that is intentional.
+The admin controls portal governance such as token enablement and deposit resume. The admin or sequencer can pause deposits as a one-way safety action. The sequencer is the operator that builds zone blocks, processes deposits, and submits batch proofs back to L1. The same key may be used for both roles, but pass it explicitly as both `ADMIN_KEY` and `SEQUENCER_KEY` when that is intentional.
 
 ```bash
 cast wallet new
@@ -151,7 +151,7 @@ cargo run -p tempo-xtask -- create-zone \
   --private-key "$SEQUENCER_KEY"
 ```
 
-`create-zone` requires the admin address explicitly. Keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token`, `pause-deposits`, and `resume-deposits`.
+`create-zone` requires the admin address explicitly. Keep the matching `ADMIN_KEY` available for admin-only portal calls such as `enable-token` and `resume-deposits`. `pause-deposits` can be signed by either the admin or sequencer.
 
 ### 5. Start the Zone Node
 
@@ -384,7 +384,7 @@ just enable-token alphausd
 
 If `ZONE_RPC_URL` is set (defaults to `http://localhost:8546`), the command waits for the zone to process the L1 block and confirms the token is available on L2.
 
-The portal admin can also pause and resume deposits for an enabled token (withdrawals are unaffected). These calls are `onlyAdmin`, so they use the same `ADMIN_KEY` as `enable-token`:
+The portal admin can resume deposits for an enabled token, and either the admin or sequencer can pause them (withdrawals are unaffected):
 
 ```bash
 just pause-deposits <token-address>
@@ -619,7 +619,7 @@ Current deployment:
 | `just send-deposit [amount] [to] [token] [memo]` | Deposit tokens from L1 to zone (defaults to sender) |
 | `just send-deposit-encrypted [amount] [to] [memo] [token] [rpc]` | Encrypted deposit — hides recipient and memo on-chain |
 | `just enable-token <token>` | Enable a TIP-20 token on the portal for bridging (admin only) |
-| `just pause-deposits <token>` | Pause deposits for an enabled token on the portal (admin only) |
+| `just pause-deposits <token>` | Pause deposits for an enabled token on the portal (admin or sequencer) |
 | `just resume-deposits <token>` | Resume deposits for a paused token on the portal (admin only) |
 | `just list-enabled-tokens [portal]` | List TIP-20 token addresses enabled on a portal |
 | `just max-approve-outbox [token] [rpc]` | Approve outbox to spend tokens on zone |

--- a/invariants.md
+++ b/invariants.md
@@ -27,7 +27,7 @@ for auditors, invariant/fuzz test authors, and production monitoring.
 | ID | Assertion | Crit | Impact |
 |---|---|---|---|
 | `TEMPO-ZONE-ADMIN-NONZERO` | Portal `admin != address(0)` for every zone | 🟡 | Token governance can become permanently unavailable |
-| `TEMPO-ZONE-ADMIN-ONLY-GOVERNANCE` | Only `admin` can call `enableToken`, `pauseDeposits`, and `resumeDeposits` | 🟡 | A sequencer or user can enable malicious assets or reopen paused deposits |
+| `TEMPO-ZONE-ADMIN-ONLY-GOVERNANCE` | Only `admin` can call `enableToken` and `resumeDeposits`; only `admin` or `sequencer` can call `pauseDeposits` | 🟡 | A sequencer or user can enable malicious assets or reopen paused deposits |
 | `TEMPO-ZONE-SEQUENCER-ONLY-OPS` | Only the registered sequencer can set gas rates, set encryption keys, set RPC URL, submit batches, and process withdrawals | 🟡 | Unauthorized operators can censor, misprice, settle, or drain queued work |
 | `TEMPO-ZONE-SEQUENCER-TWO-STEP` | Sequencer changes only complete when `pendingSequencer` accepts, and acceptance clears `pendingSequencer` | 🟡 | Sequencer control can be accidentally or maliciously transferred |
 | `TEMPO-ZONE-GAS-RATE-BOUNDED` | `zoneGasRate` and `tempoGasRate` never exceed `MAX_GAS_FEE_RATE` | 🟢 | Deposit or withdrawal fee math may overflow or become economically unusable |
@@ -41,6 +41,7 @@ for auditors, invariant/fuzz test authors, and production monitoring.
 | `TEMPO-ZONE-MESSENGER-APPROVAL` | For every enabled token, the portal approves the zone messenger for callback withdrawals | 🟡 | Callback withdrawals can fail even when the portal holds enough funds |
 | `TEMPO-ZONE-SUPPLY-SOLVENCY` | For each token, zone-side total supply equals accepted deposits plus withdrawal bounce-backs minus requested withdrawals minus deposit bounce-backs | 🔴 | The zone can mint unbacked tokens or burn user funds without matching L1 release |
 | `TEMPO-ZONE-PORTAL-SOLVENCY` | Portal token balance plus paid-out/parked refunds is sufficient for all unwithdrawn zone supply and pending withdrawals | 🔴 | Portal cannot honor exits, causing direct loss or insolvency |
+| `TEMPO-ZONE-RUNTIME-CIRCUIT-BREAKER` | Sequencer halts settlement and pauses deposits for any token whose portal-accounted balance is below computed liabilities | 🔴 | A detected insolvency can keep accepting new deposits or continue settling unsafe batches |
 | `TEMPO-ZONE-MINT-BURN-AUTHORITY` | Only `ZoneInbox` can mint zone tokens and only `ZoneOutbox` can burn zone tokens | 🔴 | Unauthorized mint or burn breaks bridge accounting and can steal or destroy funds |
 
 ### Deposits

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -347,6 +347,7 @@ interface IZoneTxContext {
 //   slot 13: _withdrawalQueue.slots (mapping(uint256 => bytes32))
 //   slot 14: rpcUrl (string)
 //   slot 15: pendingAdmin (address)
+//   slot 16: accountedBalance (mapping(address => uint256))
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via
@@ -796,6 +797,8 @@ interface IZonePortal {
     function processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) external;
 
     function refunds(address token, address owner) external view returns (uint128);
+
+    function accountedBalance(address token) external view returns (uint256);
 
     function claimRefund(address token) external returns (uint128 amount);
 

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -128,6 +128,13 @@ contract ZonePortal is IZonePortal {
     /// @notice Pending admin for two-step admin transfer
     address public pendingAdmin;
 
+    /// @notice Protocol-accounted escrow per token, excluding external donations.
+    /// @dev This records only funds that enter or leave through portal protocol
+    ///      paths. It backs zone supply, unprocessed deposits, pending withdrawals,
+    ///      and pending refunds; direct token transfers to this contract do not
+    ///      increase it.
+    mapping(address token => uint256 amount) public accountedBalance;
+
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -167,6 +174,11 @@ contract ZonePortal is IZonePortal {
 
     modifier onlyAdmin() {
         if (msg.sender != admin) revert NotAdmin();
+        _;
+    }
+
+    modifier onlyAdminOrSequencer() {
+        if (msg.sender != admin && msg.sender != sequencer) revert NotAdmin();
         _;
     }
 
@@ -289,9 +301,9 @@ contract ZonePortal is IZonePortal {
         _enableTokenInternal(_token);
     }
 
-    /// @notice Pause deposits for a token. Only callable by admin.
+    /// @notice Pause deposits for a token. Callable by admin or sequencer.
     /// @dev Does not affect withdrawal processing (non-custodial guarantee).
-    function pauseDeposits(address _token) external onlyAdmin {
+    function pauseDeposits(address _token) external onlyAdminOrSequencer {
         if (!_tokenConfigs[_token].enabled) revert TokenNotEnabled();
         _tokenConfigs[_token].depositsActive = false;
         emit DepositsPaused(_token);
@@ -520,6 +532,7 @@ contract ZonePortal is IZonePortal {
         if (fee > 0) {
             ITIP20(_token).transfer(sequencer, fee);
         }
+        accountedBalance[_token] += netAmount;
     }
 
     function _recordDeposit(bytes32 newCurrentDepositQueueHash)
@@ -706,6 +719,7 @@ contract ZonePortal is IZonePortal {
         }
 
         if (withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) {
+            accountedBalance[_token] -= withdrawal.fee;
             _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
             emit WithdrawalProcessed(
                 withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, false
@@ -734,7 +748,10 @@ contract ZonePortal is IZonePortal {
 
         if (!success) {
             // Callback failed: bounce back to zone (only amount, not fee)
+            accountedBalance[_token] -= withdrawal.fee;
             _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
+        } else {
+            accountedBalance[_token] -= uint256(withdrawal.amount) + withdrawal.fee;
         }
         emit WithdrawalProcessed(
             withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, success
@@ -758,8 +775,10 @@ contract ZonePortal is IZonePortal {
         bool success = _tryTransfer(_token, withdrawal.to, refundAmount);
 
         if (success) {
+            accountedBalance[_token] -= withdrawal.amount;
             emit DepositBounceBack(withdrawal.to, _token, refundAmount, bouncebackFee);
         } else {
+            accountedBalance[_token] -= bouncebackFee;
             refunds[_token][withdrawal.to] += refundAmount;
             emit DepositBounceBackPending(withdrawal.to, _token, refundAmount, bouncebackFee);
         }
@@ -770,6 +789,7 @@ contract ZonePortal is IZonePortal {
         refunds[token][msg.sender] = 0;
 
         if (!_tryTransfer(token, msg.sender, amount)) revert CallbackRejected();
+        accountedBalance[token] -= amount;
 
         emit RefundClaimed(msg.sender, token, amount);
     }

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -258,8 +258,22 @@ contract ZonePortalTest is BaseTest {
         assertTrue(portal.areDepositsActive(address(pathUSD)));
     }
 
-    function test_tokenGovernance_revertsIfNotAdmin() public {
+    function test_sequencerCanPauseButNotResumeOrEnableDeposits() public {
+        vm.prank(sequencer);
+        portal.pauseDeposits(address(pathUSD));
+        assertFalse(portal.areDepositsActive(address(pathUSD)));
+
         vm.startPrank(sequencer);
+        vm.expectRevert(IZonePortal.NotAdmin.selector);
+        portal.resumeDeposits(address(pathUSD));
+
+        vm.expectRevert(IZonePortal.NotAdmin.selector);
+        portal.enableToken(address(pathUSD));
+        vm.stopPrank();
+    }
+
+    function test_tokenGovernance_revertsIfCallerIsNeitherAdminNorSequencer() public {
+        vm.startPrank(alice);
         vm.expectRevert(IZonePortal.NotAdmin.selector);
         portal.pauseDeposits(address(pathUSD));
 
@@ -783,6 +797,81 @@ contract ZonePortalTest is BaseTest {
         // Slot should be cleared (back to EMPTY_SENTINEL), head advanced to 1
         assertEq(portal.withdrawalQueueSlot(0), EMPTY_SENTINEL);
         assertEq(portal.withdrawalQueueHead(), 1);
+    }
+
+
+    function test_accountedBalance_tracksDepositAndSuccessfulWithdrawal() public {
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""), alice);
+        vm.stopPrank();
+
+        assertEq(portal.accountedBalance(address(pathUSD)), 1000e6);
+
+        Withdrawal memory w =
+            _withdrawal(address(pathUSD), alice, bob, 400e6, bytes32(0), 0, alice, "");
+        w.fee = 7e6;
+        bytes32 wHash = keccak256(abi.encode(w, EMPTY_SENTINEL));
+
+        vm.roll(block.number + 1);
+        portal.submitBatch(
+            uint64(block.number - 1),
+            0,
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s1") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: portal.currentDepositQueueHash(),
+                prevDepositNumber: 0,
+                nextDepositNumber: 1
+            }),
+            wHash,
+            "",
+            ""
+        );
+
+        portal.processWithdrawal(w, bytes32(0));
+
+        assertEq(portal.accountedBalance(address(pathUSD)), 593e6);
+    }
+
+    function test_accountedBalance_tracksFailedWithdrawalFeeOnly() public {
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32(""), alice);
+        vm.stopPrank();
+
+        Withdrawal memory w = _withdrawal(
+            address(pathUSD),
+            alice,
+            address(gasConsumingReceiver),
+            400e6,
+            bytes32(0),
+            50_000,
+            bob,
+            ""
+        );
+        w.fee = 7e6;
+        bytes32 wHash = keccak256(abi.encode(w, EMPTY_SENTINEL));
+
+        vm.roll(block.number + 1);
+        portal.submitBatch(
+            uint64(block.number - 1),
+            0,
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("s2") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: portal.currentDepositQueueHash(),
+                prevDepositNumber: 0,
+                nextDepositNumber: 1
+            }),
+            wHash,
+            "",
+            ""
+        );
+
+        portal.processWithdrawal(w, bytes32(0));
+
+        assertEq(portal.accountedBalance(address(pathUSD)), 993e6);
     }
 
     function test_withdrawalQueue_multipleWithdrawalsInBatch() public {
@@ -2712,6 +2801,7 @@ contract ZonePortalTest is BaseTest {
     ///        slot 5: currentDepositQueueHash (bytes32)
     ///        slot 6: deposit counters
     ///        slot 7: _encryptionKeys.length (EncryptionKeyEntry[])
+    ///        slot 16: accountedBalance (mapping(address => uint256))
     function test_storageLayout_slotPositions() public {
         // --- Slot 0: sequencer ---
         bytes32 slot0 = vm.load(address(portal), bytes32(uint256(0)));
@@ -2772,6 +2862,19 @@ contract ZonePortalTest is BaseTest {
             address(uint160(uint256(slot15))),
             portal.pendingAdmin(),
             "slot 15: pendingAdmin mismatch"
+        );
+
+        // --- Slot 16: accountedBalance mapping ---
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32("layout"), alice);
+        vm.stopPrank();
+        bytes32 accountedSlot = keccak256(abi.encode(address(pathUSD), uint256(16)));
+        bytes32 accountedFromSlot = vm.load(address(portal), accountedSlot);
+        assertEq(
+            uint256(accountedFromSlot),
+            portal.accountedBalance(address(pathUSD)),
+            "slot 16: accountedBalance mapping mismatch"
         );
     }
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -122,7 +122,7 @@ This document specifies the zone protocol: deployment, sequencer operations, dep
 
 ## System Overview
 
-Each zone is operated by a **sequencer** that collects transactions, produces blocks, generates proofs, and submits batches to Tempo. A single registered address controls sequencer operations for each zone. Each zone also has a separate **admin** role that holds governance powers (enabling tokens, configuring deposit pause/resume); see [Access Control](#access-control). **Users** deposit TIP-20 tokens from Tempo into the zone, transact privately, and withdraw back to Tempo.
+Each zone is operated by a **sequencer** that collects transactions, produces blocks, generates proofs, and submits batches to Tempo. A single registered address controls sequencer operations for each zone. Each zone also has a separate **admin** role that holds governance powers (enabling tokens and resuming deposits); both admin and sequencer may pause deposits as a one-way safety action; see [Access Control](#access-control). **Users** deposit TIP-20 tokens from Tempo into the zone, transact privately, and withdraw back to Tempo.
 
 On the Tempo side, an onchain **verifier** contract validates that each batch was executed correctly. The verifier is abstracted behind a minimal interface (`IVerifier`) and is proof-agnostic. Any proving backend (ZK, TEE, or otherwise) can implement the interface. The portal does not care how the proof was produced.
 
@@ -174,7 +174,7 @@ Each zone has two privileged roles registered on the [`ZonePortal`](#izoneportal
 
 **Admin.**
 
-- Holds governance powers over the zone (token enablement, deposit pause/resume).
+- Holds governance powers over the zone (token enablement and deposit resume; deposit pause is shared with the sequencer).
 - Expected to be a cold key, multisig, or governance contract.
 - Set at zone creation via [`IZoneFactory.createZone`](#izonefactory).
 - Rotatable via a two-step transfer (see [Admin Transfer](#admin-transfer)), so a lost or compromised admin key can be moved to a new cold key or multisig.
@@ -198,7 +198,7 @@ The following table lists every privileged action and the role authorized to inv
 | Action | Contract | Authorized caller |
 |---|---|---|
 | `enableToken(token)` | [`ZonePortal`](#izoneportal) | **admin** |
-| `pauseDeposits(token)` | [`ZonePortal`](#izoneportal) | **admin** |
+| `pauseDeposits(token)` | [`ZonePortal`](#izoneportal) | **admin or sequencer** |
 | `resumeDeposits(token)` | [`ZonePortal`](#izoneportal) | **admin** |
 | `transferAdmin(newAdmin)` | [`ZonePortal`](#izoneportal) | **admin** |
 | `acceptAdmin()` | [`ZonePortal`](#izoneportal) | **pending admin** |
@@ -216,7 +216,7 @@ The following table lists every privileged action and the role authorized to inv
 
 Rationale notes:
 
-- **Token enablement and deposit pause/resume are admin-only** because they govern what the zone is and which deposit flows are open. A compromised sequencer hot key MUST NOT be able to enable arbitrary tokens or unilaterally re-open paused deposits.
+- **Token enablement and deposit resume are admin-only** because they govern what the zone is and which deposit flows are open. The sequencer may pause deposits to contain runtime solvency or invariant failures, but a compromised sequencer hot key MUST NOT be able to enable arbitrary tokens or unilaterally re-open paused deposits.
 - **Gas rates are sequencer-controlled** because the sequencer takes the economic risk on gas-price fluctuations and needs to react quickly to operational events without involving the cold key.
 - **Encryption key management is sequencer-only** because the proof of possession requires the encryption private key.
 - **Zone-side system calls** to `ZoneOutbox` may use `msg.sender == address(0)` so the block builder can inject protocol system transactions. Ordinary user transactions must come from the registered sequencer address for these calls.
@@ -231,7 +231,7 @@ A zone is created via `ZoneFactory.createZone(...)` on Tempo with the following 
 | Parameter | Description |
 |-----------|-------------|
 | `initialToken` | The first TIP-20 token to enable. The admin can enable additional tokens later. |
-| `admin` | The address that holds the admin role for the zone (token enablement, deposit pause/resume). MUST NOT be the zero address. May be the same as `sequencer`. See [Access Control](#access-control). |
+| `admin` | The address that holds the admin role for the zone (token enablement and deposit resume; pause is shared with the sequencer). MUST NOT be the zero address. May be the same as `sequencer`. See [Access Control](#access-control). |
 | `sequencer` | The address that will operate the zone (block production, batch submission, withdrawal processing). |
 | `verifier` | The `IVerifier` contract used to validate batch proofs. |
 | `zoneParams` | Genesis configuration: genesis block hash, genesis Tempo block hash, and genesis Tempo block number. |
@@ -290,13 +290,25 @@ The zone-side supply of each token always equals net deposits minus net withdraw
 
 ### Token Management
 
-The admin manages which TIP-20 tokens are available on the zone (see [Access Control](#access-control)):
+The admin manages which TIP-20 tokens are available on the zone, while the admin or sequencer may close deposits for an enabled token (see [Access Control](#access-control)):
 
 - `enableToken(token)`: Enable a new TIP-20 for deposits and withdrawals. This is **irreversible**. Once enabled, a token can never be disabled.
-- `pauseDeposits(token)`: Pause new deposits for a token. Does not affect withdrawals.
+- `pauseDeposits(token)`: Pause new deposits for a token. Callable by the admin or sequencer. Does not affect withdrawals.
 - `resumeDeposits(token)`: Resume deposits for a previously paused token.
 
-The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin can halt deposits but cannot disable withdrawals for an enabled token. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
+The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin or sequencer can halt deposits but cannot disable withdrawals for an enabled token. Only the admin can resume deposits. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
+
+### Runtime Solvency Circuit Breaker
+
+The sequencer MUST verify portal-accounted funds before submitting each finalized batch. For every token with outstanding liabilities, the sequencer computes:
+
+- unprocessed deposit amounts with `depositNumber > nextProcessedDepositNumber`,
+- pending deposit-bounce-back refunds that have not been claimed,
+- pending withdrawal queue amounts and fees, including the batch about to be submitted.
+
+The portal exposes `accountedBalance(token)`, which tracks funds that entered through protocol deposit paths and have not been released, paid as protocol fees, or converted into unaccounted surplus. Direct token transfers to the portal do not increase this value.
+
+If `accountedBalance(token)` is lower than the computed liability for any token, the sequencer MUST NOT submit the batch. It MUST call `pauseDeposits(token)` for each failing token and then halt settlement until an operator investigates and restarts with a corrected state or upgraded binary. Withdrawals remain processable for already-submitted batches; `resumeDeposits(token)` remains admin-only.
 
 ### Gas Rate Configuration
 
@@ -1705,6 +1717,7 @@ interface IZonePortal {
     function tokenConfig(address token) external view returns (TokenConfig memory);
     function enabledTokenCount() external view returns (uint256);
     function enabledTokenAt(uint256 index) external view returns (address);
+    function accountedBalance(address token) external view returns (uint256);
 
     // Zone RPC endpoint. Published on-chain so clients can discover how to reach the zone.
     event RpcUrlUpdated(string rpcUrl);


### PR DESCRIPTION
## Summary

Adds a runtime solvency circuit breaker for zone settlement. The sequencer now builds a per-token funds ledger before submitting a finalized batch, compares computed liabilities against the portal's protocol-accounted balance, pauses deposits for violating tokens, and halts settlement instead of submitting an unsafe batch.

This also exposes `accountedBalance(token)` on the portal reference implementation and ABI, updates portal accounting for deposits, withdrawals, bounce-backs, and refund claims, and allows the sequencer to pause deposits while keeping resume and token enablement admin-only.

Docs, invariants, and operator commands were updated to reflect the sequencer pause authority and the runtime solvency check.

## Validation

- `cargo test -p zone-sequencer`
- `git diff --check`
- `forge test --match-contract ZonePortalTest` compiles, then fails in local setup before test bodies with missing Tempo `BlockHashHistory` precompile at `0x0000F90827F1C53a10cb7A02335B175320002935` under standard Forge.