### PR TITLE
feat: add sequencer quorum settlement

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -352,6 +352,10 @@ interface IZoneTxContext {
 //   slot 16: _withdrawalReentrancyStatus (uint256)
 //   slot 17: zoneId (uint32) + messenger (address) [packed]
 //   slot 18: verifier (address) + genesisTempoBlockNumber (uint64) + _initialized (bool) [packed]
+//   slot 19: sequencerSetVersion (uint64) + sequencerQuorum (uint8) [packed]
+//   slot 20: zoneHeight (uint256)
+//   slot 21: _sequencers (address[])
+//   slot 22: isSequencer (mapping(address => bool))
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via
@@ -608,6 +612,9 @@ interface IZonePortal {
     /// @notice Emitted when the sequencer updates the zone's public RPC endpoint
     event RpcUrlUpdated(string rpcUrl);
 
+    /// @notice Emitted when the admin replaces the batch-attestation signer set.
+    event SequencerSetUpdated(uint64 indexed version, uint8 quorum, address[] sequencers);
+
     error NotSequencer();
     error NotAdmin();
     error NotFactory();
@@ -634,6 +641,10 @@ interface IZonePortal {
     error TokenAlreadyEnabled();
     error InvalidBouncebackRecipient();
     error InvalidDepositTransition();
+    error InvalidSequencerSet();
+    error SequencerSetUnchanged();
+    error InvalidQuorumCertificate();
+    error LegacyBatchSubmissionDisabled();
 
     function initialize(
         uint32 zoneId,
@@ -691,6 +702,24 @@ interface IZonePortal {
 
     function genesisTempoBlockNumber() external view returns (uint64);
 
+    /// @notice Version of the active batch-attestation signer set (zero means legacy mode).
+    function sequencerSetVersion() external view returns (uint64);
+
+    /// @notice Number of distinct registered signatures required for batch settlement.
+    function sequencerQuorum() external view returns (uint8);
+
+    /// @notice Highest zone block height accepted with a quorum certificate.
+    function zoneHeight() external view returns (uint256);
+
+    /// @notice Whether an account belongs to the active settlement signer set.
+    function isSequencer(address account) external view returns (bool);
+
+    /// @notice Number of accounts in the active settlement signer set.
+    function sequencerCount() external view returns (uint256);
+
+    /// @notice Return a signer-set member by index.
+    function sequencerAt(uint256 index) external view returns (address);
+
     /*//////////////////////////////////////////////////////////////
                           TOKEN REGISTRY
     //////////////////////////////////////////////////////////////*/
@@ -736,6 +765,10 @@ interface IZonePortal {
 
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
     function acceptSequencer() external;
+
+    /// @notice Atomically replace the settlement signer set and quorum. Only callable by admin.
+    /// @dev Signers must be nonzero, unique, and sorted in strictly ascending address order.
+    function setSequencerSet(address[] calldata sequencers, uint8 quorum) external;
 
     /// @notice Start an admin transfer. Only callable by the current admin.
     /// @param newAdmin The address that will become admin after accepting (address(0) cancels).
@@ -866,6 +899,30 @@ interface IZonePortal {
         bytes calldata proof
     )
         external;
+
+    /// @notice Submit a batch with an n-of-m certificate for its zone tip.
+    function submitBatch(
+        uint64 tempoBlockNumber,
+        uint64 recentTempoBlockNumber,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata verifierConfig,
+        bytes calldata proof,
+        uint256 zoneHeight,
+        bytes[] calldata signatures
+    )
+        external;
+
+    /// @notice Verify a certificate for a proposed successor of the current portal head.
+    function verifyBlock(
+        uint256 zoneHeight,
+        bytes32 zoneBlockHash,
+        bytes[] calldata signatures
+    )
+        external
+        view
+        returns (bool);
 
 }
 

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -914,16 +914,6 @@ interface IZonePortal {
     )
         external;
 
-    /// @notice Verify a certificate for a proposed successor of the current portal head.
-    function verifyBlock(
-        uint256 zoneHeight,
-        bytes32 zoneBlockHash,
-        bytes[] calldata signatures
-    )
-        external
-        view
-        returns (bool);
-
 }
 
 /// @title IZoneMessenger

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -26,7 +26,8 @@ struct ZoneInfo {
     address portal;
     address initialToken; // first TIP-20 enabled at zone creation (additional tokens enabled via enableToken)
     address admin;
-    address sequencer;
+    address[] sequencers;
+    uint8 threshold;
     address verifier;
     bytes32 genesisBlockHash;
     bytes32 genesisTempoBlockHash;
@@ -352,7 +353,7 @@ interface IZoneTxContext {
 //   slot 16: _withdrawalReentrancyStatus (uint256)
 //   slot 17: zoneId (uint32) + messenger (address) [packed]
 //   slot 18: verifier (address) + genesisTempoBlockNumber (uint64) + _initialized (bool) [packed]
-//   slot 19: sequencerSetVersion (uint64) + sequencerQuorum (uint8) [packed]
+//   slot 19: sequencerSetVersion (uint64) + sequencerThreshold (uint8) [packed]
 //   slot 20: zoneHeight (uint256)
 //   slot 21: _sequencers (address[])
 //   slot 22: isSequencer (mapping(address => bool))
@@ -382,14 +383,12 @@ interface IVerifier {
     ///      4. If anchorBlockNumber > tempoBlockNumber: ancestry chain from tempoBlockNumber to anchorBlockNumber
     ///      5. ZoneOutbox.lastBatch().withdrawalBatchIndex == expectedWithdrawalBatchIndex
     ///      6. ZoneOutbox.lastBatch().withdrawalQueueHash matches withdrawalQueueHash
-    ///      7. Zone block beneficiary matches sequencer
-    ///      8. Deposit processing is correct (validated via Tempo state read inside proof)
+    ///      7. Deposit processing is correct (validated via Tempo state read inside proof)
     /// @param zoneId Unique identifier of the zone whose batch is being verified
     /// @param tempoBlockNumber Block zone committed to (from TempoState)
     /// @param anchorBlockNumber Block whose hash is verified (tempoBlockNumber or recent block)
     /// @param anchorBlockHash Hash of anchorBlockNumber (from EIP-2935)
     /// @param expectedWithdrawalBatchIndex Expected batch index (portal.withdrawalBatchIndex + 1)
-    /// @param sequencer Sequencer address (zone block beneficiary must match)
     /// @param blockTransition Zone block hash transition
     /// @param depositQueueTransition Deposit queue processing transition
     /// @param withdrawalQueueHash Withdrawal queue hash chain for this batch (0 if none)
@@ -401,7 +400,6 @@ interface IVerifier {
         uint64 anchorBlockNumber,
         bytes32 anchorBlockHash,
         uint64 expectedWithdrawalBatchIndex,
-        address sequencer,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
         bytes32 withdrawalQueueHash,
@@ -423,7 +421,8 @@ interface IZoneFactory {
     struct CreateZoneParams {
         address initialToken; // first TIP-20 to enable (sequencer can enable more later)
         address admin;
-        address sequencer;
+        address[] sequencers;
+        uint8 threshold;
         address verifier;
         ZoneParams zoneParams;
         string rpcUrl;
@@ -434,7 +433,8 @@ interface IZoneFactory {
         address indexed portal,
         address initialToken,
         address admin,
-        address sequencer,
+        address[] sequencers,
+        uint8 threshold,
         address verifier,
         bytes32 genesisBlockHash,
         bytes32 genesisTempoBlockHash,
@@ -446,6 +446,7 @@ interface IZoneFactory {
     error NotOwner();
     error InvalidAdmin();
     error InvalidSequencer();
+    error InvalidSequencerSet();
     error InvalidVerifier();
     error InsufficientGas();
     error ZoneIdOverflow();
@@ -613,7 +614,7 @@ interface IZonePortal {
     event RpcUrlUpdated(string rpcUrl);
 
     /// @notice Emitted when the admin replaces the batch-attestation signer set.
-    event SequencerSetUpdated(uint64 indexed version, uint8 quorum, address[] sequencers);
+    event SequencerSetUpdated(uint64 indexed version, uint8 threshold, address[] sequencers);
 
     error NotSequencer();
     error NotAdmin();
@@ -651,7 +652,8 @@ interface IZonePortal {
         address initialToken,
         address messenger,
         address admin,
-        address sequencer,
+        address[] calldata sequencers,
+        uint8 threshold,
         address verifier,
         bytes32 genesisBlockHash,
         uint64 genesisTempoBlockNumber,
@@ -702,11 +704,11 @@ interface IZonePortal {
 
     function genesisTempoBlockNumber() external view returns (uint64);
 
-    /// @notice Version of the active batch-attestation signer set (zero means legacy mode).
+    /// @notice Version of the active sequencer configuration.
     function sequencerSetVersion() external view returns (uint64);
 
     /// @notice Number of distinct registered signatures required for batch settlement.
-    function sequencerQuorum() external view returns (uint8);
+    function sequencerThreshold() external view returns (uint8);
 
     /// @notice Highest zone block height accepted with a quorum certificate.
     function zoneHeight() external view returns (uint256);
@@ -766,9 +768,9 @@ interface IZonePortal {
     /// @notice Accept a pending sequencer transfer. Only callable by pending sequencer.
     function acceptSequencer() external;
 
-    /// @notice Atomically replace the settlement signer set and quorum. Only callable by admin.
+    /// @notice Atomically replace the sequencer set and settlement threshold. Only callable by admin.
     /// @dev Signers must be nonzero, unique, and sorted in strictly ascending address order.
-    function setSequencerSet(address[] calldata sequencers, uint8 quorum) external;
+    function setSequencerSet(address[] calldata sequencers, uint8 threshold) external;
 
     /// @notice Start an admin transfer. Only callable by the current admin.
     /// @param newAdmin The address that will become admin after accepting (address(0) cancels).

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -642,7 +642,7 @@ interface IZonePortal {
     error InvalidBouncebackRecipient();
     error InvalidDepositTransition();
     error InvalidSequencerSet();
-    error SequencerSetUnchanged();
+    error SequencerConfigurationUnchanged();
     error InvalidQuorumCertificate();
     error LegacyBatchSubmissionDisabled();
 

--- a/specs/ref-impls/src/tempo/Verifier.sol
+++ b/specs/ref-impls/src/tempo/Verifier.sol
@@ -16,7 +16,6 @@ contract Verifier is IVerifier {
         uint64,
         bytes32,
         uint64,
-        address,
         BlockTransition calldata,
         DepositQueueTransition calldata,
         bytes32,

--- a/specs/ref-impls/src/tempo/ZoneFactory.sol
+++ b/specs/ref-impls/src/tempo/ZoneFactory.sol
@@ -31,11 +31,6 @@ contract ZoneFactory is IZoneFactory {
     address internal _messenger;
     address public owner;
 
-    /// @notice Tracks deployment count for CREATE address prediction
-    /// @dev Contracts start with nonce 1, not 0. Nonce 1 is used by the Verifier deployment,
-    ///      nonce 2 by the shared ZoneMessenger, so zone deployments start at nonce 3.
-    uint256 internal _deploymentNonce = 3;
-
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
@@ -65,18 +60,12 @@ contract ZoneFactory is IZoneFactory {
             revert InvalidToken();
         }
         if (params.admin == address(0)) revert InvalidAdmin();
-        if (params.sequencer == address(0)) revert InvalidSequencer();
         if (!_validVerifiers[params.verifier]) revert InvalidVerifier();
         if (gasleft() < ZONE_CREATION_GAS) revert InsufficientGas();
 
         zoneId = _nextZoneId;
         if (zoneId == type(uint32).max) revert ZoneIdOverflow();
         _nextZoneId = zoneId + 1;
-
-        uint256 currentNonce = _deploymentNonce;
-        _deploymentNonce += 1; // We'll deploy 1 contract
-
-        address predictedPortal = _computeCreateAddress(address(this), currentNonce);
 
         // Deploy and atomically initialize the portal. TIP-1091 fixes this factory's address as
         // the portal's only initializer authority.
@@ -86,7 +75,8 @@ contract ZoneFactory is IZoneFactory {
             params.initialToken,
             _messenger,
             params.admin,
-            params.sequencer,
+            params.sequencers,
+            params.threshold,
             params.verifier,
             params.zoneParams.genesisBlockHash,
             params.zoneParams.genesisTempoBlockNumber,
@@ -94,16 +84,14 @@ contract ZoneFactory is IZoneFactory {
         );
         portal = address(portalContract);
 
-        // Verify our prediction was correct
-        require(portal == predictedPortal, "Portal address mismatch - nonce tracking error");
-
         // Store zone info
         _zones[zoneId] = ZoneInfo({
             zoneId: zoneId,
             portal: portal,
             initialToken: params.initialToken,
             admin: params.admin,
-            sequencer: params.sequencer,
+            sequencers: params.sequencers,
+            threshold: params.threshold,
             verifier: params.verifier,
             genesisBlockHash: params.zoneParams.genesisBlockHash,
             genesisTempoBlockHash: params.zoneParams.genesisTempoBlockHash,
@@ -118,7 +106,8 @@ contract ZoneFactory is IZoneFactory {
             portal,
             params.initialToken,
             params.admin,
-            params.sequencer,
+            params.sequencers,
+            params.threshold,
             params.verifier,
             params.zoneParams.genesisBlockHash,
             params.zoneParams.genesisTempoBlockHash,
@@ -134,34 +123,6 @@ contract ZoneFactory is IZoneFactory {
         address previousOwner = owner;
         owner = newOwner;
         emit OwnershipTransferred(previousOwner, newOwner);
-    }
-
-    /// @notice Compute the address of a contract deployed with CREATE
-    /// @dev address = keccak256(rlp([sender, nonce]))[12:]
-    function _computeCreateAddress(address deployer, uint256 nonce)
-        internal
-        pure
-        returns (address)
-    {
-        bytes memory data;
-        if (nonce == 0x00) {
-            data = abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, bytes1(0x80));
-        } else if (nonce <= 0x7f) {
-            data = abi.encodePacked(bytes1(0xd6), bytes1(0x94), deployer, uint8(nonce));
-        } else if (nonce <= 0xff) {
-            data =
-                abi.encodePacked(bytes1(0xd7), bytes1(0x94), deployer, bytes1(0x81), uint8(nonce));
-        } else if (nonce <= 0xffff) {
-            data =
-                abi.encodePacked(bytes1(0xd8), bytes1(0x94), deployer, bytes1(0x82), uint16(nonce));
-        } else if (nonce <= 0xffffff) {
-            data =
-                abi.encodePacked(bytes1(0xd9), bytes1(0x94), deployer, bytes1(0x83), uint24(nonce));
-        } else {
-            data =
-                abi.encodePacked(bytes1(0xda), bytes1(0x94), deployer, bytes1(0x84), uint32(nonce));
-        }
-        return address(uint160(uint256(keccak256(data))));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -67,8 +67,8 @@ contract ZonePortal is IZonePortal {
     );
     bytes32 internal constant NAME_HASH = keccak256("ZonePortal");
     bytes32 internal constant VERSION_HASH = keccak256("1");
-    bytes32 internal constant ZONE_BLOCK_ATTESTATION_TYPEHASH = keccak256(
-        "ZoneBlockAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,bytes32 parentBlockHash,bytes32 zoneBlockHash)"
+    bytes32 internal constant SETTLEMENT_ATTESTATION_TYPEHASH = keccak256(
+        "SettlementAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,uint256 withdrawalBatchIndex,address sequencer,address verifier,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,bytes32 blockTransitionHash,bytes32 depositQueueTransitionHash,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"
     );
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -1036,11 +1036,6 @@ contract ZonePortal is IZonePortal {
             revert InvalidProof();
         }
 
-        if (
-            sequencerSetVersion != 0
-                && !_verifyBlock(nextZoneHeight, blockTransition.nextBlockHash, signatures)
-        ) revert InvalidQuorumCertificate();
-
         // Validate tempoBlockNumber is valid (applies to both direct and ancestry modes)
         if (tempoBlockNumber < genesisTempoBlockNumber) {
             revert InvalidTempoBlockNumber();
@@ -1072,6 +1067,24 @@ contract ZonePortal is IZonePortal {
         }
 
         if (anchorBlockHash == bytes32(0)) revert InvalidTempoBlockNumber();
+
+        // The certificate binds every value that affects settlement, rather than only the
+        // zone block hash. A leader therefore cannot reuse signatures for this block with a
+        // different withdrawal root, deposit transition, Tempo anchor, or verifier config.
+        if (
+            sequencerSetVersion != 0
+                && !_verifySettlement(
+                    nextZoneHeight,
+                    tempoBlockNumber,
+                    anchorBlockNumber,
+                    anchorBlockHash,
+                    blockTransition,
+                    depositQueueTransition,
+                    withdrawalQueueHash,
+                    verifierConfig,
+                    signatures
+                )
+        ) revert InvalidQuorumCertificate();
 
         // These are strictly not necessary, but we'll assert them here since they are cheap while
         // the prover doesn't (yet) enforce them.
@@ -1124,22 +1137,15 @@ contract ZonePortal is IZonePortal {
         );
     }
 
-    /// @inheritdoc IZonePortal
-    function verifyBlock(
+    function _verifySettlement(
         uint256 nextZoneHeight,
-        bytes32 zoneBlockHash,
-        bytes[] calldata signatures
-    )
-        external
-        view
-        returns (bool)
-    {
-        return _verifyBlock(nextZoneHeight, zoneBlockHash, signatures);
-    }
-
-    function _verifyBlock(
-        uint256 nextZoneHeight,
-        bytes32 zoneBlockHash,
+        uint64 tempoBlockNumber,
+        uint64 anchorBlockNumber,
+        bytes32 anchorBlockHash,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata verifierConfig,
         bytes[] memory signatures
     )
         internal
@@ -1154,12 +1160,20 @@ contract ZonePortal is IZonePortal {
 
         bytes32 structHash = keccak256(
             abi.encode(
-                ZONE_BLOCK_ATTESTATION_TYPEHASH,
+                SETTLEMENT_ATTESTATION_TYPEHASH,
                 zoneId,
                 sequencerSetVersion,
                 nextZoneHeight,
-                blockHash,
-                zoneBlockHash
+                withdrawalBatchIndex + 1,
+                sequencer,
+                verifier,
+                tempoBlockNumber,
+                anchorBlockNumber,
+                anchorBlockHash,
+                keccak256(abi.encode(blockTransition)),
+                keccak256(abi.encode(depositQueueTransition)),
+                withdrawalQueueHash,
+                keccak256(verifierConfig)
             )
         );
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -59,6 +59,20 @@ contract ZonePortal is IZonePortal {
     /// @notice Maximum allowed gas fee rate to prevent overflows
     uint128 public constant MAX_GAS_FEE_RATE = 1e18;
 
+    /// @notice Maximum number of independently countable settlement signers.
+    uint256 public constant MAX_SEQUENCERS = 32;
+
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 internal constant NAME_HASH = keccak256("ZonePortal");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    bytes32 internal constant ZONE_BLOCK_ATTESTATION_TYPEHASH = keccak256(
+        "ZoneBlockAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,bytes32 parentBlockHash,bytes32 zoneBlockHash)"
+    );
+    uint256 internal constant SECP256K1N_DIV_2 =
+        0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -136,6 +150,15 @@ contract ZonePortal is IZonePortal {
     uint64 public genesisTempoBlockNumber;
     bool internal _initialized;
 
+    /// @notice Versioned signer set used to authorize and attest batch settlement.
+    /// @dev Appended after the cross-domain storage layout. Version zero preserves legacy zones
+    ///      until their admin explicitly activates quorum settlement.
+    uint64 public sequencerSetVersion;
+    uint8 public sequencerQuorum;
+    uint256 public zoneHeight;
+    address[] internal _sequencers;
+    mapping(address => bool) public isSequencer;
+
     /*//////////////////////////////////////////////////////////////
                              INITIALIZATION
     //////////////////////////////////////////////////////////////*/
@@ -179,6 +202,13 @@ contract ZonePortal is IZonePortal {
         _;
     }
 
+    modifier onlySettlementSequencer() {
+        if (sequencerSetVersion == 0 ? msg.sender != sequencer : !isSequencer[msg.sender]) {
+            revert NotSequencer();
+        }
+        _;
+    }
+
     modifier onlyAdmin() {
         if (msg.sender != admin) revert NotAdmin();
         _;
@@ -219,6 +249,56 @@ contract ZonePortal is IZonePortal {
         sequencer = pendingSequencer;
         pendingSequencer = address(0);
         emit SequencerTransferred(previousSequencer, sequencer);
+    }
+
+    /// @inheritdoc IZonePortal
+    function setSequencerSet(address[] calldata newSequencers, uint8 newQuorum) external onlyAdmin {
+        uint256 length = newSequencers.length;
+        if (length == 0 || length > MAX_SEQUENCERS || newQuorum == 0 || newQuorum > length) {
+            revert InvalidSequencerSet();
+        }
+
+        address previous = address(0);
+        for (uint256 i = 0; i < length; ++i) {
+            address signer = newSequencers[i];
+            if (signer == address(0) || signer <= previous) revert InvalidSequencerSet();
+            previous = signer;
+        }
+
+        if (newQuorum == sequencerQuorum && length == _sequencers.length) {
+            bool unchanged = true;
+            for (uint256 i = 0; i < length; ++i) {
+                if (newSequencers[i] != _sequencers[i]) {
+                    unchanged = false;
+                    break;
+                }
+            }
+            if (unchanged) revert SequencerSetUnchanged();
+        }
+
+        for (uint256 i = 0; i < _sequencers.length; ++i) {
+            isSequencer[_sequencers[i]] = false;
+        }
+        delete _sequencers;
+        for (uint256 i = 0; i < length; ++i) {
+            address signer = newSequencers[i];
+            _sequencers.push(signer);
+            isSequencer[signer] = true;
+        }
+
+        sequencerQuorum = newQuorum;
+        uint64 newVersion = ++sequencerSetVersion;
+        emit SequencerSetUpdated(newVersion, newQuorum, newSequencers);
+    }
+
+    /// @inheritdoc IZonePortal
+    function sequencerCount() external view returns (uint256) {
+        return _sequencers.length;
+    }
+
+    /// @inheritdoc IZonePortal
+    function sequencerAt(uint256 index) external view returns (address) {
+        return _sequencers[index];
     }
 
     /// @notice Set zone gas rate. Only callable by sequencer.
@@ -717,7 +797,7 @@ contract ZonePortal is IZonePortal {
         bytes32 remainingQueue
     )
         external
-        onlySequencer
+        onlySettlementSequencer
         nonReentrantWithdrawal
     {
         // Pop from withdrawal queue (library handles swap and hash verification)
@@ -879,7 +959,7 @@ contract ZonePortal is IZonePortal {
                            BATCH SUBMISSION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Submit a batch and verify the proof. Only callable by the sequencer.
+    /// @notice Submit a legacy batch before a signer set has been activated.
     /// @param tempoBlockNumber Block number zone committed to (from zone's TempoState)
     /// @param recentTempoBlockNumber Optional recent block for ancestry proof (0 = use direct lookup)
     function submitBatch(
@@ -892,11 +972,73 @@ contract ZonePortal is IZonePortal {
         bytes calldata proof
     )
         external
-        onlySequencer
+        onlySettlementSequencer
+    {
+        if (sequencerSetVersion != 0) revert LegacyBatchSubmissionDisabled();
+        bytes[] memory signatures = new bytes[](0);
+        _submitBatch(
+            tempoBlockNumber,
+            recentTempoBlockNumber,
+            blockTransition,
+            depositQueueTransition,
+            withdrawalQueueHash,
+            verifierConfig,
+            proof,
+            0,
+            signatures
+        );
+    }
+
+    /// @inheritdoc IZonePortal
+    function submitBatch(
+        uint64 tempoBlockNumber,
+        uint64 recentTempoBlockNumber,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata verifierConfig,
+        bytes calldata proof,
+        uint256 nextZoneHeight,
+        bytes[] calldata signatures
+    )
+        external
+        onlySettlementSequencer
+    {
+        if (sequencerSetVersion == 0) revert InvalidQuorumCertificate();
+        _submitBatch(
+            tempoBlockNumber,
+            recentTempoBlockNumber,
+            blockTransition,
+            depositQueueTransition,
+            withdrawalQueueHash,
+            verifierConfig,
+            proof,
+            nextZoneHeight,
+            signatures
+        );
+    }
+
+    function _submitBatch(
+        uint64 tempoBlockNumber,
+        uint64 recentTempoBlockNumber,
+        BlockTransition calldata blockTransition,
+        DepositQueueTransition calldata depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes calldata verifierConfig,
+        bytes calldata proof,
+        uint256 nextZoneHeight,
+        bytes[] memory signatures
+    )
+        internal
     {
         if (blockTransition.prevBlockHash != blockHash) {
             revert InvalidProof();
         }
+
+        if (
+            sequencerSetVersion != 0
+                && !_verifyBlock(nextZoneHeight, blockTransition.nextBlockHash, signatures)
+        ) revert InvalidQuorumCertificate();
 
         // Validate tempoBlockNumber is valid (applies to both direct and ancestry modes)
         if (tempoBlockNumber < genesisTempoBlockNumber) {
@@ -966,6 +1108,7 @@ contract ZonePortal is IZonePortal {
         blockHash = blockTransition.nextBlockHash;
         lastSyncedTempoBlockNumber = tempoBlockNumber;
         lastProcessedDepositNumber = depositQueueTransition.nextDepositNumber;
+        if (sequencerSetVersion != 0) zoneHeight = nextZoneHeight;
 
         uint256 assignedQueueIndex = _withdrawalQueue.enqueue(withdrawalQueueHash);
 
@@ -977,6 +1120,82 @@ contract ZonePortal is IZonePortal {
             blockHash,
             withdrawalQueueHash,
             lastProcessedDepositNumber
+        );
+    }
+
+    /// @inheritdoc IZonePortal
+    function verifyBlock(
+        uint256 nextZoneHeight,
+        bytes32 zoneBlockHash,
+        bytes[] calldata signatures
+    )
+        external
+        view
+        returns (bool)
+    {
+        return _verifyBlock(nextZoneHeight, zoneBlockHash, signatures);
+    }
+
+    function _verifyBlock(
+        uint256 nextZoneHeight,
+        bytes32 zoneBlockHash,
+        bytes[] memory signatures
+    )
+        internal
+        view
+        returns (bool)
+    {
+        uint256 quorum = sequencerQuorum;
+        if (
+            sequencerSetVersion == 0 || nextZoneHeight <= zoneHeight || signatures.length < quorum
+                || signatures.length > _sequencers.length
+        ) return false;
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                ZONE_BLOCK_ATTESTATION_TYPEHASH,
+                zoneId,
+                sequencerSetVersion,
+                nextZoneHeight,
+                blockHash,
+                zoneBlockHash
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+        address[] memory recovered = new address[](signatures.length);
+
+        for (uint256 i = 0; i < signatures.length; ++i) {
+            bytes memory signature = signatures[i];
+            if (signature.length != 65) return false;
+
+            bytes32 r = bytes32(0);
+            bytes32 s = bytes32(0);
+            uint8 v = 0;
+            assembly ("memory-safe") {
+                r := mload(add(signature, 0x20))
+                s := mload(add(signature, 0x40))
+                v := byte(0, mload(add(signature, 0x60)))
+            }
+            if (v < 27) v += 27;
+            if (v != 27 && v != 28) return false;
+            if (uint256(s) == 0 || uint256(s) > SECP256K1N_DIV_2) return false;
+
+            address signer = ecrecover(digest, v, r, s);
+            if (signer == address(0) || !isSequencer[signer]) return false;
+            for (uint256 j = 0; j < i; ++j) {
+                if (recovered[j] == signer) return false;
+            }
+            recovered[i] = signer;
+        }
+
+        return signatures.length >= quorum;
+    }
+
+    function _domainSeparator() internal view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, address(this)
+            )
         );
     }
 

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -68,13 +68,14 @@ contract ZonePortal is IZonePortal {
     bytes32 internal constant NAME_HASH = keccak256("ZonePortal");
     bytes32 internal constant VERSION_HASH = keccak256("1");
     bytes32 internal constant SETTLEMENT_ATTESTATION_TYPEHASH = keccak256(
-        "SettlementAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,uint256 withdrawalBatchIndex,address sequencer,address verifier,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,bytes32 blockTransitionHash,bytes32 depositQueueTransitionHash,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"
+        "SettlementAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,uint256 withdrawalBatchIndex,address verifier,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,bytes32 blockTransitionHash,bytes32 depositQueueTransitionHash,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"
     );
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Current sequencer address
+    /// @notice Legacy representative retained for storage and ABI compatibility.
+    /// @dev This address has no permissions distinct from the sequencer set.
     address public sequencer;
 
     /// @notice Governance admin address
@@ -147,11 +148,9 @@ contract ZonePortal is IZonePortal {
     uint64 public genesisTempoBlockNumber;
     bool internal _initialized;
 
-    /// @notice Versioned signer set used to authorize and attest batch settlement.
-    /// @dev Appended after the cross-domain storage layout. Version zero preserves legacy zones
-    ///      until their admin explicitly activates quorum settlement.
+    /// @notice Versioned set used for every sequencer-authorized operation and settlement.
     uint64 public sequencerSetVersion;
-    uint8 public sequencerQuorum;
+    uint8 public sequencerThreshold;
     uint256 public zoneHeight;
     address[] internal _sequencers;
     mapping(address => bool) public isSequencer;
@@ -165,7 +164,8 @@ contract ZonePortal is IZonePortal {
         address _initialToken,
         address _messenger,
         address _admin,
-        address _sequencer,
+        address[] calldata initialSequencers,
+        uint8 _threshold,
         address _verifier,
         bytes32 _genesisBlockHash,
         uint64 _genesisTempoBlockNumber,
@@ -180,11 +180,12 @@ contract ZonePortal is IZonePortal {
         zoneId = _zoneId;
         messenger = _messenger;
         admin = _admin;
-        sequencer = _sequencer;
         verifier = _verifier;
         blockHash = _genesisBlockHash;
         genesisTempoBlockNumber = _genesisTempoBlockNumber;
         rpcUrl = _rpcUrl;
+
+        _replaceSequencerSet(initialSequencers, _threshold, false);
 
         // Enable the initial token
         _enableTokenInternal(_initialToken);
@@ -195,11 +196,6 @@ contract ZonePortal is IZonePortal {
     //////////////////////////////////////////////////////////////*/
 
     modifier onlySequencer() {
-        if (msg.sender != sequencer) revert NotSequencer();
-        _;
-    }
-
-    modifier onlySettlementSequencer() {
         if (sequencerSetVersion == 0 ? msg.sender != sequencer : !isSequencer[msg.sender]) {
             revert NotSequencer();
         }
@@ -249,9 +245,25 @@ contract ZonePortal is IZonePortal {
     }
 
     /// @inheritdoc IZonePortal
-    function setSequencerSet(address[] calldata newSequencers, uint8 newQuorum) external onlyAdmin {
+    function setSequencerSet(
+        address[] calldata newSequencers,
+        uint8 newThreshold
+    )
+        external
+        onlyAdmin
+    {
+        _replaceSequencerSet(newSequencers, newThreshold, true);
+    }
+
+    function _replaceSequencerSet(
+        address[] calldata newSequencers,
+        uint8 newThreshold,
+        bool rejectUnchanged
+    )
+        internal
+    {
         uint256 length = newSequencers.length;
-        if (length == 0 || length > MAX_SEQUENCERS || newQuorum == 0 || newQuorum > length) {
+        if (length == 0 || length > MAX_SEQUENCERS || newThreshold == 0 || newThreshold > length) {
             revert InvalidSequencerSet();
         }
 
@@ -273,7 +285,7 @@ contract ZonePortal is IZonePortal {
         }
         // Quorum is part of the versioned configuration: changing only the threshold is valid
         // and must invalidate certificates collected under the previous version.
-        if (membersUnchanged && newQuorum == sequencerQuorum) {
+        if (rejectUnchanged && membersUnchanged && newThreshold == sequencerThreshold) {
             revert SequencerConfigurationUnchanged();
         }
 
@@ -287,9 +299,11 @@ contract ZonePortal is IZonePortal {
             isSequencer[signer] = true;
         }
 
-        sequencerQuorum = newQuorum;
+        // Preserve the legacy getter without granting the first member distinct permissions.
+        sequencer = newSequencers[0];
+        sequencerThreshold = newThreshold;
         uint64 newVersion = ++sequencerSetVersion;
-        emit SequencerSetUpdated(newVersion, newQuorum, newSequencers);
+        emit SequencerSetUpdated(newVersion, newThreshold, newSequencers);
     }
 
     /// @inheritdoc IZonePortal
@@ -629,9 +643,7 @@ contract ZonePortal is IZonePortal {
 
         // TIP-20 transfers revert on failure, so no boolean check is needed here.
         ITIP20(_token).transferFrom(msg.sender, address(this), amount);
-        if (fee > 0) {
-            ITIP20(_token).transfer(sequencer, fee);
-        }
+        _distributeSequencerFee(_token, fee);
     }
 
     function _recordDeposit(bytes32 newCurrentDepositQueueHash)
@@ -798,7 +810,7 @@ contract ZonePortal is IZonePortal {
         bytes32 remainingQueue
     )
         external
-        onlySettlementSequencer
+        onlySequencer
         nonReentrantWithdrawal
     {
         // Pop from withdrawal queue (library handles swap and hash verification)
@@ -811,11 +823,9 @@ contract ZonePortal is IZonePortal {
             return;
         }
 
-        // Transfer fee to sequencer.
+        // Split the fee equally across the active sequencer set.
         if (withdrawal.fee > 0) {
-            // Fee transfer can fail for e.g. TIP-403 blacklist. The sequencer
-            // forgoes the fee so the withdrawal itself does not stall.
-            _tryTransfer(_token, sequencer, withdrawal.fee);
+            _distributeSequencerFee(_token, withdrawal.fee);
         }
 
         if (withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) {
@@ -886,9 +896,7 @@ contract ZonePortal is IZonePortal {
         uint128 refundAmount = withdrawal.amount - bouncebackFee;
 
         if (bouncebackFee > 0) {
-            // If the fee transfer fails, (e.g. TIP-403 blacklist), the sequencer
-            // forgoes the fee so the bounce-back itself does not stall.
-            _tryTransfer(_token, sequencer, bouncebackFee); // ignore failure
+            _distributeSequencerFee(_token, bouncebackFee);
         }
 
         bool success = _tryTransfer(_token, withdrawal.to, refundAmount);
@@ -929,6 +937,24 @@ contract ZonePortal is IZonePortal {
             return ok;
         } catch {
             return false;
+        }
+    }
+
+    function _distributeSequencerFee(address token, uint128 fee) internal {
+        if (fee == 0) return;
+
+        uint256 length = _sequencers.length;
+        if (length == 0) {
+            // Compatibility for portals initialized before threshold sequencers.
+            _tryTransfer(token, sequencer, fee);
+            return;
+        }
+
+        uint128 share = fee / uint128(length);
+        if (share == 0) return;
+        for (uint256 i = 0; i < length; ++i) {
+            // A recipient-policy failure must not block deposits or withdrawals.
+            _tryTransfer(token, _sequencers[i], share);
         }
     }
 
@@ -973,7 +999,7 @@ contract ZonePortal is IZonePortal {
         bytes calldata proof
     )
         external
-        onlySettlementSequencer
+        onlySequencer
     {
         if (sequencerSetVersion != 0) revert LegacyBatchSubmissionDisabled();
         bytes[] memory signatures = new bytes[](0);
@@ -1003,7 +1029,7 @@ contract ZonePortal is IZonePortal {
         bytes[] calldata signatures
     )
         external
-        onlySettlementSequencer
+        onlySequencer
     {
         if (sequencerSetVersion == 0) revert InvalidQuorumCertificate();
         _submitBatch(
@@ -1108,7 +1134,6 @@ contract ZonePortal is IZonePortal {
                 anchorBlockNumber,
                 anchorBlockHash,
                 withdrawalBatchIndex + 1,
-                sequencer,
                 blockTransition,
                 depositQueueTransition,
                 withdrawalQueueHash,
@@ -1152,10 +1177,10 @@ contract ZonePortal is IZonePortal {
         view
         returns (bool)
     {
-        uint256 quorum = sequencerQuorum;
+        uint256 threshold = sequencerThreshold;
         if (
-            sequencerSetVersion == 0 || nextZoneHeight <= zoneHeight || signatures.length < quorum
-                || signatures.length > _sequencers.length
+            sequencerSetVersion == 0 || nextZoneHeight <= zoneHeight
+                || signatures.length < threshold || signatures.length > _sequencers.length
         ) return false;
 
         bytes32 structHash = keccak256(
@@ -1165,7 +1190,6 @@ contract ZonePortal is IZonePortal {
                 sequencerSetVersion,
                 nextZoneHeight,
                 withdrawalBatchIndex + 1,
-                sequencer,
                 verifier,
                 tempoBlockNumber,
                 anchorBlockNumber,
@@ -1198,7 +1222,7 @@ contract ZonePortal is IZonePortal {
             recovered[i] = signer;
         }
 
-        return signatures.length >= quorum;
+        return signatures.length >= threshold;
     }
 
     function _domainSeparator() internal view returns (bytes32) {

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -70,9 +70,6 @@ contract ZonePortal is IZonePortal {
     bytes32 internal constant ZONE_BLOCK_ATTESTATION_TYPEHASH = keccak256(
         "ZoneBlockAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,bytes32 parentBlockHash,bytes32 zoneBlockHash)"
     );
-    uint256 internal constant SECP256K1N_DIV_2 =
-        0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
-
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -265,15 +262,19 @@ contract ZonePortal is IZonePortal {
             previous = signer;
         }
 
-        if (newQuorum == sequencerQuorum && length == _sequencers.length) {
-            bool unchanged = true;
+        bool membersUnchanged = length == _sequencers.length;
+        if (membersUnchanged) {
             for (uint256 i = 0; i < length; ++i) {
                 if (newSequencers[i] != _sequencers[i]) {
-                    unchanged = false;
+                    membersUnchanged = false;
                     break;
                 }
             }
-            if (unchanged) revert SequencerSetUnchanged();
+        }
+        // Quorum is part of the versioned configuration: changing only the threshold is valid
+        // and must invalidate certificates collected under the previous version.
+        if (membersUnchanged && newQuorum == sequencerQuorum) {
+            revert SequencerConfigurationUnchanged();
         }
 
         for (uint256 i = 0; i < _sequencers.length; ++i) {
@@ -1166,21 +1167,16 @@ contract ZonePortal is IZonePortal {
 
         for (uint256 i = 0; i < signatures.length; ++i) {
             bytes memory signature = signatures[i];
-            if (signature.length != 65) return false;
-
-            bytes32 r = bytes32(0);
-            bytes32 s = bytes32(0);
-            uint8 v = 0;
-            assembly ("memory-safe") {
-                r := mload(add(signature, 0x20))
-                s := mload(add(signature, 0x40))
-                v := byte(0, mload(add(signature, 0x60)))
+            address signer;
+            // The shared TIP-1020 verifier owns signature-format and canonicality checks.
+            // Convert its reverts into `false` so the public verifier remains non-reverting.
+            try StdPrecompiles.SIGNATURE_VERIFIER.recover(digest, signature) returns (
+                address recoveredSigner
+            ) {
+                signer = recoveredSigner;
+            } catch {
+                return false;
             }
-            if (v < 27) v += 27;
-            if (v != 27 && v != 28) return false;
-            if (uint256(s) == 0 || uint256(s) > SECP256K1N_DIV_2) return false;
-
-            address signer = ecrecover(digest, v, r, s);
             if (signer == address(0) || !isSequencer[signer]) return false;
             for (uint256 j = 0; j < i; ++j) {
                 if (recovered[j] == signer) return false;

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 48305,
+      "astId": 5110,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencer",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 48308,
+      "astId": 5113,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 48311,
+      "astId": 5116,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingSequencer",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 48314,
+      "astId": 5119,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 48316,
+      "astId": 5121,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -41,7 +41,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 48318,
+      "astId": 5123,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 48321,
+      "astId": 5126,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 48324,
+      "astId": 5129,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 48327,
+      "astId": 5132,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 48330,
+      "astId": 5135,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -81,7 +81,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 48333,
+      "astId": 5138,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "bouncebackGas",
       "offset": 24,
@@ -89,23 +89,23 @@
       "type": "t_uint64"
     },
     {
-      "astId": 48338,
+      "astId": 5143,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
       "slot": "7",
-      "type": "t_array(t_struct(EncryptionKeyEntry)43537_storage)dyn_storage"
+      "type": "t_array(t_struct(EncryptionKeyEntry)2603_storage)dyn_storage"
     },
     {
-      "astId": 48344,
+      "astId": 5149,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(TokenConfig)43952_storage)"
+      "type": "t_mapping(t_address,t_struct(TokenConfig)3018_storage)"
     },
     {
-      "astId": 48348,
+      "astId": 5153,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 48355,
+      "astId": 5160,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -121,15 +121,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 48359,
+      "astId": 5164,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
       "slot": "11",
-      "type": "t_struct(WithdrawalQueue)45721_storage"
+      "type": "t_struct(WithdrawalQueue)4787_storage"
     },
     {
-      "astId": 48362,
+      "astId": 5167,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 48365,
+      "astId": 5170,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_address"
     },
     {
-      "astId": 48368,
+      "astId": 5173,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -153,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 48371,
+      "astId": 5176,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 48373,
+      "astId": 5178,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -169,7 +169,7 @@
       "type": "t_address"
     },
     {
-      "astId": 48375,
+      "astId": 5180,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -177,7 +177,7 @@
       "type": "t_address"
     },
     {
-      "astId": 48377,
+      "astId": 5182,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "genesisTempoBlockNumber",
       "offset": 20,
@@ -185,7 +185,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 48379,
+      "astId": 5184,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 28,
@@ -193,7 +193,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 48382,
+      "astId": 5187,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerSetVersion",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 48384,
+      "astId": 5189,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerThreshold",
       "offset": 8,
@@ -209,7 +209,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 48386,
+      "astId": 5191,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneHeight",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 48389,
+      "astId": 5194,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_sequencers",
       "offset": 0,
@@ -225,7 +225,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 48393,
+      "astId": 5198,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "isSequencer",
       "offset": 0,
@@ -245,11 +245,11 @@
       "numberOfBytes": "32",
       "base": "t_address"
     },
-    "t_array(t_struct(EncryptionKeyEntry)43537_storage)dyn_storage": {
+    "t_array(t_struct(EncryptionKeyEntry)2603_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct EncryptionKeyEntry[]",
       "numberOfBytes": "32",
-      "base": "t_struct(EncryptionKeyEntry)43537_storage"
+      "base": "t_struct(EncryptionKeyEntry)2603_storage"
     },
     "t_bool": {
       "encoding": "inplace",
@@ -275,12 +275,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_uint128)"
     },
-    "t_mapping(t_address,t_struct(TokenConfig)43952_storage)": {
+    "t_mapping(t_address,t_struct(TokenConfig)3018_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct TokenConfig)",
       "numberOfBytes": "32",
-      "value": "t_struct(TokenConfig)43952_storage"
+      "value": "t_struct(TokenConfig)3018_storage"
     },
     "t_mapping(t_address,t_uint128)": {
       "encoding": "mapping",
@@ -301,13 +301,13 @@
       "label": "string",
       "numberOfBytes": "32"
     },
-    "t_struct(EncryptionKeyEntry)43537_storage": {
+    "t_struct(EncryptionKeyEntry)2603_storage": {
       "encoding": "inplace",
       "label": "struct EncryptionKeyEntry",
       "numberOfBytes": "64",
       "members": [
         {
-          "astId": 43532,
+          "astId": 2598,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "x",
           "offset": 0,
@@ -315,7 +315,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 43534,
+          "astId": 2600,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "yParity",
           "offset": 0,
@@ -323,7 +323,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 43536,
+          "astId": 2602,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "activationBlock",
           "offset": 1,
@@ -332,13 +332,13 @@
         }
       ]
     },
-    "t_struct(TokenConfig)43952_storage": {
+    "t_struct(TokenConfig)3018_storage": {
       "encoding": "inplace",
       "label": "struct TokenConfig",
       "numberOfBytes": "32",
       "members": [
         {
-          "astId": 43949,
+          "astId": 3015,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "enabled",
           "offset": 0,
@@ -346,7 +346,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 43951,
+          "astId": 3017,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "depositsActive",
           "offset": 1,
@@ -355,13 +355,13 @@
         }
       ]
     },
-    "t_struct(WithdrawalQueue)45721_storage": {
+    "t_struct(WithdrawalQueue)4787_storage": {
       "encoding": "inplace",
       "label": "struct WithdrawalQueue",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 45714,
+          "astId": 4780,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "head",
           "offset": 0,
@@ -369,7 +369,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45716,
+          "astId": 4782,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "tail",
           "offset": 0,
@@ -377,7 +377,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 45720,
+          "astId": 4786,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "slots",
           "offset": 0,

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 4983,
+      "astId": 48305,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencer",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 4986,
+      "astId": 48308,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_address"
     },
     {
-      "astId": 4989,
+      "astId": 48311,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingSequencer",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_address"
     },
     {
-      "astId": 4992,
+      "astId": 48314,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 4994,
+      "astId": 48316,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -41,7 +41,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 4996,
+      "astId": 48318,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 4999,
+      "astId": 48321,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5002,
+      "astId": 48324,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5005,
+      "astId": 48327,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5008,
+      "astId": 48330,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -81,23 +81,31 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5013,
+      "astId": 48333,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "bouncebackGas",
+      "offset": 24,
+      "slot": "6",
+      "type": "t_uint64"
+    },
+    {
+      "astId": 48338,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
       "slot": "7",
-      "type": "t_array(t_struct(EncryptionKeyEntry)2600_storage)dyn_storage"
+      "type": "t_array(t_struct(EncryptionKeyEntry)43537_storage)dyn_storage"
     },
     {
-      "astId": 5019,
+      "astId": 48344,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
       "slot": "8",
-      "type": "t_mapping(t_address,t_struct(TokenConfig)3009_storage)"
+      "type": "t_mapping(t_address,t_struct(TokenConfig)43952_storage)"
     },
     {
-      "astId": 5023,
+      "astId": 48348,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -105,7 +113,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5030,
+      "astId": 48355,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -113,15 +121,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 5034,
+      "astId": 48359,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
       "slot": "11",
-      "type": "t_struct(WithdrawalQueue)4680_storage"
+      "type": "t_struct(WithdrawalQueue)45721_storage"
     },
     {
-      "astId": 5037,
+      "astId": 48362,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -129,7 +137,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 5040,
+      "astId": 48365,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -137,7 +145,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5043,
+      "astId": 48368,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -145,7 +153,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5046,
+      "astId": 48371,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -153,7 +161,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5048,
+      "astId": 48373,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -161,7 +169,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5050,
+      "astId": 48375,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -169,7 +177,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5052,
+      "astId": 48377,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "genesisTempoBlockNumber",
       "offset": 20,
@@ -177,12 +185,52 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5054,
+      "astId": 48379,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 28,
       "slot": "18",
       "type": "t_bool"
+    },
+    {
+      "astId": 48382,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "sequencerSetVersion",
+      "offset": 0,
+      "slot": "19",
+      "type": "t_uint64"
+    },
+    {
+      "astId": 48384,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "sequencerThreshold",
+      "offset": 8,
+      "slot": "19",
+      "type": "t_uint8"
+    },
+    {
+      "astId": 48386,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "zoneHeight",
+      "offset": 0,
+      "slot": "20",
+      "type": "t_uint256"
+    },
+    {
+      "astId": 48389,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "_sequencers",
+      "offset": 0,
+      "slot": "21",
+      "type": "t_array(t_address)dyn_storage"
+    },
+    {
+      "astId": 48393,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "isSequencer",
+      "offset": 0,
+      "slot": "22",
+      "type": "t_mapping(t_address,t_bool)"
     }
   ],
   "types": {
@@ -197,11 +245,11 @@
       "numberOfBytes": "32",
       "base": "t_address"
     },
-    "t_array(t_struct(EncryptionKeyEntry)2600_storage)dyn_storage": {
+    "t_array(t_struct(EncryptionKeyEntry)43537_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct EncryptionKeyEntry[]",
       "numberOfBytes": "32",
-      "base": "t_struct(EncryptionKeyEntry)2600_storage"
+      "base": "t_struct(EncryptionKeyEntry)43537_storage"
     },
     "t_bool": {
       "encoding": "inplace",
@@ -213,6 +261,13 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
+    "t_mapping(t_address,t_bool)": {
+      "encoding": "mapping",
+      "key": "t_address",
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32",
+      "value": "t_bool"
+    },
     "t_mapping(t_address,t_mapping(t_address,t_uint128))": {
       "encoding": "mapping",
       "key": "t_address",
@@ -220,12 +275,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_uint128)"
     },
-    "t_mapping(t_address,t_struct(TokenConfig)3009_storage)": {
+    "t_mapping(t_address,t_struct(TokenConfig)43952_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct TokenConfig)",
       "numberOfBytes": "32",
-      "value": "t_struct(TokenConfig)3009_storage"
+      "value": "t_struct(TokenConfig)43952_storage"
     },
     "t_mapping(t_address,t_uint128)": {
       "encoding": "mapping",
@@ -246,13 +301,13 @@
       "label": "string",
       "numberOfBytes": "32"
     },
-    "t_struct(EncryptionKeyEntry)2600_storage": {
+    "t_struct(EncryptionKeyEntry)43537_storage": {
       "encoding": "inplace",
       "label": "struct EncryptionKeyEntry",
       "numberOfBytes": "64",
       "members": [
         {
-          "astId": 2595,
+          "astId": 43532,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "x",
           "offset": 0,
@@ -260,7 +315,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 2597,
+          "astId": 43534,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "yParity",
           "offset": 0,
@@ -268,7 +323,7 @@
           "type": "t_uint8"
         },
         {
-          "astId": 2599,
+          "astId": 43536,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "activationBlock",
           "offset": 1,
@@ -277,13 +332,13 @@
         }
       ]
     },
-    "t_struct(TokenConfig)3009_storage": {
+    "t_struct(TokenConfig)43952_storage": {
       "encoding": "inplace",
       "label": "struct TokenConfig",
       "numberOfBytes": "32",
       "members": [
         {
-          "astId": 3006,
+          "astId": 43949,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "enabled",
           "offset": 0,
@@ -291,7 +346,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 3008,
+          "astId": 43951,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "depositsActive",
           "offset": 1,
@@ -300,13 +355,13 @@
         }
       ]
     },
-    "t_struct(WithdrawalQueue)4680_storage": {
+    "t_struct(WithdrawalQueue)45721_storage": {
       "encoding": "inplace",
       "label": "struct WithdrawalQueue",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 4673,
+          "astId": 45714,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "head",
           "offset": 0,
@@ -314,7 +369,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4675,
+          "astId": 45716,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "tail",
           "offset": 0,
@@ -322,7 +377,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4679,
+          "astId": 45720,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "slots",
           "offset": 0,

--- a/specs/ref-impls/test/mocks/MockVerifier.sol
+++ b/specs/ref-impls/test/mocks/MockVerifier.sol
@@ -19,7 +19,6 @@ contract MockVerifier is IVerifier {
         uint64, // anchorBlockNumber
         bytes32, // anchorBlockHash
         uint64, // expectedWithdrawalBatchIndex
-        address, // sequencer
         BlockTransition calldata,
         DepositQueueTransition calldata,
         bytes32, // withdrawalQueueHash

--- a/specs/ref-impls/test/tempo/Verifier.t.sol
+++ b/specs/ref-impls/test/tempo/Verifier.t.sol
@@ -18,7 +18,6 @@ contract VerifierTest is Test {
             1,
             bytes32("anchor"),
             1,
-            address(0x1234),
             BlockTransition({ prevBlockHash: bytes32("prev"), nextBlockHash: bytes32("next") }),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0),

--- a/specs/ref-impls/test/tempo/ZoneBridge.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneBridge.t.sol
@@ -175,13 +175,16 @@ contract ZoneBridgeTest is BaseTest {
         ZoneMessenger messengerContract = new ZoneMessenger(address(messengerFactory));
         l1Portal = new ZonePortal();
         address verifier = l1Factory.verifier();
+        address[] memory sequencers = new address[](1);
+        sequencers[0] = sequencer;
         vm.prank(_ZONE_FACTORY);
         l1Portal.initialize(
             1, // zoneId
             address(l2ZoneToken), // initialToken = MockZoneToken (NOT pathUSD)
             address(messengerContract),
             admin, // admin
-            sequencer, // sequencer
+            sequencers,
+            1,
             verifier,
             GENESIS_BLOCK_HASH,
             genesisTempoBlockNumber,

--- a/specs/ref-impls/test/tempo/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneFactory.t.sol
@@ -21,6 +21,11 @@ contract ZoneFactoryTest is BaseTest {
         zoneFactory = _deployZoneFactory();
     }
 
+    function _sequencers(address member) internal pure returns (address[] memory members) {
+        members = new address[](1);
+        members[0] = member;
+    }
+
     /*//////////////////////////////////////////////////////////////
                           VALID CREATION TESTS
     //////////////////////////////////////////////////////////////*/
@@ -29,7 +34,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -51,7 +57,9 @@ contract ZoneFactoryTest is BaseTest {
         assertEq(info.portal, portal);
         assertEq(info.initialToken, address(pathUSD));
         assertEq(info.admin, admin);
-        assertEq(info.sequencer, sequencer);
+        assertEq(info.sequencers.length, 1);
+        assertEq(info.sequencers[0], sequencer);
+        assertEq(info.threshold, 1);
         assertEq(info.verifier, zoneFactory.verifier());
         assertEq(info.genesisBlockHash, GENESIS_BLOCK_HASH);
         assertEq(info.genesisTempoBlockHash, GENESIS_TEMPO_BLOCK_HASH);
@@ -61,7 +69,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -100,7 +109,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -125,7 +135,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params1 = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -141,7 +152,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params2 = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: secondSequencer,
+            sequencers: _sequencers(secondSequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: keccak256("genesis2"),
@@ -162,8 +174,8 @@ contract ZoneFactoryTest is BaseTest {
 
         ZoneInfo memory info1 = zoneFactory.zones(zoneId1);
         ZoneInfo memory info2 = zoneFactory.zones(zoneId2);
-        assertEq(info1.sequencer, sequencer);
-        assertEq(info2.sequencer, secondSequencer);
+        assertEq(info1.sequencers[0], sequencer);
+        assertEq(info2.sequencers[0], secondSequencer);
         assertEq(ZonePortal(portal1).messenger(), zoneFactory.messenger());
         assertEq(ZonePortal(portal2).messenger(), zoneFactory.messenger());
     }
@@ -172,7 +184,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -193,7 +206,7 @@ contract ZoneFactoryTest is BaseTest {
             if (
                 logs[i].topics[0]
                     == keccak256(
-                        "ZoneCreated(uint32,address,address,address,address,address,bytes32,bytes32,uint64)"
+                        "ZoneCreated(uint32,address,address,address,address[],uint8,address,bytes32,bytes32,uint64)"
                     )
             ) {
                 found = true;
@@ -218,7 +231,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(0),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -239,7 +253,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: notTip20,
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -257,7 +272,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: alice, // EOA, not a contract
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -279,7 +295,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: address(0),
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -297,11 +314,12 @@ contract ZoneFactoryTest is BaseTest {
                        INVALID SEQUENCER TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function test_createZone_revertsOnInvalidSequencer_zeroAddress() public {
+    function test_createZone_revertsOnInvalidSequencerSet_zeroAddress() public {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: address(0),
+            sequencers: _sequencers(address(0)),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -311,7 +329,7 @@ contract ZoneFactoryTest is BaseTest {
             rpcUrl: ""
         });
 
-        vm.expectRevert(IZoneFactory.InvalidSequencer.selector);
+        vm.expectRevert(IZoneFactory.InvalidSequencerSet.selector);
         zoneFactory.createZone(params);
     }
 
@@ -323,7 +341,8 @@ contract ZoneFactoryTest is BaseTest {
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: address(0xdead),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -366,7 +385,8 @@ contract ZoneFactoryTest is BaseTest {
         return IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: _sequencers(sequencer),
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -410,7 +430,9 @@ contract ZoneFactoryTest is BaseTest {
 
         assertEq(pc.zoneId(), id);
         assertEq(pc.admin(), p.admin);
-        assertEq(pc.sequencer(), p.sequencer);
+        assertEq(pc.sequencerCount(), p.sequencers.length);
+        assertEq(pc.sequencerAt(0), p.sequencers[0]);
+        assertEq(pc.sequencerThreshold(), p.threshold);
         assertEq(pc.verifier(), p.verifier);
         assertEq(pc.messenger(), zoneFactory.messenger());
         assertEq(pc.blockHash(), p.zoneParams.genesisBlockHash);
@@ -434,19 +456,16 @@ contract ZoneFactoryTest is BaseTest {
                           METADATA ROTATION
     //////////////////////////////////////////////////////////////*/
 
-    // Factory ZoneInfo.sequencer is a snapshot taken at creation and does not track
-    // later portal rotation; the portal remains the source of truth.
-    function test_zones_sequencerIsSnapshot_afterRotation() public {
+    // Factory ZoneInfo is a creation-time snapshot; the portal remains the source of truth.
+    function test_zones_sequencerSetIsSnapshot_afterRotation() public {
         (uint32 id, address portal) = zoneFactory.createZone(_defaultParams());
-        address nextSequencer = alice;
+        address[] memory replacement = _sequencers(alice);
 
-        vm.prank(sequencer);
-        ZonePortal(portal).transferSequencer(nextSequencer);
-        vm.prank(nextSequencer);
-        ZonePortal(portal).acceptSequencer();
+        vm.prank(admin);
+        ZonePortal(portal).setSequencerSet(replacement, 1);
 
-        assertEq(ZonePortal(portal).sequencer(), nextSequencer); // portal: current
-        assertEq(zoneFactory.zones(id).sequencer, sequencer); // factory: snapshot at creation
+        assertEq(ZonePortal(portal).sequencerAt(0), alice); // portal: current
+        assertEq(zoneFactory.zones(id).sequencers[0], sequencer); // factory: snapshot
     }
 
     // Factory ZoneInfo.admin is likewise a snapshot; the portal admin can rotate via the
@@ -460,23 +479,6 @@ contract ZoneFactoryTest is BaseTest {
 
         assertEq(ZonePortal(portal).admin(), alice); // portal: current
         assertEq(zoneFactory.zones(id).admin, admin); // factory: snapshot at creation
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                    CREATE-ADDRESS RLP BOUNDARIES
-    //////////////////////////////////////////////////////////////*/
-
-    function test_computeCreateAddress_matchesReference_atRlpBoundaries() public {
-        ZoneFactoryHarness h = new ZoneFactoryHarness();
-        uint256[10] memory nonces =
-            [uint256(0), 1, 0x7f, 0x80, 0xff, 0x100, 0xffff, 0x10000, 0xffffff, 0x1000000];
-        for (uint256 i; i < nonces.length; i++) {
-            assertEq(
-                h.computeCreateAddress_(address(h), nonces[i]),
-                vm.computeCreateAddress(address(h), nonces[i]),
-                "RLP nonce branch mismatch"
-            );
-        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -495,14 +497,14 @@ contract ZoneFactoryTest is BaseTest {
         vm.assume(adminAddr != address(0) && seqAddr != address(0));
         IZoneFactory.CreateZoneParams memory p = _defaultParams();
         p.admin = adminAddr;
-        p.sequencer = seqAddr;
+        p.sequencers = _sequencers(seqAddr);
         p.zoneParams = ZoneParams(gh, tgh, tbn);
 
         (uint32 id, address portal) = zoneFactory.createZone(p);
         ZoneInfo memory info = zoneFactory.zones(id);
 
         assertEq(info.admin, adminAddr);
-        assertEq(info.sequencer, seqAddr);
+        assertEq(info.sequencers[0], seqAddr);
         assertEq(info.genesisBlockHash, gh);
         assertEq(info.genesisTempoBlockHash, tgh);
         assertEq(info.genesisTempoBlockNumber, tbn);
@@ -517,15 +519,6 @@ contract NotATIP20 {
 
     function notATIP20Function() external pure returns (bool) {
         return true;
-    }
-
-}
-
-/// @notice Harness exposing the internal CREATE-address predictor for boundary testing.
-contract ZoneFactoryHarness is ZoneFactory {
-
-    function computeCreateAddress_(address d, uint256 n) external pure returns (address) {
-        return _computeCreateAddress(d, n);
     }
 
 }

--- a/specs/ref-impls/test/tempo/ZoneIntegration.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneIntegration.t.sol
@@ -117,13 +117,16 @@ contract ZoneIntegrationTest is BaseTest {
         ZoneMessenger messengerContract = new ZoneMessenger(address(messengerFactory));
         l1Portal = new ZonePortal();
         address verifier = l1Factory.verifier();
+        address[] memory sequencers = new address[](1);
+        sequencers[0] = sequencer;
         vm.prank(_ZONE_FACTORY);
         l1Portal.initialize(
             1,
             address(l2ZoneToken),
             address(messengerContract),
             admin,
-            sequencer,
+            sequencers,
+            1,
             verifier,
             GENESIS_BLOCK_HASH,
             genesisTempoBlockNumber,

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -214,6 +214,8 @@ contract ZonePortalProxyStorageTest is Test {
         address messengerB = makeAddr("messenger B");
         address verifierA = makeAddr("verifier A");
         address verifierB = makeAddr("verifier B");
+        address[] memory sequencersA = new address[](1);
+        sequencersA[0] = makeAddr("sequencer A");
         vm.prank(makeAddr("not factory"));
         vm.expectRevert(IZonePortal.NotFactory.selector);
         ZonePortal(proxyA)
@@ -222,7 +224,8 @@ contract ZonePortalProxyStorageTest is Test {
                 initialToken,
                 messengerA,
                 makeAddr("admin A"),
-                makeAddr("sequencer A"),
+                sequencersA,
+                1,
                 verifierA,
                 keccak256("genesis A"),
                 100,
@@ -258,13 +261,16 @@ contract ZonePortalProxyStorageTest is Test {
     )
         internal
     {
+        address[] memory sequencers = new address[](1);
+        sequencers[0] = makeAddr(string.concat("sequencer ", vm.toString(id)));
         ZonePortal(target)
             .initialize(
                 id,
                 initialToken,
                 portalMessenger,
                 makeAddr(string.concat("admin ", vm.toString(id))),
-                makeAddr(string.concat("sequencer ", vm.toString(id))),
+                sequencers,
+                1,
                 portalVerifier,
                 keccak256(abi.encode("genesis", id)),
                 genesisBlockNumber,
@@ -281,7 +287,7 @@ contract ZonePortalTest is BaseTest {
         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
     );
     bytes32 internal constant SETTLEMENT_ATTESTATION_TYPEHASH = keccak256(
-        "SettlementAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,uint256 withdrawalBatchIndex,address sequencer,address verifier,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,bytes32 blockTransitionHash,bytes32 depositQueueTransitionHash,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"
+        "SettlementAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,uint256 withdrawalBatchIndex,address verifier,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,bytes32 blockTransitionHash,bytes32 depositQueueTransitionHash,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"
     );
 
     uint256 internal constant SIGNER_A_KEY = 2;
@@ -321,10 +327,13 @@ contract ZonePortalTest is BaseTest {
         genesisTempoBlockNumber = uint64(block.number);
 
         // Create a zone
+        address[] memory initialSequencers = new address[](1);
+        initialSequencers[0] = sequencer;
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: initialSequencers,
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,
@@ -393,7 +402,6 @@ contract ZonePortalTest is BaseTest {
                 portal.sequencerSetVersion(),
                 height,
                 portal.withdrawalBatchIndex() + 1,
-                portal.sequencer(),
                 portal.verifier(),
                 tempoBlockNumber,
                 anchorBlockNumber,
@@ -461,6 +469,9 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.messenger(), address(messenger));
         assertEq(portal.bouncebackGas(), 0);
         assertEq(portal.calculateBouncebackFee(), 0);
+        assertEq(portal.sequencerSetVersion(), 1);
+        assertEq(portal.sequencerThreshold(), 1);
+        assertTrue(portal.isSequencer(sequencer));
     }
 
     function test_zoneFactoryTracksZones() public view {
@@ -472,23 +483,25 @@ contract ZonePortalTest is BaseTest {
         assertEq(info.portal, address(portal));
         assertEq(info.initialToken, address(pathUSD));
         assertEq(info.admin, admin);
-        assertEq(info.sequencer, sequencer);
+        assertEq(info.sequencers.length, 1);
+        assertEq(info.sequencers[0], sequencer);
+        assertEq(info.threshold, 1);
     }
 
     /*//////////////////////////////////////////////////////////////
                          SEQUENCER QUORUM TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function test_setSequencerSet_configuresVersionedQuorum() public {
+    function test_setSequencerSet_configuresVersionedThreshold() public {
         address[] memory signers = _sequencerSet();
 
         vm.expectEmit(true, false, false, true);
-        emit IZonePortal.SequencerSetUpdated(1, 2, signers);
+        emit IZonePortal.SequencerSetUpdated(2, 2, signers);
         vm.prank(admin);
         portal.setSequencerSet(signers, 2);
 
-        assertEq(portal.sequencerSetVersion(), 1);
-        assertEq(portal.sequencerQuorum(), 2);
+        assertEq(portal.sequencerSetVersion(), 2);
+        assertEq(portal.sequencerThreshold(), 2);
         assertEq(portal.sequencerCount(), 3);
         for (uint256 i; i < signers.length; ++i) {
             assertEq(portal.sequencerAt(i), signers[i]);
@@ -527,25 +540,23 @@ contract ZonePortalTest is BaseTest {
         vm.prank(admin);
         portal.setSequencerSet(replacement, 2);
 
-        assertEq(portal.sequencerSetVersion(), 2);
+        assertEq(portal.sequencerSetVersion(), 3);
         assertFalse(portal.isSequencer(removed));
     }
 
-    function test_quorumSequencerCannotCallConfigurationMethods() public {
+    function test_allSequencersCanCallConfigurationMethods() public {
         address[] memory signers = _activateSequencerSet(2);
 
-        vm.startPrank(signers[0]);
-        vm.expectRevert(IZonePortal.NotSequencer.selector);
-        portal.setZoneGasRate(1);
-        vm.expectRevert(IZonePortal.NotSequencer.selector);
-        portal.setRpcUrl("https://follower.invalid");
-        vm.stopPrank();
+        for (uint256 i = 0; i < signers.length; ++i) {
+            vm.startPrank(signers[i]);
+            portal.setZoneGasRate(uint128(i + 1));
+            portal.setRpcUrl(string.concat("https://sequencer-", vm.toString(i), ".example"));
+            vm.stopPrank();
+        }
 
-        Withdrawal memory withdrawal =
-            _withdrawal(address(pathUSD), alice, bob, 1, bytes32(0), 0, alice, "");
         vm.prank(alice);
         vm.expectRevert(IZonePortal.NotSequencer.selector);
-        portal.processWithdrawal(withdrawal, bytes32(0));
+        portal.setZoneGasRate(4);
     }
 
     function test_submitBatch_requiresQuorumAfterActivation() public {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -276,6 +276,17 @@ contract ZonePortalProxyStorageTest is Test {
 /// @notice Tests for ZonePortal - simulating L1/zone interface
 contract ZonePortalTest is BaseTest {
 
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+    bytes32 internal constant ZONE_BLOCK_ATTESTATION_TYPEHASH = keccak256(
+        "ZoneBlockAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,bytes32 parentBlockHash,bytes32 zoneBlockHash)"
+    );
+
+    uint256 internal constant SIGNER_A_KEY = 2;
+    uint256 internal constant SIGNER_B_KEY = 3;
+    uint256 internal constant SIGNER_C_KEY = 1;
+
     ZoneFactory public zoneFactory;
     ZonePortal public portal;
     ZoneMessenger public messenger;
@@ -337,6 +348,61 @@ contract ZonePortalTest is BaseTest {
         return keccak256(abi.encodePacked(sender));
     }
 
+    function _sequencerSet() internal returns (address[] memory signers) {
+        // vm.addr(2) < vm.addr(3) < vm.addr(1); the portal requires canonical address ordering.
+        signers = new address[](3);
+        signers[0] = vm.addr(SIGNER_A_KEY);
+        signers[1] = vm.addr(SIGNER_B_KEY);
+        signers[2] = vm.addr(SIGNER_C_KEY);
+    }
+
+    function _activateSequencerSet(uint8 quorum) internal returns (address[] memory signers) {
+        signers = _sequencerSet();
+        vm.prank(admin);
+        portal.setSequencerSet(signers, quorum);
+    }
+
+    function _attestationDigest(
+        uint256 height,
+        bytes32 nextBlockHash
+    )
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256("ZonePortal"),
+                keccak256("1"),
+                block.chainid,
+                address(portal)
+            )
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(
+                ZONE_BLOCK_ATTESTATION_TYPEHASH,
+                portal.zoneId(),
+                portal.sequencerSetVersion(),
+                height,
+                portal.blockHash(),
+                nextBlockHash
+            )
+        );
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function _sign(uint256 privateKey, bytes32 digest) internal returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _quorumSignatures(bytes32 digest) internal returns (bytes[] memory signatures) {
+        signatures = new bytes[](2);
+        signatures[0] = _sign(SIGNER_A_KEY, digest);
+        signatures[1] = _sign(SIGNER_B_KEY, digest);
+    }
+
     function _withdrawal(
         address token,
         address sender,
@@ -392,6 +458,171 @@ contract ZonePortalTest is BaseTest {
         assertEq(info.initialToken, address(pathUSD));
         assertEq(info.admin, admin);
         assertEq(info.sequencer, sequencer);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         SEQUENCER QUORUM TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_setSequencerSet_configuresVersionedQuorum() public {
+        address[] memory signers = _sequencerSet();
+
+        vm.expectEmit(true, false, false, true);
+        emit IZonePortal.SequencerSetUpdated(1, 2, signers);
+        vm.prank(admin);
+        portal.setSequencerSet(signers, 2);
+
+        assertEq(portal.sequencerSetVersion(), 1);
+        assertEq(portal.sequencerQuorum(), 2);
+        assertEq(portal.sequencerCount(), 3);
+        for (uint256 i; i < signers.length; ++i) {
+            assertEq(portal.sequencerAt(i), signers[i]);
+            assertTrue(portal.isSequencer(signers[i]));
+        }
+    }
+
+    function test_setSequencerSet_revertsForNonAdminAndInvalidSets() public {
+        address[] memory signers = _sequencerSet();
+
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotAdmin.selector);
+        portal.setSequencerSet(signers, 2);
+
+        vm.prank(admin);
+        vm.expectRevert(IZonePortal.InvalidSequencerSet.selector);
+        portal.setSequencerSet(signers, 4);
+
+        (signers[0], signers[1]) = (signers[1], signers[0]);
+        vm.prank(admin);
+        vm.expectRevert(IZonePortal.InvalidSequencerSet.selector);
+        portal.setSequencerSet(signers, 2);
+    }
+
+    function test_setSequencerSet_revertsIfUnchangedAndRotatesMembership() public {
+        address[] memory signers = _activateSequencerSet(2);
+
+        vm.prank(admin);
+        vm.expectRevert(IZonePortal.SequencerSetUnchanged.selector);
+        portal.setSequencerSet(signers, 2);
+
+        address removed = signers[2];
+        address[] memory replacement = new address[](2);
+        replacement[0] = signers[0];
+        replacement[1] = signers[1];
+        vm.prank(admin);
+        portal.setSequencerSet(replacement, 2);
+
+        assertEq(portal.sequencerSetVersion(), 2);
+        assertFalse(portal.isSequencer(removed));
+    }
+
+    function test_verifyBlock_acceptsDistinctCurrentSetQuorum() public {
+        _activateSequencerSet(2);
+        bytes32 nextBlockHash = keccak256("quorum-tip");
+        bytes[] memory signatures = _quorumSignatures(_attestationDigest(10, nextBlockHash));
+
+        assertTrue(portal.verifyBlock(10, nextBlockHash, signatures));
+        assertFalse(portal.verifyBlock(10, keccak256("other-tip"), signatures));
+    }
+
+    function test_verifyBlock_rejectsDuplicatesMalformedAndInsufficientQuorum() public {
+        _activateSequencerSet(2);
+        bytes32 nextBlockHash = keccak256("quorum-tip");
+        bytes32 digest = _attestationDigest(10, nextBlockHash);
+
+        bytes[] memory signatures = new bytes[](2);
+        signatures[0] = _sign(SIGNER_A_KEY, digest);
+        signatures[1] = signatures[0];
+        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
+
+        signatures[1] = hex"1234";
+        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
+
+        bytes[] memory oneSignature = new bytes[](1);
+        oneSignature[0] = signatures[0];
+        assertFalse(portal.verifyBlock(10, nextBlockHash, oneSignature));
+
+        signatures[1] = _sign(99, digest);
+        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
+    }
+
+    function test_verifyBlock_rejectsOldCertificateAfterRotation() public {
+        address[] memory signers = _activateSequencerSet(2);
+        bytes32 nextBlockHash = keccak256("quorum-tip");
+        bytes[] memory signatures = _quorumSignatures(_attestationDigest(10, nextBlockHash));
+
+        vm.prank(admin);
+        portal.setSequencerSet(signers, 3);
+
+        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
+    }
+
+    function test_quorumSequencerCannotCallConfigurationMethods() public {
+        address[] memory signers = _activateSequencerSet(2);
+
+        vm.startPrank(signers[0]);
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setZoneGasRate(1);
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.setRpcUrl("https://follower.invalid");
+        vm.stopPrank();
+
+        Withdrawal memory withdrawal =
+            _withdrawal(address(pathUSD), alice, bob, 1, bytes32(0), 0, alice, "");
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.NotSequencer.selector);
+        portal.processWithdrawal(withdrawal, bytes32(0));
+    }
+
+    function test_submitBatch_requiresQuorumAfterActivation() public {
+        address[] memory signers = _activateSequencerSet(2);
+
+        vm.prank(signers[0]);
+        vm.expectRevert(IZonePortal.LegacyBatchSubmissionDisabled.selector);
+        portal.submitBatch(
+            uint64(block.number),
+            0,
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("tip") }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: bytes32(0),
+                prevDepositNumber: 0,
+                nextDepositNumber: 0
+            }),
+            bytes32(0),
+            "",
+            ""
+        );
+    }
+
+    function test_submitBatch_acceptsQuorumCertificateFromRegisteredSequencer() public {
+        address[] memory signers = _activateSequencerSet(2);
+        bytes32 nextBlockHash = keccak256("certified-tip");
+        uint256 nextZoneHeight = 10;
+        bytes[] memory signatures =
+            _quorumSignatures(_attestationDigest(nextZoneHeight, nextBlockHash));
+
+        vm.roll(block.number + 1);
+        vm.prank(signers[0]);
+        portal.submitBatch(
+            uint64(block.number - 1),
+            0,
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: nextBlockHash }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: bytes32(0),
+                prevDepositNumber: 0,
+                nextDepositNumber: 0
+            }),
+            bytes32(0),
+            "",
+            "",
+            nextZoneHeight,
+            signatures
+        );
+
+        assertEq(portal.blockHash(), nextBlockHash);
+        assertEq(portal.zoneHeight(), nextZoneHeight);
     }
 
     function test_adminCanPauseAndResumeDeposits() public {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -502,7 +502,7 @@ contract ZonePortalTest is BaseTest {
         address[] memory signers = _activateSequencerSet(2);
 
         vm.prank(admin);
-        vm.expectRevert(IZonePortal.SequencerSetUnchanged.selector);
+        vm.expectRevert(IZonePortal.SequencerConfigurationUnchanged.selector);
         portal.setSequencerSet(signers, 2);
 
         address removed = signers[2];
@@ -554,6 +554,8 @@ contract ZonePortalTest is BaseTest {
         vm.prank(admin);
         portal.setSequencerSet(signers, 3);
 
+        assertEq(portal.sequencerSetVersion(), 2);
+        assertEq(portal.sequencerQuorum(), 3);
         assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
     }
 

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -29,6 +29,7 @@ import {
     ZoneInfo,
     ZoneParams
 } from "../../src/interfaces/IZone.sol";
+import { getBlockHash } from "../../src/libraries/BlockHashHistory.sol";
 import { DepositQueueLib } from "../../src/libraries/DepositQueueLib.sol";
 import {
     EMPTY_SENTINEL,
@@ -279,8 +280,8 @@ contract ZonePortalTest is BaseTest {
     bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(
         "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
     );
-    bytes32 internal constant ZONE_BLOCK_ATTESTATION_TYPEHASH = keccak256(
-        "ZoneBlockAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,bytes32 parentBlockHash,bytes32 zoneBlockHash)"
+    bytes32 internal constant SETTLEMENT_ATTESTATION_TYPEHASH = keccak256(
+        "SettlementAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,uint256 withdrawalBatchIndex,address sequencer,address verifier,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,bytes32 blockTransitionHash,bytes32 depositQueueTransitionHash,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"
     );
 
     uint256 internal constant SIGNER_A_KEY = 2;
@@ -364,7 +365,13 @@ contract ZonePortalTest is BaseTest {
 
     function _attestationDigest(
         uint256 height,
-        bytes32 nextBlockHash
+        uint64 tempoBlockNumber,
+        uint64 anchorBlockNumber,
+        bytes32 anchorBlockHash,
+        BlockTransition memory blockTransition,
+        DepositQueueTransition memory depositQueueTransition,
+        bytes32 withdrawalQueueHash,
+        bytes memory verifierConfig
     )
         internal
         view
@@ -381,12 +388,20 @@ contract ZonePortalTest is BaseTest {
         );
         bytes32 structHash = keccak256(
             abi.encode(
-                ZONE_BLOCK_ATTESTATION_TYPEHASH,
+                SETTLEMENT_ATTESTATION_TYPEHASH,
                 portal.zoneId(),
                 portal.sequencerSetVersion(),
                 height,
-                portal.blockHash(),
-                nextBlockHash
+                portal.withdrawalBatchIndex() + 1,
+                portal.sequencer(),
+                portal.verifier(),
+                tempoBlockNumber,
+                anchorBlockNumber,
+                anchorBlockHash,
+                keccak256(abi.encode(blockTransition)),
+                keccak256(abi.encode(depositQueueTransition)),
+                withdrawalQueueHash,
+                keccak256(verifierConfig)
             )
         );
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -516,49 +531,6 @@ contract ZonePortalTest is BaseTest {
         assertFalse(portal.isSequencer(removed));
     }
 
-    function test_verifyBlock_acceptsDistinctCurrentSetQuorum() public {
-        _activateSequencerSet(2);
-        bytes32 nextBlockHash = keccak256("quorum-tip");
-        bytes[] memory signatures = _quorumSignatures(_attestationDigest(10, nextBlockHash));
-
-        assertTrue(portal.verifyBlock(10, nextBlockHash, signatures));
-        assertFalse(portal.verifyBlock(10, keccak256("other-tip"), signatures));
-    }
-
-    function test_verifyBlock_rejectsDuplicatesMalformedAndInsufficientQuorum() public {
-        _activateSequencerSet(2);
-        bytes32 nextBlockHash = keccak256("quorum-tip");
-        bytes32 digest = _attestationDigest(10, nextBlockHash);
-
-        bytes[] memory signatures = new bytes[](2);
-        signatures[0] = _sign(SIGNER_A_KEY, digest);
-        signatures[1] = signatures[0];
-        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
-
-        signatures[1] = hex"1234";
-        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
-
-        bytes[] memory oneSignature = new bytes[](1);
-        oneSignature[0] = signatures[0];
-        assertFalse(portal.verifyBlock(10, nextBlockHash, oneSignature));
-
-        signatures[1] = _sign(99, digest);
-        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
-    }
-
-    function test_verifyBlock_rejectsOldCertificateAfterRotation() public {
-        address[] memory signers = _activateSequencerSet(2);
-        bytes32 nextBlockHash = keccak256("quorum-tip");
-        bytes[] memory signatures = _quorumSignatures(_attestationDigest(10, nextBlockHash));
-
-        vm.prank(admin);
-        portal.setSequencerSet(signers, 3);
-
-        assertEq(portal.sequencerSetVersion(), 2);
-        assertEq(portal.sequencerQuorum(), 3);
-        assertFalse(portal.verifyBlock(10, nextBlockHash, signatures));
-    }
-
     function test_quorumSequencerCannotCallConfigurationMethods() public {
         address[] memory signers = _activateSequencerSet(2);
 
@@ -601,21 +573,34 @@ contract ZonePortalTest is BaseTest {
         address[] memory signers = _activateSequencerSet(2);
         bytes32 nextBlockHash = keccak256("certified-tip");
         uint256 nextZoneHeight = 10;
-        bytes[] memory signatures =
-            _quorumSignatures(_attestationDigest(nextZoneHeight, nextBlockHash));
-
         vm.roll(block.number + 1);
+        uint64 tempoBlockNumber = uint64(block.number - 1);
+        BlockTransition memory blockTransition =
+            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: nextBlockHash });
+        DepositQueueTransition memory depositQueueTransition = DepositQueueTransition({
+            prevProcessedHash: bytes32(0),
+            nextProcessedHash: bytes32(0),
+            prevDepositNumber: 0,
+            nextDepositNumber: 0
+        });
+        bytes[] memory signatures = _quorumSignatures(
+            _attestationDigest(
+                nextZoneHeight,
+                tempoBlockNumber,
+                tempoBlockNumber,
+                getBlockHash(tempoBlockNumber),
+                blockTransition,
+                depositQueueTransition,
+                bytes32(0),
+                ""
+            )
+        );
         vm.prank(signers[0]);
         portal.submitBatch(
-            uint64(block.number - 1),
+            tempoBlockNumber,
             0,
-            BlockTransition({ prevBlockHash: portal.blockHash(), nextBlockHash: nextBlockHash }),
-            DepositQueueTransition({
-                prevProcessedHash: bytes32(0),
-                nextProcessedHash: bytes32(0),
-                prevDepositNumber: 0,
-                nextDepositNumber: 0
-            }),
+            blockTransition,
+            depositQueueTransition,
             bytes32(0),
             "",
             "",
@@ -625,6 +610,48 @@ contract ZonePortalTest is BaseTest {
 
         assertEq(portal.blockHash(), nextBlockHash);
         assertEq(portal.zoneHeight(), nextZoneHeight);
+    }
+
+    function test_submitBatch_rejectsCertificateForDifferentWithdrawalRoot() public {
+        address[] memory signers = _activateSequencerSet(2);
+        vm.roll(block.number + 1);
+
+        uint64 tempoBlockNumber = uint64(block.number - 1);
+        BlockTransition memory blockTransition = BlockTransition({
+            prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("certified-tip")
+        });
+        DepositQueueTransition memory depositQueueTransition = DepositQueueTransition({
+            prevProcessedHash: bytes32(0),
+            nextProcessedHash: bytes32(0),
+            prevDepositNumber: 0,
+            nextDepositNumber: 0
+        });
+        bytes[] memory signatures = _quorumSignatures(
+            _attestationDigest(
+                10,
+                tempoBlockNumber,
+                tempoBlockNumber,
+                getBlockHash(tempoBlockNumber),
+                blockTransition,
+                depositQueueTransition,
+                bytes32(0),
+                ""
+            )
+        );
+
+        vm.prank(signers[0]);
+        vm.expectRevert(IZonePortal.InvalidQuorumCertificate.selector);
+        portal.submitBatch(
+            tempoBlockNumber,
+            0,
+            blockTransition,
+            depositQueueTransition,
+            keccak256("substituted-withdrawal-root"),
+            "",
+            "",
+            10,
+            signatures
+        );
     }
 
     function test_adminCanPauseAndResumeDeposits() public {

--- a/specs/ref-impls/test/tempo/ZonePortalGasLimit.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortalGasLimit.t.sol
@@ -52,13 +52,16 @@ contract ZonePortalGasLimitTest is Test {
     function setUp() public {
         token = new MockPortalToken();
         portal = new ZonePortal();
+        address[] memory sequencers = new address[](1);
+        sequencers[0] = address(this);
         vm.prank(ZONE_FACTORY_ADDRESS);
         portal.initialize(
             1,
             address(token),
             address(0x400),
             admin,
-            address(this),
+            sequencers,
+            1,
             address(0),
             keccak256("genesis"),
             uint64(block.number),

--- a/specs/ref-impls/test/zone/ZoneConfig.t.sol
+++ b/specs/ref-impls/test/zone/ZoneConfig.t.sol
@@ -34,11 +34,14 @@ contract ZoneConfigTest is BaseTest {
 
         zoneFactory = _deployZoneFactory();
         genesisTempoBlockNumber = uint64(block.number);
+        address[] memory sequencers = new address[](1);
+        sequencers[0] = sequencer;
 
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             admin: admin,
-            sequencer: sequencer,
+            sequencers: sequencers,
+            threshold: 1,
             verifier: zoneFactory.verifier(),
             zoneParams: ZoneParams({
                 genesisBlockHash: GENESIS_BLOCK_HASH,


### PR DESCRIPTION
## What changed

- require every zone to provide a sorted sequencer set and settlement threshold at creation
- initialize portals directly at sequencer-set version 1 instead of creating a privileged primary sequencer and activating quorum settlement later
- give every registered sequencer the same portal permissions; any member can submit a valid threshold-certified settlement or process withdrawals
- bind threshold signatures to the full settlement effect and remove the legacy representative address from the certificate and verifier inputs
- split sequencer fees evenly across the active set and version every admin-controlled set or threshold rotation

The legacy `sequencer()` storage slot/getter remains only for storage and ABI compatibility and grants no distinct portal authority.

## Why

There should be no primary sequencer in the multi-sequencer model. The threshold certificate authorizes settlement, while the submitting sequencer is interchangeable with every other registered member.

## Validation

- `forge fmt --check` on all changed Solidity files
- `forge build --sizes` (`ZonePortal`: 19,871-byte runtime; `ZoneFactory`: 24,089-byte runtime)
- focused Forge tests: 6 passed
- `cargo test -p tempo-zone-contracts`: 7 passed

The full local Forge suite compiles and runs 250 tests successfully, but 9 suites remain blocked in setup by the existing missing `BlockHashHistory` precompile in this local Foundry environment.

Design: https://docs.google.com/document/d/1xOo-0Ez1lz33Xkmwa9jT6uhN9xprcyRAD2M8TGykh-k/edit?tab=t.118i8icwgof9
