### PR TITLE
fix(node): restore current Rust compatibility

### DIFF
--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -74,8 +74,8 @@ k256.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-url = "2"
-zeroize.workspace = true
+url = { version = "2", optional = true }
+zeroize = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true, features = [
@@ -111,6 +111,7 @@ tempo-revm.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-tungstenite.workspace = true
+url = "2"
 
 [features]
 default = []
@@ -119,6 +120,8 @@ cli = [
   "dep:reth-consensus",
   "dep:reth-ethereum",
   "dep:reth-tracing",
+  "dep:url",
+  "dep:zeroize",
   "zone-chainspec/cli",
 ]
 jemalloc = ["reth-ethereum?/jemalloc"]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -154,7 +154,7 @@ impl ZoneEngine {
         let res = self.to_engine.fork_choice_updated(state, None).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid fork choice update {state:?}: {res:?}")
+            eyre::bail!("Invalid fork choice update {state:?}: {res:?}");
         }
 
         Ok(())
@@ -231,7 +231,7 @@ impl ZoneEngine {
             .await?;
 
         if res.is_invalid() {
-            eyre::bail!("Invalid payload status")
+            eyre::bail!("Invalid payload status");
         }
 
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
@@ -241,7 +241,7 @@ impl ZoneEngine {
             .resolve_kind(payload_id, PayloadKind::WaitForPending)
             .await
         else {
-            eyre::bail!("No payload")
+            eyre::bail!("No payload");
         };
 
         let header = payload.block().sealed_header().clone();
@@ -250,7 +250,7 @@ impl ZoneEngine {
         let res = self.to_engine.new_payload(payload).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid payload for block {block_number}")
+            eyre::bail!("Invalid payload for block {block_number}");
         }
 
         // newPayload succeeded — confirm the L1 block in the queue so it is

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -109,7 +109,9 @@ async fn ws_next_json(ws: &mut PrivateRpcWs) -> eyre::Result<Value> {
 
     match msg? {
         Message::Text(text) => Ok(serde_json::from_str(&text)?),
-        other => eyre::bail!("expected text websocket message, got {other:?}"),
+        other => {
+            eyre::bail!("expected text websocket message, got {other:?}");
+        }
     }
 }
 
@@ -136,7 +138,9 @@ async fn ws_collect_messages_until_quiet(
             Err(_) => return Ok(messages),
             Ok(Some(Ok(Message::Close(_)))) | Ok(None) => return Ok(messages),
             Ok(Some(Ok(Message::Text(text)))) => messages.push(serde_json::from_str(&text)?),
-            Ok(Some(Ok(other))) => eyre::bail!("unexpected websocket frame: {other:?}"),
+            Ok(Some(Ok(other))) => {
+                eyre::bail!("unexpected websocket frame: {other:?}");
+            }
             Ok(Some(Err(err))) => return Err(err.into()),
         }
     }

--- a/crates/rpc/test-utils/auth_tokens.rs
+++ b/crates/rpc/test-utils/auth_tokens.rs
@@ -89,7 +89,9 @@ pub(crate) fn sign_keychain_signature(
     let signing_hash = match version {
         0x03 => digest,
         0x04 => KeychainSignature::signing_hash(digest, root_account),
-        _ => eyre::bail!("unsupported keychain version"),
+        _ => {
+            eyre::bail!("unsupported keychain version");
+        }
     };
     let primitive = match sign_p256_signature(signing_hash, signing_key)? {
         TempoSignature::Primitive(primitive) => primitive,


### PR DESCRIPTION
## Summary

- terminate `eyre::bail!` invocations explicitly so current Rust toolchains no longer reject their macro expansions
- scope `url` and `zeroize` to the CLI feature while retaining `url` for integration tests

The newer compiler diagnostic is a deny-by-default future-incompatibility lint rather than a Clippy-only failure. These changes preserve behavior while allowing node tests and strict linting to run on current toolchains.