### PR TITLE
test(precompiles): add SwapAndDepositRouter coverage (part of #262)

### DIFF
--- a/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
+++ b/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
@@ -93,6 +93,12 @@ contract MockZonePortalForRouter {
         return enabledTokens[_token];
     }
 
+    bool public revertOnDeposit;
+
+    function setRevertOnDeposit(bool _v) external {
+        revertOnDeposit = _v;
+    }
+
     function deposit(
         address _token,
         address to,
@@ -103,6 +109,7 @@ contract MockZonePortalForRouter {
         external
         returns (bytes32)
     {
+        if (revertOnDeposit) revert("MockZonePortal: deposit failed");
         ITIP20(_token).transferFrom(msg.sender, address(this), amount);
         lastDepositRecipient = to;
         lastDepositBouncebackRecipient = bouncebackRecipient;
@@ -122,6 +129,7 @@ contract MockZonePortalForRouter {
         external
         returns (bytes32)
     {
+        if (revertOnDeposit) revert("MockZonePortal: deposit failed");
         ITIP20(_token).transferFrom(msg.sender, address(this), amount);
         lastEncryptedAmount = amount;
         lastEncryptedKeyIndex = keyIndex;
@@ -330,6 +338,73 @@ contract SwapAndDepositRouterTest is BaseTest {
 
         vm.prank(address(mockMessenger));
         vm.expectRevert(IStablecoinDEX.InsufficientOutput.selector);
+        router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
+    }
+
+    // Target-portal deposit failure must revert the whole callback so the
+    // withdrawal bounces back to the source zone (plaintext path).
+    function test_plaintextDepositRevert_bounces() public {
+        mockPortal.setRevertOnDeposit(true);
+
+        bytes memory data = _buildPlaintextData(
+            address(pathUSD), address(mockPortal), alice, refundBurner, bytes32("x"), 0
+        );
+
+        vm.prank(address(mockMessenger));
+        vm.expectRevert(bytes("MockZonePortal: deposit failed"));
+        router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
+    }
+
+    // Same guarantee for the encrypted path.
+    function test_encryptedDepositRevert_bounces() public {
+        mockPortal.setRevertOnDeposit(true);
+
+        EncryptedDepositPayload memory payload = _defaultEncryptedPayload();
+        bytes memory data =
+            _buildEncryptedData(address(pathUSD), address(mockPortal), 0, payload, refundBurner, 0);
+
+        vm.prank(address(mockMessenger));
+        vm.expectRevert(bytes("MockZonePortal: deposit failed"));
+        router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
+    }
+
+    // Same-token transfers perform no swap, so an impossibly high minAmountOut
+    // is ignored (documented invariant) and the full amount is deposited.
+    function test_sameToken_ignoresMinAmountOut() public {
+        bytes memory data = _buildPlaintextData(
+            address(pathUSD),
+            address(mockPortal),
+            alice,
+            refundBurner,
+            bytes32("hi"),
+            type(uint128).max
+        );
+
+        vm.prank(address(mockMessenger));
+        bytes4 ret = router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
+
+        assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
+        assertTrue(mockPortal.depositCalled());
+        assertEq(mockPortal.lastDepositAmount(), AMOUNT);
+    }
+
+    // Callback data too short to decode the leading isEncrypted bool must revert
+    // cleanly.
+    function test_malformedCallbackData_revertsCleanly() public {
+        bytes memory data = hex"00";
+
+        vm.prank(address(mockMessenger));
+        vm.expectRevert();
+        router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
+    }
+
+    // Callback data that decodes isEncrypted=false but omits the rest of the
+    // plaintext tuple must also revert cleanly.
+    function test_truncatedCallbackData_revertsCleanly() public {
+        bytes memory data = abi.encode(false);
+
+        vm.prank(address(mockMessenger));
+        vm.expectRevert();
         router.onWithdrawalReceived(senderTag, address(pathUSD), AMOUNT, data);
     }
 


### PR DESCRIPTION
## Summary

Resolves part of #262. Adds the missing Foundry coverage that issue calls out for
`SwapAndDepositRouter` (the "deposit failure reverts the callback" and "important
invariants are not pinned" items).

## New tests

- `test_plaintextDepositRevert_bounces` / `test_encryptedDepositRevert_bounces` — a
  target-portal `deposit()` / `depositEncrypted()` revert reverts the whole
  `onWithdrawalReceived` callback, which is what triggers the bounce-back to the
  source zone. Previously only swap failure was covered.
- `test_sameToken_ignoresMinAmountOut` — pins the documented invariant that the
  same-token path performs no swap and ignores `minAmountOut` (an impossible
  `type(uint128).max` still succeeds).
- `test_malformedCallbackData_revertsCleanly` / `test_truncatedCallbackData_revertsCleanly`
  — callback data too short to decode, or decoding `isEncrypted` but omitting the
  rest of the tuple, reverts cleanly.

A `revertOnDeposit` toggle was added to the existing `MockZonePortalForRouter` to
drive the deposit-failure cases; default behaviour is unchanged.

This covers the Solidity side of #262. The Rust end-to-end routed-swap scenario
(item #1 in the issue) is not included here.

## Verification

- `forge build` — compiles cleanly
- `forge fmt --check` — clean

Note: I could not run `forge test` locally. The suite needs the Tempo Foundry fork
(`hardfork = "tempo:T3"`) for BaseTest's precompiles, which is no longer installable
via `foundryup` (the `-n tempo` channel is now deprecated/ignored, and forge fails
BaseTest with `MissingPrecompile`). The new tests are written against the existing
mock harness and rely on this repo's CI (tempo:T3) to execute them — happy to adjust
if anything doesn't run green.

## AI assistance disclosure

These tests were written primarily with Claude Code (Claude Fable 5). I directed the
work, reviewed the output, and confirmed `forge build` / `forge fmt --check` pass
locally.
