### PR TITLE
fix(sequencer): avoid withdrawal-queue slot underflow on split reads

### DIFF
--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -362,12 +362,19 @@ impl WithdrawalProcessor {
             } = self.capture_store_snapshot(head_val);
             self.record_queue_metrics(head_val, tail_val, store_batch_count);
 
-            if head_val == tail_val {
+            // `head` and `tail` are read as two separate `eth_call`s against "latest",
+            // so they are not guaranteed to observe the same block. During active
+            // draining a split read can return `head > tail`; treat `head >= tail` as
+            // "nothing to do this cycle" (the queue is empty or the reads raced) and
+            // compute the slot count with a saturating subtraction so a raced read can
+            // never underflow (which panics under debug/overflow-checks and wraps to a
+            // garbage count in release).
+            if head_val >= tail_val {
                 debug!("Withdrawal queue empty, nothing to process");
                 return Ok(());
             }
 
-            let pending_slots = tail_val - head_val;
+            let pending_slots = tail_val.saturating_sub(head_val);
             info!(
                 head = head_val,
                 tail = tail_val,


### PR DESCRIPTION
fix(sequencer): avoid withdrawal-queue slot underflow on a split head/tail read

## Bug

`process_queue` reads the portal's `withdrawalQueueHead` and `withdrawalQueueTail`
as two **separate** concurrent `eth_call`s:

```rust
let (head, tail): (U256, U256) =
    tokio::try_join!(head_call.call(), tail_call.call())?;
```

Both target `"latest"`, which is not pinned, so the two calls can resolve at
different block heights. The only guard before the subtraction was equality:

```rust
if head_val == tail_val { return Ok(()); }
let pending_slots = tail_val - head_val;   // underflows when head_val > tail_val
```

During active draining, `head` advances as slots are consumed. If the `head` call is
evaluated a block or two later than the `tail` call, the read can come back with
`head_val > tail_val`. `tail_val - head_val` then underflows:

- under `debug`/`test`/`hivetests` (overflow checks on) it **panics**, killing the
  withdrawal-processing task — observed as flaky CI crashes;
- under `release` (the workspace sets no `overflow-checks`) it **wraps** to a huge
  `u64`, logging a nonsensical `pending_slots` (~1.8e19).

The sibling code at `withdrawals.rs:639` already guards this correctly with
`tail.saturating_sub(head)`, and `settlement.rs:559` uses a `head >= tail` guard —
this call site was simply missed.

## Fix

Widen the guard from `==` to `>=` so a raced read (`head > tail`) is treated as
"nothing to process this cycle" — the same as an empty queue; the next cycle re-reads
and proceeds once the reads agree. Compute `pending_slots` with `saturating_sub` as
defence in depth, matching the sibling call site. No functional change to the normal
`head < tail` path.