### PR TITLE
feat(chainspec): add `ZoneChainSpec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11136,7 +11136,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11175,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11199,7 +11199,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11258,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11270,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11328,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11366,7 +11366,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11386,7 +11386,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11409,7 +11409,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11452,7 +11452,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11475,7 +11475,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4f6f612f2e852972a3a7a93c5ab81fdf366681b8#4f6f612f2e852972a3a7a93c5ab81fdf366681b8"
+source = "git+https://github.com/tempoxyz/tempo?rev=436f6cf069a0c8aafa9a3a197ffa17488b5f1e81#436f6cf069a0c8aafa9a3a197ffa17488b5f1e81"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13373,6 +13373,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
+name = "zone-chainspec"
+version = "0.1.0"
+dependencies = [
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-genesis",
+ "alloy-primitives",
+ "eyre",
+ "reth-chainspec",
+ "reth-cli",
+ "reth-network-peers",
+ "tempo-chainspec",
+ "tempo-primitives",
+]
+
+[[package]]
 name = "zone-evm"
 version = "0.1.0"
 dependencies = [
@@ -13397,6 +13413,7 @@ dependencies = [
  "tempo-zone-contracts",
  "tokio",
  "tracing",
+ "zone-chainspec",
  "zone-l1",
  "zone-precompiles",
  "zone-primitives",
@@ -13514,6 +13531,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
+ "zone-chainspec",
  "zone-evm",
  "zone-l1",
  "zone-p2p",
@@ -13570,7 +13588,6 @@ dependencies = [
  "reth-storage-api",
  "reth-transaction-pool",
  "serde",
- "tempo-chainspec",
  "tempo-evm",
  "tempo-node",
  "tempo-payload-types",
@@ -13579,6 +13596,7 @@ dependencies = [
  "tempo-transaction-pool",
  "tempo-zone-contracts",
  "tracing",
+ "zone-chainspec",
  "zone-l1",
  "zone-precompiles",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [workspace]
 members = [
   "bin/tempo-zone",
+  "crates/chainspec",
   "crates/contracts",
   "crates/evm",
   "crates/l1",
@@ -93,28 +94,29 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "4f6f612f2e852972a3a7a93c5ab81fdf366681b8", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "436f6cf069a0c8aafa9a3a197ffa17488b5f1e81", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
+zone-chainspec = { path = "crates/chainspec" }
 zone-evm = { path = "crates/evm" }
 zone-l1 = { path = "crates/l1" }
 zone-node = { path = "crates/node" }
@@ -128,6 +130,7 @@ zone-sequencer = { path = "crates/sequencer" }
 # reth
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
 reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "zone-chainspec"
+description = "Tempo Zone chain specification"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# tempo
+tempo-chainspec.workspace = true
+tempo-primitives.workspace = true
+
+# reth
+reth-chainspec.workspace = true
+reth-cli = { workspace = true, optional = true }
+reth-network-peers.workspace = true
+
+# alloy
+alloy-eips.workspace = true
+alloy-evm.workspace = true
+alloy-genesis.workspace = true
+alloy-primitives.workspace = true
+
+# misc
+eyre = { workspace = true, optional = true }
+
+[features]
+default = []
+cli = ["dep:eyre", "dep:reth-cli", "tempo-chainspec/cli"]

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -12,7 +12,7 @@ use reth_chainspec::{
     ForkCondition, ForkFilter, ForkId, Hardfork, Hardforks, Head,
 };
 use reth_network_peers::NodeRecord;
-use std::fmt::Display;
+use std::{fmt::Display, sync::Arc};
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TempoHardforks};
 use tempo_primitives::TempoHeader;
 
@@ -21,21 +21,22 @@ use tempo_primitives::TempoHeader;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZoneChainSpec {
     /// Underlying Tempo chain specification.
-    pub inner: TempoChainSpec,
+    pub inner: Arc<TempoChainSpec>,
 }
 
 impl ZoneChainSpec {
     /// Converts a genesis configuration into a Zone chain specification.
     pub fn from_genesis(genesis: Genesis) -> Self {
         Self {
-            inner: TempoChainSpec::from_genesis(genesis),
+            inner: Arc::new(TempoChainSpec::from_genesis(genesis)),
         }
     }
 
     /// Applies Tempo hardfork activations from the parent chain.
     pub fn with_tempo_hardforks_from(mut self, parent: &impl TempoHardforks) -> Self {
+        let inner = Arc::make_mut(&mut self.inner);
         for &hardfork in TempoHardfork::VARIANTS {
-            self.inner
+            inner
                 .inner
                 .hardforks
                 .insert(hardfork, parent.tempo_fork_activation(hardfork));
@@ -46,6 +47,14 @@ impl ZoneChainSpec {
 
 impl From<TempoChainSpec> for ZoneChainSpec {
     fn from(inner: TempoChainSpec) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+impl From<Arc<TempoChainSpec>> for ZoneChainSpec {
+    fn from(inner: Arc<TempoChainSpec>) -> Self {
         Self { inner }
     }
 }
@@ -160,8 +169,7 @@ impl reth_cli::chainspec::ChainSpecParser for ZoneChainSpecParser {
     const SUPPORTED_CHAINS: &'static [&'static str] = tempo_chainspec::spec::SUPPORTED_CHAINS;
 
     fn parse(s: &str) -> eyre::Result<std::sync::Arc<Self::ChainSpec>> {
-        tempo_chainspec::spec::chain_value_parser(s)
-            .map(|spec| std::sync::Arc::new(spec.as_ref().clone().into()))
+        tempo_chainspec::spec::chain_value_parser(s).map(|spec| Arc::new(ZoneChainSpec::from(spec)))
     }
 }
 
@@ -174,10 +182,11 @@ mod tests {
 
     #[test]
     fn delegates_tempo_chain_behavior() {
-        let zone = ZoneChainSpec::from(DEV.as_ref().clone());
+        let zone = ZoneChainSpec::from(DEV.clone());
         let parent = zone.genesis_header();
         let timestamp = parent.inner.timestamp;
 
+        assert!(Arc::ptr_eq(&zone.inner, &DEV));
         assert_eq!(zone.chain(), DEV.chain());
         assert_eq!(zone.genesis_hash(), DEV.genesis_hash());
         assert_eq!(

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -1,0 +1,217 @@
+//! Zone chain specification.
+
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
+use alloy_evm::eth::spec::EthExecutorSpec;
+use alloy_genesis::Genesis;
+use alloy_primitives::{Address, B256, U256};
+use reth_chainspec::{
+    Chain, ChainSpec, DepositContract, EthChainSpec, EthereumHardfork, EthereumHardforks,
+    ForkCondition, ForkFilter, ForkId, Hardfork, Hardforks, Head,
+};
+use reth_network_peers::NodeRecord;
+use std::fmt::Display;
+use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TempoHardforks};
+use tempo_primitives::TempoHeader;
+
+/// Chain specification for a Tempo Zone.
+///
+/// Zone behavior delegates to Tempo by default. Zone-specific protocol rules can be overridden
+/// here without changing the parent Tempo chain specification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZoneChainSpec {
+    tempo: TempoChainSpec,
+}
+
+impl ZoneChainSpec {
+    /// Creates a Zone chain specification from a Tempo chain specification.
+    pub const fn new(tempo: TempoChainSpec) -> Self {
+        Self { tempo }
+    }
+
+    /// Converts a genesis configuration into a Zone chain specification.
+    pub fn from_genesis(genesis: Genesis) -> Self {
+        Self::new(TempoChainSpec::from_genesis(genesis))
+    }
+
+    /// Returns the underlying Tempo chain specification.
+    pub const fn as_tempo(&self) -> &TempoChainSpec {
+        &self.tempo
+    }
+
+    /// Applies Tempo hardfork activations from the parent chain.
+    pub fn with_tempo_hardforks_from(mut self, parent: &impl TempoHardforks) -> Self {
+        for &hardfork in TempoHardfork::VARIANTS {
+            self.tempo
+                .inner
+                .hardforks
+                .insert(hardfork, parent.tempo_fork_activation(hardfork));
+        }
+        self
+    }
+
+    /// Consumes this value and returns the underlying Tempo chain specification.
+    pub fn into_tempo(self) -> TempoChainSpec {
+        self.tempo
+    }
+}
+
+impl From<TempoChainSpec> for ZoneChainSpec {
+    fn from(value: TempoChainSpec) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<ChainSpec> for ZoneChainSpec {
+    fn from(value: ChainSpec) -> Self {
+        Self::new(value.into())
+    }
+}
+
+impl Hardforks for ZoneChainSpec {
+    fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {
+        self.tempo.fork(fork)
+    }
+
+    fn forks_iter(&self) -> impl Iterator<Item = (&dyn Hardfork, ForkCondition)> {
+        self.tempo.forks_iter()
+    }
+
+    fn fork_id(&self, head: &Head) -> ForkId {
+        self.tempo.fork_id(head)
+    }
+
+    fn latest_fork_id(&self) -> ForkId {
+        self.tempo.latest_fork_id()
+    }
+
+    fn fork_filter(&self, head: Head) -> ForkFilter {
+        self.tempo.fork_filter(head)
+    }
+}
+
+impl EthChainSpec for ZoneChainSpec {
+    type Header = TempoHeader;
+
+    fn chain(&self) -> Chain {
+        self.tempo.chain()
+    }
+
+    fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams {
+        self.tempo.base_fee_params_at_timestamp(timestamp)
+    }
+
+    fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<BlobParams> {
+        self.tempo.blob_params_at_timestamp(timestamp)
+    }
+
+    fn deposit_contract(&self) -> Option<&DepositContract> {
+        self.tempo.deposit_contract()
+    }
+
+    fn genesis_hash(&self) -> B256 {
+        self.tempo.genesis_hash()
+    }
+
+    fn prune_delete_limit(&self) -> usize {
+        self.tempo.prune_delete_limit()
+    }
+
+    fn display_hardforks(&self) -> Box<dyn Display> {
+        self.tempo.display_hardforks()
+    }
+
+    fn genesis_header(&self) -> &Self::Header {
+        self.tempo.genesis_header()
+    }
+
+    fn genesis(&self) -> &Genesis {
+        self.tempo.genesis()
+    }
+
+    fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
+        self.tempo.bootnodes()
+    }
+
+    fn final_paris_total_difficulty(&self) -> Option<U256> {
+        self.tempo.final_paris_total_difficulty()
+    }
+
+    fn next_block_base_fee(&self, parent: &TempoHeader, target_timestamp: u64) -> Option<u64> {
+        self.tempo.next_block_base_fee(parent, target_timestamp)
+    }
+}
+
+impl EthereumHardforks for ZoneChainSpec {
+    fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
+        self.tempo.ethereum_fork_activation(fork)
+    }
+}
+
+impl TempoHardforks for ZoneChainSpec {
+    fn tempo_fork_activation(&self, fork: TempoHardfork) -> ForkCondition {
+        self.tempo.tempo_fork_activation(fork)
+    }
+}
+
+impl EthExecutorSpec for ZoneChainSpec {
+    fn deposit_contract_address(&self) -> Option<Address> {
+        self.tempo.deposit_contract_address()
+    }
+}
+
+/// Zone chain specification parser.
+#[cfg(feature = "cli")]
+#[derive(Debug, Clone, Default)]
+pub struct ZoneChainSpecParser;
+
+#[cfg(feature = "cli")]
+impl reth_cli::chainspec::ChainSpecParser for ZoneChainSpecParser {
+    type ChainSpec = ZoneChainSpec;
+
+    const SUPPORTED_CHAINS: &'static [&'static str] = tempo_chainspec::spec::SUPPORTED_CHAINS;
+
+    fn parse(s: &str) -> eyre::Result<std::sync::Arc<Self::ChainSpec>> {
+        tempo_chainspec::spec::chain_value_parser(s)
+            .map(|spec| std::sync::Arc::new(spec.as_ref().clone().into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "cli")]
+    use reth_cli::chainspec::ChainSpecParser;
+    use tempo_chainspec::spec::DEV;
+
+    #[test]
+    fn delegates_tempo_chain_behavior() {
+        let zone = ZoneChainSpec::new(DEV.as_ref().clone());
+        let parent = zone.genesis_header();
+        let timestamp = parent.inner.timestamp;
+
+        assert_eq!(zone.chain(), DEV.chain());
+        assert_eq!(zone.genesis_hash(), DEV.genesis_hash());
+        assert_eq!(
+            zone.next_block_base_fee(parent, timestamp),
+            DEV.next_block_base_fee(parent, timestamp)
+        );
+        for &hardfork in TempoHardfork::VARIANTS {
+            assert_eq!(
+                zone.tempo_fork_activation(hardfork),
+                DEV.tempo_fork_activation(hardfork)
+            );
+        }
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn parser_wraps_tempo_chain_spec() {
+        let zone = ZoneChainSpecParser::parse("dev").expect("valid development chain spec");
+
+        assert_eq!(zone.chain(), DEV.chain());
+        assert_eq!(zone.genesis_hash(), DEV.genesis_hash());
+    }
+}

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -22,13 +22,14 @@ use tempo_primitives::TempoHeader;
 /// here without changing the parent Tempo chain specification.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZoneChainSpec {
-    tempo: TempoChainSpec,
+    /// Underlying Tempo chain specification.
+    pub inner: TempoChainSpec,
 }
 
 impl ZoneChainSpec {
     /// Creates a Zone chain specification from a Tempo chain specification.
-    pub const fn new(tempo: TempoChainSpec) -> Self {
-        Self { tempo }
+    pub const fn new(inner: TempoChainSpec) -> Self {
+        Self { inner }
     }
 
     /// Converts a genesis configuration into a Zone chain specification.
@@ -36,25 +37,15 @@ impl ZoneChainSpec {
         Self::new(TempoChainSpec::from_genesis(genesis))
     }
 
-    /// Returns the underlying Tempo chain specification.
-    pub const fn as_tempo(&self) -> &TempoChainSpec {
-        &self.tempo
-    }
-
     /// Applies Tempo hardfork activations from the parent chain.
     pub fn with_tempo_hardforks_from(mut self, parent: &impl TempoHardforks) -> Self {
         for &hardfork in TempoHardfork::VARIANTS {
-            self.tempo
+            self.inner
                 .inner
                 .hardforks
                 .insert(hardfork, parent.tempo_fork_activation(hardfork));
         }
         self
-    }
-
-    /// Consumes this value and returns the underlying Tempo chain specification.
-    pub fn into_tempo(self) -> TempoChainSpec {
-        self.tempo
     }
 }
 
@@ -72,23 +63,23 @@ impl From<ChainSpec> for ZoneChainSpec {
 
 impl Hardforks for ZoneChainSpec {
     fn fork<H: Hardfork>(&self, fork: H) -> ForkCondition {
-        self.tempo.fork(fork)
+        self.inner.fork(fork)
     }
 
     fn forks_iter(&self) -> impl Iterator<Item = (&dyn Hardfork, ForkCondition)> {
-        self.tempo.forks_iter()
+        self.inner.forks_iter()
     }
 
     fn fork_id(&self, head: &Head) -> ForkId {
-        self.tempo.fork_id(head)
+        self.inner.fork_id(head)
     }
 
     fn latest_fork_id(&self) -> ForkId {
-        self.tempo.latest_fork_id()
+        self.inner.latest_fork_id()
     }
 
     fn fork_filter(&self, head: Head) -> ForkFilter {
-        self.tempo.fork_filter(head)
+        self.inner.fork_filter(head)
     }
 }
 
@@ -96,69 +87,69 @@ impl EthChainSpec for ZoneChainSpec {
     type Header = TempoHeader;
 
     fn chain(&self) -> Chain {
-        self.tempo.chain()
+        self.inner.chain()
     }
 
     fn base_fee_params_at_timestamp(&self, timestamp: u64) -> BaseFeeParams {
-        self.tempo.base_fee_params_at_timestamp(timestamp)
+        self.inner.base_fee_params_at_timestamp(timestamp)
     }
 
     fn blob_params_at_timestamp(&self, timestamp: u64) -> Option<BlobParams> {
-        self.tempo.blob_params_at_timestamp(timestamp)
+        self.inner.blob_params_at_timestamp(timestamp)
     }
 
     fn deposit_contract(&self) -> Option<&DepositContract> {
-        self.tempo.deposit_contract()
+        self.inner.deposit_contract()
     }
 
     fn genesis_hash(&self) -> B256 {
-        self.tempo.genesis_hash()
+        self.inner.genesis_hash()
     }
 
     fn prune_delete_limit(&self) -> usize {
-        self.tempo.prune_delete_limit()
+        self.inner.prune_delete_limit()
     }
 
     fn display_hardforks(&self) -> Box<dyn Display> {
-        self.tempo.display_hardforks()
+        self.inner.display_hardforks()
     }
 
     fn genesis_header(&self) -> &Self::Header {
-        self.tempo.genesis_header()
+        self.inner.genesis_header()
     }
 
     fn genesis(&self) -> &Genesis {
-        self.tempo.genesis()
+        self.inner.genesis()
     }
 
     fn bootnodes(&self) -> Option<Vec<NodeRecord>> {
-        self.tempo.bootnodes()
+        self.inner.bootnodes()
     }
 
     fn final_paris_total_difficulty(&self) -> Option<U256> {
-        self.tempo.final_paris_total_difficulty()
+        self.inner.final_paris_total_difficulty()
     }
 
     fn next_block_base_fee(&self, parent: &TempoHeader, target_timestamp: u64) -> Option<u64> {
-        self.tempo.next_block_base_fee(parent, target_timestamp)
+        self.inner.next_block_base_fee(parent, target_timestamp)
     }
 }
 
 impl EthereumHardforks for ZoneChainSpec {
     fn ethereum_fork_activation(&self, fork: EthereumHardfork) -> ForkCondition {
-        self.tempo.ethereum_fork_activation(fork)
+        self.inner.ethereum_fork_activation(fork)
     }
 }
 
 impl TempoHardforks for ZoneChainSpec {
     fn tempo_fork_activation(&self, fork: TempoHardfork) -> ForkCondition {
-        self.tempo.tempo_fork_activation(fork)
+        self.inner.tempo_fork_activation(fork)
     }
 }
 
 impl EthExecutorSpec for ZoneChainSpec {
     fn deposit_contract_address(&self) -> Option<Address> {
-        self.tempo.deposit_contract_address()
+        self.inner.deposit_contract_address()
     }
 }
 

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -18,8 +18,6 @@ use tempo_primitives::TempoHeader;
 
 /// Chain specification for a Tempo Zone.
 ///
-/// Zone behavior delegates to Tempo by default. Zone-specific protocol rules can be overridden
-/// here without changing the parent Tempo chain specification.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZoneChainSpec {
     /// Underlying Tempo chain specification.

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -25,14 +25,11 @@ pub struct ZoneChainSpec {
 }
 
 impl ZoneChainSpec {
-    /// Creates a Zone chain specification from a Tempo chain specification.
-    pub const fn new(inner: TempoChainSpec) -> Self {
-        Self { inner }
-    }
-
     /// Converts a genesis configuration into a Zone chain specification.
     pub fn from_genesis(genesis: Genesis) -> Self {
-        Self::new(TempoChainSpec::from_genesis(genesis))
+        Self {
+            inner: TempoChainSpec::from_genesis(genesis),
+        }
     }
 
     /// Applies Tempo hardfork activations from the parent chain.
@@ -48,14 +45,14 @@ impl ZoneChainSpec {
 }
 
 impl From<TempoChainSpec> for ZoneChainSpec {
-    fn from(value: TempoChainSpec) -> Self {
-        Self::new(value)
+    fn from(inner: TempoChainSpec) -> Self {
+        Self { inner }
     }
 }
 
 impl From<ChainSpec> for ZoneChainSpec {
     fn from(value: ChainSpec) -> Self {
-        Self::new(value.into())
+        TempoChainSpec::from(value).into()
     }
 }
 
@@ -177,7 +174,7 @@ mod tests {
 
     #[test]
     fn delegates_tempo_chain_behavior() {
-        let zone = ZoneChainSpec::new(DEV.as_ref().clone());
+        let zone = ZoneChainSpec::from(DEV.as_ref().clone());
         let parent = zone.genesis_header();
         let timestamp = parent.inner.timestamp;
 

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # zones
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
+zone-chainspec.workspace = true
 zone-l1.workspace = true
 zone-primitives.workspace = true
 zone-precompiles = { workspace = true, features = ["std"] }
@@ -27,6 +28,7 @@ tempo-primitives.workspace = true
 tempo-revm.workspace = true
 
 # reth
+reth-chainspec.workspace = true
 reth-evm.workspace = true
 reth-primitives-traits.workspace = true
 reth-revm.workspace = true
@@ -47,5 +49,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 eyre.workspace = true
-reth-chainspec.workspace = true
 tempo-precompiles = { workspace = true, features = ["test-utils"] }

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -13,13 +13,13 @@ use alloy_evm::{
 use reth_evm::block::StateDB;
 use reth_revm::Inspector;
 use revm::context::{ContextTr, JournalTr, Transaction};
-use tempo_chainspec::TempoChainSpec;
 use tempo_evm::{TempoBlockExecutionCtx, TempoReceiptBuilder};
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS, storage::actions::StorageActions, tip_fee_manager::TipFeeManager,
 };
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::{TempoStateAccess, evm::TempoContext};
+use zone_chainspec::ZoneChainSpec;
 
 use crate::{ZoneEvm, tx_context};
 
@@ -28,7 +28,7 @@ use crate::{ZoneEvm, tx_context};
 /// Wraps [`EthBlockExecutor`] without any subblock validation, gas-section tracking,
 /// or end-of-block metadata system transaction requirements.
 pub struct ZoneBlockExecutor<'a, DB: Database, I> {
-    inner: EthBlockExecutor<'a, ZoneEvm<DB, I>, &'a TempoChainSpec, TempoReceiptBuilder>,
+    inner: EthBlockExecutor<'a, ZoneEvm<DB, I>, &'a ZoneChainSpec, TempoReceiptBuilder>,
 }
 
 impl<'a, DB, I> ZoneBlockExecutor<'a, DB, I>
@@ -39,7 +39,7 @@ where
     pub(crate) fn new(
         evm: ZoneEvm<DB, I>,
         ctx: TempoBlockExecutionCtx<'a>,
-        chain_spec: &'a TempoChainSpec,
+        chain_spec: &'a ZoneChainSpec,
     ) -> Self {
         Self {
             inner: EthBlockExecutor::new(

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -31,6 +31,7 @@ use alloy_evm::{
     revm::{Inspector, context::DBErrorMarker, inspector::NoOpInspector},
 };
 use alloy_provider::{Provider, ProviderBuilder};
+use reth_chainspec::EthChainSpec;
 use reth_evm::{
     ConfigureEngineEvm, ConfigureEvm, EvmEnvFor, ExecutableTxIterator, ExecutionCtxFor,
     block::StateDB,
@@ -39,7 +40,7 @@ use reth_evm::{
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TempoHardforks};
+use tempo_chainspec::TempoChainSpec;
 use tempo_evm::{
     TempoBlockAssembler, TempoBlockEnv, TempoBlockExecutionCtx, TempoEvmConfig, TempoEvmError,
     TempoHaltReason, TempoNextBlockEnvAttributes,
@@ -56,6 +57,7 @@ use tempo_primitives::{
     Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType,
 };
 use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_TX_CONTEXT_ADDRESS};
+use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::{L1StateCache, L1StateProvider, L1StateProviderConfig, PolicyProvider};
 
 type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
@@ -192,9 +194,9 @@ pub struct ZoneBlockAssembler {
 
 impl ZoneBlockAssembler {
     /// Create a new [`ZoneBlockAssembler`] with the given chain spec.
-    pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
+    pub fn new(chain_spec: Arc<ZoneChainSpec>) -> Self {
         Self {
-            inner: TempoBlockAssembler::new(chain_spec),
+            inner: TempoBlockAssembler::new(Arc::new(chain_spec.as_tempo().clone())),
         }
     }
 }
@@ -242,6 +244,7 @@ impl BlockAssembler<ZoneEvmConfig> for ZoneBlockAssembler {
 #[derive(Debug, Clone)]
 pub struct ZoneEvmConfig {
     inner: TempoEvmConfig,
+    chain_spec: Arc<ZoneChainSpec>,
     zone_factory: ZoneEvmFactory,
     block_assembler: ZoneBlockAssembler,
 }
@@ -249,7 +252,7 @@ pub struct ZoneEvmConfig {
 impl ZoneEvmConfig {
     /// Creates a Zone EVM config using Tempo hardfork conditions from the parent L1 spec.
     pub fn new(
-        zone_chain_spec: Arc<TempoChainSpec>,
+        zone_chain_spec: Arc<ZoneChainSpec>,
         tempo_chain_spec: Arc<TempoChainSpec>,
         l1_provider: L1StateProvider,
     ) -> Self {
@@ -258,23 +261,18 @@ impl ZoneEvmConfig {
     }
 
     /// Copies the Zone chain spec and applies the Tempo hardfork conditions from its parent chain.
-    fn compose_chain_spec(zone: &TempoChainSpec, tempo: &TempoChainSpec) -> Arc<TempoChainSpec> {
-        let mut chain_spec = zone.clone();
-        for &hardfork in TempoHardfork::VARIANTS {
-            chain_spec
-                .inner
-                .hardforks
-                .insert(hardfork, tempo.tempo_fork_activation(hardfork));
-        }
-        Arc::new(chain_spec)
+    fn compose_chain_spec(zone: &ZoneChainSpec, tempo: &TempoChainSpec) -> Arc<ZoneChainSpec> {
+        Arc::new(zone.clone().with_tempo_hardforks_from(tempo))
     }
 
-    fn from_chain_spec(chain_spec: Arc<TempoChainSpec>, l1_provider: L1StateProvider) -> Self {
+    fn from_chain_spec(chain_spec: Arc<ZoneChainSpec>, l1_provider: L1StateProvider) -> Self {
         let zone_factory = ZoneEvmFactory::new(l1_provider);
-        let inner = TempoEvmConfig::new(chain_spec.clone());
-        let block_assembler = ZoneBlockAssembler::new(chain_spec);
+        let tempo_chain_spec = Arc::new(chain_spec.as_tempo().clone());
+        let inner = TempoEvmConfig::new(tempo_chain_spec);
+        let block_assembler = ZoneBlockAssembler::new(chain_spec.clone());
         Self {
             inner,
+            chain_spec,
             zone_factory,
             block_assembler,
         }
@@ -286,7 +284,7 @@ impl ZoneEvmConfig {
     /// EVM config but don't have access to an L1 RPC connection. Tempo hardfork conditions come
     /// from `chain_spec` because the parent L1 spec cannot be resolved in this mode. The portal
     /// address defaults to zero, so sequencer reads are unavailable.
-    pub fn new_without_l1(chain_spec: Arc<TempoChainSpec>) -> Self {
+    pub fn new_without_l1(chain_spec: Arc<ZoneChainSpec>) -> Self {
         let cache = L1StateCache::default();
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_http("http://127.0.0.1:1".parse().expect("valid fallback URL"))
@@ -303,8 +301,13 @@ impl ZoneEvmConfig {
         self
     }
 
-    /// Returns the chain spec used by Tempo execution.
-    pub fn chain_spec(&self) -> &Arc<TempoChainSpec> {
+    /// Returns the Zone chain specification.
+    pub fn chain_spec(&self) -> &Arc<ZoneChainSpec> {
+        &self.chain_spec
+    }
+
+    /// Returns the underlying chain specification used by Tempo execution.
+    pub fn tempo_chain_spec(&self) -> &Arc<TempoChainSpec> {
         self.inner.chain_spec()
     }
 }
@@ -358,7 +361,14 @@ impl ConfigureEvm for ZoneEvmConfig {
         parent: &TempoHeader,
         attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnvFor<Self>, Self::Error> {
-        self.inner.next_evm_env(parent, attributes)
+        let mut env = self.inner.next_evm_env(parent, attributes)?;
+        // TempoEvmConfig is concrete over TempoChainSpec, so apply the Zone fee policy after
+        // delegating the rest of the environment construction.
+        env.block_env.inner.basefee = self
+            .chain_spec
+            .next_block_base_fee(parent, attributes.timestamp)
+            .unwrap_or_default();
+        Ok(env)
     }
 
     fn context_for_block<'a>(
@@ -429,11 +439,15 @@ impl ConfigureEngineEvm<TempoExecutionData> for ZoneEvmConfig {
 mod tests {
     use super::*;
     use reth_chainspec::{EthChainSpec, ForkCondition};
-    use tempo_chainspec::spec::{DEV, MODERATO};
+    use tempo_chainspec::{
+        hardfork::TempoHardfork,
+        spec::{DEV, MODERATO, TempoHardforks},
+    };
 
     #[test]
     fn composed_chain_spec_uses_zone_identity_and_parent_tempo_forks() {
-        let composed = ZoneEvmConfig::compose_chain_spec(&DEV, &MODERATO);
+        let zone = ZoneChainSpec::new(DEV.as_ref().clone());
+        let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
 
         assert_eq!(composed.chain().id(), DEV.chain().id());
         assert_eq!(composed.genesis_hash(), DEV.genesis_hash());
@@ -447,7 +461,8 @@ mod tests {
 
     #[test]
     fn tempo_evm_selects_parent_fork_from_zone_block_timestamp() {
-        let composed = ZoneEvmConfig::compose_chain_spec(&DEV, &MODERATO);
+        let zone = ZoneChainSpec::new(DEV.as_ref().clone());
+        let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
         let activation_timestamp = TempoHardfork::VARIANTS
             .iter()
             .find_map(|&hardfork| match MODERATO.tempo_fork_activation(hardfork) {
@@ -463,7 +478,7 @@ mod tests {
             ..Default::default()
         };
 
-        let config = TempoEvmConfig::new(composed);
+        let config = TempoEvmConfig::new(Arc::new(composed.as_tempo().clone()));
         let env = config.evm_env(&header).expect("valid EVM environment");
 
         assert_eq!(

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn composed_chain_spec_uses_zone_identity_and_parent_tempo_forks() {
-        let zone = ZoneChainSpec::new(DEV.as_ref().clone());
+        let zone = ZoneChainSpec::from(DEV.as_ref().clone());
         let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
 
         assert_eq!(composed.chain().id(), DEV.chain().id());
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn tempo_evm_selects_parent_fork_from_zone_block_timestamp() {
-        let zone = ZoneChainSpec::new(DEV.as_ref().clone());
+        let zone = ZoneChainSpec::from(DEV.as_ref().clone());
         let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
         let activation_timestamp = TempoHardfork::VARIANTS
             .iter()

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -196,7 +196,7 @@ impl ZoneBlockAssembler {
     /// Create a new [`ZoneBlockAssembler`] with the given chain spec.
     pub fn new(chain_spec: Arc<ZoneChainSpec>) -> Self {
         Self {
-            inner: TempoBlockAssembler::new(Arc::new(chain_spec.as_tempo().clone())),
+            inner: TempoBlockAssembler::new(Arc::new(chain_spec.inner.clone())),
         }
     }
 }
@@ -267,7 +267,7 @@ impl ZoneEvmConfig {
 
     fn from_chain_spec(chain_spec: Arc<ZoneChainSpec>, l1_provider: L1StateProvider) -> Self {
         let zone_factory = ZoneEvmFactory::new(l1_provider);
-        let tempo_chain_spec = Arc::new(chain_spec.as_tempo().clone());
+        let tempo_chain_spec = Arc::new(chain_spec.inner.clone());
         let inner = TempoEvmConfig::new(tempo_chain_spec);
         let block_assembler = ZoneBlockAssembler::new(chain_spec.clone());
         Self {
@@ -478,7 +478,7 @@ mod tests {
             ..Default::default()
         };
 
-        let config = TempoEvmConfig::new(Arc::new(composed.as_tempo().clone()));
+        let config = TempoEvmConfig::new(Arc::new(composed.inner.clone()));
         let env = config.evm_env(&header).expect("valid EVM environment");
 
         assert_eq!(

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -196,7 +196,7 @@ impl ZoneBlockAssembler {
     /// Create a new [`ZoneBlockAssembler`] with the given chain spec.
     pub fn new(chain_spec: Arc<ZoneChainSpec>) -> Self {
         Self {
-            inner: TempoBlockAssembler::new(Arc::new(chain_spec.inner.clone())),
+            inner: TempoBlockAssembler::new(chain_spec.inner.clone()),
         }
     }
 }
@@ -267,7 +267,7 @@ impl ZoneEvmConfig {
 
     fn from_chain_spec(chain_spec: Arc<ZoneChainSpec>, l1_provider: L1StateProvider) -> Self {
         let zone_factory = ZoneEvmFactory::new(l1_provider);
-        let tempo_chain_spec = Arc::new(chain_spec.inner.clone());
+        let tempo_chain_spec = chain_spec.inner.clone();
         let inner = TempoEvmConfig::new(tempo_chain_spec);
         let block_assembler = ZoneBlockAssembler::new(chain_spec.clone());
         Self {
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn composed_chain_spec_uses_zone_identity_and_parent_tempo_forks() {
-        let zone = ZoneChainSpec::from(DEV.as_ref().clone());
+        let zone = ZoneChainSpec::from(DEV.clone());
         let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
 
         assert_eq!(composed.chain().id(), DEV.chain().id());
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn tempo_evm_selects_parent_fork_from_zone_block_timestamp() {
-        let zone = ZoneChainSpec::from(DEV.as_ref().clone());
+        let zone = ZoneChainSpec::from(DEV.clone());
         let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
         let activation_timestamp = TempoHardfork::VARIANTS
             .iter()
@@ -478,7 +478,7 @@ mod tests {
             ..Default::default()
         };
 
-        let config = TempoEvmConfig::new(Arc::new(composed.inner.clone()));
+        let config = TempoEvmConfig::new(composed.inner.clone());
         let env = config.evm_env(&header).expect("valid EVM environment");
 
         assert_eq!(

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -20,6 +20,7 @@ tempo-transaction-pool.workspace = true
 tempo-alloy.workspace = true
 tempo-contracts.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
+zone-chainspec.workspace = true
 zone-evm.workspace = true
 zone-l1.workspace = true
 zone-p2p.workspace = true
@@ -114,7 +115,7 @@ cli = [
   "dep:reth-consensus",
   "dep:reth-ethereum",
   "dep:reth-tracing",
-  "tempo-chainspec/cli",
+  "zone-chainspec/cli",
 ]
 jemalloc = ["reth-ethereum?/jemalloc"]
 test-utils = [

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -8,7 +8,7 @@ use clap::{Args, CommandFactory, FromArgMatches};
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
-use tempo_chainspec::spec::{TempoChainSpec, TempoChainSpecParser};
+use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
 use zone_evm::ZoneEvmConfig;
 use zone_p2p::{P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
@@ -31,13 +31,13 @@ const ZONE_LOG_FILTER_DIRECTIVES: &str = concat!(
 
 /// Tempo Zone CLI entry point.
 pub enum ZoneCli {
-    Node(Box<Cli<TempoChainSpecParser, ZoneArgs>>),
+    Node(Box<Cli<ZoneChainSpecParser, ZoneArgs>>),
     Dev(DevCommand),
 }
 
 impl ZoneCli {
     fn command() -> clap::Command {
-        Cli::<TempoChainSpecParser, ZoneArgs>::command()
+        Cli::<ZoneChainSpecParser, ZoneArgs>::command()
             .about("Tempo Zone")
             .subcommand(DevCommand::command())
     }
@@ -84,11 +84,11 @@ impl ZoneCli {
 }
 
 /// Main entry point for the `node` command.
-fn run_node(mut cli: Cli<TempoChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
+fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
     prepend_log_filter(&mut cli.logs.log_stdout_filter, ZONE_LOG_FILTER_DIRECTIVES);
     prepend_log_filter(&mut cli.logs.log_file_filter, ZONE_LOG_FILTER_DIRECTIVES);
 
-    let components = |spec: Arc<TempoChainSpec>| {
+    let components = |spec: Arc<ZoneChainSpec>| {
         (
             ZoneEvmConfig::new_without_l1(spec),
             NoopConsensus::default(),

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -47,10 +47,10 @@ use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{BuiltPayload, PayloadKind, PayloadTypes};
 use reth_primitives_traits::SealedHeader;
 use std::{sync::Arc, time::Duration};
-use tempo_chainspec::spec::TempoChainSpec;
 use tempo_primitives::TempoHeader;
 use tracing::{error, warn};
 
+use zone_chainspec::ZoneChainSpec;
 use zone_l1::{DepositQueue, L1BlockDeposits, PolicyProvider, PreparedL1Block};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 
@@ -68,7 +68,7 @@ use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 #[derive(Debug)]
 pub struct ZoneEngine {
     /// Chain spec for hardfork checks when building attributes.
-    chain_spec: Arc<TempoChainSpec>,
+    chain_spec: Arc<ZoneChainSpec>,
     /// Engine API handle for FCU and newPayload.
     to_engine: ConsensusEngineHandle<ZonePayloadTypes>,
     /// Payload builder handle.
@@ -91,7 +91,7 @@ pub struct ZoneEngine {
 
 impl ZoneEngine {
     pub fn new(
-        chain_spec: Arc<TempoChainSpec>,
+        chain_spec: Arc<ZoneChainSpec>,
         to_engine: ConsensusEngineHandle<ZonePayloadTypes>,
         payload_builder: PayloadBuilderHandle<ZonePayloadTypes>,
         deposit_queue: DepositQueue,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -11,6 +11,7 @@ use alloy_primitives::Address;
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
 use k256::SecretKey;
+use reth_chainspec::EthChainSpec;
 use reth_eth_wire_types::primitives::BasicNetworkPrimitives;
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
@@ -481,15 +482,7 @@ where
             self.spawn_zone_engine(l1_provider, &ctx, sequencer_addr, sequencer_key)?;
         }
 
-        let chain_id = ctx
-            .node
-            .provider()
-            .chain_spec()
-            .as_tempo()
-            .inner
-            .genesis()
-            .config
-            .chain_id;
+        let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
         let handle = self.inner.launch_add_ons(ctx).await?;
 
         Self::launch_private_rpc(
@@ -1040,7 +1033,7 @@ where
         .with_local_transactions_config(pool_config.local_transactions_config.clone())
         .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
         .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
-        .set_block_gas_limit(ctx.chain_spec().as_tempo().inner.genesis().gas_limit)
+        .set_block_gas_limit(ctx.chain_spec().genesis().gas_limit)
         .disable_balance_check()
         .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
         .with_custom_tx_type(TempoTxType::AA as u8)

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -57,6 +57,7 @@ use tempo_zone_contracts::{
     TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
 };
 use tracing::{debug, info, warn};
+use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
     DepositQueue, L1Subscriber, L1SubscriberConfig, PolicyCache, TempoStateExt,
@@ -349,7 +350,7 @@ impl ZoneNode {
 
 impl NodeTypes for ZoneNode {
     type Primitives = TempoPrimitives;
-    type ChainSpec = TempoChainSpec;
+    type ChainSpec = ZoneChainSpec;
     type Storage = EmptyBodyStorage<TempoTxEnvelope, TempoHeader>;
     type Payload = ZonePayloadTypes;
 }
@@ -484,6 +485,7 @@ where
             .node
             .provider()
             .chain_spec()
+            .as_tempo()
             .inner
             .genesis()
             .config
@@ -917,7 +919,7 @@ impl<N: FullNodeComponents<Types = Self>> DebugNode<N> for ZoneNode {
 pub(crate) struct ZonePayloadAttributesBuilder;
 
 impl ZonePayloadAttributesBuilder {
-    pub(crate) fn new(_chain_spec: Arc<TempoChainSpec>) -> Self {
+    pub(crate) fn new(_chain_spec: Arc<ZoneChainSpec>) -> Self {
         Self
     }
 }
@@ -1027,7 +1029,7 @@ where
 
         // this store is effectively a noop
         let blob_store = InMemoryBlobStore::default();
-        let tempo_evm_config = TempoEvmConfig::new(evm_config.chain_spec().clone());
+        let tempo_evm_config = TempoEvmConfig::new(evm_config.tempo_chain_spec().clone());
         let additional_tasks = ctx.config().txpool.additional_validation_tasks;
         let task_executor = ctx.task_executor().clone();
         let mut validator = TransactionValidationTaskExecutor::eth_builder(
@@ -1038,7 +1040,7 @@ where
         .with_local_transactions_config(pool_config.local_transactions_config.clone())
         .set_tx_fee_cap(ctx.config().rpc.rpc_tx_fee_cap)
         .with_max_tx_gas_limit(ctx.config().txpool.max_tx_gas_limit)
-        .set_block_gas_limit(ctx.chain_spec().inner.genesis().gas_limit)
+        .set_block_gas_limit(ctx.chain_spec().as_tempo().inner.genesis().gas_limit)
         .disable_balance_check()
         .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
         .with_custom_tx_type(TempoTxType::AA as u8)

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -38,6 +38,7 @@ use tempo_contracts::precompiles::{
 use tempo_precompiles::{PATH_USD_ADDRESS, tip403_registry::ALLOW_ALL_POLICY_ID};
 use tempo_primitives::{TempoHeader, transaction::tt_signature::TempoSignature};
 use tempo_zone_contracts::{ZONE_FACTORY_ADDRESS, ZONE_OUTBOX_ADDRESS};
+use zone_chainspec::ZoneChainSpec;
 use zone_l1::{
     Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1Deposit, L1PortalEvents, L1StateCache,
 };
@@ -733,7 +734,7 @@ impl ZoneTestNode {
                 .expect("valid zone genesis template")
         });
         genesis.config.chain_id = chain_id;
-        let chain_spec = TempoChainSpec::from_genesis(genesis);
+        let chain_spec = ZoneChainSpec::from_genesis(genesis);
 
         let mut zone_node = ZoneNode::new(
             l1_ws_url,

--- a/crates/payload/Cargo.toml
+++ b/crates/payload/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [dependencies]
 # tempo
-tempo-chainspec.workspace = true
 tempo-evm.workspace = true
 tempo-node.workspace = true
 tempo-payload-types.workspace = true
@@ -20,6 +19,7 @@ tempo-primitives.workspace = true
 tempo-revm.workspace = true
 tempo-transaction-pool.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
+zone-chainspec.workspace = true
 zone-l1.workspace = true
 zone-precompiles = { workspace = true, features = ["std"] }
 

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -38,7 +38,6 @@ use reth_transaction_pool::{
     error::InvalidPoolTransactionError,
 };
 use std::{sync::Arc, time::Instant};
-use tempo_chainspec::spec::TempoChainSpec;
 use tempo_evm::TempoNextBlockEnvAttributes;
 use tempo_payload_types::{EncodedBlock, TempoBuiltPayload};
 use tempo_primitives::{
@@ -47,6 +46,7 @@ use tempo_primitives::{
 };
 use tempo_transaction_pool::{TempoTransactionPool, transaction::TempoPooledTransaction};
 use tracing::{error, info, warn};
+use zone_chainspec::ZoneChainSpec;
 use zone_l1::{PreparedL1Block, TempoStateExt};
 
 use crate::{ZonePayloadAttributes, ZonePayloadTypes};
@@ -92,7 +92,7 @@ where
     Node: FullNodeTypes,
     Node::Types: NodeTypes<
             Primitives = tempo_primitives::TempoPrimitives,
-            ChainSpec = TempoChainSpec,
+            ChainSpec = ZoneChainSpec,
             Payload = ZonePayloadTypes,
         >,
     EvmConfig: ConfigureEvm<
@@ -138,8 +138,7 @@ pub struct ZonePayloadBuilder<Provider, EvmConfig> {
 
 impl<Provider, EvmConfig> PayloadBuilder for ZonePayloadBuilder<Provider, EvmConfig>
 where
-    Provider:
-        StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + Clone + 'static,
+    Provider: StateProviderFactory + ChainSpecProvider<ChainSpec = ZoneChainSpec> + Clone + 'static,
     EvmConfig: ConfigureEvm<
             Primitives = tempo_primitives::TempoPrimitives,
             NextBlockEnvCtx = TempoNextBlockEnvAttributes,


### PR DESCRIPTION
This PR adds `ZoneChainSpec` and updates the Zone node to use it while preserving existing Tempo behavior.

It also bumps Tempo dependencies to the generic chain-spec changes in https://github.com/tempoxyz/tempo/pull/6862.

Depends on https://github.com/tempoxyz/tempo/pull/6862.