### PR TITLE
fix(l1): scope TIP-403 policy-set membership to the queried block

### DIFF
--- a/crates/l1/src/state/tip403/cache.rs
+++ b/crates/l1/src/state/tip403/cache.rs
@@ -271,13 +271,13 @@ impl PolicyCacheInner {
 
         match policy_type {
             PolicyType::WHITELIST => {
-                if !policy.policy_set.is_known(&user) {
+                if !policy.policy_set.is_known(&user, block_number) {
                     return None;
                 }
                 Some(policy.policy_set.contains(user, block_number))
             }
             PolicyType::BLACKLIST => {
-                if !policy.policy_set.is_known(&user) {
+                if !policy.policy_set.is_known(&user, block_number) {
                     return None;
                 }
                 Some(!policy.policy_set.contains(user, block_number))
@@ -323,13 +323,13 @@ impl PolicyCacheInner {
 
         match policy_type {
             PolicyType::WHITELIST => {
-                if !policy.policy_set.is_known(&user) {
+                if !policy.policy_set.is_known(&user, block_number) {
                     return None;
                 }
                 Some(policy.policy_set.contains(user, block_number))
             }
             PolicyType::BLACKLIST => {
-                if !policy.policy_set.is_known(&user) {
+                if !policy.policy_set.is_known(&user, block_number) {
                     return None;
                 }
                 Some(!policy.policy_set.contains(user, block_number))
@@ -522,7 +522,7 @@ mod tests {
 
         // Stale writes must not mark unknown users as observed either.
         set.record_status(USER_B, 15, false);
-        assert!(!set.is_known(&USER_B));
+        assert!(!set.is_known(&USER_B, 25));
 
         set.record_status(USER_A, 21, false);
         assert!(!set.contains(USER_A, 21));
@@ -533,15 +533,15 @@ mod tests {
         let mut set = PolicySet::default();
 
         set.record_status(USER_A, 0, false);
-        assert!(!set.is_known(&USER_A));
+        assert!(!set.is_known(&USER_A, 5));
         assert!(!set.contains(USER_A, 0));
 
         set.record_status(USER_B, 0, true);
-        assert!(!set.is_known(&USER_B));
+        assert!(!set.is_known(&USER_B, 5));
         assert!(!set.contains(USER_B, 0));
 
         set.record_status(USER_B, 1, true);
-        assert!(set.is_known(&USER_B));
+        assert!(set.is_known(&USER_B, 1));
         assert!(set.contains(USER_B, 1));
     }
 
@@ -1212,22 +1212,46 @@ mod tests {
         let mut set = PolicySet::default();
 
         // Fresh set: nobody known
-        assert!(!set.is_known(&USER_A));
-        assert!(!set.is_known(&USER_B));
+        assert!(!set.is_known(&USER_A, 10));
+        assert!(!set.is_known(&USER_B, 10));
 
         // Add USER_A
         set.record_status(USER_A, 10, true);
-        assert!(set.is_known(&USER_A));
-        assert!(!set.is_known(&USER_B));
+        assert!(set.is_known(&USER_A, 10));
+        assert!(!set.is_known(&USER_B, 10));
+
+        // A query before USER_A's first observed event is not authoritative.
+        assert!(!set.is_known(&USER_A, 9));
 
         // Advance past the event
         set.advance(20);
-        assert!(set.is_known(&USER_A), "observed must survive advance");
-        assert!(!set.is_known(&USER_B));
+        assert!(
+            set.is_known(&USER_A, 20),
+            "first_seen must survive advance"
+        );
+        assert!(!set.is_known(&USER_B, 20));
 
         // Clear resets everything
         set.clear();
-        assert!(!set.is_known(&USER_A));
+        assert!(!set.is_known(&USER_A, 10));
+    }
+
+    #[test]
+    fn policy_set_future_delta_does_not_authorize_earlier_query() {
+        // Regression: the subscriber runs ahead of the engine, so the set can hold a
+        // user's future delta while the engine queries an earlier block. The only event
+        // we have for USER_A is a removal at block 150; that tells us nothing about the
+        // user's membership at block 120, so an earlier query must be reported as unknown
+        // (forcing RPC fallback) rather than authoritatively "absent".
+        let mut set = PolicySet::default();
+        set.record_status(USER_A, 150, false);
+
+        assert!(
+            !set.is_known(&USER_A, 120),
+            "a future delta must not make an earlier block authoritative"
+        );
+        assert!(set.is_known(&USER_A, 150));
+        assert!(set.is_known(&USER_A, 200));
     }
 
     #[test]

--- a/crates/l1/src/state/tip403/policy_set.rs
+++ b/crates/l1/src/state/tip403/policy_set.rs
@@ -1,7 +1,7 @@
 //! Block-versioned policy sets for TIP-403 policy tracking.
 
 use alloy_primitives::Address;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Block-versioned policy set for TIP-403 policy tracking.
 ///
@@ -19,9 +19,11 @@ pub struct PolicySet {
     baseline_height: u64,
     /// Per-block set updates above `baseline_height`.
     pending: BTreeMap<u64, Vec<PolicySetUpdate>>,
-    /// All addresses for which we've ever recorded a set event. Survives `advance()` so
-    /// we can distinguish "explicitly absent from the set" from "never observed by the subscriber".
-    observed: HashSet<Address>,
+    /// Earliest block at which we recorded a set event for each address. Survives `advance()`
+    /// so we can distinguish "explicitly absent from the set" from "never observed by the
+    /// subscriber", *and* so that known-ness is scoped to the queried block: an event only
+    /// tells us the membership at and after the block it was observed on.
+    first_seen: HashMap<Address, u64>,
 }
 
 impl PolicySet {
@@ -45,12 +47,23 @@ impl PolicySet {
         self.baseline.contains(&user)
     }
 
-    /// Returns `true` if we've ever recorded a set event for `user` (added or removed).
+    /// Returns `true` if [`contains`](Self::contains) can be trusted for `user` at
+    /// `block_number`.
     ///
-    /// When `false`, the caller should not trust [`contains`](Self::contains) returning `false`
-    /// because the user may have been added before the subscriber started.
-    pub fn is_known(&self, user: &Address) -> bool {
-        self.observed.contains(user) || self.baseline.contains(user)
+    /// A set event only reveals membership at and after the block it was observed on. We can
+    /// therefore only answer authoritatively for a query block that is at or after the earliest
+    /// event we recorded for the user; below that block (or with no event at all) the user may
+    /// have been added before we started observing, so the caller must fall back to RPC.
+    ///
+    /// This scoping matters because the subscriber runs ahead of the engine: the set can hold a
+    /// user's *future* delta (e.g. a block-150 removal) while the engine queries an earlier block
+    /// (e.g. block 120). Without the block bound, that future delta would mark the user "known"
+    /// and suppress the RPC fallback, so a blacklist membership that only exists before the delta
+    /// would be silently treated as absent.
+    pub fn is_known(&self, user: &Address, block_number: u64) -> bool {
+        self.first_seen
+            .get(user)
+            .is_some_and(|&first| first <= block_number)
     }
 
     /// Record a set update at the given block height.
@@ -63,7 +76,10 @@ impl PolicySet {
             return;
         }
 
-        self.observed.insert(user);
+        self.first_seen
+            .entry(user)
+            .and_modify(|first| *first = (*first).min(block_number))
+            .or_insert(block_number);
         self.pending
             .entry(block_number)
             .or_default()
@@ -110,7 +126,7 @@ impl PolicySet {
         self.baseline.clear();
         self.baseline_height = 0;
         self.pending.clear();
-        self.observed.clear();
+        self.first_seen.clear();
     }
 }
 


### PR DESCRIPTION
# Scope TIP-403 policy-set membership to the queried block

## What breaks

A blacklisted account can transact on a zone, and a whitelisted account can be
wrongly rejected, whenever the L1 subscriber has observed a *later* policy-set
change for that account than the block the engine is currently authorizing.

Invariant at risk: `TEMPO-ZONE-TIP403-INHERITANCE` (🔴) — "Zone token transfer,
mint, and withdrawal paths enforce the TIP-403 policy inherited from the current
finalized Tempo view."

## Root cause

`PolicySet` answers membership per block via `contains(user, block_number)`, but the
gate that decides whether that answer is *trustworthy* was block-agnostic:

```rust
pub fn is_known(&self, user: &Address) -> bool {
    self.observed.contains(user) || self.baseline.contains(user)
}
```

`observed` was populated the moment *any* event for the user was applied, at *any*
height. The subscriber runs ahead of the engine (the cache advances only after the
engine finishes a block), so the set routinely holds a user's future delta while the
engine queries an earlier block. `is_known` then reported `true`, `check_policy` /
`check_simple` trusted `contains`, and the RPC fallback that exists precisely for
"we don't actually know" was skipped.

### Worked example (blacklist bypass)

1. Token `T` has a BLACKLIST policy. Account `B` is blacklisted as of L1 block 1 —
   before the subscriber started, so no add event is ever seen and the baseline is
   empty for `B`.
2. Subscriber starts at block 100; at block 150 `B` is removed from the blacklist
   (`MembershipChanged{in_set: false}`), recorded as a pending delta and marking `B`
   observed.
3. The engine authorizes a transfer at block 120: `is_known(B)` is `true` (observed),
   `contains(B, 120)` finds no delta ≤ 120 and no baseline entry → `false`, so
   BLACKLIST yields `Some(!false) = Some(true)` — **`B` is authorized at a block
   where it is blacklisted.** No RPC fallback fires.

The whitelist case is the mirror image: a genuinely-authorized user is rejected.

## Fix

Membership from an event is only meaningful at and after the block the event was
observed on. Replace the block-agnostic `observed` set with `first_seen:
HashMap<Address, u64>` — the earliest block at which we recorded any event for the
address — and make known-ness block-scoped:

```rust
pub fn is_known(&self, user: &Address, block_number: u64) -> bool {
    self.first_seen.get(user).is_some_and(|&first| first <= block_number)
}
```

For a query strictly earlier than the first event we hold for a user (the case
above), and for users we've never seen, `is_known` now returns `false`, so
`check_policy`/`check_simple` return `None` and the provider falls back to
authoritative L1 RPC. `first_seen` survives `advance()` (folding deltas into the
baseline keeps the earliest-seen block) and is cleared by `clear()`, mirroring the
previous `observed` lifecycle.

The four production call sites in `cache.rs` already have `block_number` in scope;
they now pass it through.

## Tests

- New `policy_set_future_delta_does_not_authorize_earlier_query` reproduces the
  ahead-of-engine scenario and asserts the earlier block is reported unknown.
- Existing `PolicySet` tests updated to pass the query block; the "observed survives
  advance" guarantee is retained (renamed to `first_seen`).
- `cargo test -p zone-l1 --lib policy_set` (rustc 1.95.0).