### PR TITLE
feat: enforce zone transaction admission policy

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -3,11 +3,15 @@
 //! A simplified block executor for zone nodes that wraps [`EthBlockExecutor`] directly.
 //! Unlike the Tempo L1 [`TempoBlockExecutor`], this executor does **not** enforce subblock
 //! ordering, shared-gas accounting, or the end-of-block subblock metadata system transaction.
+//! It does enforce the Zone-specific `advanceTempo` / `finalizeWithdrawalBatch` sequence.
 
 use alloy_consensus::transaction::TxHashRef;
 use alloy_evm::{
     Database, Evm, RecoveredTx,
-    block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, GasOutput},
+    block::{
+        BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockValidationError,
+        ExecutableTx, GasOutput,
+    },
     eth::{EthBlockExecutor, EthTxResult},
 };
 use reth_evm::block::StateDB;
@@ -21,14 +25,20 @@ use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::{TempoStateAccess, evm::TempoContext};
 use zone_chainspec::ZoneChainSpec;
 
-use crate::{ZoneEvm, tx_context};
+use crate::{
+    ZoneEvm, tx_context,
+    zone_evm::block::{ZoneBlockSequence, ZoneBlockTransactionKind, classify_transaction},
+};
 
 /// Simplified block executor for zone nodes.
 ///
 /// Wraps [`EthBlockExecutor`] without any subblock validation, gas-section tracking,
-/// or end-of-block metadata system transaction requirements.
+/// or Tempo end-of-block metadata system transaction requirements. Zone system transaction
+/// ordering is tracked separately from committed receipts.
 pub struct ZoneBlockExecutor<'a, DB: Database, I> {
     inner: EthBlockExecutor<'a, ZoneEvm<DB, I>, &'a ZoneChainSpec, TempoReceiptBuilder>,
+    sequence: ZoneBlockSequence,
+    pending_transaction_kind: Option<ZoneBlockTransactionKind>,
 }
 
 impl<'a, DB, I> ZoneBlockExecutor<'a, DB, I>
@@ -49,6 +59,8 @@ where
                 chain_spec,
                 TempoReceiptBuilder::default(),
             ),
+            sequence: ZoneBlockSequence::default(),
+            pending_transaction_kind: None,
         }
     }
 
@@ -103,6 +115,16 @@ where
             tempo_tx_env.expiring_nonce_idx = None;
         }
 
+        let kind = classify_transaction(&tx_env).map_err(block_validation_error)?;
+        self.sequence
+            .validate_next(
+                kind,
+                self.inner.receipts.len(),
+                self.inner.ctx.tx_count_hint,
+            )
+            .map_err(block_validation_error)?;
+        self.pending_transaction_kind = Some(kind);
+
         // Override the validator's fee token preference to match this
         // transaction's resolved fee token, so the handler skips FeeAMM.
         self.override_validator_token();
@@ -113,12 +135,17 @@ where
     }
 
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
-        self.inner.commit_transaction(output)
+        let gas = self.inner.commit_transaction(output);
+        if let Some(kind) = self.pending_transaction_kind.take() {
+            self.sequence.commit(kind);
+        }
+        gas
     }
 
     fn finish(
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
+        self.sequence.finish().map_err(block_validation_error)?;
         self.inner.finish()
     }
 
@@ -133,6 +160,10 @@ where
     fn receipts(&self) -> &[Self::Receipt] {
         self.inner.receipts()
     }
+}
+
+fn block_validation_error(error: tempo_revm::TempoInvalidTransaction) -> BlockExecutionError {
+    BlockValidationError::msg(error.to_string()).into()
 }
 
 #[cfg(test)]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -13,7 +13,10 @@ mod tx_context;
 mod zone_evm;
 
 pub use executor::ZoneBlockExecutor;
-pub use zone_evm::{ZoneEvm, contract_creation::validate_transaction};
+pub use zone_evm::{
+    AllowedTip20Operation, ValidatedZoneCall, ValidatedZoneTransaction, ZoneEvm,
+    validate_transaction,
+};
 
 use crate::{
     precompiles::{

--- a/crates/evm/src/zone_evm/block.rs
+++ b/crates/evm/src/zone_evm/block.rs
@@ -1,0 +1,290 @@
+//! Zone block transaction ordering.
+
+use alloy_primitives::TxKind;
+use alloy_sol_types::SolCall;
+use revm::context::Transaction;
+use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
+use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox};
+
+/// A transaction's role in a zone block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ZoneBlockTransactionKind {
+    AdvanceTempo,
+    FinalizeWithdrawalBatch,
+    PendingWithdrawalsView,
+    User,
+}
+
+/// Ordering state derived only from transactions committed to the block.
+#[derive(Debug, Default)]
+pub(crate) struct ZoneBlockSequence {
+    saw_advance_tempo: bool,
+    saw_finalize_withdrawal_batch: bool,
+    committed_pending_withdrawals_view: bool,
+}
+
+impl ZoneBlockSequence {
+    /// Check whether `kind` can be the next committed block transaction.
+    pub(crate) fn validate_next(
+        &self,
+        kind: ZoneBlockTransactionKind,
+        transaction_index: usize,
+        transaction_count_hint: Option<usize>,
+    ) -> Result<(), TempoInvalidTransaction> {
+        if self.committed_pending_withdrawals_view {
+            return Err(invalid(
+                "getPendingWithdrawals is a non-committing builder simulation",
+            ));
+        }
+
+        match kind {
+            ZoneBlockTransactionKind::PendingWithdrawalsView => Ok(()),
+            ZoneBlockTransactionKind::AdvanceTempo => {
+                if self.saw_advance_tempo || transaction_index != 0 {
+                    return Err(invalid("advanceTempo must appear exactly once and first"));
+                }
+                Ok(())
+            }
+            ZoneBlockTransactionKind::FinalizeWithdrawalBatch => {
+                if !self.saw_advance_tempo {
+                    return Err(invalid(
+                        "finalizeWithdrawalBatch cannot precede advanceTempo",
+                    ));
+                }
+                if self.saw_finalize_withdrawal_batch {
+                    return Err(invalid("finalizeWithdrawalBatch may appear at most once"));
+                }
+                if transaction_count_hint
+                    .is_some_and(|count| transaction_index.saturating_add(1) != count)
+                {
+                    return Err(invalid(
+                        "finalizeWithdrawalBatch must be the last transaction",
+                    ));
+                }
+                Ok(())
+            }
+            ZoneBlockTransactionKind::User => {
+                if !self.saw_advance_tempo {
+                    return Err(invalid("advanceTempo must be the first transaction"));
+                }
+                if self.saw_finalize_withdrawal_batch {
+                    return Err(invalid("no transaction may follow finalizeWithdrawalBatch"));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Record a successfully committed transaction.
+    pub(crate) fn commit(&mut self, kind: ZoneBlockTransactionKind) {
+        match kind {
+            ZoneBlockTransactionKind::AdvanceTempo => self.saw_advance_tempo = true,
+            ZoneBlockTransactionKind::FinalizeWithdrawalBatch => {
+                self.saw_finalize_withdrawal_batch = true;
+            }
+            ZoneBlockTransactionKind::PendingWithdrawalsView => {
+                self.committed_pending_withdrawals_view = true;
+            }
+            ZoneBlockTransactionKind::User => {}
+        }
+    }
+
+    /// Enforce the required end-of-block state.
+    pub(crate) fn finish(&self) -> Result<(), TempoInvalidTransaction> {
+        if self.committed_pending_withdrawals_view {
+            return Err(invalid(
+                "getPendingWithdrawals must not be committed to a zone block",
+            ));
+        }
+        if !self.saw_advance_tempo {
+            return Err(invalid(
+                "zone block is missing its required advanceTempo transaction",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Parse the block role of a transaction and reject user impersonation of system operations.
+pub(crate) fn classify_transaction(
+    tx: &TempoTxEnv,
+) -> Result<ZoneBlockTransactionKind, TempoInvalidTransaction> {
+    if tx.is_system_tx {
+        if tx.tempo_tx_env.is_some() {
+            return Err(invalid("zone system transactions must be direct calls"));
+        }
+
+        return match (tx.kind(), tx.data.get(..4)) {
+            (TxKind::Call(ZONE_INBOX_ADDRESS), Some(selector))
+                if selector == ZoneInbox::advanceTempoCall::SELECTOR =>
+            {
+                Ok(ZoneBlockTransactionKind::AdvanceTempo)
+            }
+            (TxKind::Call(ZONE_OUTBOX_ADDRESS), Some(selector))
+                if selector == ZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR =>
+            {
+                Ok(ZoneBlockTransactionKind::FinalizeWithdrawalBatch)
+            }
+            (TxKind::Call(ZONE_OUTBOX_ADDRESS), Some(selector))
+                if selector == ZoneOutbox::getPendingWithdrawalsCall::SELECTOR =>
+            {
+                Ok(ZoneBlockTransactionKind::PendingWithdrawalsView)
+            }
+            _ => Err(invalid("unrecognized zone system transaction")),
+        };
+    }
+
+    let impersonates_system_operation = if let Some(aa) = tx.tempo_tx_env.as_ref() {
+        aa.aa_calls
+            .iter()
+            .any(|call| is_state_changing_system_operation(call.to, &call.input))
+    } else {
+        is_state_changing_system_operation(tx.kind(), &tx.data)
+    };
+
+    if impersonates_system_operation {
+        return Err(invalid(
+            "advanceTempo and finalizeWithdrawalBatch require a system transaction",
+        ));
+    }
+
+    Ok(ZoneBlockTransactionKind::User)
+}
+
+fn is_state_changing_system_operation(target: TxKind, input: &[u8]) -> bool {
+    match (target, input.get(..4)) {
+        (TxKind::Call(ZONE_INBOX_ADDRESS), Some(selector)) => {
+            selector == ZoneInbox::advanceTempoCall::SELECTOR
+        }
+        (TxKind::Call(ZONE_OUTBOX_ADDRESS), Some(selector)) => {
+            selector == ZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR
+        }
+        _ => false,
+    }
+}
+
+const fn invalid(message: &'static str) -> TempoInvalidTransaction {
+    TempoInvalidTransaction::CallsValidation(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, U256};
+    use tempo_primitives::transaction::Call;
+    use tempo_revm::TempoBatchCallEnv;
+
+    fn call_tx(target: alloy_primitives::Address, input: Bytes, is_system_tx: bool) -> TempoTxEnv {
+        TempoTxEnv {
+            inner: revm::context::TxEnv {
+                kind: TxKind::Call(target),
+                data: input,
+                ..Default::default()
+            },
+            is_system_tx,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn enforces_required_system_transaction_order() {
+        let sequence = ZoneBlockSequence::default();
+        assert!(
+            sequence
+                .validate_next(ZoneBlockTransactionKind::User, 0, Some(2))
+                .is_err()
+        );
+        assert!(
+            sequence
+                .validate_next(
+                    ZoneBlockTransactionKind::FinalizeWithdrawalBatch,
+                    0,
+                    Some(2)
+                )
+                .is_err()
+        );
+
+        let mut sequence = ZoneBlockSequence::default();
+        sequence
+            .validate_next(ZoneBlockTransactionKind::AdvanceTempo, 0, Some(3))
+            .unwrap();
+        sequence.commit(ZoneBlockTransactionKind::AdvanceTempo);
+        sequence
+            .validate_next(ZoneBlockTransactionKind::User, 1, Some(3))
+            .unwrap();
+        sequence.commit(ZoneBlockTransactionKind::User);
+        sequence
+            .validate_next(
+                ZoneBlockTransactionKind::FinalizeWithdrawalBatch,
+                2,
+                Some(3),
+            )
+            .unwrap();
+        sequence.commit(ZoneBlockTransactionKind::FinalizeWithdrawalBatch);
+        assert!(
+            sequence
+                .validate_next(ZoneBlockTransactionKind::User, 3, None)
+                .is_err()
+        );
+        sequence.finish().unwrap();
+    }
+
+    #[test]
+    fn rejects_non_last_finalize_when_block_length_is_known() {
+        let mut sequence = ZoneBlockSequence::default();
+        sequence.commit(ZoneBlockTransactionKind::AdvanceTempo);
+        assert!(
+            sequence
+                .validate_next(
+                    ZoneBlockTransactionKind::FinalizeWithdrawalBatch,
+                    1,
+                    Some(3)
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn permits_view_simulation_but_rejects_a_committed_view() {
+        let mut sequence = ZoneBlockSequence::default();
+        sequence.commit(ZoneBlockTransactionKind::AdvanceTempo);
+        sequence
+            .validate_next(ZoneBlockTransactionKind::PendingWithdrawalsView, 1, None)
+            .unwrap();
+        sequence.finish().unwrap();
+
+        sequence.commit(ZoneBlockTransactionKind::PendingWithdrawalsView);
+        assert!(sequence.finish().is_err());
+        assert!(
+            sequence
+                .validate_next(ZoneBlockTransactionKind::User, 2, None)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn classifies_system_calls_and_rejects_user_impersonation() {
+        let advance_input = Bytes::copy_from_slice(&ZoneInbox::advanceTempoCall::SELECTOR);
+        let system = call_tx(ZONE_INBOX_ADDRESS, advance_input.clone(), true);
+        assert_eq!(
+            classify_transaction(&system).unwrap(),
+            ZoneBlockTransactionKind::AdvanceTempo
+        );
+
+        let user = call_tx(ZONE_INBOX_ADDRESS, advance_input.clone(), false);
+        assert!(classify_transaction(&user).is_err());
+
+        let aa_user = TempoTxEnv {
+            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                aa_calls: vec![Call {
+                    to: TxKind::Call(ZONE_INBOX_ADDRESS),
+                    value: U256::ZERO,
+                    input: advance_input,
+                }],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert!(classify_transaction(&aa_user).is_err());
+    }
+}

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -49,7 +49,7 @@ fn create<const IS_CREATE2: bool, DB: Database>(
 }
 
 /// Reject transaction-level contract creation unless its deployer is explicitly allowed.
-pub fn validate_transaction(
+pub(super) fn validate_transaction(
     tx: &TempoTxEnv,
     allowlist: &[Address],
 ) -> Result<(), TempoInvalidTransaction> {

--- a/crates/evm/src/zone_evm/mod.rs
+++ b/crates/evm/src/zone_evm/mod.rs
@@ -1,6 +1,8 @@
 //! Zone runtime EVM and its private execution policies.
 
+pub(crate) mod block;
 pub(crate) mod contract_creation;
+mod transaction;
 
 use crate::TempoCtx;
 use alloy_evm::{Database, Evm, EvmEnv, precompiles::PrecompilesMap, revm::Inspector};
@@ -9,6 +11,10 @@ use revm::context::result::{EVMError, ResultAndState};
 use tempo_evm::{TempoBlockEnv, TempoHaltReason, evm::TempoEvm};
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
 use zone_primitives::constants::CONTRACT_DEPLOYER_ALLOWLIST;
+
+pub use transaction::{
+    AllowedTip20Operation, ValidatedZoneCall, ValidatedZoneTransaction, validate_transaction,
+};
 
 /// Zone runtime EVM.
 ///
@@ -65,7 +71,7 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        contract_creation::validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)?;
+        validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)?;
         self.inner.transact_raw(tx)
     }
 

--- a/crates/evm/src/zone_evm/transaction.rs
+++ b/crates/evm/src/zone_evm/transaction.rs
@@ -1,0 +1,210 @@
+//! Zone transaction parsing and user-call policy.
+
+use alloy_primitives::{Address, Bytes, TxKind};
+use alloy_sol_types::SolCall;
+use revm::context::Transaction;
+use tempo_precompiles::tip20::{ITIP20, is_tip20_prefix};
+use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
+
+use super::contract_creation;
+
+/// A transaction whose zone-level call policy has been parsed successfully.
+///
+/// Constructing this value proves that the transaction does not perform forbidden contract
+/// creation and that every direct TIP-20 call is one of the user operations exposed by a zone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedZoneTransaction {
+    calls: Vec<ValidatedZoneCall>,
+}
+
+impl ValidatedZoneTransaction {
+    /// Return the parsed calls in transaction order.
+    pub fn calls(&self) -> &[ValidatedZoneCall] {
+        &self.calls
+    }
+}
+
+/// A direct call accepted by the zone transaction policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidatedZoneCall {
+    /// An allowed TIP-20 operation targeting `token`.
+    Tip20 {
+        token: Address,
+        operation: AllowedTip20Operation,
+    },
+    /// A call outside the TIP-20 address space.
+    Other { target: TxKind },
+}
+
+/// TIP-20 operations users may submit directly to a zone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllowedTip20Operation {
+    TransferFrom,
+    Approve,
+}
+
+/// Parse and enforce all stateless zone transaction invariants.
+pub fn validate_transaction(
+    tx: &TempoTxEnv,
+    contract_deployer_allowlist: &[Address],
+) -> Result<ValidatedZoneTransaction, TempoInvalidTransaction> {
+    contract_creation::validate_transaction(tx, contract_deployer_allowlist)?;
+
+    let calls = if let Some(aa) = tx.tempo_tx_env.as_ref() {
+        aa.aa_calls
+            .iter()
+            .map(|call| parse_call(call.to, &call.input))
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        vec![parse_call(tx.kind(), &tx.data)?]
+    };
+
+    Ok(ValidatedZoneTransaction { calls })
+}
+
+fn parse_call(target: TxKind, input: &Bytes) -> Result<ValidatedZoneCall, TempoInvalidTransaction> {
+    let TxKind::Call(address) = target else {
+        // Contract creation has already been checked against the deployer allowlist.
+        return Ok(ValidatedZoneCall::Other { target });
+    };
+
+    if !is_tip20_prefix(address) {
+        return Ok(ValidatedZoneCall::Other { target });
+    }
+
+    let operation = if input.starts_with(&ITIP20::transferFromCall::SELECTOR) {
+        ITIP20::transferFromCall::abi_decode(input).map_err(|_| {
+            TempoInvalidTransaction::CallsValidation("malformed TIP-20 transferFrom call")
+        })?;
+        AllowedTip20Operation::TransferFrom
+    } else if input.starts_with(&ITIP20::approveCall::SELECTOR) {
+        ITIP20::approveCall::abi_decode(input).map_err(|_| {
+            TempoInvalidTransaction::CallsValidation("malformed TIP-20 approve call")
+        })?;
+        AllowedTip20Operation::Approve
+    } else {
+        return Err(TempoInvalidTransaction::CallsValidation(
+            "TIP-20 operation is not allowed on a zone",
+        ));
+    };
+
+    Ok(ValidatedZoneCall::Tip20 {
+        token: address,
+        operation,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{U256, address};
+    use tempo_primitives::transaction::Call;
+    use tempo_revm::TempoBatchCallEnv;
+
+    const TOKEN: Address = address!("0x20C0000000000000000000000000000000000001");
+
+    fn call_tx(target: Address, input: Bytes) -> TempoTxEnv {
+        TempoTxEnv {
+            inner: revm::context::TxEnv {
+                kind: TxKind::Call(target),
+                data: input,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn parses_allowed_tip20_operations() {
+        let transfer = ITIP20::transferFromCall {
+            from: Address::repeat_byte(0x11),
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        };
+        let approve = ITIP20::approveCall {
+            spender: Address::repeat_byte(0x33),
+            amount: U256::from(9),
+        };
+
+        for (input, expected) in [
+            (
+                Bytes::from(transfer.abi_encode()),
+                AllowedTip20Operation::TransferFrom,
+            ),
+            (
+                Bytes::from(approve.abi_encode()),
+                AllowedTip20Operation::Approve,
+            ),
+        ] {
+            let parsed = validate_transaction(&call_tx(TOKEN, input), &[]).unwrap();
+            assert_eq!(
+                parsed.calls(),
+                &[ValidatedZoneCall::Tip20 {
+                    token: TOKEN,
+                    operation: expected,
+                }]
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_other_and_malformed_tip20_operations() {
+        let transfer = ITIP20::transferCall {
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        };
+
+        assert!(validate_transaction(&call_tx(TOKEN, transfer.abi_encode().into()), &[]).is_err());
+        assert!(
+            validate_transaction(
+                &call_tx(TOKEN, ITIP20::approveCall::SELECTOR.to_vec().into()),
+                &[],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn parses_every_aa_call() {
+        let allowed = ITIP20::approveCall {
+            spender: Address::repeat_byte(0x33),
+            amount: U256::from(9),
+        };
+        let forbidden = ITIP20::mintCall {
+            to: Address::repeat_byte(0x44),
+            amount: U256::from(1),
+        };
+        let tx = TempoTxEnv {
+            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                aa_calls: vec![
+                    Call {
+                        to: TxKind::Call(TOKEN),
+                        value: U256::ZERO,
+                        input: allowed.abi_encode().into(),
+                    },
+                    Call {
+                        to: TxKind::Call(TOKEN),
+                        value: U256::ZERO,
+                        input: forbidden.abi_encode().into(),
+                    },
+                ],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        assert!(validate_transaction(&tx, &[]).is_err());
+    }
+
+    #[test]
+    fn permits_non_tip20_bridge_calls() {
+        let target = Address::repeat_byte(0x1c);
+        let parsed = validate_transaction(&call_tx(target, Bytes::new()), &[]).unwrap();
+        assert_eq!(
+            parsed.calls(),
+            &[ValidatedZoneCall::Other {
+                target: TxKind::Call(target),
+            }]
+        );
+    }
+}

--- a/crates/l1/src/state/tip403/cache.rs
+++ b/crates/l1/src/state/tip403/cache.rs
@@ -41,7 +41,10 @@ use alloy_primitives::Address;
 use alloy_provider::DynProvider;
 use derive_more::Deref;
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP403Registry::PolicyType;
 use tracing::info;
@@ -92,6 +95,15 @@ impl PolicyCache {
     ) -> eyre::Result<()> {
         use tempo_contracts::precompiles::ITIP20;
 
+        // Token enablement is known independently of whether policy RPC reads succeed.
+        // Record it first so pool admission does not infer enablement from policy availability.
+        {
+            let mut cache = self.write();
+            for &token in tracked_tokens {
+                cache.track_enabled_token(token);
+            }
+        }
+
         let block_number = self.last_l1_block();
 
         let seeded = futures::future::join_all(tracked_tokens.iter().map(|token| {
@@ -134,6 +146,11 @@ impl PolicyCache {
 /// This allows the zone sequencer to evaluate transfer authorization without RPC round-trips.
 #[derive(Debug, Default)]
 pub struct PolicyCacheInner {
+    /// Tokens enabled for this zone by its L1 portal.
+    ///
+    /// This is tracked separately from policy data because a token using the default policy
+    /// remains enabled even if versioned policy entries are cleared during a resync.
+    enabled_tokens: HashSet<Address>,
     /// Per-token transfer policy ID.
     tokens: HashMap<Address, HeightVersioned<u64>>,
     /// Per-policy-ID records (type, policy set, compound data).
@@ -163,10 +180,23 @@ impl PolicyCacheInner {
 
     /// Sets the `transferPolicyId` for a token at the given block.
     pub fn set_token_policy(&mut self, token: Address, block_number: u64, policy_id: u64) {
+        self.enabled_tokens.insert(token);
         self.tokens
             .entry(token)
             .or_default()
             .set(block_number, policy_id);
+    }
+
+    /// Record a token enabled for this zone.
+    pub fn track_enabled_token(&mut self, token: Address) {
+        self.enabled_tokens.insert(token);
+    }
+
+    /// Returns every token enabled for this zone in deterministic address order.
+    pub fn enabled_tokens(&self) -> Vec<Address> {
+        let mut tokens: Vec<_> = self.enabled_tokens.iter().copied().collect();
+        tokens.sort_unstable();
+        tokens
     }
 
     /// Sets the policy type for a policy ID.
@@ -201,7 +231,7 @@ impl PolicyCacheInner {
 
     /// Returns all token addresses currently tracked by the cache.
     pub fn tracked_tokens(&self) -> Vec<Address> {
-        self.tokens.keys().copied().collect()
+        self.enabled_tokens()
     }
 
     /// Returns the number of token-to-policy mappings in the cache.
@@ -387,8 +417,9 @@ impl PolicyCacheInner {
         }
     }
 
-    /// Clears all cached policy data. `last_l1_block` is preserved — the engine
-    /// will advance it when it reprocesses blocks after a reorg.
+    /// Clears all versioned policy data. Enabled tokens and `last_l1_block` are preserved —
+    /// token enablement is append-only, while the engine will advance the height when it
+    /// reprocesses blocks after a reorg.
     pub fn clear(&mut self) {
         self.tokens.clear();
         self.policies.clear();
@@ -722,6 +753,20 @@ mod tests {
             cache.is_authorized(TOKEN, USER_A, 10, AuthRole::Transfer),
             None
         );
+        assert_eq!(cache.enabled_tokens(), vec![TOKEN]);
+    }
+
+    #[test]
+    fn tracks_enabled_tokens_without_policy_entries() {
+        let mut cache = PolicyCacheInner::default();
+        cache.track_enabled_token(USER_B);
+        cache.track_enabled_token(TOKEN);
+        cache.track_enabled_token(TOKEN);
+
+        let mut expected = vec![USER_B, TOKEN];
+        expected.sort_unstable();
+        assert_eq!(cache.enabled_tokens(), expected);
+        assert_eq!(cache.num_token_policies(), 0);
     }
 
     #[test]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -664,6 +664,13 @@ impl L1Subscriber {
     /// Write decoded portal state changes into the shared L1 cache at the
     /// confirmed block height.
     fn apply_portal_state_events(&self, block_number: u64, portal_events: &L1PortalEvents) {
+        if !portal_events.enabled_tokens.is_empty() {
+            let mut policy_cache = self.config.policy_cache.write();
+            for enabled in &portal_events.enabled_tokens {
+                policy_cache.track_enabled_token(enabled.token);
+            }
+        }
+
         if portal_events.sequencer_events.is_empty() {
             return;
         }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 tempo-chainspec.workspace = true
 tempo-evm = { workspace = true, features = ["rpc", "engine"] }
 tempo-node.workspace = true
+tempo-precompiles.workspace = true
 tempo-primitives.workspace = true
 tempo-transaction-pool.workspace = true
 tempo-alloy.workspace = true

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -8,7 +8,7 @@ use crate::{
     replication::{broadcast_persisted_blocks, run_block_sync},
     rpc::{ZoneRpc, ZoneRpcApi, rpc_connection_config, start_private_rpc},
 };
-use alloy_primitives::Address;
+use alloy_primitives::{Address, U256};
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
 use k256::SecretKey;
@@ -33,10 +33,13 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::ChainSpecProvider;
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
-use reth_storage_api::{BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProviderFactory};
+use reth_storage_api::{
+    BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProvider, StateProviderFactory,
+};
 use reth_transaction_pool::{
-    Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
-    error::InvalidPoolTransactionError,
+    Pool, PoolTransaction, TransactionValidationTaskExecutor,
+    blobstore::InMemoryBlobStore,
+    error::{InvalidPoolTransactionError, PoolTransactionError},
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tempo_alloy::TempoNetwork;
@@ -45,6 +48,7 @@ use tempo_evm::TempoEvmConfig;
 use tempo_node::{
     DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoEthApiBuilder,
 };
+use tempo_precompiles::tip20::TIP20Token;
 use tempo_primitives::{
     self as primitives, TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType,
 };
@@ -350,7 +354,7 @@ impl ZoneNode {
     {
         ComponentsBuilder::default()
             .node_types::<N>()
-            .pool(ZonePoolBuilder)
+            .pool(ZonePoolBuilder::new(executor_builder.policy_cache.clone()))
             .executor(executor_builder)
             .payload(BasicPayloadServiceBuilder::new(payload_factory))
             .network(NoopNetworkBuilder::<ZoneNetworkPrimitives>::default())
@@ -1043,9 +1047,57 @@ where
 }
 
 /// Transaction pool builder for Zone - uses Tempo pool with defaults.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 #[non_exhaustive]
-pub struct ZonePoolBuilder;
+pub struct ZonePoolBuilder {
+    policy_cache: PolicyCache,
+}
+
+impl ZonePoolBuilder {
+    /// Create a pool builder using the zone's shared enabled-token cache.
+    pub fn new(policy_cache: PolicyCache) -> Self {
+        Self { policy_cache }
+    }
+}
+
+#[derive(Debug)]
+struct ZonePoolAdmissionError(&'static str);
+
+impl std::fmt::Display for ZonePoolAdmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl std::error::Error for ZonePoolAdmissionError {}
+
+impl PoolTransactionError for ZonePoolAdmissionError {
+    fn is_bad_transaction(&self) -> bool {
+        false
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn pool_admission_error(message: &'static str) -> InvalidPoolTransactionError {
+    InvalidPoolTransactionError::other(ZonePoolAdmissionError(message))
+}
+
+fn sender_has_enabled_token_balance<E>(
+    sender: Address,
+    enabled_tokens: &[Address],
+    mut balance_at: impl FnMut(Address, U256) -> Result<Option<U256>, E>,
+) -> Result<bool, E> {
+    for &token in enabled_tokens {
+        let slot = TIP20Token::from_address_unchecked(token).balances[sender].slot();
+        if balance_at(token, slot)?.is_some_and(|balance| !balance.is_zero()) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
 
 impl<Node> PoolBuilder<Node, ZoneEvmConfig> for ZonePoolBuilder
 where
@@ -1087,7 +1139,36 @@ where
                 tx.tx_env(),
                 zone_primitives::constants::CONTRACT_DEPLOYER_ALLOWLIST,
             )
+            .map(|_| ())
             .map_err(|err| InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(err)))
+        });
+
+        let provider = ctx.provider().clone();
+        let policy_cache = self.policy_cache.clone();
+        validator.set_additional_stateful_validation(move |_origin, tx, _account_state| {
+            let enabled_tokens = policy_cache.read().enabled_tokens();
+            let state = provider.latest().map_err(|err| {
+                warn!(%err, "Failed to read latest state for zone token-balance admission check");
+                pool_admission_error("could not verify balance of an enabled zone token")
+            })?;
+
+            let sender = *tx.sender_ref();
+            let has_balance =
+                sender_has_enabled_token_balance(sender, &enabled_tokens, |token, slot| {
+                    state.storage(token, slot.into())
+                })
+                .map_err(|err| {
+                    warn!(%err, %sender, "Failed to read zone token balance during pool admission");
+                    pool_admission_error("could not verify balance of an enabled zone token")
+                })?;
+
+            if !has_balance {
+                return Err(pool_admission_error(
+                    "sender must hold a nonzero balance of an enabled zone token",
+                ));
+            }
+
+            Ok(())
         });
 
         let validator =
@@ -1139,7 +1220,7 @@ where
 mod tests {
     use super::*;
     use alloy_consensus::{Signed, TxEip1559};
-    use alloy_primitives::{Bytes, Signature, TxKind, U256};
+    use alloy_primitives::{Bytes, Signature, TxKind, U256, address};
     use reth_chainspec::EthChainSpec;
     use reth_primitives_traits::Recovered;
     use tempo_primitives::transaction::{
@@ -1177,6 +1258,34 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
         unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
+    }
+
+    #[test]
+    fn enabled_token_balance_guard_accepts_any_nonzero_balance() {
+        let sender = Address::repeat_byte(0x11);
+        let tokens = [
+            address!("0x20c0000000000000000000000000000000000001"),
+            address!("0x20c0000000000000000000000000000000000002"),
+        ];
+        let funded_token = tokens[1];
+
+        let has_balance = sender_has_enabled_token_balance(sender, &tokens, |token, _slot| {
+            Ok::<_, std::convert::Infallible>((token == funded_token).then_some(U256::from(1)))
+        })
+        .unwrap();
+        assert!(has_balance);
+
+        let has_balance = sender_has_enabled_token_balance(sender, &tokens, |_token, _slot| {
+            Ok::<_, std::convert::Infallible>(Some(U256::ZERO))
+        })
+        .unwrap();
+        assert!(!has_balance);
+
+        let has_balance = sender_has_enabled_token_balance(sender, &[], |_token, _slot| {
+            Ok::<_, std::convert::Infallible>(Some(U256::from(1)))
+        })
+        .unwrap();
+        assert!(!has_balance);
     }
 
     #[test]

--- a/invariants.md
+++ b/invariants.md
@@ -118,7 +118,10 @@ for auditors, invariant/fuzz test authors, and production monitoring.
 
 | ID | Assertion | Crit | Impact |
 |---|---|---|---|
-| `TEMPO-ZONE-ADVANCE-TEMPO-FIRST` | When present, `advanceTempo` is the first transaction in a zone block | 🟡 | User transactions can execute against the wrong Tempo binding or stale config |
+| `TEMPO-ZONE-ADVANCE-TEMPO-FIRST` | Every zone block contains exactly one `advanceTempo` system transaction and it is first | 🟡 | User transactions can execute against the wrong Tempo binding or stale config |
+| `TEMPO-ZONE-FINALIZE-WITHDRAWAL-LAST` | `finalizeWithdrawalBatch` appears at most once per block and, when present, is the final system transaction | 🔴 | A committed withdrawal batch can omit or include later state transitions |
+| `TEMPO-ZONE-USER-TIP20-OPERATIONS` | Direct user TIP-20 calls permit only `transferFrom` and `approve`, including across every AA batch call | 🟡 | Users can invoke token operations outside the zone's intended private execution surface |
+| `TEMPO-ZONE-POOL-ENABLED-TOKEN-BALANCE` | Public pool admission requires the recovered sender to hold a nonzero balance of at least one currently enabled zone token | 🟢 | Unfunded identities can fill the zero-fee transaction pool |
 | `TEMPO-ZONE-CONTRACT-CREATION-DISABLED` | User `CREATE` and `CREATE2` always revert on zones | 🟡 | Users can deploy contracts that bypass privacy and system-token assumptions |
 | `TEMPO-ZONE-BALANCE-ALLOWANCE-PRIVACY` | `balanceOf` and `allowance` reveal values only to authorized callers or the sequencer | 🟡 | Account balances and approvals leak through token precompiles |
 | `TEMPO-ZONE-FIXED-TOKEN-GAS` | TIP-20 transfer and approve operations charge fixed gas independent of account storage layout | 🟢 | Gas timing leaks whether addresses have prior token activity |

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -744,15 +744,17 @@ Sequencer encryption keys are already published (used for encrypted deposits), s
 
 Zone transactions specify which enabled TIP-20 token to use for gas fees via a `feeToken` field. The sequencer accepts all enabled tokens as gas. Transactions use Tempo transaction semantics for fee payer, max fee per gas, and gas limit.
 
+Public transaction-pool admission also requires the recovered transaction sender to hold a nonzero balance of at least one token currently enabled for the zone. Token enablement is tracked independently of TIP-403 policy-cache entries, because an enabled token can continue using the default transfer policy. This is an admission guardrail rather than a consensus balance rule: a transaction already in the pool may become ineligible for other state-dependent reasons before block construction.
+
 ### Block Structure
 
 Each zone block contains system transactions and user transactions in a fixed order:
 
-1. `ZoneInbox.advanceTempo(header, deposits, decryptions, enabledTokens)` (optional, at the start of the block). Advances the zone's view of Tempo, enables newly-bridged tokens, processes any pending deposits, and verifies encrypted deposit decryptions. If omitted, the zone's Tempo binding carries forward from the previous block.
+1. Exactly one `ZoneInbox.advanceTempo(header, deposits, decryptions, enabledTokens)` system transaction, as the first transaction in the block. It advances the zone's view of Tempo, enables newly-bridged tokens, processes any pending deposits, and verifies encrypted deposit decryptions.
 2. User transactions, executed in order.
-3. `ZoneOutbox.finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` (required in the final block of a batch, absent in intermediate blocks). Constructs the withdrawal hash chain from pending withdrawals, populates `encryptedSender` for authenticated withdrawals, and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to state. Must be called at each batch boundary even if there are zero withdrawals so the batch index advances. The builder may execute it as a zone system transaction with `msg.sender == address(0)`.
+3. At most one `ZoneOutbox.finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` system transaction, which must be the final transaction when present. It is required in the final block of a batch and absent in intermediate blocks. It constructs the withdrawal hash chain from pending withdrawals, populates `encryptedSender` for authenticated withdrawals, and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to state. It must be called at each batch boundary even if there are zero withdrawals so the batch index advances.
 
-A batch covers one or more zone blocks and ends with exactly one `finalizeWithdrawalBatch` call. The sequencer finalizes when withdrawals are present or when the current zone block number is a configured batch-cadence multiple (every 120 blocks by default). Intermediate blocks within a batch contain only `advanceTempo` (optional) and user transactions.
+A batch covers one or more zone blocks and ends with exactly one `finalizeWithdrawalBatch` call. The sequencer finalizes when withdrawals are present or when the current zone block number is a configured batch-cadence multiple (every 120 blocks by default). Intermediate blocks within a batch contain the required `advanceTempo` transaction followed by user transactions.
 
 ### Block Header Format
 
@@ -770,9 +772,10 @@ be recreated.
 
 ### Privacy Modifications
 
-Zone execution differs from standard Tempo execution in three areas. These changes are enforced at the EVM level, not just at the RPC layer, so they apply to all code paths including user transactions, `eth_call` simulations, and prover re-execution.
+Zone execution differs from standard Tempo execution in four areas. These changes are enforced at the EVM level, not just at the RPC layer, so they apply to all code paths including user transactions, `eth_call` simulations, and prover re-execution.
 
 - **Balance and allowance access control.** `balanceOf(account)` reverts unless `msg.sender` is the account owner or the sequencer. `allowance(owner, spender)` reverts unless `msg.sender` is the owner, the spender, or the sequencer.
+- **Restricted direct token operations.** A user transaction may call an enabled TIP-20 directly only through `transferFrom` or `approve`. All other direct TIP-20 selectors are rejected, including when they appear in any call of an account-abstraction batch. Calls to non-TIP-20 zone interfaces such as `ZoneOutbox.requestWithdrawal` remain available.
 - **Fixed gas for transfers.** All TIP-20 transfer and approve operations charge a fixed 100,000 gas regardless of storage layout. This eliminates a side channel where variable gas costs reveal whether a recipient has previously received tokens.
 - **Contract creation disabled.** `CREATE` and `CREATE2` revert. The zone runs only predeploys and TIP-20 token precompiles. Arbitrary contract deployment would allow users to circumvent the execution-level privacy controls.
 
@@ -800,7 +803,7 @@ Sequencers MUST NOT use uncertified follow mode (`--follow.nocertify`) or a gene
 
 `ZoneInbox.advanceTempo()` calls `TempoState.finalizeTempo(header)` to advance the zone's view of Tempo. This function decodes the RLP header, validates chain continuity (parent hash must match the previous finalized header, block number must increment by one), stores the new checkpoint, and emits the decoded state root in `TempoBlockFinalized`.
 
-If a block omits `advanceTempo`, the Tempo binding carries forward from the previous block. Multiple blocks can share the same Tempo binding.
+Every zone block imports the next finalized Tempo header through its required first `advanceTempo` transaction. The Tempo binding therefore advances once per zone block and cannot be reused by omitting the system transaction.
 
 ### Storage Reads
 
@@ -817,7 +820,7 @@ TIP-403 policy authorization on the zone is handled by a dedicated read-only pro
 
 ### Staleness and Finality
 
-The zone's view of Tempo is only as current as the most recent `advanceTempo` call. If the sequencer advances Tempo infrequently, zone-side reads of portal state (sequencer address, deposit queue, token registry) may lag behind Tempo.
+The zone's view of Tempo is bound by the required `advanceTempo` call at the start of each zone block. Zone-side reads of portal state (sequencer address, deposit queue, token registry) use that block's imported finalized Tempo state.
 
 The zone node must only finalize Tempo headers that have reached finality on Tempo. Proofs should only reference finalized Tempo blocks to avoid reorg risk.
 
@@ -995,7 +998,7 @@ The witness contains everything needed to re-execute the batch:
 
 - **PublicInputs**: `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. These are the values the portal passes to the verifier and the proof must be consistent with. `prevBlockHash` is instead derived from `prev_block_header` and bound through the public `block_transition` output.
 - **BatchWitness**: the public inputs, the previous batch's Tempo block header, the zone blocks to execute, the initial zone state, Tempo state proofs, and Tempo ancestry headers (for ancestry validation).
-- **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `beneficiary`, `tempo_header_rlp` (optional), `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
+- **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `beneficiary`, required `tempo_header_rlp`, `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
 - **ZoneStateWitness**: the initial zone state root, a deduplicated pool of zone-state trie nodes, and decoded account / storage reads needed to bootstrap execution. Only accounts and storage slots accessed during execution are included. Missing witness data must produce an error, not default to zero, to prevent the prover from omitting non-zero state.
 
 ### Input Schematic
@@ -1131,21 +1134,17 @@ pub struct ZoneBlock {
     /// Beneficiary (must match registered sequencer)
     pub beneficiary: Address,
 
-    /// Tempo header RLP used by the call (ZoneInbox.advanceTempo).
-    /// If None, the block does not advance Tempo and the binding carries over.
-    pub tempo_header_rlp: Option<Vec<u8>>,
+    /// Tempo header RLP used by the required first ZoneInbox.advanceTempo call.
+    pub tempo_header_rlp: Vec<u8>,
 
     /// Deposits processed by the system tx (oldest first, unified queue).
-    /// Must be empty if tempo_header_rlp is None.
     pub deposits: Vec<QueuedDeposit>,
 
     /// Decryption data for encrypted deposits in the system tx.
-    /// Must be empty if tempo_header_rlp is None.
     pub decryptions: Vec<DecryptionData>,
 
     /// Tokens enabled by the system tx, in the exact calldata order passed to
     /// `ZoneInbox.advanceTempo(header, deposits, decryptions, enabledTokens)`.
-    /// Must be empty if tempo_header_rlp is None.
     pub enabled_tokens: Vec<EnabledToken>,
 
     /// Sequencer-only: finalize a batch (only in final block, must be last)
@@ -1287,10 +1286,10 @@ The stateless execution function must reject the witness on any failed check, mi
    Compute `keccak256(rlp(node))` for each node in `tempo_state_proofs.node_pool` and build a hash-to-node index for proof traversal.
 
 4. **For each `zone_blocks[i]`, verify the block witness before executing it.**
-   Require `block.parent_hash == prev_block_hash`. Require `block.number == prev_header.number + 1`. Require `block.timestamp >= prev_header.timestamp`. Require `block.beneficiary == public_inputs.sequencer`. Require `finalize_withdrawal_batch_count` to be absent in intermediate blocks and present in the final block of the batch. If `tempo_header_rlp` is absent, require `deposits`, `decryptions`, and `enabled_tokens` to be empty. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
+   Require `block.parent_hash == prev_block_hash`. Require `block.number == prev_header.number + 1`. Require `block.timestamp >= prev_header.timestamp`. Require `block.beneficiary == public_inputs.sequencer`. The required `tempo_header_rlp` supplies exactly one first-position `advanceTempo` transaction. Require `finalize_withdrawal_batch_count` to be absent in intermediate blocks and present in the final block of the batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
 
-5. **Execute `advanceTempo` if the block imports a Tempo header.**
-   If `tempo_header_rlp` is present, call `TempoState.finalizeTempo(header)` in the modeled execution environment. This validates header continuity, updates the bound `tempoBlockNumber` and `tempoBlockHash`, and makes the imported header's state root available for subsequent `TempoState.readTempoStorageSlot` calls in this block. Require the finalized `tempoBlockHash` to equal `keccak256(tempo_header_rlp)`.
+5. **Execute `advanceTempo` first.**
+   Call `TempoState.finalizeTempo(header)` through the block's required first `ZoneInbox.advanceTempo` system transaction. This validates header continuity, updates the bound `tempoBlockNumber` and `tempoBlockHash`, and makes the imported header's state root available for subsequent `TempoState.readTempoStorageSlot` calls in this block. Require the finalized `tempoBlockHash` to equal `keccak256(tempo_header_rlp)`.
 
 6. **Process deposits and encrypted deposit decryptions inside `advanceTempo`.**
    Using the now-bound Tempo root for this block, verify the Tempo-side reads needed by `ZoneInbox` such as the portal's current deposit queue hash. Execute `ZoneInbox.advanceTempo(header, deposits, decryptions, enabledTokens)` using `enabled_tokens` in the exact witness order; this order is part of the system transaction calldata and therefore affects the transaction root, receipts/logs root, and resulting state transition. Process the `deposits` in witness order, enforcing the queue semantics specified in [Deposit Queue](#deposit-queue). For encrypted deposits, verify the supplied `DecryptionData` and Chaum-Pedersen proof, decode the recipient and memo when AES-GCM decryption succeeds, and enqueue a bounce-back when proof verification, AES-GCM authentication, plaintext length validation, or the decrypted-recipient mint fails as specified in [Onchain Decryption Verification](#onchain-decryption-verification).


### PR DESCRIPTION
## Summary

- enforce the zone block system-transaction sequence: exactly one `advanceTempo` first and an optional unique `finalizeWithdrawalBatch` last
- restrict direct TIP-20 calls to `transferFrom` and `approve`, including every call in an AA batch
- require transaction-pool senders to hold a non-zero balance in at least one enabled zone token
- track enabled tokens independently from TIP-403 policy entries and document the invariants

## Why

This addresses ZONE-73 and ZONE-82 and places the enabled-token balance rule at the transaction-pool admission boundary, so every pool ingress path shares the same policy. Stateless transaction parsing is also shared by pool validation and EVM execution.

## Validation

- affected crate checks passed
- 15 focused Zone EVM tests passed
- 42 Zone L1 cache tests passed
- 4 Zone node tests passed
- 4 payload tests passed
- 4 `advance_tempo` integration tests passed
- `git diff --check` passed

## Draft follow-ups

- preserve the private RPC's generic `-32003` rejection contract for the balance gate, as in #744
- add end-to-end coverage for both raw-transaction RPC methods
- make startup enabled-token discovery recoverable and review enabled-token cache behavior across L1 reorgs

Related: #744