### PR TITLE
refactor: name refund recipients by domain

### DIFF
--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -62,7 +62,7 @@ mod tests {
             sender: address!("0x0000000000000000000000000000000000000001"),
             to: address!("0x0000000000000000000000000000000000000002"),
             amount: 1000u128,
-            bouncebackRecipient: address!("0x0000000000000000000000000000000000000001"),
+            tempoRefundRecipient: address!("0x0000000000000000000000000000000000000001"),
             memo: B256::ZERO,
         };
 
@@ -86,7 +86,7 @@ mod tests {
             sender: address!("0x0000000000000000000000000000000000000001"),
             to: address!("0x0000000000000000000000000000000000000002"),
             amount: 1000u128,
-            bouncebackRecipient: address!("0x0000000000000000000000000000000000000001"),
+            tempoRefundRecipient: address!("0x0000000000000000000000000000000000000001"),
             memo: B256::ZERO,
         };
 
@@ -147,7 +147,7 @@ mod tests {
             sender: address!("0x0000000000000000000000000000000000000001"),
             to: address!("0x0000000000000000000000000000000000000002"),
             amount: 1000u128,
-            bouncebackRecipient: address!("0x0000000000000000000000000000000000000001"),
+            tempoRefundRecipient: address!("0x0000000000000000000000000000000000000001"),
             memo: B256::ZERO,
         };
         let prev_hash = B256::ZERO;
@@ -207,7 +207,7 @@ mod tests {
             token_out: address!("0x0000000000000000000000000000000000001001"),
             target_portal: address!("0x0000000000000000000000000000000000002001"),
             recipient: address!("0x0000000000000000000000000000000000003001"),
-            bounceback_recipient: address!("0x0000000000000000000000000000000000004001"),
+            tempo_refund_recipient: address!("0x0000000000000000000000000000000000004001"),
             memo: B256::from([0x11; 32]),
             min_amount_out: 1234,
         };
@@ -217,7 +217,7 @@ mod tests {
             callback.token_out,
             callback.target_portal,
             callback.recipient,
-            callback.bounceback_recipient,
+            callback.tempo_refund_recipient,
             callback.memo,
             callback.min_amount_out,
         )
@@ -254,7 +254,7 @@ mod tests {
             target_portal: address!("0x0000000000000000000000000000000000002002"),
             key_index: U256::from(7),
             encrypted: encrypted.clone(),
-            bounceback_recipient: address!("0x0000000000000000000000000000000000004002"),
+            tempo_refund_recipient: address!("0x0000000000000000000000000000000000004002"),
             min_amount_out: 5678,
         };
 
@@ -264,7 +264,7 @@ mod tests {
             callback.target_portal,
             callback.key_index,
             encrypted,
-            callback.bounceback_recipient,
+            callback.tempo_refund_recipient,
             callback.min_amount_out,
         )
             .abi_encode_params();

--- a/crates/contracts/src/precompiles/swap_and_deposit_router.rs
+++ b/crates/contracts/src/precompiles/swap_and_deposit_router.rs
@@ -32,7 +32,7 @@ pub struct SwapAndDepositRouterPlaintextCallback {
     /// Zone recipient for the downstream plaintext deposit.
     pub recipient: Address,
     /// Tempo refund recipient if the downstream zone deposit later bounces.
-    pub bounceback_recipient: Address,
+    pub tempo_refund_recipient: Address,
     /// Memo recorded on the downstream plaintext deposit.
     pub memo: B256,
     /// Minimum acceptable output from the optional swap.
@@ -49,7 +49,7 @@ impl SwapAndDepositRouterPlaintextCallback {
             self.token_out,
             self.target_portal,
             self.recipient,
-            self.bounceback_recipient,
+            self.tempo_refund_recipient,
             self.memo,
             self.min_amount_out,
         )
@@ -73,7 +73,7 @@ pub struct SwapAndDepositRouterEncryptedCallback {
     /// ECIES-encrypted `(recipient, memo)` payload for `depositEncrypted`.
     pub encrypted: EncryptedDepositPayload,
     /// Tempo refund recipient if the downstream encrypted deposit later bounces.
-    pub bounceback_recipient: Address,
+    pub tempo_refund_recipient: Address,
     /// Minimum acceptable output from the optional swap.
     ///
     /// Ignored when `tokenIn == token_out` and the router can deposit directly.
@@ -89,7 +89,7 @@ impl SwapAndDepositRouterEncryptedCallback {
             self.target_portal,
             self.key_index,
             self.encrypted.clone(),
-            self.bounceback_recipient,
+            self.tempo_refund_recipient,
             self.min_amount_out,
         )
             .abi_encode_params()

--- a/crates/contracts/src/precompiles/zone_inbox.rs
+++ b/crates/contracts/src/precompiles/zone_inbox.rs
@@ -14,7 +14,7 @@ crate::sol! {
             address sender;
             address to;
             uint128 amount;
-            address bouncebackRecipient;
+            address tempoRefundRecipient;
             bytes32 memo;
         }
 
@@ -93,7 +93,7 @@ crate::sol! {
             address indexed to,
             address token,
             uint128 amount,
-            address bouncebackRecipient
+            address tempoRefundRecipient
         );
 
         event DepositRejected(
@@ -102,7 +102,7 @@ crate::sol! {
             DepositType depositType,
             address token,
             uint128 amount,
-            address bouncebackRecipient
+            address tempoRefundRecipient
         );
 
         event WithdrawalBounceBackProcessed(address indexed fallbackRecipient, address token, uint128 amount);

--- a/crates/contracts/src/precompiles/zone_outbox.rs
+++ b/crates/contracts/src/precompiles/zone_outbox.rs
@@ -80,7 +80,7 @@ crate::sol! {
         function enqueueDepositBounceBack(
             address token,
             uint128 amount,
-            address bouncebackRecipient
+            address tempoRefundRecipient
         ) external;
         function finalizeWithdrawalBatch(uint256 count, uint64 blockNumber, bytes[] calldata encryptedSenders) external returns (bytes32 withdrawalQueueHash);
     }

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -41,7 +41,7 @@ crate::sol! {
             address token;
             address sender;
             uint128 amount;
-            address bouncebackRecipient;
+            address tempoRefundRecipient;
             uint256 keyIndex;
             EncryptedDepositPayload encrypted;
         }
@@ -68,7 +68,7 @@ crate::sol! {
             uint128 netAmount,
             uint128 fee,
             bytes32 memo,
-            address bouncebackRecipient,
+            address tempoRefundRecipient,
             uint64 depositNumber
         );
 
@@ -84,7 +84,7 @@ crate::sol! {
             bytes ciphertext,
             bytes12 nonce,
             bytes16 tag,
-            address bouncebackRecipient,
+            address tempoRefundRecipient,
             uint64 depositNumber
         );
 
@@ -121,14 +121,14 @@ crate::sol! {
         );
 
         event DepositBounceBack(
-            address indexed bouncebackRecipient,
+            address indexed tempoRefundRecipient,
             address token,
             uint128 amount,
             uint128 bouncebackFee
         );
 
         event DepositBounceBackPending(
-            address indexed bouncebackRecipient,
+            address indexed tempoRefundRecipient,
             address token,
             uint128 amount,
             uint128 bouncebackFee
@@ -209,7 +209,7 @@ crate::sol! {
             address to,
             uint128 amount,
             bytes32 memo,
-            address bouncebackRecipient
+            address tempoRefundRecipient
         )
             external
             returns (bytes32 newCurrentDepositQueueHash);
@@ -245,7 +245,7 @@ crate::sol! {
             uint128 amount,
             uint256 keyIndex,
             EncryptedDepositPayload calldata encrypted,
-            address bouncebackRecipient
+            address tempoRefundRecipient
         ) external returns (bytes32 newCurrentDepositQueueHash);
 
         function setSequencerEncryptionKey(

--- a/crates/l1/src/block.rs
+++ b/crates/l1/src/block.rs
@@ -44,7 +44,7 @@ impl L1BlockDeposits {
                         sender: d.sender,
                         to: d.to,
                         amount: d.amount,
-                        bouncebackRecipient: d.bounceback_recipient,
+                        tempoRefundRecipient: d.tempo_refund_recipient,
                         memo: d.memo,
                     };
                     queued_deposits.push(abi::QueuedDeposit {
@@ -61,7 +61,7 @@ impl L1BlockDeposits {
                                 token: d.token,
                                 sender: d.sender,
                                 amount: d.amount,
-                                bouncebackRecipient: d.bounceback_recipient,
+                                tempoRefundRecipient: d.tempo_refund_recipient,
                                 keyIndex: d.key_index,
                                 encrypted: abi::EncryptedDepositPayload {
                                     ephemeralPubkeyX: d.ephemeral_pubkey_x,

--- a/crates/l1/src/deposit.rs
+++ b/crates/l1/src/deposit.rs
@@ -14,7 +14,7 @@ pub struct Deposit {
     /// Fee paid on L1.
     pub fee: u128,
     /// Tempo recipient for a failed-deposit refund.
-    pub bounceback_recipient: Address,
+    pub tempo_refund_recipient: Address,
     /// User-provided memo.
     pub memo: B256,
 }
@@ -28,7 +28,7 @@ impl Deposit {
             to: event.to,
             amount: event.netAmount,
             fee: event.fee,
-            bounceback_recipient: event.bouncebackRecipient,
+            tempo_refund_recipient: event.tempoRefundRecipient,
             memo: event.memo,
         }
     }
@@ -43,7 +43,7 @@ impl Deposit {
             to: Address::from(encoded_nonce),
             amount: event.amount,
             fee: 0,
-            bounceback_recipient: Address::ZERO,
+            tempo_refund_recipient: Address::ZERO,
             memo: B256::ZERO,
         }
     }
@@ -61,7 +61,7 @@ pub struct EncryptedDeposit {
     /// Fee paid on L1.
     pub fee: u128,
     /// Tempo recipient for a failed-deposit refund.
-    pub bounceback_recipient: Address,
+    pub tempo_refund_recipient: Address,
     /// Index of the encryption key used.
     pub key_index: U256,
     /// Ephemeral public key X coordinate.
@@ -84,7 +84,7 @@ impl EncryptedDeposit {
             sender: event.sender,
             amount: event.netAmount,
             fee: event.fee,
-            bounceback_recipient: event.bouncebackRecipient,
+            tempo_refund_recipient: event.tempoRefundRecipient,
             key_index: event.keyIndex,
             ephemeral_pubkey_x: event.ephemeralPubkeyX,
             ephemeral_pubkey_y_parity: event.ephemeralPubkeyYParity,
@@ -116,7 +116,7 @@ impl L1Deposit {
                         sender: d.sender,
                         to: d.to,
                         amount: d.amount,
-                        bouncebackRecipient: d.bounceback_recipient,
+                        tempoRefundRecipient: d.tempo_refund_recipient,
                         memo: d.memo,
                     },
                     prev_hash,
@@ -130,7 +130,7 @@ impl L1Deposit {
                         token: d.token,
                         sender: d.sender,
                         amount: d.amount,
-                        bouncebackRecipient: d.bounceback_recipient,
+                        tempoRefundRecipient: d.tempo_refund_recipient,
                         keyIndex: d.key_index,
                         encrypted: AbiEncryptedDepositPayload {
                             ephemeralPubkeyX: d.ephemeral_pubkey_x,

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -31,7 +31,7 @@ struct EncryptedDepositFixture {
     token: String,
     sender: String,
     amount: u128,
-    bounceback_recipient: String,
+    tempo_refund_recipient: String,
     key_index: u64,
     encrypted: EncryptedDepositPayloadFixture,
 }
@@ -105,7 +105,7 @@ impl EncryptedDepositFixture {
             sender: parse_fixture_address(&self.sender),
             amount: self.amount,
             fee: 0,
-            bounceback_recipient: parse_fixture_address(&self.bounceback_recipient),
+            tempo_refund_recipient: parse_fixture_address(&self.tempo_refund_recipient),
             key_index: U256::from(self.key_index),
             ephemeral_pubkey_x: parse_fixture_b256(&self.encrypted.ephemeral_pubkey_x),
             ephemeral_pubkey_y_parity: self.encrypted.ephemeral_pubkey_y_parity,
@@ -826,7 +826,7 @@ fn test_deposit_queue_hash_chain() {
         to: address!("0x0000000000000000000000000000000000000002"),
         amount: 1000,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000001"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000001"),
         memo: B256::ZERO,
     });
 
@@ -853,7 +853,7 @@ fn test_deposit_queue_hash_chain() {
         to: address!("0x0000000000000000000000000000000000000004"),
         amount: 2000,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000003"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000003"),
         memo: B256::ZERO,
     });
 
@@ -875,7 +875,7 @@ fn test_process_deposits_transition() {
             to: address!("0x0000000000000000000000000000000000000002"),
             amount: 1000,
             fee: 0,
-            bounceback_recipient: address!("0x0000000000000000000000000000000000000001"),
+            tempo_refund_recipient: address!("0x0000000000000000000000000000000000000001"),
             memo: B256::ZERO,
         }),
         L1Deposit::Regular(Deposit {
@@ -884,7 +884,7 @@ fn test_process_deposits_transition() {
             to: address!("0x0000000000000000000000000000000000000004"),
             amount: 2000,
             fee: 0,
-            bounceback_recipient: address!("0x0000000000000000000000000000000000000003"),
+            tempo_refund_recipient: address!("0x0000000000000000000000000000000000000003"),
             memo: B256::ZERO,
         }),
     ];
@@ -916,7 +916,7 @@ fn test_queue_and_process_deposits_hashes_match() {
         to: address!("0x0000000000000000000000000000000000000002"),
         amount: 500,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000001"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000001"),
         memo: FixedBytes::from([0xABu8; 32]),
     })];
 
@@ -941,7 +941,7 @@ fn test_drain_returns_block_grouped_deposits() {
         to: address!("0x0000000000000000000000000000000000000002"),
         amount: 100,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000001"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000001"),
         memo: B256::ZERO,
     });
 
@@ -951,7 +951,7 @@ fn test_drain_returns_block_grouped_deposits() {
         to: address!("0x0000000000000000000000000000000000000004"),
         amount: 200,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000003"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000003"),
         memo: B256::ZERO,
     });
 
@@ -988,7 +988,7 @@ fn test_encrypted_deposit_hash_chain() {
         token: encrypted.token,
         sender: encrypted.sender,
         amount: encrypted.amount,
-        bouncebackRecipient: encrypted.bounceback_recipient,
+        tempoRefundRecipient: encrypted.tempo_refund_recipient,
         keyIndex: encrypted.key_index,
         encrypted: abi::EncryptedDepositPayload {
             ephemeralPubkeyX: encrypted.ephemeral_pubkey_x,
@@ -1034,7 +1034,7 @@ fn test_mixed_deposit_hash_chain() {
         to: recipient,
         amount: 500_000,
         fee: 0,
-        bounceback_recipient: sender,
+        tempo_refund_recipient: sender,
         memo: B256::ZERO,
     };
 
@@ -1043,7 +1043,7 @@ fn test_mixed_deposit_hash_chain() {
         sender,
         amount: 300_000,
         fee: 0,
-        bounceback_recipient: sender,
+        tempo_refund_recipient: sender,
         key_index: U256::from(1u64),
         ephemeral_pubkey_x: B256::with_last_byte(0xBB),
         ephemeral_pubkey_y_parity: 0x03,
@@ -1068,7 +1068,7 @@ fn test_mixed_deposit_hash_chain() {
                 sender: regular.sender,
                 to: regular.to,
                 amount: regular.amount,
-                bouncebackRecipient: regular.bounceback_recipient,
+                tempoRefundRecipient: regular.tempo_refund_recipient,
                 memo: regular.memo,
             },
             B256::ZERO,
@@ -1083,7 +1083,7 @@ fn test_mixed_deposit_hash_chain() {
                 token: encrypted.token,
                 sender: encrypted.sender,
                 amount: encrypted.amount,
-                bouncebackRecipient: encrypted.bounceback_recipient,
+                tempoRefundRecipient: encrypted.tempo_refund_recipient,
                 keyIndex: encrypted.key_index,
                 encrypted: abi::EncryptedDepositPayload {
                     ephemeralPubkeyX: encrypted.ephemeral_pubkey_x,
@@ -1112,7 +1112,7 @@ fn test_enqueue_and_transition_consistency() {
         sender,
         amount: 750_000,
         fee: 0,
-        bounceback_recipient: sender,
+        tempo_refund_recipient: sender,
         key_index: U256::from(2u64),
         ephemeral_pubkey_x: B256::with_last_byte(0xCC),
         ephemeral_pubkey_y_parity: 0x02,
@@ -1187,7 +1187,7 @@ async fn test_prepare_rejects_unauthorized_encrypted_deposit_without_decryption_
             sender,
             amount: 1_000_000,
             fee: 0,
-            bounceback_recipient: sender,
+            tempo_refund_recipient: sender,
             key_index: U256::ZERO,
             ephemeral_pubkey_x: encrypted.eph_pub_x,
             ephemeral_pubkey_y_parity: encrypted.eph_pub_y_parity,
@@ -1417,7 +1417,7 @@ fn test_purge_rolls_back_deposit_hash() {
         to: address!("0x0000000000000000000000000000000000000002"),
         amount: 100,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000001"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000001"),
         memo: B256::ZERO,
     });
     assert!(matches!(
@@ -1433,7 +1433,7 @@ fn test_purge_rolls_back_deposit_hash() {
         to: address!("0x0000000000000000000000000000000000000004"),
         amount: 200,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000003"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000003"),
         memo: B256::ZERO,
     });
     assert!(matches!(
@@ -1467,7 +1467,7 @@ fn make_deposit(amount: u128) -> L1Deposit {
         to: address!("0x0000000000000000000000000000000000000002"),
         amount,
         fee: 0,
-        bounceback_recipient: address!("0x0000000000000000000000000000000000000001"),
+        tempo_refund_recipient: address!("0x0000000000000000000000000000000000000001"),
         memo: B256::ZERO,
     })
 }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -274,7 +274,7 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
                         deposit_hash: event.newCurrentDepositQueueHash,
                         sender: event.sender,
                         recipient: event.to,
-                        bounceback_recipient: event.bouncebackRecipient,
+                        tempo_refund_recipient: event.tempoRefundRecipient,
                         token: event.token,
                         amount: event.netAmount,
                         memo: event.memo,
@@ -284,7 +284,7 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
                     deposits.push(PortalDepositRecord::Encrypted {
                         deposit_hash: event.newCurrentDepositQueueHash,
                         sender: event.sender,
-                        bounceback_recipient: event.bouncebackRecipient,
+                        tempo_refund_recipient: event.tempoRefundRecipient,
                         token: event.token,
                         amount: event.netAmount,
                     });
@@ -927,14 +927,14 @@ where
                         deposit_hash,
                         sender,
                         recipient,
-                        bounceback_recipient,
+                        tempo_refund_recipient,
                         token,
                         amount,
                         memo,
                     } => {
                         if sender != auth.caller
                             && recipient != auth.caller
-                            && bounceback_recipient != auth.caller
+                            && tempo_refund_recipient != auth.caller
                         {
                             continue;
                         }
@@ -956,7 +956,7 @@ where
                     PortalDepositRecord::Encrypted {
                         deposit_hash,
                         sender,
-                        bounceback_recipient,
+                        tempo_refund_recipient,
                         token,
                         amount,
                     } => {
@@ -964,7 +964,7 @@ where
 
                         let include = match (
                             &terminal,
-                            sender == auth.caller || bounceback_recipient == auth.caller,
+                            sender == auth.caller || tempo_refund_recipient == auth.caller,
                         ) {
                             (_, true) => true,
                             (
@@ -1017,7 +1017,7 @@ enum PortalDepositRecord {
         deposit_hash: B256,
         sender: Address,
         recipient: Address,
-        bounceback_recipient: Address,
+        tempo_refund_recipient: Address,
         token: Address,
         amount: u128,
         memo: B256,
@@ -1025,7 +1025,7 @@ enum PortalDepositRecord {
     Encrypted {
         deposit_hash: B256,
         sender: Address,
-        bounceback_recipient: Address,
+        tempo_refund_recipient: Address,
         token: Address,
         amount: u128,
     },

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -421,10 +421,10 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
 /// Cross-zone encrypted router deposit where Zone B accepts the L1 deposit but
 /// later bounces it because the decrypted recipient violates policy.
 ///
-/// The refund must go to the bounceback recipient encoded in the router payload,
+/// The refund must go to the Tempo refund recipient encoded in the router payload,
 /// not to the encrypted recipient and not to the router contract.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_cross_zone_encrypted_router_bounceback_recipient() -> eyre::Result<()> {
+async fn test_cross_zone_encrypted_router_tempo_refund_recipient() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let l1 = L1TestNode::start().await?;
@@ -492,7 +492,7 @@ async fn test_cross_zone_encrypted_router_bounceback_recipient() -> eyre::Result
         target_portal: portal_b,
         key_index,
         encrypted,
-        bounceback_recipient: refund_burner,
+        tempo_refund_recipient: refund_burner,
         min_amount_out: 0,
     });
     alice.withdraw_with(args).await?;
@@ -578,7 +578,7 @@ async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
         token_out: fixture.beta,
         target_portal: fixture.portal_address,
         recipient: fixture.account.address(),
-        bounceback_recipient: fixture.l1.signer_at(5).address(),
+        tempo_refund_recipient: fixture.l1.signer_at(5).address(),
         memo: B256::ZERO,
         min_amount_out: expected_beta,
     });
@@ -676,7 +676,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
         token_out: fixture.beta,
         target_portal: fixture.portal_address,
         recipient: fixture.account.address(),
-        bounceback_recipient: fixture.l1.signer_at(5).address(),
+        tempo_refund_recipient: fixture.l1.signer_at(5).address(),
         memo: B256::ZERO,
         min_amount_out: expected_beta,
     });
@@ -759,7 +759,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_
         .await?;
 
     let enc_key_bytes: [u8; 32] =
-        Sha256::digest(b"swap-and-deposit-router-encrypted-bounceback").into();
+        Sha256::digest(b"swap-and-deposit-router-encrypted-tempo-refund").into();
     let encryption_key = k256::SecretKey::from_slice(&enc_key_bytes).expect("valid key");
 
     fixture
@@ -795,7 +795,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_
         target_portal: fixture.portal_address,
         key_index,
         encrypted,
-        bounceback_recipient: fixture.l1.signer_at(5).address(),
+        tempo_refund_recipient: fixture.l1.signer_at(5).address(),
         min_amount_out: expected_beta,
     });
     fixture

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -1308,12 +1308,12 @@ async fn test_zone_get_deposit_status_encrypted() -> eyre::Result<()> {
     Ok(())
 }
 
-/// `zone_getDepositStatus` returns encrypted deposits to the bounceback
+/// `zone_getDepositStatus` returns encrypted deposits to the Tempo refund
 /// recipient, even when that caller is neither the L1 sender nor the revealed
 /// zone recipient. This matches SwapAndDepositRouter deposits, where the L1
 /// sender is the router and the refund owner is carried separately.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_zone_get_deposit_status_encrypted_bounceback_recipient() -> eyre::Result<()> {
+async fn test_zone_get_deposit_status_encrypted_tempo_refund_recipient() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let ctx = start_zone_with_private_rpc_l1_with_encryption().await?;
@@ -1322,8 +1322,8 @@ async fn test_zone_get_deposit_status_encrypted_bounceback_recipient() -> eyre::
 
     let depositor_signer = l1.user_signer();
     let recipient = l1.signer_at(2).address();
-    let bounceback_signer = l1.signer_at(3);
-    let bounceback_recipient = bounceback_signer.address();
+    let tempo_refund_signer = l1.signer_at(3);
+    let tempo_refund_recipient = tempo_refund_signer.address();
 
     let depositor =
         ZoneAccount::with_signer(depositor_signer.clone(), l1, &ctx.zone, portal_address);
@@ -1367,7 +1367,7 @@ async fn test_zone_get_deposit_status_encrypted_bounceback_recipient() -> eyre::
                 nonce: alloy::primitives::FixedBytes(encrypted.nonce),
                 tag: alloy::primitives::FixedBytes(encrypted.tag),
             },
-            bounceback_recipient,
+            tempo_refund_recipient,
         )
         .send()
         .await?
@@ -1388,11 +1388,11 @@ async fn test_zone_get_deposit_status_encrypted_bounceback_recipient() -> eyre::
         .block_number
         .ok_or_else(|| eyre::eyre!("depositEncrypted receipt missing block number"))?;
     let status = ctx
-        .get_deposit_status_as_user(tempo_block_number, &bounceback_signer)
+        .get_deposit_status_as_user(tempo_block_number, &tempo_refund_signer)
         .await?;
     let deposits = status["result"]["deposits"]
         .as_array()
-        .expect("bounceback recipient deposits should be an array");
+        .expect("Tempo refund recipient deposits should be an array");
 
     assert_eq!(status["result"]["processed"], true);
     assert_eq!(deposits.len(), 1);
@@ -1406,8 +1406,8 @@ async fn test_zone_get_deposit_status_encrypted_bounceback_recipient() -> eyre::
         deposits[0]["recipient"].as_str().unwrap(),
         format!("{recipient:#x}"),
     );
-    assert_ne!(depositor.address(), bounceback_recipient);
-    assert_ne!(recipient, bounceback_recipient);
+    assert_ne!(depositor.address(), tempo_refund_recipient);
+    assert_ne!(recipient, tempo_refund_recipient);
 
     Ok(())
 }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -2010,7 +2010,7 @@ pub(crate) struct PlaintextRouterCallbackArgs {
     pub token_out: Address,
     pub target_portal: Address,
     pub recipient: Address,
-    pub bounceback_recipient: Address,
+    pub tempo_refund_recipient: Address,
     pub memo: B256,
     pub min_amount_out: u128,
 }
@@ -2022,7 +2022,7 @@ pub(crate) struct EncryptedRouterCallbackArgs {
     pub target_portal: Address,
     pub key_index: U256,
     pub encrypted: tempo_zone_contracts::EncryptedDepositPayload,
-    pub bounceback_recipient: Address,
+    pub tempo_refund_recipient: Address,
     pub min_amount_out: u128,
 }
 
@@ -2048,7 +2048,7 @@ impl WithdrawalArgs {
             token_out: args.token_out,
             target_portal: args.target_portal,
             recipient: args.recipient,
-            bounceback_recipient: args.bounceback_recipient,
+            tempo_refund_recipient: args.tempo_refund_recipient,
             memo: args.memo,
             min_amount_out: args.min_amount_out,
         }
@@ -2072,7 +2072,7 @@ impl WithdrawalArgs {
             target_portal: args.target_portal,
             key_index: args.key_index,
             encrypted: args.encrypted,
-            bounceback_recipient: args.bounceback_recipient,
+            tempo_refund_recipient: args.tempo_refund_recipient,
             min_amount_out: args.min_amount_out,
         }
         .abi_encode();
@@ -2099,7 +2099,7 @@ impl WithdrawalArgs {
         target_portal: Address,
         token: Address,
         recipient: Address,
-        bounceback_recipient: Address,
+        tempo_refund_recipient: Address,
     ) -> Self {
         Self::swap_and_deposit_via_router(PlaintextRouterCallbackArgs {
             amount,
@@ -2107,7 +2107,7 @@ impl WithdrawalArgs {
             token_out: token,
             target_portal,
             recipient,
-            bounceback_recipient,
+            tempo_refund_recipient,
             memo: B256::ZERO,
             min_amount_out: 0,
         })
@@ -3643,7 +3643,7 @@ impl L1Fixture {
             to,
             amount,
             fee: 0,
-            bounceback_recipient: sender,
+            tempo_refund_recipient: sender,
             memo: B256::ZERO,
         }
     }
@@ -3705,7 +3705,7 @@ impl L1Fixture {
             sender,
             amount,
             fee: 0,
-            bounceback_recipient: sender,
+            tempo_refund_recipient: sender,
             key_index: alloy_primitives::U256::ZERO,
             ephemeral_pubkey_x: B256::ZERO,
             ephemeral_pubkey_y_parity: 0x02,
@@ -3729,7 +3729,7 @@ impl L1Fixture {
             to,
             amount,
             fee: 0,
-            bounceback_recipient: sender,
+            tempo_refund_recipient: sender,
             memo: B256::ZERO,
         }
     }
@@ -3786,7 +3786,7 @@ impl L1Fixture {
             sender,
             amount,
             fee: 0,
-            bounceback_recipient: sender,
+            tempo_refund_recipient: sender,
             key_index,
             ephemeral_pubkey_x: eph_pub_x,
             ephemeral_pubkey_y_parity: eph_pub_y_parity,

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -740,7 +740,7 @@ mod tests {
                             sender,
                             to: recipient,
                             amount: 500_000,
-                            bouncebackRecipient: recipient,
+                            tempoRefundRecipient: recipient,
                             memo: B256::ZERO,
                         }),
                     ),
@@ -753,7 +753,7 @@ mod tests {
                             token,
                             sender,
                             amount: 300_000,
-                            bouncebackRecipient: sender,
+                            tempoRefundRecipient: sender,
                             keyIndex: U256::ZERO,
                             encrypted: abi::EncryptedDepositPayload {
                                 ephemeralPubkeyX: B256::with_last_byte(0xDD),

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -263,7 +263,7 @@ The sequencer includes the withdrawal in the next batch submission to L1 and pro
 
 #### Router Swap + Deposit Demo (Same Zone)
 
-This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone via an encrypted deposit. The routed callback payload includes a public `bouncebackRecipient` for the downstream portal deposit; set `ROUTER_BOUNCEBACK_RECIPIENT` to a refund-specific burner or stealth address you control if you do not want a later refund to point at the encrypted zone recipient. If the portal does not already have the current sequencer encryption key registered, the demo registers it automatically before building the routed callback payload.
+This demo exercises the `SwapAndDepositRouter` flow against a running zone. It creates temporary `AlphaUSD` and `BetaUSD` tokens on L1, seeds matching StablecoinDEX liquidity, withdraws `AlphaUSD` from the zone to the router, swaps on L1, and deposits `BetaUSD` back into the same zone via an encrypted deposit. The routed callback payload includes a public `tempoRefundRecipient` for the downstream portal deposit; set `ROUTER_BOUNCEBACK_RECIPIENT` to a refund-specific burner or stealth address you control if you do not want a later refund to point at the encrypted zone recipient. If the portal does not already have the current sequencer encryption key registered, the demo registers it automatically before building the routed callback payload.
 
 Prerequisites:
 - A running zone with an active sequencer

--- a/xtask/src/demo_blacklist.rs
+++ b/xtask/src/demo_blacklist.rs
@@ -680,7 +680,7 @@ async fn send_encrypted_deposit<P: Provider<TempoNetwork>>(
     portal_addr: Address,
     token: Address,
     to: Address,
-    bounceback_recipient: Address,
+    tempo_refund_recipient: Address,
     amount: u128,
 ) -> eyre::Result<()> {
     let (key, key_index) = portal
@@ -704,7 +704,7 @@ async fn send_encrypted_deposit<P: Provider<TempoNetwork>>(
     };
 
     let receipt = portal
-        .depositEncrypted(token, amount, key_index, payload, bounceback_recipient)
+        .depositEncrypted(token, amount, key_index, payload, tempo_refund_recipient)
         .send_sync()
         .await
         .wrap_err("depositEncrypted send failed")?;

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -81,7 +81,7 @@ pub(crate) struct DemoSwapAndDeposit {
     /// Defaults to the operator. Use a controlled burner or stealth address when
     /// the zone recipient should stay unlinkable from a later bounce-back.
     #[arg(long, env = "ROUTER_BOUNCEBACK_RECIPIENT")]
-    bounceback_recipient: Option<Address>,
+    tempo_refund_recipient: Option<Address>,
 
     /// Demo swap amount in token base units (6 decimals for the demo tokens).
     #[arg(long, default_value_t = 100_000_000)]
@@ -121,7 +121,7 @@ impl DemoSwapAndDeposit {
 
         let operator_signer = parse_private_key(&self.private_key)?;
         let operator = operator_signer.address();
-        let bounceback_recipient = self.bounceback_recipient.unwrap_or(operator);
+        let tempo_refund_recipient = self.tempo_refund_recipient.unwrap_or(operator);
         let sequencer_signer = parse_private_key(&sequencer_key)?;
         let sequencer = sequencer_signer.address();
         let admin_signer = parse_private_key(&admin_key)?;
@@ -195,7 +195,7 @@ impl DemoSwapAndDeposit {
         println!("  Operator:         {operator}");
         println!("  Sequencer:        {sequencer}");
         println!("  Portal admin:     {portal_admin}");
-        println!("  Refund recipient: {bounceback_recipient}");
+        println!("  Refund recipient: {tempo_refund_recipient}");
         println!("  Portal:           {portal}");
         println!("  Router:           {router}");
         println!("  L1 RPC:           {http_rpc}");
@@ -349,7 +349,7 @@ impl DemoSwapAndDeposit {
                 target_portal: portal,
                 token_out: beta,
                 recipient: operator,
-                bounceback_recipient,
+                tempo_refund_recipient,
                 memo: B256::ZERO,
                 min_amount_out: expected_beta,
                 sequencer_private_key: &sequencer_key,
@@ -591,7 +591,7 @@ struct EncryptedRouterCallbackRequest<'a> {
     target_portal: Address,
     token_out: Address,
     recipient: Address,
-    bounceback_recipient: Address,
+    tempo_refund_recipient: Address,
     memo: B256,
     min_amount_out: u128,
     sequencer_private_key: &'a str,
@@ -635,7 +635,7 @@ async fn build_encrypted_router_callback<P: Provider<TempoNetwork>>(
             nonce: encrypted.nonce.into(),
             tag: encrypted.tag.into(),
         },
-        bounceback_recipient: request.bounceback_recipient,
+        tempo_refund_recipient: request.tempo_refund_recipient,
         min_amount_out: request.min_amount_out,
     };
 

--- a/xtask/src/spam_deposits.rs
+++ b/xtask/src/spam_deposits.rs
@@ -323,7 +323,7 @@ impl SpamDeposits {
                 amount: self.amount,
                 keyIndex: key_index,
                 encrypted: payload,
-                bouncebackRecipient: recipient,
+                tempoRefundRecipient: recipient,
             }
             .abi_encode())
         } else {
@@ -332,7 +332,7 @@ impl SpamDeposits {
                 to: recipient,
                 amount: self.amount,
                 memo: B256::ZERO,
-                bouncebackRecipient: recipient,
+                tempoRefundRecipient: recipient,
             }
             .abi_encode())
         }


### PR DESCRIPTION
Stack 1 of 2.

Mechanical-only recipient naming cleanup split out ahead of the closed-loop behavior changes:

- `bouncebackRecipient` / `bounceback_recipient` → `tempoRefundRecipient` / `tempo_refund_recipient`
- callback `refundRecipient` → `tempoRefundRecipient`
- `fallbackRecipient` / `fallback_recipient` → `zoneFallbackRecipient` / `zone_fallback_recipient`
- `_fallbackRecipients` → `_zoneFallbackRecipients`

Applies the mapping consistently across Solidity, the spec/reference implementation, tests, Rust bindings and models, RPC/tooling, and generated storage layout. No behavior change is intended.

Stack: this PR targets `main`; #705 targets this branch. PR #696 and `codex/closed-loop-zone` are unchanged.