### PR TITLE
fix(ci): allow same-repository Cyclops audits

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -50,6 +50,7 @@ jobs:
           command-regex: '^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b'
           permission-check-mode: association
           organization: tempoxyz
+          allow-same-repository-author: true
           events-key: ${{ secrets.EVENTS_KEY }}
           events-cert: ${{ secrets.EVENTS_CERT }}
           events-args: ${{ secrets.EVENTS_ARGS }}


### PR DESCRIPTION
## Summary

- allow trusted commenters to trigger Cyclops audits for contributor-authored PRs whose head branch is in `tempoxyz/zones`
- retain the existing commenter association and organization checks

## Root cause

The comment workflow accepted the requester as a member, then rejected PR #626 because its author is classified as `CONTRIBUTOR` and `allow-same-repository-author` defaulted to `false`. Run 29354060594 failed before publishing the Cyclops event.

## Validation

- `git diff --check`
- confirmed the action input is passed only to the comment-triggered audit path

Prompted by: @0xKitsune