### PR TITLE
refactor(portal): group transfer storage

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -335,21 +335,21 @@ interface IZoneTxContext {
 
 // ZonePortal storage layout:
 //   slot 0: sequencer (address)
-//   slot 1: admin (address)
-//   slot 2: pendingSequencer (address)
-//   slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
-//   slot 4: blockHash (bytes32)
-//   slot 5: currentDepositQueueHash (bytes32)
-//   slot 6: depositCount (uint64) + lastProcessedDepositNumber (uint64) + lastSyncedTempoBlockNumber (uint64) [packed]
-//   slot 7: _encryptionKeys (EncryptionKeyEntry[])
-//   slot 8: _tokenConfigs (mapping(address => TokenConfig))
-//   slot 9: _enabledTokens (address[])
-//   slot 10: refunds (mapping(address => mapping(address => uint128)))
-//   slot 11: _withdrawalQueue.head
-//   slot 12: _withdrawalQueue.tail
-//   slot 13: _withdrawalQueue.slots (mapping(uint256 => bytes32))
-//   slot 14: rpcUrl (string)
-//   slot 15: pendingAdmin (address)
+//   slot 1: pendingSequencer (address)
+//   slot 2: admin (address)
+//   slot 3: pendingAdmin (address)
+//   slot 4: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+//   slot 5: blockHash (bytes32)
+//   slot 6: currentDepositQueueHash (bytes32)
+//   slot 7: depositCount (uint64) + lastProcessedDepositNumber (uint64) + lastSyncedTempoBlockNumber (uint64) [packed]
+//   slot 8: _encryptionKeys (EncryptionKeyEntry[])
+//   slot 9: _tokenConfigs (mapping(address => TokenConfig))
+//   slot 10: _enabledTokens (address[])
+//   slot 11: refunds (mapping(address => mapping(address => uint128)))
+//   slot 12: _withdrawalQueue.head
+//   slot 13: _withdrawalQueue.tail
+//   slot 14: _withdrawalQueue.slots (mapping(uint256 => bytes32))
+//   slot 15: rpcUrl (string)
 //   slot 16: _withdrawalReentrancyStatus (uint256)
 //   slot 17: zoneId (uint32) + messenger (address) [packed]
 //   slot 18: verifier (address) + genesisTempoBlockNumber (uint64) + _initialized (bool) [packed]
@@ -363,13 +363,13 @@ interface IZoneTxContext {
 // TempoState.readTempoStorageSlot(). If the portal layout changes,
 // update these constants and the vm.load regression tests will catch mismatches.
 bytes32 constant PORTAL_SEQUENCER_SLOT = bytes32(uint256(0));
-bytes32 constant PORTAL_ADMIN_SLOT = bytes32(uint256(1));
-bytes32 constant PORTAL_PENDING_SEQUENCER_SLOT = bytes32(uint256(2));
-bytes32 constant PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(5));
-bytes32 constant PORTAL_ENCRYPTION_KEYS_SLOT = bytes32(uint256(7));
-bytes32 constant PORTAL_TOKEN_CONFIGS_SLOT = bytes32(uint256(8));
-bytes32 constant PORTAL_ENABLED_TOKENS_SLOT = bytes32(uint256(9));
-bytes32 constant PORTAL_PENDING_ADMIN_SLOT = bytes32(uint256(15));
+bytes32 constant PORTAL_PENDING_SEQUENCER_SLOT = bytes32(uint256(1));
+bytes32 constant PORTAL_ADMIN_SLOT = bytes32(uint256(2));
+bytes32 constant PORTAL_PENDING_ADMIN_SLOT = bytes32(uint256(3));
+bytes32 constant PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT = bytes32(uint256(6));
+bytes32 constant PORTAL_ENCRYPTION_KEYS_SLOT = bytes32(uint256(8));
+bytes32 constant PORTAL_TOKEN_CONFIGS_SLOT = bytes32(uint256(9));
+bytes32 constant PORTAL_ENABLED_TOKENS_SLOT = bytes32(uint256(10));
 
 /// @title IVerifier
 /// @notice Interface for zone proof/attestation verification

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -78,11 +78,14 @@ contract ZonePortal is IZonePortal {
     /// @dev This address has no permissions distinct from the sequencer set.
     address public sequencer;
 
+    /// @notice Pending sequencer for two-step transfer
+    address public pendingSequencer;
+
     /// @notice Governance admin address
     address public admin;
 
-    /// @notice Pending sequencer for two-step transfer
-    address public pendingSequencer;
+    /// @notice Pending admin for two-step admin transfer
+    address public pendingAdmin;
 
     /// @notice Zone gas rate (zone token units per gas unit on the zone)
     /// @dev Sequencer publishes this rate and takes the risk on zone gas costs.
@@ -108,19 +111,19 @@ contract ZonePortal is IZonePortal {
     uint64 public lastSyncedTempoBlockNumber;
 
     /// @notice Gas amount used to price a failed-deposit bounce-back on Tempo.
-    /// @dev Packed into the unused bytes in slot 6. Defaults to zero.
+    /// @dev Packed into the unused bytes in slot 7. Defaults to zero.
     uint64 public bouncebackGas;
 
     /// @notice Historical encryption keys with activation blocks
     /// @dev Users specify which key they encrypted to (by index). Maintained for key rotation.
-    ///      Stored at slot 7 in the ZonePortal storage layout.
+    ///      Stored at slot 8 in the ZonePortal storage layout.
     EncryptionKeyEntry[] internal _encryptionKeys;
 
-    /// @notice Per-token configuration (stored at slot 8)
+    /// @notice Per-token configuration (stored at slot 9)
     /// @dev TokenConfig.enabled is permanent (write-once true); depositsActive can be toggled.
     mapping(address => TokenConfig) internal _tokenConfigs;
 
-    /// @notice Append-only list of enabled tokens (stored at slot 9)
+    /// @notice Append-only list of enabled tokens (stored at slot 10)
     /// @dev Tokens can never be removed from this list (non-custodial guarantee).
     address[] internal _enabledTokens;
 
@@ -132,9 +135,6 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Public RPC endpoint for the zone
     string public rpcUrl;
-
-    /// @notice Pending admin for two-step admin transfer
-    address public pendingAdmin;
 
     /// @notice Reentrancy guard for withdrawal delivery.
     uint256 internal _withdrawalReentrancyStatus;

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -11,7 +11,7 @@
     {
       "astId": 5113,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "admin",
+      "label": "pendingSequencer",
       "offset": 0,
       "slot": "1",
       "type": "t_address"
@@ -19,7 +19,7 @@
     {
       "astId": 5116,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "pendingSequencer",
+      "label": "admin",
       "offset": 0,
       "slot": "2",
       "type": "t_address"
@@ -27,31 +27,31 @@
     {
       "astId": 5119,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "zoneGasRate",
+      "label": "pendingAdmin",
       "offset": 0,
       "slot": "3",
+      "type": "t_address"
+    },
+    {
+      "astId": 5122,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "zoneGasRate",
+      "offset": 0,
+      "slot": "4",
       "type": "t_uint128"
     },
     {
-      "astId": 5121,
+      "astId": 5124,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
-      "slot": "3",
-      "type": "t_uint64"
-    },
-    {
-      "astId": 5123,
-      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "blockHash",
-      "offset": 0,
       "slot": "4",
-      "type": "t_bytes32"
+      "type": "t_uint64"
     },
     {
       "astId": 5126,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "currentDepositQueueHash",
+      "label": "blockHash",
       "offset": 0,
       "slot": "5",
       "type": "t_bytes32"
@@ -59,90 +59,90 @@
     {
       "astId": 5129,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "depositCount",
+      "label": "currentDepositQueueHash",
       "offset": 0,
       "slot": "6",
-      "type": "t_uint64"
+      "type": "t_bytes32"
     },
     {
       "astId": 5132,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "lastProcessedDepositNumber",
-      "offset": 8,
-      "slot": "6",
+      "label": "depositCount",
+      "offset": 0,
+      "slot": "7",
       "type": "t_uint64"
     },
     {
       "astId": 5135,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "lastSyncedTempoBlockNumber",
-      "offset": 16,
-      "slot": "6",
+      "label": "lastProcessedDepositNumber",
+      "offset": 8,
+      "slot": "7",
       "type": "t_uint64"
     },
     {
       "astId": 5138,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "bouncebackGas",
-      "offset": 24,
-      "slot": "6",
+      "label": "lastSyncedTempoBlockNumber",
+      "offset": 16,
+      "slot": "7",
       "type": "t_uint64"
     },
     {
-      "astId": 5143,
+      "astId": 5141,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "bouncebackGas",
+      "offset": 24,
+      "slot": "7",
+      "type": "t_uint64"
+    },
+    {
+      "astId": 5146,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
-      "slot": "7",
+      "slot": "8",
       "type": "t_array(t_struct(EncryptionKeyEntry)2603_storage)dyn_storage"
     },
     {
-      "astId": 5149,
+      "astId": 5152,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
-      "slot": "8",
+      "slot": "9",
       "type": "t_mapping(t_address,t_struct(TokenConfig)3018_storage)"
     },
     {
-      "astId": 5153,
+      "astId": 5156,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
-      "slot": "9",
+      "slot": "10",
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5160,
+      "astId": 5163,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
-      "slot": "10",
-      "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
-    },
-    {
-      "astId": 5164,
-      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "_withdrawalQueue",
-      "offset": 0,
       "slot": "11",
-      "type": "t_struct(WithdrawalQueue)4787_storage"
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
       "astId": 5167,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "rpcUrl",
+      "label": "_withdrawalQueue",
       "offset": 0,
-      "slot": "14",
-      "type": "t_string_storage"
+      "slot": "12",
+      "type": "t_struct(WithdrawalQueue)4787_storage"
     },
     {
       "astId": 5170,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
-      "label": "pendingAdmin",
+      "label": "rpcUrl",
       "offset": 0,
       "slot": "15",
-      "type": "t_address"
+      "type": "t_string_storage"
     },
     {
       "astId": 5173,

--- a/specs/ref-impls/test/libraries/EncryptionKeyLayout.t.sol
+++ b/specs/ref-impls/test/libraries/EncryptionKeyLayout.t.sol
@@ -9,7 +9,7 @@ import { Test } from "forge-std/Test.sol";
 ///      derived slot arithmetic is identical.
 contract EncryptionKeyLayoutHarness {
 
-    // Slots 0-6: padding to match ZonePortal layout
+    // Slots 0-7: padding to match ZonePortal layout
     uint256 private _pad0;
     uint256 private _pad1;
     uint256 private _pad2;
@@ -17,8 +17,9 @@ contract EncryptionKeyLayoutHarness {
     uint256 private _pad4;
     uint256 private _pad5;
     uint256 private _pad6;
+    uint256 private _pad7;
 
-    // Slot 7: _encryptionKeys — must be at PORTAL_ENCRYPTION_KEYS_SLOT
+    // Slot 8: _encryptionKeys — must be at PORTAL_ENCRYPTION_KEYS_SLOT
     EncryptionKeyEntry[] internal _encryptionKeys;
 
     function push(bytes32 x, uint8 yParity, uint64 activationBlock) external {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -3298,13 +3298,14 @@ contract ZonePortalTest is BaseTest {
     ///
     ///      Slot layout:
     ///        slot 0: sequencer (address)
-    ///        slot 1: admin (address)
-    ///        slot 2: pendingSequencer (address)
-    ///        slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
-    ///        slot 4: blockHash (bytes32)
-    ///        slot 5: currentDepositQueueHash (bytes32)
-    ///        slot 6: deposit counters + bouncebackGas (uint64) [packed]
-    ///        slot 7: _encryptionKeys.length (EncryptionKeyEntry[])
+    ///        slot 1: pendingSequencer (address)
+    ///        slot 2: admin (address)
+    ///        slot 3: pendingAdmin (address)
+    ///        slot 4: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) [packed]
+    ///        slot 5: blockHash (bytes32)
+    ///        slot 6: currentDepositQueueHash (bytes32)
+    ///        slot 7: deposit counters + bouncebackGas (uint64) [packed]
+    ///        slot 8: _encryptionKeys.length (EncryptionKeyEntry[])
     ///        slot 17: zoneId (uint32) + messenger (address) [packed]
     ///        slot 18: verifier + genesisTempoBlockNumber + _initialized [packed]
     function test_storageLayout_slotPositions() public {
@@ -3312,65 +3313,63 @@ contract ZonePortalTest is BaseTest {
         bytes32 slot0 = vm.load(address(portal), bytes32(uint256(0)));
         assertEq(address(uint160(uint256(slot0))), portal.sequencer(), "slot 0: sequencer mismatch");
 
-        // --- Slot 1: admin ---
+        // --- Slot 2: admin ---
         bytes32 adminFromSlot = vm.load(address(portal), PORTAL_ADMIN_SLOT);
-        assertEq(address(uint160(uint256(adminFromSlot))), portal.admin(), "slot 1: admin mismatch");
+        assertEq(address(uint160(uint256(adminFromSlot))), portal.admin(), "slot 2: admin mismatch");
 
-        // --- Slot 2: pendingSequencer ---
+        // --- Slot 1: pendingSequencer ---
         // Transfer sequencer to get a non-zero pendingSequencer
         portal.transferSequencer(alice);
-        bytes32 slot1 = vm.load(address(portal), bytes32(uint256(2)));
+        bytes32 pendingSequencerFromSlot = vm.load(address(portal), PORTAL_PENDING_SEQUENCER_SLOT);
         assertEq(
-            address(uint160(uint256(slot1))),
+            address(uint160(uint256(pendingSequencerFromSlot))),
             portal.pendingSequencer(),
-            "slot 2: pendingSequencer mismatch"
+            "slot 1: pendingSequencer mismatch"
         );
 
-        // --- Slot 3: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) packed ---
-        uint128 testRate = 42;
-        portal.setZoneGasRate(testRate);
-        bytes32 slot2 = vm.load(address(portal), bytes32(uint256(3)));
-        // zoneGasRate is at the lowest 128 bits (uint128), withdrawalBatchIndex at bits 128-191
-        uint128 loadedRate = uint128(uint256(slot2));
-        assertEq(loadedRate, testRate, "slot 3: zoneGasRate mismatch");
-
-        // --- Slot 4: blockHash ---
-        bytes32 slot4 = vm.load(address(portal), bytes32(uint256(4)));
-        assertEq(slot4, portal.blockHash(), "slot 4: blockHash mismatch");
-
-        // --- Slot 5: currentDepositQueueHash ---
-        bytes32 slot5 = vm.load(address(portal), bytes32(uint256(5)));
-        assertEq(
-            slot5, portal.currentDepositQueueHash(), "slot 5: currentDepositQueueHash mismatch"
-        );
-
-        // --- Slot 6: deposit counters + bouncebackGas (uint64) packed ---
-        uint64 testBouncebackGas = 43;
-        portal.setBouncebackGas(testBouncebackGas);
-        bytes32 slot6 = vm.load(address(portal), bytes32(uint256(6)));
-        assertEq(
-            uint64(uint256(slot6) >> 128),
-            portal.lastSyncedTempoBlockNumber(),
-            "slot 6: lastSyncedTempoBlockNumber mismatch"
-        );
-        assertEq(uint64(uint256(slot6) >> 192), testBouncebackGas, "slot 6: bouncebackGas mismatch");
-
-        // --- Slot 7: _encryptionKeys array length ---
-        // Before adding keys, length should be 0
-        bytes32 slot7keys = vm.load(address(portal), PORTAL_ENCRYPTION_KEYS_SLOT);
-        assertEq(uint256(slot7keys), 0, "slot 7: _encryptionKeys length should be 0 initially");
-
-        // --- Slot 15: pendingAdmin ---
-        // Nominate a new admin to get a non-zero pendingAdmin (rpcUrl at slot 14 is short,
-        // so it stays inline and pendingAdmin lands at the next slot).
+        // --- Slot 3: pendingAdmin ---
         vm.prank(admin);
         portal.transferAdmin(bob);
-        bytes32 slot15 = vm.load(address(portal), PORTAL_PENDING_ADMIN_SLOT);
+        bytes32 pendingAdminFromSlot = vm.load(address(portal), PORTAL_PENDING_ADMIN_SLOT);
         assertEq(
-            address(uint160(uint256(slot15))),
+            address(uint160(uint256(pendingAdminFromSlot))),
             portal.pendingAdmin(),
-            "slot 15: pendingAdmin mismatch"
+            "slot 3: pendingAdmin mismatch"
         );
+
+        // --- Slot 4: zoneGasRate (uint128) + withdrawalBatchIndex (uint64) packed ---
+        uint128 testRate = 42;
+        portal.setZoneGasRate(testRate);
+        bytes32 slot4 = vm.load(address(portal), bytes32(uint256(4)));
+        // zoneGasRate is at the lowest 128 bits (uint128), withdrawalBatchIndex at bits 128-191
+        uint128 loadedRate = uint128(uint256(slot4));
+        assertEq(loadedRate, testRate, "slot 4: zoneGasRate mismatch");
+
+        // --- Slot 5: blockHash ---
+        bytes32 slot5 = vm.load(address(portal), bytes32(uint256(5)));
+        assertEq(slot5, portal.blockHash(), "slot 5: blockHash mismatch");
+
+        // --- Slot 6: currentDepositQueueHash ---
+        bytes32 slot6 = vm.load(address(portal), bytes32(uint256(6)));
+        assertEq(
+            slot6, portal.currentDepositQueueHash(), "slot 6: currentDepositQueueHash mismatch"
+        );
+
+        // --- Slot 7: deposit counters + bouncebackGas (uint64) packed ---
+        uint64 testBouncebackGas = 43;
+        portal.setBouncebackGas(testBouncebackGas);
+        bytes32 slot7 = vm.load(address(portal), bytes32(uint256(7)));
+        assertEq(
+            uint64(uint256(slot7) >> 128),
+            portal.lastSyncedTempoBlockNumber(),
+            "slot 7: lastSyncedTempoBlockNumber mismatch"
+        );
+        assertEq(uint64(uint256(slot7) >> 192), testBouncebackGas, "slot 7: bouncebackGas mismatch");
+
+        // --- Slot 8: _encryptionKeys array length ---
+        // Before adding keys, length should be 0
+        bytes32 slot8keys = vm.load(address(portal), PORTAL_ENCRYPTION_KEYS_SLOT);
+        assertEq(uint256(slot8keys), 0, "slot 8: _encryptionKeys length should be 0 initially");
 
         // --- Slot 17: zoneId (uint32) + messenger (address) packed ---
         bytes32 slot17 = vm.load(address(portal), bytes32(uint256(17)));

--- a/specs/ref-impls/test/zone/ZoneInbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneInbox.t.sol
@@ -832,12 +832,12 @@ contract ZoneInboxTest is Test {
 
     /// @notice Verify ZoneConfig.sequencerEncryptionKey() reads from the correct storage slot.
     /// @dev Regression test for the bug where ZoneConfig read the wrong slot
-    ///      instead of the _encryptionKeys dynamic array at slot 6.
+    ///      instead of the _encryptionKeys dynamic array at slot 8.
     function test_zoneConfig_sequencerEncryptionKey_readsCorrectSlot() public {
         bytes32 keyX = keccak256("config-test-key");
         uint8 keyYParity = 0x03;
 
-        // Simulate the _encryptionKeys array at slot 6:
+        // Simulate the _encryptionKeys array at slot 8:
         // Set array length = 1
         uint256 arraySlot = uint256(PORTAL_ENCRYPTION_KEYS_SLOT);
         tempoState.setMockStorageValue(mockPortal, bytes32(arraySlot), bytes32(uint256(1)));


### PR DESCRIPTION
Stacks on #669 and coordinates with tempoxyz/tempo#6902. Groups each active transfer authority beside its pending replacement and updates the cross-domain slot constants, generated layout, and layout regression tests.