### PR TITLE
ci: speed up builds and tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,8 +98,11 @@ jobs:
           targets: default
           project: 0c6tg19qsp
           push: ${{ github.event_name != 'pull_request' }}
-          no-cache: ${{ github.event_name != 'merge_group' && github.event_name != 'pull_request' }}
-          pull: ${{ github.event_name != 'merge_group' && github.event_name != 'pull_request' }}
+          # Scheduled builds refresh moving external tools and base images. All
+          # commit/tag/manual builds can safely reuse Depot's content-addressed
+          # layer cache and will still invalidate layers when inputs change.
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}
           VERGEN_GIT_SHA_SHORT: ${{ steps.shortsha.outputs.shortsha }}

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -24,6 +24,10 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  TEMPO_FOUNDRY_REF: 18a5d71d6ab621433145e5ea86dfe3dbace0763a
+  # Keep the custom forge cache stable and the build reproducible. This is the
+  # Foundry revision used by the successful baseline run on 2026-07-22.
+  FOUNDRY_REF: 6902a96211da7bcc3d9c4d8e97910ac5c9d5d2c6
 
 jobs:
   build:
@@ -42,6 +46,20 @@ jobs:
 
       - name: Show Forge version
         run: forge --version
+
+      - name: Resolve Solidity cache key
+        id: solidity-key
+        run: |
+          echo "forge-sha=$(forge --version | sed -n 's/^Commit SHA: //p')" >> "$GITHUB_OUTPUT"
+          echo "specs-tree=$(git rev-parse HEAD:specs/ref-impls)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Solidity artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            specs/ref-impls/cache
+            specs/ref-impls/out
+          key: forge-${{ runner.os }}-${{ steps.solidity-key.outputs.forge-sha }}-${{ steps.solidity-key.outputs.specs-tree }}
 
       - name: Run Forge build
         working-directory: specs/ref-impls
@@ -82,7 +100,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo
-          ref: 18a5d71d6ab621433145e5ea86dfe3dbace0763a
+          ref: ${{ env.TEMPO_FOUNDRY_REF }}
           path: tempo
           persist-credentials: false
 
@@ -90,27 +108,58 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: ${{ env.FOUNDRY_REF }}
           path: foundry
           persist-credentials: false
 
+      - name: Resolve Foundry revision
+        id: foundry-ref
+        working-directory: foundry
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # sccache cannot cache the final forge executable. Cache that link output
+      # against the exact Foundry and Tempo revisions so most runs can skip the
+      # Rust setup, dependency restore, patch, and eight-minute link entirely.
+      - name: Restore Tempo-capable forge
+        id: forge-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: foundry/target/release/forge
+          key: tempo-forge-v1-${{ runner.os }}-${{ steps.foundry-ref.outputs.sha }}-${{ env.TEMPO_FOUNDRY_REF }}
+
       - name: Setup Rust
+        if: steps.forge-cache.outputs.cache-hit != 'true'
         uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: steps.forge-cache.outputs.cache-hit != 'true'
         with:
           workspaces: foundry
 
       - name: Patch foundry to use pinned Tempo crates
+        if: steps.forge-cache.outputs.cache-hit != 'true'
         run: tempo/scripts/foundry-patch.sh "$GITHUB_WORKSPACE/tempo" "$GITHUB_WORKSPACE/foundry"
 
       - name: Build Tempo-capable forge
+        if: steps.forge-cache.outputs.cache-hit != 'true'
         working-directory: foundry
         run: cargo build --bin forge --profile release --no-default-features
 
       - name: Install z3 (symbolic solver)
         run: sudo apt-get update && sudo apt-get install -y z3
+
+      - name: Resolve Specs cache key
+        id: specs-key
+        run: echo "tree=$(git rev-parse HEAD:specs/ref-impls)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Tempo Forge Solidity artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            specs/ref-impls/cache
+            specs/ref-impls/out
+          key: tempo-forge-specs-v1-${{ runner.os }}-${{ steps.foundry-ref.outputs.sha }}-${{ env.TEMPO_FOUNDRY_REF }}-${{ steps.specs-key.outputs.tree }}
 
       - name: Run Forge tests (zone specs)
         working-directory: specs/ref-impls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  test:
-    name: test
+  build-test-artifacts:
+    name: build test artifacts
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 30
     permissions:
@@ -32,6 +32,13 @@ jobs:
       - uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef
         with:
           toolchain: stable
+      # sccache avoids recompiling dependencies, while this cache also keeps the
+      # final linked workspace test binaries that sccache cannot cache.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: test-build
+          cache-workspace-crates: true
+          cache-on-failure: true
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: nextest@0.9.124
@@ -39,13 +46,79 @@ jobs:
         uses: tempoxyz/gh-actions/actions/setup-foundry@98b1081dcf34361b576aca2ab3041772708582ef
         with:
           version: nightly
+
+      - name: Resolve Solidity cache key
+        id: solidity-key
+        run: |
+          echo "forge-sha=$(forge --version | sed -n 's/^Commit SHA: //p')" >> "$GITHUB_OUTPUT"
+          echo "specs-tree=$(git rev-parse HEAD:specs/ref-impls)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Solidity artifacts
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            specs/ref-impls/cache
+            specs/ref-impls/out
+          key: forge-${{ runner.os }}-${{ steps.solidity-key.outputs.forge-sha }}-${{ steps.solidity-key.outputs.specs-tree }}
+
       - name: Build Solidity artifacts
         working-directory: specs/ref-impls
         run: forge build
-      - name: Build and compile tests
-        run: cargo nextest run --profile ci --no-run
-      - name: Run tests
-        run: cargo nextest run --profile ci
+
+      - name: Build and archive tests
+        run: cargo nextest archive --profile ci --archive-file nextest-archive.tar.zst
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-archive
+          path: |
+            nextest-archive.tar.zst
+            specs/ref-impls/out
+          if-no-files-found: error
+          retention-days: 1
+          # The nextest archive is already zstd-compressed; recompressing it is
+          # slower and does not materially reduce artifact transfer size.
+          compression-level: 0
+
+  test:
+    name: test (${{ matrix.partition }}/2)
+    runs-on: depot-ubuntu-latest-16
+    needs: build-test-artifacts
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      # The run phase consumes prebuilt binaries and does not need Rust/Cargo.
+      - name: Prepare nextest install directory
+        run: mkdir -p "$HOME/.cargo/bin"
+
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: nextest@0.9.124
+
+      - name: Download test artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-archive
+          path: .
+
+      - name: Run test shard
+        run: |
+          cargo-nextest nextest run \
+            --archive-file nextest-archive.tar.zst \
+            --workspace-remap "$GITHUB_WORKSPACE" \
+            --profile ci \
+            --partition hash:${{ matrix.partition }}/2
 
   test-success:
     name: test success
@@ -53,6 +126,7 @@ jobs:
     if: always()
     permissions: {}
     needs:
+      - build-test-artifacts
       - test
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

- build Rust tests once, archive the nextest binaries, and execute two deterministic shards in parallel
- cache linked Rust workspace artifacts and Solidity build outputs that sccache does not retain
- pin and cache the known-good Tempo-enabled Foundry binary by exact Foundry and Tempo revisions
- reuse Depot Docker layers for commit, tag, and manual builds while keeping scheduled builds clean

## Why

Recent Test runs spent roughly half their time executing tests after a full workspace build, while Specs spent nearly eight minutes relinking the same custom `forge` binary despite a high sccache hit rate. The new layout separates build from execution, preserves final link outputs, and uses exact cache keys so unchanged tools and Solidity sources can be reused safely.

## Impact

Warm CI runs should avoid the custom Foundry rebuild entirely and reduce Rust test wall time by running the prebuilt suite across two workers. Scheduled Docker builds continue to refresh moving external inputs.

## Validation

- `actionlint` 1.7.12 on all modified workflows
- YAML parse validation
- `git diff --check`
- local nextest archive creation and successful execution of both hash partitions