### PR TITLE
feat(xtask): support the native ZoneFactory precompile in create-zone

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -78,10 +78,18 @@ use zone_sequencer::{BatchAnchorConfig, ZoneSequencerConfig, spawn_zone_sequence
 /// Returns a known Tempo chain spec for an L1 chain ID.
 ///
 /// Tempo Anvil uses chain ID 31337 and the same hardfork schedule as Tempo DEV (1337).
+///
+/// Additional dev-schedule L1 chain IDs (devnets that activate all Tempo
+/// hardforks at genesis) can be allowed via the `ZONE_L1_DEV_CHAIN_IDS`
+/// environment variable as a comma-separated list.
 fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
     chainspec_from_chain_id(chain_id).or_else(|| match chain_id {
         1337 | 31337 => Some(DEV.clone()),
-        _ => None,
+        _ => std::env::var("ZONE_L1_DEV_CHAIN_IDS")
+            .ok()?
+            .split(',')
+            .any(|id| id.trim().parse() == Ok(chain_id))
+            .then(|| DEV.clone()),
     })
 }
 
@@ -1170,6 +1178,13 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(1337).unwrap().chain().id(), 1337);
         assert_eq!(tempo_chain_spec_for_l1(31337).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
+
+        // SAFETY: test-only env mutation; no other test reads this variable.
+        unsafe { std::env::set_var("ZONE_L1_DEV_CHAIN_IDS", "31318, 31319") };
+        assert_eq!(tempo_chain_spec_for_l1(31318).unwrap().chain().id(), 1337);
+        assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
+        assert!(tempo_chain_spec_for_l1(999_999).is_none());
+        unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
     }
 
     #[test]

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -52,7 +52,28 @@ sol! {
         function messenger() external view returns (address);
         function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
     }
+
+    /// `createZone` params of the native ZoneFactory precompile (TIP-1091).
+    /// Unlike the reference Solidity factory, the precompile has no `verifier`
+    /// field: the verifier and messenger are protocol constants.
+    struct NativeCreateZoneParams {
+        address initialToken;
+        address admin;
+        address sequencer;
+        ZoneParams zoneParams;
+        string rpcUrl;
+    }
+
+    #[sol(rpc)]
+    contract NativeZoneFactory {
+        function createZone(NativeCreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
+    }
 }
+
+/// Verifier protocol constant baked into the native ZoneFactory precompile.
+const NATIVE_ZONE_VERIFIER: Address = address!("0x5A56000000000000000000000000000000000000");
+/// Messenger protocol constant baked into the native ZoneFactory precompile.
+const NATIVE_ZONE_MESSENGER: Address = address!("0x5A4D000000000000000000000000000000000000");
 
 #[derive(Debug, clap::Parser)]
 pub(crate) struct CreateZone {
@@ -118,10 +139,27 @@ impl CreateZone {
             .await?;
 
         let factory = ZoneFactory::new(self.zone_factory, &provider);
-        println!("Fetching verifier address from ZoneFactory...");
-        let verifier = Address::from(factory.verifier().call().await?.0);
+
+        // The native ZoneFactory precompile (TIP-1091) has no bytecode and no
+        // verifier()/messenger() getters: both are protocol constants.
+        let native = provider
+            .get_code_at(self.zone_factory)
+            .await
+            .wrap_err("failed fetching ZoneFactory code")?
+            .is_empty();
+        let (verifier, messenger) = if native {
+            println!(
+                "ZoneFactory at {} has no bytecode; using native precompile interface",
+                self.zone_factory
+            );
+            (NATIVE_ZONE_VERIFIER, NATIVE_ZONE_MESSENGER)
+        } else {
+            println!("Fetching verifier address from ZoneFactory...");
+            let verifier = Address::from(factory.verifier().call().await?.0);
+            let messenger = Address::from(factory.messenger().call().await?.0);
+            (verifier, messenger)
+        };
         println!("Verifier: {verifier}");
-        let messenger = Address::from(factory.messenger().call().await?.0);
         println!("Messenger: {messenger}");
 
         // Anchor before createZone so the zone replays the creation block and its
@@ -140,24 +178,37 @@ impl CreateZone {
         println!("Admin: {}", self.admin);
         println!("Sequencer: {}", self.sequencer);
 
-        let params = CreateZoneParams {
-            initialToken: self.initial_token,
-            admin: self.admin,
-            sequencer: self.sequencer,
-            verifier,
-            zoneParams: ZoneParams {
-                genesisBlockHash: B256::ZERO,
-                genesisTempoBlockHash: anchor_hash,
-                genesisTempoBlockNumber: anchor_block_number,
-            },
-            rpcUrl: self.rpc_url.clone(),
+        let zone_params = ZoneParams {
+            genesisBlockHash: B256::ZERO,
+            genesisTempoBlockHash: anchor_hash,
+            genesisTempoBlockNumber: anchor_block_number,
         };
 
         println!(
             "Creating zone on L1 via ZoneFactory at {}...",
             self.zone_factory
         );
-        let receipt = factory.createZone(params).send_sync().await?;
+        let receipt = if native {
+            let native_factory = NativeZoneFactory::new(self.zone_factory, &provider);
+            let params = NativeCreateZoneParams {
+                initialToken: self.initial_token,
+                admin: self.admin,
+                sequencer: self.sequencer,
+                zoneParams: zone_params,
+                rpcUrl: self.rpc_url.clone(),
+            };
+            native_factory.createZone(params).send_sync().await?
+        } else {
+            let params = CreateZoneParams {
+                initialToken: self.initial_token,
+                admin: self.admin,
+                sequencer: self.sequencer,
+                verifier,
+                zoneParams: zone_params,
+                rpcUrl: self.rpc_url.clone(),
+            };
+            factory.createZone(params).send_sync().await?
+        };
         println!("Transaction confirmed in block {:?}", receipt.block_number);
         println!("Status: {}", receipt.status());
         println!("Gas used: {:?}", receipt.gas_used);

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -140,13 +140,14 @@ impl CreateZone {
 
         let factory = ZoneFactory::new(self.zone_factory, &provider);
 
-        // The native ZoneFactory precompile (TIP-1091) has no bytecode and no
+        // The native ZoneFactory precompile (TIP-1091) has no real bytecode
+        // (only the 0xef stub Tempo places at precompile addresses) and no
         // verifier()/messenger() getters: both are protocol constants.
-        let native = provider
+        let factory_code = provider
             .get_code_at(self.zone_factory)
             .await
-            .wrap_err("failed fetching ZoneFactory code")?
-            .is_empty();
+            .wrap_err("failed fetching ZoneFactory code")?;
+        let native = factory_code.is_empty() || factory_code.as_ref() == [0xef];
         let (verifier, messenger) = if native {
             println!(
                 "ZoneFactory at {} has no bytecode; using native precompile interface",


### PR DESCRIPTION
The `zone-factory-hf` devnet runs the TIP-1091 native ZoneFactory precompile at `0x5aF2000000000000000000000000000000000000`. It has no bytecode, no `verifier()`/`messenger()` getters (calling them reverts `UnknownFunctionSelector`), and its `createZone` takes `CreateZoneParams` **without** the `verifier` field — verifier (`0x5A56...`) and messenger (`0x5A4D...`) are protocol constants.

`tempo-xtask create-zone` now detects the native factory by the absence of bytecode at the factory address and switches to the precompile ABI. The reference Solidity factory path is unchanged, and the `ZoneCreated` event is identical in both variants so receipt decoding is shared.

Found while pointing the `zone-regenesis` Argo workflow at the zone-factory-hf devnet:

```
Fetching verifier address from ZoneFactory...
Error: failed to create zone
Caused by: server returned an error response: error code 3: execution reverted,
data: "0xaa4bc69a2b7ac3f3..."  # UnknownFunctionSelector(verifier())
```