### PR TITLE
fix(l1): don't wipe caches on a spurious post-backfill reorg

### DIFF
--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -489,19 +489,29 @@ impl L1Subscriber {
             // If we have a buffered tip, check if the new block confirms it.
             if let Some((tip_header, tip_events, tip_policy_events)) = unconfirmed_tip.take() {
                 if sealed.parent_hash() == tip_header.hash() {
-                    // Confirmed — update the L1 state anchor, apply events, and
-                    // flush to the queue.
+                    // Confirmed. Apply the tip's L1-state anchor and cache updates
+                    // only when the queue accepts it as contiguous. If a gap exists,
+                    // applying the tip first would jump the anchor past the gap, and
+                    // the subsequent gap backfill would then look like a reorg and
+                    // wipe the policy and L1-state caches (which happens on nearly
+                    // every startup, since L1 advances by ≥2 blocks during the
+                    // initial backfill). In the gap case, `backfill` applies the
+                    // whole range — anchor, events, and enqueue — in order.
                     let tip_number = tip_header.number();
                     let tip_hash = tip_header.hash();
                     let tip_parent = tip_header.parent_hash();
-                    self.update_l1_state_anchor(tip_number, tip_hash, tip_parent);
-                    self.apply_policy_events(tip_number, &tip_policy_events);
-                    self.apply_portal_state_events(tip_number, &tip_events);
+                    // `try_enqueue` consumes the events; keep copies for the
+                    // contiguous-path cache updates.
+                    let tip_policy_events_for_cache = tip_policy_events.clone();
+                    let tip_events_for_cache = tip_events.clone();
                     match self
                         .deposit_queue
                         .try_enqueue(tip_header, tip_events, tip_policy_events)
                     {
                         EnqueueOutcome::Accepted => {
+                            self.update_l1_state_anchor(tip_number, tip_hash, tip_parent);
+                            self.apply_policy_events(tip_number, &tip_policy_events_for_cache);
+                            self.apply_portal_state_events(tip_number, &tip_events_for_cache);
                             self.subscriber_metrics.blocks_enqueued.increment(1);
                         }
                         EnqueueOutcome::Duplicate => {}


### PR DESCRIPTION
# l1 subscriber: stop a spurious reorg from wiping the caches after backfill

### Symptom

On essentially every startup, the freshly-seeded TIP-403 token policies and the
mirrored portal/sequencer state in the L1-state cache are wiped, `reorgs_detected`
ticks up, and the caches thrash — all with **no actual L1 reorg**. The caches
self-heal via RPC fallback, but the thrash adds RPC load and, combined with cache
miss windows, transient wrong answers.

### Cause

In `run()`'s confirmation path, the confirmed tip's L1-state anchor and cache events
were applied *before* the deposit queue was checked for a gap:

```rust
self.update_l1_state_anchor(tip_number, tip_hash, tip_parent);
self.apply_policy_events(tip_number, &tip_policy_events);
self.apply_portal_state_events(tip_number, &tip_events);
match self.deposit_queue.try_enqueue(tip_header, tip_events, tip_policy_events) {
    …
    NeedBackfill { from, to } => self.backfill(&provider, from, tip_number).await?,
}
```

After the initial `sync_to_l1_tip`, the L1-state anchor equals the backfill tip `T`.
L1 keeps producing blocks during backfill, so the first block the live subscription
confirms is almost always `T+k` with `k ≥ 2`. `update_l1_state_anchor(T+k, …, parent
= hash_{T+k-1})` compares that parent against the anchor `hash_T`; they differ, so it
is treated as a reorg — `l1_state_cache.clear()` + `policy_cache.clear()`.
`try_enqueue` then returns `NeedBackfill{T+1, T+k-1}`, and the gap backfill's first
block `T+1` mismatches the just-jumped anchor and clears both caches a **second**
time.

### Fix

Apply the confirmed tip's anchor and cache events **only** when `try_enqueue` returns
`Accepted` — i.e. the block is contiguous with the queue (and therefore with the
anchor), so `update_l1_state_anchor` cannot misfire. When there is a gap
(`NeedBackfill`), `backfill(from, tip_number)` already applies the anchor, policy
events, portal-state events, and enqueue for the whole range **in order**, starting
from a block that connects to the existing anchor — so no false reorg is detected.

`try_enqueue` consumes the event collections, so the tip's events are cloned for the
`Accepted`-path cache updates (both types already derive `Clone`; the cost is one
clone per confirmed L1 block). A genuine reorg — the buffered tip failing the
parent-hash confirmation, or a backfilled block whose parent does not connect — still
clears the caches exactly as before.

As a side benefit, a `Duplicate` confirmation no longer re-applies its events to the
caches (they were applied when the block was first enqueued).
