### PR TITLE
fix(rpc): scope WebSocket token validity to handshake

### DIFF
--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -22,11 +22,7 @@ use axum::{
 use futures::{SinkExt, stream::StreamExt};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, value::RawValue};
-use std::{
-    collections::HashMap,
-    sync::Arc,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
@@ -455,16 +451,6 @@ fn activate_pending_subscriptions(
     }
 }
 
-/// Time remaining until the given unix-second deadline, using the full system
-/// clock precision (not truncated to whole seconds) so the session closes as
-/// close as possible to the exact `expires_at` boundary.
-fn duration_until_unix_timestamp(timestamp: u64) -> Duration {
-    let deadline = UNIX_EPOCH + Duration::from_secs(timestamp);
-    deadline
-        .duration_since(SystemTime::now())
-        .unwrap_or_default()
-}
-
 /// Re-check keychain auth for long-lived WebSocket sessions.
 async fn keychain_auth_still_valid(auth: &AuthContext, state: &RpcState) -> bool {
     let Some(key_id) = auth.keychain_key_id else {
@@ -521,8 +507,6 @@ async fn handle_ws_session(
     let (mut ws_sender, mut ws_receiver) = socket.split();
     let (notifications, mut outbound) = mpsc::channel::<String>(MAX_WS_OUTBOUND_QUEUE);
     let (close_session, mut close_session_rx) = watch::channel(false);
-    let token_expiry = tokio::time::sleep(duration_until_unix_timestamp(auth.expires_at));
-    tokio::pin!(token_expiry);
     let mut keychain_recheck = tokio::time::interval(Duration::from_secs(1));
     let writer = tokio::spawn(async move {
         while let Some(message) = outbound.recv().await {
@@ -537,14 +521,12 @@ async fn handle_ws_session(
     loop {
         let msg = tokio::select! {
             biased;
-            _ = &mut token_expiry => break,
             _ = close_session_rx.changed() => break,
             _ = keychain_recheck.tick(), if auth.keychain_key_id.is_some() => {
-                // Revalidation may be slow; allow token expiry / forced close to
-                // interrupt it so those deadlines are not delayed by a hung RPC.
+                // Revalidation may be slow; allow a forced close to interrupt it
+                // so the close is not delayed by a hung RPC.
                 let still_valid = tokio::select! {
                     biased;
-                    _ = &mut token_expiry => false,
                     _ = close_session_rx.changed() => false,
                     valid = keychain_auth_still_valid(&auth, &state) => valid,
                 };

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -811,7 +811,7 @@ async fn ws_roundtrip_with_keychain_auth() {
 }
 
 #[tokio::test]
-async fn ws_closes_when_auth_token_expires() {
+async fn ws_session_remains_authenticated_after_token_expires() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let now = now_secs();
     let token = ctx.build_token_expiring_at(now, now + 1);
@@ -819,9 +819,21 @@ async fn ws_closes_when_auth_token_expires() {
         .await
         .expect("ws connect failed");
 
-    let _closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    ws.send(tungstenite::Message::Text(
+        jsonrpc("eth_blockNumber", 12).into(),
+    ))
+    .await
+    .expect("ws send after token expiry failed");
+    let response = tokio::time::timeout(Duration::from_secs(1), ws.next())
         .await
-        .expect("timed out waiting for token-expiry close");
+        .expect("timed out waiting for response after token expiry")
+        .expect("ws closed after token expiry")
+        .expect("ws response failed after token expiry");
+    let resp = parse_response(response);
+
+    assert_eq!(resp["id"], 12);
+    assert_eq!(resp["result"], "0x42");
 }
 
 #[tokio::test]

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -811,32 +811,6 @@ async fn ws_roundtrip_with_keychain_auth() {
 }
 
 #[tokio::test]
-async fn ws_session_remains_authenticated_after_token_expires() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
-    let now = now_secs();
-    let token = ctx.build_token_expiring_at(now, now + 1);
-    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
-        .await
-        .expect("ws connect failed");
-
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_blockNumber", 12).into(),
-    ))
-    .await
-    .expect("ws send after token expiry failed");
-    let response = tokio::time::timeout(Duration::from_secs(1), ws.next())
-        .await
-        .expect("timed out waiting for response after token expiry")
-        .expect("ws closed after token expiry")
-        .expect("ws response failed after token expiry");
-    let resp = parse_response(response);
-
-    assert_eq!(resp["id"], 12);
-    assert_eq!(resp["result"], "0x42");
-}
-
-#[tokio::test]
 async fn ws_closes_when_keychain_key_is_revoked() {
     let root_account = Address::repeat_byte(0x77);
     let access_signer = P256SigningKey::random(&mut thread_rng());

--- a/invariants.md
+++ b/invariants.md
@@ -128,7 +128,7 @@ for auditors, invariant/fuzz test authors, and production monitoring.
 | ID | Assertion | Crit | Impact |
 |---|---|---|---|
 | `TEMPO-ZONE-RPC-TOKEN-DOMAIN` | Authorization tokens bind to `TempoZoneRPC`, version, zone ID or wildcard zero, chain ID, `issuedAt`, and `expiresAt` | 🟡 | Tokens can be replayed across zones, chains, or protocol versions |
-| `TEMPO-ZONE-RPC-TOKEN-LIFETIME` | Tokens expire, are not valid too far in the future, and never exceed the 30-day maximum validity window | 🟡 | Long-lived or future-dated tokens can preserve unauthorized access |
+| `TEMPO-ZONE-RPC-TOKEN-LIFETIME` | Tokens presented with HTTP requests or WebSocket handshakes expire, are not valid too far in the future, and never exceed the 30-day maximum validity window | 🟡 | Long-lived or future-dated tokens can preserve unauthorized access |
 | `TEMPO-ZONE-RPC-SENDER-SCOPING` | `eth_sendRawTransaction`, `eth_call`, and `eth_estimateGas` require the authenticated account to match the transaction or call sender | 🟡 | Users can simulate or submit transactions as other accounts |
 | `TEMPO-ZONE-RPC-ACCOUNT-QUERY-SCOPING` | `eth_getBalance`/`eth_getTransactionCount` return `0x0` for non-self queries and `eth_getTransactionByHash`/`eth_getTransactionReceipt` return `null` when the caller is not the sender | 🟡 | Users can read other accounts' balances, nonces, or transactions, or probe account existence |
 | `TEMPO-ZONE-RPC-RAW-STATE-SEQUENCER-ONLY` | Raw state, full transaction/block, debug/admin/txpool, proof, and pending-transaction methods are unavailable to non-sequencers | 🟡 | Private transaction, storage, and mempool data leaks |

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -843,7 +843,7 @@ Zones expose a modified Ethereum JSON-RPC where every request is authenticated a
 
 ### Authorization Tokens
 
-Every RPC request must include an authorization token in the `X-Authorization-Token` HTTP header. The token proves the caller controls a Tempo account and scopes all responses to that account.
+Every HTTP RPC request must include an authorization token in the `X-Authorization-Token` HTTP header. The token proves the caller controls a Tempo account and scopes all responses to that account.
 
 The signed message is `keccak256` of a packed encoding containing a `"TempoZoneRPC"` magic prefix, a version byte (currently `0`), the `zoneId`, `chainId`, `issuedAt`, and `expiresAt` timestamps. The wire format concatenates the signature and the 29-byte token fields, with the token fields always at the end.
 
@@ -936,13 +936,13 @@ To avoid leaking how much activity occurred in a block, some fields of returned 
 
 ### WebSocket Subscriptions
 
-WebSocket connections follow the same authorization model. The authorization token is provided during the handshake and scopes all subscriptions for that connection.
+WebSocket connections are authenticated during the handshake. The authorization token is validated at handshake time and scopes all subscriptions for the lifetime of the connection. Token expiration prevents new connections but does not terminate an established connection. Reconnecting requires a currently valid token.
 
 - `eth_subscribe("newHeads")`: allowed, pushes block headers with the same header redaction as HTTP block responses for non-sequencer callers.
 - `eth_subscribe("logs")`: scoped to the authenticated account using the same event filtering rules.
 - `eth_subscribe("newPendingTransactions")`: disabled.
 
-The connection is terminated when the authorization token expires. For keychain-authenticated connections, the server must also terminate the connection within 1 second of importing a block that revokes the keychain key.
+For keychain-authenticated connections, the server must terminate the connection within 1 second of importing a block that revokes the keychain key.
 
 ### Zone-Specific Methods
 


### PR DESCRIPTION
## Summary

- clarify that every HTTP RPC request carries an authorization token
- define WebSocket token validity as a handshake-time requirement
- keep established WebSocket sessions authenticated after token expiry
- retain continuous keychain revocation enforcement

## Why

WebSocket frames do not carry the handshake authorization header, and the protocol does not define in-band reauthentication. Treating token expiry as an active-session deadline coupled credential validity to connection lifetime and forced clients to reconnect and rebuild subscriptions.

This aligns the specification, invariant, and implementation around handshake-scoped token validity. Expired tokens are still rejected for new HTTP requests and WebSocket handshakes, while keychain revocation continues to terminate active sessions.

Related: [ZONE-17](https://linear.app/tempoxyz/issue/ZONE-17/authorization-bypass-in-websocket-sessions-after-token-expiration)