### PR TITLE
chore: update Moderato ZoneFactory

### DIFF
--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -535,7 +535,7 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 | Contract | Address |
 |----------|---------|
 | pathUSD (TIP-20) | `0x20C0000000000000000000000000000000000000` |
-| ZoneFactory (moderato) | `0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5` |
+| ZoneFactory (moderato) | `0x179B44a4B7eC74f3957Ed5137Dc4F1a6dEeBB19b` |
 
 The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` uses `zoneFactory` from `zone.json` before falling back to this address. Pass `--zone-factory` or set `ZONE_FACTORY` to override it.
 
@@ -549,7 +549,7 @@ export ETH_RPC_URL=https://rpc.moderato.tempo.xyz
 export PRIVATE_KEY=<deployer_private_key>
 
 forge build
-forge create --broadcast --rpc-url "$ETH_RPC_URL" --private-key "$PRIVATE_KEY" src/l1/ZoneFactory.sol:ZoneFactory
+forge create --broadcast --rpc-url "$ETH_RPC_URL" --private-key "$PRIVATE_KEY" src/tempo/ZoneFactory.sol:ZoneFactory
 ```
 
 The `--private-key "$PRIVATE_KEY"` form is useful for controlled non-interactive deployments. For manual deployments, prefer replacing it with `--interactive` and paste the key at Foundry's prompt so the key is not written into shell history or process arguments.
@@ -570,10 +570,10 @@ Current deployment:
 
 | Field | Value |
 |-------|-------|
-| Address | `0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5` |
-| Transaction | `0x3d3f0f4ec21084d8fda0c315cfe19c92568df3320c20a56679a12935547c2c4c` |
-| Block | `25403236` |
-| Deployed | `2026-07-06 20:41:32 UTC` |
+| Address | `0x179B44a4B7eC74f3957Ed5137Dc4F1a6dEeBB19b` |
+| Transaction | `0x91b6ae5d07b7a6589242bd6c4a1ae7caffcd18d918e915e66ad40f67d5348ef9` |
+| Block | `26198694` |
+| Deployed | `2026-07-12 08:36:09 UTC` |
 
 ### Zone Node CLI Options
 

--- a/xtask/src/demo_blacklist.rs
+++ b/xtask/src/demo_blacklist.rs
@@ -75,7 +75,7 @@ use tempo_precompiles::{
     PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, tip20::ISSUER_ROLE,
 };
 use tempo_zone_contracts::{
-    EncryptedDepositPayload, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox, ZonePortal,
+    DepositType, EncryptedDepositPayload, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox, ZonePortal,
 };
 use zone_precompiles::ecies::encrypt_deposit;
 
@@ -454,7 +454,8 @@ impl DemoBlacklist {
         println!();
 
         let l2_block_before = l2.get_block_number().await.unwrap_or(0);
-        send_encrypted_deposit(&portal, self.portal, token_addr, target, self.amount).await?;
+        send_encrypted_deposit(&portal, self.portal, token_addr, target, admin, self.amount)
+            .await?;
 
         println!("  Waiting for zone to process (expecting EncryptedDepositFailed)...");
         let bounced =
@@ -523,7 +524,8 @@ impl DemoBlacklist {
         println!();
 
         let l2_block_before = l2.get_block_number().await.unwrap_or(0);
-        send_encrypted_deposit(&portal, self.portal, token_addr, target, self.amount).await?;
+        send_encrypted_deposit(&portal, self.portal, token_addr, target, admin, self.amount)
+            .await?;
 
         println!("  Waiting for zone to process (expecting EncryptedDepositProcessed)...");
         let bounced =
@@ -678,6 +680,7 @@ async fn send_encrypted_deposit<P: Provider<TempoNetwork>>(
     portal_addr: Address,
     token: Address,
     to: Address,
+    bounceback_recipient: Address,
     amount: u128,
 ) -> eyre::Result<()> {
     let (key, key_index) = portal
@@ -701,7 +704,7 @@ async fn send_encrypted_deposit<P: Provider<TempoNetwork>>(
     };
 
     let receipt = portal
-        .depositEncrypted(token, amount, key_index, payload, to)
+        .depositEncrypted(token, amount, key_index, payload, bounceback_recipient)
         .send_sync()
         .await
         .wrap_err("depositEncrypted send failed")?;
@@ -804,6 +807,10 @@ async fn wait_for_encrypted_result<P: Provider<TempoNetwork>>(
         .address(tempo_zone_contracts::ZONE_INBOX_ADDRESS)
         .event_signature(ZoneInbox::EncryptedDepositFailed::SIGNATURE_HASH)
         .from_block(from_block);
+    let rejected_filter = Filter::new()
+        .address(tempo_zone_contracts::ZONE_INBOX_ADDRESS)
+        .event_signature(ZoneInbox::DepositRejected::SIGNATURE_HASH)
+        .from_block(from_block);
 
     for _ in 0..120 {
         let logs = l2.get_logs(&processed_filter).await.unwrap_or_default();
@@ -822,6 +829,18 @@ async fn wait_for_encrypted_result<P: Provider<TempoNetwork>>(
         for log in &logs {
             if let Ok(event) = ZoneInbox::EncryptedDepositFailed::decode_log(&log.inner)
                 && event.data.sender == sender
+                && event.data.token == token
+                && event.data.amount == amount
+            {
+                return Ok(true);
+            }
+        }
+
+        let logs = l2.get_logs(&rejected_filter).await.unwrap_or_default();
+        for log in &logs {
+            if let Ok(event) = ZoneInbox::DepositRejected::decode_log(&log.inner)
+                && event.data.sender == sender
+                && event.data.depositType == DepositType::Encrypted
                 && event.data.token == token
                 && event.data.amount == amount
             {

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -21,9 +21,9 @@ pub(crate) const L1_EXPLORER: &str = "https://explore.moderato.tempo.xyz/tx";
 /// `create-zone`, `deploy-router`, and `zone-info` use this as their default
 /// factory unless the caller overrides `--zone-factory` or `ZONE_FACTORY`, or
 /// `zone.json` already provides a zone-specific value.
-/// Explorer: https://explore.moderato.tempo.xyz/address/0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5
+/// Explorer: https://explore.moderato.tempo.xyz/address/0x179B44a4B7eC74f3957Ed5137Dc4F1a6dEeBB19b
 pub(crate) const MODERATO_ZONE_FACTORY: Address =
-    address!("0xC63EF0DbaB04b0242C2898AaF0BeF81f8f9cA7c5");
+    address!("0x179B44a4B7eC74f3957Ed5137Dc4F1a6dEeBB19b");
 pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
     address!("0xDEc0000000000000000000000000000000000000");
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;


### PR DESCRIPTION
## What changed

Updated the built-in Moderato ZoneFactory address and deployment audit metadata to the newly deployed factory.

Also fixed the blacklist demo so encrypted deposits use an authorized bounceback recipient and recognize the current `DepositRejected` bounce event emitted for policy rejections.

## Why

The deployed factory baseline no longer matched the current factory deployment surface: verifier selectors changed, the portal `BatchSubmitted` event shape changed, and factory bytecode changed through child creation code.

## Impact

New `create-zone`, `zone-info`, and router deployment flows default to the replacement Moderato factory. The blacklist demo now exercises the current encrypted-deposit rejection path instead of failing before the zone can process the deposit.

## Root cause

The shared factory at the previous address could only create zones with the older verifier and portal behavior. The blacklist demo had also fallen behind the portal policy checks by using the encrypted target as the L1 bounceback recipient.
