### PR TITLE
feat: Wire commonware for p2p between sequencer nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,8 +2219,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe7362c8942f20f0eab11756932b7d1c41f4cc99e142cb563e17a04b40095d5"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2236,8 +2235,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06e32817f35fb517ceb6102d984f9a85fde85666c96f053638e323b8597f2f7"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2251,8 +2249,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e60b2b324de47773c3d4af4d83bfc76d2c287ba7f2d6eb8c2aa5068f877b4bb"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2273,8 +2270,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a67374d82c69e870105f010b895f1768952df5d0fa0d0550dedf162de16f44e"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2304,8 +2300,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f09b55dd5510c3b7613a573606a41961c2788709ffde053d4e644bec0bff2c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -2339,8 +2334,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd313d9299e13bf995999c7a0ed8cc570eef6cd0972fcffc6e2c682cfba6663"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2349,8 +2343,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc385e646d91b5397c93816985421878d627839834f7cf85a8da2ac9f8b98b7"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2362,8 +2355,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d834ed8bf601e113b9cd2ba284dd0e95adf558933dc727f52f8879434cb286"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2376,8 +2368,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c93f730bf4aaeadffb589eb50e431f7a5f8495c158dda1127c61f6e74c597ab"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "commonware-codec",
  "commonware-cryptography",
@@ -2403,8 +2394,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db29306a40279ad54d06b42c623a05fbb5333546b5003c921796bc856b423106"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2414,8 +2404,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dfe9932b33cc31a04b7c68bf543eef7e6d04b70cf6a53880d03407d60a01e6"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2435,8 +2424,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4ae4c804d0d9c1df615b1c7846e4e5e64fdb4228685487cb67803e67388411"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "axum",
  "bytes",
@@ -2472,8 +2460,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1c42cf37aa27c3f83c31591cad4f1d96317eff81c1eb442e17191adcf9b413"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2497,8 +2484,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c15b328d5f05fff750368a71e2307c380cce52df9712a5b30199b8af4e700c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -2517,8 +2503,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf66d7b5c89489d71b0669bda2e014e7c9ffcdf65629ae31886efe5361b1179"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -11388,6 +11373,9 @@ dependencies = [
  "alloy-eips",
  "alloy-rlp",
  "clap",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-math",
  "const-hex",
  "eyre",
  "futures",
@@ -13382,11 +13370,32 @@ dependencies = [
  "url",
  "zone-evm",
  "zone-l1",
+ "zone-p2p",
  "zone-payload",
  "zone-precompiles",
  "zone-primitives",
  "zone-rpc",
  "zone-sequencer",
+]
+
+[[package]]
+name = "zone-p2p"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-p2p",
+ "commonware-runtime",
+ "commonware-utils",
+ "const-hex",
+ "eyre",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/evm",
   "crates/l1",
   "crates/node",
+  "crates/p2p",
   "crates/payload",
   "crates/precompiles",
   "crates/primitives",
@@ -117,6 +118,7 @@ tempo-zone-contracts = { path = "crates/contracts", default-features = false }
 zone-evm = { path = "crates/evm" }
 zone-l1 = { path = "crates/l1" }
 zone-node = { path = "crates/node" }
+zone-p2p = { path = "crates/p2p" }
 zone-payload = { path = "crates/payload" }
 zone-precompiles = { path = "crates/precompiles", default-features = false }
 zone-primitives = { path = "crates/primitives", default-features = false }
@@ -182,6 +184,8 @@ commonware-codec = "=2026.4.0"
 commonware-consensus = "=2026.4.0"
 commonware-cryptography = "=2026.4.0"
 commonware-math = "=2026.4.0"
+commonware-p2p = "=2026.4.0"
+commonware-runtime = "=2026.4.0"
 commonware-utils = "=2026.4.0"
 
 # misc
@@ -210,6 +214,8 @@ serde = { version = "1.0.219", default-features = false, features = [
 serde_json = "1.0.142"
 thiserror = "2"
 tokio = { version = "1.45.1", features = ["full"] }
+tokio-util = "0.7.18"
+toml = "0.9.12"
 axum = "0.8"
 reqwest = { version = "0.13", default-features = false, features = [
   "json",
@@ -217,3 +223,19 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 tokio-tungstenite = "0.28"
 tracing = "0.1.41"
+
+[patch.crates-io]
+
+# Keep the Commonware stack aligned with Tempo's consensus implementation.
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -22,6 +22,7 @@ tempo-contracts.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
 zone-evm.workspace = true
 zone-l1.workspace = true
+zone-p2p.workspace = true
 zone-payload.workspace = true
 zone-precompiles = { workspace = true, features = ["std"] }
 zone-primitives = { workspace = true, features = ["std", "serde"] }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -1,6 +1,6 @@
 //! Tempo Zone CLI.
 
-use std::{sync::Arc, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
@@ -10,6 +10,7 @@ use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
 use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
 use zone_evm::ZoneEvmConfig;
+use zone_p2p::{P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
 
 use crate::{
@@ -99,6 +100,43 @@ fn run_node(mut cli: Cli<TempoChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
 
         validate_l1_rpc_url(&args.l1_rpc_url)?;
 
+        let p2p_config = args
+            .sequencer_manifest
+            .as_ref()
+            .map(|manifest_path| {
+                let ed25519_key_path = args.p2p_key.as_ref().ok_or_else(|| {
+                    eyre::eyre!("--p2p.key is required with --sequencer.manifest")
+                })?;
+                P2pConfig::load(
+                    manifest_path,
+                    ed25519_key_path,
+                    args.p2p_listen,
+                    args.zone_id,
+                    args.sequencer_role,
+                )
+            })
+            .transpose()?;
+        let manifest_role = p2p_config.as_ref().map(P2pConfig::role);
+        if let Some(config) = p2p_config.as_ref() {
+            info!(
+                target: "reth::cli",
+                role = %config.role(),
+                ed25519_public_key = %config.ed25519_public_key(),
+                listen = %config.listen(),
+                "Validated multi-sequencer manifest and local identity"
+            );
+        }
+
+        let manifest_mode = p2p_config.is_some();
+        let should_sequence_blocks = sequencer_enabled(args.enable_sequencer, manifest_role);
+        let sequencer_signer = (should_sequence_blocks || manifest_mode)
+            .then(|| {
+                args.sequencer_key
+                    .parse::<PrivateKeySigner>()
+                    .map_err(|err| eyre::eyre!("invalid --sequencer-key: {err}"))
+            })
+            .transpose()?;
+
         builder.config_mut().network.discovery.disable_discovery = true;
         builder.config_mut().rpc.disable_auth_server = true;
         builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
@@ -120,11 +158,9 @@ fn run_node(mut cli: Cli<TempoChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             ),
         });
 
-        if args.enable_sequencer {
-            let sequencer_signer: PrivateKeySigner = args
-                .sequencer_key
-                .parse()
-                .expect("invalid sequencer private key");
+        if should_sequence_blocks {
+            let sequencer_signer = sequencer_signer
+                .expect("sequencer signer is parsed whenever sequencing is enabled");
             node = node.with_sequencer(ZoneSequencerAddOnsConfig {
                 sequencer_signer,
                 zone_id: args.zone_id,
@@ -133,6 +169,12 @@ fn run_node(mut cli: Cli<TempoChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 batch_anchor_config: BatchAnchorConfig::default(),
                 withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
             });
+        }
+        if manifest_role == Some(Role::Follower) {
+            info!(target: "reth::cli", "Starting in follower mode");
+        }
+        if let Some(config) = p2p_config {
+            node = node.with_p2p(config);
         }
 
         let handle = builder.node(node).launch_with_debug_capabilities().await?;
@@ -162,6 +204,43 @@ pub struct ZoneArgs {
     /// Sequencer private key (hex, with or without 0x prefix).
     #[arg(long = "sequencer-key", env = "SEQUENCER_KEY")]
     pub sequencer_key: String,
+
+    /// Path to the static multi-sequencer manifest. Its presence activates
+    /// multi-sequencer mode and makes the manifest authoritative for role selection.
+    #[arg(
+        long = "sequencer.manifest",
+        env = "SEQUENCER_MANIFEST",
+        value_name = "PATH",
+        requires = "p2p_key",
+        conflicts_with = "enable_sequencer"
+    )]
+    pub sequencer_manifest: Option<PathBuf>,
+
+    /// Path to this node's hex-encoded Ed25519 P2P identity key.
+    #[arg(
+        long = "p2p.key",
+        env = "P2P_KEY",
+        value_name = "PATH",
+        requires = "sequencer_manifest"
+    )]
+    pub p2p_key: Option<PathBuf>,
+
+    /// Socket address bound for multi-sequencer Commonware traffic.
+    #[arg(
+        long = "p2p.listen",
+        env = "P2P_LISTEN",
+        default_value = "0.0.0.0:9200"
+    )]
+    pub p2p_listen: SocketAddr,
+
+    /// (Optional) Checked against the role derived from the manifest.
+    #[arg(
+        long = "sequencer.role",
+        env = "SEQUENCER_ROLE",
+        value_name = "ROLE",
+        requires = "sequencer_manifest"
+    )]
+    pub sequencer_role: Option<Role>,
 
     /// How often (in seconds) the zone monitor polls for new L2 blocks.
     #[arg(
@@ -233,7 +312,11 @@ pub struct ZoneArgs {
 
     /// Enable the Zone node in sequencer mode. This advances block production and submits
     /// withdrawal batches.
-    #[arg(long = "sequencer", env = "SEQUENCER")]
+    #[arg(
+        long = "sequencer",
+        env = "SEQUENCER",
+        conflicts_with = "sequencer_manifest"
+    )]
     pub enable_sequencer: bool,
 }
 
@@ -242,6 +325,14 @@ fn prepend_log_filter(filter: &mut String, directives: &str) {
         *filter = directives.to_owned();
     } else {
         *filter = format!("{directives},{filter}");
+    }
+}
+
+fn sequencer_enabled(cli_flag: bool, manifest_role: Option<Role>) -> bool {
+    match manifest_role {
+        Some(Role::Leader) => true,
+        Some(Role::Follower) => false,
+        None => cli_flag,
     }
 }
 
@@ -259,7 +350,16 @@ fn validate_l1_rpc_url(l1_rpc_url: &str) -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ZoneCli, validate_l1_rpc_url};
+    use clap::Parser as _;
+
+    use super::{ZoneArgs, ZoneCli, sequencer_enabled, validate_l1_rpc_url};
+    use zone_p2p::Role;
+
+    #[derive(Debug, clap::Parser)]
+    struct ZoneArgsParser {
+        #[command(flatten)]
+        zone: ZoneArgs,
+    }
 
     #[test]
     fn top_level_help_lists_dev_subcommand() {
@@ -273,6 +373,65 @@ mod tests {
     fn dev_is_parsed_by_the_top_level_cli() {
         let parsed = ZoneCli::try_parse_from(["tempo-zone", "dev"]).unwrap();
         assert!(matches!(parsed, ZoneCli::Dev(_)));
+    }
+
+    #[test]
+    fn manifest_mode_requires_a_p2p_key_and_conflicts_with_legacy_sequencer() {
+        let common = [
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sequencer-key",
+            "0x01",
+        ];
+
+        let missing_key = ZoneArgsParser::try_parse_from(
+            common
+                .into_iter()
+                .chain(["--sequencer.manifest", "zone.toml"]),
+        )
+        .unwrap_err();
+        assert_eq!(
+            missing_key.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let conflict = ZoneArgsParser::try_parse_from(common.into_iter().chain([
+            "--sequencer.manifest",
+            "zone.toml",
+            "--p2p.key",
+            "node.key",
+            "--sequencer",
+        ]))
+        .unwrap_err();
+        assert_eq!(conflict.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn legacy_mode_still_accepts_the_sequencer_flag_without_a_manifest() {
+        let parsed = ZoneArgsParser::try_parse_from([
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sequencer-key",
+            "0x01",
+            "--sequencer",
+        ])
+        .unwrap();
+        assert!(parsed.zone.enable_sequencer);
+        assert!(parsed.zone.sequencer_manifest.is_none());
+    }
+
+    #[test]
+    fn manifest_role_is_authoritative_for_sequencer_startup() {
+        assert!(sequencer_enabled(false, Some(Role::Leader)));
+        assert!(!sequencer_enabled(true, Some(Role::Follower)));
+        assert!(sequencer_enabled(true, None));
+        assert!(!sequencer_enabled(false, None));
     }
 
     #[test]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -111,6 +111,7 @@ fn run_node(mut cli: Cli<TempoChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                     manifest_path,
                     ed25519_key_path,
                     args.p2p_listen,
+                    args.p2p_bypass_ip_check,
                     args.zone_id,
                     args.sequencer_role,
                 )
@@ -232,6 +233,17 @@ pub struct ZoneArgs {
         default_value = "0.0.0.0:9200"
     )]
     pub p2p_listen: SocketAddr,
+
+    /// Disable Commonware's pre-authentication source-IP filter.
+    ///
+    /// Required for DNS peer addresses whose egress IPs are not known in advance.
+    /// Only enable this when network-level policy restricts access to the P2P port.
+    #[arg(
+        long = "p2p.bypass-ip-check",
+        env = "P2P_BYPASS_IP_CHECK",
+        requires = "sequencer_manifest"
+    )]
+    pub p2p_bypass_ip_check: bool,
 
     /// (Optional) Checked against the role derived from the manifest.
     #[arg(
@@ -424,6 +436,40 @@ mod tests {
         .unwrap();
         assert!(parsed.zone.enable_sequencer);
         assert!(parsed.zone.sequencer_manifest.is_none());
+    }
+
+    #[test]
+    fn p2p_ip_check_bypass_is_explicit_and_requires_manifest_mode() {
+        let common = [
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sequencer-key",
+            "0x01",
+        ];
+
+        let without_manifest =
+            ZoneArgsParser::try_parse_from(common.into_iter().chain(["--p2p.bypass-ip-check"]))
+                .unwrap_err();
+        assert_eq!(
+            without_manifest.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let default = ZoneArgsParser::try_parse_from(common).unwrap();
+        assert!(!default.zone.p2p_bypass_ip_check);
+
+        let enabled = ZoneArgsParser::try_parse_from(common.into_iter().chain([
+            "--sequencer.manifest",
+            "zone.toml",
+            "--p2p.key",
+            "node.key",
+            "--p2p.bypass-ip-check",
+        ]))
+        .unwrap();
+        assert!(enabled.zone.p2p_bypass_ip_check);
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -65,6 +65,7 @@ use zone_l1::{
         spawn_policy_resolution_task, spawn_pool_prefetch_task,
     },
 };
+use zone_p2p::{P2pConfig, P2pNetworkId, spawn_p2p};
 use zone_payload::{
     DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, WithdrawalRevealEncryptor, ZonePayloadAttributes,
     ZonePayloadFactory, ZonePayloadTypes,
@@ -177,6 +178,8 @@ pub struct ZoneNode {
     private_rpc_config: ZonePrivateRpcConfig,
     /// Optional sequencer config. When set, sequencer tasks are spawned.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Optional static Zone P2P networking config.
+    p2p_config: Option<P2pConfig>,
 }
 
 impl ZoneNode {
@@ -221,6 +224,7 @@ impl ZoneNode {
             withdrawal_reveal_encryptor: None,
             private_rpc_config: ZonePrivateRpcConfig::default(),
             sequencer_config: None,
+            p2p_config: None,
         }
     }
 
@@ -239,6 +243,12 @@ impl ZoneNode {
             config.zone_id,
         )));
         self.sequencer_config = Some(config);
+        self
+    }
+
+    /// Enable static Zone P2P networking for this node.
+    pub fn with_p2p(mut self, config: P2pConfig) -> Self {
+        self.p2p_config = Some(config);
         self
     }
 
@@ -356,6 +366,8 @@ where
     private_rpc_config: ZonePrivateRpcConfig,
     /// Sequencer configuration.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Static Zone P2P networking configuration.
+    p2p_config: Option<P2pConfig>,
 }
 
 impl<N> std::fmt::Debug for ZoneAddOns<N>
@@ -381,6 +393,7 @@ where
         initial_tokens: Option<Vec<Address>>,
         private_rpc_config: ZonePrivateRpcConfig,
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+        p2p_config: Option<P2pConfig>,
     ) -> Self {
         Self {
             inner: RpcAddOns::new(
@@ -398,6 +411,7 @@ where
             initial_tokens,
             private_rpc_config,
             sequencer_config,
+            p2p_config,
         }
     }
 }
@@ -437,13 +451,18 @@ where
         self.spawn_l1_subscriber(&ctx);
         self.spawn_policy_tasks(&l1_provider, &ctx);
 
+        let task_executor = ctx.node.task_executor().clone();
+        if let Some(config) = self.p2p_config.take() {
+            let network_id =
+                P2pNetworkId::new(l1_provider.get_chain_id().await?, self.portal_address);
+            Self::launch_p2p(config, network_id, &task_executor)?;
+        }
+
         if let Some(ref config) = self.sequencer_config {
             let sequencer_addr = config.sequencer_signer.address();
             let sequencer_key = SecretKey::from(config.sequencer_signer.credential());
             self.spawn_zone_engine(l1_provider, &ctx, sequencer_addr, sequencer_key)?;
         }
-
-        let task_executor = ctx.node.task_executor().clone();
 
         let chain_id = ctx
             .node
@@ -493,6 +512,45 @@ where
         >,
     TempoEthApiBuilder<N>: EthApiBuilder<N, EthApi: EthApiTypes<NetworkTypes = TempoNetwork>>,
 {
+    fn launch_p2p(
+        config: P2pConfig,
+        network_id: P2pNetworkId,
+        task_executor: &reth_tasks::TaskExecutor,
+    ) -> eyre::Result<()> {
+        let handle = spawn_p2p(config, network_id)?;
+        let zone_p2p::P2pHandleParts {
+            shutdown: shutdown_token,
+            mut stopped,
+            commands: _commands,
+            events: _events,
+        } = handle.into_parts();
+
+        task_executor.spawn_critical_with_graceful_shutdown_signal(
+            "zone-p2p",
+            |shutdown| async move {
+                tokio::select! {
+                    guard = shutdown => {
+                        let _guard = guard;
+                        shutdown_token.cancel();
+                        match stopped.await {
+                            Ok(Ok(())) => info!(target: "reth::cli", "P2P runtime stopped"),
+                            Ok(Err(err)) => tracing::error!(target: "reth::cli", %err, "P2P runtime failed during shutdown"),
+                            Err(err) => tracing::error!(target: "reth::cli", %err, "P2P runtime completion channel closed during shutdown"),
+                        }
+                    }
+                    result = &mut stopped => {
+                        match result {
+                            Ok(Ok(())) => tracing::error!(target: "reth::cli", "P2P runtime stopped unexpectedly"),
+                            Ok(Err(err)) => tracing::error!(target: "reth::cli", %err, "P2P runtime failed"),
+                            Err(err) => tracing::error!(target: "reth::cli", %err, "P2P runtime completion channel closed unexpectedly"),
+                        }
+                    }
+                }
+            },
+        );
+        Ok(())
+    }
+
     /// Resolve enabled tokens and seed the policy cache.
     async fn resolve_and_seed_tokens(
         &mut self,
@@ -803,6 +861,7 @@ where
             self.initial_tokens.clone(),
             self.private_rpc_config.clone(),
             self.sequencer_config.clone(),
+            self.p2p_config.clone(),
         )
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -521,6 +521,7 @@ where
         let zone_p2p::P2pHandleParts {
             shutdown: shutdown_token,
             mut stopped,
+            thread,
             commands: _commands,
             events: _events,
         } = handle.into_parts();
@@ -544,6 +545,16 @@ where
                             Ok(Err(err)) => tracing::error!(target: "reth::cli", %err, "P2P runtime failed"),
                             Err(err) => tracing::error!(target: "reth::cli", %err, "P2P runtime completion channel closed unexpectedly"),
                         }
+                    }
+                }
+
+                match tokio::task::spawn_blocking(move || thread.join()).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(_)) => {
+                        tracing::error!(target: "reth::cli", "P2P runtime thread panicked")
+                    }
+                    Err(err) => {
+                        tracing::error!(target: "reth::cli", %err, "Failed joining P2P runtime thread")
                     }
                 }
             },

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "zone-p2p"
+description = "Static authenticated P2P networking for Tempo Zones"
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-primitives.workspace = true
+
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-p2p.workspace = true
+commonware-runtime = { workspace = true, features = ["external"] }
+commonware-utils.workspace = true
+
+const-hex.workspace = true
+eyre.workspace = true
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+toml.workspace = true
+tracing.workspace = true

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -98,3 +98,10 @@ Add these arguments to the node's normal command:
 Use each node's own key file and listener address. 
 The `--sequencer` flag conflicts with `--sequencer.manifest` because the
 manifest determines whether the node starts the sequencer tasks.
+
+DNS peer addresses do not provide a stable egress IP for Commonware's inbound
+source-IP filter. A manifest containing any DNS peer therefore requires the
+explicit `--p2p.bypass-ip-check` flag. The flag disables source-IP filtering for
+all inbound P2P connections, not only the DNS peer. Only use it when a network-level
+policy restricts the P2P port to the configured peers; Ed25519 manifest membership
+authentication remains enforced.

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -1,0 +1,100 @@
+# Tempo Zone P2P
+
+This crate provides the static networking and role bootstrap for a
+multi-sequencer Tempo Zone. A manifest defines the
+single leader(block producer) and the followers. Each node loads its own Commonware 
+Ed25519 identity, validates that it appears in the manifest, and derives whether it should start as the
+leader or a follower.
+
+If a manifest is not specified, `tempo-zone` retains its existing single-sequencer startup
+behavior.
+
+## Roles
+
+- The **leader** runs the existing block-production and L1-settlement tasks in
+  addition to the P2P network.
+- A **follower** joins the P2P network and receives blocks from the leader, validating and importing the blocks and sending a signed block hash back to the leader
+
+The manifest is authoritative. The (optional) `--sequencer.role` CLI argument is
+only an assertion checked against the manifest. There is no automatic election or promotion.
+ 
+
+## Commonware network
+
+Nodes use [Commonware](https://commonware.xyz/) to communicate. Discovery is disabled: the
+manifest supplies the complete peer set, including each peer's address and
+Ed25519 public key.
+
+The Commonware Ed25519 identity answers which configured network peer sent a
+message. It is not an on-chain quorum identity. The quorum design will
+also give each node an individual secp256k1 key whose Ethereum address is
+registered with `ZonePortal`. 
+
+The authenticated-network namespace includes the P2P wire-protocol version,
+Tempo L1 chain ID, ZonePortal address, and zone ID. This prevents nodes from
+different local, test, or production environments from connecting when a key
+or endpoint is accidentally reused.
+
+## Manifest example
+
+The manifest is TOML and must contain at least three nodes. The following shows
+the configuration shape:
+
+```toml
+zone_id = 7
+leader_ed25519_public_key = "0xleader..."
+
+[[nodes]]
+name = "leader"
+ed25519_public_key = "0xleader..."
+address = "leader.zone.internal:9200"
+# Future on-chain quorum identity; not accepted by the schema yet:
+# secp256k1_address = "0x1111111111111111111111111111111111111111"
+
+[[nodes]]
+name = "follower-a"
+ed25519_public_key = "0xfa..."
+address = "follower-a.zone.internal:9200"
+# secp256k1_address = "0x2222222222222222222222222222222222222222"
+
+[[nodes]]
+name = "follower-b"
+ed25519_public_key = "0xfb..."
+address = "follower-b.zone.internal:9200"
+# secp256k1_address = "0x3333333333333333333333333333333333333333"
+```
+
+The manifest loader validates that:
+
+- there are at least three nodes;
+- node names and Ed25519 public keys are unique;
+- every address has a non-zero port;
+- `leader_ed25519_public_key` identifies one of the nodes;
+- the manifest's `zone_id` matches `--zone.id`; and
+- the local private key corresponds to a manifest member.
+
+## Generate a Commonware identity
+
+Generate a unique Ed25519 key for each node with `xtask`:
+
+```bash
+cargo run -p tempo-xtask -- generate-p2p-key --out leader-p2p.key
+```
+
+The command writes the hex-encoded private key to the requested file and prints
+the corresponding public key for the manifest. 
+
+## Start a node with a manifest
+
+Add these arguments to the node's normal command:
+
+```text
+--sequencer.manifest ./zone-manifest.toml
+--p2p.key ./leader-p2p.key
+--p2p.listen 0.0.0.0:9200
+--sequencer.role leader
+```
+
+Use each node's own key file and listener address. 
+The `--sequencer` flag conflicts with `--sequencer.manifest` because the
+manifest determines whether the node starts the sequencer tasks.

--- a/crates/p2p/src/identity.rs
+++ b/crates/p2p/src/identity.rs
@@ -1,0 +1,82 @@
+use std::{fmt, path::Path};
+
+use commonware_codec::DecodeExt as _;
+use commonware_cryptography::{
+    Signer as _,
+    ed25519::{PrivateKey, PublicKey},
+};
+
+/// An Ed25519 private key loaded as a node's Commonware identity.
+#[derive(Clone)]
+pub(crate) struct Ed25519Identity(PrivateKey);
+
+impl Ed25519Identity {
+    /// Reads an unencrypted, hex-encoded identity from `path`.
+    pub(crate) fn read_from_file(path: impl AsRef<Path>) -> Result<Self, Ed25519IdentityError> {
+        let path = path.as_ref();
+        let encoded =
+            std::fs::read_to_string(path).map_err(|source| Ed25519IdentityError::Read {
+                path: path.to_owned(),
+                source,
+            })?;
+        Self::from_hex(encoded.trim())
+    }
+
+    /// Parses an unencrypted, hex-encoded identity.
+    pub(crate) fn from_hex(encoded: &str) -> Result<Self, Ed25519IdentityError> {
+        let bytes = const_hex::decode(encoded).map_err(Ed25519IdentityError::Hex)?;
+        let key = PrivateKey::decode(&bytes[..]).map_err(Ed25519IdentityError::Decode)?;
+        Ok(Self(key))
+    }
+
+    /// Returns the Ed25519 public key corresponding to this private key.
+    pub(crate) fn ed25519_public_key(&self) -> PublicKey {
+        self.0.public_key()
+    }
+
+    pub(crate) fn into_private_key(self) -> PrivateKey {
+        self.0
+    }
+}
+
+impl fmt::Debug for Ed25519Identity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ed25519Identity")
+            .field("ed25519_public_key", &self.ed25519_public_key())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Errors produced while loading a Commonware Ed25519 identity.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Ed25519IdentityError {
+    #[error("failed reading Commonware Ed25519 identity `{path}`")]
+    Read {
+        path: std::path::PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Commonware Ed25519 identity is not valid hex")]
+    Hex(#[source] const_hex::FromHexError),
+
+    #[error("Commonware identity is not a valid Ed25519 private key")]
+    Decode(#[source] commonware_codec::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use commonware_codec::Encode as _;
+    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+
+    use super::Ed25519Identity;
+
+    #[test]
+    fn parses_hex_identity() {
+        let key = PrivateKey::from_seed(7);
+        let identity =
+            Ed25519Identity::from_hex(&const_hex::encode_prefixed(key.encode().as_ref())).unwrap();
+
+        assert_eq!(identity.ed25519_public_key(), key.public_key());
+    }
+}

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -1,0 +1,12 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod identity;
+mod manifest;
+mod messages;
+mod network;
+mod runtime;
+
+pub use manifest::{ManifestAddress, ManifestError, ManifestNode, Role, ZoneManifest};
+pub use network::P2pNetworkId;
+pub use runtime::{P2pCommand, P2pConfig, P2pEvent, P2pHandle, P2pHandleParts, spawn_p2p};

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -1,0 +1,472 @@
+use std::{
+    collections::BTreeSet,
+    fmt,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::Path,
+};
+
+use commonware_codec::DecodeExt as _;
+use commonware_cryptography::ed25519::PublicKey;
+use commonware_p2p::{Address, Ingress};
+use commonware_utils::Hostname;
+use serde::Deserialize;
+
+/// The role assigned to a node by the manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// Builds blocks and runs the existing sequencer settlement tasks.
+    Leader,
+    /// Runs without block production, follows `Leader`s blocks
+    Follower,
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Leader => f.write_str("leader"),
+            Self::Follower => f.write_str("follower"),
+        }
+    }
+}
+
+impl std::str::FromStr for Role {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "leader" => Ok(Self::Leader),
+            "follower" => Ok(Self::Follower),
+            _ => Err(format!("expected `leader` or `follower`, got `{value}`")),
+        }
+    }
+}
+
+/// A validated P2P address from the manifest.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ManifestAddress {
+    /// A literal IP address and port.
+    Socket(SocketAddr),
+    /// A DNS hostname and port.
+    Dns { host: Hostname, port: u16 },
+}
+
+impl ManifestAddress {
+    pub(crate) fn to_commonware(&self) -> Address {
+        match self {
+            Self::Socket(address) => Address::Symmetric(*address),
+            Self::Dns { host, port } => Address::Asymmetric {
+                ingress: Ingress::Dns {
+                    host: host.clone(),
+                    port: *port,
+                },
+                // DNS-only manifests cannot know a pod's egress IP ahead of time.
+                // The network enables authenticated-key-only ingress filtering when
+                // DNS addresses are present, so this placeholder is never consulted.
+                egress: SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+            },
+        }
+    }
+
+    pub(crate) const fn is_dns(&self) -> bool {
+        matches!(self, Self::Dns { .. })
+    }
+}
+
+impl fmt::Display for ManifestAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Socket(address) => address.fmt(f),
+            Self::Dns { host, port } => write!(f, "{host}:{port}"),
+        }
+    }
+}
+
+impl std::str::FromStr for ManifestAddress {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Ok(address) = value.parse::<SocketAddr>() {
+            if address.port() == 0 {
+                return Err("port must be non-zero".to_owned());
+            }
+            return Ok(Self::Socket(address));
+        }
+
+        let (host, port) = value
+            .rsplit_once(':')
+            .ok_or_else(|| "expected `host:port`".to_owned())?;
+        if host.is_empty() || host.contains(':') {
+            return Err("expected a DNS hostname or bracketed IP followed by a port".to_owned());
+        }
+        let host = Hostname::new(host).map_err(|err| format!("invalid DNS hostname: {err}"))?;
+        let port = port
+            .parse::<u16>()
+            .map_err(|err| format!("invalid port: {err}"))?;
+        if port == 0 {
+            return Err("port must be non-zero".to_owned());
+        }
+        Ok(Self::Dns { host, port })
+    }
+}
+
+/// One node in a zone's static multi-sequencer topology.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestNode {
+    name: String,
+    ed25519_public_key: PublicKey,
+    // TODO: Add `secp256k1_address`, from this
+    // node's individual L1/attestation key. It is distinct from the Commonware
+    // Ed25519 identity above and will be used for the on-chain quorum.
+    address: ManifestAddress,
+}
+
+impl ManifestNode {
+    /// Human-readable node name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Node's Ed25519 public key used to authenticate Commonware traffic.
+    pub const fn ed25519_public_key(&self) -> &PublicKey {
+        &self.ed25519_public_key
+    }
+
+    /// Node's advertised P2P address.
+    pub const fn address(&self) -> &ManifestAddress {
+        &self.address
+    }
+}
+
+/// A parsed and intrinsically validated zone manifest.
+#[derive(Debug, Clone)]
+pub struct ZoneManifest {
+    zone_id: u32,
+    leader_ed25519_public_key: PublicKey,
+    nodes: Vec<ManifestNode>,
+}
+
+impl ZoneManifest {
+    /// Parses and validates a TOML manifest.
+    pub fn parse(input: &str) -> Result<Self, ManifestError> {
+        let raw: RawManifest = toml::from_str(input).map_err(ManifestError::Toml)?;
+        if raw.nodes.len() < 3 {
+            return Err(ManifestError::TooFewNodes(raw.nodes.len()));
+        }
+
+        let leader_ed25519_public_key =
+            parse_ed25519_public_key("leader_ed25519_public_key", &raw.leader_ed25519_public_key)?;
+        let mut names = BTreeSet::new();
+        let mut ed25519_public_keys = BTreeSet::new();
+        let mut nodes = Vec::with_capacity(raw.nodes.len());
+
+        for raw_node in raw.nodes {
+            if raw_node.name.trim().is_empty() {
+                return Err(ManifestError::EmptyNodeName);
+            }
+            if !names.insert(raw_node.name.clone()) {
+                return Err(ManifestError::DuplicateNodeName(raw_node.name));
+            }
+
+            let ed25519_public_key = parse_ed25519_public_key(
+                &format!("nodes.{}.ed25519_public_key", raw_node.name),
+                &raw_node.ed25519_public_key,
+            )?;
+            if !ed25519_public_keys.insert(ed25519_public_key.clone()) {
+                return Err(ManifestError::DuplicateEd25519PublicKey(
+                    ed25519_public_key.to_string(),
+                ));
+            }
+
+            let address =
+                raw_node
+                    .address
+                    .parse()
+                    .map_err(|reason| ManifestError::InvalidAddress {
+                        node: raw_node.name.clone(),
+                        address: raw_node.address.clone(),
+                        reason,
+                    })?;
+            nodes.push(ManifestNode {
+                name: raw_node.name,
+                ed25519_public_key,
+                address,
+            });
+        }
+
+        if !ed25519_public_keys.contains(&leader_ed25519_public_key) {
+            return Err(ManifestError::LeaderEd25519PublicKeyNotFound(
+                leader_ed25519_public_key.to_string(),
+            ));
+        }
+
+        Ok(Self {
+            zone_id: raw.zone_id,
+            leader_ed25519_public_key,
+            nodes,
+        })
+    }
+
+    /// Reads, parses, and validates a TOML manifest from disk.
+    pub fn read_from_file(path: impl AsRef<Path>) -> Result<Self, ManifestError> {
+        let path = path.as_ref();
+        let input = std::fs::read_to_string(path).map_err(|source| ManifestError::Read {
+            path: path.to_owned(),
+            source,
+        })?;
+        Self::parse(&input)
+    }
+
+    /// Validates node-specific invariants and returns the manifest-derived role.
+    pub fn validate_node(
+        &self,
+        expected_zone_id: u32,
+        local_ed25519_public_key: &PublicKey,
+        asserted_role: Option<Role>,
+    ) -> Result<Role, ManifestError> {
+        if self.zone_id != expected_zone_id {
+            return Err(ManifestError::ZoneIdMismatch {
+                manifest: self.zone_id,
+                cli: expected_zone_id,
+            });
+        }
+
+        let role = self.role_of(local_ed25519_public_key).ok_or_else(|| {
+            ManifestError::LocalNodeNotFound(local_ed25519_public_key.to_string())
+        })?;
+        if let Some(asserted) = asserted_role
+            && asserted != role
+        {
+            return Err(ManifestError::RoleMismatch {
+                asserted,
+                manifest: role,
+            });
+        }
+        Ok(role)
+    }
+
+    /// Zone identifier used to domain-separate the P2P network.
+    pub const fn zone_id(&self) -> u32 {
+        self.zone_id
+    }
+
+    /// Ed25519 Commonware public key of the statically assigned leader.
+    pub const fn leader_ed25519_public_key(&self) -> &PublicKey {
+        &self.leader_ed25519_public_key
+    }
+
+    /// All nodes in the static peer set.
+    pub fn nodes(&self) -> &[ManifestNode] {
+        &self.nodes
+    }
+
+    /// Returns the role of a manifest member, or `None` for an unknown Ed25519 key.
+    pub fn role_of(&self, ed25519_public_key: &PublicKey) -> Option<Role> {
+        self.nodes
+            .iter()
+            .any(|node| node.ed25519_public_key() == ed25519_public_key)
+            .then_some(if ed25519_public_key == &self.leader_ed25519_public_key {
+                Role::Leader
+            } else {
+                Role::Follower
+            })
+    }
+
+    pub(crate) fn has_dns_addresses(&self) -> bool {
+        self.nodes.iter().any(|node| node.address.is_dns())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifest {
+    zone_id: u32,
+    leader_ed25519_public_key: String,
+    nodes: Vec<RawManifestNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawManifestNode {
+    name: String,
+    ed25519_public_key: String,
+    address: String,
+}
+
+fn parse_ed25519_public_key(field: &str, encoded: &str) -> Result<PublicKey, ManifestError> {
+    let bytes =
+        const_hex::decode(encoded).map_err(|source| ManifestError::InvalidEd25519PublicKey {
+            field: field.to_owned(),
+            reason: source.to_string(),
+        })?;
+    PublicKey::decode(&bytes[..]).map_err(|source| ManifestError::InvalidEd25519PublicKey {
+        field: field.to_owned(),
+        reason: source.to_string(),
+    })
+}
+
+/// Manifest parsing and validation errors.
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    #[error("failed reading sequencer manifest `{path}`")]
+    Read {
+        path: std::path::PathBuf,
+
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("invalid sequencer manifest TOML")]
+    Toml(#[source] toml::de::Error),
+
+    #[error("sequencer manifest must contain at least 3 nodes, found {0}")]
+    TooFewNodes(usize),
+
+    #[error("sequencer manifest node names must not be empty")]
+    EmptyNodeName,
+
+    #[error("duplicate sequencer manifest node name `{0}`")]
+    DuplicateNodeName(String),
+
+    #[error("duplicate sequencer manifest Ed25519 public key `{0}`")]
+    DuplicateEd25519PublicKey(String),
+
+    #[error("invalid Ed25519 public key in `{field}`: {reason}")]
+    InvalidEd25519PublicKey { field: String, reason: String },
+
+    #[error("invalid address `{address}` for node `{node}`: {reason}")]
+    InvalidAddress {
+        node: String,
+        address: String,
+        reason: String,
+    },
+
+    #[error("manifest leader Ed25519 public key `{0}` does not match any node")]
+    LeaderEd25519PublicKeyNotFound(String),
+
+    #[error("zone ID mismatch: manifest has {manifest}, but --zone.id is {cli}")]
+    ZoneIdMismatch { manifest: u32, cli: u32 },
+
+    #[error("this node's Ed25519 public key `{0}` is not present in the sequencer manifest")]
+    LocalNodeNotFound(String),
+
+    #[error("--sequencer.role asserts `{asserted}`, but the manifest assigns `{manifest}`")]
+    RoleMismatch { asserted: Role, manifest: Role },
+}
+
+#[cfg(test)]
+mod tests {
+    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+
+    use super::{ManifestError, Role, ZoneManifest};
+
+    fn ed25519_public_key(seed: u64) -> String {
+        let key = PrivateKey::from_seed(seed).public_key();
+        const_hex::encode_prefixed(key.as_ref())
+    }
+
+    fn manifest(leader: u64, nodes: &[(u64, &str, &str)]) -> String {
+        let mut value = format!(
+            "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n",
+            ed25519_public_key(leader)
+        );
+        for (key, name, address) in nodes {
+            value.push_str(&format!(
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\naddress = \"{address}\"\n",
+                ed25519_public_key(*key)
+            ));
+        }
+        value
+    }
+
+    #[test]
+    fn parses_and_derives_roles() {
+        let input = manifest(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200"),
+                (2, "follower-a", "follower-a.zone.local:9200"),
+                (3, "follower-b", "127.0.0.1:9202"),
+            ],
+        );
+        let manifest = ZoneManifest::parse(&input).unwrap();
+        let leader = PrivateKey::from_seed(1).public_key();
+        let follower = PrivateKey::from_seed(2).public_key();
+
+        assert_eq!(
+            manifest.validate_node(7, &leader, None).unwrap(),
+            Role::Leader
+        );
+        assert_eq!(
+            manifest
+                .validate_node(7, &follower, Some(Role::Follower))
+                .unwrap(),
+            Role::Follower
+        );
+    }
+
+    #[test]
+    fn readme_manifest_example_has_expected_shape() {
+        let (_, after_fence) = include_str!("../README.md")
+            .split_once("```toml\n")
+            .expect("README contains a TOML manifest example");
+        let (example, _) = after_fence
+            .split_once("\n```")
+            .expect("README closes the TOML manifest example");
+
+        let manifest: super::RawManifest = toml::from_str(example).unwrap();
+        assert_eq!(manifest.zone_id, 7);
+        assert_eq!(manifest.nodes.len(), 3);
+    }
+
+    #[test]
+    fn rejects_invalid_topologies_and_node_assertions() {
+        let too_small = manifest(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200"),
+                (2, "follower", "127.0.0.1:9201"),
+            ],
+        );
+        assert!(matches!(
+            ZoneManifest::parse(&too_small),
+            Err(ManifestError::TooFewNodes(2))
+        ));
+
+        let duplicate = manifest(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200"),
+                (2, "follower", "127.0.0.1:9201"),
+                (2, "follower-2", "127.0.0.1:9202"),
+            ],
+        );
+        assert!(matches!(
+            ZoneManifest::parse(&duplicate),
+            Err(ManifestError::DuplicateEd25519PublicKey(_))
+        ));
+
+        let valid = ZoneManifest::parse(&manifest(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200"),
+                (2, "follower-a", "127.0.0.1:9201"),
+                (3, "follower-b", "127.0.0.1:9202"),
+            ],
+        ))
+        .unwrap();
+        let follower = PrivateKey::from_seed(2).public_key();
+        assert!(matches!(
+            valid.validate_node(7, &follower, Some(Role::Leader)),
+            Err(ManifestError::RoleMismatch { .. })
+        ));
+        assert!(matches!(
+            valid.validate_node(8, &follower, None),
+            Err(ManifestError::ZoneIdMismatch { .. })
+        ));
+        let unknown = PrivateKey::from_seed(99).public_key();
+        assert!(matches!(
+            valid.validate_node(7, &unknown, None),
+            Err(ManifestError::LocalNodeNotFound(_))
+        ));
+    }
+}

--- a/crates/p2p/src/messages.rs
+++ b/crates/p2p/src/messages.rs
@@ -1,0 +1,67 @@
+use commonware_codec::{Error, FixedSize, Read, ReadExt as _, Write};
+use commonware_runtime::{Buf, BufMut};
+
+const HEARTBEAT_TAG: u8 = 0;
+const HEARTBEAT_ACK_TAG: u8 = 1;
+
+/// PoC messages exchanged on the P2P control channel.
+///
+/// TODO: This heartbeat exchange exists only to exercise authenticated
+/// message transport. Replace it with the v0 block, ACK/signature, transaction-forwarding,
+/// and backfill protocols. It is not a leader-election heartbeat or a source of leadership
+/// or finality, and will be removed with the next PR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ControlMessage {
+    Heartbeat { nonce: u64 },
+    HeartbeatAck { nonce: u64 },
+}
+
+impl Write for ControlMessage {
+    fn write(&self, buffer: &mut impl BufMut) {
+        match self {
+            Self::Heartbeat { nonce } => {
+                HEARTBEAT_TAG.write(buffer);
+                nonce.write(buffer);
+            }
+            Self::HeartbeatAck { nonce } => {
+                HEARTBEAT_ACK_TAG.write(buffer);
+                nonce.write(buffer);
+            }
+        }
+    }
+}
+
+impl FixedSize for ControlMessage {
+    const SIZE: usize = u8::SIZE + u64::SIZE;
+}
+
+impl Read for ControlMessage {
+    type Cfg = ();
+
+    fn read_cfg(buffer: &mut impl Buf, _cfg: &Self::Cfg) -> Result<Self, Error> {
+        let tag = u8::read(buffer)?;
+        let nonce = u64::read(buffer)?;
+        match tag {
+            HEARTBEAT_TAG => Ok(Self::Heartbeat { nonce }),
+            HEARTBEAT_ACK_TAG => Ok(Self::HeartbeatAck { nonce }),
+            other => Err(Error::InvalidEnum(other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use commonware_codec::{DecodeExt as _, Encode as _};
+
+    use super::ControlMessage;
+
+    #[test]
+    fn control_messages_round_trip() {
+        for message in [
+            ControlMessage::Heartbeat { nonce: 42 },
+            ControlMessage::HeartbeatAck { nonce: u64::MAX },
+        ] {
+            assert_eq!(ControlMessage::decode(message.encode()).unwrap(), message);
+        }
+    }
+}

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -1,0 +1,123 @@
+use std::net::SocketAddr;
+
+use alloy_primitives::Address as EthereumAddress;
+use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
+use commonware_p2p::{Address, authenticated::lookup};
+use commonware_runtime::{Metrics as _, Quota};
+use commonware_utils::{NZU32, ordered::Map};
+use eyre::WrapErr as _;
+
+use crate::ZoneManifest;
+
+/// The final block/ack/tx/backfill protocol reserves channel IDs 0 through 3.
+pub(crate) const CONTROL_CHANNEL: u64 = 4;
+pub(crate) const CONTROL_BACKLOG: usize = 128;
+pub(crate) const MAX_MESSAGE_SIZE: u32 = 10 * 1024 * 1024;
+
+/// Version of the Tempo Zone P2P wire protocol.
+pub(crate) const WIRE_PROTOCOL_VERSION: u8 = 0;
+const NETWORK_NAMESPACE_PREFIX: &[u8] = b"TEMPO_ZONE_P2P";
+
+/// Immutable L1 identity used to keep P2P networks for different deployments separate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct P2pNetworkId {
+    l1_chain_id: u64,
+    portal_address: EthereumAddress,
+}
+
+impl P2pNetworkId {
+    /// Creates the P2P identity for one ZonePortal deployment.
+    pub const fn new(l1_chain_id: u64, portal_address: EthereumAddress) -> Self {
+        Self {
+            l1_chain_id,
+            portal_address,
+        }
+    }
+}
+
+pub(crate) type Network = lookup::Network<commonware_runtime::tokio::Context, PrivateKey>;
+pub(crate) type Oracle = lookup::Oracle<PublicKey>;
+
+pub(crate) fn instantiate(
+    context: commonware_runtime::tokio::Context,
+    manifest: &ZoneManifest,
+    ed25519_private_key: PrivateKey,
+    listen: SocketAddr,
+    network_id: P2pNetworkId,
+) -> eyre::Result<(Network, Oracle, Map<PublicKey, Address>)> {
+    let namespace = namespace(manifest.zone_id(), network_id);
+    let mut config = if listen.ip().is_loopback() {
+        lookup::Config::local(ed25519_private_key, &namespace, listen, MAX_MESSAGE_SIZE)
+    } else {
+        lookup::Config::recommended(ed25519_private_key, &namespace, listen, MAX_MESSAGE_SIZE)
+    };
+
+    // Zone P2P peers commonly use pod/private addresses. Membership remains
+    // authenticated by the Ed25519 identities in the manifest.
+    config.allow_private_ips = true;
+    // A DNS-only manifest has no stable egress IP to compare against. In that
+    // topology, accept inbound attempts from any IP and rely on the authenticated
+    // manifest identity. This does not admit keys absent from the peer set.
+    config.bypass_ip_check = manifest.has_dns_addresses();
+
+    let peers = manifest
+        .nodes()
+        .iter()
+        .map(|node| {
+            (
+                node.ed25519_public_key().clone(),
+                node.address().to_commonware(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let peers = Map::try_from(peers).wrap_err("manifest contains duplicate P2P identities")?;
+    let (network, oracle) = lookup::Network::new(context.with_label("network"), config);
+    Ok((network, oracle, peers))
+}
+
+fn namespace(zone_id: u32, network_id: P2pNetworkId) -> Vec<u8> {
+    // Include both the protocol version and immutable L1 deployment identity so keys or
+    // endpoints accidentally reused across local, test, and production environments cannot
+    // authenticate into one another's P2P network.
+    let mut namespace = Vec::with_capacity(
+        NETWORK_NAMESPACE_PREFIX.len() + 1 + 8 + EthereumAddress::len_bytes() + 4,
+    );
+    namespace.extend_from_slice(NETWORK_NAMESPACE_PREFIX);
+    namespace.push(WIRE_PROTOCOL_VERSION);
+    namespace.extend_from_slice(&network_id.l1_chain_id.to_be_bytes());
+    namespace.extend_from_slice(network_id.portal_address.as_slice());
+    namespace.extend_from_slice(&zone_id.to_be_bytes());
+    namespace
+}
+
+pub(crate) fn control_quota() -> Quota {
+    Quota::per_second(NZU32!(4))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::{NETWORK_NAMESPACE_PREFIX, P2pNetworkId, WIRE_PROTOCOL_VERSION, namespace};
+
+    #[test]
+    fn namespace_separates_l1_environments_and_portals() {
+        let portal_a = address!("1111111111111111111111111111111111111111");
+        let portal_b = address!("2222222222222222222222222222222222222222");
+
+        assert_ne!(
+            namespace(7, P2pNetworkId::new(1, portal_a)),
+            namespace(7, P2pNetworkId::new(2, portal_a)),
+        );
+        assert_ne!(
+            namespace(7, P2pNetworkId::new(1, portal_a)),
+            namespace(7, P2pNetworkId::new(1, portal_b)),
+        );
+
+        let namespace = namespace(7, P2pNetworkId::new(1, portal_a));
+        assert_eq!(
+            namespace[NETWORK_NAMESPACE_PREFIX.len()],
+            WIRE_PROTOCOL_VERSION
+        );
+    }
+}

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -43,6 +43,7 @@ pub(crate) fn instantiate(
     manifest: &ZoneManifest,
     ed25519_private_key: PrivateKey,
     listen: SocketAddr,
+    bypass_ip_check: bool,
     network_id: P2pNetworkId,
 ) -> eyre::Result<(Network, Oracle, Map<PublicKey, Address>)> {
     let namespace = namespace(manifest.zone_id(), network_id);
@@ -55,10 +56,9 @@ pub(crate) fn instantiate(
     // Zone P2P peers commonly use pod/private addresses. Membership remains
     // authenticated by the Ed25519 identities in the manifest.
     config.allow_private_ips = true;
-    // A DNS-only manifest has no stable egress IP to compare against. In that
-    // topology, accept inbound attempts from any IP and rely on the authenticated
-    // manifest identity. This does not admit keys absent from the peer set.
-    config.bypass_ip_check = manifest.has_dns_addresses();
+    // This is a network-wide Commonware setting, so it must be an explicit
+    // operator choice.
+    config.bypass_ip_check = bypass_ip_check;
 
     let peers = manifest
         .nodes()

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -1,0 +1,532 @@
+use std::{collections::BTreeSet, net::SocketAddr, path::Path, sync::Arc, time::Duration};
+
+use commonware_codec::{DecodeExt as _, Encode as _};
+use commonware_cryptography::ed25519::PublicKey;
+use commonware_p2p::{
+    AddressableManager as _, Receiver as _, Recipients, Sender as _, authenticated::lookup,
+};
+use commonware_runtime::{Runner as _, Spawner as _};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::{
+    P2pNetworkId, Role, ZoneManifest,
+    identity::Ed25519Identity,
+    messages::ControlMessage,
+    network::{self, CONTROL_BACKLOG, CONTROL_CHANNEL},
+};
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const COMMAND_BACKLOG: usize = 128;
+const EVENT_BACKLOG: usize = 128;
+
+/// Fully validated configuration for one node's Zone P2P runtime.
+#[derive(Clone)]
+pub struct P2pConfig {
+    manifest: Arc<ZoneManifest>,
+    ed25519_identity: Ed25519Identity,
+    listen: SocketAddr,
+    role: Role,
+}
+
+impl P2pConfig {
+    /// Loads the Commonware Ed25519 key and manifest, then validates this node's
+    /// membership, zone ID, and optional role assertion.
+    pub fn load(
+        manifest_path: impl AsRef<Path>,
+        ed25519_key_path: impl AsRef<Path>,
+        listen: SocketAddr,
+        expected_zone_id: u32,
+        asserted_role: Option<Role>,
+    ) -> eyre::Result<Self> {
+        let ed25519_identity = Ed25519Identity::read_from_file(ed25519_key_path)?;
+        let manifest = ZoneManifest::read_from_file(manifest_path)?;
+        let role = manifest.validate_node(
+            expected_zone_id,
+            &ed25519_identity.ed25519_public_key(),
+            asserted_role,
+        )?;
+        Ok(Self {
+            manifest: Arc::new(manifest),
+            ed25519_identity,
+            listen,
+            role,
+        })
+    }
+
+    /// Manifest-derived role for this node.
+    pub const fn role(&self) -> Role {
+        self.role
+    }
+
+    /// This node's Ed25519 public key used by Commonware.
+    pub fn ed25519_public_key(&self) -> PublicKey {
+        self.ed25519_identity.ed25519_public_key()
+    }
+
+    /// Local socket bound by Commonware.
+    pub const fn listen(&self) -> SocketAddr {
+        self.listen
+    }
+}
+
+impl std::fmt::Debug for P2pConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("P2pConfig")
+            .field("zone_id", &self.manifest.zone_id())
+            .field("ed25519_public_key", &self.ed25519_public_key())
+            .field("listen", &self.listen)
+            .field("role", &self.role)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Outbound protocol commands accepted by the dedicated P2P runtime.
+///
+/// The Commonware sender remains owned by the dedicated runtime. Callers communicate with it
+/// through the bounded Tokio channel exposed by [`P2pHandle`]. These PoC variants will be
+/// replaced by the block, ACK/signature, transaction-forwarding, and backfill commands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum P2pCommand {
+    /// Send a PoC heartbeat to one authenticated peer.
+    Heartbeat {
+        /// Intended peer's Ed25519 Commonware identity.
+        recipient: PublicKey,
+        /// Heartbeat nonce.
+        nonce: u64,
+    },
+    /// Acknowledge a PoC heartbeat from one authenticated peer.
+    HeartbeatAck {
+        /// Intended peer's Ed25519 Commonware identity.
+        recipient: PublicKey,
+        /// Acknowledged nonce.
+        nonce: u64,
+    },
+}
+
+impl P2pCommand {
+    fn into_wire_parts(self) -> (PublicKey, ControlMessage) {
+        match self {
+            Self::Heartbeat { recipient, nonce } => {
+                (recipient, ControlMessage::Heartbeat { nonce })
+            }
+            Self::HeartbeatAck { recipient, nonce } => {
+                (recipient, ControlMessage::HeartbeatAck { nonce })
+            }
+        }
+    }
+}
+
+/// Observable lifecycle and heartbeat events emitted by the P2P runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum P2pEvent {
+    /// The network and control channel were started.
+    Started {
+        role: Role,
+        ed25519_public_key: PublicKey,
+        listen: SocketAddr,
+    },
+    /// A leader received a heartbeat from a follower.
+    HeartbeatReceived {
+        follower_ed25519_public_key: PublicKey,
+        nonce: u64,
+    },
+    /// A follower received the leader's acknowledgement.
+    HeartbeatAcknowledged {
+        leader_ed25519_public_key: PublicKey,
+        nonce: u64,
+    },
+}
+
+/// Handle used to communicate with, supervise, and stop the dedicated P2P runtime.
+pub struct P2pHandle {
+    shutdown: CancellationToken,
+    stopped: oneshot::Receiver<Result<(), String>>,
+    commands: mpsc::Sender<P2pCommand>,
+    events: mpsc::Receiver<P2pEvent>,
+}
+
+/// Cross-runtime channels and lifecycle controls returned by [`P2pHandle::into_parts`].
+pub struct P2pHandleParts {
+    /// Cancels the dedicated P2P runtime.
+    pub shutdown: CancellationToken,
+    /// Resolves when the dedicated P2P runtime exits.
+    pub stopped: oneshot::Receiver<Result<(), String>>,
+    /// Bounded outbound command channel into the dedicated P2P runtime.
+    pub commands: mpsc::Sender<P2pCommand>,
+    /// Bounded inbound event channel from the dedicated P2P runtime.
+    pub events: mpsc::Receiver<P2pEvent>,
+}
+
+impl P2pHandle {
+    /// Splits the handle into the pieces needed by a node supervisor or test.
+    pub fn into_parts(self) -> P2pHandleParts {
+        P2pHandleParts {
+            shutdown: self.shutdown,
+            stopped: self.stopped,
+            commands: self.commands,
+            events: self.events,
+        }
+    }
+}
+
+/// Starts Commonware and the role-specific PoC heartbeat actor on a dedicated OS thread.
+pub fn spawn_p2p(config: P2pConfig, network_id: P2pNetworkId) -> eyre::Result<P2pHandle> {
+    let shutdown = CancellationToken::new();
+    let thread_shutdown = shutdown.clone();
+    let (stopped_tx, stopped) = oneshot::channel();
+    let (commands, command_rx) = mpsc::channel(COMMAND_BACKLOG);
+    let runtime_commands = commands.clone();
+    let (events_tx, events) = mpsc::channel(EVENT_BACKLOG);
+
+    std::thread::Builder::new()
+        .name(format!("zone-p2p-{}", config.role()))
+        .spawn(move || {
+            let result = run(
+                config,
+                network_id,
+                thread_shutdown,
+                runtime_commands,
+                command_rx,
+                events_tx,
+            )
+            .map_err(|err| format!("{err:?}"));
+            let _ = stopped_tx.send(result);
+        })
+        .map_err(|err| eyre::eyre!("failed spawning P2P runtime thread: {err}"))?;
+
+    Ok(P2pHandle {
+        shutdown,
+        stopped,
+        commands,
+        events,
+    })
+}
+
+fn run(
+    config: P2pConfig,
+    network_id: P2pNetworkId,
+    shutdown: CancellationToken,
+    commands: mpsc::Sender<P2pCommand>,
+    command_rx: mpsc::Receiver<P2pCommand>,
+    events: mpsc::Sender<P2pEvent>,
+) -> eyre::Result<()> {
+    let runtime_config = commonware_runtime::tokio::Config::default()
+        .with_tcp_nodelay(Some(true))
+        .with_worker_threads(2)
+        .with_catch_panics(true);
+    commonware_runtime::tokio::Runner::new(runtime_config).start(|context| async move {
+        let local_ed25519_public_key = config.ed25519_public_key();
+        let (mut commonware, mut oracle, peers) = network::instantiate(
+            context.clone(),
+            &config.manifest,
+            config.ed25519_identity.into_private_key(),
+            config.listen,
+            network_id,
+        )?;
+        oracle.track(0, peers).await;
+        let (sender, receiver) = commonware.register(
+            CONTROL_CHANNEL,
+            network::control_quota(),
+            CONTROL_BACKLOG,
+        );
+        let mut network_task = commonware.start();
+
+        if config.manifest.has_dns_addresses() {
+            warn!(
+                target: "zone::p2p",
+                "DNS peer addresses configured; relying on manifest Ed25519 public keys instead of source-IP filtering"
+            );
+        }
+        info!(
+            target: "zone::p2p",
+            zone_id = config.manifest.zone_id(),
+            role = %config.role,
+            ed25519_public_key = %local_ed25519_public_key,
+            listen = %config.listen,
+            peers = config.manifest.nodes().len(),
+            "Started P2P networking"
+        );
+        let _ = events
+            .send(P2pEvent::Started {
+                role: config.role,
+                ed25519_public_key: local_ed25519_public_key,
+                listen: config.listen,
+            })
+            .await;
+
+        let command_loop = run_commands(sender, command_rx);
+        tokio::pin!(command_loop);
+
+        let heartbeat = run_heartbeat(
+            config.role,
+            config.manifest,
+            commands,
+            receiver,
+            events,
+        );
+        tokio::pin!(heartbeat);
+
+        let result = tokio::select! {
+            () = shutdown.cancelled() => Ok(()),
+            network_result = &mut network_task => match network_result {
+                Ok(()) => Err(eyre::eyre!("Commonware network stopped unexpectedly")),
+                Err(err) => Err(eyre::eyre!("Commonware network failed: {err}")),
+            },
+            result = &mut command_loop => result,
+            result = &mut heartbeat => result,
+        };
+
+        context
+            .stop(0, Some(SHUTDOWN_TIMEOUT))
+            .await
+            .map_err(|err| eyre::eyre!("failed stopping Commonware runtime: {err}"))?;
+        result
+    })
+}
+
+async fn run_commands(
+    mut sender: lookup::Sender<PublicKey, commonware_runtime::tokio::Context>,
+    mut commands: mpsc::Receiver<P2pCommand>,
+) -> eyre::Result<()> {
+    while let Some(command) = commands.recv().await {
+        let (recipient, message) = command.into_wire_parts();
+        let sent = sender
+            .send(Recipients::One(recipient.clone()), message.encode(), true)
+            .await
+            .map_err(|err| eyre::eyre!("failed sending P2P control message: {err}"))?;
+        if sent.is_empty() {
+            debug!(target: "zone::p2p", %recipient, ?message, "Peer is not connected; control message was not sent");
+        }
+    }
+
+    Err(eyre::eyre!("P2P command channel closed unexpectedly"))
+}
+
+async fn run_heartbeat(
+    role: Role,
+    manifest: Arc<ZoneManifest>,
+    commands: mpsc::Sender<P2pCommand>,
+    receiver: lookup::Receiver<PublicKey>,
+    events: mpsc::Sender<P2pEvent>,
+) -> eyre::Result<()> {
+    match role {
+        Role::Leader => run_leader_heartbeat(manifest, commands, receiver, events).await,
+        Role::Follower => run_follower_heartbeat(manifest, commands, receiver, events).await,
+    }
+}
+
+async fn run_leader_heartbeat(
+    manifest: Arc<ZoneManifest>,
+    commands: mpsc::Sender<P2pCommand>,
+    mut receiver: lookup::Receiver<PublicKey>,
+    events: mpsc::Sender<P2pEvent>,
+) -> eyre::Result<()> {
+    let mut seen = BTreeSet::new();
+    loop {
+        let (peer, bytes) = receiver
+            .recv()
+            .await
+            .map_err(|err| eyre::eyre!("control channel receive failed: {err}"))?;
+        let message = match ControlMessage::decode(bytes) {
+            Ok(message) => message,
+            Err(err) => {
+                warn!(target: "zone::p2p", %peer, %err, "Ignoring invalid control message");
+                continue;
+            }
+        };
+        if manifest.role_of(&peer) != Some(Role::Follower) {
+            warn!(target: "zone::p2p", %peer, ?message, "Ignoring control message from non-follower");
+            continue;
+        }
+
+        match message {
+            ControlMessage::Heartbeat { nonce } => {
+                if seen.insert(peer.clone()) {
+                    info!(target: "zone::p2p", follower = %peer, "Received first follower heartbeat");
+                } else {
+                    debug!(target: "zone::p2p", follower = %peer, nonce, "Received follower heartbeat");
+                }
+                let _ = events
+                    .send(P2pEvent::HeartbeatReceived {
+                        follower_ed25519_public_key: peer.clone(),
+                        nonce,
+                    })
+                    .await
+                    .ok();
+                commands
+                    .send(P2pCommand::HeartbeatAck {
+                        recipient: peer,
+                        nonce,
+                    })
+                    .await
+                    .map_err(|_| eyre::eyre!("P2P command channel closed"))?;
+            }
+            ControlMessage::HeartbeatAck { nonce } => {
+                warn!(target: "zone::p2p", follower = %peer, nonce, "Leader received unexpected heartbeat acknowledgement");
+            }
+        }
+    }
+}
+
+async fn run_follower_heartbeat(
+    manifest: Arc<ZoneManifest>,
+    commands: mpsc::Sender<P2pCommand>,
+    mut receiver: lookup::Receiver<PublicKey>,
+    events: mpsc::Sender<P2pEvent>,
+) -> eyre::Result<()> {
+    let leader = manifest.leader_ed25519_public_key().clone();
+    let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut next_nonce = 0_u64;
+    let mut acknowledged = false;
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                let nonce = next_nonce;
+                next_nonce = next_nonce.wrapping_add(1);
+                commands
+                    .send(P2pCommand::Heartbeat {
+                        recipient: leader.clone(),
+                        nonce,
+                    })
+                    .await
+                    .map_err(|_| eyre::eyre!("P2P command channel closed"))?;
+            }
+            received = receiver.recv() => {
+                let (peer, bytes) = received
+                    .map_err(|err| eyre::eyre!("control channel receive failed: {err}"))?;
+                let message = match ControlMessage::decode(bytes) {
+                    Ok(message) => message,
+                    Err(err) => {
+                        warn!(target: "zone::p2p", %peer, %err, "Ignoring invalid control message");
+                        continue;
+                    }
+                };
+                if peer != leader {
+                    warn!(target: "zone::p2p", %peer, ?message, "Ignoring control message from non-leader");
+                    continue;
+                }
+                match message {
+                    ControlMessage::HeartbeatAck { nonce } => {
+                        if !acknowledged {
+                            acknowledged = true;
+                            info!(target: "zone::p2p", %leader, "Established heartbeat exchange with leader");
+                        } else {
+                            debug!(target: "zone::p2p", %leader, nonce, "Leader acknowledged heartbeat");
+                        }
+                        let _ = events
+                            .send(P2pEvent::HeartbeatAcknowledged {
+                                leader_ed25519_public_key: leader.clone(),
+                                nonce,
+                            })
+                            .await;
+                    }
+                    ControlMessage::Heartbeat { nonce } => {
+                        warn!(target: "zone::p2p", %leader, nonce, "Follower received unexpected heartbeat request");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{SocketAddr, TcpListener},
+        sync::Arc,
+        time::Duration,
+    };
+
+    use alloy_primitives::address;
+    use commonware_codec::Encode as _;
+    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+
+    use super::{P2pConfig, P2pEvent, spawn_p2p};
+    use crate::{P2pNetworkId, ZoneManifest, identity::Ed25519Identity};
+
+    fn available_address() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap()
+    }
+
+    fn ed25519_identity(seed: u64) -> Ed25519Identity {
+        let key = PrivateKey::from_seed(seed);
+        Ed25519Identity::from_hex(&const_hex::encode_prefixed(key.encode().as_ref())).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn three_nodes_exchange_heartbeats() {
+        let addresses = [
+            available_address(),
+            available_address(),
+            available_address(),
+        ];
+        let identities = [
+            ed25519_identity(1),
+            ed25519_identity(2),
+            ed25519_identity(3),
+        ];
+        let mut input = format!(
+            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
+        );
+        for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
+            input.push_str(&format!(
+                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\naddress = \"{address}\"\n",
+                const_hex::encode_prefixed(identity.ed25519_public_key().as_ref())
+            ));
+        }
+        let manifest = Arc::new(ZoneManifest::parse(&input).unwrap());
+        let mut handles = identities
+            .into_iter()
+            .zip(addresses)
+            .map(|(identity, listen)| {
+                let role = manifest
+                    .validate_node(9, &identity.ed25519_public_key(), None)
+                    .unwrap();
+                spawn_p2p(
+                    P2pConfig {
+                        manifest: manifest.clone(),
+                        ed25519_identity: identity,
+                        listen,
+                        role,
+                    },
+                    P2pNetworkId::new(1, address!("1111111111111111111111111111111111111111")),
+                )
+                .unwrap()
+                .into_parts()
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles.iter_mut().skip(1) {
+            tokio::time::timeout(Duration::from_secs(15), async {
+                loop {
+                    if matches!(
+                        handle.events.recv().await,
+                        Some(P2pEvent::HeartbeatAcknowledged { .. })
+                    ) {
+                        break;
+                    }
+                }
+            })
+            .await
+            .expect("follower did not receive heartbeat acknowledgement");
+        }
+
+        for handle in &handles {
+            handle.shutdown.cancel();
+        }
+        for handle in handles {
+            tokio::time::timeout(Duration::from_secs(10), handle.stopped)
+                .await
+                .expect("P2P runtime did not stop")
+                .expect("P2P runtime dropped its completion channel")
+                .expect("P2P runtime failed");
+        }
+    }
+}

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -142,10 +142,7 @@ pub enum P2pEvent {
 
 /// Handle used to communicate with, supervise, and stop the dedicated P2P runtime.
 pub struct P2pHandle {
-    shutdown: CancellationToken,
-    stopped: oneshot::Receiver<Result<(), String>>,
-    commands: mpsc::Sender<P2pCommand>,
-    events: mpsc::Receiver<P2pEvent>,
+    parts: Option<P2pHandleParts>,
 }
 
 /// Cross-runtime channels and lifecycle controls returned by [`P2pHandle::into_parts`].
@@ -154,6 +151,8 @@ pub struct P2pHandleParts {
     pub shutdown: CancellationToken,
     /// Resolves when the dedicated P2P runtime exits.
     pub stopped: oneshot::Receiver<Result<(), String>>,
+    /// OS thread hosting the dedicated Commonware runtime.
+    pub thread: std::thread::JoinHandle<()>,
     /// Bounded outbound command channel into the dedicated P2P runtime.
     pub commands: mpsc::Sender<P2pCommand>,
     /// Bounded inbound event channel from the dedicated P2P runtime.
@@ -161,15 +160,56 @@ pub struct P2pHandleParts {
 }
 
 impl P2pHandle {
-    /// Splits the handle into the pieces needed by a node supervisor or test.
-    pub fn into_parts(self) -> P2pHandleParts {
-        P2pHandleParts {
-            shutdown: self.shutdown,
-            stopped: self.stopped,
-            commands: self.commands,
-            events: self.events,
+    /// Returns the inbound P2P event channel.
+    pub fn events_mut(&mut self) -> &mut mpsc::Receiver<P2pEvent> {
+        &mut self
+            .parts
+            .as_mut()
+            .expect("P2P handle already consumed")
+            .events
+    }
+
+    /// Requests shutdown, waits for the Commonware runtime, and joins its OS thread.
+    pub async fn shutdown(mut self) -> eyre::Result<()> {
+        let P2pHandleParts {
+            shutdown,
+            stopped,
+            thread,
+            commands,
+            events,
+        } = self.parts.take().expect("P2P handle already consumed");
+        shutdown.cancel();
+
+        // Close the caller-side channels while the runtime is winding down.
+        drop(commands);
+        drop(events);
+        let stopped_result = stopped.await;
+
+        join_runtime_thread(thread).await?;
+        stopped_result
+            .map_err(|err| eyre::eyre!("P2P runtime dropped its completion channel: {err}"))?
+            .map_err(|err| eyre::eyre!("P2P runtime failed: {err}"))
+    }
+
+    /// Splits the handle into the pieces needed by a node supervisor.
+    pub fn into_parts(mut self) -> P2pHandleParts {
+        self.parts.take().expect("P2P handle already consumed")
+    }
+}
+
+impl Drop for P2pHandle {
+    fn drop(&mut self) {
+        if let Some(parts) = &self.parts {
+            parts.shutdown.cancel();
         }
     }
+}
+
+async fn join_runtime_thread(thread: std::thread::JoinHandle<()>) -> eyre::Result<()> {
+    tokio::task::spawn_blocking(move || thread.join())
+        .await
+        .map_err(|err| eyre::eyre!("failed joining P2P runtime thread: {err}"))?
+        .map_err(|_| eyre::eyre!("P2P runtime thread panicked"))
 }
 
 /// Starts Commonware and the role-specific PoC heartbeat actor on a dedicated OS thread.
@@ -181,7 +221,7 @@ pub fn spawn_p2p(config: P2pConfig, network_id: P2pNetworkId) -> eyre::Result<P2
     let runtime_commands = commands.clone();
     let (events_tx, events) = mpsc::channel(EVENT_BACKLOG);
 
-    std::thread::Builder::new()
+    let thread = std::thread::Builder::new()
         .name(format!("zone-p2p-{}", config.role()))
         .spawn(move || {
             let result = run(
@@ -198,10 +238,13 @@ pub fn spawn_p2p(config: P2pConfig, network_id: P2pNetworkId) -> eyre::Result<P2
         .map_err(|err| eyre::eyre!("failed spawning P2P runtime thread: {err}"))?;
 
     Ok(P2pHandle {
-        shutdown,
-        stopped,
-        commands,
-        events,
+        parts: Some(P2pHandleParts {
+            shutdown,
+            stopped,
+            thread,
+            commands,
+            events,
+        }),
     })
 }
 
@@ -499,7 +542,6 @@ mod tests {
                     P2pNetworkId::new(1, address!("1111111111111111111111111111111111111111")),
                 )
                 .unwrap()
-                .into_parts()
             })
             .collect::<Vec<_>>();
 
@@ -507,7 +549,7 @@ mod tests {
             tokio::time::timeout(Duration::from_secs(15), async {
                 loop {
                     if matches!(
-                        handle.events.recv().await,
+                        handle.events_mut().recv().await,
                         Some(P2pEvent::HeartbeatAcknowledged { .. })
                     ) {
                         break;
@@ -518,14 +560,10 @@ mod tests {
             .expect("follower did not receive heartbeat acknowledgement");
         }
 
-        for handle in &handles {
-            handle.shutdown.cancel();
-        }
         for handle in handles {
-            tokio::time::timeout(Duration::from_secs(10), handle.stopped)
+            tokio::time::timeout(Duration::from_secs(10), handle.shutdown())
                 .await
                 .expect("P2P runtime did not stop")
-                .expect("P2P runtime dropped its completion channel")
                 .expect("P2P runtime failed");
         }
     }

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -28,6 +28,7 @@ pub struct P2pConfig {
     manifest: Arc<ZoneManifest>,
     ed25519_identity: Ed25519Identity,
     listen: SocketAddr,
+    bypass_ip_check: bool,
     role: Role,
 }
 
@@ -38,11 +39,13 @@ impl P2pConfig {
         manifest_path: impl AsRef<Path>,
         ed25519_key_path: impl AsRef<Path>,
         listen: SocketAddr,
+        bypass_ip_check: bool,
         expected_zone_id: u32,
         asserted_role: Option<Role>,
     ) -> eyre::Result<Self> {
         let ed25519_identity = Ed25519Identity::read_from_file(ed25519_key_path)?;
         let manifest = ZoneManifest::read_from_file(manifest_path)?;
+        validate_ip_check_configuration(&manifest, bypass_ip_check)?;
         let role = manifest.validate_node(
             expected_zone_id,
             &ed25519_identity.ed25519_public_key(),
@@ -52,6 +55,7 @@ impl P2pConfig {
             manifest: Arc::new(manifest),
             ed25519_identity,
             listen,
+            bypass_ip_check,
             role,
         })
     }
@@ -78,9 +82,21 @@ impl std::fmt::Debug for P2pConfig {
             .field("zone_id", &self.manifest.zone_id())
             .field("ed25519_public_key", &self.ed25519_public_key())
             .field("listen", &self.listen)
+            .field("bypass_ip_check", &self.bypass_ip_check)
             .field("role", &self.role)
             .finish_non_exhaustive()
     }
+}
+
+fn validate_ip_check_configuration(
+    manifest: &ZoneManifest,
+    bypass_ip_check: bool,
+) -> eyre::Result<()> {
+    eyre::ensure!(
+        !manifest.has_dns_addresses() || bypass_ip_check,
+        "DNS peer addresses require --p2p.bypass-ip-check because their egress IPs are not known; this disables pre-authentication source-IP filtering for all inbound P2P connections"
+    );
+    Ok(())
 }
 
 /// Outbound protocol commands accepted by the dedicated P2P runtime.
@@ -267,6 +283,7 @@ fn run(
             &config.manifest,
             config.ed25519_identity.into_private_key(),
             config.listen,
+            config.bypass_ip_check,
             network_id,
         )?;
         oracle.track(0, peers).await;
@@ -277,10 +294,10 @@ fn run(
         );
         let mut network_task = commonware.start();
 
-        if config.manifest.has_dns_addresses() {
+        if config.bypass_ip_check {
             warn!(
                 target: "zone::p2p",
-                "DNS peer addresses configured; relying on manifest Ed25519 public keys instead of source-IP filtering"
+                "P2P source-IP filtering is disabled; relying on network-level access controls and manifest Ed25519 public keys"
             );
         }
         info!(
@@ -489,7 +506,7 @@ mod tests {
     use commonware_codec::Encode as _;
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
-    use super::{P2pConfig, P2pEvent, spawn_p2p};
+    use super::{P2pConfig, P2pEvent, spawn_p2p, validate_ip_check_configuration};
     use crate::{P2pNetworkId, ZoneManifest, identity::Ed25519Identity};
 
     fn available_address() -> SocketAddr {
@@ -500,6 +517,30 @@ mod tests {
     fn ed25519_identity(seed: u64) -> Ed25519Identity {
         let key = PrivateKey::from_seed(seed);
         Ed25519Identity::from_hex(&const_hex::encode_prefixed(key.encode().as_ref())).unwrap()
+    }
+
+    #[test]
+    fn dns_manifest_requires_explicit_ip_check_bypass() {
+        let identities = [
+            ed25519_identity(1),
+            ed25519_identity(2),
+            ed25519_identity(3),
+        ];
+        let mut input = format!(
+            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
+        );
+        for (index, identity) in identities.iter().enumerate() {
+            input.push_str(&format!(
+                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\naddress = \"node-{index}.zone.local:9200\"\n",
+                const_hex::encode_prefixed(identity.ed25519_public_key().as_ref())
+            ));
+        }
+        let manifest = ZoneManifest::parse(&input).unwrap();
+
+        let error = validate_ip_check_configuration(&manifest, false).unwrap_err();
+        assert!(error.to_string().contains("--p2p.bypass-ip-check"));
+        validate_ip_check_configuration(&manifest, true).unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -537,6 +578,7 @@ mod tests {
                         manifest: manifest.clone(),
                         ed25519_identity: identity,
                         listen,
+                        bypass_ip_check: false,
                         role,
                     },
                     P2pNetworkId::new(1, address!("1111111111111111111111111111111111111111")),

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -39,6 +39,9 @@ alloy = { workspace = true, features = [
 alloy-eips.workspace = true
 alloy-rlp.workspace = true
 clap = { version = "4.5.45", features = ["derive", "env"] }
+commonware-codec.workspace = true
+commonware-cryptography.workspace = true
+commonware-math.workspace = true
 const-hex.workspace = true
 eyre.workspace = true
 futures.workspace = true

--- a/xtask/src/generate_p2p_key.rs
+++ b/xtask/src/generate_p2p_key.rs
@@ -1,0 +1,49 @@
+use std::{fs::OpenOptions, io::Write as _, path::PathBuf};
+
+use commonware_codec::Encode as _;
+use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+use commonware_math::algebra::Random as _;
+
+/// Generate an Ed25519 identity for multi-sequencer P2P communication.
+#[derive(Debug, clap::Parser)]
+pub(crate) struct GenerateP2pKey {
+    /// Destination for the unencrypted hex-encoded private key.
+    #[arg(long = "out", short, default_value = "p2p.key", value_name = "PATH")]
+    output: PathBuf,
+
+    /// Replace the destination if it already exists.
+    #[arg(long, short)]
+    force: bool,
+}
+
+impl GenerateP2pKey {
+    pub(crate) fn run(self) -> eyre::Result<()> {
+        let key = PrivateKey::random(&mut rand::thread_rng());
+        let mut options = OpenOptions::new();
+        options.write(true).create(true).truncate(self.force);
+        if self.force {
+            options.create(true);
+        } else {
+            options.create_new(true);
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+
+        let mut file = options.open(&self.output).map_err(|err| {
+            eyre::eyre!("failed writing P2P key `{}`: {err}", self.output.display())
+        })?;
+        writeln!(
+            file,
+            "{}",
+            const_hex::encode_prefixed(key.encode().as_ref())
+        )
+        .map_err(|err| eyre::eyre!("failed writing P2P key `{}`: {err}", self.output.display()))?;
+
+        println!("{}", const_hex::encode_prefixed(key.public_key().as_ref()));
+        Ok(())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,8 +2,9 @@
 use crate::{
     create_zone::CreateZone, demo_blacklist::DemoBlacklist,
     demo_swap_and_deposit::DemoSwapAndDeposit, deploy_router::DeployRouter,
-    encrypted_deposit::EncryptedDeposit, generate_zone_genesis::GenerateZoneGenesis,
-    set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
+    encrypted_deposit::EncryptedDeposit, generate_p2p_key::GenerateP2pKey,
+    generate_zone_genesis::GenerateZoneGenesis, set_encryption_key::SetEncryptionKey,
+    spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;
@@ -13,6 +14,7 @@ mod demo_blacklist;
 mod demo_swap_and_deposit;
 mod deploy_router;
 mod encrypted_deposit;
+mod generate_p2p_key;
 mod generate_zone_genesis;
 mod set_encryption_key;
 mod spam_deposits;
@@ -41,6 +43,7 @@ async fn main() -> eyre::Result<()> {
         Action::GenerateZoneGenesis(args) => {
             args.run().await.wrap_err("failed to generate zone genesis")
         }
+        Action::GenerateP2pKey(args) => args.run().wrap_err("failed to generate P2P key"),
         Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
         Action::SpamDeposits(args) => args.run().await.wrap_err("failed to spam deposits"),
         Action::ZoneInfo(args) => args.run().await.wrap_err("failed to fetch zone info"),
@@ -64,6 +67,7 @@ enum Action {
     DemoSwapAndDeposit(DemoSwapAndDeposit),
     DeployRouter(DeployRouter),
     EncryptedDeposit(EncryptedDeposit),
+    GenerateP2pKey(GenerateP2pKey),
     GenerateZoneGenesis(GenerateZoneGenesis),
     SetEncryptionKey(SetEncryptionKey),
     SpamDeposits(SpamDeposits),


### PR DESCRIPTION
Wire commonware (same as what tempo L1 uses) to allow sequencer nodes to communicate over p2p. 

- Use a manifest file that defines all the nodes and the leader. No p2p discovery
- Wire up commonware to start communicating between nodes.
- Added a PoC heartbeat between nodes, will be replaced by the block, tx etc... in subsequent PRs
- Add xtask to generate p2p keys