### PR TITLE
refactor(node): forward built payload execution data

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -44,7 +44,7 @@ use eyre::OptionExt;
 use reth_chainspec::EthereumHardforks;
 use reth_node_builder::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
-use reth_payload_primitives::{BuiltPayload, PayloadKind, PayloadTypes};
+use reth_payload_primitives::{BuiltPayload, PayloadKind};
 use reth_primitives_traits::SealedHeader;
 use std::{sync::Arc, time::Duration};
 use tempo_primitives::TempoHeader;
@@ -256,8 +256,7 @@ impl ZoneEngine {
 
         let header = payload.block().sealed_header().clone();
         let block_number = header.number();
-        let payload = ZonePayloadTypes::block_to_payload(payload.block().clone(), None);
-        let res = self.to_engine.new_payload(payload).await?;
+        let res = self.to_engine.new_payload(payload.into()).await?;
 
         if !res.is_valid() {
             eyre::bail!("Invalid payload for block {block_number}")


### PR DESCRIPTION
## Summary

- consume `TempoBuiltPayload` directly when submitting through the consensus engine handle
- avoid cloning and manually rewrapping the built block
- preserve payload-carried execution data such as a future block access list

The zone payload builder already attaches `Some(executed_block)` to `TempoBuiltPayload`, allowing Reth's built-payload subscriber to insert the locally executed block through its engine-tree fast path.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-A semicolon-in-expressions-from-macros' cargo check -p zone-node`

The lint override is required for an unrelated existing future-incompatibility lint in `crates/l1/src/state/tip403/provider.rs:490` on the current nightly toolchain.

cc @rjected