### PR TITLE
Draft: persist verified batch observations

### DIFF
--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -54,6 +54,7 @@ k256.workspace = true
 metrics.workspace = true
 parking_lot.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url = "2"
@@ -61,4 +62,3 @@ url = "2"
 [dev-dependencies]
 alloy-rlp.workspace = true
 const-hex.workspace = true
-serde_json.workspace = true

--- a/crates/l1/src/batch_index.rs
+++ b/crates/l1/src/batch_index.rs
@@ -1,0 +1,195 @@
+//! Durable observations of receipt-root-verified `BatchSubmitted` events.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use alloy_eips::NumHash;
+use alloy_primitives::{B256, U256};
+use parking_lot::Mutex;
+
+use crate::abi::ZonePortal;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BatchSubmissionObservation {
+    pub withdrawal_batch_index: u64,
+    pub withdrawal_queue_index: u64,
+    pub next_processed_deposit_queue_hash: B256,
+    pub next_block_hash: B256,
+    pub withdrawal_queue_hash: B256,
+    pub last_processed_deposit_number: u64,
+}
+
+impl TryFrom<ZonePortal::BatchSubmitted> for BatchSubmissionObservation {
+    type Error = eyre::Report;
+    fn try_from(event: ZonePortal::BatchSubmitted) -> Result<Self, Self::Error> {
+        Ok(Self {
+            withdrawal_batch_index: event.withdrawalBatchIndex,
+            withdrawal_queue_index: event
+                .withdrawalQueueIndex
+                .try_into()
+                .map_err(|_| eyre::eyre!("withdrawal queue index overflow in BatchSubmitted"))?,
+            next_processed_deposit_queue_hash: event.nextProcessedDepositQueueHash,
+            next_block_hash: event.nextBlockHash,
+            withdrawal_queue_hash: event.withdrawalQueueHash,
+            last_processed_deposit_number: event.lastProcessedDepositNumber,
+        })
+    }
+}
+
+impl From<BatchSubmissionObservation> for ZonePortal::BatchSubmitted {
+    fn from(event: BatchSubmissionObservation) -> Self {
+        Self {
+            withdrawalBatchIndex: event.withdrawal_batch_index,
+            withdrawalQueueIndex: U256::from(event.withdrawal_queue_index),
+            nextProcessedDepositQueueHash: event.next_processed_deposit_queue_hash,
+            nextBlockHash: event.next_block_hash,
+            withdrawalQueueHash: event.withdrawal_queue_hash,
+            lastProcessedDepositNumber: event.last_processed_deposit_number,
+        }
+    }
+}
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct PersistedIndex {
+    blocks: BTreeMap<u64, PersistedBlock>,
+}
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct PersistedBlock {
+    hash: B256,
+    observations: Vec<BatchSubmissionObservation>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BatchSubmissionIndex {
+    path: Option<Arc<PathBuf>>,
+    inner: Arc<Mutex<PersistedIndex>>,
+}
+
+impl Default for BatchSubmissionIndex {
+    fn default() -> Self {
+        Self::in_memory()
+    }
+}
+
+impl BatchSubmissionIndex {
+    pub fn in_memory() -> Self {
+        Self {
+            path: None,
+            inner: Arc::default(),
+        }
+    }
+    pub fn open(path: impl Into<PathBuf>) -> eyre::Result<Self> {
+        let path = path.into();
+        let inner = if path.exists() {
+            serde_json::from_slice(&fs::read(&path)?)?
+        } else {
+            PersistedIndex::default()
+        };
+        Ok(Self {
+            path: Some(Arc::new(path)),
+            inner: Arc::new(Mutex::new(inner)),
+        })
+    }
+    /// Replaces a block's observations and discards observations on a losing fork.
+    pub fn record_block(
+        &self,
+        block: NumHash,
+        observations: Vec<BatchSubmissionObservation>,
+    ) -> eyre::Result<()> {
+        let mut inner = self.inner.lock();
+        if inner
+            .blocks
+            .get(&block.number)
+            .is_some_and(|current| current.hash == block.hash)
+        {
+            return Ok(());
+        }
+        inner.blocks.split_off(&block.number);
+        inner.blocks.insert(
+            block.number,
+            PersistedBlock {
+                hash: block.hash,
+                observations,
+            },
+        );
+        self.persist(&inner)
+    }
+    pub fn events(&self, first_index: u64, tail: u64) -> BTreeMap<u64, ZonePortal::BatchSubmitted> {
+        self.inner
+            .lock()
+            .blocks
+            .values()
+            .flat_map(|block| block.observations.iter().cloned())
+            .filter(|event| (first_index..tail).contains(&event.withdrawal_queue_index))
+            .map(|event| (event.withdrawal_queue_index, event.into()))
+            .collect()
+    }
+    fn persist(&self, index: &PersistedIndex) -> eyre::Result<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        write_atomically(path, &serde_json::to_vec(index)?)
+    }
+}
+
+fn write_atomically(path: &Path, bytes: &[u8]) -> eyre::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| eyre::eyre!("batch index path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let temporary = path.with_extension("tmp");
+    let mut file = fs::File::create(&temporary)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    fs::rename(temporary, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn observation(index: u64) -> BatchSubmissionObservation {
+        BatchSubmissionObservation {
+            withdrawal_batch_index: index,
+            withdrawal_queue_index: index,
+            next_processed_deposit_queue_hash: B256::repeat_byte(index as u8),
+            next_block_hash: B256::repeat_byte(index as u8),
+            withdrawal_queue_hash: B256::repeat_byte(index as u8),
+            last_processed_deposit_number: index,
+        }
+    }
+
+    #[test]
+    fn replaces_observations_on_a_reorged_height() {
+        let index = BatchSubmissionIndex::in_memory();
+        index
+            .record_block(
+                NumHash::new(10, B256::repeat_byte(10)),
+                vec![observation(1)],
+            )
+            .unwrap();
+        index
+            .record_block(
+                NumHash::new(11, B256::repeat_byte(11)),
+                vec![observation(2)],
+            )
+            .unwrap();
+        index
+            .record_block(
+                NumHash::new(11, B256::repeat_byte(12)),
+                vec![observation(3)],
+            )
+            .unwrap();
+
+        let events = index.events(1, 4);
+        assert!(events.contains_key(&1));
+        assert!(!events.contains_key(&2));
+        assert!(events.contains_key(&3));
+    }
+}

--- a/crates/l1/src/event.rs
+++ b/crates/l1/src/event.rs
@@ -36,6 +36,8 @@ pub struct L1PortalEvents {
     pub enabled_tokens: Vec<EnabledToken>,
     /// Sequencer transfer events in the order they appeared in the block.
     pub sequencer_events: Vec<L1SequencerEvent>,
+    /// Receipt-root-verified batch settlements in this block.
+    pub batch_submissions: Vec<crate::BatchSubmissionObservation>,
 }
 
 /// A token newly enabled for bridging, with metadata for L2 creation.
@@ -65,13 +67,14 @@ impl EnabledToken {
 
 impl L1PortalEvents {
     /// Event signature hashes that this container knows how to decode.
-    const SIGNATURE_HASHES: [B256; 6] = [
+    const SIGNATURE_HASHES: [B256; 7] = [
         DepositMade::SIGNATURE_HASH,
         EncryptedDepositMade::SIGNATURE_HASH,
         WithdrawalBounceBack::SIGNATURE_HASH,
         TokenEnabled::SIGNATURE_HASH,
         SequencerTransferStarted::SIGNATURE_HASH,
         SequencerTransferred::SIGNATURE_HASH,
+        crate::abi::ZonePortal::BatchSubmitted::SIGNATURE_HASH,
     ];
 
     /// Create portal events from deposits only.
@@ -173,6 +176,9 @@ impl L1PortalEvents {
                     previous_sequencer: event.previousSequencer,
                     new_sequencer: event.newSequencer,
                 });
+            }
+            ZonePortalEvents::BatchSubmitted(event) => {
+                self.batch_submissions.push(event.try_into()?);
             }
             _ => {}
         }

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -79,6 +79,7 @@ use crate::{
     state::{cache::L1StateCacheInner, tip403::PolicyEvent},
 };
 
+mod batch_index;
 mod block;
 mod deposit;
 mod event;
@@ -88,6 +89,7 @@ mod subscriber;
 #[cfg(test)]
 mod tests;
 
+pub use batch_index::{BatchSubmissionIndex, BatchSubmissionObservation};
 pub use block::{L1BlockDeposits, PreparedL1Block};
 pub use deposit::{Deposit, EncryptedDeposit, L1Deposit};
 pub use event::{EnabledToken, L1PortalEvents, L1SequencerEvent};

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -26,6 +26,8 @@ pub struct L1SubscriberConfig {
     pub l1_fetch_concurrency: usize,
     /// Interval between WebSocket reconnection attempts.
     pub retry_connection_interval: std::time::Duration,
+    /// Receipt-root-verified settlements retained for sequencer restart recovery.
+    pub batch_submission_index: crate::BatchSubmissionIndex,
 }
 
 pub(crate) trait LocalTempoCheckpointReader: Send + Sync {
@@ -405,6 +407,9 @@ impl L1Subscriber {
             self.update_l1_state_anchor(block_number, sealed.hash(), sealed.parent_hash());
             self.apply_policy_events(block_number, &policy_events);
             self.apply_portal_state_events(block_number, &events);
+            self.config
+                .batch_submission_index
+                .record_block(sealed.num_hash(), events.batch_submissions.clone())?;
             self.deposit_queue
                 .enqueue_sealed(sealed, events, policy_events);
             enqueued += 1;
@@ -497,6 +502,10 @@ impl L1Subscriber {
                     self.update_l1_state_anchor(tip_number, tip_hash, tip_parent);
                     self.apply_policy_events(tip_number, &tip_policy_events);
                     self.apply_portal_state_events(tip_number, &tip_events);
+                    self.config.batch_submission_index.record_block(
+                        tip_header.num_hash(),
+                        tip_events.batch_submissions.clone(),
+                    )?;
                     match self
                         .deposit_queue
                         .try_enqueue(tip_header, tip_events, tip_policy_events)

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -151,6 +151,7 @@ fn test_subscriber(
             l1_state_cache: crate::L1StateCache::new(HashSet::from([portal_address])),
             l1_fetch_concurrency: 1,
             retry_connection_interval: Duration::from_secs(1),
+            batch_submission_index: BatchSubmissionIndex::default(),
         },
         local_state,
         deposit_queue: DepositQueue::default(),

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -10,6 +10,7 @@ use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
 use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
 use zone_evm::ZoneEvmConfig;
+use zone_l1::BatchSubmissionIndex;
 use zone_p2p::{P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
 
@@ -156,6 +157,13 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             args.l1_fetch_concurrency,
             Duration::from_millis(args.l1_retry_connection_interval_ms),
         )
+        .with_batch_submission_index(BatchSubmissionIndex::open(
+            builder
+                .config()
+                .datadir()
+                .data_dir()
+                .join("batch-submissions.json"),
+        )?)
         .with_withdrawal_batch_interval_blocks(args.zone_batch_interval_blocks)
         .with_private_rpc(ZonePrivateRpcConfig {
             private_rpc_port: args.private_rpc_port,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -62,7 +62,8 @@ use tracing::{debug, info, warn};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
-    DepositQueue, L1Subscriber, L1SubscriberConfig, PolicyCache, TempoStateExt,
+    BatchSubmissionIndex, DepositQueue, L1Subscriber, L1SubscriberConfig, PolicyCache,
+    TempoStateExt,
     state::{
         L1StateCache, L1StateProvider, L1StateProviderConfig, PolicyProvider,
         spawn_policy_resolution_task, spawn_pool_prefetch_task,
@@ -216,6 +217,7 @@ impl ZoneNode {
             l1_state_cache: l1_state_cache.clone(),
             l1_fetch_concurrency,
             retry_connection_interval,
+            batch_submission_index: BatchSubmissionIndex::default(),
         };
 
         let l1_state_provider_config = L1StateProviderConfig {
@@ -239,6 +241,12 @@ impl ZoneNode {
             sequencer_config: None,
             p2p_config: None,
         }
+    }
+
+    /// Use a durable, receipt-root-verified batch-submission observation index.
+    pub fn with_batch_submission_index(mut self, index: BatchSubmissionIndex) -> Self {
+        self.l1_config.batch_submission_index = index;
+        self
     }
 
     /// Set the private RPC configuration.
@@ -522,6 +530,7 @@ where
                 self.l1_config.l1_rpc_url,
                 self.l1_config.portal_address,
                 self.l1_config.retry_connection_interval,
+                self.l1_config.batch_submission_index.clone(),
                 sequencer_addr,
                 chain_id,
             )
@@ -790,6 +799,7 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
+        batch_submission_index: BatchSubmissionIndex,
         sequencer_addr: Address,
         chain_id: u64,
     ) -> eyre::Result<()> {
@@ -824,6 +834,7 @@ where
             zone_poll_interval: config.zone_poll_interval,
             batch_interval_blocks: config.batch_interval_blocks,
             batch_anchor_config: config.batch_anchor_config,
+            batch_submission_index,
         };
         let seq_handle = spawn_zone_sequencer(sequencer_config, config.sequencer_signer).await;
         info!(target: "reth::cli", "Sequencer tasks spawned");

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -2560,6 +2560,7 @@ pub(crate) async fn spawn_sequencer_with_anchor_config(
         zone_poll_interval: Duration::from_millis(500),
         batch_interval_blocks: 1,
         batch_anchor_config,
+        batch_submission_index: zone_l1::BatchSubmissionIndex::default(),
     };
 
     zone_sequencer::spawn_zone_sequencer(config, sequencer_signer).await

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -11,6 +11,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_transport::TransportResult;
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 use tokio::sync::Notify;
+use zone_l1::BatchSubmissionIndex;
 
 pub mod abi {
     pub use tempo_zone_contracts::*;
@@ -56,6 +57,8 @@ pub struct ZoneSequencerConfig {
     pub batch_interval_blocks: u64,
     /// EIP-2935 history and safety-margin limits used by the batch submitter.
     pub batch_anchor_config: BatchAnchorConfig,
+    /// Receipt-root-verified settlements retained by the L1 subscriber.
+    pub batch_submission_index: BatchSubmissionIndex,
 }
 
 /// Handles returned by [`spawn_zone_sequencer`] for managing background tasks.
@@ -109,6 +112,7 @@ pub async fn spawn_zone_sequencer(
         batch_interval_blocks: config.batch_interval_blocks,
         portal_address: config.portal_address,
         batch_anchor_config: config.batch_anchor_config,
+        batch_submission_index: config.batch_submission_index,
     };
 
     let withdrawal_handle = withdrawals::spawn_withdrawal_processor(

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -31,6 +31,7 @@ use eyre::{Result, WrapErr};
 use tempo_alloy::TempoNetwork;
 use tokio::sync::Notify;
 use tracing::{error, info, instrument, warn};
+use zone_l1::BatchSubmissionIndex;
 
 use alloy_sol_types::{ContractError, SolInterface as _};
 
@@ -83,6 +84,8 @@ pub struct ZoneMonitorConfig {
     pub portal_address: Address,
     /// EIP-2935 history and safety-margin limits used by the batch submitter.
     pub batch_anchor_config: BatchAnchorConfig,
+    /// Receipt-root-verified L1 batch observations for restart recovery.
+    pub batch_submission_index: BatchSubmissionIndex,
 }
 
 /// Monitors the Zone L2 chain for new finalized batch boundaries and submits
@@ -197,7 +200,8 @@ impl ZoneMonitor {
             l1_provider,
             genesis_tempo_block_number,
             config.batch_anchor_config,
-        );
+        )
+        .with_batch_submission_index(config.batch_submission_index.clone());
 
         let prev_zone_block_hash = batch_submitter
             .read_portal_block_hash()
@@ -1018,6 +1022,7 @@ mod tests {
             batch_interval_blocks: 1,
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
+            batch_submission_index: BatchSubmissionIndex::default(),
         };
         let zone_provider = mock_provider(zone);
         let l1_provider = mock_provider(l1);
@@ -1056,6 +1061,7 @@ mod tests {
             batch_interval_blocks: 1,
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
+            batch_submission_index: BatchSubmissionIndex::default(),
         };
 
         l1.push_failure_msg("boom");

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -39,6 +39,7 @@ use parking_lot::RwLock;
 use schnellru::{ByLength, LruMap};
 use tempo_alloy::{TempoNetwork, rpc::TempoCallBuilderExt};
 use tracing::{info, instrument, warn};
+use zone_l1::BatchSubmissionIndex;
 
 use crate::nonce_keys::SUBMIT_BATCH_NONCE_KEY;
 
@@ -186,6 +187,7 @@ pub struct BatchSubmitter {
     /// requests. Settlement batches are submitted in order, so later requests
     /// can reuse almost the entire preceding range.
     ancestry_header_cache: RwLock<LruMap<u64, CachedAncestryHeader>>,
+    batch_submission_index: BatchSubmissionIndex,
 }
 
 /// One validated L1 header retained for ancestry proof construction.
@@ -231,7 +233,13 @@ impl BatchSubmitter {
             ancestry_header_cache: RwLock::new(LruMap::new(ByLength::new(
                 DEFAULT_ANCESTRY_HEADER_CACHE_CAPACITY,
             ))),
+            batch_submission_index: BatchSubmissionIndex::default(),
         }
+    }
+
+    pub fn with_batch_submission_index(mut self, index: BatchSubmissionIndex) -> Self {
+        self.batch_submission_index = index;
+        self
     }
 
     /// Submit a batch to the ZonePortal on Tempo L1.
@@ -655,9 +663,16 @@ impl BatchSubmitter {
 
         // Step 2: query BatchSubmitted events for pending slots [head, tail)
         // plus the predecessor (head-1) by their indexed withdrawalQueueIndex.
-        let events = self
-            .find_batch_events_by_index(head.saturating_sub(1), tail)
-            .await?;
+        let first_index = head.saturating_sub(1);
+        let indexed_events = self.batch_submission_index.events(first_index, tail);
+        let events = if indexed_events.len() == (tail - first_index) as usize {
+            indexed_events
+        } else {
+            // A fresh index has no historical observations yet. Keep the
+            // receipt-root-verified scan from the previous recovery path as a
+            // one-time backfill rather than trusting raw `eth_getLogs`.
+            self.find_batch_events_by_index(first_index, tail).await?
+        };
 
         // Step 3: resolve each L1 event's nextBlockHash to a zone L2 block number.
         // Maps portal_slot → last zone L2 block in that batch.


### PR DESCRIPTION
## Summary
- persist receipt-root-verified `BatchSubmitted` observations under the Zone node datadir
- use the local index for withdrawal restart recovery; retain the verified receipt scan as a cold-index fallback
- discard indexed observations at and after a replaced L1 height

## Verification
- `cargo +nightly fmt --all --check`
- `git diff --check`
- `cargo check -p zone-l1 -p zone-sequencer -p zone-node` is blocked before compilation because the pinned Commonware Git dependency returns HTTP 401

## Benchmark
- Not run: this is stacked on #711 and the available benchmark environment is currently blocked by the local chain failing to advance.

Prompted by: @0xalpharush