### PR TITLE
chore(sequencer): log withdrawal gas usage

### DIFF
--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -609,6 +609,7 @@ impl WithdrawalProcessor {
             token = %withdrawal.token,
             to = %withdrawal.to,
             amount = %withdrawal.amount,
+            gas_used = receipt.gas_used,
             "✅ Withdrawal confirmed on L1"
         );
         SubmitOutcome::Confirmed


### PR DESCRIPTION
Logs the L1 receipt gas used when a withdrawal is confirmed, making withdrawal execution costs visible in sequencer logs.