### PR TITLE
chore(evm): make `ZoneEvmConfig` generic over l1 provider

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -62,11 +62,6 @@ use zone_l1::state::{L1StateCache, L1StateProvider, L1StateProviderConfig, Polic
 
 type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
 
-/// Copies the Zone chain spec and applies the Tempo hardfork conditions from its parent chain.
-fn compose_chain_spec(zone: &ZoneChainSpec, tempo: &TempoChainSpec) -> Arc<ZoneChainSpec> {
-    Arc::new(zone.clone().with_tempo_hardforks_from(tempo))
-}
-
 /// Zone EVM factory — wraps [`TempoEvmFactory`] and registers the
 /// zone-native precompiles.
 #[derive(Debug, Clone)]
@@ -466,6 +461,11 @@ where
     ) -> Result<impl ExecutableTxIterator<Self>, Self::Error> {
         self.inner.tx_iterator_for_payload(payload)
     }
+}
+
+/// Copies the Zone chain spec and applies the Tempo hardfork conditions from its parent chain.
+fn compose_chain_spec(zone: &ZoneChainSpec, tempo: &TempoChainSpec) -> Arc<ZoneChainSpec> {
+    Arc::new(zone.clone().with_tempo_hardforks_from(tempo))
 }
 
 #[cfg(test)]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -471,46 +471,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Address, B256};
     use reth_chainspec::{EthChainSpec, ForkCondition};
-    use revm::precompile::PrecompileError;
     use tempo_chainspec::{
         hardfork::TempoHardfork,
         spec::{DEV, MODERATO, TempoHardforks},
     };
-
-    #[derive(Debug, Clone)]
-    struct TestL1Provider;
-
-    impl L1StorageReader for TestL1Provider {
-        fn read_l1_storage(
-            &self,
-            _account: Address,
-            _slot: B256,
-            _block_number: u64,
-        ) -> Result<B256, PrecompileError> {
-            Ok(B256::ZERO)
-        }
-    }
-
-    impl SequencerExt for TestL1Provider {
-        fn latest_sequencer(&self) -> Option<Address> {
-            None
-        }
-    }
-
-    #[test]
-    fn config_accepts_generic_l1_provider() {
-        let config = ZoneEvmConfig::new(
-            Arc::new(ZoneChainSpec::from(DEV.clone())),
-            DEV.clone(),
-            TestL1Provider,
-        );
-
-        fn assert_configure_evm<T: ConfigureEvm>(_config: &T) {}
-        assert_configure_evm(&config);
-        assert_eq!(config.chain_spec().chain().id(), DEV.chain().id());
-    }
 
     #[test]
     fn composed_chain_spec_uses_zone_identity_and_parent_tempo_forks() {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -38,7 +38,7 @@ use reth_evm::{
     execute::{BlockAssembler, BlockAssemblerInput},
 };
 use reth_primitives_traits::{SealedBlock, SealedHeader};
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{cell::RefCell, fmt, rc::Rc, sync::Arc};
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::TempoChainSpec;
 use tempo_evm::{
@@ -61,6 +61,11 @@ use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::{L1StateCache, L1StateProvider, L1StateProviderConfig, PolicyProvider};
 
 type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
+
+/// Copies the Zone chain spec and applies the Tempo hardfork conditions from its parent chain.
+fn compose_chain_spec(zone: &ZoneChainSpec, tempo: &TempoChainSpec) -> Arc<ZoneChainSpec> {
+    Arc::new(zone.clone().with_tempo_hardforks_from(tempo))
+}
 
 /// Zone EVM factory — wraps [`TempoEvmFactory`] and registers the
 /// zone-native precompiles.
@@ -207,12 +212,15 @@ impl ZoneBlockAssembler {
     }
 }
 
-impl BlockAssembler<ZoneEvmConfig> for ZoneBlockAssembler {
+impl<L1> BlockAssembler<ZoneEvmConfig<L1>> for ZoneBlockAssembler
+where
+    L1: L1StorageReader + SequencerExt,
+{
     type Block = Block;
 
     fn assemble_block(
         &self,
-        input: BlockAssemblerInput<'_, '_, ZoneEvmConfig, TempoHeader>,
+        input: BlockAssemblerInput<'_, '_, ZoneEvmConfig<L1>, TempoHeader>,
     ) -> Result<Self::Block, alloy_evm::block::BlockExecutionError> {
         let BlockAssemblerInput {
             evm_env,
@@ -247,31 +255,29 @@ impl BlockAssembler<ZoneEvmConfig> for ZoneBlockAssembler {
 }
 
 /// Zone EVM configuration with Zone precompiles and parent Tempo hardfork conditions.
-#[derive(Debug, Clone)]
-pub struct ZoneEvmConfig {
+#[derive(Clone)]
+pub struct ZoneEvmConfig<L1 = L1StateProvider> {
     inner: TempoEvmConfig,
     chain_spec: Arc<ZoneChainSpec>,
-    zone_factory: ZoneEvmFactory,
+    zone_factory: ZoneEvmFactory<L1>,
     block_assembler: ZoneBlockAssembler,
 }
 
-impl ZoneEvmConfig {
+impl<L1> ZoneEvmConfig<L1>
+where
+    L1: L1StorageReader + SequencerExt,
+{
     /// Creates a Zone EVM config using Tempo hardfork conditions from the parent L1 spec.
     pub fn new(
         zone_chain_spec: Arc<ZoneChainSpec>,
         tempo_chain_spec: Arc<TempoChainSpec>,
-        l1_provider: L1StateProvider,
+        l1_provider: L1,
     ) -> Self {
-        let chain_spec = Self::compose_chain_spec(&zone_chain_spec, &tempo_chain_spec);
+        let chain_spec = compose_chain_spec(&zone_chain_spec, &tempo_chain_spec);
         Self::from_chain_spec(chain_spec, l1_provider)
     }
 
-    /// Copies the Zone chain spec and applies the Tempo hardfork conditions from its parent chain.
-    fn compose_chain_spec(zone: &ZoneChainSpec, tempo: &TempoChainSpec) -> Arc<ZoneChainSpec> {
-        Arc::new(zone.clone().with_tempo_hardforks_from(tempo))
-    }
-
-    fn from_chain_spec(chain_spec: Arc<ZoneChainSpec>, l1_provider: L1StateProvider) -> Self {
+    fn from_chain_spec(chain_spec: Arc<ZoneChainSpec>, l1_provider: L1) -> Self {
         let zone_factory = ZoneEvmFactory::new(l1_provider);
         let tempo_chain_spec = chain_spec.inner.clone();
         let inner = TempoEvmConfig::new(tempo_chain_spec);
@@ -282,23 +288,6 @@ impl ZoneEvmConfig {
             zone_factory,
             block_assembler,
         }
-    }
-
-    /// Creates a Zone EVM config without a usable L1 provider.
-    ///
-    /// Intended for CLI subcommands (import, stage, re-execute) that need a type-compatible
-    /// EVM config but don't have access to an L1 RPC connection. Tempo hardfork conditions come
-    /// from `chain_spec` because the parent L1 spec cannot be resolved in this mode. The portal
-    /// address defaults to zero, so sequencer reads are unavailable.
-    pub fn new_without_l1(chain_spec: Arc<ZoneChainSpec>) -> Self {
-        let cache = L1StateCache::default();
-        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect_http("http://127.0.0.1:1".parse().expect("valid fallback URL"))
-            .erased();
-        let runtime_handle = tokio::runtime::Handle::current();
-        let config = L1StateProviderConfig::default();
-        let l1_provider = L1StateProvider::new_raw(config, cache, provider, runtime_handle);
-        Self::from_chain_spec(chain_spec, l1_provider)
     }
 
     /// Set the policy provider for the TIP-403 proxy precompile.
@@ -318,8 +307,40 @@ impl ZoneEvmConfig {
     }
 }
 
-impl BlockExecutorFactory for ZoneEvmConfig {
-    type EvmFactory = ZoneEvmFactory;
+impl ZoneEvmConfig {
+    /// Creates a Zone EVM config without a usable L1 provider.
+    ///
+    /// Intended for CLI subcommands (import, stage, re-execute) that need a type-compatible
+    /// EVM config but don't have access to an L1 RPC connection. Tempo hardfork conditions come
+    /// from `chain_spec` because the parent L1 spec cannot be resolved in this mode. The portal
+    /// address defaults to zero, so sequencer reads are unavailable.
+    pub fn new_without_l1(chain_spec: Arc<ZoneChainSpec>) -> Self {
+        let cache = L1StateCache::default();
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("http://127.0.0.1:1".parse().expect("valid fallback URL"))
+            .erased();
+        let runtime_handle = tokio::runtime::Handle::current();
+        let config = L1StateProviderConfig::default();
+        let l1_provider = L1StateProvider::new_raw(config, cache, provider, runtime_handle);
+        Self::from_chain_spec(chain_spec, l1_provider)
+    }
+}
+
+impl<L1> fmt::Debug for ZoneEvmConfig<L1> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ZoneEvmConfig")
+            .field("inner", &self.inner)
+            .field("chain_spec", &self.chain_spec)
+            .field("block_assembler", &self.block_assembler)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<L1> BlockExecutorFactory for ZoneEvmConfig<L1>
+where
+    L1: L1StorageReader + SequencerExt,
+{
+    type EvmFactory = ZoneEvmFactory<L1>;
     type ExecutionCtx<'a> = TempoBlockExecutionCtx<'a>;
     type Transaction = TempoTxEnvelope;
     type Receipt = TempoReceipt;
@@ -343,7 +364,10 @@ impl BlockExecutorFactory for ZoneEvmConfig {
     }
 }
 
-impl ConfigureEvm for ZoneEvmConfig {
+impl<L1> ConfigureEvm for ZoneEvmConfig<L1>
+where
+    L1: L1StorageReader + SequencerExt + Unpin,
+{
     type Primitives = TempoPrimitives;
     type Error = TempoEvmError;
     type NextBlockEnvCtx = TempoNextBlockEnvAttributes;
@@ -416,7 +440,10 @@ impl ConfigureEvm for ZoneEvmConfig {
     }
 }
 
-impl ConfigureEngineEvm<TempoExecutionData> for ZoneEvmConfig {
+impl<L1> ConfigureEngineEvm<TempoExecutionData> for ZoneEvmConfig<L1>
+where
+    L1: L1StorageReader + SequencerExt + Unpin,
+{
     fn evm_env_for_payload(
         &self,
         payload: &TempoExecutionData,
@@ -444,16 +471,51 @@ impl ConfigureEngineEvm<TempoExecutionData> for ZoneEvmConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::{Address, B256};
     use reth_chainspec::{EthChainSpec, ForkCondition};
+    use revm::precompile::PrecompileError;
     use tempo_chainspec::{
         hardfork::TempoHardfork,
         spec::{DEV, MODERATO, TempoHardforks},
     };
 
+    #[derive(Debug, Clone)]
+    struct TestL1Provider;
+
+    impl L1StorageReader for TestL1Provider {
+        fn read_l1_storage(
+            &self,
+            _account: Address,
+            _slot: B256,
+            _block_number: u64,
+        ) -> Result<B256, PrecompileError> {
+            Ok(B256::ZERO)
+        }
+    }
+
+    impl SequencerExt for TestL1Provider {
+        fn latest_sequencer(&self) -> Option<Address> {
+            None
+        }
+    }
+
+    #[test]
+    fn config_accepts_generic_l1_provider() {
+        let config = ZoneEvmConfig::new(
+            Arc::new(ZoneChainSpec::from(DEV.clone())),
+            DEV.clone(),
+            TestL1Provider,
+        );
+
+        fn assert_configure_evm<T: ConfigureEvm>(_config: &T) {}
+        assert_configure_evm(&config);
+        assert_eq!(config.chain_spec().chain().id(), DEV.chain().id());
+    }
+
     #[test]
     fn composed_chain_spec_uses_zone_identity_and_parent_tempo_forks() {
         let zone = ZoneChainSpec::from(DEV.clone());
-        let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
+        let composed = compose_chain_spec(&zone, &MODERATO);
 
         assert_eq!(composed.chain().id(), DEV.chain().id());
         assert_eq!(composed.genesis_hash(), DEV.genesis_hash());
@@ -468,7 +530,7 @@ mod tests {
     #[test]
     fn tempo_evm_selects_parent_fork_from_zone_block_timestamp() {
         let zone = ZoneChainSpec::from(DEV.clone());
-        let composed = ZoneEvmConfig::compose_chain_spec(&zone, &MODERATO);
+        let composed = compose_chain_spec(&zone, &MODERATO);
         let activation_timestamp = TempoHardfork::VARIANTS
             .iter()
             .find_map(|&hardfork| match MODERATO.tempo_fork_activation(hardfork) {


### PR DESCRIPTION
## Summary

Make `ZoneEvmConfig` generic over l1 provider to allow for reuse in SPF.