### PR TITLE
Disable EIP-7702 on Zones

### DIFF
--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -49,6 +49,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-eips.workspace = true
 eyre.workspace = true
 zone-precompiles = { workspace = true, features = ["std", "test-utils"] }
 tempo-precompiles = { workspace = true, features = ["test-utils"] }

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -53,6 +53,17 @@ pub fn validate_transaction(
     tx: &TempoTxEnv,
     allowlist: &[Address],
 ) -> Result<(), TempoInvalidTransaction> {
+    if tx.authorization_list_len() != 0
+        || tx
+            .tempo_tx_env
+            .as_ref()
+            .is_some_and(|aa| !aa.tempo_authorization_list.is_empty())
+    {
+        return Err(TempoInvalidTransaction::CallsValidation(
+            "EIP-7702 authorization lists are not supported",
+        ));
+    }
+
     if contract_creation_deployer(tx).is_some_and(|deployer| !allowlist.contains(&deployer)) {
         return Err(TempoInvalidTransaction::CallsValidation(
             "contract creation is not supported",
@@ -74,13 +85,16 @@ fn contract_creation_deployer(tx: &TempoTxEnv) -> Option<Address> {
 mod tests {
     use super::*;
     use crate::{L1OverlayDB, ZoneEvm};
+    use alloy_eips::eip7702::Authorization;
     use alloy_evm::{Evm, EvmEnv};
-    use alloy_primitives::{Address, Bytes, TxKind, U256, bytes};
+    use alloy_primitives::{Address, Bytes, Signature, TxKind, U256, bytes};
     use revm::{
         bytecode::Bytecode,
         context::{
             TxEnv,
+            either::Either,
             result::{EVMError, ExecutionResult},
+            transaction::SignedAuthorization,
         },
         database::{EmptyDB, in_memory_db::CacheDB},
         inspector::NoOpInspector,
@@ -197,6 +211,26 @@ mod tests {
 
         assert!(validate_transaction(&tx, &[]).is_err());
         assert!(validate_transaction(&tx, &[caller]).is_ok());
+    }
+
+    #[test]
+    fn authorization_lists_are_rejected() {
+        let mut tx = TempoTxEnv::default();
+        tx.inner.authorization_list = vec![Either::Left(SignedAuthorization::new_unchecked(
+            Authorization {
+                chain_id: U256::ONE,
+                address: Address::repeat_byte(0x02),
+                nonce: 0,
+            },
+            Signature::test_signature(),
+        ))];
+
+        assert!(matches!(
+            validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST),
+            Err(TempoInvalidTransaction::CallsValidation(
+                "EIP-7702 authorization lists are not supported"
+            ))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject EIP-7702 authorization lists during Zone transaction validation
- reject Tempo AA authorization lists through the same consensus validation path
- add a regression test for 7702 transactions

Closes ZONE-101

## Testing
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- targeted Rust test could not run because Cargo dependency fetches return HTTP 401 in this sandbox

Prompted by: @0xKitsune