### PR TITLE
fix: Use block numbers instead of wall clock for batch boundaries

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -10,7 +10,7 @@ use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 use zone_evm::ZoneEvmConfig;
-use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL;
+use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
 
 use crate::{
     ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig,
@@ -71,7 +71,7 @@ impl ZoneCli {
                 args.l1_fetch_concurrency,
                 Duration::from_millis(args.l1_retry_connection_interval_ms),
             )
-            .with_withdrawal_batch_interval(Duration::from_secs(args.zone_batch_interval_secs))
+            .with_withdrawal_batch_interval_blocks(args.zone_batch_interval_blocks)
             .with_private_rpc(ZonePrivateRpcConfig {
                 private_rpc_port: args.private_rpc_port,
                 zone_id: args.zone_id,
@@ -89,7 +89,7 @@ impl ZoneCli {
                     sequencer_signer,
                     zone_id: args.zone_id,
                     zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
-                    batch_interval: Duration::from_secs(args.zone_batch_interval_secs),
+                    batch_interval_blocks: args.zone_batch_interval_blocks,
                     batch_anchor_config: BatchAnchorConfig::default(),
                     withdrawal_poll_interval: Duration::from_secs(
                         args.withdrawal_poll_interval_secs,
@@ -134,13 +134,17 @@ pub struct ZoneArgs {
     )]
     pub zone_poll_interval_secs: u64,
 
-    /// Maximum time (in seconds) between withdrawal batch boundaries.
+    /// Number of zone blocks between withdrawal batch boundaries.
+    ///
+    /// Also used by the sequencer monitor to decide when enough chain progress has
+    /// occurred to look for empty finalized batches to submit to L1. Default 120 is
+    /// ~1 minute at Tempo's expected 500 ms block time.
     #[arg(
-        long = "zone.batch-interval-secs",
-        env = "ZONE_BATCH_INTERVAL_SECS",
-        default_value_t = DEFAULT_WITHDRAWAL_BATCH_INTERVAL.as_secs()
+        long = "zone.batch-interval-blocks",
+        env = "ZONE_BATCH_INTERVAL_BLOCKS",
+        default_value_t = DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS
     )]
-    pub zone_batch_interval_secs: u64,
+    pub zone_batch_interval_blocks: u64,
 
     /// How often (in seconds) the withdrawal processor polls the L1 queue.
     #[arg(

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -66,7 +66,8 @@ use zone_l1::{
     },
 };
 use zone_payload::{
-    DEFAULT_WITHDRAWAL_BATCH_INTERVAL, ZonePayloadAttributes, ZonePayloadFactory, ZonePayloadTypes,
+    DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, ZonePayloadAttributes, ZonePayloadFactory,
+    ZonePayloadTypes,
 };
 use zone_sequencer::{BatchAnchorConfig, ZoneSequencerConfig, spawn_zone_sequencer};
 
@@ -82,8 +83,8 @@ pub struct ZoneSequencerAddOnsConfig {
     pub zone_id: u32,
     /// How often the zone monitor polls for new L2 blocks.
     pub zone_poll_interval: Duration,
-    /// Maximum time between withdrawal batch boundaries/submissions.
-    pub batch_interval: Duration,
+    /// Number of zone blocks between withdrawal batch boundaries / L1 submissions.
+    pub batch_interval_blocks: u64,
     /// EIP-2935 history and safety-margin limits used by the batch submitter.
     pub batch_anchor_config: BatchAnchorConfig,
     /// How often the withdrawal processor polls the L1 queue.
@@ -121,8 +122,8 @@ pub struct ZoneNode {
     /// Optional pre-configured list of enabled token addresses. When set, the
     /// startup L1 RPC query for `enabledTokenCount`/`enabledTokens` is skipped.
     initial_tokens: Option<Vec<Address>>,
-    /// Maximum chain-time duration between withdrawal batch finalizations.
-    withdrawal_batch_interval: Duration,
+    /// Number of zone blocks between withdrawal batch boundaries.
+    withdrawal_batch_interval_blocks: u64,
     /// Private RPC config.
     private_rpc_config: ZonePrivateRpcConfig,
     /// Optional sequencer config. When set, sequencer tasks are spawned.
@@ -167,7 +168,7 @@ impl ZoneNode {
             policy_cache,
             portal_address,
             initial_tokens: None,
-            withdrawal_batch_interval: DEFAULT_WITHDRAWAL_BATCH_INTERVAL,
+            withdrawal_batch_interval_blocks: DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS,
             private_rpc_config: ZonePrivateRpcConfig::default(),
             sequencer_config: None,
         }
@@ -193,10 +194,10 @@ impl ZoneNode {
         self
     }
 
-    /// Set the chain-time interval used by the payload builder for empty
-    /// withdrawal batch finalization.
-    pub fn with_withdrawal_batch_interval(mut self, interval: Duration) -> Self {
-        self.withdrawal_batch_interval = interval;
+    /// Set the number of zone blocks between empty withdrawal batch
+    /// finalization.
+    pub fn with_withdrawal_batch_interval_blocks(mut self, interval_blocks: u64) -> Self {
+        self.withdrawal_batch_interval_blocks = interval_blocks.max(1);
         self
     }
 
@@ -636,7 +637,7 @@ where
             tempo_state_address: TEMPO_STATE_ADDRESS,
             zone_rpc_url,
             zone_poll_interval: config.zone_poll_interval,
-            batch_interval: config.batch_interval,
+            batch_interval_blocks: config.batch_interval_blocks,
             batch_anchor_config: config.batch_anchor_config,
         };
         let seq_handle = spawn_zone_sequencer(sequencer_config, config.sequencer_signer).await;
@@ -722,7 +723,7 @@ where
             self.l1_state_cache.clone(),
             self.policy_cache.clone(),
         );
-        let payload_factory = ZonePayloadFactory::new(self.withdrawal_batch_interval);
+        let payload_factory = ZonePayloadFactory::new(self.withdrawal_batch_interval_blocks);
         Self::components_with_payload_factory(executor_builder, payload_factory)
     }
 

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -369,7 +369,7 @@ async fn test_large_deposit_batch() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Verify empty withdrawal batches finalize on the configured chain-time interval.
+/// Verify empty withdrawal batches finalize at deterministic block boundaries.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -379,13 +379,36 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     let zone_outbox = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, zone.provider());
 
     let initial_batch_index = zone_outbox.withdrawalBatchIndex().call().await?;
-    let initial_zone_block = zone.provider().get_block_number().await?;
+    // Local test nodes finalize empty batches every eight zone blocks.
+    const BATCH_INTERVAL_BLOCKS: u64 = 8;
 
-    // The first fixture block has a large timestamp jump from genesis, so it
-    // closes the first empty batch immediately.
+    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS - 1);
+
+    let before_first_boundary = poll_until(
+        DEFAULT_TIMEOUT,
+        DEFAULT_POLL,
+        "blocks before first empty withdrawal batch boundary",
+        || {
+            let provider = zone.provider();
+            async move {
+                let number = provider.get_block_number().await?;
+                if number >= BATCH_INTERVAL_BLOCKS - 1 {
+                    Ok(Some(number))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    )
+    .await?;
+    assert_eq!(before_first_boundary, BATCH_INTERVAL_BLOCKS - 1);
+    assert_eq!(
+        zone_outbox.withdrawalBatchIndex().call().await?,
+        initial_batch_index,
+        "withdrawalBatchIndex should not advance before a block-number boundary"
+    );
+
     fixture.inject_empty_block(zone.deposit_queue());
-    let first_boundary_block = initial_zone_block + 1;
-
     poll_until(
         DEFAULT_TIMEOUT,
         DEFAULT_POLL,
@@ -404,7 +427,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     )
     .await?;
 
-    fixture.inject_empty_blocks(zone.deposit_queue(), 3);
+    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS - 1);
     poll_until(
         DEFAULT_TIMEOUT,
         DEFAULT_POLL,
@@ -413,7 +436,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
             let provider = zone.provider();
             async move {
                 let number = provider.get_block_number().await?;
-                if number >= first_boundary_block + 3 {
+                if number >= (2 * BATCH_INTERVAL_BLOCKS) - 1 {
                     Ok(Some(number))
                 } else {
                     Ok(None)
@@ -427,7 +450,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     assert_eq!(
         intermediate_batch_index,
         initial_batch_index + 1,
-        "withdrawalBatchIndex should not advance before the configured interval elapses"
+        "withdrawalBatchIndex should not advance before the next block-number boundary"
     );
 
     fixture.inject_empty_blocks(zone.deposit_queue(), 1);
@@ -453,7 +476,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     assert_eq!(
         final_batch_index,
         initial_batch_index + 2,
-        "withdrawalBatchIndex should advance when the configured interval elapses"
+        "withdrawalBatchIndex should advance at the next block-number boundary"
     );
 
     // lastBatch should have zero withdrawalQueueHash (no withdrawals requested)
@@ -748,21 +771,24 @@ async fn test_consecutive_withdrawal_blocks_joined_into_one_batch() -> eyre::Res
     Ok(())
 }
 
-/// Current-only block with interval elapsed finalizes that block's withdrawals.
+/// Current-only block at a batch boundary finalizes that block's withdrawals.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_current_only_block_finalizes_when_interval_elapsed() -> eyre::Result<()> {
+async fn test_current_only_block_finalizes_at_batch_boundary() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
     let (provider, dev_address) = local_dev_zone_account(&zone)?;
     let outbox = ZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
 
+    // Local test nodes finalize empty batches every eight zone blocks.
+    const BATCH_INTERVAL_BLOCKS: u64 = 8;
+
     let batch_index = outbox.withdrawalBatchIndex().call().await?;
-    fixture.inject_empty_block(zone.deposit_queue());
+    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS);
     poll_until(
         DEFAULT_TIMEOUT,
         DEFAULT_POLL,
-        "genesis empty batch closed",
+        "first empty batch boundary closed",
         || {
             let outbox = &outbox;
             async move {
@@ -788,18 +814,49 @@ async fn test_current_only_block_finalizes_when_interval_elapsed() -> eyre::Resu
     .await?;
     approve_outbox(&mut fixture, &zone, &provider).await?;
 
-    // Advance 3 quiet blocks (3s < 4s interval) after the boundary.
-    fixture.inject_empty_blocks(zone.deposit_queue(), 3);
+    // Advance to exactly one block before the next batch boundary, then wait
+    // for those quiet blocks to be built. `inject_empty_blocks` only enqueues
+    // L1 blocks; without this wait the withdrawal can race into one of those
+    // still-building quiet zone blocks.
+    let current_block = zone.provider().get_block_number().await?;
+    let quiet_blocks_until_pre_boundary =
+        (BATCH_INTERVAL_BLOCKS - 1) - (current_block % BATCH_INTERVAL_BLOCKS);
+    let pre_boundary_block = current_block + quiet_blocks_until_pre_boundary;
+    fixture.inject_empty_blocks(zone.deposit_queue(), quiet_blocks_until_pre_boundary);
+    let observed_pre_boundary = poll_until(
+        DEFAULT_TIMEOUT,
+        DEFAULT_POLL,
+        "quiet blocks before withdrawal boundary built",
+        || {
+            let provider = zone.provider();
+            async move {
+                let number = provider.get_block_number().await?;
+                if number >= pre_boundary_block {
+                    Ok(Some(number))
+                } else {
+                    Ok(None)
+                }
+            }
+        },
+    )
+    .await?;
+    assert_eq!(
+        observed_pre_boundary, pre_boundary_block,
+        "zone should be exactly one block before the withdrawal boundary"
+    );
+    assert_eq!((observed_pre_boundary + 1) % BATCH_INTERVAL_BLOCKS, 0);
 
     let batch_index_before = outbox.withdrawalBatchIndex().call().await?;
-    // 4th block after the boundary: interval elapsed, current-only block should finalize.
+    // The next block is a deterministic batch boundary, so it finalizes its
+    // own withdrawal rather than deferring it to the following block.
     let withdrawal_block =
         submit_withdrawal(&mut fixture, &zone, &provider, dev_address, 250_000).await?;
+    assert_eq!(withdrawal_block % BATCH_INTERVAL_BLOCKS, 0);
 
     poll_until(
         DEFAULT_TIMEOUT,
         DEFAULT_POLL,
-        "interval-elapsed current-only block finalized",
+        "batch-boundary current-only block finalized",
         || {
             let outbox = &outbox;
             async move {
@@ -823,7 +880,7 @@ async fn test_current_only_block_finalizes_when_interval_elapsed() -> eyre::Resu
     assert_eq!(
         finalized_logs.len(),
         1,
-        "interval-elapsed current-only block should finalize in the same block"
+        "batch-boundary current-only block should finalize in the same block"
     );
 
     let requested_logs = outbox

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -442,7 +442,7 @@ async fn test_deferred_withdrawal_survives_sequencer_restart() -> eyre::Result<(
         l1.http_url(),
         l1.ws_url(),
         portal_address,
-        std::time::Duration::from_secs(120),
+        10_000,
     )
     .await?;
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -477,7 +477,7 @@ impl ZoneTestNode {
             next_unique_chain_id(),
             Some(genesis),
             signer,
-            Duration::from_secs(4),
+            8,
             initial_tokens,
         )
         .await
@@ -487,7 +487,7 @@ impl ZoneTestNode {
         l1_http_url: &url::Url,
         l1_ws_url: &url::Url,
         portal_address: Address,
-        withdrawal_batch_interval: Duration,
+        withdrawal_batch_interval_blocks: u64,
     ) -> eyre::Result<Self> {
         let (genesis, genesis_block_number) =
             build_l1_anchored_genesis(l1_http_url, portal_address).await?;
@@ -500,7 +500,7 @@ impl ZoneTestNode {
             next_unique_chain_id(),
             Some(genesis),
             signer,
-            withdrawal_batch_interval,
+            withdrawal_batch_interval_blocks,
             Some(vec![]),
         )
         .await
@@ -596,7 +596,7 @@ impl ZoneTestNode {
             chain_id,
             custom_genesis,
             sequencer_signer,
-            Duration::from_secs(4),
+            8,
             Some(vec![]),
         )
         .await
@@ -610,7 +610,7 @@ impl ZoneTestNode {
         chain_id: u64,
         custom_genesis: Option<Genesis>,
         sequencer_signer: alloy_signer_local::PrivateKeySigner,
-        withdrawal_batch_interval: Duration,
+        withdrawal_batch_interval_blocks: u64,
         initial_tokens: Option<Vec<Address>>,
     ) -> eyre::Result<Self> {
         let tasks = Runtime::test();
@@ -631,7 +631,7 @@ impl ZoneTestNode {
             4,
             std::time::Duration::from_millis(100),
         )
-        .with_withdrawal_batch_interval(withdrawal_batch_interval);
+        .with_withdrawal_batch_interval_blocks(withdrawal_batch_interval_blocks);
         if let Some(initial_tokens) = initial_tokens {
             zone_node = zone_node.with_initial_tokens(initial_tokens);
         }
@@ -2479,7 +2479,7 @@ pub(crate) async fn spawn_sequencer_with_anchor_config(
         tempo_state_address: TEMPO_STATE_ADDRESS,
         zone_rpc_url: zone.http_url().to_string(),
         zone_poll_interval: Duration::from_millis(500),
-        batch_interval: Duration::from_millis(500),
+        batch_interval_blocks: 1,
         batch_anchor_config,
     };
 

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -34,10 +34,7 @@ use reth_transaction_pool::{
     BestTransactions, BestTransactionsAttributes, TransactionPool,
     error::InvalidPoolTransactionError,
 };
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Instant};
 use tempo_chainspec::spec::TempoChainSpec;
 use tempo_evm::TempoNextBlockEnvAttributes;
 use tempo_payload_types::{EncodedBlock, TempoBuiltPayload};
@@ -51,26 +48,28 @@ use zone_l1::{PreparedL1Block, TempoStateExt};
 
 use crate::{ZonePayloadAttributes, ZonePayloadTypes};
 
-pub const DEFAULT_WITHDRAWAL_BATCH_INTERVAL: Duration = Duration::from_secs(60);
+/// Default empty-batch cadence: every 120 zone blocks (~60 sec at Tempo's 500 ms block time).
+pub const DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS: u64 = 120;
 
 /// Factory for constructing the zone payload builder.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ZonePayloadFactory {
-    withdrawal_batch_interval: Duration,
+    withdrawal_batch_interval_blocks: u64,
 }
 
 impl ZonePayloadFactory {
-    pub fn new(withdrawal_batch_interval: Duration) -> Self {
+    /// Create a factory that finalizes empty withdrawal batches every `interval_blocks` zone blocks.
+    pub fn new(withdrawal_batch_interval_blocks: u64) -> Self {
         Self {
-            withdrawal_batch_interval,
+            withdrawal_batch_interval_blocks: withdrawal_batch_interval_blocks.max(1),
         }
     }
 }
 
 impl Default for ZonePayloadFactory {
     fn default() -> Self {
-        Self::new(DEFAULT_WITHDRAWAL_BATCH_INTERVAL)
+        Self::new(DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS)
     }
 }
 
@@ -103,7 +102,7 @@ where
             pool,
             provider: ctx.provider().clone(),
             evm_config,
-            withdrawal_batch_interval: self.withdrawal_batch_interval,
+            withdrawal_batch_interval_blocks: self.withdrawal_batch_interval_blocks,
         })
     }
 }
@@ -117,8 +116,8 @@ pub struct ZonePayloadBuilder<Provider, EvmConfig> {
     provider: Provider,
     /// Zone-specific EVM configuration (precompiles, hardfork spec, gas params).
     evm_config: EvmConfig,
-    /// Maximum chain-time duration between withdrawal batch finalizations.
-    withdrawal_batch_interval: Duration,
+    /// Number of zone blocks between withdrawal batch boundaries.
+    withdrawal_batch_interval_blocks: u64,
 }
 
 impl<Provider, EvmConfig> PayloadBuilder for ZonePayloadBuilder<Provider, EvmConfig>
@@ -286,8 +285,6 @@ where
         let pending_withdrawals_at_block_start =
             read_pending_withdrawals_from_outbox(&mut builder, block_gas_limit, block_number)?;
         let has_prior_withdrawals = !pending_withdrawals_at_block_start.is_empty();
-        let last_finalized_timestamp =
-            read_last_finalized_timestamp_from_outbox(&mut builder, block_gas_limit, block_number)?;
 
         // Execute advanceTempo system transaction — exactly one per zone block.
         {
@@ -390,13 +387,12 @@ where
             }
         }
 
-        let batch_interval_elapsed = attributes.timestamp()
-            >= last_finalized_timestamp.saturating_add(self.withdrawal_batch_interval.as_secs());
-
         // Finalize when this block started with pending withdrawals, folding in any
-        // withdrawals created by the current block, or when the empty-batch interval
-        // elapses so the L2 and L1 batch indexes stay in lockstep.
-        if has_prior_withdrawals || batch_interval_elapsed {
+        // withdrawals created by the current block, or at a empty-batch
+        // boundary so the L2 and L1 batch indexes stay in lockstep.
+        if has_prior_withdrawals
+            || block_number.is_multiple_of(self.withdrawal_batch_interval_blocks)
+        {
             let pending_withdrawals =
                 read_pending_withdrawals_from_outbox(&mut builder, block_gas_limit, block_number)?;
             let encrypted_senders = pending_withdrawals
@@ -603,30 +599,6 @@ where
     })
 }
 
-fn read_last_finalized_timestamp_from_outbox<B>(
-    builder: &mut B,
-    gas_limit: u64,
-    block_number: u64,
-) -> Result<u64, PayloadBuilderError>
-where
-    B: BlockBuilder<Primitives = tempo_primitives::TempoPrimitives>,
-{
-    let calldata = abi::ZoneOutbox::lastFinalizedTimestampCall {}.abi_encode();
-    let output = execute_outbox_view_call(
-        builder,
-        calldata.into(),
-        gas_limit,
-        block_number,
-        "lastFinalizedTimestamp",
-    )?;
-
-    abi::ZoneOutbox::lastFinalizedTimestampCall::abi_decode_returns(&output).map_err(|err| {
-        PayloadBuilderError::Internal(reth_errors::RethError::msg(format!(
-            "failed to decode lastFinalizedTimestamp return data: {err}"
-        )))
-    })
-}
-
 fn execute_outbox_view_call<B>(
     builder: &mut B,
     calldata: Bytes,
@@ -736,6 +708,24 @@ mod tests {
 
     use crate::abi::{self, DepositType, ZoneInbox};
     use zone_l1::PreparedL1Block;
+
+    #[test]
+    fn withdrawal_batch_cadence_is_deterministic_from_block_number() {
+        let blocks = super::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
+
+        assert_eq!(blocks, 120);
+        assert_ne!(119 % blocks, 0);
+        assert_eq!(120 % blocks, 0);
+        assert_eq!(240 % blocks, 0);
+    }
+
+    #[test]
+    fn zero_batch_interval_finalizes_every_block() {
+        assert_eq!(
+            super::ZonePayloadFactory::new(0).withdrawal_batch_interval_blocks,
+            1
+        );
+    }
 
     /// Verify that `build_advance_tempo_tx` constructs valid calldata for mixed
     /// deposit types. The calldata should include `QueuedDeposit` entries with the

--- a/crates/payload/src/lib.rs
+++ b/crates/payload/src/lib.rs
@@ -12,6 +12,6 @@ mod builder;
 
 pub use attrs::{ZonePayloadAttributes, ZonePayloadTypes};
 pub use builder::{
-    DEFAULT_WITHDRAWAL_BATCH_INTERVAL, ZonePayloadBuilder, ZonePayloadFactory,
+    DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, ZonePayloadBuilder, ZonePayloadFactory,
     build_advance_tempo_tx,
 };

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -50,8 +50,8 @@ pub struct ZoneSequencerConfig {
     pub zone_rpc_url: String,
     /// How often the zone monitor polls for new L2 blocks.
     pub zone_poll_interval: Duration,
-    /// Maximum time to accumulate zone blocks before submitting a batch to L1.
-    pub batch_interval: Duration,
+    /// Number of zone blocks between empty withdrawal batch boundaries / L1 submissions.
+    pub batch_interval_blocks: u64,
     /// EIP-2935 history and safety-margin limits used by the batch submitter.
     pub batch_anchor_config: BatchAnchorConfig,
 }
@@ -104,7 +104,7 @@ pub async fn spawn_zone_sequencer(
         zone_rpc_url: config.zone_rpc_url,
         retry_connection_interval: config.retry_connection_interval,
         poll_interval: config.zone_poll_interval,
-        batch_interval: config.batch_interval,
+        batch_interval_blocks: config.batch_interval_blocks,
         portal_address: config.portal_address,
         batch_anchor_config: config.batch_anchor_config,
     };

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -50,6 +50,15 @@ const MAX_RETRIES: u32 = 3;
 /// Initial delay between retries (doubles on each attempt).
 const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(2);
 
+/// Returns true when `(last_submitted, latest]` contains a block-number batch boundary.
+///
+/// Boundaries occur at multiples of `interval_blocks`, matching the payload builder's
+/// `block_number % interval_blocks == 0` rule. A zero interval is treated as every block.
+fn crossed_batch_boundary(last_submitted: u64, latest: u64, interval_blocks: u64) -> bool {
+    let n = interval_blocks.max(1);
+    latest / n > last_submitted / n
+}
+
 /// Configuration for the [`ZoneMonitor`].
 #[derive(Debug, Clone)]
 pub struct ZoneMonitorConfig {
@@ -65,10 +74,11 @@ pub struct ZoneMonitorConfig {
     pub retry_connection_interval: Duration,
     /// How often to poll the zone L2 for new blocks (cheap RPC call).
     pub poll_interval: Duration,
-    /// Maximum time to wait before submitting available finalized L2 batches.
-    /// A non-empty finalized withdrawal batch is submitted early for user
-    /// experience.
-    pub batch_interval: Duration,
+    /// Number of zone blocks between empty withdrawal batch boundaries.
+    ///
+    /// Used to decide when enough chain progress has occurred to look for empty
+    /// finalized batches. Non-empty finalized batches are still flushed early.
+    pub batch_interval_blocks: u64,
     /// ZonePortal contract address on Tempo L1.
     pub portal_address: Address,
     /// EIP-2935 history and safety-margin limits used by the batch submitter.
@@ -263,7 +273,8 @@ impl ZoneMonitor {
     ///
     /// Polls the zone L2 frequently (`poll_interval`) but only submits a batch
     /// to L1 when:
-    /// - The `batch_interval` deadline has elapsed, OR
+    /// - Enough new zone blocks have accumulated to cross an empty-batch
+    ///   boundary (`batch_interval_blocks`), OR
     /// - Pending withdrawals are detected (flush immediately for user experience)
     #[instrument(skip_all, fields(
         outbox = %self.config.outbox_address,
@@ -272,13 +283,12 @@ impl ZoneMonitor {
     pub async fn run(&mut self) -> Result<()> {
         info!(
             zone_rpc = %self.config.zone_rpc_url,
-            batch_interval = ?self.config.batch_interval,
+            batch_interval_blocks = self.config.batch_interval_blocks,
             poll_interval = ?self.config.poll_interval,
             "Zone monitor started"
         );
 
         let mut poll = tokio::time::interval(self.config.poll_interval);
-        let mut batch_deadline = tokio::time::Instant::now();
 
         loop {
             tokio::select! {
@@ -297,18 +307,19 @@ impl ZoneMonitor {
                 continue;
             }
 
-            let deadline_elapsed = tokio::time::Instant::now() >= batch_deadline;
+            let boundary_crossed = crossed_batch_boundary(
+                self.last_submitted_zone_block,
+                latest_zone_block,
+                self.config.batch_interval_blocks,
+            );
             // Skip the eth_getLogs call when we'd submit anyway.
-            if !deadline_elapsed && !self.has_pending_withdrawals(latest_zone_block).await {
+            if !boundary_crossed && !self.has_pending_withdrawals(latest_zone_block).await {
                 continue;
             }
 
             let from = self.last_submitted_zone_block + 1;
             match self.process_block_range(from, latest_zone_block).await {
-                Ok(true) => {
-                    batch_deadline = tokio::time::Instant::now() + self.config.batch_interval;
-                }
-                Ok(false) => {}
+                Ok(_) => {}
                 Err(e) => {
                     error!(from, to = latest_zone_block, error = %e, "Failed to process zone block range");
                     continue;
@@ -387,8 +398,8 @@ impl ZoneMonitor {
     /// withdrawal batches.
     ///
     /// Empty finalized batches still need to be submitted, but they are handled
-    /// by the normal deadline path. This signal only flushes user withdrawals
-    /// early.
+    /// by the normal block-interval path. This signal only flushes user
+    /// withdrawals early.
     async fn has_pending_withdrawals(&self, latest_block: u64) -> bool {
         let from = self.last_submitted_zone_block + 1;
         for (chunk_from, chunk_to) in log_query_ranges(from, latest_block) {
@@ -933,6 +944,19 @@ mod tests {
     use tempo_alloy::rpc::TempoHeaderResponse;
     use tempo_primitives::TempoHeader;
 
+    #[test]
+    fn crossed_batch_boundary_matches_builder_modulo_boundaries() {
+        assert!(!crossed_batch_boundary(0, 119, 120));
+        assert!(crossed_batch_boundary(0, 120, 120));
+        assert!(!crossed_batch_boundary(120, 239, 120));
+        assert!(crossed_batch_boundary(120, 240, 120));
+        // A mid-interval withdrawal submit still discovers the next empty boundary.
+        assert!(crossed_batch_boundary(50, 120, 120));
+        assert!(!crossed_batch_boundary(50, 119, 120));
+        // Zero interval means every block.
+        assert!(crossed_batch_boundary(7, 8, 0));
+    }
+
     fn mock_provider(asserter: Asserter) -> DynProvider<TempoNetwork> {
         ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_mocked_client(asserter)
@@ -973,7 +997,7 @@ mod tests {
             zone_rpc_url: "http://unused.test".to_string(),
             retry_connection_interval: Duration::from_millis(100),
             poll_interval: Duration::from_secs(1),
-            batch_interval: Duration::from_secs(1),
+            batch_interval_blocks: 1,
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
         };
@@ -1012,7 +1036,7 @@ mod tests {
             zone_rpc_url: "http://unused.test".to_string(),
             retry_connection_interval: Duration::from_millis(100),
             poll_interval: Duration::from_secs(1),
-            batch_interval: Duration::from_secs(1),
+            batch_interval_blocks: 1,
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
         };

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -586,7 +586,7 @@ Current deployment:
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled |
 | `--block.interval-ms` | 250 | Block building interval |
-| `--zone.batch-interval-secs` | 60 | Max seconds to accumulate zone blocks before submitting a batch to L1 |
+| `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |
 | `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--http.port` | 8546 | HTTP JSON-RPC port |

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -629,7 +629,7 @@ for i from (count - 1) down to 0:
 
 The function writes `withdrawalQueueHash` and `withdrawalBatchIndex` to `lastBatch` storage, where the proof reads them. The call is required at each batch boundary even if there are zero withdrawals (use `count = 0`) so the batch index advances. The `withdrawalBatchIndex` ensures batches are submitted in order, preventing the sequencer from omitting batches that contain withdrawals.
 
-Batch cadence is sequencer-chosen. It closes a batch when there are pending withdrawals or otherwise closes an empty batch when the configured `withdrawalBatchInterval` elapses; the default interval is 60 seconds. Intermediate zone blocks in the same batch do not call `finalizeWithdrawalBatch`.
+Batch cadence is deterministic. It closes a batch when there are pending withdrawals or otherwise closes an empty batch at a block-number boundary. The default cadence is every 120th zone block (~1 minute at Tempo's expected 500 ms block interval), configurable as a block count. Intermediate zone blocks in the same batch do not call `finalizeWithdrawalBatch`.
 
 ### Withdrawal Queue
 
@@ -745,7 +745,7 @@ Each zone block contains system transactions and user transactions in a fixed or
 2. User transactions, executed in order.
 3. `ZoneOutbox.finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` (required in the final block of a batch, absent in intermediate blocks). Constructs the withdrawal hash chain from pending withdrawals, populates `encryptedSender` for authenticated withdrawals, and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to state. Must be called at each batch boundary even if there are zero withdrawals so the batch index advances. The builder may execute it as a zone system transaction with `msg.sender == address(0)`.
 
-A batch covers one or more zone blocks and ends with exactly one `finalizeWithdrawalBatch` call. The sequencer controls batch frequency, and finalizes when withdrawals are present or uses the configured `withdrawalBatchInterval` as the maximum time between empty batch boundaries (60 seconds by default). Intermediate blocks within a batch contain only `advanceTempo` (optional) and user transactions.
+A batch covers one or more zone blocks and ends with exactly one `finalizeWithdrawalBatch` call. The sequencer finalizes when withdrawals are present or when the current zone block number is a configured batch-cadence multiple (every 120 blocks by default). Intermediate blocks within a batch contain only `advanceTempo` (optional) and user transactions.
 
 ### Block Header Format
 


### PR DESCRIPTION
- Use block numbers to decide when to create and submit batches (if no withdrawals). Use block numbers makes the batch boundaries deterministic (instead of relying on wall clock), which makes it easier to debug + allows multiple instances to co-ordinate properly. 