### PR TITLE
fix(l1): invalidate policy storage owners

### DIFF
--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::collections::HashSet;
+use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::is_tip20_prefix;
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
@@ -8,8 +9,6 @@ const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis
 type L1ProcessedEvents = (L1PortalEvents, HashSet<Address>);
 
 fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
-    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
-
     (address == TIP403_REGISTRY_ADDRESS
         || (is_tip20_prefix(address) && topic0 == Some(&TransferPolicyUpdate::SIGNATURE_HASH)))
     .then_some(TIP403_REGISTRY_ADDRESS)
@@ -438,14 +437,16 @@ impl L1Subscriber {
                     if let Err(e) = portal_events.push_log(log, block_number) {
                         warn!(block_number, %e, "Failed to decode portal event from receipt");
                     }
-                } else if let Some(address) =
-                    cache_invalidation_address(address, log.topics().first())
-                {
-                    invalidated.insert(address);
+                } else if let Some(address) = cache_invalidation_address(address, log.topic0()) {
+                    invalidated.extend([address, log.address()]);
                 }
             }
         }
 
+        // Enabling may migrate token-local policy storage into TIP-403.
+        for event in &portal_events.enabled_tokens {
+            invalidated.extend([event.token, TIP403_REGISTRY_ADDRESS]);
+        }
         self.record_portal_event_metrics(&portal_events);
         (portal_events, invalidated)
     }
@@ -560,7 +561,6 @@ pub(crate) fn verify_receipts(
 mod tests {
     use super::*;
     use alloy_primitives::address;
-    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 
     #[test]
     fn token_policy_updates_invalidate_the_registry() {


### PR DESCRIPTION
## Summary

Policy updates can mutate storage owned by both a TIP-20 token and the TIP-403 registry. Record both addresses when processing `TransferPolicyUpdate`, and do the same for `TokenEnabled` because the portal establishes the registry binding before emitting it.

Migration calldata scanning is intentionally unnecessary: the portal enforces the binding for enabled tokens, and subsequent migrations skip an existing binding. Finalized syncing remains header-and-receipt-only.

These invalidation gaps predate #791; that PR only makes invalidation publication atomic with cache coverage advancement.

## Validation

- `cargo +nightly fmt --all --check`
- `cargo test -p zone-l1`: 71 passed
- `cargo check -p zone-node --tests`
- `cargo clippy -p zone-l1 --all-targets -- -D warnings`
- `git diff --check`