### PR TITLE
ci: update Tempo revision for Foundry specs

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo
-          ref: 1108cb7eedaef42fb148162b9b0b6dca3b336f7a
+          ref: 18a5d71d6ab621433145e5ea86dfe3dbace0763a
           path: tempo
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Update the Specs workflow's Tempo checkout to `18a5d71d6ab621433145e5ea86dfe3dbace0763a`, matching the revision declared by current Foundry.

## Why

The workflow checked out current Foundry but patched its Tempo crates to the older `1108cb7eedaef42fb148162b9b0b6dca3b336f7a` revision. Foundry's Tempo T8 support imports `CURRENT_COMMITTEE_ADDRESS`, which the older checkout does not export, so Forge failed to compile before the zone tests ran.

Aligning the Tempo checkout preserves current Foundry coverage while restoring a compatible toolchain. This unblocks the Specs check for PR #640 without adding unrelated CI changes to its tx-hash cleanup.