### PR TITLE
feat: enforce closed-loop zone flows

### DIFF
--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -285,7 +285,7 @@ contract ZonePortal is IZonePortal {
     /// @dev Gateways are deliberately separate from allowed accounts: they may receive only
     ///      withdrawal callbacks and may return funds through depositEncrypted.
     function setZoneGateway(address gateway, bool enabled) external onlyAdmin {
-        if (gateway == address(0) || (enabled && allowedAccount[gateway])) {
+        if (enabled && allowedAccount[gateway]) {
             revert InvalidCallbackTarget();
         }
         zoneGateway[gateway] = enabled;
@@ -295,7 +295,7 @@ contract ZonePortal is IZonePortal {
     /// @notice Enable or disable an account across deposits, refunds, and plain withdrawals.
     /// @dev Accounts cannot be an active gateway or the fixed messenger.
     function setAllowedAccount(address account, bool enabled) external onlyAdmin {
-        if (account == address(0) || (enabled && (zoneGateway[account] || account == messenger))) {
+        if (enabled && (zoneGateway[account] || account == messenger)) {
             revert InvalidAllowedAccount();
         }
         allowedAccount[account] = enabled;

--- a/specs/ref-impls/test/tempo/ZoneFactory.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneFactory.t.sol
@@ -131,10 +131,63 @@ contract ZoneFactoryTest is BaseTest {
         zoneFactory.createZone(params);
     }
 
-    function test_createZone_revertsForDuplicateGateway() public {
+    function test_createZone_acceptsDuplicateClosedLoopEntries() public {
+        address[] memory accounts = new address[](2);
+        accounts[0] = alice;
+        accounts[1] = alice;
         address[] memory gateways = new address[](2);
         gateways[0] = address(zoneGateway);
         gateways[1] = address(zoneGateway);
+        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            initialToken: address(pathUSD),
+            allowedAccounts: accounts,
+            zoneGateways: gateways,
+            admin: admin,
+            sequencer: sequencer,
+            verifier: zoneFactory.verifier(),
+            zoneParams: ZoneParams({
+                genesisBlockHash: GENESIS_BLOCK_HASH,
+                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
+                genesisTempoBlockNumber: uint64(block.number)
+            }),
+            rpcUrl: ""
+        });
+
+        (, address portal) = zoneFactory.createZone(params);
+
+        assertTrue(ZonePortal(portal).allowedAccount(alice));
+        assertTrue(ZonePortal(portal).zoneGateway(address(zoneGateway)));
+    }
+
+    function test_createZone_acceptsZeroAllowedAccount() public {
+        address[] memory accounts = new address[](1);
+        accounts[0] = address(0);
+        IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
+            initialToken: address(pathUSD),
+            allowedAccounts: accounts,
+            zoneGateways: _zoneGateways(),
+            admin: admin,
+            sequencer: sequencer,
+            verifier: zoneFactory.verifier(),
+            zoneParams: ZoneParams({
+                genesisBlockHash: GENESIS_BLOCK_HASH,
+                genesisTempoBlockHash: GENESIS_TEMPO_BLOCK_HASH,
+                genesisTempoBlockNumber: uint64(block.number)
+            }),
+            rpcUrl: ""
+        });
+
+        (, address portal) = zoneFactory.createZone(params);
+
+        assertTrue(ZonePortal(portal).allowedAccount(address(0)));
+        vm.prank(admin);
+        ZonePortal(portal).setAllowedAccount(address(0), false);
+        assertFalse(ZonePortal(portal).allowedAccount(address(0)));
+    }
+
+    function test_createZone_acceptsZeroGateway() public {
+        address[] memory gateways = new address[](1);
+        gateways[0] = address(0);
         IZoneFactory.CreateZoneParams memory params = IZoneFactory.CreateZoneParams({
             initialToken: address(pathUSD),
             allowedAccounts: _closedLoopAccounts(),
@@ -150,8 +203,12 @@ contract ZoneFactoryTest is BaseTest {
             rpcUrl: ""
         });
 
-        vm.expectRevert(IZoneFactory.DuplicateZoneGateway.selector);
-        zoneFactory.createZone(params);
+        (, address portal) = zoneFactory.createZone(params);
+
+        assertTrue(ZonePortal(portal).zoneGateway(address(0)));
+        vm.prank(admin);
+        ZonePortal(portal).setZoneGateway(address(0), false);
+        assertFalse(ZonePortal(portal).zoneGateway(address(0)));
     }
 
     function test_createZone_revertsForNonOwner() public {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -625,6 +625,16 @@ contract ZonePortalTest is BaseTest {
         portal.setZoneGateway(alice, true);
     }
 
+    function test_setZoneGateway_enablesAndDisablesZeroAddress() public {
+        vm.startPrank(admin);
+        portal.setZoneGateway(address(0), true);
+        assertTrue(portal.zoneGateway(address(0)));
+        portal.setZoneGateway(address(0), false);
+        vm.stopPrank();
+
+        assertFalse(portal.zoneGateway(address(0)));
+    }
+
     function test_setZoneGateway_revertsIfNotAdmin() public {
         vm.prank(alice);
         vm.expectRevert(IZonePortal.NotAdmin.selector);
@@ -667,10 +677,14 @@ contract ZonePortalTest is BaseTest {
         assertTrue(portal.allowedAccount(address(zoneGateway)));
     }
 
-    function test_setAllowedAccount_revertsForZeroAddress() public {
-        vm.prank(admin);
-        vm.expectRevert(IZonePortal.InvalidAllowedAccount.selector);
+    function test_setAllowedAccount_enablesAndDisablesZeroAddress() public {
+        vm.startPrank(admin);
         portal.setAllowedAccount(address(0), true);
+        assertTrue(portal.allowedAccount(address(0)));
+        portal.setAllowedAccount(address(0), false);
+        vm.stopPrank();
+
+        assertFalse(portal.allowedAccount(address(0)));
     }
 
     function test_setAllowedAccount_revertsIfNotAdmin() public {

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -237,8 +237,8 @@ A zone is created via `ZoneFactory.createZone(...)` on Tempo with the following 
 | Parameter | Description |
 |-----------|-------------|
 | `initialToken` | The first TIP-20 token to enable. The admin can enable additional tokens later. |
-| `allowedAccounts` | Non-empty, duplicate-free initial membership. Every member MUST be non-zero and MUST NOT be the messenger. The admin may later enable or disable members. Membership applies to deposit callers, Tempo refund recipients, and plain withdrawal destinations. |
-| `zoneGateways` | Non-empty, duplicate-free initial set of callback-only gateway contracts. Gateways MUST be non-zero and MUST NOT also be allowed accounts. The admin may later enable a replacement while retaining a legacy gateway during migration. |
+| `allowedAccounts` | Non-empty initial membership. Duplicate entries are accepted and have the same effect as one entry. Members MUST NOT be the messenger. Membership applies to deposit callers, Tempo refund recipients, and plain withdrawal destinations. |
+| `zoneGateways` | Non-empty initial set of callback-only gateway contracts. Duplicate entries are accepted and have the same effect as one entry. Gateways MUST NOT also be allowed accounts. The admin may later enable a replacement while retaining a legacy gateway during migration. |
 | `admin` | The address that holds the admin role for the zone (token enablement, deposit pause/resume). MUST NOT be the zero address. May be the same as `sequencer`. See [Access Control](#access-control). |
 | `sequencer` | The address that will operate the zone (block production, batch submission, withdrawal processing). |
 | `verifier` | The `IVerifier` contract used to validate batch proofs. |


### PR DESCRIPTION
Stack 2 of 2; based on #704.

Replays the closed-loop Zone changes on top of the mechanical recipient rename so naming and behavior changes are reviewable separately. It also:

- accepts duplicate and zero-address entries in initial membership arrays
- allows `setAllowedAccount` and `setZoneGateway` to enable or disable the zero address
- removes the obsolete zero-address caveat from the spec
- refreshes the bundled ZoneFactory/ZonePortal bytecode and final Portal storage layout

PR #696 and `codex/closed-loop-zone` are unchanged.