### PR TITLE
fix(evm): require current transaction hash

### DIFF
--- a/crates/evm/src/tx_context.rs
+++ b/crates/evm/src/tx_context.rs
@@ -7,8 +7,8 @@
 
 use std::{cell::RefCell, thread_local};
 
-use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
-use alloy_primitives::{B256, Bytes, keccak256};
+use alloy_evm::precompiles::DynPrecompile;
+use alloy_primitives::{B256, Bytes};
 use alloy_sol_types::{SolCall, SolError};
 use revm::precompile::{PrecompileId, PrecompileOutput};
 use tracing::{debug, warn};
@@ -47,18 +47,6 @@ fn clear_current_tx_hash() {
 
 fn current_tx_hash() -> Option<B256> {
     CURRENT_TX_HASH.with(|slot| *slot.borrow())
-}
-
-fn synthetic_tx_hash(input: &PrecompileInput<'_>) -> B256 {
-    let mut bytes = Vec::with_capacity(16 + 20 + 20 + 32 + 32 + 32 + input.data.len());
-    bytes.extend_from_slice(b"zone-tx-context");
-    bytes.extend_from_slice(input.caller.as_slice());
-    bytes.extend_from_slice(input.target_address.as_slice());
-    bytes.extend_from_slice(&input.value.to_be_bytes::<32>());
-    bytes.extend_from_slice(&input.internals.block_number().to_be_bytes::<32>());
-    bytes.extend_from_slice(&input.internals.block_timestamp().to_be_bytes::<32>());
-    bytes.extend_from_slice(input.data);
-    keccak256(bytes)
 }
 
 /// `DynPrecompile` implementation that returns the currently executing zone tx hash.
@@ -101,9 +89,78 @@ impl ZoneTxContext {
 
             debug!(target: "zone::precompile", "ZoneTxContext: currentTxHash");
 
-            let tx_hash = current_tx_hash().unwrap_or_else(|| synthetic_tx_hash(&input));
+            let Some(tx_hash) = current_tx_hash() else {
+                warn!(
+                    target: "zone::precompile",
+                    "ZoneTxContext: current transaction hash is not set"
+                );
+                return Ok(PrecompileOutput::revert(0, Bytes::new(), input.reservoir));
+            };
             let encoded = currentTxHashCall::abi_encode_returns(&tx_hash);
             Ok(PrecompileOutput::new(20, encoded.into(), input.reservoir))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_evm::{
+        EvmInternals,
+        precompiles::{Precompile, PrecompileInput},
+    };
+    use alloy_primitives::{Address, U256};
+    use revm::{
+        Context,
+        database::{CacheDB, EmptyDB},
+    };
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    type TestContext = Context<
+        revm::context::BlockEnv,
+        revm::context::TxEnv,
+        revm::context::CfgEnv<TempoHardfork>,
+        CacheDB<EmptyDB>,
+    >;
+
+    fn call_with_tx_hash(tx_hash: Option<B256>) -> PrecompileOutput {
+        let _guard = tx_hash.map(set_current_tx_hash);
+        let mut ctx: TestContext =
+            Context::new(CacheDB::new(EmptyDB::new()), TempoHardfork::default());
+        let calldata = currentTxHashCall {}.abi_encode();
+
+        ZoneTxContext::create()
+            .call(PrecompileInput {
+                data: &calldata,
+                gas: u64::MAX,
+                reservoir: 0,
+                caller: Address::ZERO,
+                value: U256::ZERO,
+                target_address: Address::ZERO,
+                is_static: true,
+                bytecode_address: Address::ZERO,
+                internals: EvmInternals::from_context(&mut ctx),
+            })
+            .expect("precompile call should not fail")
+    }
+
+    #[test]
+    fn returns_current_transaction_hash() {
+        let tx_hash = B256::repeat_byte(0x42);
+        let output = call_with_tx_hash(Some(tx_hash));
+
+        assert!(!output.is_revert());
+        assert_eq!(
+            output.bytes,
+            currentTxHashCall::abi_encode_returns(&tx_hash)
+        );
+    }
+
+    #[test]
+    fn reverts_when_current_transaction_hash_is_not_set() {
+        let output = call_with_tx_hash(None);
+
+        assert!(output.is_revert());
+        assert!(output.bytes.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- remove the `synthetic_tx_hash` fallback from `ZoneTxContext`
- revert when `current_tx_hash` is unavailable
- add regression coverage for both populated and missing transaction-hash context

## Why

`currentTxHash()` must expose the hash of the transaction actually being executed. Deriving a replacement from call and block fields when executor context is missing produces a non-canonical value and hides invalid execution setup. The precompile now fails closed instead.

## Impact

The precompile ABI and normal transaction execution are unchanged. Calls made without the executor-provided transaction-hash context now revert with empty data.

Linear: [ZONE-29](https://linear.app/tempoxyz/issue/ZONE-29/require-current-tx-hash-and-stop-using-synthetic-hash)