### PR TITLE
fix(evm): resolve validator fee-token override from the current transaction

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -19,7 +19,7 @@ use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS, storage::actions::StorageActions, tip_fee_manager::TipFeeManager,
 };
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
-use tempo_revm::{TempoStateAccess, evm::TempoContext};
+use tempo_revm::{TempoStateAccess, TempoTxEnv, evm::TempoContext};
 
 use crate::{ZoneEvm, tx_context};
 
@@ -53,13 +53,22 @@ where
 
     /// Overrides `validatorTokens[beneficiary]` to match the resolved fee token
     /// so the handler skips FeeAMM.
-    fn override_validator_token(&mut self) {
+    ///
+    /// The fee token is resolved from `tx_env` — the transaction that is about to
+    /// execute — rather than from `ctx.tx`. `ctx.tx` is only populated with the
+    /// current transaction later, inside revm's `transact_one`; before that it
+    /// still holds the *previous* transaction's env (or the block's default). The
+    /// override is committed into block state, so resolving it from the wrong
+    /// transaction produces a `validatorTokens[beneficiary]` value that depends on
+    /// execution order and on transactions that never make it into the block,
+    /// causing the sequencer's state root to diverge from re-executing nodes.
+    fn override_validator_token(&mut self, tx_env: &TempoTxEnv) {
         let ctx = self.inner.evm.ctx_mut();
-        let fee_payer = ctx.tx.fee_payer().unwrap_or(ctx.tx.caller());
+        let fee_payer = tx_env.fee_payer().unwrap_or(tx_env.caller());
         let spec = ctx.cfg.spec;
 
         let fee_token = match ctx.journaled_state.get_fee_token(
-            &ctx.tx,
+            tx_env,
             fee_payer,
             spec,
             StorageActions::disabled(),
@@ -100,7 +109,7 @@ where
 
         // Override the validator's fee token preference to match this
         // transaction's resolved fee token, so the handler skips FeeAMM.
-        self.override_validator_token();
+        self.override_validator_token(&tx_env);
 
         let _tx_hash_guard = tx_context::set_current_tx_hash(*recovered.tx().tx_hash());
         self.inner


### PR DESCRIPTION
# fix(evm): resolve validator fee-token override from the current transaction

## Severity

**Critical** — non-deterministic block state root → sequencer/validator consensus split.

## Background

Zones run every transaction through `ZoneBlockExecutor`. Because a zone's `FeeAMM`
holds no liquidity, the executor sets `validatorTokens[beneficiary]` to the fee
token that the *current* transaction pays in, so the Tempo fee handler takes the
`SameToken` route (`collect_fee_pre_tx`) instead of routing through the empty AMM
and failing with `InsufficientLiquidity`. That write is `override_validator_token`.

## The bug

`override_validator_token()` derived the fee token from `ctx.tx`:

```rust
let fee_payer = ctx.tx.fee_payer().unwrap_or(ctx.tx.caller());
let fee_token = ctx.journaled_state.get_fee_token(&ctx.tx, fee_payer, spec, ...);
```

but it is invoked **before** `self.inner.execute_transaction_without_commit(...)`,
and `ctx.tx` is only populated with the current transaction *inside* revm's
`transact_one` (via `set_tx`). At the point of the override, `ctx.tx` still holds
the **previous** transaction's env — or, for the first transaction in a block, the
default `TxEnv`. The `sstore` that the override performs is committed as part of the
transaction's `ResultAndState`, so the wrong value lands in block state.

The `tx_hash` guard on the very next line already used `recovered` (the current
transaction), which is what made the stale `ctx.tx` read stand out.

### Why this is a consensus bug, not just a fee glitch

`validatorTokens[beneficiary]` is written to state, so it is part of the block's
post-state root. During **building**, the executor reuses one EVM context across
view calls, `advanceTempo`, every pool transaction it *tries* (including ones later
dropped), and `finalize`. During **validation / re-execution** only the committed
block transactions run. The predecessor of any given transaction therefore differs
between the two passes:

- **Dropped transaction.** Pool tx `A` (fee token `betaUSD`) is attempted, sets
  `ctx.tx = A`, then is dropped. The next included tx `B` (also `betaUSD`) sees
  `ctx.tx = A` during build → override = `betaUSD` → `B` succeeds. On validation,
  `A` is absent, so `B`'s predecessor is `advanceTempo` (default fee token) →
  override = default → `B` fails `collect_fee_pre_tx` → the block aborts and every
  re-executing node rejects it. Two `betaUSD` transactions in the pool are enough.
- **`finalize`.** During build, `finalize` runs right after a non-committed
  `read_pending_withdrawals` view call (default token); during validation its
  predecessor is the last committed pool transaction (possibly non-default). A
  finalize occurs at least every 120 blocks, so this recurs on its own.

There is also a plain liveness failure: a lone transaction paying in a non-default
fee token can never be included, because its only predecessor is the default-token
`advanceTempo` system transaction.

## The fix

Thread the transaction that is about to execute (`tx_env`, already destructured
from `tx.into_parts()`) into `override_validator_token` and resolve the fee token
from it. The override is now a pure function of the current transaction and the
block beneficiary — identical during building and re-execution — so the committed
`validatorTokens[beneficiary]` value no longer depends on execution order or on
transactions that never enter the block.

`ZoneEvm::Tx` is `TempoTxEnv`, which is exactly the type `ctx.tx` had, so
`get_fee_token`, `fee_payer()`, and `caller()` are called on the same type as before.

## Testing

- `cargo check -p zone-evm` (rustc 1.95.0).
- Existing `multi_token_fees_with_validator_override` still models the intended
  per-transaction override behaviour, which this change makes correct at the call
  site rather than only in isolation.