### PR TITLE
ci: publish tempo-zone-xtask image with cast and ref-impl artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ contrib/
 docs/
 localnet/
 scripts/
+target/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          submodules: recursive
 
       - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
@@ -47,6 +48,24 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/tempo-zone
           bake-target: tempo-zone
+          tags: |
+            type=schedule,pattern=nightly
+            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=edge,branch=main
+            type=sha,prefix=sha-
+            type=ref,event=pr
+
+      - name: Docker metadata for tempo-zone-xtask
+        id: meta-tempo-zone-xtask
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/tempo-zone-xtask
+          bake-target: tempo-zone-xtask
           tags: |
             type=schedule,pattern=nightly
             type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
@@ -75,6 +94,7 @@ jobs:
           files: |
             docker-bake.hcl
             ${{ steps.meta-tempo-zone.outputs.bake-file }}
+            ${{ steps.meta-tempo-zone-xtask.outputs.bake-file }}
           targets: default
           project: 0c6tg19qsp
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,23 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-
     --mount=type=cache,target=$SCCACHE_DIR,sharing=locked,id=sccache \
     RUSTFLAGS="-C link-arg=-fuse-ld=mold ${EXTRA_RUSTFLAGS}" \
     cargo build --profile ${RUST_PROFILE} \
-        --bin tempo-zone --features "jemalloc"
+        --bin tempo-zone --features "jemalloc" \
+    && RUSTFLAGS="-C link-arg=-fuse-ld=mold ${EXTRA_RUSTFLAGS}" \
+    cargo build --profile ${RUST_PROFILE} \
+        --bin tempo-xtask
+
+# Solidity ref-impls compiled for deployable L1 artifacts (ZoneFactory).
+# Requires the specs/ref-impls/lib submodules to be checked out.
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS solidity
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://foundry.paradigm.xyz | bash \
+    && /root/.foundry/bin/foundryup
+ENV PATH="/root/.foundry/bin:${PATH}"
+WORKDIR /app/specs/ref-impls
+COPY specs/ref-impls .
+RUN forge build --skip test
 
 FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS base
 
@@ -29,3 +45,17 @@ FROM base AS tempo-zone
 ARG RUST_PROFILE=profiling
 COPY --from=builder /app/target/${RUST_PROFILE}/tempo-zone /usr/local/bin/tempo-zone
 ENTRYPOINT ["/usr/local/bin/tempo-zone"]
+
+# tempo-zone-xtask: zone provisioning tooling (create-zone, zone-info, deploy-router).
+# Ships the compiled ref-impls artifacts (used by create-zone via --specs-out and for
+# deploying a fresh ZoneFactory with `cast send --create`).
+FROM base AS tempo-zone-xtask
+ARG RUST_PROFILE=profiling
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/${RUST_PROFILE}/tempo-xtask /usr/local/bin/tempo-xtask
+COPY --from=solidity /root/.foundry/bin/cast /usr/local/bin/cast
+COPY --from=solidity /app/specs/ref-impls/out /app/specs/ref-impls/out
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/tempo-xtask"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ variable "VERGEN_GIT_SHA_SHORT" {
 }
 
 group "default" {
-  targets = ["tempo-zone"]
+  targets = ["tempo-zone", "tempo-zone-xtask"]
 }
 
 target "docker-metadata" {}
@@ -41,4 +41,9 @@ target "_common" {
 target "tempo-zone" {
   inherits = ["_common", "docker-metadata"]
   target = "tempo-zone"
+}
+
+target "tempo-zone-xtask" {
+  inherits = ["_common", "docker-metadata"]
+  target = "tempo-zone-xtask"
 }


### PR DESCRIPTION
Adds a `tempo-zone-xtask` image target:

- new `solidity` Docker stage compiles `specs/ref-impls` with Foundry (submodules now checked out recursively in CI)
- final image ships `tempo-xtask`, `cast`, `jq`, and the compiled artifacts at `/app/specs/ref-impls/out` (the xtask default `--specs-out`)
- bake target + metadata wired into the existing Depot build, published as `ghcr.io/tempoxyz/tempo-zone-xtask`

Needed by the `zone-regenesis` Argo workflow (tempoxyz/workflows) to re-register zones on L1 (deploy a fresh ZoneFactory, run `create-zone`, regenerate genesis) after portal ABI changes — currently blocking zone-009 withdrawals (deployed portal predates the `processWithdrawal` selector change).