### PR TITLE
fix(outbox): validate requests before L1 reads

### DIFF
--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -8,7 +8,7 @@
 //! Both a synchronous ([`L1StateProvider::get_storage`]) and an asynchronous
 //! ([`L1StateProvider::get_storage_async`]) entry point are provided. The synchronous variant is
 //! intended for use inside EVM precompiles where async is unavailable — it retries the RPC
-//! call indefinitely with exponential backoff to avoid bricking the chain on transient outages.
+//! call a bounded number of times with exponential backoff.
 
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
@@ -23,6 +23,8 @@ use zone_precompiles::{L1StateError, L1StorageReader, SequencerExt};
 
 use super::cache::L1StateCache;
 use crate::{abi::PORTAL_SEQUENCER_SLOT, rpc::rpc_connection_config};
+
+const DEFAULT_MAX_SYNC_ATTEMPTS: NonZeroU32 = NonZeroU32::new(3).unwrap();
 
 /// Configuration for the [`L1StateProvider`].
 #[derive(Debug, Clone)]
@@ -42,7 +44,8 @@ pub struct L1StateProviderConfig {
     /// Interval between WebSocket reconnection attempts.
     /// Defaults to 100ms.
     pub retry_connection_interval: std::time::Duration,
-    /// Maximum number of synchronous RPC attempts per cache miss. `None` retries indefinitely.
+    /// Maximum number of synchronous RPC attempts per cache miss. Defaults to 3.
+    /// `None` retries indefinitely and should only be used by trusted callers.
     pub max_sync_attempts: Option<NonZeroU32>,
 }
 
@@ -55,7 +58,7 @@ impl Default for L1StateProviderConfig {
             max_retries: 10,
             initial_backoff_ms: 20,
             retry_connection_interval: std::time::Duration::from_millis(100),
-            max_sync_attempts: None,
+            max_sync_attempts: Some(DEFAULT_MAX_SYNC_ATTEMPTS),
         }
     }
 }
@@ -167,10 +170,8 @@ impl L1StateProvider {
     /// Read a storage slot synchronously at a specific L1 block — cache first, RPC fallback.
     ///
     /// This method is designed for use inside EVM precompiles that run on a **blocking thread**.
-    /// On cache miss it retries the RPC call indefinitely until the value is fetched. The
-    /// transport layer handles backoff internally via [`RetryBackoffLayer`], so retries here
-    /// are immediate. This ensures a transient L1 RPC outage stalls block production rather
-    /// than bricking the chain with a hard precompile error.
+    /// On cache miss it retries the RPC call up to the configured attempt limit. The transport
+    /// layer handles backoff internally via [`RetryBackoffLayer`], so retries here are immediate.
     ///
     /// # Panics
     ///

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -8,7 +8,7 @@
 //! Both a synchronous ([`L1StateProvider::get_storage`]) and an asynchronous
 //! ([`L1StateProvider::get_storage_async`]) entry point are provided. The synchronous variant is
 //! intended for use inside EVM precompiles where async is unavailable — it retries the RPC
-//! call a bounded number of times with exponential backoff.
+//! call indefinitely with exponential backoff to avoid bricking the chain on transient outages.
 
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
@@ -23,8 +23,6 @@ use zone_precompiles::{L1StateError, L1StorageReader, SequencerExt};
 
 use super::cache::L1StateCache;
 use crate::{abi::PORTAL_SEQUENCER_SLOT, rpc::rpc_connection_config};
-
-const DEFAULT_MAX_SYNC_ATTEMPTS: NonZeroU32 = NonZeroU32::new(3).unwrap();
 
 /// Configuration for the [`L1StateProvider`].
 #[derive(Debug, Clone)]
@@ -44,8 +42,7 @@ pub struct L1StateProviderConfig {
     /// Interval between WebSocket reconnection attempts.
     /// Defaults to 100ms.
     pub retry_connection_interval: std::time::Duration,
-    /// Maximum number of synchronous RPC attempts per cache miss. Defaults to 3.
-    /// `None` retries indefinitely and should only be used by trusted callers.
+    /// Maximum number of synchronous RPC attempts per cache miss. `None` retries indefinitely.
     pub max_sync_attempts: Option<NonZeroU32>,
 }
 
@@ -58,7 +55,7 @@ impl Default for L1StateProviderConfig {
             max_retries: 10,
             initial_backoff_ms: 20,
             retry_connection_interval: std::time::Duration::from_millis(100),
-            max_sync_attempts: Some(DEFAULT_MAX_SYNC_ATTEMPTS),
+            max_sync_attempts: None,
         }
     }
 }
@@ -170,8 +167,10 @@ impl L1StateProvider {
     /// Read a storage slot synchronously at a specific L1 block — cache first, RPC fallback.
     ///
     /// This method is designed for use inside EVM precompiles that run on a **blocking thread**.
-    /// On cache miss it retries the RPC call up to the configured attempt limit. The transport
-    /// layer handles backoff internally via [`RetryBackoffLayer`], so retries here are immediate.
+    /// On cache miss it retries the RPC call indefinitely until the value is fetched. The
+    /// transport layer handles backoff internally via [`RetryBackoffLayer`], so retries here
+    /// are immediate. This ensures a transient L1 RPC outage stalls block production rather
+    /// than bricking the chain with a hard precompile error.
     ///
     /// # Panics
     ///

--- a/crates/precompiles/src/outbox/dispatch.rs
+++ b/crates/precompiles/src/outbox/dispatch.rs
@@ -55,7 +55,7 @@ impl ZoneOutbox {
                 setTempoGasRate(call) => mutate_void(call, msg_sender, |sender, call| self.set_tempo_gas_rate(l1, portal_address, sender, call)),
                 setMaxWithdrawalsPerBlock(call) => mutate_void(call, msg_sender, |sender, call| self.set_max_withdrawals_per_block(l1, portal_address, sender, call)),
                 requestWithdrawal(call) => mutate_void(call, msg_sender, |sender, call| {
-                    self.request_withdrawal(l1, portal_address, sender, fee_payer, tx_hash, call)
+                    self.request_withdrawal(sender, fee_payer, tx_hash, call)
                 }),
                 enqueueDepositBounceBack(call) => mutate_void(call, msg_sender, |sender, call| self.enqueue_deposit_bounce_back(sender, call)),
                 consumeFallbackRecipient(call) => mutate(call, msg_sender, |sender, call| self.consume_fallback_recipient(sender, call.fallbackNonce)),
@@ -63,8 +63,6 @@ impl ZoneOutbox {
             }
             ILegacyZoneOutbox::ILegacyZoneOutboxCalls {
                 requestWithdrawal(call) => mutate_void(call, msg_sender, |sender, call| self.request_withdrawal(
-                    l1,
-                    portal_address,
                     sender,
                     fee_payer,
                     tx_hash,

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -11,7 +11,7 @@ use revm::interpreter::instructions::utility::IntoAddress;
 use tempo_precompiles::{
     Result as TempoResult,
     error::TempoPrecompileError,
-    storage::{Handler, Mapping, StorageCtx},
+    storage::{ContractStorage, Handler, Mapping, StorageCtx},
     tip20::{ITIP20, TIP20Error, TIP20Token},
 };
 use tempo_precompiles_macros::{Storable, contract};
@@ -151,8 +151,9 @@ impl ZoneOutbox {
         if current_tx_hash.is_zero() {
             return Err(ZoneOutboxError::invalid_current_tx_hash().into());
         }
-        if !TIP20Token::from_address(call.token)?.is_initialized()? {
-            return Err(TIP20Error::uninitialized().into());
+        let mut zone_token = TIP20Token::from_address(call.token)?;
+        if !zone_token.is_initialized()? {
+            return Err(TempoPrecompileError::from(TIP20Error::uninitialized()).into());
         }
         self.enforce_withdrawal_block_cap()?;
 

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -13,13 +13,9 @@ use tempo_precompiles::{
     error::TempoPrecompileError,
     storage::{Handler, Mapping, StorageCtx},
     tip20::{ITIP20, TIP20Error, TIP20Token},
-    tip20_factory::TIP20Factory,
 };
 use tempo_precompiles_macros::{Storable, contract};
-use tempo_zone_contracts::{
-    IZoneOutbox, Withdrawal, ZoneOutboxError, ZoneOutboxEvent, ZonePortalError,
-    portal_token_config_slot,
-};
+use tempo_zone_contracts::{IZoneOutbox, Withdrawal, ZoneOutboxError, ZoneOutboxEvent};
 use zone_primitives::constants::{
     MAX_WITHDRAWAL_GAS_LIMIT, PORTAL_SEQUENCER_SLOT, TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS,
     ZONE_OUTBOX_ADDRESS,
@@ -88,19 +84,6 @@ impl ZoneOutbox {
         Ok(())
     }
 
-    fn ensure_token_enabled<P: L1StorageReader>(
-        &self,
-        l1: &L1State<P>,
-        portal_address: Address,
-        token: Address,
-    ) -> ZoneResult<()> {
-        let value = self.read_portal_slot(l1, portal_address, portal_token_config_slot(token))?;
-        if value.byte(0) == 0 {
-            return Err(ZonePortalError::token_not_enabled().into());
-        }
-        Ok(())
-    }
-
     fn calculate_fee_unchecked(&self, gas_limit: u64) -> TempoResult<u128> {
         let gas = u128::from(WITHDRAWAL_BASE_GAS) + u128::from(gas_limit);
         gas.checked_mul(self.tempo_gas_rate.read()?)
@@ -149,10 +132,8 @@ impl ZoneOutbox {
         Ok(())
     }
 
-    fn request_withdrawal<P: L1StorageReader>(
+    fn request_withdrawal(
         &mut self,
-        l1: &L1State<P>,
-        portal_address: Address,
         caller: Address,
         fee_payer: Address,
         current_tx_hash: B256,
@@ -170,12 +151,10 @@ impl ZoneOutbox {
         if current_tx_hash.is_zero() {
             return Err(ZoneOutboxError::invalid_current_tx_hash().into());
         }
-        if !TIP20Factory::new().is_tip20(call.token)? {
-            return Err(TIP20Error::invalid_token().into());
-        }
-
         let mut zone_token = TIP20Token::from_address(call.token)?;
-        self.ensure_token_enabled(l1, portal_address, call.token)?;
+        if !zone_token.is_initialized()? {
+            return Err(TIP20Error::uninitialized().into());
+        }
         self.enforce_withdrawal_block_cap()?;
 
         // If necessary, validate reveal

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -151,8 +151,7 @@ impl ZoneOutbox {
         if current_tx_hash.is_zero() {
             return Err(ZoneOutboxError::invalid_current_tx_hash().into());
         }
-        let mut zone_token = TIP20Token::from_address(call.token)?;
-        if !zone_token.is_initialized()? {
+        if !TIP20Token::from_address(call.token)?.is_initialized()? {
             return Err(TIP20Error::uninitialized().into());
         }
         self.enforce_withdrawal_block_cap()?;

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -12,7 +12,8 @@ use tempo_precompiles::{
     Result as TempoResult,
     error::TempoPrecompileError,
     storage::{Handler, Mapping, StorageCtx},
-    tip20::{ITIP20, TIP20Token},
+    tip20::{ITIP20, TIP20Error, TIP20Token},
+    tip20_factory::TIP20Factory,
 };
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_zone_contracts::{
@@ -166,10 +167,15 @@ impl ZoneOutbox {
 
         validate_gas_limit(call.gasLimit)?;
 
-        self.ensure_token_enabled(l1, portal_address, call.token)?;
         if current_tx_hash.is_zero() {
             return Err(ZoneOutboxError::invalid_current_tx_hash().into());
         }
+        if !TIP20Factory::new().is_tip20(call.token)? {
+            return Err(TIP20Error::invalid_token().into());
+        }
+
+        let mut zone_token = TIP20Token::from_address(call.token)?;
+        self.ensure_token_enabled(l1, portal_address, call.token)?;
         self.enforce_withdrawal_block_cap()?;
 
         // If necessary, validate reveal
@@ -178,7 +184,6 @@ impl ZoneOutbox {
         }
 
         let fee = self.calculate_fee_unchecked(call.gasLimit)?;
-        let mut zone_token = TIP20Token::from_address(call.token)?;
         if caller == fee_payer {
             let total = call
                 .amount

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -286,6 +286,31 @@ fn request_withdrawal_rejects_missing_transaction_hash() -> eyre::Result<()> {
         .abi_encode(),
     );
     assert_revert(result, ZoneOutboxError::invalid_current_tx_hash());
+    assert!(
+        harness.l1.storage_requests().is_empty(),
+        "missing transaction context must be rejected before portal reads"
+    );
+    Ok(())
+}
+
+#[test]
+fn request_withdrawal_rejects_unknown_token_before_portal_read() -> eyre::Result<()> {
+    let mut harness = Harness::new()?;
+    let result = harness.request_custom(ZoneOutboxAbi::requestWithdrawalCall {
+        token: address!("0x20c000000000000000000000000000000000ffff"),
+        to: BOB,
+        amount: 1,
+        memo: B256::ZERO,
+        gasLimit: 0,
+        fallbackRecipient: ALICE,
+        data: Bytes::new(),
+        revealTo: Bytes::new(),
+    });
+    assert_revert(result, TIP20Error::invalid_token());
+    assert!(
+        harness.l1.storage_requests().is_empty(),
+        "unknown tokens must be rejected before portal reads"
+    );
     Ok(())
 }
 

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -5,9 +5,7 @@ use alloy_primitives::{Bytes, address};
 use alloy_sol_types::{SolCall, SolInterface};
 use revm::precompile::PrecompileResult;
 use tempo_precompiles::{storage::FromWord, test_util::TIP20Setup};
-use tempo_zone_contracts::{
-    ILegacyZoneOutbox, IZoneOutbox as ZoneOutboxAbi, portal_token_config_slot,
-};
+use tempo_zone_contracts::{ILegacyZoneOutbox, IZoneOutbox as ZoneOutboxAbi};
 
 use crate::{
     create_outbox_precompile,
@@ -44,13 +42,6 @@ impl Harness {
             ANCHOR,
             SEQUENCER.to_word(),
         );
-        l1.insert(
-            PORTAL,
-            portal_token_config_slot(token).into(),
-            ANCHOR,
-            U256::ONE,
-        );
-
         {
             let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
             StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
@@ -111,16 +102,6 @@ impl Harness {
 
     fn call_static(&mut self, caller: Address, data: impl AsRef<[u8]>) -> PrecompileResult {
         self.call_inner(caller, caller, data, false, true)
-    }
-
-    fn set_token_enabled(&mut self, enabled: bool) -> eyre::Result<()> {
-        self.l1.insert(
-            PORTAL,
-            portal_token_config_slot(self.token).into(),
-            ANCHOR,
-            if enabled { U256::ONE } else { U256::ZERO },
-        );
-        Ok(())
     }
 
     fn pending(&mut self) -> eyre::Result<Vec<ZoneOutboxAbi::PendingWithdrawal>> {
@@ -250,20 +231,8 @@ fn outbox_reads_injected_l1_state_at_tempo_checkpoint() -> eyre::Result<()> {
 
     assert_eq!(
         harness.l1.storage_requests(),
-        vec![
-            (PORTAL, PORTAL_SEQUENCER_SLOT, ANCHOR),
-            (PORTAL, portal_token_config_slot(harness.token), ANCHOR,),
-        ]
+        vec![(PORTAL, PORTAL_SEQUENCER_SLOT, ANCHOR),]
     );
-    Ok(())
-}
-
-#[test]
-fn request_withdrawal_rejects_disabled_token() -> eyre::Result<()> {
-    let mut harness = Harness::new()?;
-    harness.set_token_enabled(false)?;
-    let result = harness.request(1, BOB, B256::ZERO);
-    assert_revert(result, ZonePortalError::token_not_enabled());
     Ok(())
 }
 
@@ -306,7 +275,7 @@ fn request_withdrawal_rejects_unknown_token_before_portal_read() -> eyre::Result
         data: Bytes::new(),
         revealTo: Bytes::new(),
     });
-    assert_revert(result, TIP20Error::invalid_token());
+    assert_revert(result, TIP20Error::uninitialized());
     assert!(
         harness.l1.storage_requests().is_empty(),
         "unknown tokens must be rejected before portal reads"

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -671,7 +671,6 @@ fn malformed_legacy_withdrawal_reverts_with_empty_data() -> eyre::Result<()> {
 #[test]
 fn static_mutation_reverts_with_static_call_not_allowed() -> eyre::Result<()> {
     let mut harness = Harness::new()?;
-    harness.set_token_enabled(false)?;
     let token = harness.token;
     assert_revert(
         harness.call_static(


### PR DESCRIPTION
## Summary
- reject missing transaction context before any L1 storage access
- require the withdrawal token to be initialized on L2 before processing
- remove the redundant per-withdrawal L1 portal token-enabled read
- assert missing-context and uninitialized-token paths perform zero L1 reads

Addresses https://github.com/tempoxyz/zones/pull/753#discussion_r3626397129

## Validation
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-precompiles outbox --lib` *(blocked before compilation: GitHub returned HTTP 401 while fetching `alloy-evm`)*

Prompted by: @0xrusowsky