### PR TITLE
refactor(l1): bound versioned state cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13458,6 +13458,7 @@ dependencies = [
  "reth-provider",
  "reth-storage-api",
  "reth-tasks",
+ "schnellru",
  "serde",
  "serde_json",
  "tempo-alloy",

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -45,6 +45,7 @@ futures.workspace = true
 k256.workspace = true
 metrics.workspace = true
 parking_lot.workspace = true
+schnellru.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -169,7 +169,7 @@ impl L1StateCacheInner {
     }
 
     /// Clears cached state and establishes a new contiguous receipt-coverage baseline.
-    pub fn reset(&mut self, floor: u64) {
+    fn reset(&mut self, floor: u64) {
         self.slots.clear();
         self.invalidations.clear();
         self.invalidation_count = 0;

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -121,16 +121,28 @@ impl L1StateCacheInner {
             .get(&(address, slot))?
             .range(..=block_number)
             .next_back()?;
-        let invalidated = self
+
+        // On exact match, just return the value
+        if cached_block == block_number {
+            return Some(value);
+        }
+
+        // If we didn't yet process the requested block, we can't use the cached value
+        if block_number > *self.coverage.end() {
+            return None;
+        }
+
+        // If there was an invalidation between cached and requested block, we can't use the cached value
+        if self
             .invalidations
             .get(&address)
             .and_then(|blocks| blocks.range(..=block_number).next_back())
-            .is_some_and(|&invalidated_at| invalidated_at > cached_block);
+            .is_some_and(|&invalidated_at| invalidated_at > cached_block)
+        {
+            return None;
+        }
 
-        let is_exact = cached_block == block_number;
-        let can_inherit = block_number <= *self.coverage.end() && !invalidated;
-        let is_cache_valid = cached_block >= *self.coverage.start() && (is_exact || can_inherit);
-        is_cache_valid.then_some(value)
+        Some(value)
     }
 
     /// Sets a storage slot value in the forward cache at the given block number.
@@ -156,44 +168,53 @@ impl L1StateCacheInner {
         debug_assert!(inserted, "trimmed slot history must fit cache capacity");
     }
 
-    /// Prevents values populated before the current contiguous receipt-coverage baseline from
-    /// entering the forward cache. Initialized at startup and rebased after a coverage reset.
-    pub fn initialize_floor(&mut self, block_number: u64) {
-        let floor = (*self.coverage.start()).max(block_number);
-        self.coverage = floor..=*self.coverage.end();
+    /// Clears cached state and establishes a new contiguous receipt-coverage baseline.
+    pub fn reset(&mut self, floor: u64) {
+        self.slots.clear();
+        self.invalidations.clear();
+        self.invalidation_count = 0;
+        self.coverage = floor..=floor;
     }
 
-    /// Returns the non-advancing cache floor.
-    pub fn block_floor(&self) -> u64 {
-        *self.coverage.start()
-    }
-
-    /// Invalidates inherited values for `address` starting at `block_number`.
-    pub fn invalidate(&mut self, address: Address, block_number: u64) {
-        let inserted = self
-            .invalidations
-            .entry(address)
-            .or_default()
-            .insert(block_number);
-        self.invalidation_count += usize::from(inserted);
-
-        if self.invalidation_count > self.max_invalidations {
+    /// Records mutation barriers and publishes receipt coverage for one finalized block.
+    ///
+    /// Coverage only advances one block at a time. A duplicate, skipped, or out-of-order block
+    /// invalidates the cache's continuity assumptions, so cached state is cleared and `anchor`
+    /// becomes the new coverage floor.
+    pub fn invalidate_and_set_anchor(
+        &mut self,
+        anchor: u64,
+        invalidated_addresses: impl IntoIterator<Item = Address>,
+    ) {
+        if self.coverage.end().checked_add(1) != Some(anchor) {
             warn!(
-                block_number,
-                invalidation_capacity = self.max_invalidations,
-                "L1 state invalidation capacity reached; resetting cache coverage"
+                anchor,
+                previous_anchor = *self.coverage.end(),
+                "Non-contiguous L1 state cache update; resetting cache coverage"
             );
-            // The subscriber publishes this block's coverage after recording all of its barriers.
-            // Clearing here is safe because values below this block become inadmissible.
-            self.slots.clear();
-            self.invalidations.clear();
-            self.invalidation_count = 0;
-            self.initialize_floor(block_number);
+            self.reset(anchor);
+            return;
         }
-    }
 
-    /// Updates the latest contiguous block whose receipts have been processed.
-    pub fn update_anchor(&mut self, anchor: u64) {
+        for address in invalidated_addresses {
+            let inserted = self
+                .invalidations
+                .entry(address)
+                .or_default()
+                .insert(anchor);
+            self.invalidation_count += usize::from(inserted);
+
+            if self.invalidation_count > self.max_invalidations {
+                warn!(
+                    anchor,
+                    invalidation_capacity = self.max_invalidations,
+                    "L1 state invalidation capacity reached; resetting cache coverage"
+                );
+                self.reset(anchor);
+                return;
+            }
+        }
+
         self.coverage = *self.coverage.start()..=anchor;
     }
 
@@ -286,7 +307,9 @@ mod tests {
     const PORTAL: Address = address!("0x0000000000000000000000000000000000004242");
 
     fn cover_through(cache: &mut L1StateCacheInner, block_number: u64) {
-        cache.update_anchor(block_number);
+        while cache.anchor() < block_number {
+            cache.invalidate_and_set_anchor(cache.anchor() + 1, []);
+        }
     }
 
     #[test]
@@ -360,7 +383,8 @@ mod tests {
         let old = B256::with_last_byte(0x0a);
         let new = B256::with_last_byte(0x0b);
         cache.set(PORTAL, slot, 10, old);
-        cache.invalidate(PORTAL, 11);
+        cover_through(&mut cache, 10);
+        cache.invalidate_and_set_anchor(11, [PORTAL]);
         cover_through(&mut cache, 12);
 
         assert_eq!(cache.get(PORTAL, slot, 11), None);
@@ -375,7 +399,7 @@ mod tests {
     fn floor_rejects_historical_cache_admission() {
         let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
-        cache.initialize_floor(10);
+        cache.reset(10);
         cache.set(PORTAL, slot, 9, B256::with_last_byte(9));
         cover_through(&mut cache, 11);
 
@@ -394,10 +418,24 @@ mod tests {
     }
 
     #[test]
-    fn update_anchor() {
+    fn contiguous_update_advances_anchor() {
         let mut cache = L1StateCacheInner::new();
-        cache.update_anchor(42);
-        assert_eq!(cache.anchor(), 42);
+        cache.invalidate_and_set_anchor(1, []);
+        assert_eq!(cache.anchor(), 1);
+    }
+
+    #[test]
+    fn non_contiguous_update_resets_cache_at_new_floor() {
+        let mut cache = L1StateCacheInner::new();
+        let slot = B256::with_last_byte(1);
+        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
+
+        cache.invalidate_and_set_anchor(10, [PORTAL]);
+
+        assert_eq!(cache.anchor(), 10);
+        assert_eq!(*cache.coverage.start(), 10);
+        assert!(cache.invalidations.is_empty());
+        assert_eq!(cache.get(PORTAL, slot, 10), None);
     }
 
     #[test]
@@ -502,14 +540,12 @@ mod tests {
         let mut cache = L1StateCacheInner::with_limits(10, 1);
         let slot = B256::with_last_byte(1);
 
-        cache.initialize_floor(10);
+        cache.reset(10);
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
-        cache.invalidate(PORTAL, 11);
-        cover_through(&mut cache, 11);
-        cache.invalidate(PORTAL, 12);
-        cover_through(&mut cache, 12);
+        cache.invalidate_and_set_anchor(11, [PORTAL]);
+        cache.invalidate_and_set_anchor(12, [PORTAL]);
 
-        assert_eq!(cache.block_floor(), 12);
+        assert_eq!(*cache.coverage.start(), 12);
         assert_eq!(cache.invalidation_count, 0);
         assert!(cache.invalidations.is_empty());
         assert_eq!(cache.get(PORTAL, slot, 10), None);

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -21,7 +21,7 @@
 
 use alloy_primitives::{Address, B256};
 use derive_more::Deref;
-use parking_lot::RwLock;
+use parking_lot::Mutex;
 use schnellru::{Limiter, LruMap};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -43,14 +43,14 @@ const DEFAULT_INVALIDATION_CAPACITY: usize = 100_000;
 #[derive(Debug, Clone, Deref, Default)]
 pub struct L1StateCache {
     #[deref]
-    inner: Arc<RwLock<L1StateCacheInner>>,
+    inner: Arc<Mutex<L1StateCacheInner>>,
 }
 
 impl L1StateCache {
     /// Create an empty cache.
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(L1StateCacheInner::new())),
+            inner: Arc::new(Mutex::new(L1StateCacheInner::new())),
         }
     }
 }

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -1,4 +1,4 @@
-//! Block-versioned in-memory cache of Tempo L1 contract storage slots.
+//! Bounded block-versioned cache of Tempo L1 contract storage slots.
 //!
 //! The zone's `TempoState` precompile reads Tempo L1 storage at a **specific L1 block height**
 //! (the `tempoBlockNumber` the zone committed to via `TempoState.finalizeTempo()` on Zone L2).
@@ -8,29 +8,43 @@
 //! ## Storage model
 //!
 //! Each `(contract_address, slot_key)` pair maps to a [`BTreeMap<u64, B256>`] of
-//! `block_number → value`. A lookup for block N may inherit the most recent earlier value only
-//! when verified receipt coverage and mutation barriers prove that it remained current.
+//! `block_number → value`. Slot histories live in a weighted LRU whose capacity is measured in
+//! versions, with an additional per-slot version limit so LRU eviction cannot discard an
+//! arbitrarily large history at once. A lookup for block N may inherit the most recent earlier
+//! value only when verified receipt coverage and mutation barriers prove that it remained current.
 //!
 //! ## Write path
 //!
-//! - The [`L1Subscriber`](crate::l1::L1Subscriber) writes storage diffs for tracked contracts
-//!   as they arrive, tagged with the L1 tip block number.
+//! - The [`L1Subscriber`](crate::l1::L1Subscriber) records mutation barriers from finalized L1
+//!   receipts.
 //! - The [`L1StateProvider`](super::provider::L1StateProvider) writes RPC-fetched values on
 //!   cache miss, tagged with the block number that was requested.
 //!
-//! ## Reorg handling
+//! ## Capacity handling
 //!
-//! On reorgs the caller is expected to [`L1StateCacheInner::clear`] the entire cache and
-//! re-populate from the new canonical chain segment. There is no per-block rollback.
+//! Slot histories are evicted least-recently-used when their combined version count exceeds the
+//! configured capacity. Mutation barriers have a separate bound; reaching it resets the value and
+//! barrier caches at the current finalized block rather than retaining an unbounded history.
 
-use alloy_eips::NumHash;
 use alloy_primitives::{Address, B256};
 use derive_more::Deref;
 use parking_lot::RwLock;
+use schnellru::{Limiter, LruMap};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
+    ops::RangeInclusive,
     sync::Arc,
 };
+use tracing::warn;
+
+/// Maximum total number of block-versioned values retained by the L1 state cache.
+const DEFAULT_VERSION_CAPACITY: usize = 100_000;
+
+/// Maximum number of block-versioned values retained for any individual storage slot.
+const MAX_VERSIONS_PER_SLOT: usize = 1_000;
+
+/// Maximum number of mutation barriers retained before conservatively resetting the cache.
+const DEFAULT_INVALIDATION_CAPACITY: usize = 100_000;
 
 /// Thread-safe L1 state cache backed by an `Arc<RwLock<L1StateCacheInner>>`.
 #[derive(Debug, Clone, Deref, Default)]
@@ -41,9 +55,9 @@ pub struct L1StateCache {
 
 impl L1StateCache {
     /// Create a new cache tracking the given contract addresses.
-    pub fn new(tracked_contracts: HashSet<Address>) -> Self {
+    pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(L1StateCacheInner::new(tracked_contracts))),
+            inner: Arc::new(RwLock::new(L1StateCacheInner::new())),
         }
     }
 }
@@ -59,29 +73,40 @@ impl L1StateCache {
 /// and no log from the owning contract indicates a possible mutation. The non-advancing floor
 /// excludes historical reads from before the subscriber's contiguous observation range.
 ///
-/// The anchor tracks the latest L1 block whose receipts the
-/// [`L1Subscriber`](crate::l1::L1Subscriber) has processed, and is also used for reorg detection.
-#[derive(Debug, Default)]
+/// The coverage end tracks the latest finalized L1 block whose receipts the
+/// [`L1Subscriber`](crate::l1::L1Subscriber) has processed.
+#[derive(Debug)]
 pub struct L1StateCacheInner {
-    tracked_contracts: HashSet<Address>,
-    /// Per-slot value history: `(address, slot) → { block_number → value }`.
-    /// The `BTreeMap` enables efficient range lookups for "latest value at or before block N".
-    slots: HashMap<(Address, B256), BTreeMap<u64, B256>>,
+    /// Bounded per-slot value histories, promoted as a unit on access.
+    slots: LruMap<(Address, B256), BTreeMap<u64, B256>, ByVersionCount>,
     /// Per-address mutation barriers. A value at V cannot serve a read at N when a barrier exists
     /// in `(V, N]`.
     invalidations: HashMap<Address, BTreeSet<u64>>,
-    /// Initial canonical Zone L1 anchor. Values below it are never admitted to the forward cache.
-    block_floor: u64,
-    /// Latest contiguous L1 block whose receipts the subscriber has processed.
-    anchor: NumHash,
+    invalidation_count: usize,
+    max_invalidations: usize,
+    /// Contiguous receipt coverage: earliest usable value height through latest processed block.
+    coverage: RangeInclusive<u64>,
+}
+
+impl Default for L1StateCacheInner {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl L1StateCacheInner {
     /// Create a new cache tracking the given contract addresses.
-    pub fn new(tracked_contracts: HashSet<Address>) -> Self {
+    pub fn new() -> Self {
+        Self::with_limits(DEFAULT_VERSION_CAPACITY, DEFAULT_INVALIDATION_CAPACITY)
+    }
+
+    fn with_limits(max_versions: usize, max_invalidations: usize) -> Self {
         Self {
-            tracked_contracts,
-            ..Default::default()
+            slots: LruMap::new(ByVersionCount::new(max_versions)),
+            invalidations: HashMap::new(),
+            invalidation_count: 0,
+            max_invalidations,
+            coverage: 0..=0,
         }
     }
 
@@ -90,7 +115,7 @@ impl L1StateCacheInner {
     /// An exact-height value is always valid. A value inherited from an earlier height is returned
     /// only when the subscriber has processed receipts through `block_number` and no mutation
     /// barrier exists after the value was populated.
-    pub fn get(&self, address: Address, slot: B256, block_number: u64) -> Option<B256> {
+    pub fn get(&mut self, address: Address, slot: B256, block_number: u64) -> Option<B256> {
         let (&cached_block, &value) = self
             .slots
             .get(&(address, slot))?
@@ -103,8 +128,8 @@ impl L1StateCacheInner {
             .is_some_and(|&invalidated_at| invalidated_at > cached_block);
 
         let is_exact = cached_block == block_number;
-        let can_inherit = block_number <= self.anchor.number && !invalidated;
-        let is_cache_valid = cached_block >= self.block_floor && (is_exact || can_inherit);
+        let can_inherit = block_number <= *self.coverage.end() && !invalidated;
+        let is_cache_valid = cached_block >= *self.coverage.start() && (is_exact || can_inherit);
         is_cache_valid.then_some(value)
     }
 
@@ -113,68 +138,143 @@ impl L1StateCacheInner {
     /// Values below the initial canonical floor are deliberately not admitted, so historical
     /// reads cannot later be inherited by canonical execution.
     pub fn set(&mut self, address: Address, slot: B256, block_number: u64, value: B256) {
-        if block_number < self.block_floor {
+        if block_number < *self.coverage.start() {
             return;
         }
-        self.slots
-            .entry((address, slot))
-            .or_default()
-            .insert(block_number, value);
+
+        let key = (address, slot);
+        let mut history = self.slots.remove(&key).unwrap_or_default();
+        history.insert(block_number, value);
+
+        // Bound eviction granularity and prevent one hot slot from monopolizing the cache.
+        let max_history = MAX_VERSIONS_PER_SLOT.min(self.slots.limiter().max_versions());
+        while history.len() > max_history {
+            history.pop_first();
+        }
+
+        let inserted = self.slots.insert(key, history);
+        debug_assert!(inserted, "trimmed slot history must fit cache capacity");
     }
 
     /// Prevents values populated before the current contiguous receipt-coverage baseline from
     /// entering the forward cache. Initialized at startup and rebased after a coverage reset.
     pub fn initialize_floor(&mut self, block_number: u64) {
-        self.block_floor = self.block_floor.max(block_number);
+        let floor = (*self.coverage.start()).max(block_number);
+        self.coverage = floor..=*self.coverage.end();
     }
 
     /// Returns the non-advancing cache floor.
-    pub const fn block_floor(&self) -> u64 {
-        self.block_floor
+    pub fn block_floor(&self) -> u64 {
+        *self.coverage.start()
     }
 
     /// Invalidates inherited values for `address` starting at `block_number`.
     pub fn invalidate(&mut self, address: Address, block_number: u64) {
-        self.invalidations
+        let inserted = self
+            .invalidations
             .entry(address)
             .or_default()
             .insert(block_number);
+        self.invalidation_count += usize::from(inserted);
+
+        if self.invalidation_count > self.max_invalidations {
+            warn!(
+                block_number,
+                invalidation_capacity = self.max_invalidations,
+                "L1 state invalidation capacity reached; resetting cache coverage"
+            );
+            // The subscriber publishes this block's coverage after recording all of its barriers.
+            // Clearing here is safe because values below this block become inadmissible.
+            self.slots.clear();
+            self.invalidations.clear();
+            self.invalidation_count = 0;
+            self.initialize_floor(block_number);
+        }
     }
 
     /// Updates the latest contiguous block whose receipts have been processed.
-    pub fn update_anchor(&mut self, anchor: NumHash) {
-        self.anchor = anchor;
+    pub fn update_anchor(&mut self, anchor: u64) {
+        self.coverage = *self.coverage.start()..=anchor;
     }
 
-    /// Returns `true` if the given address is one of the tracked contracts.
-    pub fn is_tracked(&self, address: &Address) -> bool {
-        self.tracked_contracts.contains(address)
+    /// Returns the current anchor block.
+    pub fn anchor(&self) -> u64 {
+        *self.coverage.end()
     }
+}
 
-    /// Clears chain-derived data while retaining the tracked-contract set and initial floor.
-    pub fn clear(&mut self) {
-        self.slots.clear();
-        self.invalidations.clear();
-        self.anchor = NumHash::default();
-    }
+/// [`schnellru`] limiter which measures capacity by the number of versions in all slot histories.
+#[derive(Debug, Clone)]
+struct ByVersionCount {
+    max_versions: usize,
+    versions: usize,
+}
 
-    /// Remove all entries with block numbers strictly less than `min_block`.
-    ///
-    /// Retains at most one entry per slot below the threshold — the latest one — so that
-    /// lookups at `min_block` still have a baseline value.
-    pub fn prune_before(&mut self, min_block: u64) {
-        for history in self.slots.values_mut() {
-            let keep_from = history.range(..min_block).next_back().map(|(k, _)| *k);
-
-            if let Some(keep) = keep_from {
-                let to_remove: Vec<u64> = history.range(..keep).map(|(k, _)| *k).collect();
-                for k in to_remove {
-                    history.remove(&k);
-                }
-            }
+impl ByVersionCount {
+    fn new(max_versions: usize) -> Self {
+        assert!(max_versions > 0, "L1 state cache capacity must be non-zero");
+        Self {
+            max_versions,
+            versions: 0,
         }
+    }
 
-        self.slots.retain(|_, history| !history.is_empty());
+    const fn max_versions(&self) -> usize {
+        self.max_versions
+    }
+
+    #[cfg(test)]
+    const fn versions(&self) -> usize {
+        self.versions
+    }
+}
+
+impl<K> Limiter<K, BTreeMap<u64, B256>> for ByVersionCount {
+    type KeyToInsert<'a> = K;
+    type LinkType = u32;
+
+    fn is_over_the_limit(&self, _length: usize) -> bool {
+        self.versions > self.max_versions
+    }
+
+    fn on_insert(
+        &mut self,
+        _length: usize,
+        key: Self::KeyToInsert<'_>,
+        value: BTreeMap<u64, B256>,
+    ) -> Option<(K, BTreeMap<u64, B256>)> {
+        if value.len() > self.max_versions {
+            return None;
+        }
+        self.versions += value.len();
+        Some((key, value))
+    }
+
+    fn on_replace(
+        &mut self,
+        _length: usize,
+        _old_key: &mut K,
+        _new_key: Self::KeyToInsert<'_>,
+        old_value: &mut BTreeMap<u64, B256>,
+        new_value: &mut BTreeMap<u64, B256>,
+    ) -> bool {
+        if new_value.len() > self.max_versions {
+            return false;
+        }
+        self.versions = self.versions - old_value.len() + new_value.len();
+        true
+    }
+
+    fn on_removed(&mut self, _key: &mut K, value: &mut BTreeMap<u64, B256>) {
+        self.versions -= value.len();
+    }
+
+    fn on_cleared(&mut self) {
+        self.versions = 0;
+    }
+
+    fn on_grow(&mut self, _new_memory_usage: usize) -> bool {
+        true
     }
 }
 
@@ -186,18 +286,18 @@ mod tests {
     const PORTAL: Address = address!("0x0000000000000000000000000000000000004242");
 
     fn cover_through(cache: &mut L1StateCacheInner, block_number: u64) {
-        cache.update_anchor(NumHash::new(block_number, B256::with_last_byte(1)));
+        cache.update_anchor(block_number);
     }
 
     #[test]
     fn get_returns_none_for_missing_slot() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         assert_eq!(cache.get(PORTAL, B256::ZERO, 100), None);
     }
 
     #[test]
     fn set_and_get_at_same_block() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         let value = B256::with_last_byte(0xff);
 
@@ -207,7 +307,7 @@ mod tests {
 
     #[test]
     fn get_returns_latest_value_at_or_before_requested_block() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
@@ -234,7 +334,7 @@ mod tests {
 
     #[test]
     fn get_returns_none_before_earliest_entry() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0xff));
@@ -243,7 +343,7 @@ mod tests {
 
     #[test]
     fn inherited_value_requires_receipt_coverage() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         let value = B256::with_last_byte(0x0a);
         cache.set(PORTAL, slot, 10, value);
@@ -255,7 +355,7 @@ mod tests {
 
     #[test]
     fn invalidation_blocks_inheritance_until_refetched() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         let old = B256::with_last_byte(0x0a);
         let new = B256::with_last_byte(0x0b);
@@ -273,7 +373,7 @@ mod tests {
 
     #[test]
     fn floor_rejects_historical_cache_admission() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         cache.initialize_floor(10);
         cache.set(PORTAL, slot, 9, B256::with_last_byte(9));
@@ -288,54 +388,21 @@ mod tests {
     }
 
     #[test]
-    fn clear_removes_chain_data_and_preserves_floor() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-
-        cache.initialize_floor(90);
-        cache.set(PORTAL, B256::ZERO, 100, B256::with_last_byte(1));
-        cache.invalidate(PORTAL, 101);
-        cache.update_anchor(NumHash {
-            number: 100,
-            hash: B256::with_last_byte(0xab),
-        });
-
-        cache.clear();
-
-        assert_eq!(cache.get(PORTAL, B256::ZERO, 100), None);
-        assert!(cache.invalidations.is_empty());
-        assert_eq!(cache.anchor, NumHash::default());
-        assert_eq!(cache.block_floor(), 90);
-    }
-
-    #[test]
     fn anchor_defaults_to_zero() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        assert_eq!(cache.anchor, NumHash::default());
+        let cache = L1StateCacheInner::new();
+        assert_eq!(cache.anchor(), 0);
     }
 
     #[test]
     fn update_anchor() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        let hash = B256::with_last_byte(0xbe);
-        cache.update_anchor(NumHash { number: 42, hash });
-        assert_eq!(cache.anchor, NumHash { number: 42, hash });
-    }
-
-    #[test]
-    fn is_tracked_returns_true_for_portal() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        assert!(cache.is_tracked(&PORTAL));
-    }
-
-    #[test]
-    fn is_tracked_returns_false_for_unknown_address() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        assert!(!cache.is_tracked(&address!("0x0000000000000000000000000000000000000001")));
+        let mut cache = L1StateCacheInner::new();
+        cache.update_anchor(42);
+        assert_eq!(cache.anchor(), 42);
     }
 
     #[test]
     fn different_addresses_same_slot_are_independent() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let addr_b = address!("0x0000000000000000000000000000000000004343");
         let slot = B256::with_last_byte(1);
 
@@ -353,29 +420,108 @@ mod tests {
     }
 
     #[test]
-    fn prune_keeps_baseline_entry() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        let slot = B256::with_last_byte(1);
+    fn lru_evicts_the_least_recently_used_slot_history_by_version_weight() {
+        let mut cache = L1StateCacheInner::with_limits(3, 10);
+        let slot_a = B256::with_last_byte(1);
+        let slot_b = B256::with_last_byte(2);
+        let slot_c = B256::with_last_byte(3);
 
-        cache.set(PORTAL, slot, 5, B256::with_last_byte(0x05));
-        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
-        cache.set(PORTAL, slot, 20, B256::with_last_byte(0x14));
+        cache.set(PORTAL, slot_a, 10, B256::with_last_byte(0x0a));
+        cache.set(PORTAL, slot_b, 10, B256::with_last_byte(0x0b));
         cover_through(&mut cache, 20);
 
-        cache.prune_before(15);
+        // Keep A hot, then insert a two-version history for C. B is the oldest history and is
+        // evicted to keep the total version count at three.
+        assert_eq!(
+            cache.get(PORTAL, slot_a, 20),
+            Some(B256::with_last_byte(0x0a))
+        );
+        cache.set(PORTAL, slot_c, 10, B256::with_last_byte(0x0c));
+        cache.set(PORTAL, slot_c, 20, B256::with_last_byte(0x1c));
 
-        assert_eq!(cache.get(PORTAL, slot, 5), None);
+        assert_eq!(cache.slots.limiter().versions(), 3);
+        assert_eq!(cache.get(PORTAL, slot_b, 20), None);
         assert_eq!(
-            cache.get(PORTAL, slot, 10),
+            cache.get(PORTAL, slot_a, 20),
             Some(B256::with_last_byte(0x0a))
         );
         assert_eq!(
-            cache.get(PORTAL, slot, 15),
-            Some(B256::with_last_byte(0x0a))
+            cache.get(PORTAL, slot_c, 20),
+            Some(B256::with_last_byte(0x1c))
         );
+    }
+
+    #[test]
+    fn a_single_slot_history_cannot_exceed_the_version_capacity() {
+        let mut cache = L1StateCacheInner::with_limits(2, 10);
+        let slot = B256::with_last_byte(1);
+
+        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
+        cache.set(PORTAL, slot, 20, B256::with_last_byte(0x14));
+        cache.set(PORTAL, slot, 30, B256::with_last_byte(0x1e));
+        cover_through(&mut cache, 30);
+
+        assert_eq!(cache.slots.limiter().versions(), 2);
+        assert_eq!(cache.get(PORTAL, slot, 10), None);
         assert_eq!(
             cache.get(PORTAL, slot, 20),
             Some(B256::with_last_byte(0x14))
+        );
+        assert_eq!(
+            cache.get(PORTAL, slot, 30),
+            Some(B256::with_last_byte(0x1e))
+        );
+    }
+
+    #[test]
+    fn slot_history_retains_only_the_newest_versions() {
+        let mut cache = L1StateCacheInner::with_limits(MAX_VERSIONS_PER_SLOT + 1, 10);
+        let slot = B256::with_last_byte(1);
+
+        for block_number in 0..=MAX_VERSIONS_PER_SLOT as u64 {
+            cache.set(
+                PORTAL,
+                slot,
+                block_number,
+                B256::with_last_byte((block_number % 256) as u8),
+            );
+        }
+        cover_through(&mut cache, MAX_VERSIONS_PER_SLOT as u64);
+
+        assert_eq!(cache.slots.limiter().versions(), MAX_VERSIONS_PER_SLOT);
+        assert_eq!(cache.get(PORTAL, slot, 0), None);
+        assert_eq!(cache.get(PORTAL, slot, 1), Some(B256::with_last_byte(1)));
+        assert_eq!(
+            cache.get(PORTAL, slot, MAX_VERSIONS_PER_SLOT as u64),
+            Some(B256::with_last_byte((MAX_VERSIONS_PER_SLOT % 256) as u8))
+        );
+    }
+
+    #[test]
+    fn invalidation_capacity_resets_cache_at_the_new_coverage_floor() {
+        let mut cache = L1StateCacheInner::with_limits(10, 1);
+        let slot = B256::with_last_byte(1);
+
+        cache.initialize_floor(10);
+        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
+        cache.invalidate(PORTAL, 11);
+        cover_through(&mut cache, 11);
+        cache.invalidate(PORTAL, 12);
+        cover_through(&mut cache, 12);
+
+        assert_eq!(cache.block_floor(), 12);
+        assert_eq!(cache.invalidation_count, 0);
+        assert!(cache.invalidations.is_empty());
+        assert_eq!(cache.get(PORTAL, slot, 10), None);
+
+        cache.set(PORTAL, slot, 11, B256::with_last_byte(0x0b));
+        assert_eq!(cache.get(PORTAL, slot, 11), None);
+
+        cache.set(PORTAL, slot, 12, B256::with_last_byte(0x0c));
+        cover_through(&mut cache, 13);
+        assert_eq!(
+            cache.get(PORTAL, slot, 13),
+            Some(B256::with_last_byte(0x0c))
         );
     }
 }

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -1,4 +1,4 @@
-//! Bounded block-versioned cache of Tempo L1 contract storage slots.
+//! Block-versioned in-memory cache of Tempo L1 contract storage slots.
 //!
 //! The zone's `TempoState` precompile reads Tempo L1 storage at a **specific L1 block height**
 //! (the `tempoBlockNumber` the zone committed to via `TempoState.finalizeTempo()` on Zone L2).
@@ -8,10 +8,9 @@
 //! ## Storage model
 //!
 //! Each `(contract_address, slot_key)` pair maps to a [`BTreeMap<u64, B256>`] of
-//! `block_number → value`. Slot histories live in a weighted LRU whose capacity is measured in
-//! versions, with an additional per-slot version limit so LRU eviction cannot discard an
-//! arbitrarily large history at once. A lookup for block N may inherit the most recent earlier
-//! value only when verified receipt coverage and mutation barriers prove that it remained current.
+//! `block_number → value`. Slot histories are bounded by both a weighted LRU and a per-slot limit.
+//! A lookup for block N may inherit the most recent earlier value only when verified receipt
+//! coverage and mutation barriers prove that it remained current.
 //!
 //! ## Write path
 //!
@@ -19,12 +18,6 @@
 //!   receipts.
 //! - The [`L1StateProvider`](super::provider::L1StateProvider) writes RPC-fetched values on
 //!   cache miss, tagged with the block number that was requested.
-//!
-//! ## Capacity handling
-//!
-//! Slot histories are evicted least-recently-used when their combined version count exceeds the
-//! configured capacity. Mutation barriers have a separate bound; reaching it resets the value and
-//! barrier caches at the current finalized block rather than retaining an unbounded history.
 
 use alloy_primitives::{Address, B256};
 use derive_more::Deref;
@@ -54,7 +47,7 @@ pub struct L1StateCache {
 }
 
 impl L1StateCache {
-    /// Create a new cache tracking the given contract addresses.
+    /// Create an empty cache.
     pub fn new() -> Self {
         Self {
             inner: Arc::new(RwLock::new(L1StateCacheInner::new())),
@@ -70,19 +63,17 @@ impl L1StateCache {
 /// the `tempoBlockNumber` it committed to, even if the L1 chain has since advanced.
 ///
 /// Inherited values are valid only when the subscriber has processed every intervening L1 block
-/// and no log from the owning contract indicates a possible mutation. The non-advancing floor
-/// excludes historical reads from before the subscriber's contiguous observation range.
-///
-/// The coverage end tracks the latest finalized L1 block whose receipts the
-/// [`L1Subscriber`](crate::l1::L1Subscriber) has processed.
+/// and no log from the owning contract indicates a possible mutation. The coverage range starts
+/// at the current floor and ends at the latest finalized block whose receipts were processed.
 #[derive(Debug)]
 pub struct L1StateCacheInner {
     /// Bounded per-slot value histories, promoted as a unit on access.
     slots: LruMap<(Address, B256), BTreeMap<u64, B256>, ByVersionCount>,
-    /// Per-address mutation barriers. A value at V cannot serve a read at N when a barrier exists
-    /// in `(V, N]`.
+    /// Per-address block heights that prevent reuse across possible mutations.
     invalidations: HashMap<Address, BTreeSet<u64>>,
+    /// Total number of retained mutation barriers.
     invalidation_count: usize,
+    /// Maximum number of mutation barriers retained before resetting.
     max_invalidations: usize,
     /// Contiguous receipt coverage: earliest usable value height through latest processed block.
     coverage: RangeInclusive<u64>,
@@ -95,7 +86,7 @@ impl Default for L1StateCacheInner {
 }
 
 impl L1StateCacheInner {
-    /// Create a new cache tracking the given contract addresses.
+    /// Create an empty cache.
     pub fn new() -> Self {
         Self::with_limits(DEFAULT_VERSION_CAPACITY, DEFAULT_INVALIDATION_CAPACITY)
     }
@@ -147,7 +138,7 @@ impl L1StateCacheInner {
 
     /// Sets a storage slot value in the forward cache at the given block number.
     ///
-    /// Values below the initial canonical floor are deliberately not admitted, so historical
+    /// Values below the current coverage floor are deliberately not admitted, so historical
     /// reads cannot later be inherited by canonical execution.
     pub fn set(&mut self, address: Address, slot: B256, block_number: u64, value: B256) {
         if block_number < *self.coverage.start() {
@@ -218,7 +209,7 @@ impl L1StateCacheInner {
         self.coverage = *self.coverage.start()..=anchor;
     }
 
-    /// Returns the current anchor block.
+    /// Returns the end of contiguous receipt coverage.
     pub fn anchor(&self) -> u64 {
         *self.coverage.end()
     }

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -208,11 +208,6 @@ impl L1StateCacheInner {
 
         self.coverage = *self.coverage.start()..=anchor;
     }
-
-    /// Returns the end of contiguous receipt coverage.
-    pub fn anchor(&self) -> u64 {
-        *self.coverage.end()
-    }
 }
 
 /// [`schnellru`] limiter which measures capacity by the number of versions in all slot histories.
@@ -298,8 +293,8 @@ mod tests {
     const PORTAL: Address = address!("0x0000000000000000000000000000000000004242");
 
     fn cover_through(cache: &mut L1StateCacheInner, block_number: u64) {
-        while cache.anchor() < block_number {
-            cache.invalidate_and_set_anchor(cache.anchor() + 1, []);
+        while *cache.coverage.end() < block_number {
+            cache.invalidate_and_set_anchor(*cache.coverage.end() + 1, []);
         }
     }
 
@@ -403,16 +398,16 @@ mod tests {
     }
 
     #[test]
-    fn anchor_defaults_to_zero() {
+    fn coverage_defaults_to_zero() {
         let cache = L1StateCacheInner::new();
-        assert_eq!(cache.anchor(), 0);
+        assert_eq!(*cache.coverage.end(), 0);
     }
 
     #[test]
-    fn contiguous_update_advances_anchor() {
+    fn contiguous_update_advances_coverage() {
         let mut cache = L1StateCacheInner::new();
         cache.invalidate_and_set_anchor(1, []);
-        assert_eq!(cache.anchor(), 1);
+        assert_eq!(*cache.coverage.end(), 1);
     }
 
     #[test]
@@ -423,7 +418,7 @@ mod tests {
 
         cache.invalidate_and_set_anchor(10, [PORTAL]);
 
-        assert_eq!(cache.anchor(), 10);
+        assert_eq!(*cache.coverage.end(), 10);
         assert_eq!(*cache.coverage.start(), 10);
         assert!(cache.invalidations.is_empty());
         assert_eq!(cache.get(PORTAL, slot, 10), None);

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -174,7 +174,7 @@ impl L1StateProvider {
     /// docs).
     pub fn get_storage(&self, address: Address, slot: B256, block_number: u64) -> Result<B256> {
         {
-            let mut cache = self.cache.write();
+            let mut cache = self.cache.lock();
             if let Some(value) = cache.get(address, slot, block_number) {
                 return Ok(value);
             }
@@ -194,7 +194,7 @@ impl L1StateProvider {
 
             match result {
                 Ok(value) => {
-                    self.cache.write().set(address, slot, block_number, value);
+                    self.cache.lock().set(address, slot, block_number, value);
                     if attempt > 1 {
                         info!(%address, %slot, block_number, %value, ?elapsed, attempt, "L1 storage RPC fetch succeeded after retries");
                     } else {
@@ -228,7 +228,7 @@ impl L1StateProvider {
         block_number: u64,
     ) -> Result<B256> {
         {
-            let mut cache = self.cache.write();
+            let mut cache = self.cache.lock();
             if let Some(value) = cache.get(address, slot, block_number) {
                 return Ok(value);
             }
@@ -237,7 +237,7 @@ impl L1StateProvider {
         warn!(%address, %slot, block_number, "L1 storage cache miss, fetching from RPC");
 
         let value = self.fetch_slot(address, slot, block_number).await?;
-        self.cache.write().set(address, slot, block_number, value);
+        self.cache.lock().set(address, slot, block_number, value);
         Ok(value)
     }
 

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -176,7 +176,6 @@ impl L1StateProvider {
         {
             let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
-                debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);
             }
         }
@@ -231,7 +230,6 @@ impl L1StateProvider {
         {
             let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
-                debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);
             }
         }

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -174,7 +174,7 @@ impl L1StateProvider {
     /// docs).
     pub fn get_storage(&self, address: Address, slot: B256, block_number: u64) -> Result<B256> {
         {
-            let cache = self.cache.read();
+            let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
                 debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);
@@ -229,7 +229,7 @@ impl L1StateProvider {
         block_number: u64,
     ) -> Result<B256> {
         {
-            let cache = self.cache.read();
+            let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
                 debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -367,7 +367,7 @@ impl L1Subscriber {
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
             let sealed = SealedHeader::seal_slow(header);
-            self.update_l1_state_anchor(block_number, sealed.hash(), &invalidated);
+            self.update_l1_state_anchor(block_number, &invalidated);
             self.deposit_queue.enqueue_sealed(sealed, events);
             enqueued += 1;
             self.subscriber_metrics.blocks_enqueued.increment(1);
@@ -489,7 +489,6 @@ impl L1Subscriber {
     pub(crate) fn update_l1_state_anchor(
         &self,
         number: u64,
-        hash: B256,
         invalidated_accounts: &HashSet<Address>,
     ) {
         let mut guard = self.config.l1_state_cache.write();
@@ -497,7 +496,7 @@ impl L1Subscriber {
             guard.invalidate(address, number);
         }
         // Publish receipt coverage only after every mutation barrier from this block is visible.
-        guard.update_anchor(NumHash::new(number, hash));
+        guard.update_anchor(number);
     }
 }
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -491,12 +491,10 @@ impl L1Subscriber {
         number: u64,
         invalidated_accounts: &HashSet<Address>,
     ) {
-        let mut guard = self.config.l1_state_cache.write();
-        for &address in invalidated_accounts {
-            guard.invalidate(address, number);
-        }
-        // Publish receipt coverage only after every mutation barrier from this block is visible.
-        guard.update_anchor(number);
+        self.config
+            .l1_state_cache
+            .write()
+            .invalidate_and_set_anchor(number, invalidated_accounts.iter().copied());
     }
 }
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -494,7 +494,7 @@ impl L1Subscriber {
     ) {
         self.config
             .l1_state_cache
-            .write()
+            .lock()
             .invalidate_and_set_anchor(number, invalidated_accounts.iter().copied());
     }
 }

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::collections::HashSet;
+use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::is_tip20_prefix;
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
@@ -8,8 +9,6 @@ const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis
 type L1ProcessedEvents = (L1PortalEvents, HashSet<Address>);
 
 fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
-    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
-
     (address == TIP403_REGISTRY_ADDRESS
         || (is_tip20_prefix(address) && topic0 == Some(&TransferPolicyUpdate::SIGNATURE_HASH)))
     .then_some(TIP403_REGISTRY_ADDRESS)
@@ -438,14 +437,16 @@ impl L1Subscriber {
                     if let Err(e) = portal_events.push_log(log, block_number) {
                         warn!(block_number, %e, "Failed to decode portal event from receipt");
                     }
-                } else if let Some(address) =
-                    cache_invalidation_address(address, log.topics().first())
-                {
-                    invalidated.insert(address);
+                } else if let Some(address) = cache_invalidation_address(address, log.topic0()) {
+                    invalidated.extend([address, log.address()]);
                 }
             }
         }
 
+        // Enabling may migrate token-local policy storage into TIP-403.
+        for event in &portal_events.enabled_tokens {
+            invalidated.extend([event.token, TIP403_REGISTRY_ADDRESS]);
+        }
         self.record_portal_event_metrics(&portal_events);
         (portal_events, invalidated)
     }
@@ -560,7 +561,6 @@ pub(crate) fn verify_receipts(
 mod tests {
     use super::*;
     use alloy_primitives::address;
-    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 
     #[test]
     fn token_policy_updates_invalidate_the_registry() {

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -148,7 +148,7 @@ fn test_subscriber(
             l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
             portal_address,
             genesis_tempo_block_number,
-            l1_state_cache: crate::L1StateCache::new(HashSet::from([portal_address])),
+            l1_state_cache: crate::L1StateCache::new(),
             l1_fetch_concurrency: 1,
             retry_connection_interval: Duration::from_secs(1),
         },
@@ -435,23 +435,18 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
         .write()
         .set(stable_account, stable_slot, 10, stable_value);
 
-    let hash_10 = B256::with_last_byte(10);
-    subscriber.update_l1_state_anchor(10, hash_10, &HashSet::new());
+    subscriber.update_l1_state_anchor(10, &HashSet::new());
     assert_eq!(
         subscriber
             .config
             .l1_state_cache
-            .read()
+            .write()
             .get(TIP403_REGISTRY_ADDRESS, slot, 10),
         Some(value)
     );
 
-    subscriber.update_l1_state_anchor(
-        11,
-        B256::with_last_byte(11),
-        &HashSet::from([TIP403_REGISTRY_ADDRESS]),
-    );
-    let cache = subscriber.config.l1_state_cache.read();
+    subscriber.update_l1_state_anchor(11, &HashSet::from([TIP403_REGISTRY_ADDRESS]));
+    let mut cache = subscriber.config.l1_state_cache.write();
     assert_eq!(
         cache.get(stable_account, stable_slot, 11),
         Some(stable_value)

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -427,17 +427,17 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     subscriber
         .config
         .l1_state_cache
-        .write()
+        .lock()
         .invalidate_and_set_anchor(9, []);
     subscriber
         .config
         .l1_state_cache
-        .write()
+        .lock()
         .set(TIP403_REGISTRY_ADDRESS, slot, 10, value);
     subscriber
         .config
         .l1_state_cache
-        .write()
+        .lock()
         .set(stable_account, stable_slot, 10, stable_value);
 
     subscriber.update_l1_state_anchor(10, &HashSet::new());
@@ -445,13 +445,13 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
         subscriber
             .config
             .l1_state_cache
-            .write()
+            .lock()
             .get(TIP403_REGISTRY_ADDRESS, slot, 10),
         Some(value)
     );
 
     subscriber.update_l1_state_anchor(11, &HashSet::from([TIP403_REGISTRY_ADDRESS]));
-    let mut cache = subscriber.config.l1_state_cache.write();
+    let mut cache = subscriber.config.l1_state_cache.lock();
     assert_eq!(
         cache.get(stable_account, stable_slot, 11),
         Some(stable_value)

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -424,7 +424,11 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     let stable_account = address!("0x0000000000000000000000000000000000000ABC");
     let stable_slot = B256::with_last_byte(3);
     let stable_value = B256::with_last_byte(4);
-    subscriber.config.l1_state_cache.write().reset(9);
+    subscriber
+        .config
+        .l1_state_cache
+        .write()
+        .invalidate_and_set_anchor(9, []);
     subscriber
         .config
         .l1_state_cache

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -424,6 +424,7 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     let stable_account = address!("0x0000000000000000000000000000000000000ABC");
     let stable_slot = B256::with_last_byte(3);
     let stable_value = B256::with_last_byte(4);
+    subscriber.config.l1_state_cache.write().reset(9);
     subscriber
         .config
         .l1_state_cache

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -38,7 +38,7 @@ use reth_transaction_pool::{
     Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
 };
-use std::{collections::HashSet, num::NonZeroU32, sync::Arc, time::Duration};
+use std::{num::NonZeroU32, sync::Arc, time::Duration};
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
 use tempo_node::{
@@ -206,7 +206,7 @@ impl ZoneNode {
     ) -> Self {
         let deposit_queue = DepositQueue::default();
 
-        let l1_state_cache = L1StateCache::new(HashSet::from([portal_address]));
+        let l1_state_cache = L1StateCache::new();
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
             portal_address,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -33,7 +33,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::ChainSpecProvider;
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
-use reth_storage_api::{BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProviderFactory};
+use reth_storage_api::{BlockNumReader, EmptyBodyStorage, HeaderProvider};
 use reth_transaction_pool::{
     Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
@@ -59,7 +59,7 @@ use tracing::{debug, info};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
-    DepositQueue, L1Subscriber, L1SubscriberConfig, TempoStateExt,
+    DepositQueue, L1Subscriber, L1SubscriberConfig,
     state::{L1StateCache, L1StateProvider, L1StateProviderConfig},
 };
 use zone_p2p::{P2pConfig, P2pNetworkId, Role, spawn_p2p};
@@ -440,14 +440,6 @@ where
     > as NodeAddOns<N>>::Handle;
 
     async fn launch_add_ons(mut self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
-        let sp = ctx.node.provider().latest()?;
-        let tempo_block_number = sp.tempo_block_number()?;
-        self.l1_config
-            .l1_state_cache
-            .write()
-            .reset(tempo_block_number);
-        info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber and reset cache");
-
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
                 &self.l1_config.l1_rpc_url,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -445,8 +445,8 @@ where
         self.l1_config
             .l1_state_cache
             .write()
-            .initialize_floor(tempo_block_number);
-        info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber and initialized cache");
+            .reset(tempo_block_number);
+        info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber and reset cache");
 
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -1897,7 +1897,7 @@ async fn test_plaintext_deposit_policy_failure_bounces_to_tempo_refund_recipient
     assert!(l1.is_authorized(policy_id, rejected_recipient).await?);
     let policy_block = l1.provider().get_block_number().await?;
     seed_raw_tip403_token_policy(
-        &mut zone.l1_state_cache().write(),
+        &mut zone.l1_state_cache().lock(),
         policy_block,
         PATH_USD_ADDRESS,
         policy_id,

--- a/crates/node/tests/it/tip403_policy.rs
+++ b/crates/node/tests/it/tip403_policy.rs
@@ -121,7 +121,7 @@ async fn test_l1_blacklisted_sender_cannot_pay_for_empty_transaction() -> eyre::
 
     const BLACKLIST_POLICY_ID: u64 = 42;
     seed_raw_tip403_token_policy(
-        &mut zone.l1_state_cache().write(),
+        &mut zone.l1_state_cache().lock(),
         anchor,
         PATH_USD_ADDRESS,
         BLACKLIST_POLICY_ID,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1,6 +1,5 @@
 use alloy::genesis::{Genesis, GenesisAccount};
 use alloy_consensus::Header;
-use alloy_eips::NumHash;
 use alloy_network::{EthereumWallet, ReceiptResponse};
 use alloy_primitives::{Address, B256, U256, address, keccak256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
@@ -347,7 +346,7 @@ pub(crate) fn seed_raw_tip403_policy(
     let registry = TIP403Registry::new();
     let counter_slot = registry.policy_id_counter.slot();
     let existing_next_policy_id = cache
-        .read()
+        .write()
         .get(TIP403_REGISTRY_ADDRESS, counter_slot.into(), block_number)
         .and_then(|value| U256::from_be_bytes(value.0).try_into().ok())
         .unwrap_or(2u64);
@@ -3804,6 +3803,20 @@ impl PrivateRpcTestCtx {
         eyre::ensure!(receipt.status(), "revokeKey failed");
         Ok(())
     }
+
+    /// Query `zone_getDepositStatus` via the private RPC as a specific user.
+    pub(crate) async fn get_deposit_status_as_user(
+        &self,
+        tempo_block_number: u64,
+        signer: &alloy_signer_local::PrivateKeySigner,
+    ) -> eyre::Result<serde_json::Value> {
+        self.call_as_user(
+            "zone_getDepositStatus",
+            serde_json::json!([format!("0x{tempo_block_number:x}")]),
+            signer,
+        )
+        .await
+    }
 }
 
 async fn zone_chain_id(zone: &ZoneTestNode) -> eyre::Result<u64> {
@@ -4043,10 +4056,7 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        cache.update_anchor(NumHash {
-            number: num_blocks,
-            hash: B256::ZERO,
-        });
+        cache.update_anchor(num_blocks);
         drop(cache);
         self.caches.lock().unwrap().push(cache_handle.clone());
     }
@@ -4092,6 +4102,20 @@ impl L1Fixture {
         }
     }
 
+    /// Extend the fixture caches' contiguous receipt coverage through a generated block.
+    ///
+    /// `seed_l1_cache` may seed only the blocks a test normally needs. Tests that subsequently
+    /// cross that horizon still need unchanged slots to inherit their last seeded value rather
+    /// than falling back to the deliberately unavailable dummy L1 RPC.
+    fn extend_cache_coverage(&self, block_number: u64) {
+        for cache in self.caches.lock().unwrap().iter() {
+            let mut cache = cache.write();
+            if block_number > cache.anchor() {
+                cache.update_anchor(block_number);
+            }
+        }
+    }
+
     /// Build a [`TempoHeader`] for the next L1 block.
     fn next_header(&mut self) -> TempoHeader {
         let number = self.next_block_number;
@@ -4115,13 +4139,12 @@ impl L1Fixture {
         self.last_hash = keccak256(&rlp_buf);
         self.next_block_number += 1;
         self.next_timestamp += 1; // 1s per L1 block
+        self.extend_cache_coverage(number);
 
         // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
         // coverage the subscriber would publish before the engine consumes this block.
         for cache in self.caches.lock().unwrap().iter() {
-            cache
-                .write()
-                .update_anchor(NumHash::new(number, self.last_hash));
+            cache.write().update_anchor(number);
         }
 
         header

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3958,12 +3958,7 @@ pub(crate) struct L1Fixture {
     next_timestamp: u64,
     last_hash: B256,
     /// Raw L1 caches seeded by this fixture, updated with state implied by injected deposits.
-    caches: Mutex<Vec<FixtureL1Cache>>,
-}
-
-struct FixtureL1Cache {
-    handle: L1StateCache,
-    coverage_end: u64,
+    caches: Mutex<Vec<L1StateCache>>,
 }
 
 impl L1Fixture {
@@ -4047,14 +4042,8 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        for block_number in 1..=num_blocks {
-            cache.invalidate_and_set_anchor(block_number, []);
-        }
         drop(cache);
-        self.caches.lock().unwrap().push(FixtureL1Cache {
-            handle: cache_handle.clone(),
-            coverage_end: num_blocks,
-        });
+        self.caches.lock().unwrap().push(cache_handle.clone());
     }
 
     /// Seed the absence of an address-level TIP-403 receive policy at the current Zone anchor.
@@ -4067,7 +4056,7 @@ impl L1Fixture {
         // TODO(rusowsky): make `ReceivePolicy` public upstream to use the handlers
         let receive_policy_slot = recipient.mapping_slot(tip403_registry_slots::RECEIVE_POLICIES);
         for cache in self.caches.lock().unwrap().iter() {
-            cache.handle.write().set(
+            cache.write().set(
                 TIP403_REGISTRY_ADDRESS,
                 B256::from(receive_policy_slot.to_be_bytes()),
                 block_number,
@@ -4086,7 +4075,7 @@ impl L1Fixture {
 
     fn seed_enabled_token_policy_state(&self, block_number: u64, tokens: &[EnabledToken]) {
         for cache in self.caches.lock().unwrap().iter() {
-            let mut cache = cache.handle.write();
+            let mut cache = cache.write();
             for token in tokens {
                 seed_raw_tip403_token_policy(
                     &mut cache,
@@ -4094,21 +4083,6 @@ impl L1Fixture {
                     token.token,
                     ALLOW_ALL_POLICY_ID,
                 );
-            }
-        }
-    }
-
-    /// Extend the fixture caches' contiguous receipt coverage through a generated block.
-    ///
-    /// `seed_l1_cache` may seed only the blocks a test normally needs. Tests that subsequently
-    /// cross that horizon still need unchanged slots to inherit their last seeded value rather
-    /// than falling back to the deliberately unavailable dummy L1 RPC.
-    fn extend_cache_coverage(&self, block_number: u64) {
-        for cache in self.caches.lock().unwrap().iter_mut() {
-            let mut handle = cache.handle.write();
-            while cache.coverage_end < block_number {
-                cache.coverage_end += 1;
-                handle.invalidate_and_set_anchor(cache.coverage_end, []);
             }
         }
     }
@@ -4136,7 +4110,12 @@ impl L1Fixture {
         self.last_hash = keccak256(&rlp_buf);
         self.next_block_number += 1;
         self.next_timestamp += 1; // 1s per L1 block
-        self.extend_cache_coverage(number);
+
+        // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
+        // coverage the subscriber would publish before the engine consumes this block.
+        for cache in self.caches.lock().unwrap().iter() {
+            cache.write().invalidate_and_set_anchor(number, []);
+        }
 
         header
     }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3958,7 +3958,12 @@ pub(crate) struct L1Fixture {
     next_timestamp: u64,
     last_hash: B256,
     /// Raw L1 caches seeded by this fixture, updated with state implied by injected deposits.
-    caches: Mutex<Vec<L1StateCache>>,
+    caches: Mutex<Vec<FixtureL1Cache>>,
+}
+
+struct FixtureL1Cache {
+    handle: L1StateCache,
+    coverage_end: u64,
 }
 
 impl L1Fixture {
@@ -4042,12 +4047,14 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        while cache.anchor() < num_blocks {
-            let next_anchor = cache.anchor() + 1;
-            cache.invalidate_and_set_anchor(next_anchor, []);
+        for block_number in 1..=num_blocks {
+            cache.invalidate_and_set_anchor(block_number, []);
         }
         drop(cache);
-        self.caches.lock().unwrap().push(cache_handle.clone());
+        self.caches.lock().unwrap().push(FixtureL1Cache {
+            handle: cache_handle.clone(),
+            coverage_end: num_blocks,
+        });
     }
 
     /// Seed the absence of an address-level TIP-403 receive policy at the current Zone anchor.
@@ -4060,7 +4067,7 @@ impl L1Fixture {
         // TODO(rusowsky): make `ReceivePolicy` public upstream to use the handlers
         let receive_policy_slot = recipient.mapping_slot(tip403_registry_slots::RECEIVE_POLICIES);
         for cache in self.caches.lock().unwrap().iter() {
-            cache.write().set(
+            cache.handle.write().set(
                 TIP403_REGISTRY_ADDRESS,
                 B256::from(receive_policy_slot.to_be_bytes()),
                 block_number,
@@ -4079,7 +4086,7 @@ impl L1Fixture {
 
     fn seed_enabled_token_policy_state(&self, block_number: u64, tokens: &[EnabledToken]) {
         for cache in self.caches.lock().unwrap().iter() {
-            let mut cache = cache.write();
+            let mut cache = cache.handle.write();
             for token in tokens {
                 seed_raw_tip403_token_policy(
                     &mut cache,
@@ -4097,11 +4104,11 @@ impl L1Fixture {
     /// cross that horizon still need unchanged slots to inherit their last seeded value rather
     /// than falling back to the deliberately unavailable dummy L1 RPC.
     fn extend_cache_coverage(&self, block_number: u64) {
-        for cache in self.caches.lock().unwrap().iter() {
-            let mut cache = cache.write();
-            while cache.anchor() < block_number {
-                let next_anchor = cache.anchor() + 1;
-                cache.invalidate_and_set_anchor(next_anchor, []);
+        for cache in self.caches.lock().unwrap().iter_mut() {
+            let mut handle = cache.handle.write();
+            while cache.coverage_end < block_number {
+                cache.coverage_end += 1;
+                handle.invalidate_and_set_anchor(cache.coverage_end, []);
             }
         }
     }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -346,7 +346,7 @@ pub(crate) fn seed_raw_tip403_policy(
     let registry = TIP403Registry::new();
     let counter_slot = registry.policy_id_counter.slot();
     let existing_next_policy_id = cache
-        .write()
+        .lock()
         .get(TIP403_REGISTRY_ADDRESS, counter_slot.into(), block_number)
         .and_then(|value| U256::from_be_bytes(value.0).try_into().ok())
         .unwrap_or(2u64);
@@ -394,7 +394,7 @@ pub(crate) fn seed_raw_tip403_policy(
         Ok(())
     })?;
 
-    let mut cache = cache.write();
+    let mut cache = cache.lock();
     for slot in slots {
         let value = storage.sload(TIP403_REGISTRY_ADDRESS, slot)?;
         cache.set(
@@ -987,7 +987,7 @@ impl ZoneTestNode {
         let deposit_queue = zone_node.deposit_queue();
         let l1_state_cache = zone_node.l1_state_cache();
         if is_local_dummy_l1 {
-            let mut cache = l1_state_cache.write();
+            let mut cache = l1_state_cache.lock();
             seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
         }
 
@@ -3991,7 +3991,7 @@ impl L1Fixture {
         sequencer: Address,
         num_blocks: u64,
     ) {
-        let mut cache = cache_handle.write();
+        let mut cache = cache_handle.lock();
         let deposit_queue_hash_slot = B256::with_last_byte(3);
         let refunds_slot = B256::with_last_byte(8);
         let sequencer_membership_slot =
@@ -4056,7 +4056,7 @@ impl L1Fixture {
         // TODO(rusowsky): make `ReceivePolicy` public upstream to use the handlers
         let receive_policy_slot = recipient.mapping_slot(tip403_registry_slots::RECEIVE_POLICIES);
         for cache in self.caches.lock().unwrap().iter() {
-            cache.write().set(
+            cache.lock().set(
                 TIP403_REGISTRY_ADDRESS,
                 B256::from(receive_policy_slot.to_be_bytes()),
                 block_number,
@@ -4075,7 +4075,7 @@ impl L1Fixture {
 
     fn seed_enabled_token_policy_state(&self, block_number: u64, tokens: &[EnabledToken]) {
         for cache in self.caches.lock().unwrap().iter() {
-            let mut cache = cache.write();
+            let mut cache = cache.lock();
             for token in tokens {
                 seed_raw_tip403_token_policy(
                     &mut cache,
@@ -4114,7 +4114,7 @@ impl L1Fixture {
         // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
         // coverage the subscriber would publish before the engine consumes this block.
         for cache in self.caches.lock().unwrap().iter() {
-            cache.write().invalidate_and_set_anchor(number, []);
+            cache.lock().invalidate_and_set_anchor(number, []);
         }
 
         header

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3803,20 +3803,6 @@ impl PrivateRpcTestCtx {
         eyre::ensure!(receipt.status(), "revokeKey failed");
         Ok(())
     }
-
-    /// Query `zone_getDepositStatus` via the private RPC as a specific user.
-    pub(crate) async fn get_deposit_status_as_user(
-        &self,
-        tempo_block_number: u64,
-        signer: &alloy_signer_local::PrivateKeySigner,
-    ) -> eyre::Result<serde_json::Value> {
-        self.call_as_user(
-            "zone_getDepositStatus",
-            serde_json::json!([format!("0x{tempo_block_number:x}")]),
-            signer,
-        )
-        .await
-    }
 }
 
 async fn zone_chain_id(zone: &ZoneTestNode) -> eyre::Result<u64> {
@@ -4056,7 +4042,10 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        cache.update_anchor(num_blocks);
+        while cache.anchor() < num_blocks {
+            let next_anchor = cache.anchor() + 1;
+            cache.invalidate_and_set_anchor(next_anchor, []);
+        }
         drop(cache);
         self.caches.lock().unwrap().push(cache_handle.clone());
     }
@@ -4110,8 +4099,9 @@ impl L1Fixture {
     fn extend_cache_coverage(&self, block_number: u64) {
         for cache in self.caches.lock().unwrap().iter() {
             let mut cache = cache.write();
-            if block_number > cache.anchor() {
-                cache.update_anchor(block_number);
+            while cache.anchor() < block_number {
+                let next_anchor = cache.anchor() + 1;
+                cache.invalidate_and_set_anchor(next_anchor, []);
             }
         }
     }
@@ -4140,12 +4130,6 @@ impl L1Fixture {
         self.next_block_number += 1;
         self.next_timestamp += 1; // 1s per L1 block
         self.extend_cache_coverage(number);
-
-        // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
-        // coverage the subscriber would publish before the engine consumes this block.
-        for cache in self.caches.lock().unwrap().iter() {
-            cache.write().update_anchor(number);
-        }
 
         header
     }

--- a/crates/node/tests/l1_state_reader.rs
+++ b/crates/node/tests/l1_state_reader.rs
@@ -78,7 +78,7 @@ async fn l1_provider_caches_result() {
 
     assert_eq!(v1, v2, "cached and fresh values must match");
 
-    let cached = provider.cache().write().get(ZONE_PORTAL, B256::ZERO, block);
+    let cached = provider.cache().lock().get(ZONE_PORTAL, B256::ZERO, block);
     assert_eq!(cached, Some(v1), "value should be in cache after read");
     println!("Cache hit verified for slot 0 at block {block}: {v1}");
 }
@@ -109,7 +109,7 @@ async fn l1_provider_reads_multiple_slots() {
     }
 
     // Slot 0 should be non-zero (contains init data)
-    let v0 = provider.cache().write().get(ZONE_PORTAL, B256::ZERO, block);
+    let v0 = provider.cache().lock().get(ZONE_PORTAL, B256::ZERO, block);
     assert!(
         v0.is_some_and(|v| v != B256::ZERO),
         "slot 0 should be non-zero"

--- a/crates/node/tests/l1_state_reader.rs
+++ b/crates/node/tests/l1_state_reader.rs
@@ -4,8 +4,6 @@
 //!
 //! Requires `L1_RPC_URL` env var or defaults to moderato RPC.
 
-use std::collections::HashSet;
-
 use alloy_primitives::{Address, B256, address};
 use alloy_provider::{Provider, ProviderBuilder};
 use tempo_alloy::TempoNetwork;
@@ -24,7 +22,7 @@ async fn make_provider() -> L1StateProvider {
         portal_address: ZONE_PORTAL,
         ..Default::default()
     };
-    let cache = L1StateCache::new(HashSet::from([ZONE_PORTAL]));
+    let cache = L1StateCache::new();
     let rt = tokio::runtime::Handle::current();
     L1StateProvider::new(config, cache, rt)
         .await
@@ -80,7 +78,7 @@ async fn l1_provider_caches_result() {
 
     assert_eq!(v1, v2, "cached and fresh values must match");
 
-    let cached = provider.cache().read().get(ZONE_PORTAL, B256::ZERO, block);
+    let cached = provider.cache().write().get(ZONE_PORTAL, B256::ZERO, block);
     assert_eq!(cached, Some(v1), "value should be in cache after read");
     println!("Cache hit verified for slot 0 at block {block}: {v1}");
 }
@@ -111,7 +109,7 @@ async fn l1_provider_reads_multiple_slots() {
     }
 
     // Slot 0 should be non-zero (contains init data)
-    let v0 = provider.cache().read().get(ZONE_PORTAL, B256::ZERO, block);
+    let v0 = provider.cache().write().get(ZONE_PORTAL, B256::ZERO, block);
     assert!(
         v0.is_some_and(|v| v != B256::ZERO),
         "slot 0 should be non-zero"


### PR DESCRIPTION
## Summary

- bound the L1 state cache with a weighted `schnellru` capacity measured in retained block versions
- cap each slot history to limit eviction granularity while preserving predecessor reads across heights
- retain mutation barriers with a bounded capacity
- make invalidation and coverage advancement one atomic transition, resetting conservatively on gaps
- remove the public/startup reset now that #790 makes sequencer membership use the executing block's Tempo anchor

## Why

The previous per-slot histories and invalidation sets could grow without bound. Exact-height-only caching would avoid that growth but lose useful reuse of unchanged L1 values across block heights.

This keeps historical reuse while bounding both value versions and invalidation metadata. Non-contiguous receipt coverage clears inherited assumptions instead of risking stale reads.

## Impact

L1 cache memory is bounded without changing exact-height behavior or sacrificing safe cross-height reuse. Followers that do not observe L1 receipts continue to fall back to exact-height RPC reads above their known coverage.

Stacked on #790.

## Validation

- `cargo test -p zone-l1` (70 tests)
- `cargo test -p zone-precompiles` (76 tests)
- `cargo test -p zone-evm` (22 tests)
- `cargo check -p zone-node --tests`
- `cargo clippy -p zone-l1 --all-targets -- -D warnings`
- `git diff --check`
