### PR TITLE
Remove unencrypted deposits into zones

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -93,28 +93,6 @@ max-approve-portal token="0x20C0000000000000000000000000000000000000":
     echo "Approved!"
 
 [group('zone')]
-[doc('Sends a test deposit to the ZonePortal on L1 (moderato). Requires L1_RPC_URL and PRIVATE_KEY env vars. Run max-approve-portal first.')]
-send-deposit amount="1000000" to="" token="0x20C0000000000000000000000000000000000000" memo="0x0000000000000000000000000000000000000000000000000000000000000000":
-    #!/bin/bash
-    set -euo pipefail
-    RPC="${L1_RPC_URL:?Set L1_RPC_URL env var}"
-    PK="${PRIVATE_KEY:?Set PRIVATE_KEY env var}"
-    PORTAL="${L1_PORTAL_ADDRESS:?Set L1_PORTAL_ADDRESS env var}"
-    SENDER=$(cast wallet address "$PK")
-    TO="{{to}}"
-    if [[ -z "$TO" ]]; then
-        TO="$SENDER"
-    fi
-    echo "Depositing {{amount}} to $TO..."
-    TX_OUTPUT=$(cast send "$PORTAL" "deposit(address,address,uint128,bytes32,address)" "{{token}}" "$TO" "{{amount}}" "{{memo}}" "$SENDER" \
-        --rpc-url "$RPC" --private-key "$PK" --json)
-    TX_HASH=$(echo "$TX_OUTPUT" | jq -r '.transactionHash')
-    L1_BLOCK=$(echo "$TX_OUTPUT" | jq -r '.blockNumber')
-    L1_BLOCK_DEC=$(printf '%d' "$L1_BLOCK")
-    echo "Deposit sent! (block $L1_BLOCK_DEC)"
-    echo "Explorer: https://explore.moderato.tempo.xyz/tx/$TX_HASH"
-
-[group('zone')]
 [doc('Sends an encrypted deposit to the ZonePortal on L1 (recipient and memo are hidden on-chain). Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and PRIVATE_KEY env vars. Run max-approve-portal first.')]
 send-deposit-encrypted amount="1000000" to="" memo="0x0000000000000000000000000000000000000000000000000000000000000000" token="0x20C0000000000000000000000000000000000000" rpc=zone_rpc:
     #!/bin/bash

--- a/README.md
+++ b/README.md
@@ -83,12 +83,6 @@ export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
 export PRIVATE_KEY=$(jq -r '.sequencerKey' generated/my-zone/zone.json)
 just max-approve-portal
 
-# deposit into the zone
-just send-deposit 1000000                       # deposit to your own address
-just send-deposit 1000000 <recipient-address>   # deposit to a specific address
-```
-
-```bash
 # send an encrypted deposit
 just send-deposit-encrypted 1000000                       # to your own address
 just send-deposit-encrypted 1000000 <recipient-address>   # to a specific address

--- a/crates/contracts/src/lib.rs
+++ b/crates/contracts/src/lib.rs
@@ -203,31 +203,6 @@ mod tests {
     }
 
     #[test]
-    fn test_router_plaintext_callback_encoding_matches_tuple() {
-        let callback = SwapAndDepositRouterPlaintextCallback {
-            token_out: address!("0x0000000000000000000000000000000000001001"),
-            target_portal: address!("0x0000000000000000000000000000000000002001"),
-            recipient: address!("0x0000000000000000000000000000000000003001"),
-            tempo_refund_recipient: address!("0x0000000000000000000000000000000000004001"),
-            memo: B256::from([0x11; 32]),
-            min_amount_out: 1234,
-        };
-
-        let tuple_encoding = (
-            false,
-            callback.token_out,
-            callback.target_portal,
-            callback.recipient,
-            callback.tempo_refund_recipient,
-            callback.memo,
-            callback.min_amount_out,
-        )
-            .abi_encode_params();
-
-        assert_eq!(callback.abi_encode(), tuple_encoding);
-    }
-
-    #[test]
     fn test_sender_tag_matches_plaintext_hash() {
         let sender = address!("0x0000000000000000000000000000000000000001");
         let tx_hash = B256::repeat_byte(0x22);
@@ -260,7 +235,6 @@ mod tests {
         };
 
         let tuple_encoding = (
-            true,
             callback.token_out,
             callback.target_portal,
             callback.key_index,

--- a/crates/contracts/src/precompiles/swap_and_deposit_router.rs
+++ b/crates/contracts/src/precompiles/swap_and_deposit_router.rs
@@ -2,7 +2,7 @@
 
 use crate::EncryptedDepositPayload;
 use alloc::vec::Vec;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolValue;
 
 crate::sol! {
@@ -16,44 +16,6 @@ crate::sol! {
             uint128 amount,
             bytes calldata data
         ) external returns (bytes4);
-    }
-}
-
-/// Plaintext callback payload for `SwapAndDepositRouter.onWithdrawalReceived`.
-///
-/// This payload tells the router to optionally swap the withdrawn token on L1
-/// and then perform a regular `ZonePortal.deposit(...)`.
-#[derive(Debug, Clone)]
-pub struct SwapAndDepositRouterPlaintextCallback {
-    /// Token that should be deposited after the optional L1 swap.
-    pub token_out: Address,
-    /// Target zone portal that receives the downstream deposit.
-    pub target_portal: Address,
-    /// Zone recipient for the downstream plaintext deposit.
-    pub recipient: Address,
-    /// Tempo refund recipient if the downstream zone deposit later bounces.
-    pub tempo_refund_recipient: Address,
-    /// Memo recorded on the downstream plaintext deposit.
-    pub memo: B256,
-    /// Minimum acceptable output from the optional swap.
-    ///
-    /// Ignored when `tokenIn == token_out` and the router can deposit directly.
-    pub min_amount_out: u128,
-}
-
-impl SwapAndDepositRouterPlaintextCallback {
-    /// ABI-encode the router callback data expected by the Solidity router.
-    pub fn abi_encode(&self) -> Vec<u8> {
-        (
-            false,
-            self.token_out,
-            self.target_portal,
-            self.recipient,
-            self.tempo_refund_recipient,
-            self.memo,
-            self.min_amount_out,
-        )
-            .abi_encode_params()
     }
 }
 
@@ -84,7 +46,6 @@ impl SwapAndDepositRouterEncryptedCallback {
     /// ABI-encode the router callback data expected by the Solidity router.
     pub fn abi_encode(&self) -> Vec<u8> {
         (
-            true,
             self.token_out,
             self.target_portal,
             self.key_index,

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -186,16 +186,6 @@ crate::sol! {
 
         // -- State-changing functions --
 
-        function deposit(
-            address token,
-            address to,
-            uint128 amount,
-            bytes32 memo,
-            address tempoRefundRecipient
-        )
-            external
-            returns (bytes32 newCurrentDepositQueueHash);
-
         function processWithdrawals(Withdrawal[] calldata withdrawals, bytes32 remainingQueue) external;
 
         function submitBatch(

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -45,7 +45,7 @@ cast rpc tempo_fundAddress "$ADDR" --rpc-url "$L1_RPC_URL"
 # Approve the portal and deposit tokens to the zone
 export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
 just max-approve-portal
-just send-deposit 1000000
+just send-deposit-encrypted 1000000
 
 # Check your balance on the zone
 just check-balance "$ADDR"
@@ -212,17 +212,6 @@ cast rpc tempo_fundAddress "$ADDR" --rpc-url "$L1_RPC_URL"
 ```
 
 #### Deposit from L1 to Zone
-
-Approve the portal to spend your tokens, then deposit:
-
-```bash
-export L1_PORTAL_ADDRESS=$(jq -r '.portal' generated/my-zone/zone.json)
-just max-approve-portal
-just send-deposit 1000000                       # deposit to your own address
-just send-deposit 1000000 <recipient-address>   # deposit to a specific address
-```
-
-#### Encrypted Deposit (Private Recipient)
 
 Encrypted deposits hide the recipient address and memo on-chain using ECIES encryption to the sequencer's public key. Only the sequencer can decrypt them during block building.
 
@@ -424,7 +413,7 @@ Once the token is enabled, approve the portal and deposit as usual — just pass
 just max-approve-portal <token-address>
 
 # Deposit the custom token into the zone
-just send-deposit 1000000 "" <token-address>
+just send-deposit-encrypted 1000000 "" 0x0000000000000000000000000000000000000000000000000000000000000000 <token-address>
 
 # Check balance on the zone (pass the token address)
 just check-balance "$ADDR" <token-address>
@@ -625,7 +614,6 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `just deploy-router <name> [dex]` | Deploy `SwapAndDepositRouter` on L1 for the zone and save it to `zone.json` |
 | `just zone-up <name> [reset] [profile]` | Start the zone node. `reset=true` wipes datadir. `profile=release` for production. |
 | `just max-approve-portal [token]` | Approve portal to spend tokens on L1 |
-| `just send-deposit [amount] [to] [token] [memo]` | Deposit tokens from L1 to zone (defaults to sender) |
 | `just send-deposit-encrypted [amount] [to] [memo] [token] [rpc]` | Encrypted deposit — hides recipient and memo on-chain |
 | `just enable-token <token>` | Enable a TIP-20 token on the portal for bridging (admin only) |
 | `just pause-deposits <token>` | Pause deposits for an enabled token on the portal (admin only) |

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -494,18 +494,6 @@ struct TokenConfig {
 /// @notice Interface for zone portal on Tempo
 interface IZonePortal {
 
-    event DepositMade(
-        bytes32 indexed newCurrentDepositQueueHash,
-        address indexed sender,
-        address token,
-        address to,
-        uint128 netAmount,
-        uint128 fee,
-        bytes32 memo,
-        address tempoRefundRecipient,
-        uint64 depositNumber
-    );
-
     /// @notice Emitted after a batch is accepted by `submitBatch`.
     /// @dev `withdrawalQueueIndex` is the logical (non-wrapping) withdrawal queue index the
     ///      batch's hash chain was enqueued under, or `NO_QUEUE_INDEX` (`type(uint256).max`)
@@ -809,16 +797,6 @@ interface IZonePortal {
         external
         view
         returns (bool valid, uint64 expiresAtBlock);
-
-    function deposit(
-        address token,
-        address to,
-        uint128 amount,
-        bytes32 memo,
-        address tempoRefundRecipient
-    )
-        external
-        returns (bytes32 newCurrentDepositQueueHash);
 
     /// @notice Deposit with encrypted recipient and memo
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key

--- a/specs/ref-impls/src/tempo/SwapAndDepositRouter.sol
+++ b/specs/ref-impls/src/tempo/SwapAndDepositRouter.sol
@@ -16,7 +16,7 @@ import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 /// @notice Router contract for cross-zone transfers with optional token swap
 /// @dev Receives withdrawal callbacks, swaps tokens if needed via StablecoinDEX, and deposits to target zone.
 ///      Handles both same-token (no swap) and different-token (swap) cross-zone transfers.
-///      Supports both plaintext and encrypted deposits.
+///      Supports encrypted deposits.
 ///      On any failure (swap or deposit), the entire callback reverts, causing the withdrawal
 ///      to bounce back to the zoneFallbackRecipient on the source zone.
 contract SwapAndDepositRouter is IWithdrawalReceiver {
@@ -59,8 +59,7 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
     /// @param data ABI-encoded callbackData (see format below)
     /// @return selector The function selector to confirm successful handling
     ///
-    /// Plaintext format: (bool isEncrypted=false, address tokenOut, address targetPortal, address recipient, address tempoRefundRecipient, bytes32 memo, uint128 minAmountOut)
-    /// Encrypted format: (bool isEncrypted=true, address tokenOut, address targetPortal, uint256 keyIndex, EncryptedDepositPayload encrypted, address tempoRefundRecipient, uint128 minAmountOut)
+    /// Data format: (address tokenOut, address targetPortal, uint256 keyIndex, EncryptedDepositPayload encrypted, address tempoRefundRecipient, uint128 minAmountOut)
     ///
     /// Note: minAmountOut is ignored for same-token transfers (no swap)
     function onWithdrawalReceived(
@@ -83,45 +82,22 @@ contract SwapAndDepositRouter is IWithdrawalReceiver {
             revert InvalidSourcePortal();
         }
 
-        bool isEncrypted = abi.decode(data, (bool));
+        (
+            address tokenOut,
+            address targetPortal,
+            uint256 keyIndex,
+            EncryptedDepositPayload memory encrypted,
+            address tempoRefundRecipient,
+            uint128 minAmountOut
+        ) = abi.decode(
+            data, (address, address, uint256, EncryptedDepositPayload, address, uint128)
+        );
 
-        if (isEncrypted) {
-            (, // skip isEncrypted
-                address tokenOut,
-                address targetPortal,
-                uint256 keyIndex,
-                EncryptedDepositPayload memory encrypted,
-                address tempoRefundRecipient,
-                uint128 minAmountOut
-            ) = abi.decode(
-                data, (bool, address, address, uint256, EncryptedDepositPayload, address, uint128)
-            );
-
-            _validateTarget(targetPortal, tokenOut);
-
-            uint128 amountOut = _swapIfNeeded(tokenIn, tokenOut, amount, minAmountOut);
-
-            ITIP20(tokenOut).approve(targetPortal, amountOut);
-            IZonePortal(targetPortal)
-                .depositEncrypted(tokenOut, amountOut, keyIndex, encrypted, tempoRefundRecipient);
-        } else {
-            (, // skip isEncrypted
-                address tokenOut,
-                address targetPortal,
-                address recipient,
-                address tempoRefundRecipient,
-                bytes32 memo,
-                uint128 minAmountOut
-            ) = abi.decode(data, (bool, address, address, address, address, bytes32, uint128));
-
-            _validateTarget(targetPortal, tokenOut);
-
-            uint128 amountOut = _swapIfNeeded(tokenIn, tokenOut, amount, minAmountOut);
-
-            ITIP20(tokenOut).approve(targetPortal, amountOut);
-            IZonePortal(targetPortal)
-                .deposit(tokenOut, recipient, amountOut, memo, tempoRefundRecipient);
-        }
+        _validateTarget(targetPortal, tokenOut);
+        uint128 amountOut = _swapIfNeeded(tokenIn, tokenOut, amount, minAmountOut);
+        ITIP20(tokenOut).approve(targetPortal, amountOut);
+        IZonePortal(targetPortal)
+            .depositEncrypted(tokenOut, amountOut, keyIndex, encrypted, tempoRefundRecipient);
 
         return IWithdrawalReceiver.onWithdrawalReceived.selector;
     }

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -639,57 +639,6 @@ contract ZonePortal is IZonePortal {
         thisDeposit = ++depositCount;
     }
 
-    /// @notice Deposit a TIP-20 token into the zone. Returns the new current deposit queue hash.
-    /// @dev Fee is deducted from amount and paid to the admin in the same token.
-    ///      The token must be enabled and deposits must be active.
-    /// @param _token The TIP-20 token to deposit
-    /// @param to Recipient address on the zone
-    /// @param amount Total amount to deposit (fee will be deducted)
-    /// @param memo User-provided context
-    /// @return newCurrentDepositQueueHash The new deposit queue hash after this deposit
-    function deposit(
-        address _token,
-        address to,
-        uint128 amount,
-        bytes32 memo,
-        address tempoRefundRecipient
-    )
-        external
-        returns (bytes32 newCurrentDepositQueueHash)
-    {
-        if (tempoRefundRecipient == address(0)) revert InvalidBouncebackRecipient();
-
-        _validateDepositsActive(_token);
-        _validateDepositPolicy(_token, to, tempoRefundRecipient);
-        (uint128 fee, uint128 netAmount) = _collectDepositFunds(_token, amount);
-
-        // Build deposit struct with net amount (fee already paid to the admin on Tempo)
-        Deposit memory depositData = Deposit({
-            token: _token,
-            sender: msg.sender,
-            to: to,
-            amount: netAmount,
-            tempoRefundRecipient: tempoRefundRecipient,
-            memo: memo
-        });
-
-        // Insert deposit into queue
-        newCurrentDepositQueueHash = DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
-        uint64 thisDeposit = _recordDeposit(newCurrentDepositQueueHash);
-
-        emit DepositMade(
-            newCurrentDepositQueueHash,
-            msg.sender,
-            _token,
-            to,
-            netAmount,
-            fee,
-            memo,
-            tempoRefundRecipient,
-            thisDeposit
-        );
-    }
-
     /// @notice Deposit with encrypted recipient and memo
     /// @dev The encrypted payload contains (to, memo) encrypted to the sequencer's key.
     ///      The token identity is public (not encrypted) since the portal must escrow it.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -21,7 +21,6 @@
     - [Sequencer Set Rotation](#sequencer-set-rotation)
     - [Admin Transfer](#admin-transfer)
   - [Deposits](#deposits)
-    - [Regular Deposits](#regular-deposits)
     - [Deposit Fees](#deposit-fees)
     - [Deposit Queue](#deposit-queue)
     - [Encrypted Deposits](#encrypted-deposits)
@@ -142,11 +141,11 @@ sequenceDiagram
     participant Z as Zone
 
     Note over T: Deposit
-    U->>T: ZonePortal.deposit()
+    U->>T: ZonePortal.depositEncrypted()
     T->>T: lock tokens, append to deposit queue
 
     Note over Z: Process deposit
-    Z-->>T: observe DepositMade
+    Z-->>T: observe EncryptedDepositMade
     Z->>Z: ZoneInbox.advanceTempo()
     Z->>Z: mint tokens to recipient
 
@@ -364,37 +363,6 @@ Until `acceptAdmin()` is called the current admin retains all governance powers,
 
 Deposits move TIP-20 tokens from Tempo into a zone. The user deposits on Tempo, the portal locks the tokens and appends the deposit to a hash chain, and the sequencer mints equivalent tokens on the zone.
 
-### Regular Deposits
-
-A user deposits by calling `deposit(token, to, amount, memo, tempoRefundRecipient)` on the portal. The portal:
-
-1. Validates the token is enabled and deposits are active.
-2. Requires `tempoRefundRecipient != address(0)` (reverts `InvalidBouncebackRecipient` otherwise), validates `to` against the token's TIP-403 recipient and mint-recipient policies, and validates `tempoRefundRecipient` against the token's TIP-403 recipient policy (reverts otherwise).
-3. Computes `depositFee` from `zoneGasRate` and checks `amount >= depositFee + currentBouncebackFee`, where `currentBouncebackFee = ceil(bouncebackGas * block.basefee / 1e12)` (reverts `DepositTooSmall` otherwise). This prevents obvious dust deposits that could not pay for an immediate Tempo refund when bounce-back gas is configured.
-4. Transfers `amount` from the user into the portal.
-5. Pays the `depositFee` to the portal admin immediately.
-6. Appends the deposit to the deposit queue hash chain with the net amount (`amount - depositFee`) and `tempoRefundRecipient`. No bounce-back fee is snapshotted or stored on the deposit.
-7. Emits `DepositMade`.
-
-The sequencer observes `DepositMade` events and relays deposits to the zone via `ZoneInbox.advanceTempo()`. This function processes deposits in order, minting the zone-side TIP-20 token to each recipient: `mint(deposit.to, deposit.amount)`.
-
-If the zone-side mint reverts (for example, because the recipient is blocked by a TIP-403 policy active on the zone at processing time), the deposit bounces back to `tempoRefundRecipient` on Tempo. See [Deposit Failures and Bounce-Back](#deposit-failures-and-bounce-back) for the full mechanism. If the sequencer withholds deposits, funds remain locked in the portal with no forced inclusion mechanism.
-
-```mermaid
-sequenceDiagram
-    participant U as User
-    participant T as Tempo
-    participant Z as Zone
-
-    U->>T: ZonePortal.deposit()
-    T->>T: append to depositQueue
-    Note over T: emit DepositMade
-    Z-->>T: observe DepositMade
-    Z->>Z: ZoneInbox.advanceTempo()
-    Z->>Z: process deposit
-    Z->>Z: TIP20.mint(to, amount)
-```
-
 ### Deposit Fees
 
 Every deposit is associated with a deposit fee and a possible bounce-back fee:
@@ -416,14 +384,14 @@ The two fees are conceptually independent because their work happens on differen
 Deposits flow from Tempo to the zone through a hash chain. The portal tracks a single `currentDepositQueueHash` representing the head of the chain. Each new deposit wraps the existing hash:
 
 ```
-currentDepositQueueHash = keccak256(abi.encode(DepositType.Regular, deposit, currentDepositQueueHash))
+currentDepositQueueHash = keccak256(abi.encode(DepositType.Encrypted, encryptedDeposit, currentDepositQueueHash))
 ```
 
 The newest deposit is always outermost, making onchain addition O(1). The zone tracks its own `processedDepositQueueHash` and `processedDepositNumber` in state. During `advanceTempo()`, the zone processes deposits oldest-first, rebuilding the hash chain and validating that the result matches `currentDepositQueueHash` read from Tempo state via `TempoState.readTempoStorageSlot()`.
 
 `advanceTempo()` reads the portal's `currentDepositQueueHash` from Tempo state via `TempoState.readTempoStorageSlot()`. The call must process deposits through the current queue head: after rebuilding the hash chain, the resulting `processedDepositQueueHash` must equal the portal's `currentDepositQueueHash`.
 
-After a batch is accepted, the portal updates `lastSyncedTempoBlockNumber` to record how far Tempo state was synced, and updates `lastProcessedDepositNumber` from the proven `DepositQueueTransition`. Users should track deposit inclusion by deposit number: `DepositMade` and `EncryptedDepositMade` emit `depositNumber`, `ZoneInbox.TempoAdvanced` emits the inbox's `lastProcessedDepositNumber`, and `ZonePortal.BatchSubmitted` emits the accepted portal value. A deposit with number `N` is processed once `lastProcessedDepositNumber >= N`.
+After a batch is accepted, the portal updates `lastSyncedTempoBlockNumber` to record how far Tempo state was synced, and updates `lastProcessedDepositNumber` from the proven `DepositQueueTransition`. Users should track deposit inclusion by deposit number: `EncryptedDepositMade` emits `depositNumber`, `ZoneInbox.TempoAdvanced` emits the inbox's `lastProcessedDepositNumber`, and `ZonePortal.BatchSubmitted` emits the accepted portal value. A deposit with number `N` is processed once `lastProcessedDepositNumber >= N`.
 
 ### Encrypted Deposits
 
@@ -434,13 +402,13 @@ The encryption scheme is ECIES with secp256k1:
 1. The user generates an ephemeral keypair and derives a shared secret via ECDH with the sequencer's published encryption key.
 2. The user derives an AES-256 key from the shared secret using HKDF-SHA256.
 3. The user encrypts `(to || memo || padding)` with AES-256-GCM, producing ciphertext, a nonce, and an authentication tag.
-4. The user calls `depositEncrypted(token, amount, keyIndex, encryptedPayload, tempoRefundRecipient)` on the portal, where `keyIndex` references which encryption key they encrypted to (see [Encryption Key Management](#encryption-key-management)), and `tempoRefundRecipient` is the Tempo address that receives a refund if zone-side processing fails (see [Deposit Failures and Bounce-Back](#deposit-failures-and-bounce-back)). Like `deposit()`, `depositEncrypted` requires `tempoRefundRecipient != address(0)` (reverts `InvalidBouncebackRecipient` otherwise), requires it to be authorized by the token's TIP-403 recipient policy, and requires `amount >= depositFee + currentBouncebackFee` (reverts `DepositTooSmall` otherwise).
+4. The user calls `depositEncrypted(token, amount, keyIndex, encryptedPayload, tempoRefundRecipient)` on the portal, where `keyIndex` references which encryption key they encrypted to (see [Encryption Key Management](#encryption-key-management)), and `tempoRefundRecipient` is the Tempo address that receives a refund if zone-side processing fails (see [Deposit Failures and Bounce-Back](#deposit-failures-and-bounce-back)). `depositEncrypted` requires `tempoRefundRecipient != address(0)` (reverts `InvalidBouncebackRecipient` otherwise), requires it to be authorized by the token's TIP-403 recipient policy, and requires `amount >= depositFee + currentBouncebackFee` (reverts `DepositTooSmall` otherwise).
 
 Before queue insertion, the portal also validates encrypted-payload shape. `depositEncrypted` reverts `InvalidEphemeralPubkey` if the ephemeral public key parity is not `0x02` or `0x03`, or if the X coordinate is not a valid secp256k1 X coordinate. It reverts `InvalidCiphertextLength(actual, expected)` unless `ciphertext.length == 64`, the fixed plaintext size for `(to, memo, padding)`. These are Tempo-side deposit-time reverts: no queue entry is created and no zone-side bounce-back is needed.
 
 The portal locks the tokens, appends the encrypted deposit to the deposit queue, and emits `EncryptedDepositMade`, including `tempoRefundRecipient`. The sequencer provides the ECDH shared secret and proof when processing the deposit on the zone via `advanceTempo()`; the zone decrypts `(to, memo)` from the ciphertext onchain.
 
-Regular and encrypted deposits share a single ordered queue with a type discriminator in the hash:
+Encrypted user deposits and unencrypted protocol bounce-backs share a single ordered queue with a type discriminator in the hash:
 
 ```
 keccak256(abi.encode(DepositType.Regular, deposit, prevHash))
@@ -504,13 +472,12 @@ sequenceDiagram
 
 ### Deposit Failures and Bounce-Back
 
-Deposits can fail because the zone-side mint reverts (including a TIP-403 policy rejection) or because an encrypted deposit fails onchain decryption verification. To make sure that all cases can be handled without loss of user funds, every deposit carries a `tempoRefundRecipient`: a Tempo address that receives a refund if zone-side processing fails. The sequencer has no discretionary rejection flag: every regular deposit attempts its mint, and every encrypted deposit is verified and then attempts its mint when decryption succeeds.
+Deposits can fail because the zone-side mint reverts (including a TIP-403 policy rejection) or because an encrypted deposit fails onchain decryption verification. To make sure that all cases can be handled without loss of user funds, every deposit carries a `tempoRefundRecipient`: a Tempo address that receives a refund if zone-side processing fails. The sequencer has no discretionary rejection flag: every encrypted deposit is verified and then attempts its mint when decryption succeeds.
 
-**Validation at deposit time.** Both `deposit(...)` and `depositEncrypted(...)` require `tempoRefundRecipient != address(0)` and require it to be authorized by the token's TIP-403 recipient policy. If the on-Tempo refund transfer later reverts because policy changed, the funds are parked in a per-recipient refund registry on the portal and the recipient claims them via `claimRefund(token)` (see [Tempo-side refund](#tempo-side-refund) below).
+**Validation at deposit time.** `depositEncrypted(...)` requires `tempoRefundRecipient != address(0)` and requires it to be authorized by the token's TIP-403 recipient policy. If the on-Tempo refund transfer later reverts because policy changed, the funds are parked in a per-recipient refund registry on the portal and the recipient claims them via `claimRefund(token)` (see [Tempo-side refund](#tempo-side-refund) below).
 
 **Triggering conditions.** There are two triggering sites:
 
-- **Regular deposit, mint reverts.** `ZoneInbox.advanceTempo` calls `TIP20.mint(deposit.to, deposit.amount)`. If that mint reverts the deposit bounces back to the user-supplied `tempoRefundRecipient`. The user-facing `deposit(...)` entry point ensures `tempoRefundRecipient != address(0)`, so the queue can always advance past a failed mint.
 - **Encrypted deposit.** Two failure modes, both of which unconditionally bounce back (no zone-side mint is attempted as a fallback):
   - **Invalid encryption.** The Chaum-Pedersen proof, AES-GCM tag, or decrypted plaintext length check fails during [Onchain Decryption Verification](#onchain-decryption-verification). There is no well-defined recipient on the zone in this case, so the zone does not try to mint to the depositor; it bounces back immediately.
   - **Valid decryption, mint reverts.** `TIP20.mint(decryptedTo, amount)` reverts (for example, because a TIP-403 policy active on the zone forbids minting to the decrypted recipient, or a custom TIP-20 `mint` reverts for some token-specific reason). The deposit bounces back.
@@ -549,11 +516,11 @@ sequenceDiagram
     participant T as Tempo
     participant Z as Zone
 
-    U->>T: ZonePortal.deposit(..., tempoRefundRecipient)
+    U->>T: ZonePortal.depositEncrypted(..., tempoRefundRecipient)
     Note over T: require tempoRefundRecipient != address(0)
     T->>T: append to depositQueue
-    Note over T: emit DepositMade
-    Z-->>T: observe DepositMade
+    Note over T: emit EncryptedDepositMade
+    Z-->>T: observe EncryptedDepositMade
     Z->>Z: ZoneInbox.advanceTempo(..., QueuedDeposit)
     Z->>Z: try TIP20.mint(deposit.to, amount)
     alt mint succeeds
@@ -679,7 +646,7 @@ This enables composable withdrawals where funds flow directly into Tempo contrac
 - Plaintext: `abi.encode(false, tokenOut, targetPortal, recipient, tempoRefundRecipient, memo, minAmountOut)`
 - Encrypted: `abi.encode(true, tokenOut, targetPortal, keyIndex, encryptedPayload, tempoRefundRecipient, minAmountOut)`
 
-The router validates the target portal and token, optionally swaps on Tempo, and then passes `tempoRefundRecipient` through to `ZonePortal.deposit(...)` or `ZonePortal.depositEncrypted(...)`. For encrypted deposits this field is public, matching native `depositEncrypted`; callers that do not want a later Tempo-side refund to identify the encrypted zone recipient should use a controlled refund-specific or stealth address.
+The router validates the target portal and token, optionally swaps on Tempo, and then passes `tempoRefundRecipient` through to `ZonePortal.depositEncrypted(...)`. This field is public, matching native `depositEncrypted`; callers that do not want a later Tempo-side refund to identify the encrypted zone recipient should use a controlled refund-specific or stealth address.
 
 ### Withdrawal Failures and Bounce-Back
 
@@ -1658,17 +1625,6 @@ interface IZoneFactory {
 ```solidity
 interface IZonePortal {
     // Events
-    event DepositMade(
-        bytes32 indexed newCurrentDepositQueueHash,
-        address indexed sender,
-        address token,
-        address to,
-        uint128 netAmount,
-        uint128 fee,
-        bytes32 memo,
-        address tempoRefundRecipient,
-        uint64 depositNumber
-    );
     event EncryptedDepositMade(
         bytes32 indexed newCurrentDepositQueueHash,
         address indexed sender,
@@ -1776,9 +1732,6 @@ interface IZonePortal {
     ///      if the on-Tempo refund transfer later reverts, the funds are parked in the
     ///      per-recipient refund registry exposed via `refunds(token, owner)` /
     ///      `claimRefund(token)`.
-    function deposit(
-        address token, address to, uint128 amount, bytes32 memo, address tempoRefundRecipient
-    ) external returns (bytes32 newCurrentDepositQueueHash);
     /// @dev Reverts (`InvalidBouncebackRecipient`) if `tempoRefundRecipient == address(0)`.
     ///      A ciphertext that fails onchain decryption verification has no well-defined
     ///      recipient on the zone, so the bounce-back target must always be set.


### PR DESCRIPTION
## Summary
- remove the public unencrypted `ZonePortal.deposit` API and ABI binding
- make swap-and-deposit callbacks encrypted-only
- update the zone specification and operator docs to describe encrypted deposits only

## Validation
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Solidity and Rust builds could not fetch git dependencies because the sandbox git transport returned HTTP 401. Existing test/demo callers of the removed API still need migration before this is ready to merge.

Prompted by: @jenpaff