### PR TITLE
feat(precompiles): pass `zoneId` to verifier

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -375,6 +375,7 @@ interface IVerifier {
     ///      6. ZoneOutbox.lastBatch().withdrawalQueueHash matches withdrawalQueueHash
     ///      7. Zone block beneficiary matches sequencer
     ///      8. Deposit processing is correct (validated via Tempo state read inside proof)
+    /// @param zoneId Unique identifier of the zone whose batch is being verified
     /// @param tempoBlockNumber Block zone committed to (from TempoState)
     /// @param anchorBlockNumber Block whose hash is verified (tempoBlockNumber or recent block)
     /// @param anchorBlockHash Hash of anchorBlockNumber (from EIP-2935)
@@ -386,6 +387,7 @@ interface IVerifier {
     /// @param verifierConfig Opaque payload for verifier (TEE attestation envelope, etc.)
     /// @param proof Validity proof or TEE attestation
     function verify(
+        uint32 zoneId,
         uint64 tempoBlockNumber,
         uint64 anchorBlockNumber,
         bytes32 anchorBlockHash,

--- a/specs/ref-impls/src/tempo/Verifier.sol
+++ b/specs/ref-impls/src/tempo/Verifier.sol
@@ -11,6 +11,7 @@ contract Verifier is IVerifier {
 
     /// @inheritdoc IVerifier
     function verify(
+        uint32,
         uint64,
         uint64,
         bytes32,

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -898,6 +898,7 @@ contract ZonePortal is IZonePortal {
         // Verify proof (handles both direct and ancestry modes)
         bool valid = IVerifier(verifier)
             .verify(
+                zoneId,
                 tempoBlockNumber,
                 anchorBlockNumber,
                 anchorBlockHash,

--- a/specs/ref-impls/test/mocks/MockVerifier.sol
+++ b/specs/ref-impls/test/mocks/MockVerifier.sol
@@ -14,6 +14,7 @@ contract MockVerifier is IVerifier {
     }
 
     function verify(
+        uint32, // zoneId
         uint64, // tempoBlockNumber
         uint64, // anchorBlockNumber
         bytes32, // anchorBlockHash

--- a/specs/ref-impls/test/tempo/Verifier.t.sol
+++ b/specs/ref-impls/test/tempo/Verifier.t.sol
@@ -15,6 +15,7 @@ contract VerifierTest is Test {
         bool ok = verifier.verify(
             1,
             1,
+            1,
             bytes32("anchor"),
             1,
             address(0x1234),

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1372,6 +1372,7 @@ The portal calls the verifier to validate each batch:
 ```solidity
 interface IVerifier {
     function verify(
+        uint32 zoneId,
         uint64 tempoBlockNumber,
         uint64 anchorBlockNumber,
         bytes32 anchorBlockHash,
@@ -1386,7 +1387,7 @@ interface IVerifier {
 }
 ```
 
-The portal computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)) and passes them alongside the portal's current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex` and the registered `sequencer` address. The `verifierConfig` and `proof` are opaque to the portal.
+The portal passes its `zoneId`, computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)), and passes them alongside the portal's current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex` and the registered `sequencer` address. The `verifierConfig` and `proof` are opaque to the portal.
 
 ### Anchor Block Validation
 


### PR DESCRIPTION
## Summary

Add `zoneId` argument to `IVerifier.verify`.  `ZonePortal` now forwards its immutable zone ID to the configured verifier for every batch verification.