### PR TITLE
refactor(evm): remove legacy TIP-20 policy mirroring

### DIFF
--- a/crates/evm/src/database.rs
+++ b/crates/evm/src/database.rs
@@ -17,7 +17,7 @@ use revm::{
 use thiserror::Error;
 use zone_precompiles::{
     TIP403_REGISTRY_ADDRESS,
-    storage::{self, L1State, L1StateError, L1StorageReader},
+    storage::{L1State, L1StateError, L1StorageReader},
     tempo_state::TEMPO_BLOCK_NUMBER_SLOT,
 };
 use zone_primitives::constants::TEMPO_STATE_ADDRESS;
@@ -127,7 +127,7 @@ impl<DB: Database, L1: L1StorageReader> L1OverlayDB<DB, L1> {
             .map_err(ZoneDbError::L1State)
     }
 
-    /// Rejects writes to the L1-mirrored slots and removes the mirrored field from packed TIP-20 transitions.
+    /// Rejects writes to the L1-mirrored TIP-403 registry.
     pub fn sanitize_state(
         &mut self,
         state: &mut AddressMap<Account>,
@@ -153,31 +153,6 @@ impl<DB: Database, L1: L1StorageReader> L1OverlayDB<DB, L1> {
             state.remove(&TIP403_REGISTRY_ADDRESS);
         }
 
-        // TODO(rusowsky): remove once TIP-1092 is implemented
-        for (address, account) in state {
-            for (slot, value) in &mut account.storage {
-                if !storage::is_tip20_policy_id_slot(*address, *slot) {
-                    continue;
-                }
-
-                if storage::merge_transfer_policy_id(U256::ZERO, value.present_value)
-                    != storage::merge_transfer_policy_id(U256::ZERO, value.original_value)
-                {
-                    return Err(ZoneDbError::L1Write {
-                        address: *address,
-                        slot: *slot,
-                    });
-                }
-
-                let local = self
-                    .inner
-                    .storage(*address, *slot)
-                    .map_err(ZoneDbError::Inner)?;
-                value.original_value =
-                    storage::merge_transfer_policy_id(value.original_value, local);
-                value.present_value = storage::merge_transfer_policy_id(value.present_value, local);
-            }
-        }
         Ok(())
     }
 }
@@ -196,22 +171,15 @@ impl<DB: Database, L1: L1StorageReader> RevmDatabase for L1OverlayDB<DB, L1> {
     }
 
     fn storage(&mut self, address: Address, slot: StorageKey) -> Result<StorageValue, Self::Error> {
-        let local = self
-            .inner
-            .storage(address, slot)
-            .map_err(ZoneDbError::Inner)?;
-        if address != TIP403_REGISTRY_ADDRESS && !storage::is_tip20_policy_id_slot(address, slot) {
-            return Ok(local);
+        if address != TIP403_REGISTRY_ADDRESS {
+            return self
+                .inner
+                .storage(address, slot)
+                .map_err(ZoneDbError::Inner);
         }
 
         let anchor = self.anchor()?;
-        let l1 = self.l1_storage(address, slot, anchor)?;
-
-        if storage::is_tip20_policy_id_slot(address, slot) {
-            Ok(storage::merge_transfer_policy_id(local, l1))
-        } else {
-            Ok(l1)
-        }
+        self.l1_storage(address, slot, anchor)
     }
 
     fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
@@ -227,7 +195,6 @@ mod tests {
         database_interface::DatabaseCommit,
         state::EvmStorageSlot,
     };
-    use tempo_precompiles::{PATH_USD_ADDRESS, tip20::tip20_slots};
     use zone_precompiles::test_utils::MockL1Reader as TestL1;
 
     fn test_db(anchor: u64) -> CacheDB<EmptyDB> {
@@ -316,77 +283,13 @@ mod tests {
     }
 
     #[test]
-    fn packed_policy_field_is_removed_from_canonical_transition() {
-        let (anchor, token, slot) = (42, PATH_USD_ADDRESS, tip20_slots::TRANSFER_POLICY_ID);
-        let offset = tempo_precompiles::tip20::tip20_slots::TRANSFER_POLICY_ID_OFFSET * 8;
-        let local = storage::merge_transfer_policy_id(U256::from(10), U256::from(2) << offset);
-        let l1_value = U256::from(99) << offset;
-        let l1 = TestL1::default();
-        l1.insert(token, slot, anchor, l1_value);
-        let mut inner = test_db(anchor);
-        inner.insert_account_storage(token, slot, local).unwrap();
-        let mut db = L1OverlayDB::new(inner, l1, Address::ZERO);
-        let observed = db.storage(token, slot).unwrap();
-
-        let mut state = AddressMap::default();
-        let mut account = Account::default();
-        account.storage.insert(
-            slot,
-            EvmStorageSlot {
-                original_value: observed,
-                present_value: observed + U256::ONE,
-                ..Default::default()
-            },
-        );
-        state.insert(token, account);
-        db.sanitize_state(&mut state).unwrap();
-
-        let sanitized = state[&token].storage[&slot].present_value;
-        assert_eq!(
-            storage::merge_transfer_policy_id(U256::ZERO, sanitized),
-            storage::merge_transfer_policy_id(U256::ZERO, local)
-        );
-        assert_eq!(sanitized & U256::from(u64::MAX), U256::from(11));
-    }
-
-    #[test]
-    fn packed_policy_field_write_is_rejected() {
-        let (anchor, token, slot) = (42, PATH_USD_ADDRESS, tip20_slots::TRANSFER_POLICY_ID);
-        let offset = tip20_slots::TRANSFER_POLICY_ID_OFFSET * 8;
-        let l1 = TestL1::default();
-        l1.insert(token, slot, anchor, U256::from(99) << offset);
-        let mut db = L1OverlayDB::new(test_db(anchor), l1, Address::ZERO);
-        let observed = db.storage(token, slot).unwrap();
-
-        let mut account = Account::default();
-        account.storage.insert(
-            slot,
-            EvmStorageSlot {
-                original_value: observed,
-                present_value: storage::merge_transfer_policy_id(
-                    observed,
-                    U256::from(100) << offset,
-                ),
-                ..Default::default()
-            },
-        );
-        let mut state = AddressMap::from_iter([(token, account)]);
-
-        assert!(matches!(
-            db.sanitize_state(&mut state),
-            Err(ZoneDbError::L1Write { address, slot: written_slot })
-                if address == token && written_slot == slot
-        ));
-    }
-
-    #[test]
     fn transaction_reset_clears_anchor() {
-        let (anchor, token, slot) = (42, PATH_USD_ADDRESS, tip20_slots::TRANSFER_POLICY_ID);
+        let (anchor, slot) = (42, U256::from(7));
         let l1 = TestL1::default();
-        l1.insert(token, slot, anchor, U256::from(7));
+        l1.insert(TIP403_REGISTRY_ADDRESS, slot, anchor, U256::from(7));
         let mut db = L1OverlayDB::new(test_db(anchor), l1, Address::ZERO);
 
-        db.storage(token, slot).unwrap();
+        db.storage(TIP403_REGISTRY_ADDRESS, slot).unwrap();
         assert_eq!(db.l1_state().get_anchor(), Some(anchor));
 
         db.reset_transaction_state();

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,10 +1,19 @@
 use super::*;
 use std::collections::HashSet;
+use tempo_primitives::is_tip20_prefix;
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
 const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
 
 type L1ProcessedEvents = (L1PortalEvents, HashSet<Address>);
+
+fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
+    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
+
+    (address == TIP403_REGISTRY_ADDRESS
+        || (is_tip20_prefix(address) && topic0 == Some(&TransferPolicyUpdate::SIGNATURE_HASH)))
+    .then_some(TIP403_REGISTRY_ADDRESS)
+}
 
 /// Configuration for the L1 subscriber.
 #[derive(Debug, Clone)]
@@ -405,8 +414,6 @@ impl L1Subscriber {
         block_number: u64,
         receipts: &[tempo_alloy::rpc::TempoTransactionReceipt],
     ) -> L1ProcessedEvents {
-        use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
-
         let portal_address = self.config.portal_address;
         let mut portal_events = L1PortalEvents::default();
         let mut invalidated = HashSet::new();
@@ -420,7 +427,9 @@ impl L1Subscriber {
                     if let Err(e) = portal_events.push_log(log, block_number) {
                         warn!(block_number, %e, "Failed to decode portal event from receipt");
                     }
-                } else if address == TIP403_REGISTRY_ADDRESS {
+                } else if let Some(address) =
+                    cache_invalidation_address(address, log.topics().first())
+                {
                     invalidated.insert(address);
                 }
             }
@@ -537,4 +546,21 @@ pub(crate) fn verify_receipts(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::address;
+    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
+
+    #[test]
+    fn token_policy_updates_invalidate_the_registry() {
+        let token = address!("20C0000000000000000000000000000000000999");
+
+        assert_eq!(
+            cache_invalidation_address(token, Some(&TransferPolicyUpdate::SIGNATURE_HASH)),
+            Some(TIP403_REGISTRY_ADDRESS)
+        );
+    }
 }

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,6 +1,5 @@
 use super::*;
 use std::collections::HashSet;
-use tempo_primitives::is_tip20_prefix;
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
 const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
@@ -406,7 +405,7 @@ impl L1Subscriber {
         block_number: u64,
         receipts: &[tempo_alloy::rpc::TempoTransactionReceipt],
     ) -> L1ProcessedEvents {
-        use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
+        use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 
         let portal_address = self.config.portal_address;
         let mut portal_events = L1PortalEvents::default();
@@ -421,10 +420,7 @@ impl L1Subscriber {
                     if let Err(e) = portal_events.push_log(log, block_number) {
                         warn!(block_number, %e, "Failed to decode portal event from receipt");
                     }
-                } else if address == TIP403_REGISTRY_ADDRESS
-                    || (is_tip20_prefix(address)
-                        && log.topics().first() == Some(&TransferPolicyUpdate::SIGNATURE_HASH))
-                {
+                } else if address == TIP403_REGISTRY_ADDRESS {
                     invalidated.insert(address);
                 }
             }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -47,7 +47,6 @@ use tempo_precompiles::{
     storage::{
         Handler, PrecompileStorageProvider, StorageCtx, StorageKey, hashmap::HashMapStorageProvider,
     },
-    tip20::tip20_slots,
     tip403_registry::{
         ALLOW_ALL_POLICY_ID, CompoundPolicyData as RawCompoundPolicyData, PolicyData, PolicyType,
         TIP403Registry, tip403_registry_slots,
@@ -266,22 +265,6 @@ pub(crate) fn seed_raw_tip403_token_policy(
     cache.set(
         TIP403_REGISTRY_ADDRESS,
         slot,
-        block_number,
-        B256::from(packed.to_be_bytes()),
-    );
-}
-
-/// Seed the token-local transfer-policy field used by Tempo's TIP-1092 compatibility fallback.
-fn seed_raw_legacy_tip20_policy(
-    cache: &mut zone_l1::state::L1StateCacheInner,
-    block_number: u64,
-    token: Address,
-    policy_id: u64,
-) {
-    let packed = U256::from(policy_id) << (tip20_slots::TRANSFER_POLICY_ID_OFFSET * 8);
-    cache.set(
-        token,
-        B256::from(tip20_slots::TRANSFER_POLICY_ID.to_be_bytes()),
         block_number,
         B256::from(packed.to_be_bytes()),
     );
@@ -3644,15 +3627,6 @@ impl L1Fixture {
             let mut cache = cache.write();
             for token in tokens {
                 seed_raw_tip403_token_policy(
-                    &mut cache,
-                    block_number,
-                    token.token,
-                    ALLOW_ALL_POLICY_ID,
-                );
-                // Synthetic enable-token events do not include the accompanying L1 state
-                // transition. Model both the TIP-1092 registry binding and its supported
-                // token-local fallback so same-block deposits remain self-contained.
-                seed_raw_legacy_tip20_policy(
                     &mut cache,
                     block_number,
                     token.token,

--- a/crates/precompiles/src/storage.rs
+++ b/crates/precompiles/src/storage.rs
@@ -7,8 +7,6 @@ use core::{cell::Cell, fmt};
 use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_sol_types::SolValue;
 use revm::{context::result::AnyError, precompile::PrecompileError};
-use tempo_precompiles::tip20::tip20_slots;
-use tempo_primitives::TempoAddressExt;
 use thiserror::Error;
 use zone_primitives::constants::PORTAL_IS_SEQUENCER_SLOT;
 
@@ -181,19 +179,6 @@ impl From<L1StateError> for PrecompileError {
     fn from(error: L1StateError) -> Self {
         Self::FatalAny(AnyError::new(error))
     }
-}
-
-/// Returns whether this is the packed TIP-20 transfer-policy slot.
-pub fn is_tip20_policy_id_slot(address: Address, key: U256) -> bool {
-    address.is_tip20() && key == tip20_slots::TRANSFER_POLICY_ID
-}
-
-/// Replaces the L1-owned transfer-policy field while preserving Zone-local packed fields.
-pub fn merge_transfer_policy_id(local_slot: U256, l1_slot: U256) -> U256 {
-    let offset_bits = tip20_slots::TRANSFER_POLICY_ID_OFFSET * 8;
-    let field_bits = core::mem::size_of::<u64>() * 8;
-    let field_mask = ((U256::ONE << field_bits) - U256::ONE) << offset_bits;
-    (local_slot & !field_mask) | (l1_slot & field_mask)
 }
 
 #[cfg(test)]

--- a/crates/precompiles/src/storage.rs
+++ b/crates/precompiles/src/storage.rs
@@ -4,7 +4,7 @@
 use alloc::{rc::Rc, string::String};
 use core::{cell::Cell, fmt};
 
-use alloy_primitives::{Address, B256, U256, keccak256};
+use alloy_primitives::{Address, B256, keccak256};
 use alloy_sol_types::SolValue;
 use revm::{context::result::AnyError, precompile::PrecompileError};
 use thiserror::Error;

--- a/crates/precompiles/src/test_utils/l1_reader.rs
+++ b/crates/precompiles/src/test_utils/l1_reader.rs
@@ -21,7 +21,6 @@ pub struct MockL1Reader {
     registry_storage: Shared<HashMapStorageProvider>,
     storage_requests: Shared<Vec<L1Slot>>,
     fallback: B256,
-    policy_id: u64,
     fail_storage: bool,
 }
 
@@ -32,7 +31,6 @@ impl Default for MockL1Reader {
             registry_storage: Arc::new(Mutex::new(HashMapStorageProvider::new(1))),
             storage_requests: Default::default(),
             fallback: B256::ZERO,
-            policy_id: 0,
             fail_storage: false,
         }
     }
@@ -41,24 +39,6 @@ impl Default for MockL1Reader {
 impl MockL1Reader {
     pub fn insert(&self, address: Address, slot: U256, anchor: u64, value: U256) {
         self.set_u256(address, slot, anchor, value);
-    }
-
-    pub fn allow_all() -> Self {
-        Self::with_policy_id(1)
-    }
-
-    pub fn failing() -> Self {
-        Self {
-            fail_storage: true,
-            ..Self::allow_all()
-        }
-    }
-
-    pub fn with_policy_id(policy_id: u64) -> Self {
-        Self {
-            policy_id,
-            ..Default::default()
-        }
     }
 
     pub fn returning(value: B256) -> Self {
@@ -106,18 +86,6 @@ impl MockL1Reader {
             U256::ONE,
         );
     }
-
-    pub fn seed_transfer_policy_id(&self, token: Address, block_number: u64) {
-        let packed = U256::from(self.policy_id)
-            << (tempo_precompiles::tip20::tip20_slots::TRANSFER_POLICY_ID_OFFSET * 8);
-        self.set_u256(
-            token,
-            tempo_precompiles::tip20::tip20_slots::TRANSFER_POLICY_ID,
-            block_number,
-            packed,
-        );
-    }
-
     pub fn seed_simple_policy(
         &self,
         policy_id: u64,


### PR DESCRIPTION
Stacked on #789.

Removes the legacy TIP-20 transfer-policy slot dependency now that TIP-403 is the sole mirrored policy owner:

- stop overlaying and sanitizing the packed TIP-20 policy field in `L1OverlayDB`
- stop invalidating `L1StateCache` from TIP-20 `TransferPolicyUpdate` logs
- remove legacy TIP-20 slot seeding and helpers from test fixtures

Validation:

- `cargo test -p zone-evm -p zone-l1 -p zone-precompiles`
- `cargo test -p zone-node --tests --no-run`
- `cargo clippy -p zone-evm -p zone-l1 -p zone-precompiles --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
