### PR TITLE
fix(node): disable EIP-7702 at the txpool

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -951,6 +951,7 @@ where
                 .disable_balance_check()
                 .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
                 .with_custom_tx_type(TempoTxType::AA as u8)
+                .no_eip7702()
                 .no_eip4844()
                 .build::<TempoPooledTransaction, _>(blob_store.clone());
 


### PR DESCRIPTION
## Summary

- disable EIP-7702 transactions through the existing Reth txpool validator setting
- keep Zone EVM validation unchanged

This supersedes the approach in #762. Calling `no_eip7702()` rejects type-`0x04` transactions during stateless txpool admission, before they can enter or propagate through the pool. That is the appropriate layer for a node transaction-acceptance policy and avoids turning the restriction into an execution/consensus rule in the shared Zone EVM validator.

Checked with `cargo +nightly fmt --all -- --check`, `cargo test -p zone-node --lib`, and `git diff --check`.