### PR TITLE
chore(evm): export `ZoneBlockExecutor`

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -36,7 +36,8 @@ where
     DB: StateDB,
     I: Inspector<TempoContext<DB>>,
 {
-    pub(crate) fn new(
+    /// Create a zone block executor for `evm` and the current block context.
+    pub fn new(
         evm: ZoneEvm<DB, I>,
         ctx: TempoBlockExecutionCtx<'a>,
         chain_spec: &'a ZoneChainSpec,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -13,9 +13,9 @@ mod tx_context;
 mod zone_evm;
 
 pub use zone_evm::{ZoneEvm, contract_creation::validate_transaction};
+pub use executor::ZoneBlockExecutor;
 
 use crate::{
-    executor::ZoneBlockExecutor,
     precompiles::{
         AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
         SequencerExt, TempoState, ZONE_TIP20_FACTORY_ADDRESS, ZONE_TIP403_PROXY_ADDRESS,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -12,8 +12,8 @@ pub mod precompiles;
 mod tx_context;
 mod zone_evm;
 
-pub use zone_evm::{ZoneEvm, contract_creation::validate_transaction};
 pub use executor::ZoneBlockExecutor;
+pub use zone_evm::{ZoneEvm, contract_creation::validate_transaction};
 
 use crate::{
     precompiles::{


### PR DESCRIPTION
## Summary

Make the zone block executor available to downstream crates.