### PR TITLE
fix: allow large websocket responses

### DIFF
--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -64,26 +64,6 @@ pub(crate) mod rpc {
                     .max_message_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)),
             )
     }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn rpc_connection_config_allows_large_ws_responses() {
-            let config = rpc_connection_config(Duration::from_secs(1));
-            let ws_config = config.ws_config.unwrap();
-
-            assert_eq!(
-                ws_config.max_frame_size,
-                Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
-            );
-            assert_eq!(
-                ws_config.max_message_size,
-                Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
-            );
-        }
-    }
 }
 
 use crate::{

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -49,12 +49,40 @@ pub(crate) mod precompiles {
 pub(crate) mod rpc {
     use std::time::Duration;
 
-    use alloy_rpc_client::ConnectionConfig;
+    use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
+
+    const MAX_WS_FRAME_AND_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
     pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> ConnectionConfig {
         ConnectionConfig::new()
             .with_max_retries(u32::MAX)
             .with_retry_interval(retry_connection_interval)
+            .with_ws_config(
+                WebSocketConfig::default()
+                    // Large blocks can exceed tungstenite's default 16 MiB frame limit.
+                    .max_frame_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE))
+                    .max_message_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)),
+            )
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn rpc_connection_config_allows_large_ws_responses() {
+            let config = rpc_connection_config(Duration::from_secs(1));
+            let ws_config = config.ws_config.unwrap();
+
+            assert_eq!(
+                ws_config.max_frame_size,
+                Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
+            );
+            assert_eq!(
+                ws_config.max_message_size,
+                Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
+            );
+        }
     }
 }
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1155,21 +1155,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rpc_connection_config_allows_large_ws_responses() {
-        let config = rpc_connection_config(Duration::from_secs(1));
-        let ws_config = config.ws_config.unwrap();
-
-        assert_eq!(
-            ws_config.max_frame_size,
-            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
-        );
-        assert_eq!(
-            ws_config.max_message_size,
-            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
-        );
-    }
-
-    #[test]
     fn regular_deposit_status_maps_terminal_events() {
         assert_eq!(
             regular_deposit_status(Some(TerminalDepositEvent::RegularProcessed)).unwrap(),

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -45,7 +45,7 @@ use tokio::{
     time::{MissedTickBehavior, interval},
 };
 
-use alloy_rpc_client::ConnectionConfig;
+use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
 use tempo_zone_contracts::{
     DepositType, TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZoneInbox, ZonePortal,
 };
@@ -60,6 +60,7 @@ use zone_rpc::{
 
 type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
 const FILTER_OWNER_PRUNE_INTERVAL: Duration = Duration::from_secs(60);
+const MAX_WS_FRAME_AND_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
 fn filter_not_found_error() -> JsonRpcError {
     JsonRpcError::invalid_params("filter not found")
@@ -1141,11 +1142,32 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
     ConnectionConfig::new()
         .with_max_retries(u32::MAX)
         .with_retry_interval(retry_connection_interval)
+        .with_ws_config(
+            WebSocketConfig::default()
+                // Large blocks can exceed tungstenite's default 16 MiB frame limit.
+                .max_frame_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE))
+                .max_message_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)),
+        )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rpc_connection_config_allows_large_ws_responses() {
+        let config = rpc_connection_config(Duration::from_secs(1));
+        let ws_config = config.ws_config.unwrap();
+
+        assert_eq!(
+            ws_config.max_frame_size,
+            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
+        );
+        assert_eq!(
+            ws_config.max_message_size,
+            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
+        );
+    }
 
     #[test]
     fn regular_deposit_status_maps_terminal_events() {

--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -1,9 +1,37 @@
 use std::time::Duration;
 
-use alloy_rpc_client::ConnectionConfig;
+use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
+
+const MAX_WS_FRAME_AND_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
 pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> ConnectionConfig {
     ConnectionConfig::new()
         .with_max_retries(u32::MAX)
         .with_retry_interval(retry_connection_interval)
+        .with_ws_config(
+            WebSocketConfig::default()
+                // Large blocks can exceed tungstenite's default 16 MiB frame limit.
+                .max_frame_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE))
+                .max_message_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)),
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_connection_config_allows_large_ws_responses() {
+        let config = rpc_connection_config(Duration::from_secs(1));
+        let ws_config = config.ws_config.unwrap();
+
+        assert_eq!(
+            ws_config.max_frame_size,
+            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
+        );
+        assert_eq!(
+            ws_config.max_message_size,
+            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
+        );
+    }
 }

--- a/crates/sequencer/src/rpc.rs
+++ b/crates/sequencer/src/rpc.rs
@@ -15,23 +15,3 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
                 .max_message_size(Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)),
         )
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rpc_connection_config_allows_large_ws_responses() {
-        let config = rpc_connection_config(Duration::from_secs(1));
-        let ws_config = config.ws_config.unwrap();
-
-        assert_eq!(
-            ws_config.max_frame_size,
-            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
-        );
-        assert_eq!(
-            ws_config.max_message_size,
-            Some(MAX_WS_FRAME_AND_MESSAGE_SIZE)
-        );
-    }
-}


### PR DESCRIPTION
Raises WebSocket frame and message limits to 128 MiB for the shared node, L1, and sequencer provider configurations. This prevents large receipt responses, such as Tempo L1 block 26,665,619, from tripping tungstenite's 16 MiB incoming-frame default. It matches [Reth's debug-client configuration](https://github.com/paradigmxyz/reth/blob/24c298133f0325f9acaaf955f9dc666c34195920/crates/consensus/debug-client/src/providers/rpc.rs#L29-L38), which uses the same limits for large blocks.