### PR TITLE
refactor(evm): use L1 reader portal address

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -99,13 +99,8 @@ where
         precompiles.apply_precompile(&ZONE_TX_CONTEXT_ADDRESS, |_| Some(ZoneTxContext::create()));
         let outbox_env = env.clone();
         let outbox_l1 = l1.clone();
-        let outbox_portal = self.portal_address;
         precompiles.apply_precompile(&ZONE_OUTBOX_ADDRESS, move |_| {
-            Some(create_outbox_precompile(
-                outbox_portal,
-                outbox_l1.clone(),
-                &outbox_env,
-            ))
+            Some(create_outbox_precompile(outbox_l1.clone(), &outbox_env))
         });
         precompiles.apply_precompile(&CHAUM_PEDERSEN_VERIFY_ADDRESS, |_| {
             Some(ChaumPedersenVerify::create(&env))

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -69,11 +69,7 @@ use tempo_precompiles::{Precompile as _, tip20::TIP20Token, tip403_registry::TIP
 
 /// Creates the native ZoneOutbox over ordinary Zone storage and direct finalized portal reads.
 #[cfg(feature = "std")]
-pub fn create_outbox_precompile<P>(
-    portal_address: Address,
-    l1: L1State<P>,
-    env: &ZonePrecompileEnv,
-) -> DynPrecompile
+pub fn create_outbox_precompile<P>(l1: L1State<P>, env: &ZonePrecompileEnv) -> DynPrecompile
 where
     P: L1StorageReader,
 {
@@ -84,14 +80,7 @@ where
         move |data, caller| {
             let (tx_hash, fee_payer) =
                 tx_context::current_transaction().unwrap_or((Default::default(), caller));
-            ZoneOutbox::new().call_with_transaction(
-                &l1,
-                portal_address,
-                data,
-                caller,
-                tx_hash,
-                fee_payer,
-            )
+            ZoneOutbox::new().call_with_transaction(&l1, data, caller, tx_hash, fee_payer)
         },
     )
 }

--- a/crates/precompiles/src/outbox/dispatch.rs
+++ b/crates/precompiles/src/outbox/dispatch.rs
@@ -20,7 +20,6 @@ impl ZoneOutbox {
     pub(crate) fn call_with_transaction<P: L1StorageReader>(
         &mut self,
         l1: &L1State<P>,
-        portal_address: Address,
         calldata: &[u8],
         msg_sender: Address,
         tx_hash: B256,
@@ -40,10 +39,10 @@ impl ZoneOutbox {
                 nextWithdrawalIndex(_) => metadata::<IZoneOutbox::nextWithdrawalIndexCall>(|| self.next_withdrawal_index.read()),
                 lastFallbackNonce(_) => metadata::<IZoneOutbox::lastFallbackNonceCall>(|| self.last_fallback_nonce.read()),
                 pendingWithdrawalsCount(_) => typed_metadata::<IZoneOutbox::pendingWithdrawalsCountCall, _>(|| {
-                    self.pending_withdrawals_count(l1, portal_address, msg_sender)
+                    self.pending_withdrawals_count(l1, msg_sender)
                 }),
                 getPendingWithdrawals(_) => typed_metadata::<IZoneOutbox::getPendingWithdrawalsCall, _>(|| {
-                    self.get_pending_withdrawals(l1, portal_address, msg_sender)
+                    self.get_pending_withdrawals(l1, msg_sender)
                 }),
                 calculateWithdrawalFee(call) => view(call, |call| self.calculate_withdrawal_fee(call.gasLimit)),
                 MAX_CALLBACK_DATA_SIZE(_) => metadata::<IZoneOutbox::MAX_CALLBACK_DATA_SIZECall>(|| Ok(U256::from(MAX_CALLBACK_DATA_SIZE))),
@@ -52,14 +51,14 @@ impl ZoneOutbox {
                 WITHDRAWAL_BASE_GAS(_) => metadata::<IZoneOutbox::WITHDRAWAL_BASE_GASCall>(|| Ok(WITHDRAWAL_BASE_GAS)),
                 REVEAL_TO_KEY_LENGTH(_) => metadata::<IZoneOutbox::REVEAL_TO_KEY_LENGTHCall>(|| Ok(U256::from(COMPRESSED_PUBLIC_KEY_SIZE))),
                 AUTHENTICATED_WITHDRAWAL_CIPHERTEXT_LENGTH(_) => metadata::<IZoneOutbox::AUTHENTICATED_WITHDRAWAL_CIPHERTEXT_LENGTHCall>(|| Ok(U256::from(AUTHENTICATED_WITHDRAWAL_ENCRYPTED_SIZE))),
-                setTempoGasRate(call) => mutate_void(call, msg_sender, |sender, call| self.set_tempo_gas_rate(l1, portal_address, sender, call)),
-                setMaxWithdrawalsPerBlock(call) => mutate_void(call, msg_sender, |sender, call| self.set_max_withdrawals_per_block(l1, portal_address, sender, call)),
+                setTempoGasRate(call) => mutate_void(call, msg_sender, |sender, call| self.set_tempo_gas_rate(l1, sender, call)),
+                setMaxWithdrawalsPerBlock(call) => mutate_void(call, msg_sender, |sender, call| self.set_max_withdrawals_per_block(l1, sender, call)),
                 requestWithdrawal(call) => mutate_void(call, msg_sender, |sender, call| {
                     self.request_withdrawal(sender, fee_payer, tx_hash, call)
                 }),
                 enqueueDepositBounceBack(call) => mutate_void(call, msg_sender, |sender, call| self.enqueue_deposit_bounce_back(sender, call)),
                 consumeFallbackRecipient(call) => mutate(call, msg_sender, |sender, call| self.consume_fallback_recipient(sender, call.fallbackNonce)),
-                finalizeWithdrawalBatch(call) => mutate(call, msg_sender, |sender, call| self.finalize_withdrawal_batch(l1, portal_address, sender, call)),
+                finalizeWithdrawalBatch(call) => mutate(call, msg_sender, |sender, call| self.finalize_withdrawal_batch(l1, sender, call)),
             }
         })
     }

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -53,24 +53,22 @@ impl ZoneOutbox {
     fn read_portal_slot<P: L1StorageReader>(
         &self,
         l1: &L1State<P>,
-        portal_address: Address,
         slot: B256,
     ) -> ZoneResult<U256> {
         let anchor = TempoState::new().tempo_block_number.read()?;
-        Ok(l1.read_l1_storage(portal_address, slot, anchor)?.into())
+        Ok(l1.read_l1_storage(l1.portal(), slot, anchor)?.into())
     }
 
     fn ensure_sequencer<P: L1StorageReader>(
         &self,
         l1: &L1State<P>,
-        portal_address: Address,
         caller: Address,
     ) -> ZoneResult<()> {
         if caller == Address::ZERO {
             return Ok(());
         }
         let membership_slot = caller.mapping_slot(PORTAL_IS_SEQUENCER_SLOT.into());
-        if self.read_portal_slot(l1, portal_address, membership_slot.into())? == U256::ZERO {
+        if self.read_portal_slot(l1, membership_slot.into())? == U256::ZERO {
             return Err(ZoneOutboxError::only_sequencer().into());
         }
         Ok(())
@@ -232,11 +230,10 @@ impl ZoneOutbox {
     fn finalize_withdrawal_batch<P: L1StorageReader>(
         &mut self,
         l1: &L1State<P>,
-        portal_address: Address,
         caller: Address,
         call: IZoneOutbox::finalizeWithdrawalBatchCall,
     ) -> ZoneResult<B256> {
-        self.ensure_sequencer(l1, portal_address, caller)?;
+        self.ensure_sequencer(l1, caller)?;
         if call.blockNumber != self.storage.block_number() {
             return Err(ZoneOutboxError::invalid_block_number().into());
         }
@@ -285,11 +282,10 @@ impl ZoneOutbox {
     fn set_tempo_gas_rate<P: L1StorageReader>(
         &mut self,
         l1: &L1State<P>,
-        portal_address: Address,
         caller: Address,
         call: IZoneOutbox::setTempoGasRateCall,
     ) -> ZoneResult<()> {
-        self.ensure_sequencer(l1, portal_address, caller)?;
+        self.ensure_sequencer(l1, caller)?;
         if call._tempoGasRate > MAX_GAS_FEE_RATE {
             return Err(ZoneOutboxError::gas_fee_rate_too_high().into());
         }
@@ -301,11 +297,10 @@ impl ZoneOutbox {
     fn set_max_withdrawals_per_block<P: L1StorageReader>(
         &mut self,
         l1: &L1State<P>,
-        portal_address: Address,
         caller: Address,
         call: IZoneOutbox::setMaxWithdrawalsPerBlockCall,
     ) -> ZoneResult<()> {
-        self.ensure_sequencer(l1, portal_address, caller)?;
+        self.ensure_sequencer(l1, caller)?;
         self.max_withdrawals_per_block
             .write(call._maxWithdrawalsPerBlock)?;
         self.emit_event(ZoneOutboxEvent::max_withdrawals_per_block_updated(
@@ -317,10 +312,9 @@ impl ZoneOutbox {
     fn pending_withdrawals_count<P: L1StorageReader>(
         &self,
         l1: &L1State<P>,
-        portal_address: Address,
         caller: Address,
     ) -> ZoneResult<U256> {
-        self.ensure_sequencer(l1, portal_address, caller)?;
+        self.ensure_sequencer(l1, caller)?;
         self.pending_withdrawals
             .len()
             .map(U256::from)
@@ -330,10 +324,9 @@ impl ZoneOutbox {
     fn get_pending_withdrawals<P: L1StorageReader>(
         &self,
         l1: &L1State<P>,
-        portal_address: Address,
         caller: Address,
     ) -> ZoneResult<Vec<IZoneOutbox::PendingWithdrawal>> {
-        self.ensure_sequencer(l1, portal_address, caller)?;
+        self.ensure_sequencer(l1, caller)?;
         let len = self.pending_withdrawals.len()?;
         let mut pending = Vec::with_capacity(len);
         for index in 0..len {

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -69,7 +69,7 @@ impl Harness {
         }
 
         let env = test_env(&ctx);
-        let precompile = create_outbox_precompile(PORTAL, L1State::new(l1.clone(), PORTAL), &env);
+        let precompile = create_outbox_precompile(L1State::new(l1.clone(), PORTAL), &env);
 
         Ok(Self {
             ctx,

--- a/crates/precompiles/src/storage.rs
+++ b/crates/precompiles/src/storage.rs
@@ -74,6 +74,11 @@ impl<P> L1State<P> {
         self.anchor.get()
     }
 
+    /// Returns the ZonePortal configured for this execution-local L1 state.
+    pub(crate) const fn portal(&self) -> Address {
+        self.portal_address
+    }
+
     fn set_anchor(&self, new: u64) -> Result<(), L1StateError> {
         match self.get_anchor() {
             None => {


### PR DESCRIPTION
## Summary
- make `L1StorageReader::portal_address()` the authoritative ZonePortal configuration
- derive the Outbox portal from its shared `L1State` instead of accepting a second address
- remove duplicate portal arguments from `ZoneEvmFactory` and `ZoneEvmConfig`
- update the production provider and test reader implementations

This prevents Inbox/Outbox and L1-backed execution from being configured against different portal accounts.

## Validation
- `cargo test -p zone-precompiles outbox::tests --lib`
- `cargo test -p zone-evm --lib`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
