### PR TITLE
fix TIP-1092 zone cache and proxy guards

### DIFF
--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -15,6 +15,12 @@ fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option
     .then_some(TIP403_REGISTRY_ADDRESS)
 }
 
+fn portal_event_cache_invalidation_address(topic0: Option<&B256>) -> Option<Address> {
+    use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
+
+    (topic0 == Some(&TokenEnabled::SIGNATURE_HASH)).then_some(TIP403_REGISTRY_ADDRESS)
+}
+
 /// Configuration for the L1 subscriber.
 #[derive(Debug, Clone)]
 pub struct L1SubscriberConfig {
@@ -424,6 +430,11 @@ impl L1Subscriber {
 
                 if address == portal_address {
                     invalidated.insert(address);
+                    if let Some(address) =
+                        portal_event_cache_invalidation_address(log.topics().first())
+                    {
+                        invalidated.insert(address);
+                    }
                     if let Err(e) = portal_events.push_log(log, block_number) {
                         warn!(block_number, %e, "Failed to decode portal event from receipt");
                     }
@@ -562,5 +573,14 @@ mod tests {
             cache_invalidation_address(token, Some(&TransferPolicyUpdate::SIGNATURE_HASH)),
             Some(TIP403_REGISTRY_ADDRESS)
         );
+    }
+
+    #[test]
+    fn token_enabled_events_invalidate_the_registry() {
+        assert_eq!(
+            portal_event_cache_invalidation_address(Some(&TokenEnabled::SIGNATURE_HASH)),
+            Some(TIP403_REGISTRY_ADDRESS)
+        );
+        assert_eq!(portal_event_cache_invalidation_address(None), None);
     }
 }

--- a/crates/precompiles/src/tip403_proxy/mod.rs
+++ b/crates/precompiles/src/tip403_proxy/mod.rs
@@ -18,6 +18,7 @@ const TIP403_MUTATING_SELECTORS: &[[u8; 4]] = &[
     ITIP403Registry::modifyPolicyBlacklistCall::SELECTOR,
     ITIP403Registry::createCompoundPolicyCall::SELECTOR,
     ITIP403Registry::setReceivePolicyCall::SELECTOR,
+    ITIP403Registry::migrateTransferPolicyIdsCall::SELECTOR,
 ];
 
 alloy_sol_types::sol! {
@@ -120,6 +121,19 @@ mod tests {
                 CallCheck::Revert(data) if data == ReadOnlyRegistry {}.abi_encode()
             ));
         }
+    }
+
+    #[test]
+    fn transfer_policy_migration_is_rejected_by_admission() {
+        let call = ITIP403Registry::migrateTransferPolicyIdsCall {
+            tokens: vec![Address::repeat_byte(0x20)],
+        }
+        .abi_encode();
+
+        assert!(matches!(
+            Tip403Rules.admit(&call, CALLER),
+            CallCheck::Revert(data) if data == ReadOnlyRegistry {}.abi_encode()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- invalidate the L1-backed TIP-403 registry cache when a portal emits `TokenEnabled`
- reject `migrateTransferPolicyIds` through the zone's read-only TIP-403 proxy
- add regression coverage for both mutation paths

## Why

`TokenEnabled` can follow a TIP-1092 policy migration that writes the registry without emitting a registry log. Invalidating only the portal allowed older cached registry slots to be inherited at later finalized anchors.

The zone proxy's mutating-selector denylist also omitted `migrateTransferPolicyIds`. At T9, a transaction could pass pool validation, write mirrored L1 state during execution, and then fail the state sanitizer during payload construction.

This addresses the two findings from https://github.com/tempoxyz/zones/pull/697#pullrequestreview-4758891092.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p zone-l1 -p zone-precompiles`
- `cargo clippy -p zone-l1 -p zone-precompiles --all-targets -- -D warnings`
- `git diff --check`
