### PR TITLE
ci: Add GitHub Actions scanner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-latest
+    - depot-ubuntu-latest-4
+    - depot-ubuntu-latest-16

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0

--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: shortsha
-        run: echo "shortsha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+        run: echo "shortsha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker images
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: shortsha
-        run: echo "shortsha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+        run: echo "shortsha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker images
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly
+      - uses: dtolnay/rust-toolchain@efcb852328a9f50117170cc43094fb6f09eaf1ae # nightly
         with:
           # Pin nightly to avoid breakage from str::as_str() stabilization
           # which breaks shellexpand 3.1.1 method resolution.
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly
+      - uses: dtolnay/rust-toolchain@efcb852328a9f50117170cc43094fb6f09eaf1ae # nightly
         with:
           toolchain: nightly-2026-02-21
           components: rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Verify crate version matches tag
         # Check that the Cargo version starts with the tag,
         # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.platform.target }}
 
@@ -145,8 +145,10 @@ jobs:
           cp "$BINARY_PATH" "$BINARY_NAME"
           tar czf "$ARCHIVE_NAME" "$BINARY_NAME"
 
-          echo "archive_name=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
-          echo "archive_path=$ARCHIVE_NAME" >> $GITHUB_OUTPUT
+          {
+            echo "archive_name=$ARCHIVE_NAME"
+            echo "archive_path=$ARCHIVE_NAME"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate checksums
         shell: bash

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -41,9 +41,11 @@ jobs:
           set -euo pipefail
           SHORT=$(git rev-parse --short=7 HEAD)
           SHA=$(git rev-parse HEAD)
-          echo "version=sha-$SHORT" >> "$GITHUB_OUTPUT"
-          echo "artifact=reproducible-hash-${SHA}" >> "$GITHUB_OUTPUT"
-          echo "bin=tempo-zone-sha-${SHORT}-x86_64-unknown-linux-gnu" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=sha-$SHORT"
+            echo "artifact=reproducible-hash-${SHA}"
+            echo "bin=tempo-zone-sha-${SHORT}-x86_64-unknown-linux-gnu"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -67,14 +67,16 @@ jobs:
         id: hash
         env:
           BIN: ${{ steps.cfg.outputs.bin }}
+          REF_INPUT: ${{ inputs.ref }}
+          VERSION: ${{ steps.cfg.outputs.version }}
         run: |
           set -euo pipefail
           mv out/tempo-zone "$BIN"
           shasum -a 256 "$BIN" > "${BIN}.reproducible.sha256"
           echo "::group::Reproducible verification result"
-          echo "ref_input         = ${{ inputs.ref }}"
+          echo "ref_input         = $REF_INPUT"
           echo "commit            = $(git rev-parse HEAD)"
-          echo "version           = ${{ steps.cfg.outputs.version }}"
+          echo "version           = $VERSION"
           echo "binary            = $BIN"
           echo "SOURCE_DATE_EPOCH = $(git log -1 --pretty=%ct)"
           cat "${BIN}.reproducible.sha256"

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -13,12 +13,12 @@ on:
   schedule:
     - cron: "19 7 * * 1"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   scan:
     name: Scan GitHub Actions
     uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
     permissions:
+      actions: read
       contents: read

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -1,0 +1,24 @@
+name: Scan GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "19 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan GitHub Actions
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
+    permissions:
+      contents: read

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -95,7 +95,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0


### PR DESCRIPTION
## Summary
- add the pinned `tempoxyz/gh-actions` GitHub Actions scanner workflow
- fix existing zizmor/actionlint findings without adding ignore baselines
- pin mutable reusable workflow/action refs and move unsafe template expressions through env where needed

Prompted by: @0xalpharush

## Validation
- `uvx zizmor --offline .github/workflows`: passes locally
- `actionlint`: passes locally
