### PR TITLE
fix(l1): resolve `policyIdCounter` deterministically from L1

### DIFF
--- a/crates/l1/src/state/tip403/provider.rs
+++ b/crates/l1/src/state/tip403/provider.rs
@@ -583,6 +583,38 @@ impl PolicyProvider {
         })
     }
 
+    /// Resolve the policy ID counter from L1 (sync).
+    ///
+    /// Always queries the registry at `last_l1_block` rather than inferring the value
+    /// from cached policy keys. The cache is not a complete mirror of L1 — it holds only
+    /// policies seen via events plus ad-hoc RPC fallbacks — so its key set differs across
+    /// nodes and over time. Since the counter is observable by zone transactions and thus
+    /// feeds the block state root, a cache-derived value would diverge between the block
+    /// producer and re-executing nodes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from within an async context on the same tokio runtime.
+    pub fn policy_id_counter_sync(&self) -> Result<u64> {
+        let block_number = self.cache.read().last_l1_block();
+        debug!(block_number, "Resolving policyIdCounter from L1 RPC");
+        let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &self.provider);
+        tokio::task::block_in_place(|| {
+            self.runtime_handle.block_on(async {
+                registry
+                    .policyIdCounter()
+                    .block(BlockId::number(block_number))
+                    .call()
+                    .await
+                    .map_err(|e| {
+                        self.metrics.rpc_errors.increment(1);
+                        warn!(block_number, %e, "policyIdCounter RPC failed");
+                        eyre::eyre!("policyIdCounter RPC failed: {e}")
+                    })
+            })
+        })
+    }
+
     /// Call `isAuthorized(policyId, user)` on the TIP403Registry via L1 RPC.
     async fn rpc_is_authorized(
         &self,
@@ -658,8 +690,9 @@ impl PolicyCheck for PolicyProvider {
         })
     }
 
-    fn policy_id_counter(&self) -> u64 {
-        let cache = self.cache.read();
-        cache.policies().keys().max().map_or(2, |max| max + 1)
+    fn policy_id_counter(&self) -> Result<u64, PrecompileError> {
+        self.policy_id_counter_sync().map_err(|e| {
+            zone_precompiles::zone_rpc_error(format!("policyIdCounter failed: {e}"))
+        })
     }
 }

--- a/crates/precompiles/src/policy.rs
+++ b/crates/precompiles/src/policy.rs
@@ -40,6 +40,10 @@ pub trait PolicyCheck {
     /// Check whether a policy exists.
     fn policy_exists(&self, policy_id: u64) -> Result<bool, PrecompileError>;
 
-    /// Return the highest known policy ID counter.
-    fn policy_id_counter(&self) -> u64;
+    /// Return the current policy ID counter.
+    ///
+    /// Must be resolved deterministically (e.g. from the finalized L1 view at a fixed
+    /// block), not inferred from local cache contents, because the result is observable
+    /// by zone transactions and therefore affects the block state root.
+    fn policy_id_counter(&self) -> Result<u64, PrecompileError>;
 }

--- a/crates/precompiles/src/tip403_proxy/dispatch.rs
+++ b/crates/precompiles/src/tip403_proxy/dispatch.rs
@@ -202,11 +202,11 @@ impl<P: PolicyCheck> ZoneTip403ProxyRegistry<P> {
 
     /// Handle `policyIdCounter() -> uint64`.
     fn handle_policy_id_counter(&self) -> PrecompileResult {
-        let counter = self.provider.policy_id_counter();
         let mut storage = StorageCtx::default();
         if storage.deduct_gas(POLICY_DATA_GAS).is_err() {
             return Ok(storage.halt_output(PrecompileHalt::OutOfGas));
         }
+        let counter = self.provider.policy_id_counter()?;
         let encoded = ITIP403Registry::policyIdCounterCall::abi_encode_returns(&counter);
         Ok(storage.success_output(encoded.into()))
     }

--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -325,8 +325,8 @@ mod tests {
             Ok(true)
         }
 
-        fn policy_id_counter(&self) -> u64 {
-            self.policy_id
+        fn policy_id_counter(&self) -> Result<u64, PrecompileError> {
+            Ok(self.policy_id)
         }
     }
 


### PR DESCRIPTION


## Problem

`PolicyProvider::policy_id_counter` computed its result from local cache state:

```rust
fn policy_id_counter(&self) -> u64 {
    let cache = self.cache.read();
    cache.policies().keys().max().map_or(2, |max| max + 1)
}
```

Every sibling resolver in this file (`is_authorized_by_policy`,
`resolve_policy_type_sync`, `policy_exists_sync`) deliberately anchors to
`last_l1_block` and falls back to L1 RPC precisely so that results are
deterministic across nodes. `policy_id_counter` was the odd one out: the policy
cache is **not** a complete mirror of L1 — it holds only the policies a node has
seen via events plus whatever ad-hoc RPC fallbacks it has performed — so
`policies().keys().max()` differs from node to node and over time.

This value is surfaced to the EVM through the TIP-403 proxy precompile
(`policyIdCounter()`), so a contract that reads it and writes state makes the
result part of the block state root.

Consequences:

- **Consensus split.** Node A (observed policies 2–5) returns `6`; node B (started
  later, observed only policy 2) returns `3`. When a validator re-executes the
  sequencer's payload via `newPayload`, its state root diverges and the block is
  rejected.
- **Cold start.** Right after startup the cache is empty and the method returns the
  constant `2` regardless of the real on-chain counter.

## Change

Resolve the counter from the registry at `last_l1_block`, mirroring
`policy_exists_sync`:

- New `PolicyProvider::policy_id_counter_sync` calls
  `ITIP403Registry::policyIdCounter()` pinned to `BlockId::number(last_l1_block)`
  via `block_in_place`, incrementing `rpc_errors` and returning an `eyre` error on
  failure (never a silent fallback that would reintroduce non-determinism).
- The `PolicyCheck::policy_id_counter` trait method now returns
  `Result<u64, PrecompileError>` instead of `u64`, so an RPC failure surfaces as a
  precompile revert rather than a fabricated number. The proxy precompile handler
  (`handle_policy_id_counter`) propagates the error with `?` after charging gas.

All nodes now query the same finalized L1 block through the same registry, so the
returned counter is identical everywhere.

## Compatibility

`PolicyCheck` has two implementors in-tree: `PolicyProvider` (updated) and the
`ztip20` test mock (updated to return `Ok(..)`). The trait doc now states the
determinism requirement so future implementors (e.g. the prover guest) don't
reintroduce a cache-derived value.

## Verification

- `cargo check -p zone-l1 -p zone-precompiles` (rustc 1.95.0).