### PR TITLE
feat: validate zone user calls during payload conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13612,6 +13612,7 @@ dependencies = [
  "reth-storage-api",
  "reth-transaction-pool",
  "serde",
+ "tempo-contracts",
  "tempo-evm",
  "tempo-node",
  "tempo-payload-types",

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -21,6 +21,7 @@ zone-precompiles = { workspace = true, features = ["std"] }
 # tempo
 tempo-alloy.workspace = true
 tempo-chainspec.workspace = true
+tempo-contracts.workspace = true
 tempo-evm = { workspace = true, features = ["rpc", "engine"] }
 tempo-payload-types.workspace = true
 tempo-precompiles.workspace = true

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -437,4 +437,14 @@ mod tests {
 
         assert!(validate_transaction(&tx, &[]).is_err());
     }
+
+    #[test]
+    fn system_operations_require_system_transactions() {
+        let mut tx = call_tx(Address::repeat_byte(0x11), ZONE_INBOX_ADDRESS);
+        tx.inner.data = ZoneInbox::advanceTempoCall::SELECTOR.to_vec().into();
+
+        assert!(validate_transaction(&tx, &[]).is_err());
+        tx.is_system_tx = true;
+        assert!(validate_transaction(&tx, &[]).is_ok());
+    }
 }

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -64,17 +64,25 @@ pub fn validate_transaction(
     }
 
     for (target, input) in tx.calls() {
-        validate_call(*target, input)?;
+        validate_call(*target, input, tx.is_system_tx)?;
     }
 
     Ok(())
 }
 
-fn validate_call(target: TxKind, input: &[u8]) -> Result<(), TempoInvalidTransaction> {
+fn validate_call(
+    target: TxKind,
+    input: &[u8],
+    is_system_tx: bool,
+) -> Result<(), TempoInvalidTransaction> {
     if is_state_changing_system_operation(target, input) {
-        return Err(TempoInvalidTransaction::CallsValidation(
-            "zone system operations require a system transaction",
-        ));
+        return if is_system_tx {
+            Ok(())
+        } else {
+            Err(TempoInvalidTransaction::CallsValidation(
+                "zone system operations require a system transaction",
+            ))
+        };
     }
 
     let TxKind::Call(address) = target else {

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -1,7 +1,8 @@
 //! Contract creation validation and runtime enforcement.
 
 use alloy_evm::Database;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, TxKind};
+use alloy_sol_types::SolCall;
 use revm::{
     bytecode::opcode::{CREATE, CREATE2},
     context::Transaction,
@@ -11,8 +12,11 @@ use revm::{
         interpreter_types::InputsTr,
     },
 };
+use tempo_contracts::precompiles::ITIP20;
 use tempo_evm::evm::TempoEvm;
+use tempo_primitives::is_tip20_prefix;
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv, evm::TempoContext};
+use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox};
 use zone_primitives::constants::CONTRACT_DEPLOYER_ALLOWLIST;
 
 type ZoneInstructionCtx<'a, DB> = InstructionContext<'a, TempoContext<DB>, EthInterpreter>;
@@ -59,7 +63,54 @@ pub fn validate_transaction(
         ));
     }
 
+    for (target, input) in tx.calls() {
+        validate_call(*target, input)?;
+    }
+
     Ok(())
+}
+
+fn validate_call(target: TxKind, input: &[u8]) -> Result<(), TempoInvalidTransaction> {
+    if is_state_changing_system_operation(target, input) {
+        return Err(TempoInvalidTransaction::CallsValidation(
+            "zone system operations require a system transaction",
+        ));
+    }
+
+    let TxKind::Call(address) = target else {
+        return Ok(());
+    };
+    if !is_tip20_prefix(address) {
+        return Ok(());
+    }
+
+    if input.starts_with(&ITIP20::transferFromCall::SELECTOR) {
+        ITIP20::transferFromCall::abi_decode(input).map_err(|_| {
+            TempoInvalidTransaction::CallsValidation("malformed TIP-20 transferFrom call")
+        })?;
+    } else if input.starts_with(&ITIP20::approveCall::SELECTOR) {
+        ITIP20::approveCall::abi_decode(input).map_err(|_| {
+            TempoInvalidTransaction::CallsValidation("malformed TIP-20 approve call")
+        })?;
+    } else {
+        return Err(TempoInvalidTransaction::CallsValidation(
+            "TIP-20 operation is not allowed on zones",
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_state_changing_system_operation(target: TxKind, input: &[u8]) -> bool {
+    match (target, input.get(..4)) {
+        (TxKind::Call(ZONE_INBOX_ADDRESS), Some(selector)) => {
+            selector == ZoneInbox::advanceTempoCall::SELECTOR
+        }
+        (TxKind::Call(ZONE_OUTBOX_ADDRESS), Some(selector)) => {
+            selector == ZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR
+        }
+        _ => false,
+    }
 }
 
 fn contract_creation_deployer(tx: &TempoTxEnv) -> Option<Address> {
@@ -75,7 +126,7 @@ mod tests {
     use super::*;
     use crate::{L1OverlayDB, ZoneEvm};
     use alloy_evm::{Evm, EvmEnv};
-    use alloy_primitives::{Address, Bytes, TxKind, U256, bytes};
+    use alloy_primitives::{Address, Bytes, TxKind, U256, address, bytes};
     use revm::{
         bytecode::Bytecode,
         context::{
@@ -95,6 +146,7 @@ mod tests {
     type TestAdaptedDb = L1OverlayDB<TestDb, TestL1>;
 
     const TEST_DEPLOYER: Address = Address::new([0x42; 20]);
+    const TOKEN: Address = address!("0x20C0000000000000000000000000000000000001");
 
     fn test_create<const IS_CREATE2: bool>(
         context: ZoneInstructionCtx<'_, TestAdaptedDb>,
@@ -314,5 +366,67 @@ mod tests {
 
         assert!(validate_transaction(&tx, &[]).is_err());
         assert!(validate_transaction(&tx, &[caller]).is_ok());
+    }
+
+    #[test]
+    fn validates_tip20_calls_for_pool_and_rpc_execution() {
+        let mut tx = call_tx(Address::repeat_byte(0x11), TOKEN);
+        tx.inner.data = ITIP20::transferFromCall {
+            from: Address::repeat_byte(0x11),
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        }
+        .abi_encode()
+        .into();
+        assert!(validate_transaction(&tx, &[]).is_ok());
+
+        tx.inner.data = ITIP20::transferCall {
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        }
+        .abi_encode()
+        .into();
+        assert!(validate_transaction(&tx, &[]).is_err());
+
+        tx.inner.data = ITIP20::approveCall::SELECTOR.to_vec().into();
+        assert!(validate_transaction(&tx, &[]).is_err());
+    }
+
+    #[test]
+    fn validates_every_tip20_call_in_an_aa_batch() {
+        let tx = TempoTxEnv {
+            inner: TxEnv {
+                caller: Address::repeat_byte(0x11),
+                ..Default::default()
+            },
+            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                aa_calls: vec![
+                    Call {
+                        to: TxKind::Call(TOKEN),
+                        value: U256::ZERO,
+                        input: ITIP20::approveCall {
+                            spender: Address::repeat_byte(0x33),
+                            amount: U256::from(9),
+                        }
+                        .abi_encode()
+                        .into(),
+                    },
+                    Call {
+                        to: TxKind::Call(TOKEN),
+                        value: U256::ZERO,
+                        input: ITIP20::mintCall {
+                            to: Address::repeat_byte(0x44),
+                            amount: U256::from(1),
+                        }
+                        .abi_encode()
+                        .into(),
+                    },
+                ],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        assert!(validate_transaction(&tx, &[]).is_err());
     }
 }

--- a/crates/node/tests/it/demo_shield_and_send.rs
+++ b/crates/node/tests/it/demo_shield_and_send.rs
@@ -73,8 +73,16 @@ async fn test_shield_and_send() -> eyre::Result<()> {
             .connect_http(zone.http_url().clone());
 
         let zone_token = ITIP20::new(ZONE_TOKEN_ADDRESS, &alice_l2_provider);
+        let approve_receipt = zone_token
+            .approve(alice.address(), U256::MAX)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(approve_receipt.status(), "L2 approval from Alice failed");
+
         let receipt = zone_token
-            .transfer(bob_address, U256::from(transfer_amount))
+            .transferFrom(alice.address(), bob_address, U256::from(transfer_amount))
             .send()
             .await?
             .get_receipt()

--- a/crates/node/tests/it/enable_token.rs
+++ b/crates/node/tests/it/enable_token.rs
@@ -8,13 +8,15 @@ use alloy::primitives::{U256, address};
 use zone_l1::{EnabledToken, L1Deposit, L1PortalEvents};
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, local_dev_zone_account, start_local_zone_with_fixture,
+    DEFAULT_TIMEOUT, L1Fixture, TEST_MNEMONIC, TIP20_TX_GAS, start_local_zone_with_fixture,
 };
 
 // Imports for real-L1 tests
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
 use alloy::primitives::B256;
 use alloy_provider::Provider;
+use alloy_signer_local::{MnemonicBuilder, coins_bip39::English};
+use tempo_alloy::{TempoNetwork, rpc::TempoCallBuilderExt};
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::ITIP20;
 
@@ -122,11 +124,16 @@ async fn test_pool_validation_uses_enabled_token_anchored_policy() -> eyre::Resu
     reth_tracing::init_test_tracing();
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-    let (provider, sender) = local_dev_zone_account(&zone)?;
+    let signer = MnemonicBuilder::<English>::default()
+        .phrase(TEST_MNEMONIC)
+        .build()?;
+    let sender = signer.address();
+    let provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
+        .wallet(signer)
+        .connect_http(zone.http_url().clone());
     let recipient = address!("0x000000000000000000000000000000000000B0B0");
     let token_address = address!("0x20C0000000000000000000000000000000CC0001");
     let deposit_amount = 1_000_000u128;
-    let transfer_amount = 100_000u128;
 
     let block = fixture.next_block();
     let deposit = L1Fixture::make_deposit_for_block(token_address, sender, sender, deposit_amount);
@@ -161,18 +168,24 @@ async fn test_pool_validation_uses_enabled_token_anchored_policy() -> eyre::Resu
         "execution should observe the anchored allow-all policy"
     );
 
-    // Stateful RPC simulation uses ZoneEvmConfig and therefore the L1 overlay.
+    // Stateful RPC simulation uses ZoneEvmConfig and therefore the L1 overlay. Use the allowed
+    // transferFrom operation with a zero amount so the test stays focused on policy anchoring and
+    // FeeAMM admission without needing a preceding approval transaction.
     let simulated = token
-        .transfer(recipient, U256::from(transfer_amount))
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
+        .transferFrom(sender, recipient, U256::ZERO)
+        .fee_token(token_address)
+        .max_fee_per_gas(TEMPO_T0_BASE_FEE as u128)
+        .max_priority_fee_per_gas(0)
         .gas(TIP20_TX_GAS)
         .call()
         .await?;
     assert!(simulated, "the anchored policy should allow execution");
 
     let error = token
-        .transfer(recipient, U256::from(transfer_amount))
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
+        .transferFrom(sender, recipient, U256::ZERO)
+        .fee_token(token_address)
+        .max_fee_per_gas(TEMPO_T0_BASE_FEE as u128)
+        .max_priority_fee_per_gas(0)
         .gas(TIP20_TX_GAS)
         .send()
         .await

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -1375,7 +1375,7 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
 
     let tip20 = tempo_contracts::precompiles::ITIP20::new(ZONE_TOKEN_ADDRESS, &alice_provider);
     let transfer = tip20
-        .transfer(bob, U256::from(200_000u128))
+        .transferFrom(alice, bob, U256::from(200_000u128))
         .from(alice)
         .call()
         .await;

--- a/crates/node/tests/it/tip403_policy.rs
+++ b/crates/node/tests/it/tip403_policy.rs
@@ -16,8 +16,8 @@ use tempo_contracts::precompiles::{
 use tempo_precompiles::{PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS};
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, PolicySeed, TEST_MNEMONIC, TIP20_TX_GAS, seed_raw_tip20_policy_id,
-    seed_raw_tip403_policy, start_local_zone_with_fixture,
+    DEFAULT_TIMEOUT, PolicySeed, TEST_MNEMONIC, TIP20_TX_GAS, approve_tip20,
+    seed_raw_tip20_policy_id, seed_raw_tip403_policy, start_local_zone_with_fixture,
 };
 
 /// Deposit pathUSD to Alice, then transfer a portion to Bob on the zone.
@@ -58,10 +58,19 @@ async fn test_tip20_transfer_on_zone() -> eyre::Result<()> {
     // T6+ transfers also consult the recipient's address-level receive policy on L1.
     // Seed the anchor before pool validation; the next execution block inherits this baseline.
     fixture.seed_no_receive_policy(bob)?;
+    approve_tip20(
+        &mut fixture,
+        &zone,
+        &alice_provider,
+        PATH_USD_ADDRESS,
+        alice,
+        U256::MAX,
+    )
+    .await?;
 
     let tip20 = ITIP20::new(PATH_USD_ADDRESS, &alice_provider);
     let pending = tip20
-        .transfer(bob, U256::from(transfer_amount))
+        .transferFrom(alice, bob, U256::from(transfer_amount))
         .gas_price(TEMPO_T0_BASE_FEE as u128)
         .gas(TIP20_TX_GAS)
         .send()

--- a/crates/node/tests/it/tip403_transfers.rs
+++ b/crates/node/tests/it/tip403_transfers.rs
@@ -19,7 +19,7 @@ use tempo_precompiles::PATH_USD_ADDRESS;
 use tempo_zone_contracts::{ZONE_OUTBOX_ADDRESS, ZoneOutbox};
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, WITHDRAWAL_TX_GAS, approve_outbox,
+    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, WITHDRAWAL_TX_GAS, approve_outbox, approve_tip20,
     local_dev_zone_account, start_local_zone_with_fixture,
 };
 
@@ -55,6 +55,15 @@ async fn test_deposit_then_transfer() -> eyre::Result<()> {
     let transfer_amount: u128 = 400_000;
     // Seed the current anchor before estimation/pool validation. The next empty block inherits it.
     fixture.seed_no_receive_policy(bob)?;
+    approve_tip20(
+        &mut fixture,
+        &zone,
+        &provider,
+        PATH_USD_ADDRESS,
+        dev_address,
+        U256::MAX,
+    )
+    .await?;
     let tip20 = ITIP20::new(PATH_USD_ADDRESS, &provider);
 
     let native_balance = provider.get_balance(dev_address).await?;
@@ -64,14 +73,14 @@ async fn test_deposit_then_transfer() -> eyre::Result<()> {
     );
 
     let estimated_gas = tip20
-        .transfer(bob, U256::from(transfer_amount))
+        .transferFrom(dev_address, bob, U256::from(transfer_amount))
         .gas_price(TEMPO_T0_BASE_FEE as u128)
         .estimate_gas()
         .await?;
     assert!(estimated_gas > 0, "transfer gas estimate should be nonzero");
 
     let pending = tip20
-        .transfer(bob, U256::from(transfer_amount))
+        .transferFrom(dev_address, bob, U256::from(transfer_amount))
         .gas_price(TEMPO_T0_BASE_FEE as u128)
         .send()
         .await?;
@@ -240,10 +249,19 @@ async fn test_sequential_transfers() -> eyre::Result<()> {
         .wallet(alice_signer)
         .connect_http(zone.http_url().clone());
     fixture.seed_no_receive_policy(bob)?;
+    approve_tip20(
+        &mut fixture,
+        &zone,
+        &alice_provider,
+        PATH_USD_ADDRESS,
+        alice,
+        U256::MAX,
+    )
+    .await?;
     let tip20_alice = ITIP20::new(PATH_USD_ADDRESS, &alice_provider);
 
     let pending = tip20_alice
-        .transfer(bob, U256::from(alice_to_bob))
+        .transferFrom(alice, bob, U256::from(alice_to_bob))
         .gas_price(TEMPO_T0_BASE_FEE as u128)
         .gas(TIP20_TX_GAS)
         .send()
@@ -269,10 +287,19 @@ async fn test_sequential_transfers() -> eyre::Result<()> {
         .wallet(bob_signer)
         .connect_http(zone.http_url().clone());
     fixture.seed_no_receive_policy(charlie)?;
+    approve_tip20(
+        &mut fixture,
+        &zone,
+        &bob_provider,
+        PATH_USD_ADDRESS,
+        bob,
+        U256::MAX,
+    )
+    .await?;
     let tip20_bob = ITIP20::new(PATH_USD_ADDRESS, &bob_provider);
 
     let pending = tip20_bob
-        .transfer(charlie, U256::from(bob_to_charlie))
+        .transferFrom(bob, charlie, U256::from(bob_to_charlie))
         .gas_price(TEMPO_T0_BASE_FEE as u128)
         .gas(TIP20_TX_GAS)
         .send()
@@ -353,10 +380,19 @@ async fn test_transfer_emits_events() -> eyre::Result<()> {
 
     // Transfer to Bob. Seed its receive-policy baseline before pool validation.
     fixture.seed_no_receive_policy(bob)?;
+    approve_tip20(
+        &mut fixture,
+        &zone,
+        &provider,
+        PATH_USD_ADDRESS,
+        dev_address,
+        U256::MAX,
+    )
+    .await?;
     let tip20 = ITIP20::new(PATH_USD_ADDRESS, &provider);
 
     let pending = tip20
-        .transfer(bob, U256::from(transfer_amount))
+        .transferFrom(dev_address, bob, U256::from(transfer_amount))
         .gas_price(TEMPO_T0_BASE_FEE as u128)
         .gas(TIP20_TX_GAS)
         .send()
@@ -393,19 +429,18 @@ async fn test_transfer_emits_events() -> eyre::Result<()> {
     Ok(())
 }
 
-/// `transferWithMemo` emits a `TransferWithMemo` event with the correct memo.
+/// `approve` emits an `Approval` event with the correct fields.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_transfer_with_memo() -> eyre::Result<()> {
+async fn test_approve_emits_event() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
 
     let (provider, dev_address) = local_dev_zone_account(&zone)?;
 
-    let bob = address!("0x0000000000000000000000000000000000000B0B");
+    let spender = address!("0x0000000000000000000000000000000000000B0B");
     let deposit_amount: u128 = 1_000_000;
-    let transfer_amount: u128 = 300_000;
-    let memo = B256::with_last_byte(0x42);
+    let allowance_amount: u128 = 300_000;
 
     // Deposit to dev
     let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
@@ -418,43 +453,28 @@ async fn test_transfer_with_memo() -> eyre::Result<()> {
     )
     .await?;
 
-    // Transfer with memo. Seed its receive-policy baseline before pool validation.
-    fixture.seed_no_receive_policy(bob)?;
-    let tip20 = ITIP20::new(PATH_USD_ADDRESS, &provider);
-
-    let pending = tip20
-        .transferWithMemo(bob, U256::from(transfer_amount), memo)
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(TIP20_TX_GAS)
-        .send()
-        .await?;
-
-    // Inject L1 block to finalize
-    fixture.inject_empty_block(zone.deposit_queue());
-    let receipt = pending.get_receipt().await?;
-    assert!(receipt.status(), "transferWithMemo should succeed");
-
-    // Wait for Bob's balance
-    zone.wait_for_balance(
+    approve_tip20(
+        &mut fixture,
+        &zone,
+        &provider,
         PATH_USD_ADDRESS,
-        bob,
-        U256::from(transfer_amount),
-        DEFAULT_TIMEOUT,
+        spender,
+        U256::from(allowance_amount),
     )
     .await?;
 
-    // Query TransferWithMemo events
+    // Query Approval events from pathUSD.
     let tip20_readonly = ITIP20::new(PATH_USD_ADDRESS, zone.provider());
-    let memo_filter = tip20_readonly.TransferWithMemo_filter().from_block(0);
-    let events = memo_filter.query().await?;
+    let approval_filter = tip20_readonly.Approval_filter().from_block(0);
+    let events = approval_filter.query().await?;
 
     let found = events.iter().any(|(e, _)| {
-        e.from == dev_address
-            && e.to == bob
-            && e.amount == U256::from(transfer_amount)
-            && e.memo == memo
+        e.owner == dev_address && e.spender == spender && e.amount == U256::from(allowance_amount)
     });
-    assert!(found, "should find TransferWithMemo event with memo {memo}");
+    assert!(
+        found,
+        "should find Approval event from {dev_address} to {spender} for {allowance_amount}"
+    );
 
     Ok(())
 }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -129,9 +129,31 @@ pub(crate) async fn approve_outbox<P>(
 where
     P: Provider + Clone,
 {
-    let zone_token = ITIP20::new(PATH_USD_ADDRESS, provider);
+    approve_tip20(
+        fixture,
+        zone,
+        provider,
+        PATH_USD_ADDRESS,
+        ZONE_OUTBOX_ADDRESS,
+        U256::MAX,
+    )
+    .await
+}
+
+pub(crate) async fn approve_tip20<P>(
+    fixture: &mut L1Fixture,
+    zone: &ZoneTestNode,
+    provider: P,
+    token: Address,
+    spender: Address,
+    amount: U256,
+) -> eyre::Result<()>
+where
+    P: Provider + Clone,
+{
+    let zone_token = ITIP20::new(token, provider);
     let approve_pending = zone_token
-        .approve(ZONE_OUTBOX_ADDRESS, U256::MAX)
+        .approve(spender, amount)
         .gas_price(TEMPO_T0_BASE_FEE as u128)
         .gas(TIP20_TX_GAS)
         .send()

--- a/crates/payload/Cargo.toml
+++ b/crates/payload/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 # tempo
+tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-node.workspace = true
 tempo-payload-types.workspace = true

--- a/crates/payload/Cargo.toml
+++ b/crates/payload/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [dependencies]
 # tempo
-tempo-contracts.workspace = true
 tempo-evm.workspace = true
 tempo-node.workspace = true
 tempo-payload-types.workspace = true

--- a/crates/payload/src/attrs.rs
+++ b/crates/payload/src/attrs.rs
@@ -16,10 +16,11 @@ use reth_node_api::{
 use reth_payload_primitives::PayloadAttributes;
 use reth_primitives_traits::{AlloyBlockHeader, SealedBlock};
 use serde::{Deserialize, Serialize};
+use tempo_contracts::precompiles::ITIP20;
 use tempo_node::engine::TempoEngineValidator;
 use tempo_payload_types::{TempoBuiltPayload, TempoExecutionData};
-use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
-use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZoneInbox};
+use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope, is_tip20_prefix};
+use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox};
 use zone_l1::PreparedL1Block;
 
 /// Zone RPC payload attributes — the type that flows through FCU.
@@ -140,10 +141,22 @@ impl PayloadValidator<ZonePayloadTypes> for TempoEngineValidator {
             )));
         }
 
-        if transactions.any(is_advance_tempo) {
-            return Err(NewPayloadError::other(reth_errors::RethError::msg(
-                "advanceTempo must appear exactly once in every zone block",
-            )));
+        for tx in transactions {
+            if is_advance_tempo(tx) {
+                return Err(NewPayloadError::other(reth_errors::RethError::msg(
+                    "advanceTempo must appear exactly once in every zone block",
+                )));
+            }
+
+            if tx.is_system_tx() {
+                if !is_finalize_withdrawal_batch(tx) {
+                    return Err(NewPayloadError::other(reth_errors::RethError::msg(
+                        "unrecognized zone system transaction",
+                    )));
+                }
+            } else {
+                parse_user_transaction(tx)?;
+            }
         }
 
         Ok(block)
@@ -165,4 +178,293 @@ fn is_advance_tempo(tx: &TempoTxEnvelope) -> bool {
     tx.is_system_tx()
         && tx.kind() == TxKind::Call(ZONE_INBOX_ADDRESS)
         && tx.input().get(..4) == Some(ZoneInbox::advanceTempoCall::SELECTOR.as_slice())
+}
+fn is_finalize_withdrawal_batch(tx: &TempoTxEnvelope) -> bool {
+    tx.is_system_tx()
+        && tx.kind() == TxKind::Call(ZONE_OUTBOX_ADDRESS)
+        && tx.input().get(..4) == Some(ZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR.as_slice())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParsedZoneUserCall {
+    TransferFrom,
+    Approve,
+    Other,
+}
+
+fn parse_user_transaction(tx: &TempoTxEnvelope) -> Result<(), NewPayloadError> {
+    tx.calls()
+        .try_for_each(|(target, input)| parse_user_call(target, input).map(drop))
+}
+
+fn parse_user_call(target: TxKind, input: &Bytes) -> Result<ParsedZoneUserCall, NewPayloadError> {
+    if is_state_changing_system_operation(target, input) {
+        return Err(NewPayloadError::other(reth_errors::RethError::msg(
+            "advanceTempo and finalizeWithdrawalBatch require a system transaction",
+        )));
+    }
+
+    let TxKind::Call(address) = target else {
+        return Ok(ParsedZoneUserCall::Other);
+    };
+
+    if !is_tip20_prefix(address) {
+        return Ok(ParsedZoneUserCall::Other);
+    }
+
+    if input.starts_with(&ITIP20::transferFromCall::SELECTOR) {
+        ITIP20::transferFromCall::abi_decode(input).map_err(|_| {
+            NewPayloadError::other(reth_errors::RethError::msg(
+                "malformed TIP-20 transferFrom call",
+            ))
+        })?;
+        Ok(ParsedZoneUserCall::TransferFrom)
+    } else if input.starts_with(&ITIP20::approveCall::SELECTOR) {
+        ITIP20::approveCall::abi_decode(input).map_err(|_| {
+            NewPayloadError::other(reth_errors::RethError::msg("malformed TIP-20 approve call"))
+        })?;
+        Ok(ParsedZoneUserCall::Approve)
+    } else {
+        Err(NewPayloadError::other(reth_errors::RethError::msg(
+            "TIP-20 operation is not allowed in a zone block",
+        )))
+    }
+}
+
+fn is_state_changing_system_operation(target: TxKind, input: &[u8]) -> bool {
+    match (target, input.get(..4)) {
+        (TxKind::Call(ZONE_INBOX_ADDRESS), Some(selector)) => {
+            selector == ZoneInbox::advanceTempoCall::SELECTOR
+        }
+        (TxKind::Call(ZONE_OUTBOX_ADDRESS), Some(selector)) => {
+            selector == ZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_primitives::{Address, Signature, U256, address};
+    use reth_primitives_traits::SealedBlock;
+    use tempo_primitives::{
+        BlockBody,
+        transaction::{
+            AASigned, Call, PrimitiveSignature, TempoSignature, TempoTransaction,
+            envelope::TEMPO_SYSTEM_TX_SIGNATURE,
+        },
+    };
+
+    const TOKEN: Address = address!("0x20C0000000000000000000000000000000000001");
+
+    fn legacy_call(target: Address, input: Bytes, signature: Signature) -> TempoTxEnvelope {
+        TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy {
+                to: target.into(),
+                input,
+                ..Default::default()
+            },
+            signature,
+        ))
+    }
+
+    fn payload_with_call(
+        target: Address,
+        input: Bytes,
+        signature: Signature,
+    ) -> TempoExecutionData {
+        let advance_tempo = legacy_call(
+            ZONE_INBOX_ADDRESS,
+            ZoneInbox::advanceTempoCall::SELECTOR.to_vec().into(),
+            TEMPO_SYSTEM_TX_SIGNATURE,
+        );
+        let transaction = legacy_call(target, input, signature);
+        let block = Block {
+            header: TempoHeader::default(),
+            body: BlockBody {
+                transactions: vec![advance_tempo, transaction],
+                ommers: Vec::new(),
+                withdrawals: None,
+            },
+        };
+
+        TempoExecutionData {
+            block: SealedBlock::seal_slow(block).into(),
+            block_access_list: None,
+            validator_set: None,
+        }
+    }
+
+    fn convert_payload(payload: TempoExecutionData) -> Result<SealedBlock<Block>, NewPayloadError> {
+        <TempoEngineValidator as PayloadValidator<ZonePayloadTypes>>::convert_payload_to_block(
+            &TempoEngineValidator::new(),
+            payload,
+        )
+    }
+
+    #[test]
+    fn parses_allowed_tip20_user_calls() {
+        let transfer = ITIP20::transferFromCall {
+            from: Address::repeat_byte(0x11),
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        };
+        let approve = ITIP20::approveCall {
+            spender: Address::repeat_byte(0x33),
+            amount: U256::from(9),
+        };
+
+        for (input, expected) in [
+            (
+                Bytes::from(transfer.abi_encode()),
+                ParsedZoneUserCall::TransferFrom,
+            ),
+            (
+                Bytes::from(approve.abi_encode()),
+                ParsedZoneUserCall::Approve,
+            ),
+        ] {
+            assert_eq!(
+                parse_user_call(TxKind::Call(TOKEN), &input).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_disallowed_and_malformed_tip20_user_calls() {
+        let transfer = ITIP20::transferCall {
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        };
+
+        assert!(parse_user_call(TxKind::Call(TOKEN), &transfer.abi_encode().into()).is_err());
+        assert!(
+            parse_user_call(
+                TxKind::Call(TOKEN),
+                &ITIP20::approveCall::SELECTOR.to_vec().into(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn permits_non_tip20_protocol_calls() {
+        let target = Address::repeat_byte(0x1c);
+        assert_eq!(
+            parse_user_call(TxKind::Call(target), &Bytes::new()).unwrap(),
+            ParsedZoneUserCall::Other
+        );
+    }
+
+    #[test]
+    fn parses_every_call_in_an_aa_batch() {
+        let allowed = ITIP20::approveCall {
+            spender: Address::repeat_byte(0x33),
+            amount: U256::from(9),
+        };
+        let forbidden = ITIP20::mintCall {
+            to: Address::repeat_byte(0x44),
+            amount: U256::from(1),
+        };
+        let transaction = TempoTransaction {
+            calls: vec![
+                Call {
+                    to: TxKind::Call(TOKEN),
+                    value: U256::ZERO,
+                    input: allowed.abi_encode().into(),
+                },
+                Call {
+                    to: TxKind::Call(TOKEN),
+                    value: U256::ZERO,
+                    input: forbidden.abi_encode().into(),
+                },
+            ],
+            ..Default::default()
+        };
+        let signature =
+            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+        let envelope = AASigned::new_unhashed(transaction, signature).into();
+
+        assert!(parse_user_transaction(&envelope).is_err());
+    }
+
+    #[test]
+    fn enforces_user_call_policy_during_payload_conversion() {
+        let allowed = ITIP20::transferFromCall {
+            from: Address::repeat_byte(0x11),
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        };
+        assert!(
+            convert_payload(payload_with_call(
+                TOKEN,
+                allowed.abi_encode().into(),
+                Signature::test_signature(),
+            ))
+            .is_ok()
+        );
+
+        let forbidden = ITIP20::transferCall {
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        };
+        let error = convert_payload(payload_with_call(
+            TOKEN,
+            forbidden.abi_encode().into(),
+            Signature::test_signature(),
+        ))
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("TIP-20 operation is not allowed in a zone block")
+        );
+    }
+
+    #[test]
+    fn enforces_system_and_user_signature_roles_during_payload_conversion() {
+        let transfer = ITIP20::transferFromCall {
+            from: Address::repeat_byte(0x11),
+            to: Address::repeat_byte(0x22),
+            amount: U256::from(7),
+        };
+        let error = convert_payload(payload_with_call(
+            TOKEN,
+            transfer.abi_encode().into(),
+            TEMPO_SYSTEM_TX_SIGNATURE,
+        ))
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("unrecognized zone system transaction")
+        );
+
+        let finalize: Bytes = ZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR
+            .to_vec()
+            .into();
+        assert!(
+            convert_payload(payload_with_call(
+                ZONE_OUTBOX_ADDRESS,
+                finalize.clone(),
+                TEMPO_SYSTEM_TX_SIGNATURE,
+            ))
+            .is_ok()
+        );
+
+        let error = convert_payload(payload_with_call(
+            ZONE_OUTBOX_ADDRESS,
+            finalize,
+            Signature::test_signature(),
+        ))
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("advanceTempo and finalizeWithdrawalBatch require a system transaction")
+        );
+    }
 }

--- a/crates/payload/src/attrs.rs
+++ b/crates/payload/src/attrs.rs
@@ -16,10 +16,9 @@ use reth_node_api::{
 use reth_payload_primitives::PayloadAttributes;
 use reth_primitives_traits::{AlloyBlockHeader, SealedBlock};
 use serde::{Deserialize, Serialize};
-use tempo_contracts::precompiles::ITIP20;
 use tempo_node::engine::TempoEngineValidator;
 use tempo_payload_types::{TempoBuiltPayload, TempoExecutionData};
-use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope, is_tip20_prefix};
+use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
 use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZoneInbox, ZoneOutbox};
 use zone_l1::PreparedL1Block;
 
@@ -154,8 +153,10 @@ impl PayloadValidator<ZonePayloadTypes> for TempoEngineValidator {
                         "unrecognized zone system transaction",
                     )));
                 }
-            } else {
-                parse_user_transaction(tx)?;
+            } else if is_state_changing_system_operation(tx.kind(), tx.input()) {
+                return Err(NewPayloadError::other(reth_errors::RethError::msg(
+                    "advanceTempo and finalizeWithdrawalBatch require a system transaction",
+                )));
             }
         }
 
@@ -185,52 +186,6 @@ fn is_finalize_withdrawal_batch(tx: &TempoTxEnvelope) -> bool {
         && tx.input().get(..4) == Some(ZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR.as_slice())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ParsedZoneUserCall {
-    TransferFrom,
-    Approve,
-    Other,
-}
-
-fn parse_user_transaction(tx: &TempoTxEnvelope) -> Result<(), NewPayloadError> {
-    tx.calls()
-        .try_for_each(|(target, input)| parse_user_call(target, input).map(drop))
-}
-
-fn parse_user_call(target: TxKind, input: &Bytes) -> Result<ParsedZoneUserCall, NewPayloadError> {
-    if is_state_changing_system_operation(target, input) {
-        return Err(NewPayloadError::other(reth_errors::RethError::msg(
-            "advanceTempo and finalizeWithdrawalBatch require a system transaction",
-        )));
-    }
-
-    let TxKind::Call(address) = target else {
-        return Ok(ParsedZoneUserCall::Other);
-    };
-
-    if !is_tip20_prefix(address) {
-        return Ok(ParsedZoneUserCall::Other);
-    }
-
-    if input.starts_with(&ITIP20::transferFromCall::SELECTOR) {
-        ITIP20::transferFromCall::abi_decode(input).map_err(|_| {
-            NewPayloadError::other(reth_errors::RethError::msg(
-                "malformed TIP-20 transferFrom call",
-            ))
-        })?;
-        Ok(ParsedZoneUserCall::TransferFrom)
-    } else if input.starts_with(&ITIP20::approveCall::SELECTOR) {
-        ITIP20::approveCall::abi_decode(input).map_err(|_| {
-            NewPayloadError::other(reth_errors::RethError::msg("malformed TIP-20 approve call"))
-        })?;
-        Ok(ParsedZoneUserCall::Approve)
-    } else {
-        Err(NewPayloadError::other(reth_errors::RethError::msg(
-            "TIP-20 operation is not allowed in a zone block",
-        )))
-    }
-}
-
 fn is_state_changing_system_operation(target: TxKind, input: &[u8]) -> bool {
     match (target, input.get(..4)) {
         (TxKind::Call(ZONE_INBOX_ADDRESS), Some(selector)) => {
@@ -247,17 +202,14 @@ fn is_state_changing_system_operation(target: TxKind, input: &[u8]) -> bool {
 mod tests {
     use super::*;
     use alloy_consensus::{Signed, TxLegacy};
-    use alloy_primitives::{Address, Signature, U256, address};
+    use alloy_primitives::{Address, Signature};
     use reth_primitives_traits::SealedBlock;
     use tempo_primitives::{
         BlockBody,
-        transaction::{
-            AASigned, Call, PrimitiveSignature, TempoSignature, TempoTransaction,
-            envelope::TEMPO_SYSTEM_TX_SIGNATURE,
-        },
+        transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
     };
 
-    const TOKEN: Address = address!("0x20C0000000000000000000000000000000000001");
+    const TOKEN: Address = Address::new([0x20; 20]);
 
     fn legacy_call(target: Address, input: Bytes, signature: Signature) -> TempoTxEnvelope {
         TempoTxEnvelope::Legacy(Signed::new_unhashed(
@@ -305,135 +257,10 @@ mod tests {
     }
 
     #[test]
-    fn parses_allowed_tip20_user_calls() {
-        let transfer = ITIP20::transferFromCall {
-            from: Address::repeat_byte(0x11),
-            to: Address::repeat_byte(0x22),
-            amount: U256::from(7),
-        };
-        let approve = ITIP20::approveCall {
-            spender: Address::repeat_byte(0x33),
-            amount: U256::from(9),
-        };
-
-        for (input, expected) in [
-            (
-                Bytes::from(transfer.abi_encode()),
-                ParsedZoneUserCall::TransferFrom,
-            ),
-            (
-                Bytes::from(approve.abi_encode()),
-                ParsedZoneUserCall::Approve,
-            ),
-        ] {
-            assert_eq!(
-                parse_user_call(TxKind::Call(TOKEN), &input).unwrap(),
-                expected
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_disallowed_and_malformed_tip20_user_calls() {
-        let transfer = ITIP20::transferCall {
-            to: Address::repeat_byte(0x22),
-            amount: U256::from(7),
-        };
-
-        assert!(parse_user_call(TxKind::Call(TOKEN), &transfer.abi_encode().into()).is_err());
-        assert!(
-            parse_user_call(
-                TxKind::Call(TOKEN),
-                &ITIP20::approveCall::SELECTOR.to_vec().into(),
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn permits_non_tip20_protocol_calls() {
-        let target = Address::repeat_byte(0x1c);
-        assert_eq!(
-            parse_user_call(TxKind::Call(target), &Bytes::new()).unwrap(),
-            ParsedZoneUserCall::Other
-        );
-    }
-
-    #[test]
-    fn parses_every_call_in_an_aa_batch() {
-        let allowed = ITIP20::approveCall {
-            spender: Address::repeat_byte(0x33),
-            amount: U256::from(9),
-        };
-        let forbidden = ITIP20::mintCall {
-            to: Address::repeat_byte(0x44),
-            amount: U256::from(1),
-        };
-        let transaction = TempoTransaction {
-            calls: vec![
-                Call {
-                    to: TxKind::Call(TOKEN),
-                    value: U256::ZERO,
-                    input: allowed.abi_encode().into(),
-                },
-                Call {
-                    to: TxKind::Call(TOKEN),
-                    value: U256::ZERO,
-                    input: forbidden.abi_encode().into(),
-                },
-            ],
-            ..Default::default()
-        };
-        let signature =
-            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
-        let envelope = AASigned::new_unhashed(transaction, signature).into();
-
-        assert!(parse_user_transaction(&envelope).is_err());
-    }
-
-    #[test]
-    fn enforces_user_call_policy_during_payload_conversion() {
-        let allowed = ITIP20::transferFromCall {
-            from: Address::repeat_byte(0x11),
-            to: Address::repeat_byte(0x22),
-            amount: U256::from(7),
-        };
-        assert!(
-            convert_payload(payload_with_call(
-                TOKEN,
-                allowed.abi_encode().into(),
-                Signature::test_signature(),
-            ))
-            .is_ok()
-        );
-
-        let forbidden = ITIP20::transferCall {
-            to: Address::repeat_byte(0x22),
-            amount: U256::from(7),
-        };
-        let error = convert_payload(payload_with_call(
-            TOKEN,
-            forbidden.abi_encode().into(),
-            Signature::test_signature(),
-        ))
-        .unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("TIP-20 operation is not allowed in a zone block")
-        );
-    }
-
-    #[test]
     fn enforces_system_and_user_signature_roles_during_payload_conversion() {
-        let transfer = ITIP20::transferFromCall {
-            from: Address::repeat_byte(0x11),
-            to: Address::repeat_byte(0x22),
-            amount: U256::from(7),
-        };
         let error = convert_payload(payload_with_call(
             TOKEN,
-            transfer.abi_encode().into(),
+            Bytes::new(),
             TEMPO_SYSTEM_TX_SIGNATURE,
         ))
         .unwrap_err();


### PR DESCRIPTION
## Summary

- validate direct and batched Zone user calls in the shared Zone EVM transaction validator used by txpool admission and RPC simulation
- allow TIP-20 `transferFrom` and `approve` only after full ABI decoding
- keep system-signature and block-layout validation at the payload conversion boundary
- preserve non-TIP20 protocol calls such as withdrawals

## Why

User-call policy is an admission concern and should fail at txpool/RPC validation rather than only when a payload is converted. Consensus-critical system transaction ordering and signature roles remain enforced on imported payloads.

## Validation

- `cargo +nightly fmt -- crates/evm/src/zone_evm/contract_creation.rs`
- targeted Cargo test blocked locally by private `alloy-evm` dependency authentication (401); CI is authoritative
- `git diff --check`

Stacked on #760.

Prompted by: @0xalpharush