### PR TITLE
draft: disable portal canonical-factory check (zone-009 Moderato regenesis)

### DIFF
--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -153,7 +153,11 @@ contract ZonePortal is IZonePortal {
     )
         external
     {
-        if (msg.sender != ZONE_FACTORY_ADDRESS) revert NotFactory();
+        // DRAFT — DO NOT MERGE: the TIP-1091 canonical factory check is disabled so a
+        // freshly deployed ZoneFactory can initialize portals on chains where the
+        // protocol-managed factory at ZONE_FACTORY_ADDRESS does not exist yet
+        // (e.g. Moderato). Restore before merging.
+        // if (msg.sender != ZONE_FACTORY_ADDRESS) revert NotFactory();
         if (_initialized) revert AlreadyInitialized();
 
         _initialized = true;


### PR DESCRIPTION
DO NOT MERGE as-is.

The TIP-1091 protocol-managed ZoneFactory (`0x5aF2...0000`) does not exist on Moderato (no genesis alloc, no node precompile), so since #625 `ZonePortal.initialize` reverts `NotFactory` for any freshly deployed factory — zone creation is currently impossible on Moderato.

This draft comments out the `msg.sender` check so a fresh `ZoneFactory` can deploy + initialize portals there. Used only to build a one-off `tempo-zone-xtask` / `tempo-zone` image pair for the zone-009 regenesis (its portal predates the `processWithdrawal` ABI change, wedging withdrawals — see the `Withdrawal processing cycle failed` loop in the sequencer logs).

Once an L1 exposes the canonical factory (genesis-installed or via hardfork), zone regenesis goes through the normal path and this branch is obsolete.