### PR TITLE
fix(precompiles): enforce TIP-403 policy on ztip20 reward movements

### DIFF
--- a/crates/precompiles/src/ztip20/dispatch.rs
+++ b/crates/precompiles/src/ztip20/dispatch.rs
@@ -138,6 +138,27 @@ impl<P: PolicyCheck> ZoneTip20Token<P> {
                 let call = decode_or_revert!(IRolesAuth::hasRoleCall, args);
                 self.enforce_balance_of(call.account, caller)
             }
+            // Reward token movements are TIP-403-gated on L1 (`ensure_transfer_authorized`
+            // in `tip20/rewards.rs`), but the vanilla token only consults the zone-local
+            // ALLOW_ALL policy. Mirror the exact L1 role mapping so a blacklisted party
+            // cannot distribute, claim, or redirect reward tokens on the zone.
+            ITIP20::distributeRewardCall::SELECTOR => {
+                // L1: ensure_transfer_authorized(msg_sender, token).
+                self.enforce_transfer(address, caller, address)
+            }
+            ITIP20::claimRewardsCall::SELECTOR => {
+                // L1: ensure_transfer_authorized(token, msg_sender).
+                self.enforce_transfer(address, address, caller)
+            }
+            ITIP20::setRewardRecipientCall::SELECTOR => {
+                let call = decode_or_revert!(ITIP20::setRewardRecipientCall, args);
+                // L1 only checks authorization when a non-zero recipient is set.
+                if call.recipient == Address::ZERO {
+                    None
+                } else {
+                    self.enforce_transfer(address, caller, call.recipient)
+                }
+            }
             _ => None,
         }
     }

--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -283,6 +283,16 @@ mod tests {
                 ..Default::default()
             }
         }
+
+        /// Resolves a policy id successfully but denies every transfer/mint.
+        fn deny_all() -> Self {
+            Self {
+                transfer_authorized: false,
+                mint_authorized: false,
+                policy_id: 2,
+                fail_policy_id_resolution: false,
+            }
+        }
     }
 
     impl PolicyCheck for MockPolicyProvider {
@@ -1015,6 +1025,80 @@ mod tests {
         assert!(
             result.is_ok(),
             "mint must proceed when policy resolution errors (L1 enforces policy at deposit time)"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn reward_movements_enforce_transfer_policy() -> TestResult {
+        let mut harness = PrecompileHarness::new(MockPolicyProvider::deny_all())?;
+        let forbidden = Bytes::from(TIP20Error::policy_forbids().selector().to_vec());
+
+        // claimRewards: L1 authorizes token -> caller, so a blacklisted claimer is rejected.
+        let claim = harness.call(
+            harness.alice,
+            ITIP20::claimRewardsCall {}.abi_encode().into(),
+            200_000,
+            false,
+        )?;
+        assert!(claim.is_revert(), "claimRewards must be policy-gated");
+        assert_eq!(claim.bytes, forbidden);
+
+        // distributeReward: L1 authorizes caller -> token.
+        let distribute = harness.call(
+            harness.alice,
+            ITIP20::distributeRewardCall {
+                amount: U256::from(1u64),
+            }
+            .abi_encode()
+            .into(),
+            200_000,
+            false,
+        )?;
+        assert!(distribute.is_revert(), "distributeReward must be policy-gated");
+        assert_eq!(distribute.bytes, forbidden);
+
+        // setRewardRecipient with a non-zero recipient: L1 authorizes caller -> recipient.
+        let set_recipient = harness.call(
+            harness.alice,
+            ITIP20::setRewardRecipientCall { recipient: harness.bob }
+                .abi_encode()
+                .into(),
+            200_000,
+            false,
+        )?;
+        assert!(
+            set_recipient.is_revert(),
+            "setRewardRecipient must be policy-gated for a non-zero recipient"
+        );
+        assert_eq!(set_recipient.bytes, forbidden);
+
+        Ok(())
+    }
+
+    #[test]
+    fn set_reward_recipient_zero_is_not_policy_gated() -> TestResult {
+        // Clearing the reward recipient (recipient == 0) is not a transfer authorization
+        // on L1, so the zone wrapper must not reject it via the policy layer. With a
+        // denying policy it should fall through to the vanilla token rather than
+        // returning the policy_forbids revert.
+        let mut harness = PrecompileHarness::new(MockPolicyProvider::deny_all())?;
+        let forbidden = Bytes::from(TIP20Error::policy_forbids().selector().to_vec());
+
+        let cleared = harness.call(
+            harness.alice,
+            ITIP20::setRewardRecipientCall {
+                recipient: Address::ZERO,
+            }
+            .abi_encode()
+            .into(),
+            200_000,
+            false,
+        )?;
+        assert_ne!(
+            cleared.bytes, forbidden,
+            "clearing the reward recipient must not be blocked by the policy layer"
         );
 
         Ok(())


### PR DESCRIPTION
## Enforce TIP-403 policy on ztip20 reward movements

### Problem

Reward token movements bypass the zone's TIP-403 policy enforcement, so a
blacklisted account can still receive or redirect reward tokens.

`ZoneTip20Token` is the *only* place TIP-403 is actually enforced on a zone. As its
module doc explains, every zone token is created with `transferPolicyId = 1`
(`ALLOW_ALL`) and the zone-side registry storage is empty, so the vanilla
`TIP20Token` authorization check is a no-op. The wrapper compensates by intercepting
transfer/mint selectors in `precheck` and running `enforce_transfer` /
`enforce_mint` against the **real** L1 policy via the `PolicyCheck` provider.

But the vanilla token also moves tokens through three reward selectors —
`distributeReward`, `claimRewards`, `setRewardRecipient` — and on L1 each of these is
TIP-403-gated (`ensure_transfer_authorized` in `tip20/rewards.rs`). The wrapper's
`precheck` listed none of them, so they fell through the `_ => None` arm straight to
the vanilla implementation, which checks only the local `ALLOW_ALL` policy and always
authorizes.

**Exploit:** an account `B` blacklisted under the token's real L1 transfer policy is
blocked from ordinary transfers by `enforce_transfer`, but can call `claimRewards()`
(reward tokens flow contract → `B`) and receive tokens, or call
`setRewardRecipient(blacklisted_C)` to funnel future rewards to a blacklisted
address. Invariant `TEMPO-ZONE-TIP403-INHERITANCE` is violated for reward flows.

### Fix

Intercept the three reward selectors in `precheck` and apply `enforce_transfer` with
exactly the `(from, to)` role mapping L1 uses in `tip20/rewards.rs`:

| selector | L1 authorization | zone `enforce_transfer(token, from, to)` |
|---|---|---|
| `distributeReward` | `ensure_transfer_authorized(msg_sender, token)` | `(caller, token)` |
| `claimRewards` | `ensure_transfer_authorized(token, msg_sender)` | `(token, caller)` |
| `setRewardRecipient(r)` | `ensure_transfer_authorized(msg_sender, r)` if `r != 0` | `(caller, r)`, skipped when `r == 0` |

When the policy authorizes, `precheck` returns `None` and the call delegates to the
vanilla token exactly as before, so no legitimate reward flow changes. Only a party
the L1 policy forbids now gets a `policyForbids` revert instead of silently moving
reward tokens. As with the existing transfer/mint interception, zones configured
without a policy registry are unaffected (`enforce_transfer` returns `None`).

`setRewardRecipient(0)` clears the recipient and is not a transfer authorization on
L1, so it is deliberately *not* policy-gated.

### Tests

- `reward_movements_enforce_transfer_policy` — with a denying policy,
  `claimRewards` / `distributeReward` / `setRewardRecipient(non-zero)` all revert with
  `policyForbids`.
- `set_reward_recipient_zero_is_not_policy_gated` — `setRewardRecipient(0)` is not
  blocked by the policy layer.
- `cargo test -p zone-precompiles --lib ztip20::` (rustc 1.95.0).