### PR TITLE
fix Cyclops audit comment triggers

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -19,7 +19,7 @@ jobs:
       )
     permissions:
       contents: read
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@a3be1f9b7f217e4b7a241e124cf85e6c338f18c9
     with:
       required-labels: |
         cyclops
@@ -45,7 +45,7 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
+      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@a3be1f9b7f217e4b7a241e124cf85e6c338f18c9
         with:
           command-regex: '^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b'
           permission-check-mode: association


### PR DESCRIPTION
## Summary

- update the PR audit workflow and comment action to the `gh-actions#34` merge commit
- restore `cyclops audit fast` for trusted members auditing their own PRs

## Root cause

The issue-comment payload identifies a private organization member as trusted, but the repo-scoped token can report the same PR author as `CONTRIBUTOR` when the action fetches the PR. The older pinned action rejected that trusted author before parsing or publishing the audit command.

The updated action matches the trusted commenter and PR author by immutable GitHub user ID, while retaining the existing author-association check for different users.

Fixes the failure observed on `tempoxyz/zones#638` in Actions run `29331176071`.

## Validation

- `actionlint .github/workflows/pr-audit.yml`
- `git diff --check`