### PR TITLE
Draft: verify recovery and reuse batch observations

### DIFF
--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -94,7 +94,7 @@ pub use event::{EnabledToken, L1PortalEvents, L1SequencerEvent};
 pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::{L1StateCache, PolicyCache, PolicyProvider};
-pub use subscriber::{L1Subscriber, L1SubscriberConfig};
+pub use subscriber::{L1Subscriber, L1SubscriberConfig, fetch_and_verify_receipts_for_header};
 
 pub(crate) use event::EnqueueOutcome;
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -700,7 +700,7 @@ impl L1Subscriber {
 
 /// Fetch receipts for the L1 header by block hash and verify they match the
 /// header's receipts root and logs bloom before returning them.
-async fn fetch_and_verify_receipts_for_header(
+pub async fn fetch_and_verify_receipts_for_header(
     provider: &impl Provider<TempoNetwork>,
     block: NumHash,
     expected_receipts_root: B256,
@@ -721,7 +721,7 @@ async fn fetch_and_verify_receipts_for_header(
     Ok(receipts)
 }
 
-pub(crate) fn verify_receipts(
+pub fn verify_receipts(
     block: NumHash,
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -14,12 +14,14 @@ workspace = true
 # tempo
 tempo-alloy.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
+zone-l1.workspace = true
 
 # reth
 reth-metrics.workspace = true
 
 # alloy
 alloy-consensus.workspace = true
+alloy-eips.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["ws"] }

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -38,8 +38,8 @@ use crate::{
     abi::{self, NO_QUEUE_INDEX, TempoState, ZoneInbox, ZoneOutbox, ZonePortal},
     rpc::rpc_connection_config,
     settlement::{
-        BatchAnchorConfig, BatchData, BatchSubmitter, ZoneBlockSnapshot, fetch_finalized_batch,
-        fetch_finalized_batch_boundaries, log_query_ranges,
+        BatchAnchorConfig, BatchData, BatchSubmitter, FinalizedBatchLog, ZoneBlockSnapshot,
+        fetch_finalized_batch_from_log, fetch_finalized_batch_logs,
     },
     withdrawals::SharedWithdrawalStore,
 };
@@ -302,13 +302,33 @@ impl ZoneMonitor {
                 latest_zone_block,
                 self.config.batch_interval_blocks,
             );
-            // Skip the eth_getLogs call when we'd submit anyway.
-            if !boundary_crossed && !self.has_pending_withdrawals(latest_zone_block).await {
+            let from = self.last_submitted_zone_block + 1;
+            let finalized_batches = match fetch_finalized_batch_logs(
+                &self.outbox,
+                from,
+                latest_zone_block,
+            )
+            .await
+            {
+                Ok(batches) => batches,
+                Err(error) => {
+                    warn!(from, to = latest_zone_block, %error, "Failed to fetch finalized batch boundaries");
+                    continue;
+                }
+            };
+
+            if finalized_batches.is_empty() {
                 continue;
             }
 
-            let from = self.last_submitted_zone_block + 1;
-            match self.process_block_range(from, latest_zone_block).await {
+            if !boundary_crossed && !Self::has_pending_withdrawals(&finalized_batches) {
+                continue;
+            }
+
+            match self
+                .process_block_range(from, latest_zone_block, finalized_batches)
+                .await
+            {
                 Ok(_) => {}
                 Err(e) => {
                     error!(from, to = latest_zone_block, error = %e, "Failed to process zone block range");
@@ -390,38 +410,10 @@ impl ZoneMonitor {
     /// Empty finalized batches still need to be submitted, but they are handled
     /// by the normal block-interval path. This signal only flushes user
     /// withdrawals early.
-    async fn has_pending_withdrawals(&self, latest_block: u64) -> bool {
-        let from = self.last_submitted_zone_block + 1;
-        for (chunk_from, chunk_to) in log_query_ranges(from, latest_block) {
-            match self
-                .outbox
-                .BatchFinalized_filter()
-                .from_block(chunk_from)
-                .to_block(chunk_to)
-                .query()
-                .await
-            {
-                Ok(events) => {
-                    if events
-                        .iter()
-                        .any(|(event, _)| !event.withdrawalQueueHash.is_zero())
-                    {
-                        return true;
-                    }
-                }
-                Err(e) => {
-                    warn!(
-                        from = chunk_from,
-                        to = chunk_to,
-                        error = %e,
-                        "Failed to check for finalized withdrawal batches"
-                    );
-                    return false;
-                }
-            }
-        }
-
-        false
+    fn has_pending_withdrawals(finalized_batches: &[FinalizedBatchLog]) -> bool {
+        finalized_batches
+            .iter()
+            .any(|batch| !batch.withdrawal_queue_hash.is_zero())
     }
 
     /// Process finalized batch boundaries in `[from, to]`.
@@ -430,26 +422,26 @@ impl ZoneMonitor {
     /// The monitor must walk those boundaries one at a time so the L2 outbox
     /// index and L1 portal index advance in lockstep.
     #[instrument(skip(self), fields(from, to))]
-    async fn process_block_range(&mut self, from: u64, to: u64) -> Result<bool> {
+    async fn process_block_range(
+        &mut self,
+        from: u64,
+        to: u64,
+        finalized_batches: Vec<FinalizedBatchLog>,
+    ) -> Result<bool> {
         let block_count = to - from + 1;
         info!(from, to, block_count, "Processing zone block range");
 
-        let boundaries = fetch_finalized_batch_boundaries(&self.outbox, from, to).await?;
-        if boundaries.is_empty() {
-            info!(from, to, "No finalized batch boundaries ready to submit");
-            return Ok(false);
-        }
-
         info!(
-            boundary_count = boundaries.len(),
+            boundary_count = finalized_batches.len(),
             from,
             to,
-            first_boundary = boundaries[0],
-            last_boundary = boundaries[boundaries.len() - 1],
+            first_boundary = finalized_batches[0].block_number,
+            last_boundary = finalized_batches[finalized_batches.len() - 1].block_number,
             "Submitting finalized zone batches"
         );
 
-        for (idx, boundary) in boundaries.into_iter().enumerate() {
+        for (idx, finalized_batch) in finalized_batches.into_iter().enumerate() {
+            let boundary = finalized_batch.block_number;
             if boundary <= self.last_submitted_zone_block {
                 continue;
             }
@@ -461,7 +453,8 @@ impl ZoneMonitor {
                 "Submitting finalized zone batch"
             );
             let before_submit = self.last_submitted_zone_block;
-            self.process_finalized_batch(range_start, boundary).await?;
+            self.process_finalized_batch(range_start, &finalized_batch)
+                .await?;
             if self.last_submitted_zone_block <= before_submit {
                 warn!(
                     before_submit,
@@ -477,8 +470,15 @@ impl ZoneMonitor {
     }
 
     /// Process one boundary-aligned finalized batch.
-    async fn process_finalized_batch(&mut self, from: u64, to: u64) -> Result<()> {
-        let finalized_batch = fetch_finalized_batch(&self.outbox, &self.provider, from, to).await?;
+    async fn process_finalized_batch(
+        &mut self,
+        from: u64,
+        finalized_batch_log: &FinalizedBatchLog,
+    ) -> Result<()> {
+        let to = finalized_batch_log.block_number;
+        let finalized_batch =
+            fetch_finalized_batch_from_log(&self.outbox, &self.provider, from, finalized_batch_log)
+                .await?;
         let end_state = self.fetch_block_snapshot(to).await?;
 
         let expected_l2_index = self
@@ -953,6 +953,26 @@ mod tests {
         assert!(!crossed_batch_boundary(50, 119, 120));
         // Zero interval means every block.
         assert!(crossed_batch_boundary(7, 8, 0));
+    }
+
+    #[test]
+    fn pending_withdrawals_are_derived_from_already_fetched_boundaries() {
+        let empty = FinalizedBatchLog {
+            block_number: 12,
+            tx_index: 0,
+            log_index: 0,
+            tx_hash: B256::ZERO,
+            withdrawal_queue_hash: B256::ZERO,
+            withdrawal_batch_index: 1,
+        };
+        let non_empty = FinalizedBatchLog {
+            block_number: 13,
+            withdrawal_queue_hash: B256::repeat_byte(1),
+            ..empty.clone()
+        };
+
+        assert!(!ZoneMonitor::has_pending_withdrawals(&[empty]));
+        assert!(ZoneMonitor::has_pending_withdrawals(&[non_empty]));
     }
 
     fn mock_provider(asserter: Asserter) -> DynProvider<TempoNetwork> {

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -49,6 +49,9 @@ const DEFAULT_EIP2935_HISTORY_WINDOW: u64 = 8192 - 1;
 /// the block falls out of the window between our check and on-chain execution.
 const DEFAULT_EIP2935_SAFETY_MARGIN: u64 = 360;
 
+/// Bound receipt-root verification requests during the rare recovery fallback.
+const WITHDRAWAL_RECOVERY_RECEIPT_CONCURRENCY: usize = 8;
+
 /// Maximum number of encoded L1 headers retained between ancestry submissions.
 ///
 /// At roughly 600 bytes per header, this caps payload storage near 150 MiB plus
@@ -749,23 +752,30 @@ impl BatchSubmitter {
         while hi >= self.genesis_tempo_block_number && found.len() < needed {
             let lo = backward_log_query_start(hi, self.genesis_tempo_block_number);
 
-            for block_number in (lo..=hi).rev() {
-                let block = self
-                    .l1_provider
-                    .get_block_by_number(block_number.into())
-                    .await?
-                    .ok_or_else(|| {
-                        eyre::eyre!("L1 block {block_number} not found during withdrawal recovery")
-                    })?;
-                let header = &block.header;
-                let receipts = zone_l1::fetch_and_verify_receipts_for_header(
-                    &self.l1_provider,
-                    NumHash::new(block_number, header.hash()),
-                    header.receipts_root(),
-                    header.logs_bloom(),
-                )
-                .await?;
+            let mut blocks = futures::stream::iter((lo..=hi).rev())
+                .map(|block_number| async move {
+                    let block = self
+                        .l1_provider
+                        .get_block_by_number(block_number.into())
+                        .await?
+                        .ok_or_else(|| {
+                            eyre::eyre!(
+                                "L1 block {block_number} not found during withdrawal recovery"
+                            )
+                        })?;
+                    let header = &block.header;
+                    let receipts = zone_l1::fetch_and_verify_receipts_for_header(
+                        &self.l1_provider,
+                        NumHash::new(block_number, header.hash()),
+                        header.receipts_root(),
+                        header.logs_bloom(),
+                    )
+                    .await?;
+                    Ok::<_, eyre::Report>(receipts)
+                })
+                .buffered(WITHDRAWAL_RECOVERY_RECEIPT_CONCURRENCY);
 
+            while let Some(receipts) = blocks.try_next().await? {
                 for receipt in receipts {
                     for log in receipt.logs() {
                         if log.address() != self.portal_address {

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -887,29 +887,29 @@ struct RequestedWithdrawalLog {
 }
 
 #[derive(Debug, Clone)]
-struct FinalizedBatchLog {
-    block_number: u64,
+pub(crate) struct FinalizedBatchLog {
+    pub(crate) block_number: u64,
     tx_index: u64,
     log_index: u64,
     tx_hash: B256,
-    withdrawal_queue_hash: B256,
-    withdrawal_batch_index: u64,
+    pub(crate) withdrawal_queue_hash: B256,
+    pub(crate) withdrawal_batch_index: u64,
 }
 
 /// Fetch all zone block numbers in `[from, to]` that finalized a withdrawal batch.
 ///
 /// This includes zero-withdrawal batches because they still advance the L2
 /// withdrawal batch index and therefore require a matching L1 `submitBatch`.
-pub(crate) async fn fetch_finalized_batch_boundaries(
+pub(crate) async fn fetch_finalized_batch_logs(
     outbox: &ZoneOutbox::ZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     from: u64,
     to: u64,
-) -> Result<Vec<u64>> {
+) -> Result<Vec<FinalizedBatchLog>> {
     if from > to {
         return Ok(Vec::new());
     }
 
-    let mut boundaries: Vec<_> = outbox
+    let mut finalized_batches: Vec<_> = outbox
         .BatchFinalized_filter()
         .from_block(from)
         .to_block(to)
@@ -919,12 +919,22 @@ pub(crate) async fn fetch_finalized_batch_boundaries(
         .query()
         .await?
         .into_iter()
-        .map(|(_, log)| log.block_number.unwrap_or(0))
-        .collect();
+        .map(|(event, log)| -> Result<_> {
+            Ok(FinalizedBatchLog {
+                block_number: log.block_number.unwrap_or(0),
+                tx_index: log.transaction_index.unwrap_or(0),
+                log_index: log.log_index.unwrap_or(0),
+                tx_hash: log
+                    .transaction_hash
+                    .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?,
+                withdrawal_queue_hash: event.withdrawalQueueHash,
+                withdrawal_batch_index: event.withdrawalBatchIndex,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
 
-    boundaries.sort_unstable();
-    boundaries.dedup();
-    Ok(boundaries)
+    finalized_batches.sort_by_key(|batch| (batch.block_number, batch.tx_index, batch.log_index));
+    Ok(finalized_batches)
 }
 
 /// Fetch one finalized L2 withdrawal batch for a range ending at `to`.
@@ -939,7 +949,7 @@ pub(crate) async fn fetch_finalized_batch(
     from: u64,
     to: u64,
 ) -> Result<FinalizedBatch> {
-    let mut finalized_batches = fetch_finalized_batch_logs(outbox, from, to).await?;
+    let finalized_batches = fetch_finalized_batch_logs(outbox, from, to).await?;
 
     if finalized_batches.is_empty() {
         return Err(eyre::eyre!(
@@ -947,7 +957,6 @@ pub(crate) async fn fetch_finalized_batch(
         ));
     }
 
-    finalized_batches.sort_by_key(|batch| (batch.block_number, batch.tx_index, batch.log_index));
     let target_position = finalized_batches
         .iter()
         .rposition(|batch| batch.block_number == to)
@@ -966,12 +975,31 @@ pub(crate) async fn fetch_finalized_batch(
         ));
     }
 
-    let target = finalized_batches[target_position].clone();
     let previous_boundary = finalized_batches[..target_position]
         .last()
         .map(|batch| batch.block_number)
         .unwrap_or(from.saturating_sub(1));
-    let request_from = previous_boundary.saturating_add(1);
+
+    fetch_finalized_batch_from_log(
+        outbox,
+        zone_provider,
+        previous_boundary.saturating_add(1),
+        &finalized_batches[target_position],
+    )
+    .await
+}
+
+/// Reconstruct a finalized withdrawal batch using a previously fetched
+/// `BatchFinalized` log. Callers processing one range can share that initial
+/// log query across both the early-flush check and every submission.
+pub(crate) async fn fetch_finalized_batch_from_log(
+    outbox: &ZoneOutbox::ZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
+    zone_provider: &DynProvider<TempoNetwork>,
+    from: u64,
+    target: &FinalizedBatchLog,
+) -> Result<FinalizedBatch> {
+    let to = target.block_number;
+    let request_from = from;
 
     let requests = if request_from <= to {
         fetch_requested_withdrawal_logs(outbox, request_from, to).await?
@@ -1075,38 +1103,6 @@ async fn fetch_requested_withdrawal_logs(
     requests.sort_by_key(|request| (request.block_number, request.tx_index, request.log_index));
 
     Ok(requests)
-}
-
-async fn fetch_finalized_batch_logs(
-    outbox: &ZoneOutbox::ZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
-    from: u64,
-    to: u64,
-) -> Result<Vec<FinalizedBatchLog>> {
-    let mut finalized_batches: Vec<_> = outbox
-        .BatchFinalized_filter()
-        .from_block(from)
-        .to_block(to)
-        .chunked()
-        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
-        .concurrent(2)
-        .query()
-        .await?
-        .into_iter()
-        .map(|(event, log)| -> Result<_> {
-            Ok(FinalizedBatchLog {
-                block_number: log.block_number.unwrap_or(0),
-                tx_index: log.transaction_index.unwrap_or(0),
-                log_index: log.log_index.unwrap_or(0),
-                tx_hash: log
-                    .transaction_hash
-                    .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?,
-                withdrawal_queue_hash: event.withdrawalQueueHash,
-                withdrawal_batch_index: event.withdrawalBatchIndex,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    finalized_batches.sort_by_key(|batch| (batch.block_number, batch.tx_index, batch.log_index));
-    Ok(finalized_batches)
 }
 
 /// Lazily split an inclusive block range into bounded query windows.

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -27,7 +27,8 @@ use std::collections::BTreeMap;
 
 use crate::abi::{self, BlockTransition, DepositQueueTransition, ZoneOutbox, ZonePortal};
 use alloy_consensus::Transaction;
-use alloy_network::ReceiptResponse;
+use alloy_eips::NumHash;
+use alloy_network::{ReceiptResponse, primitives::HeaderResponse as _};
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::{DynProvider, Provider};
 use alloy_rlp::Encodable;
@@ -723,10 +724,9 @@ impl BatchSubmitter {
     }
 
     /// Fetch `BatchSubmitted` events for logical queue indices `[first_index, tail)`
-    /// by walking L1 backwards in chunks while filtering by the indexed
-    /// `withdrawalQueueIndex` topic. Logical queue indices never repeat
-    /// (head/tail are non-wrapping counters), so the topic filter identifies
-    /// each batch exactly without positional counting.
+    /// from receipt-root-verified L1 blocks. We deliberately do not use
+    /// `eth_getLogs` here: the recovery result becomes input to local withdrawal
+    /// bookkeeping, so an RPC log response alone is not an adequate trust root.
     ///
     /// The caller passes `first_index = head - 1` so the predecessor batch is
     /// included (its `nextBlockHash` bounds the zone block range of the first
@@ -741,10 +741,7 @@ impl BatchSubmitter {
             return Ok(BTreeMap::new());
         }
 
-        let index_topics: Vec<B256> = (first_index..tail)
-            .map(|index| B256::from(U256::from(index)))
-            .collect();
-        let needed = index_topics.len();
+        let needed = (tail - first_index) as usize;
 
         let mut found = BTreeMap::new();
         let mut hi = self.l1_provider.get_block_number().await?;
@@ -752,21 +749,43 @@ impl BatchSubmitter {
         while hi >= self.genesis_tempo_block_number && found.len() < needed {
             let lo = backward_log_query_start(hi, self.genesis_tempo_block_number);
 
-            let events = self
-                .portal
-                .BatchSubmitted_filter()
-                .topic2(index_topics.clone())
-                .from_block(lo)
-                .to_block(hi)
-                .query()
+            for block_number in (lo..=hi).rev() {
+                let block = self
+                    .l1_provider
+                    .get_block_by_number(block_number.into())
+                    .await?
+                    .ok_or_else(|| {
+                        eyre::eyre!("L1 block {block_number} not found during withdrawal recovery")
+                    })?;
+                let header = &block.header;
+                let receipts = zone_l1::fetch_and_verify_receipts_for_header(
+                    &self.l1_provider,
+                    NumHash::new(block_number, header.hash()),
+                    header.receipts_root(),
+                    header.logs_bloom(),
+                )
                 .await?;
 
-            for (event, _) in events {
-                let index: u64 = event.withdrawalQueueIndex.try_into().map_err(|_| {
-                    eyre::eyre!("withdrawal queue index overflow in BatchSubmitted")
-                })?;
-                if found.insert(index, event).is_some() {
-                    eyre::bail!("duplicate BatchSubmitted event for portal queue index {index}");
+                for receipt in receipts {
+                    for log in receipt.logs() {
+                        if log.address() != self.portal_address {
+                            continue;
+                        }
+                        let Ok(event) = ZonePortal::BatchSubmitted::decode_log(&log.inner) else {
+                            continue;
+                        };
+                        let index: u64 = event.withdrawalQueueIndex.try_into().map_err(|_| {
+                            eyre::eyre!("withdrawal queue index overflow in BatchSubmitted")
+                        })?;
+                        if !(first_index..tail).contains(&index) {
+                            continue;
+                        }
+                        if found.insert(index, event).is_some() {
+                            eyre::bail!(
+                                "duplicate BatchSubmitted event for portal queue index {index}"
+                            );
+                        }
+                    }
                 }
             }
 

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -618,6 +618,53 @@ impl WithdrawalProcessor {
             return SubmitOutcome::Reverted;
         }
 
+        if receipt.transaction_hash() != tx_hash {
+            self.metrics.withdrawals_failed_total.increment(1);
+            error!(
+                slot,
+                index,
+                expected_tx_hash = %tx_hash,
+                receipt_tx_hash = %receipt.transaction_hash(),
+                "processWithdrawal receipt does not belong to the submitted transaction"
+            );
+            return SubmitOutcome::Unconfirmed;
+        }
+
+        // A successful receipt alone is not sufficient to remove local work: a
+        // faulty RPC could report success for an unrelated transaction. Confirm
+        // the Portal queue made the exact state transition requested by this call.
+        let (queue_head, slot_hash) = match tokio::try_join!(
+            self.portal.withdrawalQueueHead().call(),
+            self.portal
+                .withdrawalQueueSlot(U256::from(slot % WITHDRAWAL_QUEUE_CAPACITY))
+                .call(),
+        ) {
+            Ok(values) => values,
+            Err(error) => {
+                error!(slot, index, %tx_hash, %error, "failed to reconcile Portal withdrawal queue after receipt");
+                self.metrics.withdrawals_failed_total.increment(1);
+                return SubmitOutcome::Unconfirmed;
+            }
+        };
+        let queue_transition_matches = if remaining_queue == B256::ZERO {
+            queue_head > U256::from(slot)
+        } else {
+            queue_head == U256::from(slot) && slot_hash == remaining_queue
+        };
+        if !queue_transition_matches {
+            self.metrics.withdrawals_failed_total.increment(1);
+            error!(
+                slot,
+                index,
+                %tx_hash,
+                %queue_head,
+                %slot_hash,
+                expected_remaining_queue = %remaining_queue,
+                "Portal withdrawal queue did not reflect the submitted withdrawal"
+            );
+            return SubmitOutcome::Unconfirmed;
+        }
+
         self.metrics.withdrawals_confirmed_total.increment(1);
         info!(
             slot,


### PR DESCRIPTION
## Summary

- recover `BatchSubmitted` observations only from receipt-root- and logs-bloom-verified L1 receipts, not raw `eth_getLogs`
- bound the secure recovery fallback to eight concurrent header/receipt fetches
- fetch `BatchFinalized` logs once per monitor range and reuse them for the early-withdrawal decision and submission loop

## Remaining work

- A durable subscriber-backed `BatchSubmitted` index is still needed to remove the historical recovery scan entirely. This draft establishes the verified observation path and removes the repeated steady-state query without adding a new persistence layer.

## Verification

- `cargo +nightly fmt --all --check`
- `cargo check -p tempo-zone-sequencer` *(blocked before compilation: pinned Commonware Git dependency returns HTTP 401)*

Prompted by: @0xalpharush