### PR TITLE
refactor: clean up eyre error handling

### DIFF
--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -276,7 +276,7 @@ impl L1Subscriber {
             next_block = self.sync_finalized_once(l1_provider, next_block).await?;
         }
 
-        eyre::bail!("L1 head notification stream ended")
+        Err(eyre::eyre!("L1 head notification stream ended"))
     }
 
     /// Backfill L1 blocks from `from..=to` with pipelined RPC fetching.

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -34,7 +34,7 @@ use alloy_rlp::Encodable;
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent, SolStruct, SolValue, eip712_domain, sol};
-use eyre::Result;
+use eyre::{OptionExt as _, Result};
 use futures::{StreamExt, TryStreamExt};
 use parking_lot::RwLock;
 use schnellru::{ByLength, LruMap};
@@ -404,13 +404,14 @@ impl BatchSubmitter {
             .l1_provider
             .get_block_by_number(anchor_block_number.into())
             .await?
-            .ok_or_else(|| eyre::eyre!("L1 anchor block {anchor_block_number} not found"))?
+            .ok_or_eyre(format!("L1 anchor block {anchor_block_number} not found"))?
             .header
             .hash;
 
-        let signer = self.signer.as_ref().ok_or_else(|| {
-            eyre::eyre!("TIP-1091 batch submission requires the local sequencer signer")
-        })?;
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or_eyre("TIP-1091 batch submission requires the local sequencer signer")?;
         let verifier_config = Bytes::new();
         let signature = self
             .sign_settlement_attestation(


### PR DESCRIPTION
Collects the focused error-handling cleanup currently mixed into #750 and #788.

- return subscriber stream termination as the function's tail error
- use `eyre::OptionExt` for settlement option conversions

No functional changes from either source PR are included.
