### PR TITLE
fix(zones): bound withdrawal delivery gas

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -270,7 +270,7 @@ interface IAesGcmDecrypt {
 
 }
 
-// Maximum callback gas a withdrawal may request.
+// Maximum delivery gas a callback withdrawal may request.
 // The processor adds fixed overhead, so this value keeps the outer
 // `processWithdrawals` transaction well below a 30M gas L1 block
 // limit.
@@ -282,7 +282,7 @@ struct Withdrawal {
     address to; // Tempo recipient
     uint128 amount; // amount to send to recipient (excludes fee)
     bytes32 memo; // user-provided context
-    uint64 gasLimit; // max gas for IWithdrawalReceiver callback (0 = no callback)
+    uint64 gasLimit; // max gas for callback withdrawal delivery (0 = no callback)
     uint64 fallbackNonce; // resolves to the zone bounce-back recipient in ZoneOutbox
     bytes callbackData; // calldata for IWithdrawalReceiver (if gasLimit > 0)
     bytes encryptedSender; // optional encrypted (sender, txHash) reveal payload
@@ -295,7 +295,7 @@ struct PendingWithdrawal {
     address to; // Tempo recipient
     uint128 amount; // amount to send to recipient (excludes fee)
     bytes32 memo; // user-provided context
-    uint64 gasLimit; // max gas for IWithdrawalReceiver callback (0 = no callback)
+    uint64 gasLimit; // max gas for callback withdrawal delivery (0 = no callback)
     uint64 fallbackNonce; // resolves to the zone bounce-back recipient in ZoneOutbox
     bytes callbackData; // calldata for IWithdrawalReceiver (if gasLimit > 0)
     bytes revealTo; // optional compressed secp256k1 pubkey for sender reveal encryption
@@ -659,7 +659,7 @@ interface IZonePortal {
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
 
-    /// @notice Maximum callback gas accepted for withdrawals
+    /// @notice Maximum delivery gas accepted for callback withdrawals
     function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);
 
     /// @notice Maximum allowed gas fee rate (1e18)
@@ -894,7 +894,6 @@ interface IZonePortal {
         address target,
         uint128 amount,
         bytes32 senderTag,
-        uint64 gasLimit,
         bytes calldata data
     )
         external;
@@ -931,7 +930,6 @@ interface IZoneMessenger {
     /// @param senderTag The authenticated sender commitment from the zone
     /// @param target The Tempo recipient
     /// @param amount Tokens to transfer from portal to target
-    /// @param gasLimit Max gas for the callback
     /// @param data Calldata for the target
     function relayMessage(
         uint32 zoneId,
@@ -939,7 +937,6 @@ interface IZoneMessenger {
         bytes32 senderTag,
         address target,
         uint128 amount,
-        uint64 gasLimit,
         bytes calldata data
     )
         external;
@@ -1139,7 +1136,7 @@ interface IZoneOutbox {
     /// @notice Maximum callback data size (1KB)
     function MAX_CALLBACK_DATA_SIZE() external view returns (uint256);
 
-    /// @notice Maximum callback gas accepted for withdrawals
+    /// @notice Maximum delivery gas accepted for callback withdrawals
     function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);
 
     /// @notice Base gas cost for processing a withdrawal on Tempo (excluding callback)

--- a/specs/ref-impls/src/tempo/ZoneMessenger.sol
+++ b/specs/ref-impls/src/tempo/ZoneMessenger.sol
@@ -39,7 +39,6 @@ contract ZoneMessenger is IZoneMessenger {
         bytes32 senderTag,
         address target,
         uint128 amount,
-        uint64 gasLimit,
         bytes calldata data
     )
         external
@@ -59,11 +58,24 @@ contract ZoneMessenger is IZoneMessenger {
             revert TransferFailed();
         }
 
-        bytes4 selector = IWithdrawalReceiver(target).onWithdrawalReceived{ gas: gasLimit }(
-            zoneId, msg.sender, senderTag, token, amount, data
+        bytes memory callback = abi.encodeCall(
+            IWithdrawalReceiver.onWithdrawalReceived,
+            (zoneId, msg.sender, senderTag, token, amount, data)
         );
+        bool success;
+        bytes4 selector;
+        assembly ("memory-safe") {
+            success := call(gas(), target, 0, add(callback, 0x20), mload(callback), 0, 0)
+            if success {
+                if lt(returndatasize(), 4) { success := false }
+                if success {
+                    returndatacopy(0, 0, 4)
+                    selector := mload(0)
+                }
+            }
+        }
 
-        if (selector != IWithdrawalReceiver.onWithdrawalReceived.selector) {
+        if (!success || selector != IWithdrawalReceiver.onWithdrawalReceived.selector) {
             revert CallbackRejected();
         }
     }

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -941,13 +941,13 @@ contract ZonePortal is IZonePortal {
                 && _isAllowed(withdrawal.to)
                 && _tryTransfer(_token, withdrawal.to, withdrawal.amount);
         } else {
-            // Isolate callback effects so failure can be caught without reverting the dequeue.
-            try this.deliverWithdrawal(
+            // Isolate and bound callback effects so failure can be caught without reverting the
+            // dequeue.
+            try this.deliverWithdrawal{ gas: withdrawal.gasLimit }(
                 _token,
                 withdrawal.to,
                 withdrawal.amount,
                 withdrawal.senderTag,
-                withdrawal.gasLimit,
                 withdrawal.callbackData
             ) {
                 success = true;
@@ -971,7 +971,6 @@ contract ZonePortal is IZonePortal {
         address target,
         uint128 amount,
         bytes32 senderTag,
-        uint64 gasLimit,
         bytes calldata data
     )
         external
@@ -986,8 +985,7 @@ contract ZonePortal is IZonePortal {
 
         bytes32 depositQueueHashBefore = currentDepositQueueHash;
 
-        IZoneMessenger(messenger)
-            .relayMessage(zoneId, token, senderTag, target, amount, gasLimit, data);
+        IZoneMessenger(messenger).relayMessage(zoneId, token, senderTag, target, amount, data);
 
         // In closed access, this proves only that some deposit was appended to this portal; it does
         // not bind that deposit to the callback's token, amount, or recipient. Callback data is

--- a/specs/ref-impls/src/zone/ZoneOutbox.sol
+++ b/specs/ref-impls/src/zone/ZoneOutbox.sol
@@ -145,10 +145,10 @@ contract ZoneOutbox is IZoneOutbox {
         emit MaxWithdrawalsPerBlockUpdated(maxWithdrawals);
     }
 
-    /// @notice Calculate the fee for a withdrawal with the given callback gas limit
+    /// @notice Calculate the fee for a withdrawal with the given delivery gas limit
     /// @dev Reverts if `gasLimit` exceeds MAX_WITHDRAWAL_GAS_LIMIT.
     ///      Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate.
-    /// @param gasLimit L1 callback gas limit (0 = no callback)
+    /// @param gasLimit L1 callback withdrawal delivery gas limit (0 = no callback)
     /// @return fee The total fee in zone token units
     function calculateWithdrawalFee(uint64 gasLimit) public view returns (uint128 fee) {
         _validateGasLimit(gasLimit);
@@ -169,7 +169,7 @@ contract ZoneOutbox is IZoneOutbox {
     /// @param to The Tempo recipient address
     /// @param amount Amount to send to recipient (fee is additional)
     /// @param memo User-provided context (e.g., payment reference)
-    /// @param gasLimit L1 callback gas limit (0 = no callback, capped by MAX_WITHDRAWAL_GAS_LIMIT)
+    /// @param gasLimit L1 callback withdrawal delivery gas limit (0 = no callback, capped by MAX_WITHDRAWAL_GAS_LIMIT)
     /// @param zoneFallbackRecipient Zone address for bounce-back if callback fails
     /// @param data Calldata for IWithdrawalReceiver callback
     function requestWithdrawal(
@@ -196,7 +196,7 @@ contract ZoneOutbox is IZoneOutbox {
     /// @param to The Tempo recipient address
     /// @param amount Amount to send to recipient (fee is additional)
     /// @param memo User-provided context (e.g., payment reference)
-    /// @param gasLimit L1 callback gas limit (0 = no callback, capped by MAX_WITHDRAWAL_GAS_LIMIT)
+    /// @param gasLimit L1 callback withdrawal delivery gas limit (0 = no callback, capped by MAX_WITHDRAWAL_GAS_LIMIT)
     /// @param zoneFallbackRecipient Zone address for bounce-back if callback fails
     /// @param data Calldata for IWithdrawalReceiver callback
     /// @param revealTo Optional compressed secp256k1 pubkey for encrypted sender reveal
@@ -216,14 +216,14 @@ contract ZoneOutbox is IZoneOutbox {
     }
 
     /// @notice Shared implementation for withdrawal requests with optional sender reveal
-    /// @dev Validates the callback gas cap before fee calculation and before storing
+    /// @dev Validates the callback withdrawal delivery gas cap before fee calculation and storage
     ///      the withdrawal, so over-cap requests cannot enter the L2 withdrawal queue.
     ///      Transfers and burns `amount + fee` before appending the pending withdrawal.
     /// @param token The TIP-20 token to withdraw
     /// @param to The Tempo recipient address
     /// @param amount Amount to send to recipient (fee is additional)
     /// @param memo User-provided context (e.g., payment reference)
-    /// @param gasLimit L1 callback gas limit (0 = no callback)
+    /// @param gasLimit L1 callback withdrawal delivery gas limit (0 = no callback)
     /// @param zoneFallbackRecipient Zone address for bounce-back if callback fails
     /// @param data Calldata for IWithdrawalReceiver callback
     /// @param revealTo Optional compressed secp256k1 pubkey for encrypted sender reveal
@@ -484,10 +484,10 @@ contract ZoneOutbox is IZoneOutbox {
         });
     }
 
-    /// @notice Revert if a withdrawal callback gas limit exceeds the protocol cap
+    /// @notice Revert if a callback withdrawal delivery gas limit exceeds the protocol cap
     /// @dev Applied by both fee estimation and request submission to keep the L2
     ///      withdrawal queue free of callbacks that cannot fit in an L1 block.
-    /// @param gasLimit L1 callback gas limit requested by the user
+    /// @param gasLimit L1 callback withdrawal delivery gas limit requested by the user
     function _validateGasLimit(uint64 gasLimit) internal pure {
         if (gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) revert GasLimitTooHigh();
     }
@@ -495,7 +495,7 @@ contract ZoneOutbox is IZoneOutbox {
     /// @notice Calculate the withdrawal processing fee for a validated gas limit
     /// @dev Caller must validate `gasLimit` with _validateGasLimit() first.
     ///      Fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate.
-    /// @param gasLimit L1 callback gas limit included in the fee
+    /// @param gasLimit L1 callback withdrawal delivery gas limit included in the fee
     /// @return fee The total fee in zone token units
     function _calculateWithdrawalFee(uint64 gasLimit) internal view returns (uint128) {
         return uint128(WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate;

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 5228,
+      "astId": 5224,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5231,
+      "astId": 5227,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5233,
+      "astId": 5229,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -25,7 +25,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5235,
+      "astId": 5231,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5238,
+      "astId": 5234,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5241,
+      "astId": 5237,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5244,
+      "astId": 5240,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -57,7 +57,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5247,
+      "astId": 5243,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5250,
+      "astId": 5246,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "bouncebackGas",
       "offset": 24,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5255,
+      "astId": 5251,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_array(t_struct(EncryptionKeyEntry)2654_storage)dyn_storage"
     },
     {
-      "astId": 5261,
+      "astId": 5257,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_mapping(t_address,t_struct(TokenConfig)3061_storage)"
     },
     {
-      "astId": 5265,
+      "astId": 5261,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5272,
+      "astId": 5268,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -105,15 +105,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 5276,
+      "astId": 5272,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
       "slot": "9",
-      "type": "t_struct(WithdrawalQueue)4902_storage"
+      "type": "t_struct(WithdrawalQueue)4898_storage"
     },
     {
-      "astId": 5279,
+      "astId": 5275,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 5282,
+      "astId": 5278,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5285,
+      "astId": 5281,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5288,
+      "astId": 5284,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5291,
+      "astId": 5287,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -153,7 +153,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5293,
+      "astId": 5289,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5295,
+      "astId": 5291,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 20,
@@ -169,7 +169,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5298,
+      "astId": 5294,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerSetVersion",
       "offset": 21,
@@ -177,7 +177,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5300,
+      "astId": 5296,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerThreshold",
       "offset": 29,
@@ -185,7 +185,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 5302,
+      "astId": 5298,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneHeight",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5305,
+      "astId": 5301,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_sequencers",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5309,
+      "astId": 5305,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "isSequencer",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 5314,
+      "astId": 5310,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "role",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_mapping(t_address,t_enum(Role)2497)"
     },
     {
-      "astId": 5317,
+      "astId": 5313,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isAccessEnforced",
       "offset": 0,
@@ -225,7 +225,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5319,
+      "astId": 5315,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isGatewayEnforced",
       "offset": 1,
@@ -233,7 +233,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5322,
+      "astId": 5318,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enforcementModesPadding",
       "offset": 2,
@@ -241,7 +241,7 @@
       "type": "t_uint240"
     },
     {
-      "astId": 5325,
+      "astId": 5321,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "maxTempoGasRate",
       "offset": 0,
@@ -383,13 +383,13 @@
         }
       ]
     },
-    "t_struct(WithdrawalQueue)4902_storage": {
+    "t_struct(WithdrawalQueue)4898_storage": {
       "encoding": "inplace",
       "label": "struct WithdrawalQueue",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 4895,
+          "astId": 4891,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "head",
           "offset": 0,
@@ -397,7 +397,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4897,
+          "astId": 4893,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "tail",
           "offset": 0,
@@ -405,7 +405,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4901,
+          "astId": 4897,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "slots",
           "offset": 0,

--- a/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.13;
 import {
     IWithdrawalReceiver,
     IZonePortal,
-    MAX_WITHDRAWAL_CALLBACK_GAS,
     Role,
     ZONE_FACTORY_ADDRESS,
     ZONE_MESSENGER_ADDRESS,
@@ -80,12 +79,41 @@ contract RejectingWithdrawalReceiver is IWithdrawalReceiver {
 
 }
 
+contract OversizedReturnWithdrawalReceiver is IWithdrawalReceiver {
+
+    bool internal immutable _succeeds;
+
+    constructor(bool succeeds) {
+        _succeeds = succeeds;
+    }
+
+    function onWithdrawalReceived(
+        uint32,
+        address,
+        bytes32,
+        address,
+        uint128,
+        bytes calldata
+    )
+        external
+        view
+        returns (bytes4)
+    {
+        bool succeeds = _succeeds;
+        bytes4 selector = IWithdrawalReceiver.onWithdrawalReceived.selector;
+        assembly ("memory-safe") {
+            mstore(0, selector)
+            if succeeds { return(0, 0x10000) }
+            revert(0, 0x10000)
+        }
+    }
+
+}
+
 contract ZoneMessengerTest is BaseTest {
 
     uint32 internal constant ZONE_ID = 1;
     uint32 internal constant OTHER_ZONE_ID = 2;
-    uint64 internal constant CALLBACK_GAS_LIMIT = MAX_WITHDRAWAL_CALLBACK_GAS;
-
     MockZoneFactoryForMessenger public messengerFactory;
     ZoneMessenger public messenger;
     MockZoneToken public zoneToken;
@@ -137,13 +165,13 @@ contract ZoneMessengerTest is BaseTest {
 
     function test_relayMessage_revertsUnauthorizedPortalForNonPortalCaller() public {
         vm.expectRevert(ZoneMessenger.UnauthorizedPortal.selector);
-        messenger.relayMessage(ZONE_ID, token, bytes32("sender"), alice, 1, 50_000, "");
+        messenger.relayMessage(ZONE_ID, token, bytes32("sender"), alice, 1, "");
     }
 
     function test_relayMessage_revertsUnauthorizedPortalForWrongZoneId() public {
         vm.prank(portal);
         vm.expectRevert(ZoneMessenger.UnauthorizedPortal.selector);
-        messenger.relayMessage(OTHER_ZONE_ID, token, bytes32("sender"), alice, 1, 50_000, "");
+        messenger.relayMessage(OTHER_ZONE_ID, token, bytes32("sender"), alice, 1, "");
     }
 
     function test_relayMessage_revertsTransferFailedWhenTransferReturnsFalse() public {
@@ -153,7 +181,7 @@ contract ZoneMessengerTest is BaseTest {
         vm.prank(portal);
         vm.expectRevert(ZoneMessenger.TransferFailed.selector);
         messenger.relayMessage(
-            ZONE_ID, token, bytes32("sender"), address(receiver), 1, 50_000, _callback()
+            ZONE_ID, token, bytes32("sender"), address(receiver), 1, _callback()
         );
     }
 
@@ -164,7 +192,7 @@ contract ZoneMessengerTest is BaseTest {
         vm.prank(portal);
         vm.expectRevert(ZoneMessenger.CallbackRejected.selector);
         messenger.relayMessage(
-            ZONE_ID, token, bytes32("sender"), address(receiver), 1, 50_000, _callback()
+            ZONE_ID, token, bytes32("sender"), address(receiver), 1, _callback()
         );
     }
 
@@ -173,7 +201,28 @@ contract ZoneMessengerTest is BaseTest {
 
         vm.prank(portal);
         vm.expectRevert();
-        messenger.relayMessage(ZONE_ID, token, bytes32("sender"), alice, 1, 50_000, _callback());
+        messenger.relayMessage(ZONE_ID, token, bytes32("sender"), alice, 1, _callback());
+    }
+
+    function test_relayMessage_revertsCallbackRejectedWithoutCopyingRevertData() public {
+        OversizedReturnWithdrawalReceiver receiver = new OversizedReturnWithdrawalReceiver(false);
+        _mockTransfer(address(receiver), 1, true);
+
+        vm.prank(portal);
+        vm.expectRevert(ZoneMessenger.CallbackRejected.selector);
+        messenger.relayMessage(
+            ZONE_ID, token, bytes32("sender"), address(receiver), 1, _callback()
+        );
+    }
+
+    function test_relayMessage_copiesOnlySelectorFromSuccessfulReturnData() public {
+        OversizedReturnWithdrawalReceiver receiver = new OversizedReturnWithdrawalReceiver(true);
+        _mockTransfer(address(receiver), 1, true);
+
+        vm.prank(portal);
+        messenger.relayMessage(
+            ZONE_ID, token, bytes32("sender"), address(receiver), 1, _callback()
+        );
     }
 
     function test_relayMessage_successWithFlattenedFactoryGetter() public {
@@ -184,9 +233,7 @@ contract ZoneMessengerTest is BaseTest {
         _allowGateway(address(receiver));
 
         vm.prank(portal);
-        messenger.relayMessage(
-            ZONE_ID, address(zoneToken), senderTag, address(receiver), 123, CALLBACK_GAS_LIMIT, data
-        );
+        messenger.relayMessage(ZONE_ID, address(zoneToken), senderTag, address(receiver), 123, data);
 
         assertEq(zoneToken.balanceOf(address(receiver)), 123);
         assertEq(receiver.lastZoneId(), ZONE_ID);
@@ -207,13 +254,7 @@ contract ZoneMessengerTest is BaseTest {
 
         vm.prank(portal);
         messenger.relayMessage(
-            ZONE_ID,
-            address(zoneToken),
-            senderTag,
-            address(receiver),
-            amount,
-            CALLBACK_GAS_LIMIT,
-            data
+            ZONE_ID, address(zoneToken), senderTag, address(receiver), amount, data
         );
 
         assertEq(zoneToken.balanceOf(address(receiver)), amount);
@@ -227,13 +268,7 @@ contract ZoneMessengerTest is BaseTest {
 
         vm.prank(portal);
         messenger.relayMessage(
-            ZONE_ID,
-            address(zoneToken),
-            bytes32("sender"),
-            address(receiver),
-            1,
-            CALLBACK_GAS_LIMIT,
-            data
+            ZONE_ID, address(zoneToken), bytes32("sender"), address(receiver), 1, data
         );
 
         assertEq(zoneToken.balanceOf(address(receiver)), 1);
@@ -251,13 +286,7 @@ contract ZoneMessengerTest is BaseTest {
         vm.prank(portal);
         vm.expectRevert(ZoneMessenger.InvalidCallbackTarget.selector);
         messenger.relayMessage(
-            ZONE_ID,
-            address(zoneToken),
-            bytes32("sender"),
-            address(receiver),
-            1,
-            50_000,
-            _callback()
+            ZONE_ID, address(zoneToken), bytes32("sender"), address(receiver), 1, _callback()
         );
     }
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -650,7 +650,7 @@ fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
     = (50,000 + gasLimit) * tempoGasRate
 ```
 
-`WITHDRAWAL_BASE_GAS` (50,000) covers the fixed overhead of processing a withdrawal on Tempo (queue dequeue, transfer, event emission). The user specifies `gasLimit` covering any additional Tempo callback gas. `gasLimit` must be at most `MAX_WITHDRAWAL_GAS_LIMIT` (10,000,000), which keeps the outer `processWithdrawals` transaction below the Tempo L1 block gas limit after portal overhead is added. For simple withdrawals with no callback, use `gasLimit = 0`. The fee is charged in the same token being withdrawn and burned with the withdrawal amount on the zone. It is not included in the cross-chain `Withdrawal` data and the portal does not transfer it from escrow. On success, `amount` goes to the recipient. Failed plain transfers and callbacks re-deposit `amount` using `fallbackNonce`.
+`WITHDRAWAL_BASE_GAS` (50,000) covers the fixed overhead of processing a withdrawal on Tempo (queue dequeue and event emission). The user specifies `gasLimit` covering the callback withdrawal delivery, including its transfers and receiver callback. `gasLimit` must be at most `MAX_WITHDRAWAL_GAS_LIMIT` (10,000,000), which keeps the outer `processWithdrawals` transaction below the Tempo L1 block gas limit after portal overhead is added. For simple withdrawals with no callback, use `gasLimit = 0`. The fee is charged in the same token being withdrawn and burned with the withdrawal amount on the zone. It is not included in the cross-chain `Withdrawal` data and the portal does not transfer it from escrow. On success, `amount` goes to the recipient. Failed plain transfers and callbacks re-deposit `amount` using `fallbackNonce` to the zone's `zoneFallbackRecipient`.
 
 `tempoGasRate` lives on the zone-side `ZoneOutbox` (see [Gas Rate Configuration](#gas-rate-configuration)). The outbox reads it at request time and snapshots it onto the queued withdrawal.
 
@@ -1886,7 +1886,7 @@ interface IZonePortal {
 interface IZoneMessenger {
     function relayMessage(
         uint32 zoneId, address token, bytes32 senderTag, address target,
-        uint128 amount, uint64 gasLimit, bytes calldata data
+        uint128 amount, bytes calldata data
     ) external;
 }
 ```


### PR DESCRIPTION
## Summary
- apply the withdrawal gas limit to the full `deliverWithdrawal` self-call
- remove the nested callback gas parameter from `ZoneMessenger`
- copy only the first four return-data bytes after successful callbacks and reject failed/short/wrong-selector responses
- document the delivery-level gas semantics and add oversized return/revert-data coverage

## Validation
- `forge fmt --check`
- `forge build --force`
- focused tests compile but cannot run under stock Forge in this pod because Tempo precompiles are unavailable (`MissingPrecompile("BlockHashHistory", ...)`)

Prompted by: @0xalpharush