### PR TITLE
feat(rpc): expose tempo block in zone info

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -901,11 +901,18 @@ where
         Box::pin(async move {
             let zone_tokens = self.zone_tokens().await?;
             let sequencer = self.zone_sequencer().await?;
+            let tempo_block_number = self
+                .tempo_state
+                .tempoBlockNumber()
+                .call()
+                .await
+                .map_err(internal)?;
             to_raw(&ZoneInfoResponse {
                 zone_id: U64::from(self.config.zone_id),
                 zone_tokens,
                 sequencer,
                 chain_id: U64::from(self.config.chain_id),
+                tempo_block_number: U64::from(tempo_block_number),
             })
         })
     }

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -1134,6 +1134,7 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
         zone_info["result"]["chainId"].as_str().unwrap(),
         format!("0x{:x}", ctx.config.chain_id),
     );
+    assert_eq!(zone_info["result"]["tempoBlockNumber"], "0x0");
 
     Ok(())
 }

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -864,6 +864,7 @@ mod tests {
                     "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
                     "sequencer": format!("{:#x}", Address::repeat_byte(0x22)),
                     "chainId": "0x2a",
+                    "tempoBlockNumber": "0x7",
                 }))
             })
         }
@@ -972,6 +973,7 @@ mod tests {
             format!("{:#x}", Address::repeat_byte(0x22))
         );
         assert_eq!(body["chainId"], "0x2a");
+        assert_eq!(body["tempoBlockNumber"], "0x7");
     }
 
     #[tokio::test]

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -181,6 +181,8 @@ pub struct ZoneInfoResponse {
     pub sequencer: Address,
     /// The zone chain ID.
     pub chain_id: U64,
+    /// The latest Tempo block imported into the zone.
+    pub tempo_block_number: U64,
 }
 
 /// Response payload for `zone_getDepositStatus`.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -954,7 +954,7 @@ The zone exposes four methods under the `zone_` namespace:
 | Method | Access | Description |
 |--------|--------|-------------|
 | `zone_getAuthorizationTokenInfo` | Any authenticated | Returns the authenticated account address and token expiry |
-| `zone_getZoneInfo` | Any authenticated | Returns `zoneId`, `zoneTokens`, `sequencer`, `chainId` |
+| `zone_getZoneInfo` | Any authenticated | Returns `zoneId`, `zoneTokens`, `sequencer`, `chainId`, `tempoBlockNumber` |
 | `zone_getEncryptionKey` | Any authenticated | Returns the active sequencer encryption key at the current Tempo L1 head |
 | `zone_getDepositStatus(tempoBlockNumber)` | Scoped | Returns deposit processing status for the given Tempo block, filtered to deposits where the caller is the sender or recipient |
 


### PR DESCRIPTION
## Summary
- add `tempoBlockNumber` to `zone_getZoneInfo`
- source the value from the zone-local `TempoState` checkpoint
- update RPC tests and the Zone spec

## Testing
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-rpc dispatches_zone_get_zone_info` *(blocked: Cargo cannot authenticate to the pinned `alloy-rs/evm` dependency in this sandbox)*

Prompted by: aditya