### PR TITLE
chore(ci): shard nextest execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  test:
-    name: test
+  build-test-artifacts:
+    name: build test artifacts
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 30
     permissions:
@@ -42,10 +42,52 @@ jobs:
       - name: Build Solidity artifacts
         working-directory: specs/ref-impls
         run: forge build
-      - name: Build and compile tests
-        run: cargo nextest run --profile ci --no-run
-      - name: Run tests
-        run: cargo nextest run --profile ci
+      - name: Build and archive tests
+        run: cargo nextest archive --profile ci --archive-file nextest-archive.tar.zst
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nextest-archive
+          path: |
+            nextest-archive.tar.zst
+            specs/ref-impls/out
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  test:
+    name: test (${{ matrix.partition }}/2)
+    runs-on: depot-ubuntu-latest-16
+    needs: build-test-artifacts
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Prepare nextest install directory
+        run: mkdir -p "$HOME/.cargo/bin"
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: nextest@0.9.124
+      - name: Download test artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nextest-archive
+          path: .
+      - name: Run test shard
+        run: |
+          cargo-nextest nextest run \
+            --archive-file nextest-archive.tar.zst \
+            --workspace-remap "$GITHUB_WORKSPACE" \
+            --profile ci \
+            --partition hash:${{ matrix.partition }}/2
 
   test-success:
     name: test success
@@ -53,6 +95,7 @@ jobs:
     if: always()
     permissions: {}
     needs:
+      - build-test-artifacts
       - test
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

- build the nextest archive once
- run two deterministic hash shards in parallel
- keep Rust, Solidity, and Docker caching unchanged so timing isolates sharding

## Measurement

Compared successful runs on the same `depot-ubuntu-latest-16` runner class:

- Existing CI ([run 29887932546](https://github.com/tempoxyz/zones/actions/runs/29887932546)): test 7m49s; required gate 7m52s end to end
- This PR ([run 29890201067](https://github.com/tempoxyz/zones/actions/runs/29890201067)): build/archive 5m31s; shards 2m54s / 2m39s; required gate 8m33s end to end
- Result: sharding alone is 41s slower (8.7%) end to end

The parallel test phase is shorter, but archive upload/download and provisioning two runners outweigh that gain.

Prompted by: @0xalpharush