### PR TITLE
feat(node): load sequencer key from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13534,6 +13534,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
+ "zeroize",
  "zone-chainspec",
  "zone-evm",
  "zone-l1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 ] }
 tokio-tungstenite = "0.28"
 tracing = "0.1.41"
+zeroize = "1.9.0"
 
 # Keep Commonware aligned with the revision used by upstream Tempo. Cargo does
 # not inherit a git dependency's `[patch]` section into this workspace.

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -76,6 +76,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url = "2"
+zeroize.workspace = true
 
 [dev-dependencies]
 alloy = { workspace = true, features = [

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -8,6 +8,7 @@ use clap::{Args, CommandFactory, FromArgMatches};
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
+use zeroize::Zeroizing;
 use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
 use zone_evm::ZoneEvmConfig;
 use zone_p2p::{P2pConfig, Role};
@@ -141,13 +142,14 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             builder.config_mut().engine.memory_block_buffer_target = 0;
         }
         let should_sequence_blocks = sequencer_enabled(args.enable_sequencer, manifest_role);
-        let sequencer_signer = (should_sequence_blocks || manifest_mode)
-            .then(|| {
-                args.sequencer_key
-                    .parse::<PrivateKeySigner>()
-                    .map_err(|err| eyre::eyre!("invalid --sequencer-key: {err}"))
-            })
-            .transpose()?;
+        let sequencer_signer = if should_sequence_blocks || manifest_mode {
+            Some(
+                load_sequencer_signer(args.sequencer_key, args.sequencer_key_file.as_deref())
+                    .await?,
+            )
+        } else {
+            None
+        };
 
         builder.config_mut().network.discovery.disable_discovery = true;
         builder.config_mut().rpc.disable_auth_server = true;
@@ -194,6 +196,43 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
     })
 }
 
+async fn load_sequencer_signer(
+    inline_key: Option<String>,
+    key_file: Option<&std::path::Path>,
+) -> eyre::Result<PrivateKeySigner> {
+    let (key, source) = match (inline_key, key_file) {
+        (Some(key), None) => (Zeroizing::new(key), "--sequencer-key".to_owned()),
+        (None, Some(path)) => {
+            let path = path.to_path_buf();
+            let source = format!("--sequencer-key-file {}", path.display());
+            let display_path = path.display().to_string();
+            let key = tokio::task::spawn_blocking(move || std::fs::read_to_string(path))
+                .await
+                .map_err(|err| {
+                    eyre::eyre!("sequencer key reader task failed for {display_path}: {err}")
+                })?
+                .map_err(|err| {
+                    eyre::eyre!("failed to read sequencer key from {display_path}: {err}")
+                })?;
+            (Zeroizing::new(key), source)
+        }
+        (Some(_), Some(_)) => {
+            return Err(eyre::eyre!(
+                "--sequencer-key and --sequencer-key-file are mutually exclusive"
+            ));
+        }
+        (None, None) => {
+            return Err(eyre::eyre!(
+                "one of --sequencer-key or --sequencer-key-file is required"
+            ));
+        }
+    };
+
+    key.trim()
+        .parse::<PrivateKeySigner>()
+        .map_err(|_| eyre::eyre!("invalid sequencer key from {source}"))
+}
+
 /// Tempo Zone CLI arguments.
 #[derive(Debug, Clone, Args)]
 pub struct ZoneArgs {
@@ -214,8 +253,24 @@ pub struct ZoneArgs {
     pub block_interval_ms: u64,
 
     /// Sequencer private key (hex, with or without 0x prefix).
-    #[arg(long = "sequencer-key", env = "SEQUENCER_KEY")]
-    pub sequencer_key: String,
+    #[arg(
+        long = "sequencer-key",
+        env = "SEQUENCER_KEY",
+        value_name = "HEX",
+        required_unless_present = "sequencer_key_file",
+        conflicts_with = "sequencer_key_file"
+    )]
+    pub sequencer_key: Option<String>,
+
+    /// Path to a file or FIFO containing the sequencer private key.
+    #[arg(
+        long = "sequencer-key-file",
+        env = "SEQUENCER_KEY_FILE",
+        value_name = "PATH",
+        required_unless_present = "sequencer_key",
+        conflicts_with = "sequencer_key"
+    )]
+    pub sequencer_key_file: Option<PathBuf>,
 
     /// Path to the static multi-sequencer manifest. Its presence activates
     /// multi-sequencer mode and makes the manifest authoritative for role selection.
@@ -382,9 +437,11 @@ fn validate_l1_rpc_url(l1_rpc_url: &str) -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::{io::Write as _, process::Command, thread, time::Duration};
+
     use clap::Parser as _;
 
-    use super::{ZoneArgs, ZoneCli, sequencer_enabled, validate_l1_rpc_url};
+    use super::{ZoneArgs, ZoneCli, load_sequencer_signer, sequencer_enabled, validate_l1_rpc_url};
     use zone_p2p::Role;
 
     #[derive(Debug, clap::Parser)]
@@ -405,6 +462,104 @@ mod tests {
     fn dev_is_parsed_by_the_top_level_cli() {
         let parsed = ZoneCli::try_parse_from(["tempo-zone", "dev"]).unwrap();
         assert!(matches!(parsed, ZoneCli::Dev(_)));
+    }
+
+    #[test]
+    fn sequencer_key_file_is_accepted_and_conflicts_with_inline_key() {
+        let common = [
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+        ];
+
+        let parsed = ZoneArgsParser::try_parse_from(
+            common
+                .into_iter()
+                .chain(["--sequencer-key-file", "/run/secrets/sequencer-key"]),
+        )
+        .unwrap();
+        assert_eq!(
+            parsed.zone.sequencer_key_file.as_deref(),
+            Some(std::path::Path::new("/run/secrets/sequencer-key"))
+        );
+        assert!(parsed.zone.sequencer_key.is_none());
+
+        let error = ZoneArgsParser::try_parse_from(common.into_iter().chain([
+            "--sequencer-key",
+            "0x01",
+            "--sequencer-key-file",
+            "/run/secrets/sequencer-key",
+        ]))
+        .unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn loads_sequencer_key_from_file_with_trailing_newline() {
+        let path =
+            std::env::temp_dir().join(format!("tempo-zone-sequencer-key-{}", std::process::id()));
+        std::fs::write(
+            &path,
+            "0000000000000000000000000000000000000000000000000000000000000001\n",
+        )
+        .unwrap();
+
+        let signer = load_sequencer_signer(None, Some(&path)).await.unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(
+            signer.address(),
+            "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+                .parse::<alloy_primitives::Address>()
+                .unwrap()
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn loads_sequencer_key_from_fifo() {
+        let path = std::env::temp_dir().join(format!(
+            "tempo-zone-sequencer-key-{}.fifo",
+            std::process::id()
+        ));
+        let status = Command::new("mkfifo")
+            .args(["-m", "600"])
+            .arg(&path)
+            .status()
+            .expect("mkfifo must be available");
+        assert!(status.success(), "mkfifo failed: {status}");
+
+        let writer_path = path.clone();
+        let writer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(50));
+            let mut fifo = std::fs::OpenOptions::new()
+                .write(true)
+                .open(writer_path)
+                .unwrap();
+            writeln!(
+                fifo,
+                "0000000000000000000000000000000000000000000000000000000000000001"
+            )
+            .unwrap();
+        });
+
+        let signer = tokio::time::timeout(
+            Duration::from_secs(2),
+            load_sequencer_signer(None, Some(&path)),
+        )
+        .await
+        .expect("FIFO read timed out")
+        .unwrap();
+        writer.join().unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(
+            signer.address(),
+            "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"
+                .parse::<alloy_primitives::Address>()
+                .unwrap()
+        );
     }
 
     #[test]

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -605,7 +605,8 @@ Current deployment:
 | `--l1.genesis-block-number` | (from zone.json) | L1 block when the zone was created |
 | `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` (mainnet) or `1424310000 + (zone_id % 723173648)` (testnet). |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
-| `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled |
+| `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |
+| `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |
 | `--block.interval-ms` | 250 | Block building interval |
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |
 | `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |
@@ -620,6 +621,7 @@ Current deployment:
 |----------|----------|-------------|
 | `L1_RPC_URL` | Yes | Certified Tempo follower WebSocket RPC URL (`wss://...`) |
 | `SEQUENCER_KEY` | For sequencing | Sequencer private key |
+| `SEQUENCER_KEY_FILE` | For sequencing | File or FIFO containing the sequencer private key |
 | `ADMIN_KEY` | For portal governance | Portal admin private key for `enableToken` / deposit pause controls. `SEQUENCER_KEY` only works for legacy zones where admin == sequencer. |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |
 | `L1_PORTAL_ADDRESS` | For deposits | ZonePortal address (from `zone.json`) |


### PR DESCRIPTION
## Summary
- add mutually exclusive `--sequencer-key-file` / `SEQUENCER_KEY_FILE` support
- allow regular files or FIFOs so sequencer keys do not need to appear in argv
- zeroize raw key input after constructing the signer
- document the new key source

## Testing
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-node --features cli cli::tests --no-fail-fast` *(blocked: Cargo dependency fetch for private Commonware revision returns HTTP 401 in sandbox)*

Prompted by: @kamsz