### PR TITLE
fix Cyclops PR comment permissions

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -43,7 +43,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: tempoxyz/gh-actions/actions/pr-audit-comment@a3be1f9b7f217e4b7a241e124cf85e6c338f18c9
         with:


### PR DESCRIPTION
## Summary

Grant the comment-triggered Cyclops audit job write access to pull requests.

## Why

The shared audit action acknowledges requests by reacting to and commenting on the pull request before publishing the audit event. The job previously had `issues: write` but only `pull-requests: read`, so GitHub rejected the acknowledgement with `403 Resource not accessible by integration` and execution never reached event publication.

This matches the permission used by Tempo's working comment-triggered audit workflow.

## Validation

- `git diff --check`
- Confirmed the resulting workflow diff changes only `pull-requests: read` to `pull-requests: write`
