### PR TITLE
feat(sequencer): batch withdrawal processing

### DIFF
--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -115,7 +115,7 @@ header chain linking back to the target block.
 3. At batch finalization, withdrawals are hashed into a chain and submitted to
    L1 as part of the batch proof.
 4. The `WithdrawalProcessor` polls the L1 portal queue and calls
-   `processWithdrawals` for each pending withdrawal.
+   gas-bounded `processWithdrawals` batches using ordered, concurrently in-flight transactions.
 
 ## TIP-403 Policy Enforcement
 

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -115,7 +115,7 @@ header chain linking back to the target block.
 3. At batch finalization, withdrawals are hashed into a chain and submitted to
    L1 as part of the batch proof.
 4. The `WithdrawalProcessor` polls the L1 portal queue and calls
-   gas-bounded `processWithdrawals` batches using ordered, concurrently in-flight transactions.
+   gas-bounded `processWithdrawals` batches through an ordered, bounded in-flight queue.
 
 ## TIP-403 Policy Enforcement
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -368,11 +368,13 @@ pub struct ZoneArgs {
     )]
     pub withdrawal_poll_interval_secs: u64,
 
-    /// Maximum gas reserved by one processWithdrawals transaction.
+    /// Maximum gas reserved by one processWithdrawals transaction. An oversized withdrawal is
+    /// submitted alone.
     #[arg(
         long = "withdrawal-max-batch-gas",
         env = "WITHDRAWAL_MAX_BATCH_GAS",
-        default_value_t = DEFAULT_MAX_WITHDRAWAL_BATCH_GAS
+        default_value_t = DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
+        value_parser = clap::value_parser!(u64).range(1..)
     )]
     pub withdrawal_max_batch_gas: u64,
 
@@ -380,15 +382,18 @@ pub struct ZoneArgs {
     #[arg(
         long = "withdrawal-max-in-flight-batches",
         env = "WITHDRAWAL_MAX_IN_FLIGHT_BATCHES",
-        default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES
+        default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES,
+        value_parser = clap::value_parser!(usize).range(1..)
     )]
     pub withdrawal_max_in_flight_batches: usize,
 
-    /// Maximum aggregate gas reserved across in-flight processWithdrawals transactions.
+    /// Maximum aggregate gas reserved across in-flight processWithdrawals transactions. Must be
+    /// at least withdrawal-max-batch-gas. An oversized withdrawal is submitted alone.
     #[arg(
         long = "withdrawal-max-in-flight-gas",
         env = "WITHDRAWAL_MAX_IN_FLIGHT_GAS",
-        default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS
+        default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS,
+        value_parser = clap::value_parser!(u64).range(1..)
     )]
     pub withdrawal_max_in_flight_gas: u64,
 
@@ -683,46 +688,6 @@ mod tests {
         .unwrap();
         assert!(parsed.zone.enable_sequencer);
         assert!(parsed.zone.sequencer_manifest.is_none());
-    }
-
-    #[test]
-    fn withdrawal_batch_limits_have_defaults_and_cli_overrides() {
-        let common = [
-            "tempo-zone",
-            "--l1.rpc-url",
-            "ws://localhost:8546",
-            "--l1.portal-address",
-            "0x0000000000000000000000000000000000000001",
-            "--sequencer-key",
-            "0x01",
-        ];
-        let defaults = ZoneArgsParser::try_parse_from(common).unwrap().zone;
-        assert_eq!(
-            defaults.withdrawal_max_batch_gas,
-            zone_sequencer::DEFAULT_MAX_WITHDRAWAL_BATCH_GAS
-        );
-        assert_eq!(
-            defaults.withdrawal_max_in_flight_batches,
-            zone_sequencer::DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES
-        );
-        assert_eq!(
-            defaults.withdrawal_max_in_flight_gas,
-            zone_sequencer::DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS
-        );
-
-        let configured = ZoneArgsParser::try_parse_from(common.into_iter().chain([
-            "--withdrawal-max-batch-gas",
-            "7000000",
-            "--withdrawal-max-in-flight-batches",
-            "3",
-            "--withdrawal-max-in-flight-gas",
-            "15000000",
-        ]))
-        .unwrap()
-        .zone;
-        assert_eq!(configured.withdrawal_max_batch_gas, 7_000_000);
-        assert_eq!(configured.withdrawal_max_in_flight_batches, 3);
-        assert_eq!(configured.withdrawal_max_in_flight_gas, 15_000_000);
     }
 
     #[test]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -19,8 +19,8 @@ use crate::{
     rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 use zone_sequencer::{
-    BatchAnchorConfig, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES,
-    DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS, WithdrawalBatchLimits,
+    BatchAnchorConfig, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
+    WithdrawalBatchLimits,
 };
 
 const MAX_LOGS_PER_RESPONSE: u64 = 1_000_000;
@@ -191,7 +191,6 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 withdrawal_batch_limits: WithdrawalBatchLimits {
                     max_batch_gas: args.withdrawal_max_batch_gas,
                     max_in_flight_batches: args.withdrawal_max_in_flight_batches,
-                    max_in_flight_gas: args.withdrawal_max_in_flight_gas,
                 },
             });
         }
@@ -386,16 +385,6 @@ pub struct ZoneArgs {
         value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
     )]
     pub withdrawal_max_in_flight_batches: usize,
-
-    /// Maximum aggregate gas reserved across in-flight processWithdrawals transactions. Must be
-    /// at least withdrawal-max-batch-gas. An oversized withdrawal is submitted alone.
-    #[arg(
-        long = "withdrawal-max-in-flight-gas",
-        env = "WITHDRAWAL_MAX_IN_FLIGHT_GAS",
-        default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS,
-        value_parser = clap::value_parser!(u64).range(1..)
-    )]
-    pub withdrawal_max_in_flight_gas: u64,
 
     /// Genesis Tempo L1 block number override.
     #[arg(long = "l1.genesis-block-number", env = "L1_GENESIS_BLOCK_NUMBER")]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -383,7 +383,7 @@ pub struct ZoneArgs {
         long = "withdrawal-max-in-flight-batches",
         env = "WITHDRAWAL_MAX_IN_FLIGHT_BATCHES",
         default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES,
-        value_parser = clap::value_parser!(usize).range(1..)
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
     )]
     pub withdrawal_max_in_flight_batches: usize,
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -18,7 +18,10 @@ use crate::{
     ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig, dev::DevCommand,
     rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
-use zone_sequencer::BatchAnchorConfig;
+use zone_sequencer::{
+    BatchAnchorConfig, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES,
+    DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS, WithdrawalBatchLimits,
+};
 
 const MAX_LOGS_PER_RESPONSE: u64 = 1_000_000;
 const MAX_BLOCKS_PER_FILTER: u64 = 1_000_000;
@@ -185,6 +188,11 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 batch_interval_blocks: args.zone_batch_interval_blocks,
                 batch_anchor_config: BatchAnchorConfig::default(),
                 withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
+                withdrawal_batch_limits: WithdrawalBatchLimits {
+                    max_batch_gas: args.withdrawal_max_batch_gas,
+                    max_in_flight_batches: args.withdrawal_max_in_flight_batches,
+                    max_in_flight_gas: args.withdrawal_max_in_flight_gas,
+                },
             });
         }
         if manifest_role == Some(Role::Follower) {
@@ -359,6 +367,30 @@ pub struct ZoneArgs {
         default_value_t = 5
     )]
     pub withdrawal_poll_interval_secs: u64,
+
+    /// Maximum gas reserved by one processWithdrawals transaction.
+    #[arg(
+        long = "withdrawal-max-batch-gas",
+        env = "WITHDRAWAL_MAX_BATCH_GAS",
+        default_value_t = DEFAULT_MAX_WITHDRAWAL_BATCH_GAS
+    )]
+    pub withdrawal_max_batch_gas: u64,
+
+    /// Maximum number of ordered processWithdrawals transactions kept in flight.
+    #[arg(
+        long = "withdrawal-max-in-flight-batches",
+        env = "WITHDRAWAL_MAX_IN_FLIGHT_BATCHES",
+        default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES
+    )]
+    pub withdrawal_max_in_flight_batches: usize,
+
+    /// Maximum aggregate gas reserved across in-flight processWithdrawals transactions.
+    #[arg(
+        long = "withdrawal-max-in-flight-gas",
+        env = "WITHDRAWAL_MAX_IN_FLIGHT_GAS",
+        default_value_t = DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS
+    )]
+    pub withdrawal_max_in_flight_gas: u64,
 
     /// Genesis Tempo L1 block number override.
     #[arg(long = "l1.genesis-block-number", env = "L1_GENESIS_BLOCK_NUMBER")]
@@ -651,6 +683,46 @@ mod tests {
         .unwrap();
         assert!(parsed.zone.enable_sequencer);
         assert!(parsed.zone.sequencer_manifest.is_none());
+    }
+
+    #[test]
+    fn withdrawal_batch_limits_have_defaults_and_cli_overrides() {
+        let common = [
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sequencer-key",
+            "0x01",
+        ];
+        let defaults = ZoneArgsParser::try_parse_from(common).unwrap().zone;
+        assert_eq!(
+            defaults.withdrawal_max_batch_gas,
+            zone_sequencer::DEFAULT_MAX_WITHDRAWAL_BATCH_GAS
+        );
+        assert_eq!(
+            defaults.withdrawal_max_in_flight_batches,
+            zone_sequencer::DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES
+        );
+        assert_eq!(
+            defaults.withdrawal_max_in_flight_gas,
+            zone_sequencer::DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS
+        );
+
+        let configured = ZoneArgsParser::try_parse_from(common.into_iter().chain([
+            "--withdrawal-max-batch-gas",
+            "7000000",
+            "--withdrawal-max-in-flight-batches",
+            "3",
+            "--withdrawal-max-in-flight-gas",
+            "15000000",
+        ]))
+        .unwrap()
+        .zone;
+        assert_eq!(configured.withdrawal_max_batch_gas, 7_000_000);
+        assert_eq!(configured.withdrawal_max_in_flight_batches, 3);
+        assert_eq!(configured.withdrawal_max_in_flight_gas, 15_000_000);
     }
 
     #[test]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use zone_sequencer::{
     BatchAnchorConfig, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
-    WithdrawalBatchLimits,
+    MAX_WITHDRAWAL_BATCH_GAS, WithdrawalBatchLimits,
 };
 
 const MAX_LOGS_PER_RESPONSE: u64 = 1_000_000;
@@ -367,13 +367,14 @@ pub struct ZoneArgs {
     )]
     pub withdrawal_poll_interval_secs: u64,
 
-    /// Maximum gas reserved by one processWithdrawals transaction. An oversized withdrawal is
-    /// submitted alone.
+    /// Maximum gas reserved by one processWithdrawals transaction, up to 20,000,000. An oversized
+    /// withdrawal is submitted alone.
     #[arg(
         long = "withdrawal-max-batch-gas",
         env = "WITHDRAWAL_MAX_BATCH_GAS",
         default_value_t = DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
-        value_parser = clap::value_parser!(u64).range(1..)
+        value_parser = clap::builder::RangedU64ValueParser::<u64>::new()
+            .range(1..=MAX_WITHDRAWAL_BATCH_GAS)
     )]
     pub withdrawal_max_batch_gas: u64,
 
@@ -483,6 +484,7 @@ mod tests {
         validate_portal_address,
     };
     use zone_p2p::Role;
+    use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
     #[derive(Debug, clap::Parser)]
     struct ZoneArgsParser {
@@ -677,6 +679,24 @@ mod tests {
         .unwrap();
         assert!(parsed.zone.enable_sequencer);
         assert!(parsed.zone.sequencer_manifest.is_none());
+    }
+
+    #[test]
+    fn withdrawal_batch_gas_rejects_values_above_the_safe_limit() {
+        let above_limit = (MAX_WITHDRAWAL_BATCH_GAS + 1).to_string();
+        let error = ZoneArgsParser::try_parse_from([
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sequencer-key",
+            "0x01",
+            "--withdrawal-max-batch-gas",
+            &above_limit,
+        ])
+        .unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -67,7 +67,9 @@ use zone_payload::{
     DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, WithdrawalRevealEncryptor, ZonePayloadAttributes,
     ZonePayloadFactory, ZonePayloadTypes,
 };
-use zone_sequencer::{BatchAnchorConfig, ZoneSequencerConfig, spawn_zone_sequencer};
+use zone_sequencer::{
+    BatchAnchorConfig, WithdrawalBatchLimits, ZoneSequencerConfig, spawn_zone_sequencer,
+};
 
 /// Returns a known Tempo chain spec for an L1 chain ID.
 ///
@@ -152,6 +154,8 @@ pub struct ZoneSequencerAddOnsConfig {
     pub batch_anchor_config: BatchAnchorConfig,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: Duration,
+    /// Gas and concurrency limits for withdrawal processing transactions.
+    pub withdrawal_batch_limits: WithdrawalBatchLimits,
 }
 
 /// Configuration for the Zone private RPC server extension.
@@ -710,6 +714,7 @@ where
             l1_rpc_url,
             retry_connection_interval,
             withdrawal_poll_interval: config.withdrawal_poll_interval,
+            withdrawal_batch_limits: config.withdrawal_batch_limits,
             outbox_address: ZONE_OUTBOX_ADDRESS,
             inbox_address: ZONE_INBOX_ADDRESS,
             tempo_state_address: TEMPO_STATE_ADDRESS,

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -6,15 +6,22 @@
 
 use crate::utils::{
     EncryptedRouterCallbackArgs, L1TestNode, PlaintextRouterCallbackArgs, STABLECOIN_DEX_ADDRESS,
-    WithdrawalArgs, ZoneAccount, ZoneTestNode, spawn_sequencer,
+    WithdrawalArgs, ZoneAccount, ZoneTestNode, poll_until, spawn_sequencer,
+    spawn_sequencer_with_config,
 };
 use alloy::{
     primitives::{Address, B256, U256},
     providers::Provider,
+    sol_types::SolCall,
 };
-use std::time::Duration;
+use alloy_consensus::Transaction;
+use futures::future::try_join_all;
+use std::{collections::HashMap, time::Duration};
 use tempo_precompiles::PATH_USD_ADDRESS;
-use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, TempoState, ZONE_TOKEN_ADDRESS};
+use tempo_zone_contracts::{
+    IZoneOutbox, TEMPO_STATE_ADDRESS, TempoState, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS,
+    ZonePortal,
+};
 use zone_node::dev::{ProvisionConfig, provision_zone};
 
 /// Longer timeout for real L1 tests — the L1 dev node produces blocks every
@@ -274,6 +281,219 @@ async fn test_deposit_via_real_l1() -> eyre::Result<()> {
         l2_balance_after <= U256::from(deposit_amount - withdrawal_amount),
         "L2 balance should decrease by at least the withdrawal amount (got {l2_balance_after})"
     );
+
+    Ok(())
+}
+
+/// Deposit to enough independent accounts to force several gas-bounded withdrawal transactions,
+/// then submit the accounts concurrently, including repeated withdrawals from half of them.
+///
+/// The processed events prove that withdrawals were both packed together and drained through
+/// more transactions than the configured in-flight window can hold at once.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_many_concurrent_withdrawals_are_batched() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    const ACCOUNT_COUNT: u32 = 64;
+    const REPEATED_ACCOUNT_COUNT: usize = ACCOUNT_COUNT as usize / 2;
+    const WITHDRAWALS_PER_REPEATED_ACCOUNT: usize = 3;
+    const WITHDRAWAL_COUNT: usize =
+        ACCOUNT_COUNT as usize + REPEATED_ACCOUNT_COUNT * (WITHDRAWALS_PER_REPEATED_ACCOUNT - 1);
+    const MAX_WITHDRAWALS_PER_BATCH: usize = 2;
+    const TEST_MAX_BATCH_GAS: u64 = 2_500_000;
+    const TEST_MAX_IN_FLIGHT_BATCHES: usize = 4;
+    const FIRST_ACCOUNT_INDEX: u32 = 3;
+    const DEPOSIT_AMOUNT: u128 = 2_000_000;
+    const WITHDRAWAL_AMOUNT: u128 = 250_000;
+    const WITHDRAWAL_TIMEOUT: Duration = Duration::from_secs(120);
+
+    let l1 = L1TestNode::start().await?;
+    let portal_address = l1.deploy_zone().await?;
+    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
+    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+
+    let signers = (FIRST_ACCOUNT_INDEX..FIRST_ACCOUNT_INDEX + ACCOUNT_COUNT)
+        .map(|index| l1.signer_at(index))
+        .collect::<Vec<_>>();
+    let recipients = signers
+        .iter()
+        .map(|signer| signer.address())
+        .collect::<Vec<_>>();
+
+    let admin_provider = l1.admin_provider();
+    let admin_portal = ZonePortal::new(portal_address, &admin_provider);
+    // Closed-loop portals only accept deposits to and deliver withdrawals to registered accounts.
+    for recipient in &recipients {
+        let receipt = admin_portal
+            .setAllowedAccount(*recipient, true)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(receipt.status(), "allowing withdrawal recipient failed");
+    }
+
+    // A single funded depositor keeps L1 setup deterministic while still exercising deposits to
+    // many distinct zone accounts.
+    let mut depositor = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
+    let total_deposit = DEPOSIT_AMOUNT * u128::from(ACCOUNT_COUNT);
+    l1.fund_user(depositor.address(), total_deposit * 2).await?;
+    for recipient in &recipients {
+        depositor
+            .deposit_to(*recipient, DEPOSIT_AMOUNT, L1_TIMEOUT, &zone)
+            .await?;
+    }
+
+    let mut accounts = signers
+        .into_iter()
+        .map(|signer| ZoneAccount::with_signer(signer, &l1, &zone, portal_address))
+        .collect::<Vec<_>>();
+    // Start the sequencer only after L1 setup so its shared signer cannot race the funding and
+    // deposit transactions.
+    let sequencer = spawn_sequencer_with_config(
+        &l1,
+        &zone,
+        portal_address,
+        l1.dev_signer(),
+        zone_sequencer::BatchAnchorConfig::default(),
+        zone_sequencer::WithdrawalBatchLimits {
+            max_batch_gas: TEST_MAX_BATCH_GAS,
+            max_in_flight_batches: TEST_MAX_IN_FLIGHT_BATCHES,
+        },
+    )
+    .await;
+    let withdrawal_start_block = l1.provider().get_block_number().await?;
+
+    try_join_all(
+        accounts
+            .iter_mut()
+            .enumerate()
+            .map(|(index, account)| async move {
+                let count = if index < REPEATED_ACCOUNT_COUNT {
+                    WITHDRAWALS_PER_REPEATED_ACCOUNT
+                } else {
+                    1
+                };
+                for _ in 0..count {
+                    account.withdraw(WITHDRAWAL_AMOUNT).await?;
+                }
+                Ok::<(), eyre::Report>(())
+            }),
+    )
+    .await?;
+
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    let processed = poll_until(
+        WITHDRAWAL_TIMEOUT,
+        Duration::from_millis(250),
+        "all concurrent withdrawals to be processed on L1",
+        || {
+            let portal = &portal;
+            let sequencer = &sequencer;
+            async move {
+                eyre::ensure!(
+                    !sequencer.monitor_handle.is_finished(),
+                    "zone monitor exited while processing concurrent withdrawals"
+                );
+                eyre::ensure!(
+                    !sequencer.withdrawal_handle.is_finished(),
+                    "withdrawal processor exited while processing concurrent withdrawals"
+                );
+
+                let events = portal
+                    .WithdrawalProcessed_filter()
+                    .from_block(withdrawal_start_block)
+                    .query()
+                    .await?;
+                if events.len() < WITHDRAWAL_COUNT {
+                    return Ok(None);
+                }
+
+                Ok(Some(events))
+            }
+        },
+    )
+    .await?;
+
+    assert_eq!(
+        processed.len(),
+        WITHDRAWAL_COUNT,
+        "each requested withdrawal should be processed exactly once"
+    );
+
+    let mut withdrawals_per_recipient = HashMap::with_capacity(ACCOUNT_COUNT as usize);
+    let mut withdrawals_per_transaction = HashMap::new();
+
+    for (event, log) in processed {
+        assert_eq!(event.token, PATH_USD_ADDRESS);
+        assert_eq!(event.amount, WITHDRAWAL_AMOUNT);
+        assert!(event.callbackSuccess, "simple withdrawal should succeed");
+        *withdrawals_per_recipient.entry(event.to).or_insert(0usize) += 1;
+
+        let tx_hash = log
+            .transaction_hash
+            .ok_or_else(|| eyre::eyre!("WithdrawalProcessed log missing transaction hash"))?;
+        *withdrawals_per_transaction.entry(tx_hash).or_insert(0usize) += 1;
+    }
+
+    for (index, recipient) in recipients.iter().enumerate() {
+        let expected = if index < REPEATED_ACCOUNT_COUNT {
+            WITHDRAWALS_PER_REPEATED_ACCOUNT
+        } else {
+            1
+        };
+        assert_eq!(withdrawals_per_recipient.get(recipient), Some(&expected));
+    }
+
+    let zone_provider = zone.provider();
+    let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &zone_provider);
+    let finalized_batches = outbox.BatchFinalized_filter().from_block(0).query().await?;
+    let mut slot_sizes = Vec::new();
+    for (_, log) in finalized_batches {
+        let tx_hash = log
+            .transaction_hash
+            .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?;
+        let tx = zone_provider
+            .get_transaction_by_hash(tx_hash)
+            .await?
+            .ok_or_else(|| eyre::eyre!("finalizeWithdrawalBatch tx {tx_hash} not found"))?;
+        let call = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(tx.input().as_ref())?;
+        slot_sizes.push(call.count.to::<usize>());
+    }
+    assert_eq!(
+        slot_sizes.iter().sum::<usize>(),
+        WITHDRAWAL_COUNT,
+        "finalized slots should contain every requested withdrawal"
+    );
+    let largest_slot = slot_sizes.iter().copied().max().unwrap_or_default();
+    assert!(
+        largest_slot.div_ceil(MAX_WITHDRAWALS_PER_BATCH) > TEST_MAX_IN_FLIGHT_BATCHES,
+        "at least one queue slot must require refilling the in-flight window"
+    );
+
+    assert!(
+        withdrawals_per_transaction.values().any(|count| *count > 1),
+        "at least one processWithdrawals transaction should contain multiple withdrawals"
+    );
+    assert!(
+        withdrawals_per_transaction
+            .values()
+            .all(|count| *count <= MAX_WITHDRAWALS_PER_BATCH),
+        "the configured gas limit should cap each transaction at two withdrawals"
+    );
+    let expected_transaction_count = slot_sizes
+        .iter()
+        .map(|count| count.div_ceil(MAX_WITHDRAWALS_PER_BATCH))
+        .sum::<usize>();
+    assert_eq!(
+        withdrawals_per_transaction.len(),
+        expected_transaction_count,
+        "every finalized slot should be split into gas-bounded transactions"
+    );
+    let head_call = portal.withdrawalQueueHead();
+    let tail_call = portal.withdrawalQueueTail();
+    let (head, tail) = tokio::try_join!(head_call.call(), tail_call.call())?;
+    assert_eq!(head, tail, "withdrawal queue should be fully drained");
 
     Ok(())
 }

--- a/crates/node/tests/it/stepping_e2e.rs
+++ b/crates/node/tests/it/stepping_e2e.rs
@@ -6,7 +6,7 @@
 //! ancestry path instead of the simpler direct-mode case.
 
 use crate::utils::{
-    L1TestNode, ZoneTestNode, poll_until, spawn_sequencer, spawn_sequencer_with_anchor_config,
+    L1TestNode, ZoneTestNode, poll_until, spawn_sequencer, spawn_sequencer_with_config,
 };
 use alloy::providers::Provider;
 use alloy_sol_types::SolCall;
@@ -273,12 +273,13 @@ async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<(
         l1_tip.saturating_sub(first_step_tempo),
     );
 
-    let seq = spawn_sequencer_with_anchor_config(
+    let seq = spawn_sequencer_with_config(
         &l1,
         &zone,
         portal_address,
         l1.dev_signer(),
         anchor_config,
+        zone_sequencer::WithdrawalBatchLimits::default(),
     )
     .await;
 
@@ -379,12 +380,13 @@ async fn test_configured_short_l1_gap_submits_multiple_batch_boundaries() -> eyr
     );
 
     // Start the sequencer only after the backlog has accumulated.
-    let seq = spawn_sequencer_with_anchor_config(
+    let seq = spawn_sequencer_with_config(
         &l1,
         &zone,
         portal_address,
         l1.dev_signer(),
         anchor_config,
+        zone_sequencer::WithdrawalBatchLimits::default(),
     )
     .await;
 
@@ -513,12 +515,13 @@ async fn test_boundary_ancestry_submission_uses_recent_anchor() -> eyre::Result<
         l1_tip.saturating_sub(first_step_tempo),
     );
 
-    let seq = spawn_sequencer_with_anchor_config(
+    let seq = spawn_sequencer_with_config(
         &l1,
         &zone,
         portal_address,
         l1.dev_signer(),
         anchor_config,
+        zone_sequencer::WithdrawalBatchLimits::default(),
     )
     .await;
 

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -2641,23 +2641,25 @@ pub(crate) async fn spawn_sequencer(
     portal_address: Address,
     sequencer_signer: alloy_signer_local::PrivateKeySigner,
 ) -> zone_sequencer::ZoneSequencerHandle {
-    spawn_sequencer_with_anchor_config(
+    spawn_sequencer_with_config(
         l1,
         zone,
         portal_address,
         sequencer_signer,
         zone_sequencer::BatchAnchorConfig::default(),
+        zone_sequencer::WithdrawalBatchLimits::default(),
     )
     .await
 }
 
-/// Spawn the zone sequencer background tasks with custom EIP-2935 anchor limits.
-pub(crate) async fn spawn_sequencer_with_anchor_config(
+/// Spawn the zone sequencer background tasks with custom limits.
+pub(crate) async fn spawn_sequencer_with_config(
     l1: &L1TestNode,
     zone: &ZoneTestNode,
     portal_address: Address,
     sequencer_signer: alloy_signer_local::PrivateKeySigner,
     batch_anchor_config: zone_sequencer::BatchAnchorConfig,
+    withdrawal_batch_limits: zone_sequencer::WithdrawalBatchLimits,
 ) -> zone_sequencer::ZoneSequencerHandle {
     use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
@@ -2666,7 +2668,7 @@ pub(crate) async fn spawn_sequencer_with_anchor_config(
         l1_rpc_url: l1.http_url().to_string(),
         retry_connection_interval: Duration::from_millis(100),
         withdrawal_poll_interval: Duration::from_millis(500),
-        withdrawal_batch_limits: zone_sequencer::WithdrawalBatchLimits::default(),
+        withdrawal_batch_limits,
         outbox_address: ZONE_OUTBOX_ADDRESS,
         inbox_address: ZONE_INBOX_ADDRESS,
         tempo_state_address: TEMPO_STATE_ADDRESS,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -2666,6 +2666,7 @@ pub(crate) async fn spawn_sequencer_with_anchor_config(
         l1_rpc_url: l1.http_url().to_string(),
         retry_connection_interval: Duration::from_millis(100),
         withdrawal_poll_interval: Duration::from_millis(500),
+        withdrawal_batch_limits: zone_sequencer::WithdrawalBatchLimits::default(),
         outbox_address: ZONE_OUTBOX_ADDRESS,
         inbox_address: ZONE_INBOX_ADDRESS,
         tempo_state_address: TEMPO_STATE_ADDRESS,

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -28,9 +28,8 @@ pub use encryption_key::register_encryption_key;
 pub use monitor::{ZoneMonitorConfig, spawn_zone_monitor};
 pub use settlement::{BatchAnchorConfig, BatchData, BatchSubmitter};
 pub use withdrawals::{
-    DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS,
-    DEFAULT_MAX_WITHDRAWAL_BATCH_GAS, SharedWithdrawalStore, WithdrawalBatchLimits,
-    WithdrawalProcessorConfig, WithdrawalStore,
+    DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
+    SharedWithdrawalStore, WithdrawalBatchLimits, WithdrawalProcessorConfig, WithdrawalStore,
 };
 
 use crate::rpc::rpc_connection_config;

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -27,7 +27,11 @@ pub mod withdrawals;
 pub use encryption_key::register_encryption_key;
 pub use monitor::{ZoneMonitorConfig, spawn_zone_monitor};
 pub use settlement::{BatchAnchorConfig, BatchData, BatchSubmitter};
-pub use withdrawals::{SharedWithdrawalStore, WithdrawalProcessorConfig, WithdrawalStore};
+pub use withdrawals::{
+    DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS,
+    DEFAULT_MAX_WITHDRAWAL_BATCH_GAS, PlannedWithdrawalBatch, SharedWithdrawalStore,
+    WithdrawalBatchLimits, WithdrawalBatchPlanner, WithdrawalProcessorConfig, WithdrawalStore,
+};
 
 use crate::rpc::rpc_connection_config;
 
@@ -42,6 +46,8 @@ pub struct ZoneSequencerConfig {
     pub retry_connection_interval: Duration,
     /// How often the withdrawal processor polls the L1 queue.
     pub withdrawal_poll_interval: Duration,
+    /// Gas and concurrency limits for withdrawal processing transactions.
+    pub withdrawal_batch_limits: WithdrawalBatchLimits,
     /// ZoneOutbox contract address on Zone L2.
     pub outbox_address: Address,
     /// ZoneInbox contract address on Zone L2.
@@ -81,6 +87,7 @@ pub async fn spawn_zone_sequencer(
     config: ZoneSequencerConfig,
     signer: PrivateKeySigner,
 ) -> ZoneSequencerHandle {
+    let sequencer_address = signer.address();
     // Build a single shared L1 provider with the sequencer wallet.
     // Both the batch submitter (inside the zone monitor) and the withdrawal
     // processor use this provider, ensuring nonces are tracked in one place.
@@ -100,6 +107,8 @@ pub async fn spawn_zone_sequencer(
         portal_address: config.portal_address,
         l1_rpc_url: config.l1_rpc_url.clone(),
         fallback_poll_interval: config.withdrawal_poll_interval,
+        sequencer_address,
+        batch_limits: config.withdrawal_batch_limits,
     };
 
     let monitor_config = ZoneMonitorConfig {

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -29,8 +29,8 @@ pub use monitor::{ZoneMonitorConfig, spawn_zone_monitor};
 pub use settlement::{BatchAnchorConfig, BatchData, BatchSubmitter};
 pub use withdrawals::{
     DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS,
-    DEFAULT_MAX_WITHDRAWAL_BATCH_GAS, PlannedWithdrawalBatch, SharedWithdrawalStore,
-    WithdrawalBatchLimits, WithdrawalBatchPlanner, WithdrawalProcessorConfig, WithdrawalStore,
+    DEFAULT_MAX_WITHDRAWAL_BATCH_GAS, SharedWithdrawalStore, WithdrawalBatchLimits,
+    WithdrawalProcessorConfig, WithdrawalStore,
 };
 
 use crate::rpc::rpc_connection_config;

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -29,7 +29,8 @@ pub use monitor::{ZoneMonitorConfig, spawn_zone_monitor};
 pub use settlement::{BatchAnchorConfig, BatchData, BatchSubmitter};
 pub use withdrawals::{
     DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
-    SharedWithdrawalStore, WithdrawalBatchLimits, WithdrawalProcessorConfig, WithdrawalStore,
+    MAX_WITHDRAWAL_BATCH_GAS, SharedWithdrawalStore, WithdrawalBatchLimits,
+    WithdrawalProcessorConfig, WithdrawalStore,
 };
 
 use crate::rpc::rpc_connection_config;

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -24,8 +24,17 @@ pub(crate) struct WithdrawalProcessorMetrics {
     /// Number of `processWithdrawals` attempts started.
     pub(crate) withdrawals_processed_total: Counter,
 
+    /// Number of gas-bounded `processWithdrawals` transactions broadcast.
+    pub(crate) batches_submitted_total: Counter,
+
+    /// Number of withdrawals packed into each `processWithdrawals` transaction.
+    pub(crate) withdrawals_per_batch: Histogram,
+
     /// Number of withdrawals confirmed on L1.
     pub(crate) withdrawals_confirmed_total: Counter,
+
+    /// Number of `processWithdrawals` transactions confirmed on L1.
+    pub(crate) batches_confirmed_total: Counter,
 
     /// Number of withdrawals that failed to send, confirm, or reverted after inclusion.
     pub(crate) withdrawals_failed_total: Counter,

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -21,11 +21,8 @@ pub(crate) struct WithdrawalProcessorMetrics {
     /// Number of withdrawal batches currently stored in memory.
     pub(crate) store_batch_count: Gauge,
 
-    /// Number of `processWithdrawals` attempts started.
+    /// Number of withdrawals submitted in `processWithdrawals` transactions.
     pub(crate) withdrawals_processed_total: Counter,
-
-    /// Number of gas-bounded `processWithdrawals` transactions broadcast.
-    pub(crate) batches_submitted_total: Counter,
 
     /// Number of withdrawals packed into each `processWithdrawals` transaction.
     pub(crate) withdrawals_per_batch: Histogram,
@@ -39,7 +36,7 @@ pub(crate) struct WithdrawalProcessorMetrics {
     /// Number of withdrawals that failed to send, confirm, or reverted after inclusion.
     pub(crate) withdrawals_failed_total: Counter,
 
-    /// Number of `processWithdrawals` transactions that were included on L1 but reverted.
+    /// Number of withdrawals in `processWithdrawals` transactions that reverted on L1.
     pub(crate) withdrawals_reverted_total: Counter,
 
     /// Time spent processing a withdrawal queue slot.

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -49,17 +49,44 @@ use crate::{
 use tempo_alloy::rpc::TempoCallBuilderExt;
 
 const PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
-const PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS: u64 = 100_000;
-const PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS: u64 = 2_000_000;
 
-/// Default gas budget for one `processWithdrawals` transaction.
+// These planner allowances were calibrated against the current ZonePortal/ZoneMessenger bytecode.
+// Pre-refund T1 dev-L1 traces used 553,703, 1,068,088, and 1,348,063 gas for one, two, and four
+// successful simple items, and 1,347,339 gas around a callback. T3 Foundry traces used 1,026,857
+// gas for a failed simple transfer with a bounceback and at most 1,030,017 for deposit bouncebacks.
+// Re-run the traces when the contracts or Tempo gas accounting change.
+
+/// Planner-only gas reserved once per `processWithdrawals` transaction for batch-level portal
+/// work.
+const PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS: u64 = 500_000;
+
+/// Planner-only gas reserved for a simple withdrawal.
+const PROCESS_SIMPLE_WITHDRAWAL_ITEM_OVERHEAD_GAS: u64 = 1_000_000;
+
+/// Planner-only fixed allowance for a callback withdrawal, excluding its forwarded callback gas.
+const PROCESS_CALLBACK_WITHDRAWAL_ITEM_OVERHEAD_GAS: u64 = 1_750_000;
+
+/// Planner-only gas reserved for a failed-deposit bounceback withdrawal.
+const PROCESS_DEPOSIT_BOUNCEBACK_ITEM_OVERHEAD_GAS: u64 = 1_250_000;
+
+/// Default planned gas budget for one `processWithdrawals` transaction.
+///
+/// This is an operator-side batching limit, not the protocol callback cap. The planner charges the
+/// allowances above against this budget. It currently has the same numeric value as
+/// [`MAX_WITHDRAWAL_GAS_LIMIT`]; a single withdrawal may exceed the budget so it cannot block the
+/// queue.
 pub const DEFAULT_MAX_WITHDRAWAL_BATCH_GAS: u64 = 10_000_000;
 
+/// Largest supported planned gas budget for one `processWithdrawals` transaction.
+///
+/// Tempo L1 currently caps transaction gas at 30,000,000. Packed batches cannot exceed this
+/// 20,000,000 budget. Oversized singletons bypass the budget, but the protocol callback cap keeps
+/// their maximum planned gas at 12,250,000. Both remain below the L1 limit, avoiding repeated
+/// submission of a transaction that can never be mined.
+pub const MAX_WITHDRAWAL_BATCH_GAS: u64 = 20_000_000;
+
 /// Default maximum number of ordered withdrawal transactions kept in flight.
-pub const DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES: usize = 4;
-#[cfg(test)]
-const MAX_PROCESS_WITHDRAWAL_TX_GAS: u64 =
-    PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT);
+pub const DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES: usize = 8;
 
 /// Shared handle to the withdrawal store.
 #[derive(Clone)]
@@ -109,6 +136,10 @@ pub struct WithdrawalBatchLimits {
 impl WithdrawalBatchLimits {
     fn assert_valid(self) {
         assert!(self.max_batch_gas > 0, "max_batch_gas must be non-zero");
+        assert!(
+            self.max_batch_gas <= MAX_WITHDRAWAL_BATCH_GAS,
+            "max_batch_gas must not exceed {MAX_WITHDRAWAL_BATCH_GAS}"
+        );
         assert!(
             self.max_in_flight_batches > 0,
             "max_in_flight_batches must be non-zero"
@@ -729,17 +760,26 @@ pub fn spawn_withdrawal_processor(
 
 /// Return the gas reserved for one withdrawal inside a `processWithdrawals` transaction.
 ///
-/// The callback portion is capped at [`MAX_WITHDRAWAL_GAS_LIMIT`] before adding the
-/// per-item portal/messenger overhead. This keeps legacy over-cap withdrawals submit-able
-/// while bounding the batcher's gas accounting.
-const fn process_withdrawal_item_gas(callback_gas_limit: u64) -> u64 {
+/// Deposit bouncebacks and simple withdrawals use separate fixed allowances. Callback withdrawals
+/// add their requested callback gas directly. The callback portion is capped at
+/// [`MAX_WITHDRAWAL_GAS_LIMIT`], keeping legacy over-cap withdrawals submit-able while bounding
+/// the batcher's gas accounting.
+const fn process_withdrawal_item_gas(callback_gas_limit: u64, fallback_nonce: u64) -> u64 {
+    if fallback_nonce == 0 {
+        return PROCESS_DEPOSIT_BOUNCEBACK_ITEM_OVERHEAD_GAS;
+    }
+
+    if callback_gas_limit == 0 {
+        return PROCESS_SIMPLE_WITHDRAWAL_ITEM_OVERHEAD_GAS;
+    }
+
     let bounded_callback_gas = if callback_gas_limit > MAX_WITHDRAWAL_GAS_LIMIT {
         MAX_WITHDRAWAL_GAS_LIMIT
     } else {
         callback_gas_limit
     };
 
-    bounded_callback_gas + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS
+    PROCESS_CALLBACK_WITHDRAWAL_ITEM_OVERHEAD_GAS + bounded_callback_gas
 }
 
 /// A contiguous, gas-bounded transaction within one withdrawal queue slot.
@@ -771,8 +811,11 @@ fn build_withdrawal_batches(
         let mut gas_limit = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS;
 
         while end < withdrawals.len() {
-            let next_gas =
-                gas_limit.saturating_add(process_withdrawal_item_gas(withdrawals[end].gasLimit));
+            let withdrawal = &withdrawals[end];
+            let next_gas = gas_limit.saturating_add(process_withdrawal_item_gas(
+                withdrawal.gasLimit,
+                withdrawal.fallbackNonce,
+            ));
             if end > start && next_gas > max_batch_gas {
                 break;
             }
@@ -914,21 +957,32 @@ mod tests {
     }
 
     #[test]
-    fn callback_tx_gas_limit_is_capped_below_l1_block_limit() {
+    fn withdrawal_gas_limits_are_classified_and_bounded() {
         let at_cap = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
-            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT);
+            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT, 1);
         let over_cap = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
-            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT + 1);
+            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT + 1, 1);
 
         assert_eq!(over_cap, at_cap);
-        assert_eq!(at_cap, MAX_PROCESS_WITHDRAWAL_TX_GAS);
+        assert_eq!(
+            process_withdrawal_item_gas(0, 1),
+            PROCESS_SIMPLE_WITHDRAWAL_ITEM_OVERHEAD_GAS
+        );
+        assert_eq!(
+            process_withdrawal_item_gas(0, 0),
+            PROCESS_DEPOSIT_BOUNCEBACK_ITEM_OVERHEAD_GAS
+        );
+        assert_eq!(
+            process_withdrawal_item_gas(3_000_000, 1),
+            PROCESS_CALLBACK_WITHDRAWAL_ITEM_OVERHEAD_GAS + 3_000_000
+        );
         assert_eq!(
             at_cap,
-            MAX_WITHDRAWAL_GAS_LIMIT
-                + PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
-                + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS
+            PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
+                + PROCESS_CALLBACK_WITHDRAWAL_ITEM_OVERHEAD_GAS
+                + MAX_WITHDRAWAL_GAS_LIMIT
         );
-        assert!(at_cap < 30_000_000);
+        assert!(at_cap <= MAX_WITHDRAWAL_BATCH_GAS);
     }
 
     fn simple_withdrawals(count: usize) -> Vec<abi::Withdrawal> {
@@ -940,7 +994,7 @@ mod tests {
     #[test]
     fn batches_withdrawals_by_transaction_gas() {
         let withdrawals = simple_withdrawals(3);
-        let one = PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
+        let one = PROCESS_SIMPLE_WITHDRAWAL_ITEM_OVERHEAD_GAS;
         let batches =
             build_withdrawal_batches(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one);
 

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -249,80 +249,6 @@ struct StoreSnapshot {
     withdrawals: Option<Vec<abi::Withdrawal>>,
 }
 
-/// Return the gas reserved for one withdrawal inside a `processWithdrawals` transaction.
-///
-/// The callback portion is capped at [`MAX_WITHDRAWAL_GAS_LIMIT`] before adding the
-/// per-item portal/messenger overhead. This keeps legacy over-cap withdrawals submit-able
-/// while bounding the batcher's gas accounting.
-const fn process_withdrawal_item_gas(callback_gas_limit: u64) -> u64 {
-    let bounded_callback_gas = if callback_gas_limit > MAX_WITHDRAWAL_GAS_LIMIT {
-        MAX_WITHDRAWAL_GAS_LIMIT
-    } else {
-        callback_gas_limit
-    };
-
-    bounded_callback_gas + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS
-}
-
-/// A contiguous, gas-bounded transaction within one withdrawal queue slot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct WithdrawalBatch {
-    start: usize,
-    end: usize,
-    gas_limit: u64,
-}
-
-impl WithdrawalBatch {
-    fn len(self) -> usize {
-        self.end - self.start
-    }
-}
-
-/// Split FIFO withdrawals by the configured per-transaction gas limit.
-///
-/// A withdrawal that exceeds the limit is kept as a singleton so it cannot block the queue.
-fn build_withdrawal_batches(
-    withdrawals: &[abi::Withdrawal],
-    max_batch_gas: u64,
-) -> Vec<WithdrawalBatch> {
-    let mut batches = Vec::new();
-    let mut start = 0;
-
-    while start < withdrawals.len() {
-        let mut end = start;
-        let mut gas_limit = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS;
-
-        while end < withdrawals.len() {
-            let next_gas =
-                gas_limit.saturating_add(process_withdrawal_item_gas(withdrawals[end].gasLimit));
-            if end > start && next_gas > max_batch_gas {
-                break;
-            }
-
-            gas_limit = next_gas;
-            end += 1;
-        }
-
-        batches.push(WithdrawalBatch {
-            start,
-            end,
-            gas_limit,
-        });
-        start = end;
-    }
-
-    batches
-}
-
-/// Outcome of submitting and confirming a sequence of `processWithdrawals` transactions.
-enum SubmitOutcome {
-    /// Every transaction was included on L1 and succeeded.
-    Confirmed,
-    /// At least one transaction failed to send, reverted, or could not be confirmed. The next
-    /// cycle reconciles the on-chain queue and retries the unfinished suffix.
-    Retry,
-}
-
 /// Background task that processes withdrawals from the ZonePortal queue on Tempo L1.
 ///
 /// The processor waits for a [`Notify`] signal from the batch submitter (indicating a batch
@@ -799,6 +725,80 @@ pub fn spawn_withdrawal_processor(
             }
         }
     })
+}
+
+/// Return the gas reserved for one withdrawal inside a `processWithdrawals` transaction.
+///
+/// The callback portion is capped at [`MAX_WITHDRAWAL_GAS_LIMIT`] before adding the
+/// per-item portal/messenger overhead. This keeps legacy over-cap withdrawals submit-able
+/// while bounding the batcher's gas accounting.
+const fn process_withdrawal_item_gas(callback_gas_limit: u64) -> u64 {
+    let bounded_callback_gas = if callback_gas_limit > MAX_WITHDRAWAL_GAS_LIMIT {
+        MAX_WITHDRAWAL_GAS_LIMIT
+    } else {
+        callback_gas_limit
+    };
+
+    bounded_callback_gas + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS
+}
+
+/// A contiguous, gas-bounded transaction within one withdrawal queue slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WithdrawalBatch {
+    start: usize,
+    end: usize,
+    gas_limit: u64,
+}
+
+impl WithdrawalBatch {
+    fn len(self) -> usize {
+        self.end - self.start
+    }
+}
+
+/// Split FIFO withdrawals by the configured per-transaction gas limit.
+///
+/// A withdrawal that exceeds the limit is kept as a singleton so it cannot block the queue.
+fn build_withdrawal_batches(
+    withdrawals: &[abi::Withdrawal],
+    max_batch_gas: u64,
+) -> Vec<WithdrawalBatch> {
+    let mut batches = Vec::new();
+    let mut start = 0;
+
+    while start < withdrawals.len() {
+        let mut end = start;
+        let mut gas_limit = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS;
+
+        while end < withdrawals.len() {
+            let next_gas =
+                gas_limit.saturating_add(process_withdrawal_item_gas(withdrawals[end].gasLimit));
+            if end > start && next_gas > max_batch_gas {
+                break;
+            }
+
+            gas_limit = next_gas;
+            end += 1;
+        }
+
+        batches.push(WithdrawalBatch {
+            start,
+            end,
+            gas_limit,
+        });
+        start = end;
+    }
+
+    batches
+}
+
+/// Outcome of submitting and confirming a sequence of `processWithdrawals` transactions.
+enum SubmitOutcome {
+    /// Every transaction was included on L1 and succeeded.
+    Confirmed,
+    /// At least one transaction failed to send, reverted, or could not be confirmed. The next
+    /// cycle reconciles the on-chain queue and retries the unfinished suffix.
+    Retry,
 }
 
 #[cfg(test)]

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -57,9 +57,6 @@ pub const DEFAULT_MAX_WITHDRAWAL_BATCH_GAS: u64 = 10_000_000;
 
 /// Default maximum number of ordered withdrawal transactions kept in flight.
 pub const DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES: usize = 4;
-
-/// Default aggregate gas budget across concurrently in-flight withdrawal transactions.
-pub const DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS: u64 = 20_000_000;
 #[cfg(test)]
 const MAX_PROCESS_WITHDRAWAL_TX_GAS: u64 =
     PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT);
@@ -107,9 +104,6 @@ pub struct WithdrawalBatchLimits {
     pub max_batch_gas: u64,
     /// Maximum number of transactions to keep concurrently in flight.
     pub max_in_flight_batches: usize,
-    /// Maximum sum of gas across concurrently in-flight transactions. An oversized singleton is
-    /// admitted alone so it cannot permanently block the queue.
-    pub max_in_flight_gas: u64,
 }
 
 impl WithdrawalBatchLimits {
@@ -119,14 +113,6 @@ impl WithdrawalBatchLimits {
             self.max_in_flight_batches > 0,
             "max_in_flight_batches must be non-zero"
         );
-        assert!(
-            self.max_in_flight_gas > 0,
-            "max_in_flight_gas must be non-zero"
-        );
-        assert!(
-            self.max_in_flight_gas >= self.max_batch_gas,
-            "max_in_flight_gas must be at least max_batch_gas"
-        );
     }
 }
 
@@ -135,7 +121,6 @@ impl Default for WithdrawalBatchLimits {
         Self {
             max_batch_gas: DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
             max_in_flight_batches: DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES,
-            max_in_flight_gas: DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS,
         }
     }
 }
@@ -327,20 +312,6 @@ fn build_withdrawal_batches(
     }
 
     batches
-}
-
-/// Whether the next transaction fits the configured in-flight queue.
-///
-/// The first transaction is always admitted so an oversized singleton can make progress.
-fn has_in_flight_capacity(
-    in_flight_count: usize,
-    in_flight_gas: u64,
-    next_gas: u64,
-    limits: WithdrawalBatchLimits,
-) -> bool {
-    in_flight_count == 0
-        || (in_flight_count < limits.max_in_flight_batches
-            && in_flight_gas.saturating_add(next_gas) <= limits.max_in_flight_gas)
 }
 
 /// Outcome of submitting and confirming a sequence of `processWithdrawals` transactions.
@@ -630,21 +601,16 @@ impl WithdrawalProcessor {
 
         let limits = self.config.batch_limits;
         let batch_count = batches.len();
-        let mut batches = batches.into_iter().peekable();
+        let mut batches = batches.into_iter();
         let mut in_flight = FuturesUnordered::new();
-        let mut in_flight_gas = 0u64;
         let mut submitted = 0usize;
         let mut retry = false;
 
         loop {
-            while !retry {
-                let Some(batch) = batches.peek().copied() else {
+            while !retry && in_flight.len() < limits.max_in_flight_batches {
+                let Some(batch) = batches.next() else {
                     break;
                 };
-                if !has_in_flight_capacity(in_flight.len(), in_flight_gas, batch.gas_limit, limits)
-                {
-                    break;
-                }
 
                 let nonce = first_nonce + submitted as u64;
                 let absolute_start = offset + batch.start;
@@ -696,7 +662,6 @@ impl WithdrawalProcessor {
                             .withdrawals_per_batch
                             .record(batch.len() as f64);
 
-                        in_flight_gas = in_flight_gas.saturating_add(batch.gas_limit);
                         in_flight.push(async move {
                             let receipt = pending
                                 .with_timeout(Some(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT))
@@ -704,7 +669,6 @@ impl WithdrawalProcessor {
                                 .await;
                             (batch, nonce, tx_hash, remaining_queue, receipt)
                         });
-                        batches.next();
                         submitted += 1;
                     }
                     Err(e) => {
@@ -728,7 +692,6 @@ impl WithdrawalProcessor {
             else {
                 break;
             };
-            in_flight_gas = in_flight_gas.saturating_sub(batch.gas_limit);
 
             match receipt {
                 Ok(receipt) if receipt.status() => {
@@ -1010,20 +973,6 @@ mod tests {
             compute_remaining_queue(&withdrawals, batches[0].end),
             abi::Withdrawal::queue_hash(&withdrawals[1..])
         );
-    }
-
-    #[test]
-    fn in_flight_capacity_applies_count_then_gas_limits() {
-        let limits = WithdrawalBatchLimits {
-            max_batch_gas: 10,
-            max_in_flight_batches: 2,
-            max_in_flight_gas: 20,
-        };
-
-        assert!(has_in_flight_capacity(0, 0, 25, limits));
-        assert!(has_in_flight_capacity(1, 10, 10, limits));
-        assert!(!has_in_flight_capacity(2, 10, 1, limits));
-        assert!(!has_in_flight_capacity(1, 15, 10, limits));
     }
 
     #[test]

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -33,8 +33,8 @@ use std::{
 
 use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, B256, U256};
-use alloy_provider::{DynProvider, PendingTransactionBuilder};
-use futures::future::join_all;
+use alloy_provider::DynProvider;
+use futures::{StreamExt, stream::FuturesUnordered};
 use parking_lot::Mutex;
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderExt};
 use tokio::sync::Notify;
@@ -51,7 +51,6 @@ use tempo_alloy::rpc::TempoCallBuilderExt;
 const PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
 const PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS: u64 = 100_000;
 const PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS: u64 = 2_000_000;
-const MAX_WITHDRAWALS_PER_PROCESS_BATCH: usize = 64;
 
 /// Default gas budget for one `processWithdrawals` transaction.
 pub const DEFAULT_MAX_WITHDRAWAL_BATCH_GAS: u64 = 10_000_000;
@@ -96,11 +95,11 @@ pub struct WithdrawalProcessorConfig {
     pub fallback_poll_interval: Duration,
     /// Address whose lane-2 nonces order withdrawal processing transactions.
     pub sequencer_address: Address,
-    /// Gas and concurrency limits for withdrawal transaction planning.
+    /// Gas and concurrency limits for withdrawal transactions.
     pub batch_limits: WithdrawalBatchLimits,
 }
 
-/// Limits applied while packing and pipelining `processWithdrawals` transactions.
+/// Limits applied while packing and submitting `processWithdrawals` transactions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WithdrawalBatchLimits {
     /// Maximum planned gas for one transaction. A single oversized withdrawal is still emitted
@@ -108,17 +107,26 @@ pub struct WithdrawalBatchLimits {
     pub max_batch_gas: u64,
     /// Maximum number of transactions to keep concurrently in flight.
     pub max_in_flight_batches: usize,
-    /// Maximum sum of planned gas across the in-flight transaction window.
+    /// Maximum sum of gas across concurrently in-flight transactions. An oversized singleton is
+    /// admitted alone so it cannot permanently block the queue.
     pub max_in_flight_gas: u64,
 }
 
 impl WithdrawalBatchLimits {
-    fn normalized(self) -> Self {
-        Self {
-            max_batch_gas: self.max_batch_gas.max(1),
-            max_in_flight_batches: self.max_in_flight_batches.max(1),
-            max_in_flight_gas: self.max_in_flight_gas.max(1),
-        }
+    fn assert_valid(self) {
+        assert!(self.max_batch_gas > 0, "max_batch_gas must be non-zero");
+        assert!(
+            self.max_in_flight_batches > 0,
+            "max_in_flight_batches must be non-zero"
+        );
+        assert!(
+            self.max_in_flight_gas > 0,
+            "max_in_flight_gas must be non-zero"
+        );
+        assert!(
+            self.max_in_flight_gas >= self.max_batch_gas,
+            "max_in_flight_gas must be at least max_batch_gas"
+        );
     }
 }
 
@@ -178,6 +186,11 @@ impl WithdrawalStore {
     /// Remove a batch after all its withdrawals are processed.
     pub fn remove_batch(&mut self, batch_index: u64) {
         self.batches.remove(&batch_index);
+    }
+
+    /// Remove slots that the portal head has already passed.
+    fn remove_before(&mut self, batch_index: u64) {
+        self.batches.retain(|&index, _| index >= batch_index);
     }
 
     pub fn has_batch(&self, batch_index: u64) -> bool {
@@ -255,7 +268,7 @@ struct StoreSnapshot {
 ///
 /// The callback portion is capped at [`MAX_WITHDRAWAL_GAS_LIMIT`] before adding the
 /// per-item portal/messenger overhead. This keeps legacy over-cap withdrawals submit-able
-/// while bounding the planner's gas accounting.
+/// while bounding the batcher's gas accounting.
 const fn process_withdrawal_item_gas(callback_gas_limit: u64) -> u64 {
     let bounded_callback_gas = if callback_gas_limit > MAX_WITHDRAWAL_GAS_LIMIT {
         MAX_WITHDRAWAL_GAS_LIMIT
@@ -266,104 +279,77 @@ const fn process_withdrawal_item_gas(callback_gas_limit: u64) -> u64 {
     bounded_callback_gas + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS
 }
 
-/// A gas-bounded `processWithdrawals` transaction planned from one portal queue slot.
-#[derive(Debug, Clone)]
-pub struct PlannedWithdrawalBatch {
-    /// Index of the first withdrawal relative to the reconciled queue suffix.
-    pub start_index: usize,
-    /// FIFO-ordered withdrawals included in this transaction.
-    pub withdrawals: Vec<abi::Withdrawal>,
-    /// Queue hash expected after the transaction consumes all included withdrawals.
-    pub remaining_queue: B256,
-    /// Conservative outer transaction gas limit.
-    pub gas_limit: u64,
+/// A contiguous, gas-bounded transaction within one withdrawal queue slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WithdrawalBatch {
+    start: usize,
+    end: usize,
+    gas_limit: u64,
 }
 
-impl PlannedWithdrawalBatch {
-    fn end_index(&self) -> usize {
-        self.start_index + self.withdrawals.len()
+impl WithdrawalBatch {
+    fn len(self) -> usize {
+        self.end - self.start
     }
 }
 
-/// Pure planner that packs queue-ordered withdrawals into a bounded in-flight window.
+/// Split FIFO withdrawals by the configured per-transaction gas limit.
 ///
-/// Keeping this component independent from RPC and storage makes the queue-hash, gas-budget, and
-/// concurrency rules directly unit testable.
-#[derive(Debug, Clone, Copy)]
-pub struct WithdrawalBatchPlanner {
-    limits: WithdrawalBatchLimits,
-}
+/// A withdrawal that exceeds the limit is kept as a singleton so it cannot block the queue.
+fn build_withdrawal_batches(
+    withdrawals: &[abi::Withdrawal],
+    max_batch_gas: u64,
+) -> Vec<WithdrawalBatch> {
+    let mut batches = Vec::new();
+    let mut start = 0;
 
-impl WithdrawalBatchPlanner {
-    pub fn new(limits: WithdrawalBatchLimits) -> Self {
-        Self {
-            limits: limits.normalized(),
-        }
-    }
+    while start < withdrawals.len() {
+        let mut end = start;
+        let mut gas_limit = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS;
 
-    /// Plan the next in-flight transaction window for a reconciled queue suffix.
-    pub fn plan(&self, withdrawals: &[abi::Withdrawal]) -> Vec<PlannedWithdrawalBatch> {
-        let mut batches = Vec::new();
-        let mut start = 0;
-        let mut in_flight_gas = 0u64;
-
-        while start < withdrawals.len() && batches.len() < self.limits.max_in_flight_batches {
-            let remaining_window_gas = self.limits.max_in_flight_gas.saturating_sub(in_flight_gas);
-            let batch_budget = self.limits.max_batch_gas.min(remaining_window_gas);
-            let first_item_gas = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
-                .saturating_add(process_withdrawal_item_gas(withdrawals[start].gasLimit));
-
-            // A singleton may exceed the per-transaction limit so an expensive FIFO item cannot
-            // block progress. Only the first transaction may exceed the aggregate window limit;
-            // later expensive items wait until the next reconciled window.
-            if !batches.is_empty() && first_item_gas > remaining_window_gas {
+        while end < withdrawals.len() {
+            let next_gas =
+                gas_limit.saturating_add(process_withdrawal_item_gas(withdrawals[end].gasLimit));
+            if end > start && next_gas > max_batch_gas {
                 break;
             }
 
-            let mut end = start;
-            let mut gas_limit = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS;
-            while end < withdrawals.len() && end - start < MAX_WITHDRAWALS_PER_PROCESS_BATCH {
-                let next_gas = gas_limit
-                    .saturating_add(process_withdrawal_item_gas(withdrawals[end].gasLimit));
-                if end > start && next_gas > batch_budget {
-                    break;
-                }
-
-                gas_limit = next_gas;
-                end += 1;
-            }
-
-            batches.push(PlannedWithdrawalBatch {
-                start_index: start,
-                withdrawals: withdrawals[start..end].to_vec(),
-                remaining_queue: compute_remaining_queue(withdrawals, end),
-                gas_limit,
-            });
-            in_flight_gas = in_flight_gas.saturating_add(gas_limit);
-            start = end;
+            gas_limit = next_gas;
+            end += 1;
         }
 
-        batches
+        batches.push(WithdrawalBatch {
+            start,
+            end,
+            gas_limit,
+        });
+        start = end;
     }
+
+    batches
 }
 
-/// Outcome of submitting and confirming one `processWithdrawals` transaction.
+/// Whether the next transaction fits the configured in-flight queue.
+///
+/// The first transaction is always admitted so an oversized singleton can make progress.
+fn has_in_flight_capacity(
+    in_flight_count: usize,
+    in_flight_gas: u64,
+    next_gas: u64,
+    limits: WithdrawalBatchLimits,
+) -> bool {
+    in_flight_count == 0
+        || (in_flight_count < limits.max_in_flight_batches
+            && in_flight_gas.saturating_add(next_gas) <= limits.max_in_flight_gas)
+}
+
+/// Outcome of submitting and confirming a sequence of `processWithdrawals` transactions.
 enum SubmitOutcome {
-    /// The transaction was included on L1 and succeeded.
+    /// Every transaction was included on L1 and succeeded.
     Confirmed,
-    /// The transaction was included on L1 but reverted — the provided data does
-    /// not match the portal's on-chain state.
-    Reverted,
-    /// The transaction was broadcast but no receipt was obtained in time, or it
-    /// failed to send. The next cycle re-reads the on-chain slot hash and
-    /// resumes from wherever the portal actually is.
-    Unconfirmed,
-}
-
-struct PendingWithdrawalBatch {
-    batch: PlannedWithdrawalBatch,
-    nonce: u64,
-    pending: PendingTransactionBuilder<TempoNetwork>,
+    /// At least one transaction failed to send, reverted, or could not be confirmed. The next
+    /// cycle reconciles the on-chain queue and retries the unfinished suffix.
+    Retry,
 }
 
 /// Background task that processes withdrawals from the ZonePortal queue on Tempo L1.
@@ -377,9 +363,9 @@ struct PendingWithdrawalBatch {
 /// current on-chain hash and trims withdrawals the portal has already consumed,
 /// so it can safely run at any time from any state (crash, timeout, restart).
 ///
-/// Withdrawals are gas-bounded into contract batches. Several consecutive-nonce transactions are
-/// broadcast without waiting for receipts, then confirmed concurrently. On any uncertain or
-/// reverted result, the next cycle reconciles the portal queue before planning more work.
+/// Withdrawals are first split by the configured per-transaction gas limit, then submitted through
+/// a bounded queue of consecutive-nonce transactions. On any failure, the next cycle reconciles
+/// the portal queue and retries its unfinished suffix.
 pub struct WithdrawalProcessor {
     config: WithdrawalProcessorConfig,
     provider: DynProvider<TempoNetwork>,
@@ -401,6 +387,7 @@ impl WithdrawalProcessor {
         notify: Arc<Notify>,
         repair_notify: Arc<Notify>,
     ) -> Self {
+        config.batch_limits.assert_valid();
         let portal = ZonePortal::new(config.portal_address, provider.clone());
 
         Self {
@@ -474,6 +461,15 @@ impl WithdrawalProcessor {
 
             let head_val: u64 = head.try_into().map_err(|_| eyre::eyre!("head overflow"))?;
             let tail_val: u64 = tail.try_into().map_err(|_| eyre::eyre!("tail overflow"))?;
+            if head_val > tail_val {
+                warn!(
+                    head = head_val,
+                    tail = tail_val,
+                    "Inconsistent withdrawal queue bounds"
+                );
+                return Ok(());
+            }
+            self.store.lock().remove_before(head_val);
             let StoreSnapshot {
                 batch_count: store_batch_count,
                 first_slot: store_first_slot,
@@ -516,8 +512,19 @@ impl WithdrawalProcessor {
                 }
             };
 
-            // Read the head slot's current on-chain hash and skip
-            // withdrawals the portal has already consumed.
+            // Read the committed nonce before the slot. If an older pending transaction lands
+            // between these reads, reusing its now-stale nonce fails safely instead of pairing a
+            // stale slot snapshot with a newer nonce.
+            let first_nonce = self
+                .provider
+                .get_transaction_count_with_nonce_key(
+                    self.config.sequencer_address,
+                    PROCESS_WITHDRAWAL_NONCE_KEY,
+                )
+                .await?;
+
+            // Read the head slot's current on-chain hash and skip withdrawals the portal has
+            // already consumed.
             let slot_hash = self
                 .portal
                 .withdrawalQueueSlot(U256::from(head_val % WITHDRAWAL_QUEUE_CAPACITY))
@@ -566,32 +573,26 @@ impl WithdrawalProcessor {
                 return Ok(());
             }
 
-            let planner = WithdrawalBatchPlanner::new(self.config.batch_limits);
-            let planned_batches = planner.plan(remaining);
-            let planned_withdrawals = planned_batches
-                .last()
-                .map_or(0, PlannedWithdrawalBatch::end_index);
-            let planned_gas = planned_batches
+            let batches =
+                build_withdrawal_batches(remaining, self.config.batch_limits.max_batch_gas);
+            let total_gas = batches
                 .iter()
                 .fold(0u64, |total, batch| total.saturating_add(batch.gas_limit));
             info!(
                 slot = head_val,
-                remaining_withdrawals = remaining.len(),
-                planned_withdrawals,
-                planned_transactions = planned_batches.len(),
-                planned_gas,
-                "Processing withdrawal window"
+                withdrawals = remaining.len(),
+                transactions = batches.len(),
+                total_gas,
+                "Processing withdrawal batches"
             );
             let slot_started_at = Instant::now();
             let outcome = self
-                .submit_and_confirm_batches(head_val, offset, remaining.len(), planned_batches)
+                .submit_and_confirm_batches(head_val, offset, first_nonce, remaining, batches)
                 .await?;
             self.record_slot_duration(slot_started_at.elapsed());
 
             match outcome {
-                SubmitOutcome::Confirmed if planned_withdrawals == remaining.len() => {
-                    // The entire slot confirmed — safe to remove. Continue the loop to drain any
-                    // further pending slots.
+                SubmitOutcome::Confirmed => {
                     self.store.lock().remove_batch(head_val);
                     info!(
                         slot = head_val,
@@ -599,194 +600,201 @@ impl WithdrawalProcessor {
                         "Slot fully processed and removed from store"
                     );
                 }
-                SubmitOutcome::Confirmed => {
-                    // The configured in-flight window was smaller than the slot. Re-read the
-                    // on-chain suffix before planning the next window.
-                    continue;
-                }
-                SubmitOutcome::Reverted => {
-                    self.repair_notify.notify_one();
-                    return Ok(());
-                }
-                SubmitOutcome::Unconfirmed => {
-                    // The next cycle re-reads the on-chain slot hash and resumes from wherever the
-                    // portal actually is.
+                SubmitOutcome::Retry => {
+                    // A lower nonce may have succeeded, changing every later batch's expected
+                    // queue suffix. The next poll reconciles the slot before retrying.
                     return Ok(());
                 }
             }
         }
     }
 
-    /// Broadcast a window of consecutive-nonce `processWithdrawals` transactions, then wait for
-    /// all broadcast receipts concurrently.
+    /// Run all batches through a bounded queue of consecutive-nonce transactions.
+    ///
+    /// A failure stops new submissions. Already submitted transactions are still drained because
+    /// dropping their receipt futures would not cancel them. The next cycle then reconciles the
+    /// on-chain queue and retries only the unfinished suffix.
     async fn submit_and_confirm_batches(
         &self,
         slot: u64,
         offset: usize,
-        total: usize,
-        batches: Vec<PlannedWithdrawalBatch>,
+        first_nonce: u64,
+        withdrawals: &[abi::Withdrawal],
+        batches: Vec<WithdrawalBatch>,
     ) -> eyre::Result<SubmitOutcome> {
-        let first_nonce = self
-            .provider
-            .get_transaction_count_with_nonce_key(
-                self.config.sequencer_address,
-                PROCESS_WITHDRAWAL_NONCE_KEY,
-            )
-            .await?;
-        let mut pending_batches = Vec::with_capacity(batches.len());
-        let mut broadcast_failed = false;
+        let nonce_count = u64::try_from(batches.len())
+            .map_err(|_| eyre::eyre!("processWithdrawals batch count overflow"))?;
+        first_nonce.checked_add(nonce_count).ok_or_else(|| {
+            eyre::eyre!("processWithdrawals nonce range exhausted at {first_nonce}")
+        })?;
 
-        // Broadcast in nonce order without waiting for inclusion. Once accepted by the RPC, all
-        // transactions remain concurrently in flight and Tempo's lane-2 nonce ordering preserves
-        // the portal queue dependency between them.
-        for (batch_index, batch) in batches.into_iter().enumerate() {
-            let nonce = first_nonce
-                .checked_add(batch_index as u64)
-                .ok_or_else(|| eyre::eyre!("processWithdrawals nonce overflow at {first_nonce}"))?;
-            let absolute_start = offset + batch.start_index;
-            let withdrawal_count = batch.withdrawals.len();
-            let has_callback = batch.withdrawals.iter().any(|w| w.gasLimit > 0);
+        let limits = self.config.batch_limits;
+        let batch_count = batches.len();
+        let mut batches = batches.into_iter().peekable();
+        let mut in_flight = FuturesUnordered::new();
+        let mut in_flight_gas = 0u64;
+        let mut submitted = 0usize;
+        let mut retry = false;
 
-            for (item_index, withdrawal) in batch.withdrawals.iter().enumerate() {
-                if withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT {
-                    warn!(
-                        slot,
-                        index = absolute_start + item_index,
-                        requested_gas_limit = withdrawal.gasLimit,
-                        max_gas_limit = MAX_WITHDRAWAL_GAS_LIMIT,
-                        "withdrawal callback gas exceeds protocol cap; reserving bounded gas"
-                    );
-                }
-            }
-
-            info!(
-                slot,
-                batch_index,
-                nonce,
-                start_index = absolute_start,
-                withdrawal_count,
-                total,
-                gas_limit = batch.gas_limit,
-                has_callback,
-                expected_remaining_queue = %batch.remaining_queue,
-                "📤 Broadcasting withdrawal batch to L1"
-            );
-
-            let call = self
-                .portal
-                .processWithdrawals(batch.withdrawals.clone(), batch.remaining_queue)
-                .nonce_key(PROCESS_WITHDRAWAL_NONCE_KEY)
-                .nonce(nonce)
-                .gas(batch.gas_limit);
-
-            match call.send().await {
-                Ok(pending) => {
-                    self.metrics
-                        .withdrawals_processed_total
-                        .increment(withdrawal_count as u64);
-                    self.metrics.batches_submitted_total.increment(1);
-                    self.metrics
-                        .withdrawals_per_batch
-                        .record(withdrawal_count as f64);
-                    pending_batches.push(PendingWithdrawalBatch {
-                        batch,
-                        nonce,
-                        pending,
-                    });
-                }
-                Err(e) => {
-                    self.metrics
-                        .withdrawals_failed_total
-                        .increment(withdrawal_count as u64);
-                    error!(
-                        slot,
-                        batch_index,
-                        nonce,
-                        start_index = absolute_start,
-                        withdrawal_count,
-                        error = %e,
-                        "processWithdrawals tx failed to send; stopping at the first nonce gap"
-                    );
-                    broadcast_failed = true;
+        loop {
+            while !retry {
+                let Some(batch) = batches.peek().copied() else {
+                    break;
+                };
+                if !has_in_flight_capacity(in_flight.len(), in_flight_gas, batch.gas_limit, limits)
+                {
                     break;
                 }
+
+                let nonce = first_nonce + submitted as u64;
+                let absolute_start = offset + batch.start;
+                let batch_withdrawals = withdrawals[batch.start..batch.end].to_vec();
+                let remaining_queue = compute_remaining_queue(withdrawals, batch.end);
+
+                for (item_index, withdrawal) in batch_withdrawals.iter().enumerate() {
+                    if withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT {
+                        warn!(
+                            slot,
+                            index = absolute_start + item_index,
+                            requested_gas_limit = withdrawal.gasLimit,
+                            max_gas_limit = MAX_WITHDRAWAL_GAS_LIMIT,
+                            "withdrawal callback gas exceeds protocol cap; reserving bounded gas"
+                        );
+                    }
+                }
+
+                info!(
+                    slot,
+                    nonce,
+                    start_index = absolute_start,
+                    withdrawal_count = batch.len(),
+                    total = withdrawals.len(),
+                    gas_limit = batch.gas_limit,
+                    expected_remaining_queue = %remaining_queue,
+                    "📤 Broadcasting withdrawal batch to L1"
+                );
+
+                let call = self
+                    .portal
+                    .processWithdrawals(batch_withdrawals, remaining_queue)
+                    .nonce_key(PROCESS_WITHDRAWAL_NONCE_KEY)
+                    .nonce(nonce)
+                    .gas(batch.gas_limit);
+
+                let pending = tokio::time::timeout(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT, call.send())
+                    .await
+                    .map_err(|_| eyre::eyre!("processWithdrawals tx send timed out"))
+                    .and_then(|result| result.map_err(Into::into));
+
+                match pending {
+                    Ok(pending) => {
+                        let tx_hash = *pending.tx_hash();
+                        self.metrics
+                            .withdrawals_processed_total
+                            .increment(batch.len() as u64);
+                        self.metrics
+                            .withdrawals_per_batch
+                            .record(batch.len() as f64);
+
+                        in_flight_gas = in_flight_gas.saturating_add(batch.gas_limit);
+                        in_flight.push(async move {
+                            let receipt = pending
+                                .with_timeout(Some(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT))
+                                .get_receipt()
+                                .await;
+                            (batch, nonce, tx_hash, remaining_queue, receipt)
+                        });
+                        batches.next();
+                        submitted += 1;
+                    }
+                    Err(e) => {
+                        self.metrics
+                            .withdrawals_failed_total
+                            .increment(batch.len() as u64);
+                        error!(
+                            slot,
+                            nonce,
+                            start_index = absolute_start,
+                            withdrawal_count = batch.len(),
+                            error = %e,
+                            "processWithdrawals tx failed to send; queue will be reconciled and retried"
+                        );
+                        retry = true;
+                    }
+                }
             }
-        }
 
-        let receipt_results =
-            join_all(pending_batches.into_iter().map(|pending_batch| async move {
-                let tx_hash = *pending_batch.pending.tx_hash();
-                let receipt = pending_batch
-                    .pending
-                    .with_timeout(Some(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT))
-                    .get_receipt()
-                    .await;
-                (pending_batch.batch, pending_batch.nonce, tx_hash, receipt)
-            }))
-            .await;
+            let Some((batch, nonce, tx_hash, remaining_queue, receipt)) = in_flight.next().await
+            else {
+                break;
+            };
+            in_flight_gas = in_flight_gas.saturating_sub(batch.gas_limit);
 
-        let mut outcome = if broadcast_failed {
-            SubmitOutcome::Unconfirmed
-        } else {
-            SubmitOutcome::Confirmed
-        };
-
-        // Interpret receipts in nonce order even though they were awaited concurrently.
-        for (batch, nonce, tx_hash, receipt) in receipt_results {
-            let withdrawal_count = batch.withdrawals.len();
             match receipt {
                 Ok(receipt) if receipt.status() => {
                     self.metrics
                         .withdrawals_confirmed_total
-                        .increment(withdrawal_count as u64);
+                        .increment(batch.len() as u64);
                     self.metrics.batches_confirmed_total.increment(1);
                     info!(
                         slot,
                         nonce,
                         %tx_hash,
-                        start_index = offset + batch.start_index,
-                        withdrawal_count,
+                        start_index = offset + batch.start,
+                        withdrawal_count = batch.len(),
+                        gas_used = receipt.gas_used,
                         "✅ Withdrawal batch confirmed on L1"
                     );
                 }
                 Ok(_) => {
                     self.metrics
                         .withdrawals_failed_total
-                        .increment(withdrawal_count as u64);
-                    self.metrics.withdrawals_reverted_total.increment(1);
+                        .increment(batch.len() as u64);
+                    self.metrics
+                        .withdrawals_reverted_total
+                        .increment(batch.len() as u64);
                     error!(
                         slot,
                         nonce,
                         %tx_hash,
-                        start_index = offset + batch.start_index,
-                        withdrawal_count,
-                        expected_remaining_queue = %batch.remaining_queue,
-                        "processWithdrawals tx reverted; later planned batches are invalid"
+                        start_index = offset + batch.start,
+                        withdrawal_count = batch.len(),
+                        expected_remaining_queue = %remaining_queue,
+                        "processWithdrawals tx reverted; queue will be reconciled and retried"
                     );
-                    outcome = SubmitOutcome::Reverted;
-                    break;
+                    retry = true;
                 }
                 Err(e) => {
                     self.metrics
                         .withdrawals_failed_total
-                        .increment(withdrawal_count as u64);
+                        .increment(batch.len() as u64);
                     error!(
                         slot,
                         nonce,
                         %tx_hash,
-                        start_index = offset + batch.start_index,
-                        withdrawal_count,
-                        expected_remaining_queue = %batch.remaining_queue,
+                        start_index = offset + batch.start,
+                        withdrawal_count = batch.len(),
+                        expected_remaining_queue = %remaining_queue,
                         error = %e,
-                        "processWithdrawals tx not confirmed; queue will be reconciled"
+                        "processWithdrawals tx not confirmed; queue will be reconciled and retried"
                     );
-                    outcome = SubmitOutcome::Unconfirmed;
-                    break;
+                    retry = true;
                 }
             }
         }
 
-        Ok(outcome)
+        if retry {
+            warn!(
+                slot,
+                submitted,
+                total_batches = batch_count,
+                "Withdrawal processing incomplete; retrying from reconciled on-chain state"
+            );
+            Ok(SubmitOutcome::Retry)
+        } else {
+            debug_assert_eq!(submitted, batch_count);
+            Ok(SubmitOutcome::Confirmed)
+        }
     }
 
     fn record_queue_metrics(&mut self, head: u64, tail: u64, store_batch_count: usize) {
@@ -960,18 +968,6 @@ mod tests {
         assert!(at_cap < 30_000_000);
     }
 
-    fn planner(
-        max_batch_gas: u64,
-        max_in_flight_batches: usize,
-        max_in_flight_gas: u64,
-    ) -> WithdrawalBatchPlanner {
-        WithdrawalBatchPlanner::new(WithdrawalBatchLimits {
-            max_batch_gas,
-            max_in_flight_batches,
-            max_in_flight_gas,
-        })
-    }
-
     fn simple_withdrawals(count: usize) -> Vec<abi::Withdrawal> {
         (0..count)
             .map(|i| test_withdrawal(Address::with_last_byte((i + 1) as u8), (i + 1) as u128))
@@ -979,114 +975,55 @@ mod tests {
     }
 
     #[test]
-    fn planner_packs_by_gas_and_preserves_full_queue_suffixes() {
+    fn batches_withdrawals_by_transaction_gas() {
         let withdrawals = simple_withdrawals(3);
         let one = PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
-        let plans =
-            planner(PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one, 4, 10_000_000).plan(&withdrawals);
+        let batches =
+            build_withdrawal_batches(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one);
 
-        assert_eq!(plans.len(), 2);
-        assert_eq!(plans[0].start_index, 0);
-        assert_eq!(plans[0].withdrawals.len(), 2);
-        assert_eq!(plans[0].withdrawals[0].amount, withdrawals[0].amount);
-        assert_eq!(plans[0].withdrawals[1].amount, withdrawals[1].amount);
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].start, 0);
+        assert_eq!(batches[0].end, 2);
+        assert_eq!(batches[1].start, 2);
+        assert_eq!(batches[1].end, 3);
         assert_eq!(
-            plans[0].remaining_queue,
+            compute_remaining_queue(&withdrawals, batches[0].end),
             abi::Withdrawal::queue_hash(&withdrawals[2..])
         );
-        assert_eq!(plans[1].start_index, 2);
-        assert_eq!(plans[1].withdrawals.len(), 1);
-        assert_eq!(plans[1].withdrawals[0].amount, withdrawals[2].amount);
-        assert_eq!(plans[1].remaining_queue, B256::ZERO);
-    }
-
-    #[test]
-    fn planner_bounds_the_in_flight_gas_window() {
-        let withdrawals = simple_withdrawals(10);
-        let one_batch = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
-        let plans = planner(one_batch, 10, one_batch * 2).plan(&withdrawals);
-
-        assert_eq!(plans.len(), 2);
         assert_eq!(
-            plans.iter().map(|batch| batch.gas_limit).sum::<u64>(),
-            one_batch * 2
-        );
-        assert_eq!(
-            plans[1].remaining_queue,
-            abi::Withdrawal::queue_hash(&withdrawals[2..])
+            compute_remaining_queue(&withdrawals, batches[1].end),
+            B256::ZERO
         );
     }
 
     #[test]
-    fn planner_bounds_the_number_of_in_flight_transactions() {
-        let withdrawals = simple_withdrawals(5);
-        let one_batch = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
-        let plans = planner(one_batch, 2, u64::MAX).plan(&withdrawals);
-
-        assert_eq!(plans.len(), 2);
-        assert_eq!(plans[0].start_index, 0);
-        assert_eq!(plans[1].start_index, 1);
-        assert_eq!(
-            plans[1].remaining_queue,
-            abi::Withdrawal::queue_hash(&withdrawals[2..])
-        );
-    }
-
-    #[test]
-    fn planner_emits_an_oversized_head_as_a_singleton() {
+    fn oversized_withdrawal_is_a_singleton() {
         let mut withdrawals = simple_withdrawals(2);
         withdrawals[0].gasLimit = MAX_WITHDRAWAL_GAS_LIMIT;
-        let plans = planner(1_000_000, 4, 20_000_000).plan(&withdrawals);
+        let batches = build_withdrawal_batches(&withdrawals, 1_000_000);
 
-        assert_eq!(plans.len(), 2);
-        assert_eq!(plans[0].withdrawals.len(), 1);
-        assert!(plans[0].gas_limit > 1_000_000);
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].start, 0);
+        assert_eq!(batches[0].end, 1);
+        assert!(batches[0].gas_limit > 1_000_000);
         assert_eq!(
-            plans[0].remaining_queue,
+            compute_remaining_queue(&withdrawals, batches[0].end),
             abi::Withdrawal::queue_hash(&withdrawals[1..])
         );
     }
 
     #[test]
-    fn planner_defers_an_oversized_item_that_does_not_fit_the_current_window() {
-        let mut withdrawals = simple_withdrawals(2);
-        withdrawals[1].gasLimit = MAX_WITHDRAWAL_GAS_LIMIT;
-        let simple_gas = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
-        let callback_gas = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
-            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT);
-        let planner = planner(simple_gas, 4, simple_gas + callback_gas - 1);
+    fn in_flight_capacity_applies_count_then_gas_limits() {
+        let limits = WithdrawalBatchLimits {
+            max_batch_gas: 10,
+            max_in_flight_batches: 2,
+            max_in_flight_gas: 20,
+        };
 
-        let first_window = planner.plan(&withdrawals);
-        assert_eq!(first_window.len(), 1);
-        assert_eq!(first_window[0].withdrawals[0].amount, withdrawals[0].amount);
-
-        let next_window = planner.plan(&withdrawals[1..]);
-        assert_eq!(next_window.len(), 1);
-        assert_eq!(next_window[0].gas_limit, callback_gas);
-    }
-
-    #[test]
-    fn planner_caps_calldata_even_when_gas_budget_is_large() {
-        let withdrawals = simple_withdrawals(MAX_WITHDRAWALS_PER_PROCESS_BATCH + 1);
-        let plans = planner(u64::MAX, 2, u64::MAX).plan(&withdrawals);
-
-        assert_eq!(plans.len(), 2);
-        assert_eq!(
-            plans[0].withdrawals.len(),
-            MAX_WITHDRAWALS_PER_PROCESS_BATCH
-        );
-        assert_eq!(plans[1].withdrawals.len(), 1);
-        assert_eq!(plans[1].remaining_queue, B256::ZERO);
-    }
-
-    #[test]
-    fn planner_normalizes_zero_limits_without_stalling() {
-        let withdrawals = simple_withdrawals(1);
-        let plans = planner(0, 0, 0).plan(&withdrawals);
-
-        assert_eq!(plans.len(), 1);
-        assert_eq!(plans[0].withdrawals.len(), 1);
-        assert_eq!(plans[0].withdrawals[0].amount, withdrawals[0].amount);
+        assert!(has_in_flight_capacity(0, 0, 25, limits));
+        assert!(has_in_flight_capacity(1, 10, 10, limits));
+        assert!(!has_in_flight_capacity(2, 10, 1, limits));
+        assert!(!has_in_flight_capacity(1, 15, 10, limits));
     }
 
     #[test]
@@ -1150,6 +1087,21 @@ mod tests {
 
         store.add_batch(1, vec![test_withdrawal(addr, 999)]);
         assert_eq!(store.batch_count(), 2);
+    }
+
+    #[test]
+    fn store_prunes_slots_before_portal_head() {
+        let mut store = WithdrawalStore::new();
+        let withdrawal = test_withdrawal(Address::repeat_byte(0x42), 100);
+        store.add_batch(4, vec![withdrawal.clone()]);
+        store.add_batch(5, vec![withdrawal.clone()]);
+        store.add_batch(6, vec![withdrawal]);
+
+        store.remove_before(5);
+
+        assert!(!store.has_batch(4));
+        assert!(store.has_batch(5));
+        assert!(store.has_batch(6));
     }
 
     #[test]
@@ -1225,6 +1177,7 @@ mod tests {
         // head = 5, tail = 6, slot hash that matches no suffix of the stored batch.
         l1.push_success(&abi_encode_u64(5));
         l1.push_success(&abi_encode_u64(6));
+        l1.push_success(&abi_encode_u64(0));
         l1.push_success(&abi_encode_b256(B256::repeat_byte(0xde)));
 
         let store = SharedWithdrawalStore::new();
@@ -1254,6 +1207,7 @@ mod tests {
         // between our head read and the slot read).
         l1.push_success(&abi_encode_u64(5));
         l1.push_success(&abi_encode_u64(6));
+        l1.push_success(&abi_encode_u64(0));
         l1.push_success(&abi_encode_b256(EMPTY_SENTINEL));
 
         let store = SharedWithdrawalStore::new();

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -33,9 +33,10 @@ use std::{
 
 use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, B256, U256};
-use alloy_provider::DynProvider;
+use alloy_provider::{DynProvider, PendingTransactionBuilder};
+use futures::future::join_all;
 use parking_lot::Mutex;
-use tempo_alloy::TempoNetwork;
+use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderExt};
 use tokio::sync::Notify;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -48,10 +49,21 @@ use crate::{
 use tempo_alloy::rpc::TempoCallBuilderExt;
 
 const PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
-const PROCESS_WITHDRAWAL_CALLBACK_OVERHEAD_GAS: u64 = 2_000_000;
+const PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS: u64 = 100_000;
+const PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS: u64 = 2_000_000;
+const MAX_WITHDRAWALS_PER_PROCESS_BATCH: usize = 64;
+
+/// Default gas budget for one `processWithdrawals` transaction.
+pub const DEFAULT_MAX_WITHDRAWAL_BATCH_GAS: u64 = 10_000_000;
+
+/// Default maximum number of ordered withdrawal transactions kept in flight.
+pub const DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES: usize = 4;
+
+/// Default aggregate gas budget across concurrently in-flight withdrawal transactions.
+pub const DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS: u64 = 20_000_000;
 #[cfg(test)]
 const MAX_PROCESS_WITHDRAWAL_TX_GAS: u64 =
-    process_withdrawal_tx_gas_limit(MAX_WITHDRAWAL_GAS_LIMIT);
+    PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT);
 
 /// Shared handle to the withdrawal store.
 #[derive(Clone)]
@@ -82,6 +94,42 @@ pub struct WithdrawalProcessorConfig {
     pub l1_rpc_url: String,
     /// Fallback timeout for checking the withdrawal queue if no notification arrives.
     pub fallback_poll_interval: Duration,
+    /// Address whose lane-2 nonces order withdrawal processing transactions.
+    pub sequencer_address: Address,
+    /// Gas and concurrency limits for withdrawal transaction planning.
+    pub batch_limits: WithdrawalBatchLimits,
+}
+
+/// Limits applied while packing and pipelining `processWithdrawals` transactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WithdrawalBatchLimits {
+    /// Maximum planned gas for one transaction. A single oversized withdrawal is still emitted
+    /// so that it cannot permanently block the queue.
+    pub max_batch_gas: u64,
+    /// Maximum number of transactions to keep concurrently in flight.
+    pub max_in_flight_batches: usize,
+    /// Maximum sum of planned gas across the in-flight transaction window.
+    pub max_in_flight_gas: u64,
+}
+
+impl WithdrawalBatchLimits {
+    fn normalized(self) -> Self {
+        Self {
+            max_batch_gas: self.max_batch_gas.max(1),
+            max_in_flight_batches: self.max_in_flight_batches.max(1),
+            max_in_flight_gas: self.max_in_flight_gas.max(1),
+        }
+    }
+}
+
+impl Default for WithdrawalBatchLimits {
+    fn default() -> Self {
+        Self {
+            max_batch_gas: DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
+            max_in_flight_batches: DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES,
+            max_in_flight_gas: DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_GAS,
+        }
+    }
 }
 
 /// In-memory store for withdrawal data grouped by batch index.
@@ -203,20 +251,100 @@ struct StoreSnapshot {
     withdrawals: Option<Vec<abi::Withdrawal>>,
 }
 
-/// Return the outer transaction gas limit for a callback withdrawal.
+/// Return the gas reserved for one withdrawal inside a `processWithdrawals` transaction.
 ///
 /// The callback portion is capped at [`MAX_WITHDRAWAL_GAS_LIMIT`] before adding the
-/// fixed portal/messenger overhead. This keeps legacy over-cap withdrawals submit-able
-/// so the portal can dequeue and bounce them instead of letting the RPC reject the
-/// transaction before it reaches L1 execution.
-const fn process_withdrawal_tx_gas_limit(callback_gas_limit: u64) -> u64 {
+/// per-item portal/messenger overhead. This keeps legacy over-cap withdrawals submit-able
+/// while bounding the planner's gas accounting.
+const fn process_withdrawal_item_gas(callback_gas_limit: u64) -> u64 {
     let bounded_callback_gas = if callback_gas_limit > MAX_WITHDRAWAL_GAS_LIMIT {
         MAX_WITHDRAWAL_GAS_LIMIT
     } else {
         callback_gas_limit
     };
 
-    bounded_callback_gas + PROCESS_WITHDRAWAL_CALLBACK_OVERHEAD_GAS
+    bounded_callback_gas + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS
+}
+
+/// A gas-bounded `processWithdrawals` transaction planned from one portal queue slot.
+#[derive(Debug, Clone)]
+pub struct PlannedWithdrawalBatch {
+    /// Index of the first withdrawal relative to the reconciled queue suffix.
+    pub start_index: usize,
+    /// FIFO-ordered withdrawals included in this transaction.
+    pub withdrawals: Vec<abi::Withdrawal>,
+    /// Queue hash expected after the transaction consumes all included withdrawals.
+    pub remaining_queue: B256,
+    /// Conservative outer transaction gas limit.
+    pub gas_limit: u64,
+}
+
+impl PlannedWithdrawalBatch {
+    fn end_index(&self) -> usize {
+        self.start_index + self.withdrawals.len()
+    }
+}
+
+/// Pure planner that packs queue-ordered withdrawals into a bounded in-flight window.
+///
+/// Keeping this component independent from RPC and storage makes the queue-hash, gas-budget, and
+/// concurrency rules directly unit testable.
+#[derive(Debug, Clone, Copy)]
+pub struct WithdrawalBatchPlanner {
+    limits: WithdrawalBatchLimits,
+}
+
+impl WithdrawalBatchPlanner {
+    pub fn new(limits: WithdrawalBatchLimits) -> Self {
+        Self {
+            limits: limits.normalized(),
+        }
+    }
+
+    /// Plan the next in-flight transaction window for a reconciled queue suffix.
+    pub fn plan(&self, withdrawals: &[abi::Withdrawal]) -> Vec<PlannedWithdrawalBatch> {
+        let mut batches = Vec::new();
+        let mut start = 0;
+        let mut in_flight_gas = 0u64;
+
+        while start < withdrawals.len() && batches.len() < self.limits.max_in_flight_batches {
+            let remaining_window_gas = self.limits.max_in_flight_gas.saturating_sub(in_flight_gas);
+            let batch_budget = self.limits.max_batch_gas.min(remaining_window_gas);
+            let first_item_gas = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
+                .saturating_add(process_withdrawal_item_gas(withdrawals[start].gasLimit));
+
+            // A singleton may exceed the per-transaction limit so an expensive FIFO item cannot
+            // block progress. Only the first transaction may exceed the aggregate window limit;
+            // later expensive items wait until the next reconciled window.
+            if !batches.is_empty() && first_item_gas > remaining_window_gas {
+                break;
+            }
+
+            let mut end = start;
+            let mut gas_limit = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS;
+            while end < withdrawals.len() && end - start < MAX_WITHDRAWALS_PER_PROCESS_BATCH {
+                let next_gas = gas_limit
+                    .saturating_add(process_withdrawal_item_gas(withdrawals[end].gasLimit));
+                if end > start && next_gas > batch_budget {
+                    break;
+                }
+
+                gas_limit = next_gas;
+                end += 1;
+            }
+
+            batches.push(PlannedWithdrawalBatch {
+                start_index: start,
+                withdrawals: withdrawals[start..end].to_vec(),
+                remaining_queue: compute_remaining_queue(withdrawals, end),
+                gas_limit,
+            });
+            in_flight_gas = in_flight_gas.saturating_add(gas_limit);
+            start = end;
+        }
+
+        batches
+    }
 }
 
 /// Outcome of submitting and confirming one `processWithdrawals` transaction.
@@ -232,6 +360,12 @@ enum SubmitOutcome {
     Unconfirmed,
 }
 
+struct PendingWithdrawalBatch {
+    batch: PlannedWithdrawalBatch,
+    nonce: u64,
+    pending: PendingTransactionBuilder<TempoNetwork>,
+}
+
 /// Background task that processes withdrawals from the ZonePortal queue on Tempo L1.
 ///
 /// The processor waits for a [`Notify`] signal from the batch submitter (indicating a batch
@@ -243,14 +377,12 @@ enum SubmitOutcome {
 /// current on-chain hash and trims withdrawals the portal has already consumed,
 /// so it can safely run at any time from any state (crash, timeout, restart).
 ///
-/// ## POC limitations
-///
-/// - Transactions are submitted sequentially and the processor waits for each confirmation.
-///   On failure, processing stops and remaining withdrawals are retried on the next cycle.
-/// - The portal automatically pays the processing fee to the sequencer; this processor does not
-///   handle fee accounting.
+/// Withdrawals are gas-bounded into contract batches. Several consecutive-nonce transactions are
+/// broadcast without waiting for receipts, then confirmed concurrently. On any uncertain or
+/// reverted result, the next cycle reconciles the portal queue before planning more work.
 pub struct WithdrawalProcessor {
     config: WithdrawalProcessorConfig,
+    provider: DynProvider<TempoNetwork>,
     portal: ZonePortal::ZonePortalInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     store: SharedWithdrawalStore,
     notify: Arc<Notify>,
@@ -269,10 +401,11 @@ impl WithdrawalProcessor {
         notify: Arc<Notify>,
         repair_notify: Arc<Notify>,
     ) -> Self {
-        let portal = ZonePortal::new(config.portal_address, provider);
+        let portal = ZonePortal::new(config.portal_address, provider.clone());
 
         Self {
             config,
+            provider,
             portal,
             store,
             notify,
@@ -433,186 +566,227 @@ impl WithdrawalProcessor {
                 return Ok(());
             }
 
+            let planner = WithdrawalBatchPlanner::new(self.config.batch_limits);
+            let planned_batches = planner.plan(remaining);
+            let planned_withdrawals = planned_batches
+                .last()
+                .map_or(0, PlannedWithdrawalBatch::end_index);
+            let planned_gas = planned_batches
+                .iter()
+                .fold(0u64, |total, batch| total.saturating_add(batch.gas_limit));
             info!(
                 slot = head_val,
-                count = remaining.len(),
-                "Processing withdrawal batch"
+                remaining_withdrawals = remaining.len(),
+                planned_withdrawals,
+                planned_transactions = planned_batches.len(),
+                planned_gas,
+                "Processing withdrawal window"
             );
             let slot_started_at = Instant::now();
-
-            for (i, withdrawal) in remaining.iter().enumerate() {
-                let remaining_queue = compute_remaining_queue(remaining, i + 1);
-                let outcome = self
-                    .submit_and_confirm(
-                        head_val,
-                        offset + i,
-                        remaining.len(),
-                        withdrawal,
-                        remaining_queue,
-                    )
-                    .await;
-
-                match outcome {
-                    SubmitOutcome::Confirmed => {}
-                    SubmitOutcome::Reverted => {
-                        self.record_slot_duration(slot_started_at.elapsed());
-                        self.repair_notify.notify_one();
-                        return Ok(());
-                    }
-                    SubmitOutcome::Unconfirmed => {
-                        // The next cycle re-reads the on-chain slot hash and resumes
-                        // from wherever the portal actually is.
-                        self.record_slot_duration(slot_started_at.elapsed());
-                        return Ok(());
-                    }
-                }
-            }
+            let outcome = self
+                .submit_and_confirm_batches(head_val, offset, remaining.len(), planned_batches)
+                .await?;
             self.record_slot_duration(slot_started_at.elapsed());
 
-            // All withdrawals in this slot confirmed — safe to remove. Continue
-            // the loop to drain any further pending slots.
-            self.store.lock().remove_batch(head_val);
-
-            info!(
-                slot = head_val,
-                count = remaining.len(),
-                "Batch fully processed and removed from store"
-            );
+            match outcome {
+                SubmitOutcome::Confirmed if planned_withdrawals == remaining.len() => {
+                    // The entire slot confirmed — safe to remove. Continue the loop to drain any
+                    // further pending slots.
+                    self.store.lock().remove_batch(head_val);
+                    info!(
+                        slot = head_val,
+                        count = remaining.len(),
+                        "Slot fully processed and removed from store"
+                    );
+                }
+                SubmitOutcome::Confirmed => {
+                    // The configured in-flight window was smaller than the slot. Re-read the
+                    // on-chain suffix before planning the next window.
+                    continue;
+                }
+                SubmitOutcome::Reverted => {
+                    self.repair_notify.notify_one();
+                    return Ok(());
+                }
+                SubmitOutcome::Unconfirmed => {
+                    // The next cycle re-reads the on-chain slot hash and resumes from wherever the
+                    // portal actually is.
+                    return Ok(());
+                }
+            }
         }
     }
 
-    /// Submit one `processWithdrawals` transaction and wait for its receipt.
-    async fn submit_and_confirm(
+    /// Broadcast a window of consecutive-nonce `processWithdrawals` transactions, then wait for
+    /// all broadcast receipts concurrently.
+    async fn submit_and_confirm_batches(
         &self,
         slot: u64,
-        index: usize,
+        offset: usize,
         total: usize,
-        withdrawal: &abi::Withdrawal,
-        remaining_queue: B256,
-    ) -> SubmitOutcome {
-        self.metrics.withdrawals_processed_total.increment(1);
+        batches: Vec<PlannedWithdrawalBatch>,
+    ) -> eyre::Result<SubmitOutcome> {
+        let first_nonce = self
+            .provider
+            .get_transaction_count_with_nonce_key(
+                self.config.sequencer_address,
+                PROCESS_WITHDRAWAL_NONCE_KEY,
+            )
+            .await?;
+        let mut pending_batches = Vec::with_capacity(batches.len());
+        let mut broadcast_failed = false;
 
-        info!(
-            slot,
-            index,
-            total,
-            token = %withdrawal.token,
-            to = %withdrawal.to,
-            amount = %withdrawal.amount,
-            has_callback = withdrawal.gasLimit > 0,
-            "📤 Submitting withdrawal to L1"
-        );
+        // Broadcast in nonce order without waiting for inclusion. Once accepted by the RPC, all
+        // transactions remain concurrently in flight and Tempo's lane-2 nonce ordering preserves
+        // the portal queue dependency between them.
+        for (batch_index, batch) in batches.into_iter().enumerate() {
+            let nonce = first_nonce
+                .checked_add(batch_index as u64)
+                .ok_or_else(|| eyre::eyre!("processWithdrawals nonce overflow at {first_nonce}"))?;
+            let absolute_start = offset + batch.start_index;
+            let withdrawal_count = batch.withdrawals.len();
+            let has_callback = batch.withdrawals.iter().any(|w| w.gasLimit > 0);
 
-        let call = self
-            .portal
-            .processWithdrawals(vec![withdrawal.clone()], remaining_queue)
-            .nonce_key(PROCESS_WITHDRAWAL_NONCE_KEY);
-
-        // When the withdrawal has a callback (`gasLimit > 0`), we must
-        // override `eth_estimateGas` because the estimate only covers the
-        // revert / bounce-back path, which is much cheaper than the happy
-        // path where the callback actually executes.
-        //
-        // The tx gas limit is composed of two parts:
-        //
-        //   txGas = min(gasLimit, MAX_WITHDRAWAL_GAS_LIMIT)
-        //         + CALLBACK_OVERHEAD
-        //
-        // 1. `gasLimit`          — gas the user requested for their callback.
-        // 2. `CALLBACK_OVERHEAD` — fixed cost for the portal + messenger
-        //    logic that runs *around* the callback: queue dequeue & hash
-        //    verification, TIP-20 transfers, messenger relay
-        //    setup, fee payment, event emission, and the bounce-back path
-        //    if the callback reverts.
-        //
-        // `MAX_WITHDRAWAL_GAS_LIMIT` mirrors the contract-level cap. It
-        // also bounds legacy over-cap withdrawals so RPC nodes do not
-        // reject the transaction before the portal can dequeue and
-        // bounce them back.
-        let call = if withdrawal.gasLimit > 0 {
-            let tx_gas_limit = process_withdrawal_tx_gas_limit(withdrawal.gasLimit);
-            if withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT {
-                warn!(
-                    slot,
-                    index,
-                    requested_gas_limit = withdrawal.gasLimit,
-                    max_gas_limit = MAX_WITHDRAWAL_GAS_LIMIT,
-                    tx_gas_limit,
-                    "withdrawal callback gas exceeds protocol cap; submitting bounded tx"
-                );
+            for (item_index, withdrawal) in batch.withdrawals.iter().enumerate() {
+                if withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT {
+                    warn!(
+                        slot,
+                        index = absolute_start + item_index,
+                        requested_gas_limit = withdrawal.gasLimit,
+                        max_gas_limit = MAX_WITHDRAWAL_GAS_LIMIT,
+                        "withdrawal callback gas exceeds protocol cap; reserving bounded gas"
+                    );
+                }
             }
-            call.gas(tx_gas_limit)
-        } else {
-            call
-        };
 
-        let pending = match call.send().await {
-            Ok(pending) => pending,
-            Err(e) => {
-                self.metrics.withdrawals_failed_total.increment(1);
-                error!(
-                    slot,
-                    index,
-                    expected_remaining_queue = %remaining_queue,
-                    to = %withdrawal.to,
-                    amount = %withdrawal.amount,
-                    error = %e,
-                    "processWithdrawals tx failed to send, stopping batch processing"
-                );
-                return SubmitOutcome::Unconfirmed;
-            }
-        };
-
-        let tx_hash = *pending.tx_hash();
-        let receipt = match pending
-            .with_timeout(Some(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT))
-            .get_receipt()
-            .await
-        {
-            Ok(receipt) => receipt,
-            Err(e) => {
-                self.metrics.withdrawals_failed_total.increment(1);
-                error!(
-                    slot,
-                    index,
-                    %tx_hash,
-                    expected_remaining_queue = %remaining_queue,
-                    to = %withdrawal.to,
-                    amount = %withdrawal.amount,
-                    error = %e,
-                    "processWithdrawals tx not confirmed, stopping batch processing"
-                );
-                return SubmitOutcome::Unconfirmed;
-            }
-        };
-
-        if !receipt.status() {
-            self.metrics.withdrawals_failed_total.increment(1);
-            self.metrics.withdrawals_reverted_total.increment(1);
-            error!(
+            info!(
                 slot,
-                index,
-                %tx_hash,
-                to = %withdrawal.to,
-                amount = %withdrawal.amount,
-                expected_remaining_queue = %remaining_queue,
-                "processWithdrawals tx was included but reverted; keeping batch in store and requesting repair"
+                batch_index,
+                nonce,
+                start_index = absolute_start,
+                withdrawal_count,
+                total,
+                gas_limit = batch.gas_limit,
+                has_callback,
+                expected_remaining_queue = %batch.remaining_queue,
+                "📤 Broadcasting withdrawal batch to L1"
             );
-            return SubmitOutcome::Reverted;
+
+            let call = self
+                .portal
+                .processWithdrawals(batch.withdrawals.clone(), batch.remaining_queue)
+                .nonce_key(PROCESS_WITHDRAWAL_NONCE_KEY)
+                .nonce(nonce)
+                .gas(batch.gas_limit);
+
+            match call.send().await {
+                Ok(pending) => {
+                    self.metrics
+                        .withdrawals_processed_total
+                        .increment(withdrawal_count as u64);
+                    self.metrics.batches_submitted_total.increment(1);
+                    self.metrics
+                        .withdrawals_per_batch
+                        .record(withdrawal_count as f64);
+                    pending_batches.push(PendingWithdrawalBatch {
+                        batch,
+                        nonce,
+                        pending,
+                    });
+                }
+                Err(e) => {
+                    self.metrics
+                        .withdrawals_failed_total
+                        .increment(withdrawal_count as u64);
+                    error!(
+                        slot,
+                        batch_index,
+                        nonce,
+                        start_index = absolute_start,
+                        withdrawal_count,
+                        error = %e,
+                        "processWithdrawals tx failed to send; stopping at the first nonce gap"
+                    );
+                    broadcast_failed = true;
+                    break;
+                }
+            }
         }
 
-        self.metrics.withdrawals_confirmed_total.increment(1);
-        info!(
-            slot,
-            index,
-            %tx_hash,
-            token = %withdrawal.token,
-            to = %withdrawal.to,
-            amount = %withdrawal.amount,
-            gas_used = receipt.gas_used,
-            "✅ Withdrawal confirmed on L1"
-        );
-        SubmitOutcome::Confirmed
+        let receipt_results =
+            join_all(pending_batches.into_iter().map(|pending_batch| async move {
+                let tx_hash = *pending_batch.pending.tx_hash();
+                let receipt = pending_batch
+                    .pending
+                    .with_timeout(Some(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT))
+                    .get_receipt()
+                    .await;
+                (pending_batch.batch, pending_batch.nonce, tx_hash, receipt)
+            }))
+            .await;
+
+        let mut outcome = if broadcast_failed {
+            SubmitOutcome::Unconfirmed
+        } else {
+            SubmitOutcome::Confirmed
+        };
+
+        // Interpret receipts in nonce order even though they were awaited concurrently.
+        for (batch, nonce, tx_hash, receipt) in receipt_results {
+            let withdrawal_count = batch.withdrawals.len();
+            match receipt {
+                Ok(receipt) if receipt.status() => {
+                    self.metrics
+                        .withdrawals_confirmed_total
+                        .increment(withdrawal_count as u64);
+                    self.metrics.batches_confirmed_total.increment(1);
+                    info!(
+                        slot,
+                        nonce,
+                        %tx_hash,
+                        start_index = offset + batch.start_index,
+                        withdrawal_count,
+                        "✅ Withdrawal batch confirmed on L1"
+                    );
+                }
+                Ok(_) => {
+                    self.metrics
+                        .withdrawals_failed_total
+                        .increment(withdrawal_count as u64);
+                    self.metrics.withdrawals_reverted_total.increment(1);
+                    error!(
+                        slot,
+                        nonce,
+                        %tx_hash,
+                        start_index = offset + batch.start_index,
+                        withdrawal_count,
+                        expected_remaining_queue = %batch.remaining_queue,
+                        "processWithdrawals tx reverted; later planned batches are invalid"
+                    );
+                    outcome = SubmitOutcome::Reverted;
+                    break;
+                }
+                Err(e) => {
+                    self.metrics
+                        .withdrawals_failed_total
+                        .increment(withdrawal_count as u64);
+                    error!(
+                        slot,
+                        nonce,
+                        %tx_hash,
+                        start_index = offset + batch.start_index,
+                        withdrawal_count,
+                        expected_remaining_queue = %batch.remaining_queue,
+                        error = %e,
+                        "processWithdrawals tx not confirmed; queue will be reconciled"
+                    );
+                    outcome = SubmitOutcome::Unconfirmed;
+                    break;
+                }
+            }
+        }
+
+        Ok(outcome)
     }
 
     fn record_queue_metrics(&mut self, head: u64, tail: u64, store_batch_count: usize) {
@@ -770,16 +944,149 @@ mod tests {
 
     #[test]
     fn callback_tx_gas_limit_is_capped_below_l1_block_limit() {
-        let at_cap = process_withdrawal_tx_gas_limit(MAX_WITHDRAWAL_GAS_LIMIT);
-        let over_cap = process_withdrawal_tx_gas_limit(MAX_WITHDRAWAL_GAS_LIMIT + 1);
+        let at_cap = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
+            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT);
+        let over_cap = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
+            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT + 1);
 
         assert_eq!(over_cap, at_cap);
         assert_eq!(at_cap, MAX_PROCESS_WITHDRAWAL_TX_GAS);
         assert_eq!(
             at_cap,
-            MAX_WITHDRAWAL_GAS_LIMIT + PROCESS_WITHDRAWAL_CALLBACK_OVERHEAD_GAS
+            MAX_WITHDRAWAL_GAS_LIMIT
+                + PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
+                + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS
         );
         assert!(at_cap < 30_000_000);
+    }
+
+    fn planner(
+        max_batch_gas: u64,
+        max_in_flight_batches: usize,
+        max_in_flight_gas: u64,
+    ) -> WithdrawalBatchPlanner {
+        WithdrawalBatchPlanner::new(WithdrawalBatchLimits {
+            max_batch_gas,
+            max_in_flight_batches,
+            max_in_flight_gas,
+        })
+    }
+
+    fn simple_withdrawals(count: usize) -> Vec<abi::Withdrawal> {
+        (0..count)
+            .map(|i| test_withdrawal(Address::with_last_byte((i + 1) as u8), (i + 1) as u128))
+            .collect()
+    }
+
+    #[test]
+    fn planner_packs_by_gas_and_preserves_full_queue_suffixes() {
+        let withdrawals = simple_withdrawals(3);
+        let one = PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
+        let plans =
+            planner(PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one, 4, 10_000_000).plan(&withdrawals);
+
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].start_index, 0);
+        assert_eq!(plans[0].withdrawals.len(), 2);
+        assert_eq!(plans[0].withdrawals[0].amount, withdrawals[0].amount);
+        assert_eq!(plans[0].withdrawals[1].amount, withdrawals[1].amount);
+        assert_eq!(
+            plans[0].remaining_queue,
+            abi::Withdrawal::queue_hash(&withdrawals[2..])
+        );
+        assert_eq!(plans[1].start_index, 2);
+        assert_eq!(plans[1].withdrawals.len(), 1);
+        assert_eq!(plans[1].withdrawals[0].amount, withdrawals[2].amount);
+        assert_eq!(plans[1].remaining_queue, B256::ZERO);
+    }
+
+    #[test]
+    fn planner_bounds_the_in_flight_gas_window() {
+        let withdrawals = simple_withdrawals(10);
+        let one_batch = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
+        let plans = planner(one_batch, 10, one_batch * 2).plan(&withdrawals);
+
+        assert_eq!(plans.len(), 2);
+        assert_eq!(
+            plans.iter().map(|batch| batch.gas_limit).sum::<u64>(),
+            one_batch * 2
+        );
+        assert_eq!(
+            plans[1].remaining_queue,
+            abi::Withdrawal::queue_hash(&withdrawals[2..])
+        );
+    }
+
+    #[test]
+    fn planner_bounds_the_number_of_in_flight_transactions() {
+        let withdrawals = simple_withdrawals(5);
+        let one_batch = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
+        let plans = planner(one_batch, 2, u64::MAX).plan(&withdrawals);
+
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].start_index, 0);
+        assert_eq!(plans[1].start_index, 1);
+        assert_eq!(
+            plans[1].remaining_queue,
+            abi::Withdrawal::queue_hash(&withdrawals[2..])
+        );
+    }
+
+    #[test]
+    fn planner_emits_an_oversized_head_as_a_singleton() {
+        let mut withdrawals = simple_withdrawals(2);
+        withdrawals[0].gasLimit = MAX_WITHDRAWAL_GAS_LIMIT;
+        let plans = planner(1_000_000, 4, 20_000_000).plan(&withdrawals);
+
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].withdrawals.len(), 1);
+        assert!(plans[0].gas_limit > 1_000_000);
+        assert_eq!(
+            plans[0].remaining_queue,
+            abi::Withdrawal::queue_hash(&withdrawals[1..])
+        );
+    }
+
+    #[test]
+    fn planner_defers_an_oversized_item_that_does_not_fit_the_current_window() {
+        let mut withdrawals = simple_withdrawals(2);
+        withdrawals[1].gasLimit = MAX_WITHDRAWAL_GAS_LIMIT;
+        let simple_gas = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + PROCESS_WITHDRAWAL_ITEM_OVERHEAD_GAS;
+        let callback_gas = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
+            + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT);
+        let planner = planner(simple_gas, 4, simple_gas + callback_gas - 1);
+
+        let first_window = planner.plan(&withdrawals);
+        assert_eq!(first_window.len(), 1);
+        assert_eq!(first_window[0].withdrawals[0].amount, withdrawals[0].amount);
+
+        let next_window = planner.plan(&withdrawals[1..]);
+        assert_eq!(next_window.len(), 1);
+        assert_eq!(next_window[0].gas_limit, callback_gas);
+    }
+
+    #[test]
+    fn planner_caps_calldata_even_when_gas_budget_is_large() {
+        let withdrawals = simple_withdrawals(MAX_WITHDRAWALS_PER_PROCESS_BATCH + 1);
+        let plans = planner(u64::MAX, 2, u64::MAX).plan(&withdrawals);
+
+        assert_eq!(plans.len(), 2);
+        assert_eq!(
+            plans[0].withdrawals.len(),
+            MAX_WITHDRAWALS_PER_PROCESS_BATCH
+        );
+        assert_eq!(plans[1].withdrawals.len(), 1);
+        assert_eq!(plans[1].remaining_queue, B256::ZERO);
+    }
+
+    #[test]
+    fn planner_normalizes_zero_limits_without_stalling() {
+        let withdrawals = simple_withdrawals(1);
+        let plans = planner(0, 0, 0).plan(&withdrawals);
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].withdrawals.len(), 1);
+        assert_eq!(plans[0].withdrawals[0].amount, withdrawals[0].amount);
     }
 
     #[test]
@@ -879,6 +1186,8 @@ mod tests {
             portal_address: address!("0x7069DeC4E64Fd07334A0933eDe836C17259c9B23"),
             l1_rpc_url: "http://unused.test".to_string(),
             fallback_poll_interval: Duration::from_secs(1),
+            sequencer_address: Address::repeat_byte(0x77),
+            batch_limits: WithdrawalBatchLimits::default(),
         };
         WithdrawalProcessor::new(
             config,

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -599,7 +599,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--withdrawal-max-batch-gas` | 10000000 | Maximum planned gas for one `processWithdrawals` transaction; an oversized FIFO head is still sent alone |
 | `--withdrawal-max-in-flight-batches` | 4 | Maximum ordered withdrawal transactions kept concurrently in flight |
-| `--withdrawal-max-in-flight-gas` | 20000000 | Maximum aggregate planned gas across the in-flight withdrawal window |
+| `--withdrawal-max-in-flight-gas` | 20000000 | Maximum aggregate gas across in-flight withdrawal transactions; must be at least the per-transaction limit; an oversized singleton runs alone |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
 | `--private-rpc.port` | 8544 | Private RPC server port |
 | `--private-rpc.max-auth-token-validity-secs` | 2592000 | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -597,8 +597,8 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |
 | `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
-| `--withdrawal-max-batch-gas` | 10000000 | Maximum planned gas for one `processWithdrawals` transaction; an oversized FIFO head is still sent alone |
-| `--withdrawal-max-in-flight-batches` | 4 | Maximum ordered withdrawal transactions kept concurrently in flight |
+| `--withdrawal-max-batch-gas` | 10000000 | Maximum planned gas for one `processWithdrawals` transaction (up to 20000000); an oversized FIFO head is still sent alone |
+| `--withdrawal-max-in-flight-batches` | 8 | Maximum ordered withdrawal transactions kept concurrently in flight |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
 | `--private-rpc.port` | 8544 | Private RPC server port |
 | `--private-rpc.max-auth-token-validity-secs` | 2592000 | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
@@ -615,7 +615,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
 | `ROUTER_BOUNCEBACK_RECIPIENT` | No | Optional controlled burner/stealth address for `demo-swap-and-deposit` routed deposit refunds |
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
-| `WITHDRAWAL_MAX_BATCH_GAS` | No | Override the per-transaction withdrawal gas budget |
+| `WITHDRAWAL_MAX_BATCH_GAS` | No | Override the per-transaction withdrawal gas budget (maximum 20000000) |
 | `WITHDRAWAL_MAX_IN_FLIGHT_BATCHES` | No | Override the maximum number of ordered withdrawal transactions in flight |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 | `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -599,7 +599,6 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--withdrawal-max-batch-gas` | 10000000 | Maximum planned gas for one `processWithdrawals` transaction; an oversized FIFO head is still sent alone |
 | `--withdrawal-max-in-flight-batches` | 4 | Maximum ordered withdrawal transactions kept concurrently in flight |
-| `--withdrawal-max-in-flight-gas` | 20000000 | Maximum aggregate gas across in-flight withdrawal transactions; must be at least the per-transaction limit; an oversized singleton runs alone |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
 | `--private-rpc.port` | 8544 | Private RPC server port |
 | `--private-rpc.max-auth-token-validity-secs` | 2592000 | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
@@ -618,7 +617,6 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
 | `WITHDRAWAL_MAX_BATCH_GAS` | No | Override the per-transaction withdrawal gas budget |
 | `WITHDRAWAL_MAX_IN_FLIGHT_BATCHES` | No | Override the maximum number of ordered withdrawal transactions in flight |
-| `WITHDRAWAL_MAX_IN_FLIGHT_GAS` | No | Override the aggregate in-flight withdrawal gas budget |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 | `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |
 

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -597,6 +597,9 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |
 | `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
+| `--withdrawal-max-batch-gas` | 10000000 | Maximum planned gas for one `processWithdrawals` transaction; an oversized FIFO head is still sent alone |
+| `--withdrawal-max-in-flight-batches` | 4 | Maximum ordered withdrawal transactions kept concurrently in flight |
+| `--withdrawal-max-in-flight-gas` | 20000000 | Maximum aggregate planned gas across the in-flight withdrawal window |
 | `--http.port` | 8546 | HTTP JSON-RPC port |
 | `--private-rpc.port` | 8544 | Private RPC server port |
 | `--private-rpc.max-auth-token-validity-secs` | 2592000 | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
@@ -613,6 +616,9 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |
 | `ROUTER_BOUNCEBACK_RECIPIENT` | No | Optional controlled burner/stealth address for `demo-swap-and-deposit` routed deposit refunds |
 | `PRIVATE_RPC_MAX_AUTH_TOKEN_VALIDITY_SECS` | No | Maximum auth token validity the private RPC accepts, in seconds. The effective limit is capped at 30 days. |
+| `WITHDRAWAL_MAX_BATCH_GAS` | No | Override the per-transaction withdrawal gas budget |
+| `WITHDRAWAL_MAX_IN_FLIGHT_BATCHES` | No | Override the maximum number of ordered withdrawal transactions in flight |
+| `WITHDRAWAL_MAX_IN_FLIGHT_GAS` | No | Override the aggregate in-flight withdrawal gas budget |
 | `ZONE_TOKEN` | No | Default initial TIP-20 for `just create-zone` / `just deploy-zone`; defaults to `pathUSD` |
 | `ZONE_FACTORY` | No | Optional ZoneFactory override; xtasks default to the current Moderato shared deployment |
 

--- a/specs/ref-impls/test/tempo/ZonePortalGasLimit.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortalGasLimit.t.sol
@@ -137,6 +137,32 @@ contract ZonePortalGasLimitTest is Test {
         assertTrue(portal.currentDepositQueueHash() != bytes32(0));
     }
 
+    function test_processWithdrawal_simpleTransferFailureBouncesBackWithinPlannerLimit() public {
+        token.mint(address(portal), 500e6);
+        token.setBlockedRecipient(recipient, true);
+
+        Withdrawal memory w = Withdrawal({
+            token: address(token),
+            senderTag: keccak256("sender"),
+            to: recipient,
+            amount: 500e6,
+            memo: bytes32(0),
+            gasLimit: 0,
+            fallbackNonce: 1,
+            callbackData: "",
+            encryptedSender: ""
+        });
+        _storeSingleWithdrawal(w);
+
+        (bool success,) = address(portal).call{ gas: 1_500_000 }(
+            abi.encodeCall(IZonePortal.processWithdrawals, (_singleWithdrawal(w), bytes32(0)))
+        );
+
+        assertTrue(success);
+        assertEq(portal.withdrawalQueueHead(), 1);
+        assertTrue(portal.currentDepositQueueHash() != bytes32(0));
+    }
+
     function test_processWithdrawal_depositBounceBack_paysFeeAndRefundsNetAmount() public {
         _configureBouncebackFee();
         token.mint(address(portal), 1000e6);

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -671,6 +671,8 @@ The sequencer processes ordered withdrawals atomically on Tempo by calling `proc
 
 The portal dequeues before executing the withdrawal, then independently requires `withdrawal.token` to be enabled. Failed callbacks roll back in an external self-call and become bounce-backs, so the dequeue remains committed and cannot block the FIFO. If `remainingQueue` is zero (last item in the slot), processing sets the slot to `EMPTY_SENTINEL` and advances `head`; otherwise it updates the slot to `remainingQueue`.
 
+The sequencer packs withdrawals into transactions using a configurable gas budget rather than consuming the full L1 block gas limit. It may keep multiple batches in flight using consecutive nonces on its dedicated withdrawal nonce key. The nonce order preserves FIFO queue transitions even when the transactions are broadcast before earlier receipts arrive.
+
 For a plain withdrawal (`gasLimit == 0`), the portal requires `to` to be an allowed account and not a registered ZoneGateway, then transfers directly. A failed transfer creates a withdrawal bounce-back deposit for the Zone-local `zoneFallbackRecipient`.
 
 ### Withdrawal Callbacks

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -671,7 +671,7 @@ The sequencer processes ordered withdrawals atomically on Tempo by calling `proc
 
 The portal dequeues before executing the withdrawal, then independently requires `withdrawal.token` to be enabled. Failed callbacks roll back in an external self-call and become bounce-backs, so the dequeue remains committed and cannot block the FIFO. If `remainingQueue` is zero (last item in the slot), processing sets the slot to `EMPTY_SENTINEL` and advances `head`; otherwise it updates the slot to `remainingQueue`.
 
-The sequencer packs withdrawals into transactions using a configurable gas budget rather than consuming the full L1 block gas limit. It may keep multiple batches in flight using consecutive nonces on its dedicated withdrawal nonce key. The nonce order preserves FIFO queue transitions even when the transactions are broadcast before earlier receipts arrive.
+The sequencer first packs withdrawals into transactions using a configurable per-transaction gas budget, then submits them through a queue bounded by transaction count. Transactions use consecutive nonces on the dedicated withdrawal nonce key, preserving FIFO queue transitions even when later transactions are broadcast before earlier receipts arrive. If a submission reverts or cannot be confirmed, the sequencer stops admitting new transactions, drains those already submitted, then reconciles the on-chain queue and retries its unfinished suffix.
 
 For a plain withdrawal (`gasLimit == 0`), the portal requires `to` to be an allowed account and not a registered ZoneGateway, then transfers directly. A failed transfer creates a withdrawal bounce-back deposit for the Zone-local `zoneFallbackRecipient`.
 


### PR DESCRIPTION
## Summary

- add CLI/env limits for per-transaction withdrawal gas and maximum in-flight transactions
- split FIFO withdrawals by gas and submit ordered batches through a bounded `FuturesUnordered` queue with consecutive keyed nonces
- drain submitted receipts, reconcile on-chain progress, and retry unfinished withdrawals after failures
