### PR TITLE
feat(l1): bind finalized headers to consensus finalizations

### DIFF
--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -19,6 +19,7 @@ zone-primitives = { workspace = true, features = ["std", "serde"] }
 # tempo
 tempo-alloy.workspace = true
 tempo-contracts.workspace = true
+tempo-node.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives.workspace = true
 tempo-revm.workspace = true

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tempo_node::rpc::consensus::{CertifiedBlock, Query};
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
 const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
@@ -342,6 +343,11 @@ impl L1Subscriber {
                     })?;
                     let block_hash = header_resp.hash();
                     let block = NumHash::new(block_number, block_hash);
+                    fetch_and_validate_finalization_for_header(provider, block)
+                        .await
+                        .inspect_err(|_| {
+                            fetch_failures.increment(1);
+                        })?;
                     let expected_receipts_root = header_resp.receipts_root();
                     let expected_logs_bloom = header_resp.logs_bloom();
                     let receipts = fetch_and_verify_receipts_for_header(
@@ -575,6 +581,65 @@ impl L1Subscriber {
             .write()
             .update_anchor(NumHash::new(number, hash));
     }
+}
+
+/// Require the configured L1 endpoint to attest that the header is finalized by Tempo consensus.
+///
+/// `eth_getBlockByNumber("finalized")` is a transport-level label. The follower's consensus RPC
+/// supplies the corresponding certificate-bearing finalized block. The follower verifies the BLS
+/// certificate before exposing it; this check binds that result to the header and receipts that the
+/// subscriber is about to ingest.
+///
+/// This deliberately does not treat an RPC response as an independently verified BLS certificate:
+/// doing so requires an authenticated, epoch-aware Tempo DKG scheme provider, which Zones does not
+/// yet have. Until that interface exists, `l1_rpc_url` must point to a Tempo follower that verifies
+/// finalizations.
+async fn fetch_and_validate_finalization_for_header(
+    provider: &impl Provider<TempoNetwork>,
+    block: NumHash,
+) -> eyre::Result<CertifiedBlock> {
+    let finalization: CertifiedBlock = provider
+        .raw_request(
+            "consensus_getFinalization".into(),
+            [Query::Height(block.number)],
+        )
+        .await?;
+
+    verify_finalization_matches_header(
+        block,
+        finalization.block.number(),
+        finalization.block.hash(),
+        &finalization.certificate,
+    )?;
+
+    Ok(finalization)
+}
+
+fn verify_finalization_matches_header(
+    block: NumHash,
+    finalization_height: u64,
+    finalization_hash: B256,
+    certificate: &str,
+) -> eyre::Result<()> {
+    eyre::ensure!(
+        !certificate.is_empty(),
+        "consensus finalization for block {} did not include a certificate",
+        block.number,
+    );
+    eyre::ensure!(
+        finalization_height == block.number,
+        "consensus finalization height mismatch: expected {}, got {}",
+        block.number,
+        finalization_height,
+    );
+    eyre::ensure!(
+        finalization_hash == block.hash,
+        "consensus finalization hash mismatch at height {}: expected {}, got {}",
+        block.number,
+        block.hash,
+        finalization_hash,
+    );
+    Ok(())
 }
 
 /// Fetch receipts for the L1 header by block hash and verify they match the

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -160,6 +160,20 @@ fn test_subscriber(
     }
 }
 
+#[test]
+fn consensus_finalization_must_match_the_finalized_header() {
+    let block = NumHash::new(42, B256::repeat_byte(0x42));
+
+    verify_finalization_matches_header(block, 42, B256::repeat_byte(0x42), "0x1234").unwrap();
+    assert!(
+        verify_finalization_matches_header(block, 43, B256::repeat_byte(0x42), "0x1234").is_err()
+    );
+    assert!(
+        verify_finalization_matches_header(block, 42, B256::repeat_byte(0x43), "0x1234").is_err()
+    );
+    assert!(verify_finalization_matches_header(block, 42, B256::repeat_byte(0x42), "").is_err());
+}
+
 fn make_test_header(number: u64) -> TempoHeader {
     TempoHeader {
         inner: Header {


### PR DESCRIPTION
## Summary

- require each L1 header selected through `eth_getBlockByNumber("finalized")` to have a matching `consensus_getFinalization({"height": N})` response before receipt/event ingestion
- require the returned Tempo block height and hash to match the header and reject an absent certificate
- add regression coverage for height/hash/certificate mismatches

This makes the configured L1 endpoint explicitly certificate-aware and fails closed on an EL/consensus mismatch. It relies on the endpoint being a Tempo follower that verifies Simplex certificates before serving the RPC response. Independent BLS verification in Zones still requires an authenticated, epoch-aware DKG scheme provider; Zones does not currently have that interface.

## Validation

- `cargo +nightly fmt --all --check`
- `cargo check -p zone-l1` *(blocked: this environment receives HTTP 401 while fetching the pinned `paradigmxyz/reth` revision)*

Prompted by: @0xalpharush