### PR TITLE
fix(l1): restore enabled tokens in state cache

### DIFF
--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -64,6 +64,10 @@ impl L1StateCache {
 #[derive(Debug, Default)]
 pub struct L1StateCacheInner {
     tracked_contracts: HashSet<Address>,
+    /// Tokens enabled on the ZonePortal at the current canonical L1 anchor.
+    enabled_tokens: HashSet<Address>,
+    /// Enabled tokens discovered at the persisted zone checkpoint.
+    initial_enabled_tokens: HashSet<Address>,
     /// Per-slot value history: `(address, slot) → { block_number → value }`.
     /// The `BTreeMap` enables efficient range lookups for "latest value at or before block N".
     slots: HashMap<(Address, B256), BTreeMap<u64, B256>>,
@@ -156,10 +160,31 @@ impl L1StateCacheInner {
         self.tracked_contracts.contains(address)
     }
 
+    /// Initializes enabled tokens from the persisted zone's L1 checkpoint.
+    pub fn initialize_enabled_tokens(&mut self, tokens: impl IntoIterator<Item = Address>) {
+        self.initial_enabled_tokens.extend(tokens);
+        self.enabled_tokens
+            .extend(self.initial_enabled_tokens.iter().copied());
+        self.tracked_contracts
+            .extend(self.initial_enabled_tokens.iter().copied());
+    }
+
+    /// Records a token enabled by a canonical ZonePortal event.
+    pub fn enable_token(&mut self, token: Address) {
+        self.enabled_tokens.insert(token);
+        self.tracked_contracts.insert(token);
+    }
+
+    /// Returns the tokens enabled at the current canonical L1 anchor.
+    pub fn enabled_tokens(&self) -> &HashSet<Address> {
+        &self.enabled_tokens
+    }
+
     /// Clears chain-derived data while retaining the tracked-contract set and initial floor.
     pub fn clear(&mut self) {
         self.slots.clear();
         self.invalidations.clear();
+        self.enabled_tokens = self.initial_enabled_tokens.clone();
         self.anchor = NumHash::default();
     }
 
@@ -336,6 +361,23 @@ mod tests {
     fn is_tracked_returns_false_for_unknown_address() {
         let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         assert!(!cache.is_tracked(&address!("0x0000000000000000000000000000000000000001")));
+    }
+
+    #[test]
+    fn enabled_tokens_are_tracked_and_reset_to_checkpoint_on_clear() {
+        let initial = address!("0x20c0000000000000000000000000000000000001");
+        let observed = address!("0x20c0000000000000000000000000000000000002");
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+
+        cache.initialize_enabled_tokens([initial]);
+        cache.enable_token(observed);
+
+        assert_eq!(cache.enabled_tokens(), &HashSet::from([initial, observed]));
+        assert!(cache.is_tracked(&initial));
+        assert!(cache.is_tracked(&observed));
+
+        cache.clear();
+        assert_eq!(cache.enabled_tokens(), &HashSet::from([initial]));
     }
 
     #[test]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -614,11 +614,14 @@ impl L1Subscriber {
     /// Write decoded portal state changes into the shared L1 cache at the
     /// confirmed block height.
     fn apply_portal_state_events(&self, block_number: u64, portal_events: &L1PortalEvents) {
-        if portal_events.sequencer_events.is_empty() {
+        if portal_events.sequencer_events.is_empty() && portal_events.enabled_tokens.is_empty() {
             return;
         }
 
         let mut cache = self.config.l1_state_cache.write();
+        for enabled in &portal_events.enabled_tokens {
+            cache.enable_token(enabled.token);
+        }
         apply_sequencer_events_to_cache(
             &mut cache,
             self.config.portal_address,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -454,9 +454,13 @@ where
             .await?
             .erased();
 
-        let enabled_tokens = ZonePortal::new(self.portal_address, &l1_provider)
-            .enabled_tokens_at(alloy_rpc_types_eth::BlockId::number(tempo_block_number))
-            .await?;
+        let enabled_tokens = if self.portal_address.is_zero() {
+            Vec::new()
+        } else {
+            ZonePortal::new(self.portal_address, &l1_provider)
+                .enabled_tokens_at(alloy_rpc_types_eth::BlockId::number(tempo_block_number))
+                .await?
+        };
         self.l1_config
             .l1_state_cache
             .write()

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -57,7 +57,7 @@ use tempo_transaction_pool::{
 use tempo_zone_contracts::{
     TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
@@ -454,21 +454,14 @@ where
             .await?
             .erased();
 
-        match ZonePortal::new(self.portal_address, &l1_provider)
+        let enabled_tokens = ZonePortal::new(self.portal_address, &l1_provider)
             .enabled_tokens_at(alloy_rpc_types_eth::BlockId::number(tempo_block_number))
-            .await
-        {
-            Ok(tokens) => {
-                self.l1_config
-                    .l1_state_cache
-                    .write()
-                    .initialize_enabled_tokens(tokens.iter().copied());
-                info!(target: "reth::cli", count = tokens.len(), tempo_block_number, "Initialized enabled-token L1 cache");
-            }
-            Err(err) => {
-                warn!(target: "reth::cli", %err, tempo_block_number, "Failed to initialize enabled-token L1 cache")
-            }
-        }
+            .await?;
+        self.l1_config
+            .l1_state_cache
+            .write()
+            .initialize_enabled_tokens(enabled_tokens.iter().copied());
+        info!(target: "reth::cli", count = enabled_tokens.len(), tempo_block_number, "Initialized enabled-token L1 cache");
 
         let p2p_role = self.p2p_config.as_ref().map(P2pConfig::role);
         if p2p_role == Some(Role::Follower) {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -54,8 +54,10 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
-use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
-use tracing::{debug, info};
+use tempo_zone_contracts::{
+    TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
+};
+use tracing::{debug, info, warn};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
@@ -451,6 +453,22 @@ where
             )
             .await?
             .erased();
+
+        match ZonePortal::new(self.portal_address, &l1_provider)
+            .enabled_tokens_at(alloy_rpc_types_eth::BlockId::number(tempo_block_number))
+            .await
+        {
+            Ok(tokens) => {
+                self.l1_config
+                    .l1_state_cache
+                    .write()
+                    .initialize_enabled_tokens(tokens.iter().copied());
+                info!(target: "reth::cli", count = tokens.len(), tempo_block_number, "Initialized enabled-token L1 cache");
+            }
+            Err(err) => {
+                warn!(target: "reth::cli", %err, tempo_block_number, "Failed to initialize enabled-token L1 cache")
+            }
+        }
 
         let p2p_role = self.p2p_config.as_ref().map(P2pConfig::role);
         if p2p_role == Some(Role::Follower) {


### PR DESCRIPTION
## Summary
- seed enabled tokens into `L1StateCacheInner` at the persisted L1 checkpoint
- update the cache from confirmed `TokenEnabled` events
- reset event-derived tokens to the checkpoint baseline on reorgs
- add regression coverage for tracking and reset behavior

## Validation
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-l1 state::cache::tests` *(blocked: sandbox Git credentials cannot fetch pinned `alloy-evm` revision)*

Prompted by: @0xrusowsky