### PR TITLE
fix: invalidate enabled token cache entries

### DIFF
--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -94,7 +94,7 @@ pub use event::{EnabledToken, L1PortalEvents, L1SequencerEvent};
 pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
-pub use subscriber::{L1Subscriber, L1SubscriberConfig};
+pub use subscriber::{L1Subscriber, L1SubscriberConfig, rebuild_token_activations};
 
 pub(crate) use event::EnqueueOutcome;
 

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -64,6 +64,7 @@ impl L1StateCache {
 #[derive(Debug, Default)]
 pub struct L1StateCacheInner {
     tracked_contracts: HashSet<Address>,
+    enabled_tokens: HashSet<Address>,
     /// Per-slot value history: `(address, slot) → { block_number → value }`.
     /// The `BTreeMap` enables efficient range lookups for "latest value at or before block N".
     slots: HashMap<(Address, B256), BTreeMap<u64, B256>>,
@@ -110,10 +111,14 @@ impl L1StateCacheInner {
 
     /// Sets a storage slot value in the forward cache at the given block number.
     ///
-    /// Values below the initial canonical floor are deliberately not admitted, so historical
-    /// reads cannot later be inherited by canonical execution.
+    /// Only static tracked contracts and canonically enabled TIP-20s are admitted. Values below
+    /// the initial canonical floor are also rejected, so historical reads cannot later be
+    /// inherited by canonical execution.
     pub fn set(&mut self, address: Address, slot: B256, block_number: u64, value: B256) {
-        if block_number < self.block_floor {
+        if block_number < self.block_floor
+            || !(self.tracked_contracts.contains(&address)
+                || self.enabled_tokens.contains(&address))
+        {
             return;
         }
         self.slots
@@ -156,10 +161,16 @@ impl L1StateCacheInner {
         self.tracked_contracts.contains(address)
     }
 
-    /// Clears chain-derived data while retaining the tracked-contract set and initial floor.
+    /// Allows cache admission for a canonically enabled TIP-20.
+    pub fn enable_token(&mut self, address: Address) {
+        self.enabled_tokens.insert(address);
+    }
+
+    /// Clears chain-derived data while retaining the static tracked-contract set and initial floor.
     pub fn clear(&mut self) {
         self.slots.clear();
         self.invalidations.clear();
+        self.enabled_tokens.clear();
         self.anchor = NumHash::default();
     }
 
@@ -277,19 +288,17 @@ mod tests {
     }
 
     #[test]
-    fn token_enablement_invalidates_cached_token_state() {
+    fn cache_rejects_tokens_until_enabled() {
         let token = address!("0x20c0000000000000000000000000000000000042");
         let policy_slot = B256::with_last_byte(1);
         let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
 
-        // An RPC read can observe the deterministic address before token creation and cache the
-        // empty-account value.
+        // Ignore reads made before the deterministic token address is deployed and enabled.
         cache.set(token, policy_slot, 10, B256::ZERO);
         cover_through(&mut cache, 10);
-        assert_eq!(cache.get(token, policy_slot, 10), Some(B256::ZERO));
+        assert_eq!(cache.get(token, policy_slot, 10), None);
 
-        // TokenEnabled is emitted by the portal, so the subscriber must install a barrier for the
-        // token address rather than only for the portal emitter.
+        cache.enable_token(token);
         cache.invalidate(token, 11);
         cover_through(&mut cache, 11);
         assert_eq!(cache.get(token, policy_slot, 11), None);
@@ -318,8 +327,10 @@ mod tests {
     #[test]
     fn clear_removes_chain_data_and_preserves_floor() {
         let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let token = address!("0x20c0000000000000000000000000000000000042");
 
         cache.initialize_floor(90);
+        cache.enable_token(token);
         cache.set(PORTAL, B256::ZERO, 100, B256::with_last_byte(1));
         cache.invalidate(PORTAL, 101);
         cache.update_anchor(NumHash {
@@ -333,6 +344,8 @@ mod tests {
         assert!(cache.invalidations.is_empty());
         assert_eq!(cache.anchor(), NumHash::default());
         assert_eq!(cache.block_floor(), 90);
+        cache.set(token, B256::ZERO, 100, B256::with_last_byte(1));
+        assert_eq!(cache.get(token, B256::ZERO, 100), None);
     }
 
     #[test]

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -376,8 +376,8 @@ mod tests {
 
     #[test]
     fn different_addresses_same_slot_are_independent() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let addr_b = address!("0x0000000000000000000000000000000000004343");
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL, addr_b]));
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0xaa));

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -64,7 +64,8 @@ impl L1StateCache {
 #[derive(Debug, Default)]
 pub struct L1StateCacheInner {
     tracked_contracts: HashSet<Address>,
-    enabled_tokens: HashSet<Address>,
+    /// Canonical `TokenEnabled` height for each dynamically tracked TIP-20.
+    token_activations: HashMap<Address, u64>,
     /// Per-slot value history: `(address, slot) → { block_number → value }`.
     /// The `BTreeMap` enables efficient range lookups for "latest value at or before block N".
     slots: HashMap<(Address, B256), BTreeMap<u64, B256>>,
@@ -111,13 +112,16 @@ impl L1StateCacheInner {
 
     /// Sets a storage slot value in the forward cache at the given block number.
     ///
-    /// Only static tracked contracts and canonically enabled TIP-20s are admitted. Values below
-    /// the initial canonical floor are also rejected, so historical reads cannot later be
-    /// inherited by canonical execution.
+    /// Only static tracked contracts and TIP-20s enabled at or before `block_number` are admitted.
+    /// Values below the initial canonical floor are also rejected, so historical reads cannot
+    /// later be inherited by canonical execution.
     pub fn set(&mut self, address: Address, slot: B256, block_number: u64, value: B256) {
+        let token_is_active = self
+            .token_activations
+            .get(&address)
+            .is_some_and(|&activation_block| block_number >= activation_block);
         if block_number < self.block_floor
-            || !(self.tracked_contracts.contains(&address)
-                || self.enabled_tokens.contains(&address))
+            || !(self.tracked_contracts.contains(&address) || token_is_active)
         {
             return;
         }
@@ -161,16 +165,24 @@ impl L1StateCacheInner {
         self.tracked_contracts.contains(address)
     }
 
-    /// Allows cache admission for a canonically enabled TIP-20.
-    pub fn enable_token(&mut self, address: Address) {
-        self.enabled_tokens.insert(address);
+    /// Allows cache admission for a TIP-20 from its canonical activation block onward.
+    pub fn enable_token_at(&mut self, address: Address, block_number: u64) {
+        self.token_activations
+            .entry(address)
+            .and_modify(|activation| *activation = (*activation).min(block_number))
+            .or_insert(block_number);
+    }
+
+    /// Replaces dynamic TIP-20 admission state rebuilt from canonical `TokenEnabled` history.
+    pub fn replace_token_activations(&mut self, activations: HashMap<Address, u64>) {
+        self.token_activations = activations;
     }
 
     /// Clears chain-derived data while retaining the static tracked-contract set and initial floor.
     pub fn clear(&mut self) {
         self.slots.clear();
         self.invalidations.clear();
-        self.enabled_tokens.clear();
+        self.token_activations.clear();
         self.anchor = NumHash::default();
     }
 
@@ -298,7 +310,10 @@ mod tests {
         cover_through(&mut cache, 10);
         assert_eq!(cache.get(token, policy_slot, 10), None);
 
-        cache.enable_token(token);
+        cache.enable_token_at(token, 11);
+        // A delayed historical response must still be rejected after activation is known.
+        cache.set(token, policy_slot, 10, B256::ZERO);
+        assert_eq!(cache.get(token, policy_slot, 10), None);
         cache.invalidate(token, 11);
         cover_through(&mut cache, 11);
         assert_eq!(cache.get(token, policy_slot, 11), None);
@@ -306,6 +321,20 @@ mod tests {
         let initialized_policy = B256::with_last_byte(1);
         cache.set(token, policy_slot, 11, initialized_policy);
         assert_eq!(cache.get(token, policy_slot, 11), Some(initialized_policy));
+    }
+
+    #[test]
+    fn rebuilt_token_activations_gate_cache_by_height() {
+        let token = address!("0x20c0000000000000000000000000000000000042");
+        let slot = B256::with_last_byte(1);
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        cache.replace_token_activations(HashMap::from([(token, 25)]));
+
+        cache.set(token, slot, 24, B256::with_last_byte(24));
+        cache.set(token, slot, 25, B256::with_last_byte(25));
+
+        assert_eq!(cache.get(token, slot, 24), None);
+        assert_eq!(cache.get(token, slot, 25), Some(B256::with_last_byte(25)));
     }
 
     #[test]
@@ -330,7 +359,7 @@ mod tests {
         let token = address!("0x20c0000000000000000000000000000000000042");
 
         cache.initialize_floor(90);
-        cache.enable_token(token);
+        cache.enable_token_at(token, 90);
         cache.set(PORTAL, B256::ZERO, 100, B256::with_last_byte(1));
         cache.invalidate(PORTAL, 101);
         cache.update_anchor(NumHash {

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -277,6 +277,30 @@ mod tests {
     }
 
     #[test]
+    fn token_enablement_blocks_pre_creation_value_inheritance() {
+        let token = address!("0x20c0000000000000000000000000000000000042");
+        let policy_slot = B256::with_last_byte(1);
+        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+
+        // An RPC read can observe the deterministic address before token creation and cache the
+        // empty-account value.
+        cache.set(token, policy_slot, 10, B256::ZERO);
+        cover_through(&mut cache, 10);
+        assert_eq!(cache.get(token, policy_slot, 10), Some(B256::ZERO));
+
+        // TokenEnabled is emitted by the portal, so the subscriber must install a barrier for the
+        // token address rather than only for the portal emitter.
+        cache.invalidate(token, 11);
+        cache.enable_token(token);
+        cover_through(&mut cache, 11);
+        assert_eq!(cache.get(token, policy_slot, 11), None);
+
+        let initialized_policy = B256::with_last_byte(1);
+        cache.set(token, policy_slot, 11, initialized_policy);
+        assert_eq!(cache.get(token, policy_slot, 11), Some(initialized_policy));
+    }
+
+    #[test]
     fn floor_rejects_historical_cache_admission() {
         let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
         let slot = B256::with_last_byte(1);

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -277,7 +277,7 @@ mod tests {
     }
 
     #[test]
-    fn token_enablement_blocks_pre_creation_value_inheritance() {
+    fn token_enablement_invalidates_cached_token_state() {
         let token = address!("0x20c0000000000000000000000000000000000042");
         let policy_slot = B256::with_last_byte(1);
         let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -291,7 +291,6 @@ mod tests {
         // TokenEnabled is emitted by the portal, so the subscriber must install a barrier for the
         // token address rather than only for the portal emitter.
         cache.invalidate(token, 11);
-        cache.enable_token(token);
         cover_through(&mut cache, 11);
         assert_eq!(cache.get(token, policy_slot, 11), None);
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -554,6 +554,17 @@ impl L1Subscriber {
             }
         }
 
+        // TokenEnabled is emitted by the portal, but enabling a token changes which L1 TIP-20
+        // state is consensus-relevant to the zone. Invalidate the token address itself so a
+        // value cached before the deterministic TIP-20 address was created cannot be inherited
+        // past enablement.
+        invalidated.extend(
+            portal_events
+                .enabled_tokens
+                .iter()
+                .map(|enabled| enabled.token),
+        );
+
         self.record_portal_event_metrics(&portal_events);
         (portal_events, invalidated)
     }

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -396,6 +396,7 @@ impl L1Subscriber {
                 sealed.hash(),
                 sealed.parent_hash(),
                 &invalidated,
+                &events.enabled_tokens,
             );
             self.apply_portal_state_events(block_number, &events);
             self.deposit_queue.enqueue_sealed(sealed, events);
@@ -478,7 +479,13 @@ impl L1Subscriber {
                     let tip_number = tip_header.number();
                     let tip_hash = tip_header.hash();
                     let tip_parent = tip_header.parent_hash();
-                    self.update_l1_state_anchor(tip_number, tip_hash, tip_parent, &tip_invalidated);
+                    self.update_l1_state_anchor(
+                        tip_number,
+                        tip_hash,
+                        tip_parent,
+                        &tip_invalidated,
+                        &tip_events.enabled_tokens,
+                    );
                     self.apply_portal_state_events(tip_number, &tip_events);
                     match self.deposit_queue.try_enqueue(tip_header, tip_events) {
                         EnqueueOutcome::Accepted => {
@@ -644,6 +651,7 @@ impl L1Subscriber {
         hash: B256,
         parent_hash: B256,
         invalidated_accounts: &HashSet<Address>,
+        enabled_tokens: &[EnabledToken],
     ) {
         let mut guard = self.config.l1_state_cache.write();
         let anchor = guard.anchor();
@@ -662,6 +670,9 @@ impl L1Subscriber {
         }
         for &address in invalidated_accounts {
             guard.invalidate(address, number);
+        }
+        for token in enabled_tokens {
+            guard.enable_token(token.token);
         }
         // Publish receipt coverage only after every mutation barrier from this block is visible.
         guard.update_anchor(NumHash::new(number, hash));

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -554,7 +554,7 @@ impl L1Subscriber {
             }
         }
 
-        // Prevent pre-enablement TIP-20 values from being inherited.
+        // Prevent values cached before TIP-20 deployment from being inherited.
         invalidated.extend(
             portal_events
                 .enabled_tokens

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -561,14 +561,6 @@ impl L1Subscriber {
             }
         }
 
-        // Prevent values cached before TIP-20 deployment from being inherited.
-        invalidated.extend(
-            portal_events
-                .enabled_tokens
-                .iter()
-                .map(|enabled| enabled.token),
-        );
-
         self.record_portal_event_metrics(&portal_events);
         (portal_events, invalidated)
     }

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,11 +1,65 @@
 use super::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use tempo_primitives::is_tip20_prefix;
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
 const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
 
+/// Maximum block span for one historical `eth_getLogs` request.
+const TOKEN_ACTIVATION_LOG_CHUNK_SIZE: u64 = 10_000;
+
 type L1ProcessedEvents = (L1PortalEvents, HashSet<Address>);
+
+/// Rebuild canonical TIP-20 activation heights from portal event history through a finalized
+/// Zone L1 checkpoint.
+///
+/// The returned block number is the earliest observed `TokenEnabled` height for each token. Log
+/// queries are chunked to stay within common RPC range limits.
+pub async fn rebuild_token_activations(
+    l1_provider: &impl Provider<TempoNetwork>,
+    portal_address: Address,
+    finalized_through_block: u64,
+) -> eyre::Result<HashMap<Address, u64>> {
+    let mut activations: HashMap<Address, u64> = HashMap::new();
+    let mut from_block = 0u64;
+
+    loop {
+        let to_block = from_block
+            .saturating_add(TOKEN_ACTIVATION_LOG_CHUNK_SIZE - 1)
+            .min(finalized_through_block);
+        let filter = alloy_rpc_types_eth::Filter::new()
+            .address(portal_address)
+            .from_block(from_block)
+            .to_block(to_block)
+            .event_signature(TokenEnabled::SIGNATURE_HASH);
+
+        for log in l1_provider.get_logs(&filter).await? {
+            if log.address() != portal_address || log.removed {
+                eyre::bail!("invalid TokenEnabled log returned during activation rebuild");
+            }
+            let block_number = log.block_number.ok_or_else(|| {
+                eyre::eyre!("TokenEnabled log missing block number during activation rebuild")
+            })?;
+            if !(from_block..=to_block).contains(&block_number) {
+                eyre::bail!(
+                    "TokenEnabled log block {block_number} outside requested range {from_block}..={to_block}"
+                );
+            }
+            let event = TokenEnabled::decode_log(&log.inner)?.data;
+            activations
+                .entry(event.token)
+                .and_modify(|activation| *activation = (*activation).min(block_number))
+                .or_insert(block_number);
+        }
+
+        if to_block == finalized_through_block {
+            break;
+        }
+        from_block = to_block + 1;
+    }
+
+    Ok(activations)
+}
 
 /// Configuration for the L1 subscriber.
 #[derive(Debug, Clone)]
@@ -317,6 +371,26 @@ impl L1Subscriber {
         result
     }
 
+    async fn rebuild_cache_token_activations(
+        &self,
+        l1_provider: &impl Provider<TempoNetwork>,
+        through_block: u64,
+    ) -> eyre::Result<()> {
+        let activations =
+            rebuild_token_activations(l1_provider, self.config.portal_address, through_block)
+                .await?;
+        let token_count = activations.len();
+        self.config
+            .l1_state_cache
+            .write()
+            .replace_token_activations(activations);
+        info!(
+            token_count,
+            through_block, "Rebuilt TIP-20 activation history after cache reset"
+        );
+        Ok(())
+    }
+
     /// Backfill L1 blocks from `from..=to` with pipelined RPC fetching.
     ///
     /// Fetches headers and receipts for up to `l1_fetch_concurrency` blocks in
@@ -391,13 +465,17 @@ impl L1Subscriber {
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
             let sealed = SealedHeader::seal_slow(header);
-            self.update_l1_state_anchor(
+            let reorged = self.update_l1_state_anchor(
                 block_number,
                 sealed.hash(),
                 sealed.parent_hash(),
                 &invalidated,
                 &events.enabled_tokens,
             );
+            if reorged {
+                self.rebuild_cache_token_activations(l1_provider, block_number)
+                    .await?;
+            }
             self.apply_portal_state_events(block_number, &events);
             self.deposit_queue.enqueue_sealed(sealed, events);
             enqueued += 1;
@@ -479,13 +557,17 @@ impl L1Subscriber {
                     let tip_number = tip_header.number();
                     let tip_hash = tip_header.hash();
                     let tip_parent = tip_header.parent_hash();
-                    self.update_l1_state_anchor(
+                    let reorged = self.update_l1_state_anchor(
                         tip_number,
                         tip_hash,
                         tip_parent,
                         &tip_invalidated,
                         &tip_events.enabled_tokens,
                     );
+                    if reorged {
+                        self.rebuild_cache_token_activations(&provider, tip_number)
+                            .await?;
+                    }
                     self.apply_portal_state_events(tip_number, &tip_events);
                     match self.deposit_queue.try_enqueue(tip_header, tip_events) {
                         EnqueueOutcome::Accepted => {
@@ -515,11 +597,15 @@ impl L1Subscriber {
                         new_parent = %sealed.parent_hash(),
                         "Discarding unconfirmed L1 block (reorg)"
                     );
-                    let mut cache = self.config.l1_state_cache.write();
-                    let confirmed_anchor = cache.anchor().number;
-                    cache.clear();
-                    cache.initialize_floor(confirmed_anchor);
-                    drop(cache);
+                    let confirmed_anchor = {
+                        let mut cache = self.config.l1_state_cache.write();
+                        let confirmed_anchor = cache.anchor().number;
+                        cache.clear();
+                        cache.initialize_floor(confirmed_anchor);
+                        confirmed_anchor
+                    };
+                    self.rebuild_cache_token_activations(&provider, confirmed_anchor)
+                        .await?;
                 }
             }
 
@@ -644,10 +730,11 @@ impl L1Subscriber {
         parent_hash: B256,
         invalidated_accounts: &HashSet<Address>,
         enabled_tokens: &[EnabledToken],
-    ) {
+    ) -> bool {
         let mut guard = self.config.l1_state_cache.write();
         let anchor = guard.anchor();
-        if anchor.hash != B256::ZERO && parent_hash != anchor.hash {
+        let reorged = anchor.hash != B256::ZERO && parent_hash != anchor.hash;
+        if reorged {
             self.subscriber_metrics.reorgs_detected.increment(1);
             warn!(
                 old_anchor = %anchor.hash,
@@ -664,10 +751,12 @@ impl L1Subscriber {
             guard.invalidate(address, number);
         }
         for token in enabled_tokens {
-            guard.enable_token(token.token);
+            guard.enable_token_at(token.token, number);
+            guard.invalidate(token.token, number);
         }
         // Publish receipt coverage only after every mutation barrier from this block is visible.
         guard.update_anchor(NumHash::new(number, hash));
+        reorged
     }
 }
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -554,10 +554,7 @@ impl L1Subscriber {
             }
         }
 
-        // TokenEnabled is emitted by the portal, but enabling a token changes which L1 TIP-20
-        // state is consensus-relevant to the zone. Invalidate the token address itself so a
-        // value cached before the deterministic TIP-20 address was created cannot be inherited
-        // past enablement.
+        // Prevent pre-enablement TIP-20 values from being inherited.
         invalidated.extend(
             portal_events
                 .enabled_tokens

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -148,7 +148,10 @@ fn test_subscriber(
             l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
             portal_address,
             genesis_tempo_block_number,
-            l1_state_cache: crate::L1StateCache::new(HashSet::from([portal_address])),
+            l1_state_cache: crate::L1StateCache::new(HashSet::from([
+                portal_address,
+                TIP403_REGISTRY_ADDRESS,
+            ])),
             l1_fetch_concurrency: 1,
             retry_connection_interval: Duration::from_secs(1),
         },
@@ -411,7 +414,7 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
         .set(TIP403_REGISTRY_ADDRESS, slot, 10, value);
 
     let hash_10 = B256::with_last_byte(10);
-    subscriber.update_l1_state_anchor(10, hash_10, B256::ZERO, &HashSet::new());
+    subscriber.update_l1_state_anchor(10, hash_10, B256::ZERO, &HashSet::new(), &[]);
     assert_eq!(
         subscriber
             .config
@@ -426,6 +429,7 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
         B256::with_last_byte(11),
         hash_10,
         &HashSet::from([TIP403_REGISTRY_ADDRESS]),
+        &[],
     );
     let cache = subscriber.config.l1_state_cache.read();
     assert_eq!(cache.anchor().number, 11);
@@ -443,7 +447,13 @@ fn update_l1_state_anchor_reorg_clears_raw_state_and_rebases_floor() {
 
     let old_header = make_test_header(10);
     let old_hash = header_hash(&old_header);
-    subscriber.update_l1_state_anchor(10, old_hash, old_header.inner.parent_hash, &HashSet::new());
+    subscriber.update_l1_state_anchor(
+        10,
+        old_hash,
+        old_header.inner.parent_hash,
+        &HashSet::new(),
+        &[],
+    );
     subscriber
         .config
         .l1_state_cache
@@ -457,6 +467,7 @@ fn update_l1_state_anchor_reorg_clears_raw_state_and_rebases_floor() {
         header_hash(&replacement_header),
         replacement_parent,
         &HashSet::new(),
+        &[],
     );
 
     let cache = subscriber.config.l1_state_cache.read();

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -507,6 +507,62 @@ fn make_portal_log<E: SolEvent>(portal_address: Address, event: E) -> Log {
     }
 }
 
+fn make_token_enabled_log(portal_address: Address, token: Address, block_number: u64) -> Log {
+    let mut log = make_portal_log(
+        portal_address,
+        TokenEnabled {
+            token,
+            name: "Test Token".to_owned(),
+            symbol: "TEST".to_owned(),
+            currency: "USD".to_owned(),
+        },
+    );
+    log.block_number = Some(block_number);
+    log
+}
+
+#[tokio::test]
+async fn rebuild_token_activations_scans_history_and_keeps_earliest_height() {
+    let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+    let token_a = address!("0x20C00000000000000000000000000000000000A1");
+    let token_b = address!("0x20C00000000000000000000000000000000000B2");
+    let asserter = Asserter::new();
+
+    asserter.push_success(&vec![make_token_enabled_log(portal_address, token_a, 7)]);
+    asserter.push_success(&vec![
+        make_token_enabled_log(portal_address, token_a, 12_000),
+        make_token_enabled_log(portal_address, token_b, 15_000),
+    ]);
+    asserter.push_success(&Vec::<Log>::new());
+
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter);
+    let activations = rebuild_token_activations(&provider, portal_address, 20_000)
+        .await
+        .unwrap();
+
+    assert_eq!(activations.get(&token_a), Some(&7));
+    assert_eq!(activations.get(&token_b), Some(&15_000));
+}
+
+#[tokio::test]
+async fn rebuild_token_activations_rejects_unanchored_logs() {
+    let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+    let token = address!("0x20C00000000000000000000000000000000000A1");
+    let mut log = make_token_enabled_log(portal_address, token, 7);
+    log.block_number = None;
+    let asserter = Asserter::new();
+    asserter.push_success(&vec![log]);
+
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter);
+    let error = rebuild_token_activations(&provider, portal_address, 7)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("missing block number"));
+}
+
 #[tokio::test]
 async fn test_resolve_start_block_reads_live_local_state_each_time() {
     let subscriber = test_subscriber(

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -204,6 +204,7 @@ impl ZoneNode {
 
         let l1_state_cache = L1StateCache::new(HashSet::from([
             portal_address,
+            tempo_contracts::precompiles::PATH_USD_ADDRESS,
             tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS,
         ]));
         let l1_config = L1SubscriberConfig {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -202,7 +202,10 @@ impl ZoneNode {
     ) -> Self {
         let deposit_queue = DepositQueue::default();
 
-        let l1_state_cache = L1StateCache::new(HashSet::from([portal_address]));
+        let l1_state_cache = L1StateCache::new(HashSet::from([
+            portal_address,
+            tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS,
+        ]));
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
             portal_address,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -59,7 +59,7 @@ use tracing::{debug, info};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
-    DepositQueue, L1Subscriber, L1SubscriberConfig, TempoStateExt,
+    DepositQueue, L1Subscriber, L1SubscriberConfig, TempoStateExt, rebuild_token_activations,
     state::{L1StateCache, L1StateProvider, L1StateProviderConfig},
 };
 use zone_p2p::{P2pConfig, P2pNetworkId, Role, spawn_p2p};
@@ -455,6 +455,27 @@ where
             )
             .await?
             .erased();
+
+        let finalized_l1_block_number = l1_provider.get_block_number().await?;
+        eyre::ensure!(
+            finalized_l1_block_number >= tempo_block_number,
+            "finalized L1 RPC head {finalized_l1_block_number} is behind local Tempo checkpoint {tempo_block_number}"
+        );
+
+        // TODO: Persist finalized token activations keyed by chain and portal so restarts only
+        // scan the suffix after the last persisted checkpoint.
+        let token_activations = rebuild_token_activations(
+            &l1_provider,
+            self.l1_config.portal_address,
+            finalized_l1_block_number,
+        )
+        .await?;
+        let token_count = token_activations.len();
+        self.l1_config
+            .l1_state_cache
+            .write()
+            .replace_token_activations(token_activations);
+        info!(target: "reth::cli", token_count, finalized_l1_block_number, "Rebuilt finalized TIP-20 activation history");
 
         let p2p_role = self.p2p_config.as_ref().map(P2pConfig::role);
         if p2p_role == Some(Role::Follower) {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -38,7 +38,12 @@ use reth_transaction_pool::{
     Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
 };
-use std::{collections::HashSet, num::NonZeroU32, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroU32,
+    sync::Arc,
+    time::Duration,
+};
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
 use tempo_node::{
@@ -456,26 +461,27 @@ where
             .await?
             .erased();
 
-        let finalized_l1_block_number = l1_provider.get_block_number().await?;
-        eyre::ensure!(
-            finalized_l1_block_number >= tempo_block_number,
-            "finalized L1 RPC head {finalized_l1_block_number} is behind local Tempo checkpoint {tempo_block_number}"
-        );
-
         // TODO: Persist finalized token activations keyed by chain and portal so restarts only
         // scan the suffix after the last persisted checkpoint.
-        let token_activations = rebuild_token_activations(
-            &l1_provider,
-            self.l1_config.portal_address,
-            finalized_l1_block_number,
-        )
-        .await?;
+        // At genesis there is no canonical history to rebuild. In addition to avoiding an
+        // unnecessary RPC request, this preserves the existing ability to start nodes that do not
+        // consume L1 deposits with a deliberately unreachable L1 endpoint.
+        let token_activations = if tempo_block_number == 0 {
+            HashMap::new()
+        } else {
+            rebuild_token_activations(
+                &l1_provider,
+                self.l1_config.portal_address,
+                tempo_block_number,
+            )
+            .await?
+        };
         let token_count = token_activations.len();
         self.l1_config
             .l1_state_cache
             .write()
             .replace_token_activations(token_activations);
-        info!(target: "reth::cli", token_count, finalized_l1_block_number, "Rebuilt finalized TIP-20 activation history");
+        info!(target: "reth::cli", token_count, finalized_l1_block_number = tempo_block_number, "Rebuilt finalized TIP-20 activation history");
 
         let p2p_role = self.p2p_config.as_ref().map(P2pConfig::role);
         if p2p_role == Some(Role::Follower) {

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3720,6 +3720,7 @@ impl L1Fixture {
         for cache in self.caches.lock().unwrap().iter() {
             let mut cache = cache.write();
             for token in tokens {
+                cache.enable_token(token.token);
                 seed_raw_tip20_policy_id(
                     &mut cache,
                     block_number,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3720,7 +3720,7 @@ impl L1Fixture {
         for cache in self.caches.lock().unwrap().iter() {
             let mut cache = cache.write();
             for token in tokens {
-                cache.enable_token(token.token);
+                cache.enable_token_at(token.token, block_number);
                 seed_raw_tip20_policy_id(
                     &mut cache,
                     block_number,


### PR DESCRIPTION
## Summary

- invalidate the enabled TIP-20 address before publishing L1 receipt coverage
- prevent pre-creation policy values from inheriting past `TokenEnabled`
- add regression coverage for poisoned policy `0` followed by initialized policy `1`

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- focused test blocked before compilation by a 401 fetching private `alloy-evm`

Prompted by: @0xalpharush
