### PR TITLE
feat(evm): use unique transaction identifiers for sender tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,8 +312,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
+source = "git+https://github.com/mattsse/evm-1?rev=e3ae7301443a726d379b96fdebbef628c93e3e77#e3ae7301443a726d379b96fdebbef628c93e3e77"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11009,7 +11008,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11048,7 +11047,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11072,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11084,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11096,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11129,7 +11128,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11141,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11199,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11237,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11257,7 +11256,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11279,7 +11278,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11290,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11322,7 +11321,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11345,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac33b5b86a79edb1b9284450ba1a87fc645c4bb7#ac33b5b86a79edb1b9284450ba1a87fc645c4bb7"
+source = "git+https://github.com/mattsse/tempo?rev=d05eae3afc38021708ab7409482d152139ba447c#d05eae3afc38021708ab7409482d152139ba447c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,26 +91,28 @@ panic = "abort"
 incremental = false
 
 [workspace.dependencies]
-# tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false, features = [
+# tempo
+# Fork of ac33b5b with the generic transaction-environment bounds required by the Alloy
+# `EvmInternals` downcast hook below.
+tempo-alloy = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c" }
+tempo-chainspec = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false }
+tempo-consensus = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false }
+tempo-contracts = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false, features = [
+tempo-evm = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false }
+tempo-node = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c" }
+tempo-payload-types = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false }
+tempo-precompiles = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c" }
+tempo-primitives = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "ac33b5b86a79edb1b9284450ba1a87fc645c4bb7", default-features = false }
+tempo-revm = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/mattsse/tempo", rev = "d05eae3afc38021708ab7409482d152139ba447c", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
@@ -217,3 +219,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 tokio-tungstenite = "0.28"
 tracing = "0.1.41"
+
+[patch.crates-io]
+# Adds `EvmInternals::tx_env_downcast_ref`, mirroring block-environment downcasting.
+alloy-evm = { git = "https://github.com/mattsse/evm-1", rev = "e3ae7301443a726d379b96fdebbef628c93e3e77" }

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -227,17 +227,13 @@ mod tests {
     }
 
     #[test]
-    fn test_sender_tag_matches_plaintext_hash() {
+    fn test_authenticated_sender_plaintext_contains_unique_identifier() {
         let sender = address!("0x0000000000000000000000000000000000000001");
-        let tx_hash = B256::repeat_byte(0x22);
-        let plaintext = Withdrawal::authenticated_sender_plaintext(sender, tx_hash);
+        let unique_tx_identifier = B256::repeat_byte(0x22);
+        let plaintext = Withdrawal::authenticated_sender_plaintext(sender, unique_tx_identifier);
 
         assert_eq!(&plaintext[..20], sender.as_slice());
-        assert_eq!(&plaintext[20..], tx_hash.as_slice());
-        assert_eq!(
-            Withdrawal::sender_tag(sender, tx_hash),
-            keccak256(plaintext)
-        );
+        assert_eq!(&plaintext[20..], unique_tx_identifier.as_slice());
     }
 
     #[test]

--- a/crates/contracts/src/precompiles/zone_outbox.rs
+++ b/crates/contracts/src/precompiles/zone_outbox.rs
@@ -15,7 +15,7 @@ crate::sol! {
         struct PendingWithdrawal {
             address token;
             address sender;
-            bytes32 txHash;
+            bytes32 uniqueTxIdentifier;
             address to;
             uint128 amount;
             uint128 fee;
@@ -31,6 +31,7 @@ crate::sol! {
         event WithdrawalRequested(
             uint64 indexed withdrawalIndex,
             address indexed sender,
+            bytes32 uniqueTxIdentifier,
             address token,
             address to,
             uint128 amount,

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -345,34 +345,23 @@ impl core::fmt::Display for ZonePortal::ZonePortalErrors {
 }
 
 impl Withdrawal {
-    /// Build the authenticated-withdrawal sender plaintext `[sender(20) | tx_hash(32)]`.
-    pub fn authenticated_sender_plaintext(sender: Address, tx_hash: B256) -> [u8; 52] {
+    /// Build the authenticated-withdrawal plaintext
+    /// `[sender(20) | unique_tx_identifier(32)]`.
+    pub fn authenticated_sender_plaintext(sender: Address, unique_tx_identifier: B256) -> [u8; 52] {
         let mut plaintext = [0u8; 52];
         plaintext[..20].copy_from_slice(sender.as_slice());
-        plaintext[20..].copy_from_slice(tx_hash.as_slice());
+        plaintext[20..].copy_from_slice(unique_tx_identifier.as_slice());
         plaintext
-    }
-
-    /// Compute the authenticated sender tag `keccak256(sender || tx_hash)`.
-    pub fn sender_tag(sender: Address, tx_hash: B256) -> B256 {
-        keccak256(Self::authenticated_sender_plaintext(sender, tx_hash))
     }
 
     /// Reconstruct the public L1-facing withdrawal from a zone-side withdrawal request event.
     pub fn from_requested_event(
         event: &ZoneOutbox::WithdrawalRequested,
-        tx_hash: B256,
         encrypted_sender: Bytes,
     ) -> Self {
-        let sender_tag = if event.sender.is_zero() && event.fallbackRecipient.is_zero() {
-            Self::sender_tag(Address::ZERO, B256::ZERO)
-        } else {
-            Self::sender_tag(event.sender, tx_hash)
-        };
-
         Self {
             token: event.token,
-            senderTag: sender_tag,
+            senderTag: event.uniqueTxIdentifier,
             to: event.to,
             amount: event.amount,
             fee: event.fee,

--- a/crates/contracts/src/precompiles/zone_tx_context.rs
+++ b/crates/contracts/src/precompiles/zone_tx_context.rs
@@ -3,6 +3,6 @@
 crate::sol! {
     #[derive(Debug)]
     contract ZoneTxContext {
-        function currentTxHash() external returns (bytes32);
+        function currentUniqueTxIdentifier() external returns (bytes32);
     }
 }

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -4,9 +4,8 @@
 //! Unlike the Tempo L1 [`TempoBlockExecutor`], this executor does **not** enforce subblock
 //! ordering, shared-gas accounting, or the end-of-block subblock metadata system transaction.
 
-use alloy_consensus::transaction::TxHashRef;
 use alloy_evm::{
-    Database, Evm, RecoveredTx,
+    Database, Evm,
     block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, GasOutput},
     eth::{EthBlockExecutor, EthTxResult},
 };
@@ -20,8 +19,6 @@ use tempo_precompiles::{
 };
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::{TempoStateAccess, evm::TempoContext};
-
-use crate::tx_context;
 
 /// Simplified block executor for zone nodes.
 ///
@@ -96,15 +93,11 @@ where
         &mut self,
         tx: impl ExecutableTx<Self>,
     ) -> Result<Self::Result, BlockExecutionError> {
-        let (tx_env, recovered) = tx.into_parts();
-
         // Override the validator's fee token preference to match this
         // transaction's resolved fee token, so the handler skips FeeAMM.
         self.override_validator_token();
 
-        let _tx_hash_guard = tx_context::set_current_tx_hash(*recovered.tx().tx_hash());
-        self.inner
-            .execute_transaction_without_commit((tx_env, recovered))
+        self.inner.execute_transaction_without_commit(tx)
     }
 
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {

--- a/crates/evm/src/tx_context.rs
+++ b/crates/evm/src/tx_context.rs
@@ -56,13 +56,22 @@ impl ZoneTxContext {
 
             debug!(target: "zone::precompile", "ZoneTxContext: currentUniqueTxIdentifier");
 
+            // This downcast is guaranteed by ZoneEvmFactory: its context is TempoContext<DB>,
+            // whose transaction type is TempoTxEnv. EvmInternals only erases that concrete type
+            // when it constructs the precompile input.
             let tx_env = input
                 .internals
                 .tx_env_downcast_ref::<TempoTxEnv>()
                 .expect("ZoneTxContext requires TempoTxEnv");
-            let unique_tx_identifier = tx_env
-                .unique_tx_identifier()
-                .expect("unique transaction identifier must be set before EVM execution");
+            // Regular transaction execution always populates this while constructing TempoTxEnv;
+            // it can only be absent in manually constructed or synthetic environments.
+            let Some(unique_tx_identifier) = tx_env.unique_tx_identifier() else {
+                warn!(
+                    target: "zone::precompile",
+                    "ZoneTxContext: unique transaction identifier is not set"
+                );
+                return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
+            };
             let encoded = currentUniqueTxIdentifierCall::abi_encode_returns(&unique_tx_identifier);
 
             Ok(PrecompileOutput::new(20, encoded.into(), input.reservoir))
@@ -122,8 +131,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unique transaction identifier must be set before EVM execution")]
-    fn requires_unique_transaction_identifier() {
-        call_with_identifier(None);
+    fn reverts_when_unique_transaction_identifier_is_not_set() {
+        let output = call_with_identifier(None);
+
+        assert!(output.is_revert());
+        assert!(output.bytes.is_empty());
     }
 }

--- a/crates/evm/src/tx_context.rs
+++ b/crates/evm/src/tx_context.rs
@@ -1,67 +1,22 @@
-//! Transaction-hash execution context for authenticated withdrawals.
+//! Transaction execution context for authenticated withdrawals.
 //!
-//! The zone outbox needs the real hash of the currently executing user transaction so it can
-//! commit `senderTag = keccak256(sender || txHash)` on-chain. The block executor publishes that
-//! hash into a thread-local context before EVM execution, and this precompile exposes it to
-//! Solidity at a fixed system address.
+//! The zone outbox uses Tempo's sender-scoped unique transaction identifier as the public
+//! `senderTag`. This precompile reads the identifier directly from the concrete [`TempoTxEnv`]
+//! through [`EvmInternals`](alloy_evm::EvmInternals), avoiding any executor-side context.
 
-use std::{cell::RefCell, thread_local};
-
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_primitives::{B256, Bytes, keccak256};
+use alloy_evm::precompiles::DynPrecompile;
+use alloy_primitives::Bytes;
 use alloy_sol_types::{SolCall, SolError};
 use revm::precompile::{PrecompileId, PrecompileOutput};
+use tempo_revm::TempoTxEnv;
 use tracing::{debug, warn};
 
 alloy_sol_types::sol! {
-    function currentTxHash() external returns (bytes32);
+    function currentUniqueTxIdentifier() external returns (bytes32);
     error DelegateCallNotAllowed();
 }
 
-thread_local! {
-    static CURRENT_TX_HASH: RefCell<Option<B256>> = const { RefCell::new(None) };
-}
-
-/// Guard that clears the current tx hash when dropped.
-pub(crate) struct TxHashGuard;
-
-impl Drop for TxHashGuard {
-    fn drop(&mut self) {
-        clear_current_tx_hash();
-    }
-}
-
-/// Publish the current executing transaction hash for the duration of EVM execution.
-pub(crate) fn set_current_tx_hash(tx_hash: B256) -> TxHashGuard {
-    CURRENT_TX_HASH.with(|slot| {
-        *slot.borrow_mut() = Some(tx_hash);
-    });
-    TxHashGuard
-}
-
-fn clear_current_tx_hash() {
-    CURRENT_TX_HASH.with(|slot| {
-        *slot.borrow_mut() = None;
-    });
-}
-
-fn current_tx_hash() -> Option<B256> {
-    CURRENT_TX_HASH.with(|slot| *slot.borrow())
-}
-
-fn synthetic_tx_hash(input: &PrecompileInput<'_>) -> B256 {
-    let mut bytes = Vec::with_capacity(16 + 20 + 20 + 32 + 32 + 32 + input.data.len());
-    bytes.extend_from_slice(b"zone-tx-context");
-    bytes.extend_from_slice(input.caller.as_slice());
-    bytes.extend_from_slice(input.target_address.as_slice());
-    bytes.extend_from_slice(&input.value.to_be_bytes::<32>());
-    bytes.extend_from_slice(&input.internals.block_number().to_be_bytes::<32>());
-    bytes.extend_from_slice(&input.internals.block_timestamp().to_be_bytes::<32>());
-    bytes.extend_from_slice(input.data);
-    keccak256(bytes)
-}
-
-/// `DynPrecompile` implementation that returns the currently executing zone tx hash.
+/// `DynPrecompile` implementation that returns the current Tempo transaction's unique identifier.
 pub(crate) struct ZoneTxContext;
 
 impl ZoneTxContext {
@@ -90,7 +45,7 @@ impl ZoneTxContext {
             }
 
             let selector: [u8; 4] = data[..4].try_into().expect("len >= 4");
-            if selector != currentTxHashCall::SELECTOR {
+            if selector != currentUniqueTxIdentifierCall::SELECTOR {
                 warn!(
                     target: "zone::precompile",
                     ?selector,
@@ -99,11 +54,76 @@ impl ZoneTxContext {
                 return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
             }
 
-            debug!(target: "zone::precompile", "ZoneTxContext: currentTxHash");
+            debug!(target: "zone::precompile", "ZoneTxContext: currentUniqueTxIdentifier");
 
-            let tx_hash = current_tx_hash().unwrap_or_else(|| synthetic_tx_hash(&input));
-            let encoded = currentTxHashCall::abi_encode_returns(&tx_hash);
+            let tx_env = input
+                .internals
+                .tx_env_downcast_ref::<TempoTxEnv>()
+                .expect("ZoneTxContext requires TempoTxEnv");
+            let unique_tx_identifier = tx_env
+                .unique_tx_identifier()
+                .expect("unique transaction identifier must be set before EVM execution");
+            let encoded = currentUniqueTxIdentifierCall::abi_encode_returns(&unique_tx_identifier);
+
             Ok(PrecompileOutput::new(20, encoded.into(), input.reservoir))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_evm::{
+        EvmInternals,
+        precompiles::{Precompile, PrecompileInput},
+        revm::Context,
+    };
+    use alloy_primitives::{Address, B256, U256};
+    use revm::{MainContext, context::CfgEnv, database::EmptyDB};
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_evm::TempoBlockEnv;
+
+    fn call_with_identifier(unique_tx_identifier: Option<B256>) -> PrecompileOutput {
+        let mut ctx = Context::mainnet()
+            .with_db(EmptyDB::default())
+            .with_block(TempoBlockEnv::default())
+            .with_cfg(CfgEnv::<TempoHardfork>::default())
+            .with_tx(TempoTxEnv {
+                unique_tx_identifier,
+                ..Default::default()
+            });
+        let calldata = currentUniqueTxIdentifierCall {}.abi_encode();
+        let precompile = ZoneTxContext::create();
+
+        precompile
+            .call(PrecompileInput {
+                data: &calldata,
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: Address::ZERO,
+                is_static: false,
+                bytecode_address: Address::ZERO,
+                internals: EvmInternals::from_context(&mut ctx),
+            })
+            .expect("precompile call should not fail")
+    }
+
+    #[test]
+    fn returns_unique_transaction_identifier_from_tempo_tx_env() {
+        let unique_tx_identifier = B256::repeat_byte(0x42);
+        let output = call_with_identifier(Some(unique_tx_identifier));
+
+        assert_eq!(
+            output.bytes,
+            currentUniqueTxIdentifierCall::abi_encode_returns(&unique_tx_identifier)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "unique transaction identifier must be set before EVM execution")]
+    fn requires_unique_transaction_identifier() {
+        call_with_identifier(None);
     }
 }

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -611,11 +611,8 @@ async fn test_withdrawal_requests_finalize_next_block() -> eyre::Result<()> {
         .query()
         .await?;
     assert_eq!(requested_logs.len(), 1);
-    let (requested, requested_log) = &requested_logs[0];
-    let withdrawal_tx_hash = requested_log
-        .transaction_hash
-        .ok_or_else(|| eyre::eyre!("WithdrawalRequested log missing transaction hash"))?;
-    let withdrawal = Withdrawal::from_requested_event(requested, withdrawal_tx_hash, Bytes::new());
+    let (requested, _) = &requested_logs[0];
+    let withdrawal = Withdrawal::from_requested_event(requested, Bytes::new());
     let expected_hash = Withdrawal::queue_hash(&[withdrawal]);
 
     let finalized_logs = outbox
@@ -738,15 +735,8 @@ async fn test_consecutive_withdrawal_blocks_joined_into_one_batch() -> eyre::Res
     assert_eq!(requested_n1.len(), 1);
 
     let mut withdrawals = Vec::new();
-    for (requested, log) in requested_n.iter().chain(requested_n1.iter()) {
-        let tx_hash = log
-            .transaction_hash
-            .ok_or_else(|| eyre::eyre!("WithdrawalRequested log missing transaction hash"))?;
-        withdrawals.push(Withdrawal::from_requested_event(
-            requested,
-            tx_hash,
-            Bytes::new(),
-        ));
+    for (requested, _) in requested_n.iter().chain(requested_n1.iter()) {
+        withdrawals.push(Withdrawal::from_requested_event(requested, Bytes::new()));
     }
     let expected_hash = Withdrawal::queue_hash(&withdrawals);
     let (finalized, log) = &finalized_logs[0];
@@ -889,11 +879,8 @@ async fn test_current_only_block_finalizes_at_batch_boundary() -> eyre::Result<(
         .to_block(withdrawal_block)
         .query()
         .await?;
-    let (requested, requested_log) = &requested_logs[0];
-    let withdrawal_tx_hash = requested_log
-        .transaction_hash
-        .ok_or_else(|| eyre::eyre!("WithdrawalRequested log missing transaction hash"))?;
-    let withdrawal = Withdrawal::from_requested_event(requested, withdrawal_tx_hash, Bytes::new());
+    let (requested, _) = &requested_logs[0];
+    let withdrawal = Withdrawal::from_requested_event(requested, Bytes::new());
     assert_eq!(
         finalized_logs[0].0.withdrawalQueueHash,
         Withdrawal::queue_hash(&[withdrawal])

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -404,13 +404,13 @@ where
                         zone_precompiles::ecies::encrypt_authenticated_withdrawal(
                             request.revealTo.as_ref(),
                             request.sender,
-                            request.txHash,
+                            request.uniqueTxIdentifier,
                         )
                         .map(Bytes::from)
                         .ok_or_else(|| {
                             PayloadBuilderError::Internal(reth_errors::RethError::msg(format!(
                                 "failed to encrypt authenticated sender reveal for tx {}",
-                                request.txHash
+                                request.uniqueTxIdentifier
                             )))
                         })
                     }

--- a/crates/precompiles/src/ecies.rs
+++ b/crates/precompiles/src/ecies.rs
@@ -21,7 +21,8 @@ use crate::{
 /// Plaintext size for encrypted deposits: 20 bytes (address) + 32 bytes (memo) + 12 bytes (padding).
 pub const ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE: usize = 64;
 
-/// Plaintext size for authenticated-withdrawal sender reveals: 20 bytes (sender) + 32 bytes (tx hash).
+/// Plaintext size for authenticated-withdrawal sender reveals: 20 bytes (sender) + 32 bytes
+/// (unique transaction identifier).
 pub const AUTHENTICATED_WITHDRAWAL_PLAINTEXT_SIZE: usize = 52;
 
 /// Total encoded size of `encryptedSender`.
@@ -153,14 +154,14 @@ pub struct EncryptedDepositArgs {
     pub tag: [u8; 16],
 }
 
-/// Encrypt `(sender, tx_hash)` for authenticated withdrawals.
+/// Encrypt `(sender, unique_tx_identifier)` for authenticated withdrawals.
 ///
 /// The output is:
 /// `compressed_ephemeral_pubkey(33) || nonce(12) || ciphertext(52) || tag(16)`.
 pub fn encrypt_authenticated_withdrawal(
     reveal_to: &[u8],
     sender: Address,
-    tx_hash: B256,
+    unique_tx_identifier: B256,
 ) -> Option<Vec<u8>> {
     if reveal_to.len() != 33 {
         return None;
@@ -187,7 +188,7 @@ pub fn encrypt_authenticated_withdrawal(
     let info = authenticated_withdrawal_hkdf_info(&eph_pubkey);
     let aes_key = hkdf_sha256(&shared_secret_x, b"authenticated-withdrawal-aes-key", &info);
 
-    let plaintext = build_authenticated_withdrawal_plaintext(&sender, &tx_hash);
+    let plaintext = build_authenticated_withdrawal_plaintext(&sender, &unique_tx_identifier);
     let cipher = Aes256Gcm::new((&aes_key).into());
     let nonce_bytes: [u8; 12] = rand::random();
     let nonce = Nonce::from_slice(&nonce_bytes);
@@ -241,8 +242,8 @@ pub fn decrypt_authenticated_withdrawal(
     }
 
     let sender = Address::from_slice(&plaintext[..20]);
-    let tx_hash = B256::from_slice(&plaintext[20..]);
-    Some((sender, tx_hash))
+    let unique_tx_identifier = B256::from_slice(&plaintext[20..]);
+    Some((sender, unique_tx_identifier))
 }
 
 /// Encrypt deposit data for `ZonePortal.depositEncrypted`.
@@ -390,14 +391,15 @@ pub fn build_plaintext(to: &Address, memo: &B256) -> [u8; ENCRYPTED_PAYLOAD_PLAI
     buf
 }
 
-/// Build authenticated-withdrawal sender plaintext: `[sender(20)|tx_hash(32)]`.
+/// Build authenticated-withdrawal sender plaintext:
+/// `[sender(20)|unique_tx_identifier(32)]`.
 pub fn build_authenticated_withdrawal_plaintext(
     sender: &Address,
-    tx_hash: &B256,
+    unique_tx_identifier: &B256,
 ) -> [u8; AUTHENTICATED_WITHDRAWAL_PLAINTEXT_SIZE] {
     let mut buf = [0u8; AUTHENTICATED_WITHDRAWAL_PLAINTEXT_SIZE];
     buf[..20].copy_from_slice(sender.as_slice());
-    buf[20..].copy_from_slice(tx_hash.as_slice());
+    buf[20..].copy_from_slice(unique_tx_identifier.as_slice());
     buf
 }
 
@@ -465,15 +467,16 @@ mod tests {
         let encoded = pubkey.to_encoded_point(true);
 
         let sender = Address::repeat_byte(0x11);
-        let tx_hash = B256::repeat_byte(0x22);
+        let unique_tx_identifier = B256::repeat_byte(0x22);
         let encrypted =
-            encrypt_authenticated_withdrawal(encoded.as_bytes(), sender, tx_hash).unwrap();
+            encrypt_authenticated_withdrawal(encoded.as_bytes(), sender, unique_tx_identifier)
+                .unwrap();
         assert_eq!(encrypted.len(), AUTHENTICATED_WITHDRAWAL_ENCRYPTED_SIZE);
 
-        let (decrypted_sender, decrypted_tx_hash) =
+        let (decrypted_sender, decrypted_unique_tx_identifier) =
             decrypt_authenticated_withdrawal(&privkey, &encrypted).unwrap();
         assert_eq!(decrypted_sender, sender);
-        assert_eq!(decrypted_tx_hash, tx_hash);
+        assert_eq!(decrypted_unique_tx_identifier, unique_tx_identifier);
     }
 
     #[test]

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -782,7 +782,6 @@ struct RequestedWithdrawalLog {
     block_number: u64,
     tx_index: u64,
     log_index: u64,
-    tx_hash: B256,
     event: abi::ZoneOutbox::WithdrawalRequested,
 }
 
@@ -912,7 +911,7 @@ pub(crate) async fn fetch_finalized_batch(
         .into_iter()
         .zip(encrypted_senders)
         .map(|(request, encrypted_sender)| {
-            abi::Withdrawal::from_requested_event(&request.event, request.tx_hash, encrypted_sender)
+            abi::Withdrawal::from_requested_event(&request.event, encrypted_sender)
         })
         .collect::<Vec<_>>();
 
@@ -965,9 +964,6 @@ async fn fetch_requested_withdrawal_logs(
                 block_number: log.block_number.unwrap_or(0),
                 tx_index: log.transaction_index.unwrap_or(0),
                 log_index: log.log_index.unwrap_or(0),
-                tx_hash: log.transaction_hash.ok_or_else(|| {
-                    eyre::eyre!("WithdrawalRequested log missing transaction hash")
-                })?,
                 event,
             })
         })

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -544,7 +544,7 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 | Precompile | Address | Description |
 |------------|---------|-------------|
 | TempoStateReader | `0x1c00…0004` | Reads L1 contract storage from zone contracts via the L1 state cache. |
-| ZoneTxContext | `0x1c00…0005` | Exposes the hash of the currently executing zone transaction (`currentTxHash`), used by ZoneOutbox for authenticated withdrawals. |
+| ZoneTxContext | `0x1c00…0005` | Exposes the sender-scoped identifier of the currently executing zone transaction (`currentUniqueTxIdentifier`), used directly as the ZoneOutbox authenticated-withdrawal `senderTag`. |
 | ChaumPedersenVerify | `0x1c00…0100` | Verifies DLOG equality proofs for ECDH key exchange (encrypted deposits). |
 | AesGcmDecrypt | `0x1c00…0101` | AES-256-GCM authenticated decryption (encrypted deposit payloads). |
 

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -273,7 +273,7 @@ uint64 constant MAX_WITHDRAWAL_CALLBACK_GAS = 10_000_000;
 
 struct Withdrawal {
     address token; // TIP-20 token being withdrawn
-    bytes32 senderTag; // keccak256(abi.encodePacked(sender, txHash))
+    bytes32 senderTag; // sender-scoped unique transaction identifier
     address to; // Tempo recipient
     uint128 amount; // amount to send to recipient (excludes fee)
     uint128 fee; // processing fee for sequencer (calculated at request time)
@@ -281,13 +281,13 @@ struct Withdrawal {
     uint64 gasLimit; // max gas for IWithdrawalReceiver callback (0 = no callback)
     address fallbackRecipient; // zone address for bounce-back if call fails
     bytes callbackData; // calldata for IWithdrawalReceiver (if gasLimit > 0)
-    bytes encryptedSender; // optional encrypted (sender, txHash) reveal payload
+    bytes encryptedSender; // optional encrypted (sender, uniqueTxIdentifier) reveal payload
 }
 
 struct PendingWithdrawal {
     address token; // TIP-20 token being withdrawn
     address sender; // who initiated the withdrawal on the zone
-    bytes32 txHash; // hash of the zone transaction that requested the withdrawal
+    bytes32 uniqueTxIdentifier; // sender-scoped identifier for the requesting zone transaction
     address to; // Tempo recipient
     uint128 amount; // amount to send to recipient (excludes fee)
     uint128 fee; // processing fee for sequencer (calculated at request time)
@@ -318,11 +318,11 @@ address constant ZONE_CONFIG = 0x1c00000000000000000000000000000000000003;
 address constant ZONE_TX_CONTEXT = 0x1C00000000000000000000000000000000000005;
 
 /// @title IZoneTxContext
-/// @notice Interface for the zone precompile that exposes the currently executing tx hash
+/// @notice Interface for the zone precompile that exposes Tempo transaction context
 interface IZoneTxContext {
 
-    /// @notice Returns the hash of the currently executing zone transaction
-    function currentTxHash() external returns (bytes32);
+    /// @notice Returns the sender-scoped identifier of the currently executing zone transaction
+    function currentUniqueTxIdentifier() external returns (bytes32);
 
 }
 
@@ -1048,6 +1048,7 @@ interface IZoneOutbox {
     event WithdrawalRequested(
         uint64 indexed withdrawalIndex,
         address indexed sender,
+        bytes32 uniqueTxIdentifier,
         address token,
         address to,
         uint128 amount,

--- a/specs/ref-impls/src/zone/ZoneOutbox.sol
+++ b/specs/ref-impls/src/zone/ZoneOutbox.sol
@@ -106,7 +106,7 @@ contract ZoneOutbox is IZoneOutbox {
     error InvalidBlockNumber();
     error TooManyWithdrawalsThisBlock();
     error InvalidRevealTo();
-    error InvalidCurrentTxHash();
+    error InvalidCurrentUniqueTxIdentifier();
     error InvalidWithdrawalCount(uint256 actual, uint256 expected);
     error InvalidEncryptedSenderCount(uint256 actual, uint256 expected);
     error InvalidEncryptedSenderLength(uint256 actual, uint256 expected);
@@ -274,8 +274,8 @@ contract ZoneOutbox is IZoneOutbox {
         // Fee is paid in the same token being withdrawn
         uint128 fee = _calculateWithdrawalFee(gasLimit);
         uint128 totalBurn = amount + fee;
-        bytes32 txHash = IZoneTxContext(ZONE_TX_CONTEXT).currentTxHash();
-        if (txHash == bytes32(0)) revert InvalidCurrentTxHash();
+        bytes32 uniqueTxIdentifier = IZoneTxContext(ZONE_TX_CONTEXT).currentUniqueTxIdentifier();
+        if (uniqueTxIdentifier == bytes32(0)) revert InvalidCurrentUniqueTxIdentifier();
 
         // Transfer tokens from sender to this contract, then burn
         // (Using transferFrom so user must approve first)
@@ -293,7 +293,7 @@ contract ZoneOutbox is IZoneOutbox {
             PendingWithdrawal({
                 token: token,
                 sender: msg.sender,
-                txHash: txHash,
+                uniqueTxIdentifier: uniqueTxIdentifier,
                 to: to,
                 amount: amount,
                 fee: fee,
@@ -311,6 +311,7 @@ contract ZoneOutbox is IZoneOutbox {
         emit WithdrawalRequested(
             index,
             msg.sender,
+            uniqueTxIdentifier,
             token,
             to,
             amount,
@@ -338,7 +339,7 @@ contract ZoneOutbox is IZoneOutbox {
             PendingWithdrawal({
                 token: token,
                 sender: address(0),
-                txHash: bytes32(0),
+                uniqueTxIdentifier: bytes32(0),
                 to: bouncebackRecipient,
                 amount: amount,
                 fee: 0,
@@ -354,6 +355,7 @@ contract ZoneOutbox is IZoneOutbox {
         emit WithdrawalRequested(
             index,
             address(0),
+            bytes32(0),
             token,
             bouncebackRecipient,
             amount,
@@ -426,9 +428,7 @@ contract ZoneOutbox is IZoneOutbox {
 
                 Withdrawal memory w = Withdrawal({
                     token: pendingWithdrawal.token,
-                    senderTag: keccak256(
-                        abi.encodePacked(pendingWithdrawal.sender, pendingWithdrawal.txHash)
-                    ),
+                    senderTag: pendingWithdrawal.uniqueTxIdentifier,
                     to: pendingWithdrawal.to,
                     amount: pendingWithdrawal.amount,
                     fee: pendingWithdrawal.fee,

--- a/specs/ref-impls/test/mocks/MockZoneTxContext.sol
+++ b/specs/ref-impls/test/mocks/MockZoneTxContext.sol
@@ -2,19 +2,18 @@
 pragma solidity ^0.8.13;
 
 /// @notice Mock tx context precompile for Solidity-only tests.
-/// @dev Returns deterministic pseudo tx hashes in increasing sequence order so tests
-///      can reconstruct sender tags exactly.
+/// @dev Returns deterministic unique transaction identifiers in increasing sequence order.
 contract MockZoneTxContext {
 
     uint256 public sequence;
 
-    function currentTxHash() external returns (bytes32) {
+    function currentUniqueTxIdentifier() external returns (bytes32) {
         sequence++;
-        return txHashFor(sequence);
+        return uniqueTxIdentifierFor(sequence);
     }
 
-    function txHashFor(uint256 seq) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked("mock-zone-tx-hash", seq));
+    function uniqueTxIdentifierFor(uint256 seq) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked("mock-zone-unique-tx-identifier", seq));
     }
 
 }

--- a/specs/ref-impls/test/tempo/ZoneBridge.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneBridge.t.sol
@@ -194,8 +194,8 @@ contract ZoneBridgeTest is BaseTest {
         l2BlockHash = GENESIS_BLOCK_HASH;
     }
 
-    function _senderTag(address sender, uint256 txSequence) internal view returns (bytes32) {
-        return keccak256(abi.encodePacked(sender, zoneTxContext.txHashFor(txSequence)));
+    function _senderTag(address, uint256 txSequence) internal view returns (bytes32) {
+        return zoneTxContext.uniqueTxIdentifierFor(txSequence);
     }
 
     function _withdrawal(
@@ -1133,7 +1133,7 @@ contract ZoneBridgeTest is BaseTest {
 
         Withdrawal memory bounce = Withdrawal({
             token: address(l2ZoneToken),
-            senderTag: keccak256(abi.encodePacked(address(0), bytes32(0))),
+            senderTag: bytes32(0),
             to: alice,
             amount: netAmount,
             fee: 0,

--- a/specs/ref-impls/test/tempo/ZoneIntegration.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneIntegration.t.sol
@@ -145,8 +145,8 @@ contract ZoneIntegrationTest is BaseTest {
         );
     }
 
-    function _senderTag(address sender, uint256 txSequence) internal view returns (bytes32) {
-        return keccak256(abi.encodePacked(sender, zoneTxContext.txHashFor(txSequence)));
+    function _senderTag(address, uint256 txSequence) internal view returns (bytes32) {
+        return zoneTxContext.uniqueTxIdentifierFor(txSequence);
     }
 
     function _withdrawal(

--- a/specs/ref-impls/test/tempo/ZonePortalGasLimit.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortalGasLimit.t.sol
@@ -174,7 +174,7 @@ contract ZonePortalGasLimitTest is Test {
     {
         return Withdrawal({
             token: address(token),
-            senderTag: keccak256(abi.encodePacked(address(0), bytes32(0))),
+            senderTag: bytes32(0),
             to: recipient,
             amount: amount,
             fee: 0,

--- a/specs/ref-impls/test/zone/ZoneOutbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneOutbox.t.sol
@@ -21,7 +21,7 @@ import { Test } from "forge-std/Test.sol";
 
 contract ZeroTxContext {
 
-    function currentTxHash() external pure returns (bytes32) {
+    function currentUniqueTxIdentifier() external pure returns (bytes32) {
         return bytes32(0);
     }
 
@@ -73,8 +73,8 @@ contract ZoneOutboxTest is Test {
         zoneToken.mint(charlie, 10_000e6);
     }
 
-    function _senderTag(address sender, uint256 txSequence) internal view returns (bytes32) {
-        return keccak256(abi.encodePacked(sender, txContext.txHashFor(txSequence)));
+    function _senderTag(address, uint256 txSequence) internal view returns (bytes32) {
+        return txContext.uniqueTxIdentifierFor(txSequence);
     }
 
     function _withdrawal(
@@ -126,7 +126,18 @@ contract ZoneOutboxTest is Test {
 
         vm.expectEmit(true, true, false, true);
         emit IZoneOutbox.WithdrawalRequested(
-            0, address(0), address(zoneToken), bob, amount, 0, bytes32(0), 0, address(0), "", ""
+            0,
+            address(0),
+            bytes32(0),
+            address(zoneToken),
+            bob,
+            amount,
+            0,
+            bytes32(0),
+            0,
+            address(0),
+            "",
+            ""
         );
 
         vm.prank(ZONE_INBOX);
@@ -134,7 +145,7 @@ contract ZoneOutboxTest is Test {
 
         Withdrawal memory expected = Withdrawal({
             token: address(zoneToken),
-            senderTag: keccak256(abi.encodePacked(address(0), bytes32(0))),
+            senderTag: bytes32(0),
             to: bob,
             amount: amount,
             fee: 0,
@@ -196,12 +207,12 @@ contract ZoneOutboxTest is Test {
         PendingWithdrawal[] memory pending = outbox.getPendingWithdrawals();
         assertEq(pending.length, 2);
         assertEq(pending[0].sender, alice);
-        assertEq(pending[0].txHash, txContext.txHashFor(1));
+        assertEq(pending[0].uniqueTxIdentifier, txContext.uniqueTxIdentifierFor(1));
         assertEq(pending[0].to, alice);
         assertEq(pending[0].amount, 500e6);
         assertEq(pending[0].memo, bytes32("first"));
         assertEq(pending[1].sender, alice);
-        assertEq(pending[1].txHash, txContext.txHashFor(2));
+        assertEq(pending[1].uniqueTxIdentifier, txContext.uniqueTxIdentifierFor(2));
         assertEq(pending[1].to, bob);
         assertEq(pending[1].amount, 300e6);
         assertEq(pending[1].memo, bytes32("second"));
@@ -223,13 +234,13 @@ contract ZoneOutboxTest is Test {
         assertEq(disabledToken.balanceOf(alice), 1000e6);
     }
 
-    function test_requestWithdrawal_revertsOnInvalidCurrentTxHash() public {
+    function test_requestWithdrawal_revertsOnInvalidCurrentUniqueTxIdentifier() public {
         ZeroTxContext zeroTxContext = new ZeroTxContext();
         vm.etch(ZONE_TX_CONTEXT, address(zeroTxContext).code);
 
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
-        vm.expectRevert(ZoneOutbox.InvalidCurrentTxHash.selector);
+        vm.expectRevert(ZoneOutbox.InvalidCurrentUniqueTxIdentifier.selector);
         outbox.requestWithdrawal(address(zoneToken), bob, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
@@ -974,6 +985,7 @@ contract ZoneOutboxTest is Test {
         emit IZoneOutbox.WithdrawalRequested(
             0, // index
             alice, // sender
+            txContext.uniqueTxIdentifierFor(1),
             address(zoneToken), // token
             bob, // to
             500e6, // amount

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -270,7 +270,7 @@ Each zone has five system contracts deployed at genesis at fixed addresses:
 | [`ZoneInbox`](#izoneinbox) | `0x1c00...0001` | Advances the zone's view of Tempo and processes incoming deposits. Sole mint authority. |
 | [`ZoneOutbox`](#izoneoutbox) | `0x1c00...0002` | Handles withdrawal requests and batch finalization. Sole burn authority. |
 | [`ZoneConfig`](#izoneconfig) | `0x1c00...0003` | Central configuration. Reads the sequencer address and token registry from Tempo via `TempoState`. |
-| `ZoneTxContext` | `0x1c00...0005` | Provides the current transaction hash to system contracts (used by `ZoneOutbox` for `senderTag` computation). |
+| `ZoneTxContext` | `0x1c00...0005` | Provides the current sender-scoped unique transaction identifier to system contracts (used directly as `ZoneOutbox`'s `senderTag`). |
 
 `ZoneConfig` reads the sequencer address and token registry from the portal on Tempo via `TempoState` storage reads, making Tempo the single source of truth for zone configuration. See [Tempo State Reads](#tempo-state-reads) for details.
 
@@ -503,7 +503,7 @@ Because both deposit entry points require a non-zero `bouncebackRecipient`, ever
 
 The portal's internal withdrawal-bounce-back deposits are the only entries with `bouncebackRecipient == address(0)`. They are introduced by `_enqueueWithdrawalBounceBack` after a withdrawal callback fails, and their zone-side mint failure path is the symmetric refund-registry described in [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back). The sequencer cannot reject these entries: a `rejected` flag on an internal withdrawal-bounce-back deposit is silently ignored and the deposit is processed as if not rejected, preserving the terminal-bounce invariant.
 
-**Zone-side handling.** When an encrypted deposit fails (either branch), when a regular deposit's mint reverts, or when the sequencer rejects a deposit, the `ZoneInbox` calls `ZoneOutbox.enqueueDepositBounceBack(token, amount, bouncebackRecipient)`. For a regular deposit whose mint reverted the revert is caught in a `try/catch`; for an encrypted deposit with invalid encryption no mint is attempted and the inbox enqueues the bounce-back directly; for a sequencer-rejected deposit the inbox skips processing entirely and enqueues the bounce-back without ever calling the token contract (and, for encrypted deposits, without performing onchain decryption verification). `enqueueDepositBounceBack` records a zero-fee, zero-callback, zero-`fallbackRecipient` withdrawal in the outbox's pending list with `sender = address(0)` and `txHash = bytes32(0)`. The inbox emits one of three events so off-chain observers can distinguish the failure mode: `DepositFailed` (regular deposit whose mint reverted), `EncryptedDepositFailed` (encrypted deposit, either invalid encryption or mint revert), or `DepositRejected` (sequencer-initiated rejection, regardless of deposit type). The deposit queue hash chain advances normally; no retries are performed on the zone.
+**Zone-side handling.** When an encrypted deposit fails (either branch), when a regular deposit's mint reverts, or when the sequencer rejects a deposit, the `ZoneInbox` calls `ZoneOutbox.enqueueDepositBounceBack(token, amount, bouncebackRecipient)`. For a regular deposit whose mint reverted the revert is caught in a `try/catch`; for an encrypted deposit with invalid encryption no mint is attempted and the inbox enqueues the bounce-back directly; for a sequencer-rejected deposit the inbox skips processing entirely and enqueues the bounce-back without ever calling the token contract (and, for encrypted deposits, without performing onchain decryption verification). `enqueueDepositBounceBack` records a zero-fee, zero-callback, zero-`fallbackRecipient` withdrawal in the outbox's pending list with `sender = address(0)` and `uniqueTxIdentifier = bytes32(0)`. The inbox emits one of three events so off-chain observers can distinguish the failure mode: `DepositFailed` (regular deposit whose mint reverted), `EncryptedDepositFailed` (encrypted deposit, either invalid encryption or mint revert), or `DepositRejected` (sequencer-initiated rejection, regardless of deposit type). The deposit queue hash chain advances normally; no retries are performed on the zone.
 
 **Tempo-side refund.** The bounce-back withdrawal is submitted in the next batch alongside any user-initiated withdrawals. When `ZonePortal.processWithdrawal` runs on the deposit-bounce-back entry (`gasLimit == 0`, `fee == 0`, `fallbackRecipient == address(0)`), it computes `bouncebackFee = min(ceil(FIXED_BOUNCEBACK_GAS * block.basefee / 1e12), amount)`, attempts to pay it to the sequencer, and attempts `ITIP20.transfer(bouncebackRecipient, amount - bouncebackFee)` from the portal's escrow, wrapped in `try/catch`.
 
@@ -574,11 +574,11 @@ Withdrawals move tokens from a zone back to Tempo. The user requests a withdrawa
 
 A user withdraws by calling `requestWithdrawal(token, to, amount, memo, gasLimit, fallbackRecipient, data, revealTo)` on the `ZoneOutbox`. The user must first approve the outbox to spend `amount + fee` of the token. The outbox requires `fallbackRecipient != address(0)` (reverts with `InvalidFallbackRecipient`) and requires `token` to be enabled (reverts with `TokenNotEnabled`). The outbox does **not** validate `fallbackRecipient` against the token's TIP-403 policy at request time; if the zone-side refund mint is later rejected by the policy, the funds are parked in a per-recipient refund registry on `ZoneInbox` and the recipient claims them via `ZoneInbox.claimRefund(token)` (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
 
-Withdrawal requests are bounded before they enter the pending queue. `gasLimit` must be less than or equal to `MAX_WITHDRAWAL_GAS_LIMIT` or the request reverts with `GasLimitTooHigh`; `data.length` must be less than or equal to `MAX_CALLBACK_DATA_SIZE` (1,024 bytes) or the request reverts with `CallbackDataTooLarge`; and `revealTo`, when non-empty, must be a valid 33-byte compressed secp256k1 public key or the request reverts with `InvalidRevealTo`. The outbox reads the current zone transaction hash from `ZoneTxContext`; if it is zero, the request reverts with `InvalidCurrentTxHash`, because the transaction hash is part of the authenticated-withdrawal sender tag.
+Withdrawal requests are bounded before they enter the pending queue. `gasLimit` must be less than or equal to `MAX_WITHDRAWAL_GAS_LIMIT` or the request reverts with `GasLimitTooHigh`; `data.length` must be less than or equal to `MAX_CALLBACK_DATA_SIZE` (1,024 bytes) or the request reverts with `CallbackDataTooLarge`; and `revealTo`, when non-empty, must be a valid 33-byte compressed secp256k1 public key or the request reverts with `InvalidRevealTo`. The outbox reads the current sender-scoped unique transaction identifier from `ZoneTxContext`; if it is zero, the request reverts with `InvalidCurrentUniqueTxIdentifier`, because that identifier becomes the authenticated-withdrawal sender tag.
 
 The sequencer can additionally configure `maxWithdrawalsPerBlock` on the outbox. A value of `0` means unlimited. When nonzero, only that many `requestWithdrawal` calls can be accepted in a single zone block; further requests in the same block revert with `TooManyWithdrawalsThisBlock` before any token transfer or burn. The outbox tracks the last block number counted and resets the per-block counter when `block.number` changes.
 
-The outbox transfers `amount + fee` from the user via `transferFrom`, burns the tokens, and stores the withdrawal in a pending array. The `WithdrawalRequested` event is emitted with the plaintext sender (zone events are private).
+The outbox transfers `amount + fee` from the user via `transferFrom`, burns the tokens, and stores the withdrawal in a pending array. The `WithdrawalRequested` event is emitted with the plaintext sender and `uniqueTxIdentifier` (zone events are private), allowing settlement reconstruction without the malleable signed transaction hash.
 
 ```mermaid
 sequenceDiagram
@@ -619,7 +619,7 @@ fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
 
 ### Withdrawal Batching
 
-A withdrawal batch ends with exactly one call to `finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` on the `ZoneOutbox` in the final block of that batch. The block builder may include this as a zone system transaction (`msg.sender == address(0)`), and the `blockNumber` argument must match the current zone block number. The encrypted-senders array carries one sequencer-supplied ciphertext per finalized withdrawal for [authenticated withdrawals](#authenticated-withdrawals) (empty bytes for withdrawals without `revealTo`); `senderTag` is recomputed by the outbox from the queued withdrawal sender and transaction hash. This constructs a hash chain from pending withdrawals in LIFO order (newest to oldest), so the oldest withdrawal ends up outermost, enabling FIFO processing on Tempo:
+A withdrawal batch ends with exactly one call to `finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` on the `ZoneOutbox` in the final block of that batch. The block builder may include this as a zone system transaction (`msg.sender == address(0)`), and the `blockNumber` argument must match the current zone block number. The encrypted-senders array carries one sequencer-supplied ciphertext per finalized withdrawal for [authenticated withdrawals](#authenticated-withdrawals) (empty bytes for withdrawals without `revealTo`); `senderTag` is copied from the unique transaction identifier stored with the pending withdrawal. This constructs a hash chain from pending withdrawals in LIFO order (newest to oldest), so the oldest withdrawal ends up outermost, enabling FIFO processing on Tempo:
 
 ```
 withdrawalQueueHash = EMPTY_SENTINEL
@@ -697,22 +697,23 @@ The sequencer keeps the withdrawal fee regardless of whether the withdrawal succ
 
 ### Authenticated Withdrawals
 
-Zone transactions are private, but when a withdrawal is processed on Tempo, the `Withdrawal` struct is passed in calldata and publicly visible. To avoid leaking the sender's identity, the `sender` field is replaced with a `senderTag` commitment:
+Zone transactions are private, but when a withdrawal is processed on Tempo, the `Withdrawal` struct is passed in calldata and publicly visible. To avoid leaking the sender's identity, the `sender` field is replaced with the sender-scoped unique transaction identifier of the `requestWithdrawal` transaction:
 
 ```
-senderTag = keccak256(abi.encodePacked(sender, txHash))
+senderTag = uniqueTxIdentifier
+          = keccak256(encodeForSigning(transaction) || sender)
 ```
 
-The `txHash` is the hash of the `requestWithdrawal` transaction on the zone. Since zone transaction data is not published, `txHash` acts as a blinding factor known only to the sender and the sequencer.
+Tempo derives this identifier from the unsigned transaction payload and recovered sender before execution. Unlike the signed transaction hash, it is stable across signature malleation while remaining scoped to both the sender and transaction contents. `ZoneTxContext.currentUniqueTxIdentifier()` reads it from the current `TempoTxEnv`; every real transaction and standard RPC simulation must populate it.
 
-The sender can optionally specify a `revealTo` public key (compressed secp256k1, 33 bytes) when requesting the withdrawal. If provided, the sequencer encrypts `(sender, txHash)` to that key using ECDH and populates `encryptedSender` in the withdrawal struct. The wire format is `ephemeralPubKey (33 bytes) || nonce (12 bytes) || ciphertext (52 bytes) || tag (16 bytes)` totaling 113 bytes.
+The sender can optionally specify a `revealTo` public key (compressed secp256k1, 33 bytes) when requesting the withdrawal. If provided, the sequencer encrypts `(sender, uniqueTxIdentifier)` to that key using ECDH and populates `encryptedSender` in the withdrawal struct. The wire format is `ephemeralPubKey (33 bytes) || nonce (12 bytes) || ciphertext (52 bytes) || tag (16 bytes)` totaling 113 bytes.
 
 Two disclosure modes are available:
 
-- **Manual reveal**: The sender shares `txHash` with a verifier off-chain. The verifier checks `keccak256(abi.encodePacked(sender, txHash)) == senderTag`.
-- **Encrypted reveal**: The holder of the `revealTo` private key decrypts `encryptedSender` to obtain `(sender, txHash)` and verifies against `senderTag`. No off-chain communication needed.
+- **Manual reveal**: The sender shares the encoded signing payload off-chain. The verifier checks `keccak256(encodeForSigning(transaction) || sender) == senderTag`.
+- **Encrypted reveal**: The holder of the `revealTo` private key decrypts `encryptedSender` to obtain `(sender, uniqueTxIdentifier)` and checks that the identifier equals `senderTag`. Independently verifying the disclosed sender against the tag additionally requires the encoded signing payload; without it, the sender value in the ciphertext is sequencer-attested.
 
-During `finalizeWithdrawalBatch`, the outbox recomputes `senderTag` from the sender and `txHash` stored when `requestWithdrawal` executed. The sequencer supplies only `encryptedSender`; this is trusted because a malicious sequencer could provide an incorrect ciphertext or omit it. The plaintext sender commitment remains deterministic and is covered by the same state transition checks as the rest of the withdrawal queue.
+During `finalizeWithdrawalBatch`, the outbox copies `senderTag` from the `uniqueTxIdentifier` stored when `requestWithdrawal` executed. The sequencer supplies only `encryptedSender`; this is trusted because a malicious sequencer can provide an incorrect ciphertext or omit it. The public tag itself remains deterministic and is covered by the same state transition checks as the rest of the withdrawal queue.
 
 For callback withdrawals, `IWithdrawalReceiver.onWithdrawalReceived` receives `bytes32 senderTag` instead of a plaintext sender address.
 
@@ -724,8 +725,8 @@ The sender on Zone A requests a withdrawal with `revealTo` set to Zone B's seque
 
 1. Zone A processes the withdrawal and submits the batch to Tempo.
 2. `processWithdrawal` on Tempo transfers tokens to Zone B's portal via the messenger callback.
-3. Zone B's sequencer observes the incoming deposit and decrypts `encryptedSender` to learn `(sender, txHash)`.
-4. Zone B verifies `keccak256(sender || txHash) == senderTag`, enabling sender-aware processing.
+3. Zone B's sequencer observes the incoming deposit and decrypts `encryptedSender` to learn `(sender, uniqueTxIdentifier)`.
+4. Zone B checks `uniqueTxIdentifier == senderTag` and can verify the sender binding when the encoded signing payload is available, enabling sender-aware processing.
 
 Sequencer encryption keys are already published (used for encrypted deposits), so no additional infrastructure is needed. This pattern generalizes beyond zone-to-zone: a withdrawal can swap on a Tempo DEX and deposit into another zone in a single composable flow.
 
@@ -1312,7 +1313,7 @@ The stateless execution function must reject the witness on any failed check, mi
    Run each user transaction against the materialized zone state using the current block environment. Whenever execution calls `TempoState.readTempoStorageSlot`, satisfy that call by locating the corresponding `L1StateRead`, proving it against the Tempo root currently bound for this block, and requiring the decoded value to match the witness entry. Any zone-state or Tempo-state access not covered by the witness is an error. `ZoneOutbox.requestWithdrawal` execution must include the `maxWithdrawalsPerBlock` state machine exactly, including the `block.number`-based counter reset, because rejected withdrawal requests must not enter the pending queue or contribute to `withdrawal_queue_hash`.
 
 8. **Execute `finalizeWithdrawalBatch` at the end of the final block.**
-   If `finalize_withdrawal_batch_count` is present, execute `ZoneOutbox.finalizeWithdrawalBatch(count, block.number, finalize_withdrawal_batch_encrypted_senders)` as the final zone system transaction after all user transactions in that block. This call uses the zone system caller (`msg.sender == address(0)`) and must update the outbox's last-batch state and compute the `withdrawal_queue_hash` committed by the batch. The encrypted-sender array is not derivable from `(sender, txHash, revealTo)` because the ciphertext is randomized, and it is part of each public `Withdrawal` encoded into the withdrawal hash chain. Intermediate blocks must not execute this call.
+   If `finalize_withdrawal_batch_count` is present, execute `ZoneOutbox.finalizeWithdrawalBatch(count, block.number, finalize_withdrawal_batch_encrypted_senders)` as the final zone system transaction after all user transactions in that block. This call uses the zone system caller (`msg.sender == address(0)`) and must update the outbox's last-batch state and compute the `withdrawal_queue_hash` committed by the batch. The encrypted-sender array is not derivable from `(sender, uniqueTxIdentifier, revealTo)` because the ciphertext is randomized, and it is part of each public `Withdrawal` encoded into the withdrawal hash chain. Intermediate blocks must not execute this call.
 
 9. **Compute the resulting block header and carry it forward.**
     After block execution, compute the `transactionsRoot` and `receiptsRoot` over the full ordered list of transactions and receipts for that block. Construct the simplified `ZoneHeader` from `parent_hash`, `beneficiary`, `state_root`, `transactions_root`, `receipts_root`, `number`, `timestamp`, and `protocol_version`, then compute `next_block_hash = keccak256(rlp(header))`. Set `prev_block_hash = next_block_hash` and `prev_header = header` before moving to the next block.
@@ -1495,7 +1496,7 @@ struct Deposit {
 
 struct Withdrawal {
     address token;
-    bytes32 senderTag;          // keccak256(abi.encodePacked(sender, txHash))
+    bytes32 senderTag;          // sender-scoped unique transaction identifier
     address to;
     uint128 amount;
     uint128 fee;
@@ -1503,7 +1504,7 @@ struct Withdrawal {
     uint64 gasLimit;
     address fallbackRecipient;
     bytes callbackData;         // max 1KB
-    bytes encryptedSender;      // ECDH-encrypted (sender, txHash), or empty
+    bytes encryptedSender;      // ECDH-encrypted (sender, uniqueTxIdentifier), or empty
 }
 
 struct EncryptedDeposit {
@@ -1945,8 +1946,8 @@ interface IZoneOutbox {
     function WITHDRAWAL_BASE_GAS() external view returns (uint64);
 
     event WithdrawalRequested(
-        uint64 indexed withdrawalIndex, address indexed sender, address token, address to,
-        uint128 amount, uint128 fee, bytes32 memo, uint64 gasLimit,
+        uint64 indexed withdrawalIndex, address indexed sender, bytes32 uniqueTxIdentifier,
+        address token, address to, uint128 amount, uint128 fee, bytes32 memo, uint64 gasLimit,
         address fallbackRecipient, bytes data, bytes revealTo
     );
     event TempoGasRateUpdated(uint128 tempoGasRate);
@@ -1962,7 +1963,7 @@ interface IZoneOutbox {
     error InvalidBlockNumber();
     error TooManyWithdrawalsThisBlock();
     error InvalidRevealTo();
-    error InvalidCurrentTxHash();
+    error InvalidCurrentUniqueTxIdentifier();
     error InvalidEncryptedSenderCount(uint256 actual, uint256 expected);
     error InvalidEncryptedSenderLength(uint256 actual, uint256 expected);
     error GasLimitTooHigh();


### PR DESCRIPTION
## Summary

- rename `ZoneTxContext.currentTxHash()` to `currentUniqueTxIdentifier()` and require the identifier from `TempoTxEnv`
- use the unique transaction identifier directly as withdrawal `senderTag`, including pending storage, events, settlement reconstruction, and encrypted reveal payloads
- remove the synthetic hash fallback and executor-managed thread-local hash context
- update Solidity/Rust ABIs, reference implementations, tests, and the protocol documentation

## Why

The signed transaction hash is malleable and duplicated transaction context that Tempo already computes as `unique_tx_identifier = keccak256(encode_for_signing || sender)`. Reading that value from the concrete transaction environment gives withdrawals the stable, sender-scoped identifier they need without a synthetic fallback or side channel.

## Impact

This intentionally changes the ZoneTxContext function selector, the `WithdrawalRequested` event ABI, the pending-withdrawal field name, and the authenticated-withdrawal sender-tag semantics. Deposit bouncebacks now use the zero identifier/tag sentinel.

Alloy 0.37.1 does not yet expose transaction-environment downcasting, so this branch pins two minimal dependency commits: [the Alloy `EvmInternals::tx_env_downcast_ref` hook](https://github.com/mattsse/evm-1/commit/e3ae7301443a726d379b96fdebbef628c93e3e77) and [the corresponding Tempo generic bounds](https://github.com/mattsse/tempo/commit/d05eae3afc38021708ab7409482d152139ba447c).

Fixes Linear issue ZONE-29.