### PR TITLE
feat: require advanceTempo first in zone blocks

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -91,7 +91,17 @@ where
             && tx_env.tempo_tx_env.is_none()
             && tx_env.kind() == TxKind::Call(ZONE_INBOX_ADDRESS)
             && tx_env.data.get(..4) == Some(ZoneInbox::advanceTempoCall::SELECTOR.as_slice());
-        validate_advance_tempo_position(is_advance_tempo, self.inner.receipts.len())?;
+        if self.inner.receipts.is_empty() {
+            if !is_advance_tempo {
+                return Err(validation_error(
+                    "advanceTempo must be the first transaction in every zone block",
+                ));
+            }
+        } else if is_advance_tempo {
+            return Err(validation_error(
+                "advanceTempo must appear exactly once in every zone block",
+            ));
+        }
         self.pending_advance_tempo = is_advance_tempo;
 
         let _tx_context_guard = tx_context::set_current_transaction(
@@ -115,7 +125,11 @@ where
     fn finish(
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
-        validate_advance_tempo_present(self.saw_advance_tempo)?;
+        if !self.saw_advance_tempo {
+            return Err(validation_error(
+                "zone block is missing its required advanceTempo transaction",
+            ));
+        }
         self.inner.finish()
     }
 
@@ -136,31 +150,6 @@ fn validation_error(message: &'static str) -> BlockExecutionError {
     BlockValidationError::msg(message).into()
 }
 
-fn validate_advance_tempo_position(
-    is_advance_tempo: bool,
-    transaction_index: usize,
-) -> Result<(), BlockExecutionError> {
-    match (transaction_index, is_advance_tempo) {
-        (0, false) => Err(validation_error(
-            "advanceTempo must be the first transaction in every zone block",
-        )),
-        (1.., true) => Err(validation_error(
-            "advanceTempo must appear exactly once in every zone block",
-        )),
-        _ => Ok(()),
-    }
-}
-
-fn validate_advance_tempo_present(saw_advance_tempo: bool) -> Result<(), BlockExecutionError> {
-    if saw_advance_tempo {
-        Ok(())
-    } else {
-        Err(validation_error(
-            "zone block is missing its required advanceTempo transaction",
-        ))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
@@ -171,17 +160,6 @@ mod tests {
         tip_fee_manager::{TipFeeManager, amm::PoolKey},
     };
     use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
-
-    #[test]
-    fn requires_exactly_one_advance_tempo_as_first_transaction() {
-        assert!(validate_advance_tempo_position(false, 0).is_err());
-        assert!(validate_advance_tempo_position(true, 0).is_ok());
-        assert!(validate_advance_tempo_position(false, 1).is_ok());
-        assert!(validate_advance_tempo_position(true, 1).is_err());
-
-        assert!(validate_advance_tempo_present(false).is_err());
-        assert!(validate_advance_tempo_present(true).is_ok());
-    }
 
     #[test]
     fn clears_only_prewarming_expiring_nonce_index() {

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -7,20 +7,14 @@
 use alloy_consensus::transaction::TxHashRef;
 use alloy_evm::{
     Database, Evm, RecoveredTx,
-    block::{
-        BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockValidationError,
-        ExecutableTx, GasOutput,
-    },
+    block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, GasOutput},
     eth::{EthBlockExecutor, EthTxResult},
 };
-use alloy_primitives::TxKind;
-use alloy_sol_types::SolCall;
 use reth_evm::block::StateDB;
 use reth_revm::Inspector;
 use tempo_evm::{TempoBlockExecutionCtx, TempoReceiptBuilder};
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::evm::TempoContext;
-use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZoneInbox};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{L1StorageReader, tx_context};
@@ -33,8 +27,6 @@ use crate::{L1OverlayDB, ZoneEvm};
 /// or end-of-block metadata system transaction requirements.
 pub struct ZoneBlockExecutor<'a, DB: Database, I, L1: L1StorageReader = L1StateProvider> {
     inner: EthBlockExecutor<'a, ZoneEvm<DB, I, L1>, &'a ZoneChainSpec, TempoReceiptBuilder>,
-    saw_advance_tempo: bool,
-    pending_advance_tempo: bool,
 }
 
 impl<'a, DB, I, L1> ZoneBlockExecutor<'a, DB, I, L1>
@@ -56,8 +48,6 @@ where
                 chain_spec,
                 TempoReceiptBuilder::default(),
             ),
-            saw_advance_tempo: false,
-            pending_advance_tempo: false,
         }
     }
 }
@@ -87,23 +77,6 @@ where
             tempo_tx_env.expiring_nonce_idx = None;
         }
 
-        let is_advance_tempo = tx_env.is_system_tx
-            && tx_env.tempo_tx_env.is_none()
-            && tx_env.kind() == TxKind::Call(ZONE_INBOX_ADDRESS)
-            && tx_env.data.get(..4) == Some(ZoneInbox::advanceTempoCall::SELECTOR.as_slice());
-        if self.inner.receipts.is_empty() {
-            if !is_advance_tempo {
-                return Err(validation_error(
-                    "advanceTempo must be the first transaction in every zone block",
-                ));
-            }
-        } else if is_advance_tempo {
-            return Err(validation_error(
-                "advanceTempo must appear exactly once in every zone block",
-            ));
-        }
-        self.pending_advance_tempo = is_advance_tempo;
-
         let _tx_context_guard = tx_context::set_current_transaction(
             *recovered.tx().tx_hash(),
             tx_env.fee_payer().unwrap_or(tx_env.caller),
@@ -117,19 +90,12 @@ where
     }
 
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
-        let gas = self.inner.commit_transaction(output);
-        self.saw_advance_tempo |= std::mem::take(&mut self.pending_advance_tempo);
-        gas
+        self.inner.commit_transaction(output)
     }
 
     fn finish(
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
-        if !self.saw_advance_tempo {
-            return Err(validation_error(
-                "zone block is missing its required advanceTempo transaction",
-            ));
-        }
         self.inner.finish()
     }
 
@@ -144,10 +110,6 @@ where
     fn receipts(&self) -> &[Self::Receipt] {
         self.inner.receipts()
     }
-}
-
-fn validation_error(message: &'static str) -> BlockExecutionError {
-    BlockValidationError::msg(message).into()
 }
 
 #[cfg(test)]

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -7,14 +7,20 @@
 use alloy_consensus::transaction::TxHashRef;
 use alloy_evm::{
     Database, Evm, RecoveredTx,
-    block::{BlockExecutionError, BlockExecutionResult, BlockExecutor, ExecutableTx, GasOutput},
+    block::{
+        BlockExecutionError, BlockExecutionResult, BlockExecutor, BlockValidationError,
+        ExecutableTx, GasOutput,
+    },
     eth::{EthBlockExecutor, EthTxResult},
 };
+use alloy_primitives::TxKind;
+use alloy_sol_types::SolCall;
 use reth_evm::block::StateDB;
 use reth_revm::Inspector;
 use tempo_evm::{TempoBlockExecutionCtx, TempoReceiptBuilder};
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::evm::TempoContext;
+use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZoneInbox};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{L1StorageReader, tx_context};
@@ -27,6 +33,8 @@ use crate::{L1OverlayDB, ZoneEvm};
 /// or end-of-block metadata system transaction requirements.
 pub struct ZoneBlockExecutor<'a, DB: Database, I, L1: L1StorageReader = L1StateProvider> {
     inner: EthBlockExecutor<'a, ZoneEvm<DB, I, L1>, &'a ZoneChainSpec, TempoReceiptBuilder>,
+    saw_advance_tempo: bool,
+    pending_advance_tempo: bool,
 }
 
 impl<'a, DB, I, L1> ZoneBlockExecutor<'a, DB, I, L1>
@@ -48,6 +56,8 @@ where
                 chain_spec,
                 TempoReceiptBuilder::default(),
             ),
+            saw_advance_tempo: false,
+            pending_advance_tempo: false,
         }
     }
 }
@@ -77,6 +87,23 @@ where
             tempo_tx_env.expiring_nonce_idx = None;
         }
 
+        let is_advance_tempo = tx_env.is_system_tx
+            && tx_env.tempo_tx_env.is_none()
+            && tx_env.kind() == TxKind::Call(ZONE_INBOX_ADDRESS)
+            && tx_env.data.get(..4) == Some(ZoneInbox::advanceTempoCall::SELECTOR.as_slice());
+        if self.inner.receipts.is_empty() {
+            if !is_advance_tempo {
+                return Err(validation_error(
+                    "advanceTempo must be the first transaction in every zone block",
+                ));
+            }
+        } else if is_advance_tempo {
+            return Err(validation_error(
+                "advanceTempo must appear exactly once in every zone block",
+            ));
+        }
+        self.pending_advance_tempo = is_advance_tempo;
+
         let _tx_context_guard = tx_context::set_current_transaction(
             *recovered.tx().tx_hash(),
             tx_env.fee_payer().unwrap_or(tx_env.caller),
@@ -90,12 +117,19 @@ where
     }
 
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
-        self.inner.commit_transaction(output)
+        let gas = self.inner.commit_transaction(output);
+        self.saw_advance_tempo |= std::mem::take(&mut self.pending_advance_tempo);
+        gas
     }
 
     fn finish(
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
+        if !self.saw_advance_tempo {
+            return Err(validation_error(
+                "zone block is missing its required advanceTempo transaction",
+            ));
+        }
         self.inner.finish()
     }
 
@@ -110,6 +144,10 @@ where
     fn receipts(&self) -> &[Self::Receipt] {
         self.inner.receipts()
     }
+}
+
+fn validation_error(message: &'static str) -> BlockExecutionError {
+    BlockValidationError::msg(message).into()
 }
 
 #[cfg(test)]

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -91,17 +91,7 @@ where
             && tx_env.tempo_tx_env.is_none()
             && tx_env.kind() == TxKind::Call(ZONE_INBOX_ADDRESS)
             && tx_env.data.get(..4) == Some(ZoneInbox::advanceTempoCall::SELECTOR.as_slice());
-        if self.inner.receipts.is_empty() {
-            if !is_advance_tempo {
-                return Err(validation_error(
-                    "advanceTempo must be the first transaction in every zone block",
-                ));
-            }
-        } else if is_advance_tempo {
-            return Err(validation_error(
-                "advanceTempo must appear exactly once in every zone block",
-            ));
-        }
+        validate_advance_tempo_position(is_advance_tempo, self.inner.receipts.len())?;
         self.pending_advance_tempo = is_advance_tempo;
 
         let _tx_context_guard = tx_context::set_current_transaction(
@@ -125,11 +115,7 @@ where
     fn finish(
         self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
-        if !self.saw_advance_tempo {
-            return Err(validation_error(
-                "zone block is missing its required advanceTempo transaction",
-            ));
-        }
+        validate_advance_tempo_present(self.saw_advance_tempo)?;
         self.inner.finish()
     }
 
@@ -150,6 +136,31 @@ fn validation_error(message: &'static str) -> BlockExecutionError {
     BlockValidationError::msg(message).into()
 }
 
+fn validate_advance_tempo_position(
+    is_advance_tempo: bool,
+    transaction_index: usize,
+) -> Result<(), BlockExecutionError> {
+    match (transaction_index, is_advance_tempo) {
+        (0, false) => Err(validation_error(
+            "advanceTempo must be the first transaction in every zone block",
+        )),
+        (1.., true) => Err(validation_error(
+            "advanceTempo must appear exactly once in every zone block",
+        )),
+        _ => Ok(()),
+    }
+}
+
+fn validate_advance_tempo_present(saw_advance_tempo: bool) -> Result<(), BlockExecutionError> {
+    if saw_advance_tempo {
+        Ok(())
+    } else {
+        Err(validation_error(
+            "zone block is missing its required advanceTempo transaction",
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, U256};
@@ -160,6 +171,17 @@ mod tests {
         tip_fee_manager::{TipFeeManager, amm::PoolKey},
     };
     use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
+
+    #[test]
+    fn requires_exactly_one_advance_tempo_as_first_transaction() {
+        assert!(validate_advance_tempo_position(false, 0).is_err());
+        assert!(validate_advance_tempo_position(true, 0).is_ok());
+        assert!(validate_advance_tempo_position(false, 1).is_ok());
+        assert!(validate_advance_tempo_position(true, 1).is_err());
+
+        assert!(validate_advance_tempo_present(false).is_err());
+        assert!(validate_advance_tempo_present(true).is_ok());
+    }
 
     #[test]
     fn clears_only_prewarming_expiring_nonce_index() {

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -8,7 +8,9 @@
 use std::{net::TcpListener, time::Duration};
 
 use alloy::primitives::{Address, B256, Bytes, TxKind, U256, address};
-use alloy_consensus::Transaction;
+use alloy_consensus::{
+    Transaction, constants::EMPTY_ROOT_HASH, proofs::calculate_transaction_root,
+};
 use alloy_eips::NumHash;
 use alloy_provider::{DynProvider, Provider};
 use alloy_rpc_types_eth::TransactionRequest;
@@ -31,6 +33,50 @@ use crate::utils::{
 const CONTRACT_CREATION_TX_GAS: u64 = 1_000_000;
 const LEADER_INCLUSION_TIMEOUT: Duration = Duration::from_secs(30);
 const P2P_RECOVERY_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// A full execution payload without the required first `advanceTempo` transaction is rejected.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_payload_without_advance_tempo_is_rejected() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
+    fixture.inject_empty_block(zone.deposit_queue());
+    zone.wait_for_block_number(1, DEFAULT_TIMEOUT).await?;
+
+    let parent = zone
+        .block_by_number(0)?
+        .ok_or_else(|| eyre::eyre!("missing genesis block"))?;
+    let mut block = zone
+        .block_by_number(1)?
+        .ok_or_else(|| eyre::eyre!("missing first zone block"))?;
+    let first = block
+        .body
+        .transactions
+        .first()
+        .ok_or_else(|| eyre::eyre!("first zone block has no transactions"))?;
+    eyre::ensure!(
+        first.is_system_tx(),
+        "first transaction is not a system transaction"
+    );
+
+    block.body.transactions.remove(0);
+    block.header.inner.transactions_root = calculate_transaction_root(&block.body.transactions);
+    block.header.inner.state_root = parent.header.inner.state_root;
+    block.header.inner.receipts_root = EMPTY_ROOT_HASH;
+    block.header.inner.logs_bloom = Default::default();
+    block.header.inner.gas_used = 0;
+
+    let status = zone.submit_payload(block).await?;
+    assert!(
+        !status.is_valid(),
+        "payload without advanceTempo was accepted"
+    );
+    assert!(
+        format!("{status:?}").contains("missing its required advanceTempo transaction"),
+        "unexpected payload rejection: {status:?}"
+    );
+    Ok(())
+}
 
 /// A follower imports the leader's executed block and exposes the resulting state over RPC.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -13,11 +13,11 @@ use commonware_cryptography::{Signer as _, ed25519::PrivateKey as Ed25519Private
 use eyre::WrapErr;
 use k256::SecretKey;
 use p256::ecdsa::SigningKey as P256SigningKey;
-use reth_node_api::FullNodeComponents;
+use reth_node_api::{ConsensusEngineHandle, FullNodeComponents, PayloadTypes};
 use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle, rpc::RethRpcAddOns};
 use reth_node_core::{args::RpcServerArgs, exit::NodeExitFuture};
-use reth_primitives_traits::SealedHeader;
-use reth_provider::{BlockNumReader, ChainSpecProvider, HeaderProvider};
+use reth_primitives_traits::{SealedBlock, SealedHeader};
+use reth_provider::{BlockNumReader, BlockReader, ChainSpecProvider, HeaderProvider};
 use reth_rpc_builder::RpcModuleSelection;
 use reth_tasks::Runtime;
 use std::{
@@ -54,7 +54,7 @@ use tempo_precompiles::{
         TIP403Registry, tip403_registry_slots,
     },
 };
-use tempo_primitives::{TempoHeader, transaction::tt_signature::TempoSignature};
+use tempo_primitives::{Block, TempoHeader, transaction::tt_signature::TempoSignature};
 use tempo_zone_contracts::{
     PORTAL_IS_SEQUENCER_SLOT, PORTAL_MAX_TEMPO_GAS_RATE_SLOT, ZONE_FACTORY_ADDRESS,
     ZONE_OUTBOX_ADDRESS,
@@ -70,6 +70,7 @@ use zone_node::ZoneNode;
 use zone_p2p::{P2pConfig, Role};
 use zone_precompiles::ZONE_FEE_MANAGER_ADDRESS;
 use zone_primitives::constants::PORTAL_ACCESS_MODE_SLOT;
+use zone_payload::ZonePayloadTypes;
 
 #[path = "../../../rpc/test-utils/auth_tokens.rs"]
 mod auth_tokens;
@@ -430,6 +431,8 @@ pub(crate) trait TestNodeHandle: Send {
     ) -> reth_provider::CanonStateNotifications<tempo_primitives::TempoPrimitives>;
 
     fn node_exit_future_mut(&mut self) -> &mut NodeExitFuture;
+
+    fn block_by_number(&self, number: u64) -> eyre::Result<Option<Block>>;
 }
 
 impl<Node, AddOns> TestNodeHandle for NodeHandle<Node, AddOns>
@@ -448,6 +451,10 @@ where
 
     fn node_exit_future_mut(&mut self) -> &mut NodeExitFuture {
         &mut self.node_exit_future
+    }
+
+    fn block_by_number(&self, number: u64) -> eyre::Result<Option<Block>> {
+        Ok(self.node.provider().block_by_number(number)?)
     }
 }
 
@@ -469,6 +476,9 @@ where
 type RpcApiFuture =
     Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn zone_node::rpc::ZoneRpcApi>>>>>;
 type RpcApiFactory = dyn Fn(zone_node::rpc::PrivateRpcConfig) -> RpcApiFuture + Send + Sync;
+type PayloadSubmitFuture =
+    Pin<Box<dyn Future<Output = eyre::Result<alloy_rpc_types_engine::PayloadStatus>> + Send>>;
+type PayloadSubmitter = dyn Fn(Block) -> PayloadSubmitFuture + Send + Sync;
 
 pub(crate) struct ZoneTestNode {
     http_url: url::Url,
@@ -476,6 +486,7 @@ pub(crate) struct ZoneTestNode {
     l1_state_cache: L1StateCache,
     l1_block_tracker: L1BlockTracker,
     rpc_api_factory: Arc<RpcApiFactory>,
+    payload_submitter: Arc<PayloadSubmitter>,
     node_handle: Box<dyn TestNodeHandle>,
     _tasks: Runtime,
 }
@@ -575,6 +586,17 @@ impl ZoneTestNode {
         &self,
     ) -> reth_provider::CanonStateNotifications<tempo_primitives::TempoPrimitives> {
         self.node_handle.subscribe_to_canonical_state()
+    }
+
+    pub(crate) fn block_by_number(&self, number: u64) -> eyre::Result<Option<Block>> {
+        self.node_handle.block_by_number(number)
+    }
+
+    pub(crate) async fn submit_payload(
+        &self,
+        block: Block,
+    ) -> eyre::Result<alloy_rpc_types_engine::PayloadStatus> {
+        (self.payload_submitter)(block).await
     }
 
     pub(crate) async fn wait_for_node_exit(&mut self) -> eyre::Result<()> {
@@ -1051,12 +1073,23 @@ impl ZoneTestNode {
                 as Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn zone_node::rpc::ZoneRpcApi>>>>>
         });
 
+        let engine_handle = node_handle.node.add_ons_handle.beacon_engine_handle.clone();
+        let payload_submitter = Arc::new(move |block: Block| {
+            let engine_handle = engine_handle.clone();
+            Box::pin(async move {
+                let payload =
+                    ZonePayloadTypes::block_to_payload(SealedBlock::seal_slow(block), None);
+                Ok(engine_handle.new_payload(payload).await?)
+            }) as PayloadSubmitFuture
+        });
+
         Ok(Self {
             deposit_queue,
             http_url,
             l1_state_cache,
             l1_block_tracker,
             rpc_api_factory,
+            payload_submitter,
             node_handle: Box::new(node_handle),
             _tasks: tasks,
         })

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -68,9 +68,9 @@ use zone_l1::{
 };
 use zone_node::ZoneNode;
 use zone_p2p::{P2pConfig, Role};
+use zone_payload::ZonePayloadTypes;
 use zone_precompiles::ZONE_FEE_MANAGER_ADDRESS;
 use zone_primitives::constants::PORTAL_ACCESS_MODE_SLOT;
-use zone_payload::ZonePayloadTypes;
 
 #[path = "../../../rpc/test-utils/auth_tokens.rs"]
 mod auth_tokens;

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{Signer as _, ed25519::PrivateKey as Ed25519Private
 use eyre::WrapErr;
 use k256::SecretKey;
 use p256::ecdsa::SigningKey as P256SigningKey;
-use reth_node_api::{ConsensusEngineHandle, FullNodeComponents, PayloadTypes};
+use reth_node_api::{FullNodeComponents, PayloadTypes};
 use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle, rpc::RethRpcAddOns};
 use reth_node_core::{args::RpcServerArgs, exit::NodeExitFuture};
 use reth_primitives_traits::{SealedBlock, SealedHeader};

--- a/crates/payload/src/attrs.rs
+++ b/crates/payload/src/attrs.rs
@@ -129,21 +129,21 @@ impl PayloadValidator<ZonePayloadTypes> for TempoEngineValidator {
         let mut transactions = block.body().transactions.iter();
 
         let Some(first) = transactions.next() else {
-            return Err(invalid_payload(
+            return Err(NewPayloadError::other(reth_errors::RethError::msg(
                 "zone block is missing its required advanceTempo transaction",
-            ));
+            )));
         };
 
         if !is_advance_tempo(first) {
-            return Err(invalid_payload(
+            return Err(NewPayloadError::other(reth_errors::RethError::msg(
                 "advanceTempo must be the first transaction in every zone block",
-            ));
+            )));
         }
 
         if transactions.any(is_advance_tempo) {
-            return Err(invalid_payload(
+            return Err(NewPayloadError::other(reth_errors::RethError::msg(
                 "advanceTempo must appear exactly once in every zone block",
-            ));
+            )));
         }
 
         Ok(block)
@@ -165,8 +165,4 @@ fn is_advance_tempo(tx: &TempoTxEnvelope) -> bool {
     tx.is_system_tx()
         && tx.kind() == TxKind::Call(ZONE_INBOX_ADDRESS)
         && tx.input().get(..4) == Some(ZoneInbox::advanceTempoCall::SELECTOR.as_slice())
-}
-
-fn invalid_payload(message: &'static str) -> NewPayloadError {
-    NewPayloadError::other(reth_errors::RethError::msg(message))
 }

--- a/crates/payload/src/attrs.rs
+++ b/crates/payload/src/attrs.rs
@@ -5,9 +5,11 @@
 //! portion. This avoids pulling in Tempo-specific concepts the zone doesn't
 //! use (interrupts, subblocks, DKG extra-data).
 
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_consensus::Transaction;
+use alloy_primitives::{Address, B256, Bytes, TxKind};
 use alloy_rpc_types_engine::{PayloadAttributes as EthPayloadAttributes, PayloadId};
 use alloy_rpc_types_eth::Withdrawal;
+use alloy_sol_types::SolCall;
 use reth_node_api::{
     InvalidPayloadAttributesError, NewPayloadError, PayloadTypes, PayloadValidator,
 };
@@ -16,7 +18,8 @@ use reth_primitives_traits::{AlloyBlockHeader, SealedBlock};
 use serde::{Deserialize, Serialize};
 use tempo_node::engine::TempoEngineValidator;
 use tempo_payload_types::{TempoBuiltPayload, TempoExecutionData};
-use tempo_primitives::{Block, TempoHeader};
+use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
+use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZoneInbox};
 use zone_l1::PreparedL1Block;
 
 /// Zone RPC payload attributes — the type that flows through FCU.
@@ -122,7 +125,28 @@ impl PayloadValidator<ZonePayloadTypes> for TempoEngineValidator {
             block_access_list: _,
             validator_set: _,
         } = payload;
-        Ok(block.into_sealed_block())
+        let block = block.into_sealed_block();
+        let mut transactions = block.body().transactions.iter();
+
+        let Some(first) = transactions.next() else {
+            return Err(invalid_payload(
+                "zone block is missing its required advanceTempo transaction",
+            ));
+        };
+
+        if !is_advance_tempo(first) {
+            return Err(invalid_payload(
+                "advanceTempo must be the first transaction in every zone block",
+            ));
+        }
+
+        if transactions.any(is_advance_tempo) {
+            return Err(invalid_payload(
+                "advanceTempo must appear exactly once in every zone block",
+            ));
+        }
+
+        Ok(block)
     }
 
     fn validate_payload_attributes_against_header(
@@ -135,4 +159,14 @@ impl PayloadValidator<ZonePayloadTypes> for TempoEngineValidator {
         }
         Ok(())
     }
+}
+
+fn is_advance_tempo(tx: &TempoTxEnvelope) -> bool {
+    tx.is_system_tx()
+        && tx.kind() == TxKind::Call(ZONE_INBOX_ADDRESS)
+        && tx.input().get(..4) == Some(ZoneInbox::advanceTempoCall::SELECTOR.as_slice())
+}
+
+fn invalid_payload(message: &'static str) -> NewPayloadError {
+    NewPayloadError::other(reth_errors::RethError::msg(message))
 }


### PR DESCRIPTION
## Summary

- require the first transaction in every zone block submitted through `newPayload` to be the `advanceTempo` system transaction
- reject duplicate `advanceTempo` transactions and blocks that omit it during `convert_payload_to_block`
- keep the block executor stateless so payload-builder view simulations are not subject to whole-block layout checks
- add an end-to-end `newPayload` regression test for a block with `advanceTempo` removed
- keep the change scoped to the required block-layout invariant, excluding the unrelated policy changes in #745

This enforces the one-to-one block mapping documented in #759 at the payload-validation boundary.

## Validation

- `cargo +nightly fmt -- crates/evm/src/executor.rs crates/payload/src/attrs.rs`
- `cargo check -p zone-payload`
- `cargo test -p zone-node --test it test_payload_without_advance_tempo_is_rejected -- --nocapture`
- `git diff --check`

Prompted by: @0xalpharush