### PR TITLE
feat: emit role updates during portal initialization

### DIFF
--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -175,10 +175,12 @@ contract ZonePortal is IZonePortal {
 
         for (uint256 i; i < _zoneGateways.length; ++i) {
             role[_zoneGateways[i]] = Role.CallbackGateway;
+            emit RoleUpdated(_zoneGateways[i], Role.None, Role.CallbackGateway);
         }
 
         for (uint256 i; i < _allowedAccounts.length; ++i) {
             role[_allowedAccounts[i]] = Role.Account;
+            emit RoleUpdated(_allowedAccounts[i], Role.None, Role.Account);
         }
 
         // Enable the initial token. The admin may enable additional TIP-20s later.

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -233,6 +233,12 @@ contract ZonePortalProxyStorageTest is Test {
             );
 
         vm.startPrank(ZONE_FACTORY_ADDRESS);
+        vm.expectEmit(true, false, false, true, proxyA);
+        emit IZonePortal.RoleUpdated(messengerA, Role.None, Role.CallbackGateway);
+        vm.expectEmit(true, false, false, true, proxyA);
+        emit IZonePortal.RoleUpdated(makeAddr("admin 1"), Role.None, Role.Account);
+        vm.expectEmit(true, false, false, true, proxyA);
+        emit IZonePortal.RoleUpdated(makeAddr("sequencer 1"), Role.None, Role.Account);
         _initializePortal(proxyA, initialToken, 1, messengerA, verifierA, 100);
         _initializePortal(proxyB, initialToken, 2, messengerB, verifierB, 200);
 


### PR DESCRIPTION
## Summary
- emit `RoleUpdated` when initial callback gateways are configured
- emit `RoleUpdated` when initial allowed accounts are configured
- assert initialization event order and payloads in the proxy storage test

## Testing
- `forge test --root specs/ref-impls --match-contract ZonePortalProxyStorageTest`

Prompted by: @0xrusowsky