### PR TITLE
fix(sequencer): don't reset submission anchor to genesis on RPC error

### DIFF
--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -205,7 +205,9 @@ impl ZoneMonitor {
             .wrap_err("failed to read portal block hash during zone monitor startup")?;
 
         let last_submitted_zone_block =
-            Self::resolve_zone_block_number(&provider, prev_zone_block_hash).await;
+            Self::resolve_zone_block_number(&provider, prev_zone_block_hash)
+                .await
+                .wrap_err("failed to resolve zone block number during zone monitor startup")?;
         let prev_processed_deposit_hash = Self::read_processed_deposit_hash_at_block(
             &inbox,
             last_submitted_zone_block,
@@ -720,7 +722,17 @@ impl ZoneMonitor {
         match self.batch_submitter.read_portal_block_hash().await {
             Ok(portal_hash) => {
                 let last_submitted_zone_block =
-                    Self::resolve_zone_block_number(&self.provider, portal_hash).await;
+                    match Self::resolve_zone_block_number(&self.provider, portal_hash).await {
+                        Ok(number) => number,
+                        Err(e) => {
+                            error!(
+                                error = %e,
+                                "Failed to resolve zone block number during resync; \
+                                 keeping prior submission anchor"
+                            );
+                            return;
+                        }
+                    };
                 let deposit_hash = Self::read_processed_deposit_hash_at_block(
                     &self.inbox,
                     last_submitted_zone_block,
@@ -778,32 +790,34 @@ impl ZoneMonitor {
         }
     }
 
+    /// Resolve the zone L2 block number for a portal `blockHash`.
+    ///
+    /// Returns `Ok(0)` only for a genuine reset — a zero hash, or a hash the zone
+    /// node does not have (`Ok(None)`), which means the zone was reset to genesis. A
+    /// transient RPC failure (`Err`) is propagated rather than collapsed into `0`:
+    /// resetting the submission anchor to genesis on a one-off RPC hiccup would make
+    /// the next batch mismatch the portal's batch index and wedge settlement.
     async fn resolve_zone_block_number(
         provider: &DynProvider<TempoNetwork>,
         zone_block_hash: B256,
-    ) -> u64 {
+    ) -> eyre::Result<u64> {
         if zone_block_hash.is_zero() {
-            return 0;
+            return Ok(0);
         }
 
         match provider.get_block_by_hash(zone_block_hash).await {
-            Ok(Some(block)) => block.number(),
+            Ok(Some(block)) => Ok(block.number()),
             Ok(None) => {
                 warn!(
                     %zone_block_hash,
                     "Portal blockHash not found on zone L2 — zone may have been reset. \
                      Starting from genesis."
                 );
-                0
+                Ok(0)
             }
-            Err(e) => {
-                warn!(
-                    %zone_block_hash,
-                    error = %e,
-                    "Failed to look up zone block by hash, starting from genesis"
-                );
-                0
-            }
+            Err(e) => Err(eyre::eyre!(
+                "failed to look up zone block {zone_block_hash} by hash: {e}"
+            )),
         }
     }
 


### PR DESCRIPTION
# Don't reset the sequencer submission anchor to genesis on a transient RPC error

## What happens today

`ZoneMonitor::resolve_zone_block_number` maps a portal `blockHash` to its zone L2
block number. It collapses **both** "block not found" and "RPC call failed" into
`0`:

```rust
match provider.get_block_by_hash(zone_block_hash).await {
    Ok(Some(block)) => block.number(),
    Ok(None)        => { warn!(...); 0 }
    Err(e)          => { warn!(...); 0 }   // <-- transient error treated as "reset to genesis"
}
```

Its two callers — monitor startup and `resync_from_portal` — then set
`last_submitted_zone_block = 0` while leaving `prev_zone_block_hash` at the real
portal hash. So a single transient L2 RPC hiccup silently rewinds the submission
anchor to genesis.

### Why that wedges settlement

After the anchor rewinds to `0`, the next poll runs `process_block_range(1, latest)`
and, in `process_finalized_batch`, compares the L2 `finalized_index` (e.g. `1`)
against `portal.withdrawalBatchIndex + 1` (e.g. `87`). They don't match, so the batch
guard `bail!`s on every poll. The monitor stops settling *all* batches — withdrawals
and deposits stall — until an operator restarts the process. No funds are lost (the
batch-index guard is what prevents a wrong-state commit), but the bridge halts on a
transient error, which is exactly the failure this guard is meant to survive.

## Fix

Return `eyre::Result<u64>` from `resolve_zone_block_number` and keep the two cases
distinct:

- zero hash or `Ok(None)` (hash genuinely absent → zone reset) → `Ok(0)` as before;
- `Err(..)` (transport/RPC failure) → propagate the error.

Callers:

- **Startup** already returns `Result`, so it propagates with `?` and a context
  message — startup fails loudly instead of silently anchoring at genesis.
- **`resync_from_portal`** matches on the result and, on error, logs and returns
  **without mutating** `last_submitted_zone_block` / `prev_zone_block_hash`, so the
  prior anchor is preserved and the next resync retries — the same fail-safe behaviour
  the outer `read_portal_block_hash` error arm already uses.

## Verification

- `cargo check -p zone-sequencer` (rustc 1.95.0).