### PR TITLE
refactor: use canonical ZonePortal storage slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11148,7 +11148,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11223,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11270,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11282,7 +11282,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11342,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11380,7 +11380,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11400,7 +11400,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11434,7 +11434,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11466,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11489,7 +11489,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=2163eb53a6419b53f4388bfde9177ea96dffb570#2163eb53a6419b53f4388bfde9177ea96dffb570"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcade9c228d52d0f6215580809fca8929a13649f#bcade9c228d52d0f6215580809fca8929a13649f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11580,6 +11580,7 @@ dependencies = [
  "const-hex",
  "futures",
  "serde",
+ "tempo-precompiles",
  "tokio",
  "zone-primitives",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,25 +94,25 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "2163eb53a6419b53f4388bfde9177ea96dffb570", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "bcade9c228d52d0f6215580809fca8929a13649f", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -14,6 +14,9 @@ workspace = true
 # zones
 zone-primitives = { workspace = true, default-features = false }
 
+# tempo
+tempo-precompiles = { workspace = true, default-features = false }
+
 # alloy
 alloy-primitives = { workspace = true, default-features = false }
 alloy-sol-types = { workspace = true, default-features = false }

--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -19,8 +19,12 @@ pub use zone_tx_context::*;
 // Address and storage-slot constants the bindings build on. These live in `zone-primitives`
 // (shared with the proof system) and are re-exported here so callers can reach them through the
 // contracts crate, e.g. `tempo_zone_contracts::TEMPO_STATE_ADDRESS`.
+pub use tempo_precompiles::zone_factory::zone_portal_slots::{
+    ADMIN as PORTAL_ADMIN_SLOT, IS_SEQUENCER as PORTAL_IS_SEQUENCER_SLOT,
+    TOKEN_CONFIGS as PORTAL_TOKEN_CONFIGS_SLOT,
+};
 pub use zone_primitives::constants::{
-    EMPTY_SENTINEL, MAX_WITHDRAWAL_GAS_LIMIT, NO_QUEUE_INDEX, PORTAL_ADMIN_SLOT,
-    PORTAL_IS_SEQUENCER_SLOT, PORTAL_TOKEN_CONFIGS_SLOT, TEMPO_STATE_ADDRESS, ZONE_CONFIG_ADDRESS,
-    ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZONE_TX_CONTEXT_ADDRESS,
+    EMPTY_SENTINEL, MAX_WITHDRAWAL_GAS_LIMIT, NO_QUEUE_INDEX, TEMPO_STATE_ADDRESS,
+    ZONE_CONFIG_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS,
+    ZONE_TX_CONTEXT_ADDRESS,
 };

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -8,7 +8,8 @@ pub use ZonePortal::{
 use crate::IZoneOutbox;
 use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_sol_types::SolValue;
-use zone_primitives::constants::{EMPTY_SENTINEL, PORTAL_TOKEN_CONFIGS_SLOT};
+use tempo_precompiles::zone_factory::zone_portal_slots::TOKEN_CONFIGS;
+use zone_primitives::constants::EMPTY_SENTINEL;
 
 crate::sol! {
     #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -412,5 +413,5 @@ impl Withdrawal {
 
 /// Return the storage slot for `token` in the portal token-config mapping.
 pub fn portal_token_config_slot(token: Address) -> B256 {
-    keccak256((token, PORTAL_TOKEN_CONFIGS_SLOT).abi_encode())
+    keccak256((token, TOKEN_CONFIGS).abi_encode())
 }

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -18,7 +18,7 @@ use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS, storage::actions::StorageActions, tip_fee_manager::TipFeeManager,
 };
 use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
-use tempo_revm::{TempoStateAccess, evm::TempoContext};
+use tempo_revm::{FeeTokenResolver, TempoFeeManager, evm::TempoContext};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{L1StorageReader, tx_context};
@@ -63,7 +63,8 @@ where
         let fee_payer = ctx.tx.fee_payer().unwrap_or(ctx.tx.caller());
         let spec = ctx.cfg.spec;
 
-        let fee_token = match ctx.journaled_state.get_fee_token(
+        let fee_token = match TempoFeeManager::new().resolve_fee_token(
+            &mut ctx.journaled_state,
             &ctx.tx,
             fee_payer,
             spec,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -40,7 +40,7 @@ use reth_evm::{
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use std::{cell::RefCell, fmt, num::NonZeroU32, rc::Rc, sync::Arc};
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::TempoChainSpec;
+use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork};
 use tempo_evm::{
     TempoBlockAssembler, TempoBlockEnv, TempoBlockExecutionCtx, TempoEvmConfig, TempoEvmError,
     TempoHaltReason, TempoNextBlockEnvAttributes,
@@ -50,13 +50,14 @@ use tempo_payload_types::TempoExecutionData;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PrecompileEnv,
     RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    account_keychain::AccountKeychain, nonce::NonceManager,
+    account_keychain::AccountKeychain, error::Result as TempoResult, nonce::NonceManager,
     receive_policy_guard::ReceivePolicyGuard, storage::actions::StorageActions,
     storage_credits::NonCreditableSlots, tip_fee_manager::TipFeeManager, tip20::is_tip20_prefix,
 };
 use tempo_primitives::{
     Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType,
 };
+use tempo_revm::{FeeTokenResolver, TempoStateAccess, TempoTxEnv};
 use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_TX_CONTEXT_ADDRESS};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::{L1StateCache, L1StateProvider, L1StateProviderConfig};
@@ -239,6 +240,23 @@ pub struct ZoneEvmConfig<L1 = L1StateProvider> {
     chain_spec: Arc<ZoneChainSpec>,
     zone_factory: ZoneEvmFactory<L1>,
     block_assembler: ZoneBlockAssembler,
+}
+
+impl<L1> FeeTokenResolver for ZoneEvmConfig<L1> {
+    fn resolve_fee_token<S, M>(
+        &self,
+        state: &mut S,
+        tx: &TempoTxEnv,
+        fee_payer: Address,
+        spec: TempoHardfork,
+        actions: StorageActions,
+    ) -> TempoResult<Address>
+    where
+        S: TempoStateAccess<M>,
+    {
+        self.inner
+            .resolve_fee_token(state, tx, fee_payer, spec, actions)
+    }
 }
 
 impl<L1> ZoneEvmConfig<L1>

--- a/crates/node/tests/advance_tempo.rs
+++ b/crates/node/tests/advance_tempo.rs
@@ -12,8 +12,9 @@ use revm::{
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
+use tempo_precompiles::zone_factory::zone_portal_slots::{ADMIN, IS_SEQUENCER};
 use tempo_revm::TempoBlockEnv;
-use zone_primitives::constants::{PORTAL_ADMIN_SLOT, PORTAL_IS_SEQUENCER_SLOT, zone_chain_id};
+use zone_primitives::constants::zone_chain_id;
 
 const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
 const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
@@ -563,13 +564,9 @@ fn advance_tempo_repro() {
     println!("\n=== Test complete ===");
 }
 
-/// Pins the Rust portal storage-slot constants to the ZonePortal storage layout.
+/// The canonical Tempo layout exposes the slots consumed by Zones.
 #[test]
-fn zone_portal_storage_slot_constants_match_solidity() {
-    assert_eq!(PORTAL_ADMIN_SLOT, B256::ZERO, "admin is slot 0");
-    assert_eq!(
-        PORTAL_IS_SEQUENCER_SLOT,
-        B256::from(U256::from(19)),
-        "isSequencer is slot 19"
-    );
+fn zone_portal_storage_slots_are_exported() {
+    assert_eq!(ADMIN, U256::ZERO);
+    assert_eq!(IS_SEQUENCER, U256::from(19));
 }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -140,8 +140,8 @@ where
 }
 
 fn portal_token_config_slot(token: Address) -> B256 {
-    let portal_token_configs_slot = B256::with_last_byte(6);
-    keccak256((token, portal_token_configs_slot).abi_encode())
+    use tempo_precompiles::zone_factory::zone_portal_slots::TOKEN_CONFIGS;
+    keccak256((token, TOKEN_CONFIGS).abi_encode())
 }
 
 fn enabled_deposits_active_token_config() -> B256 {

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -12,11 +12,12 @@ use tempo_precompiles::{
     error::TempoPrecompileError,
     storage::{ContractStorage, Handler, Mapping, StorageKey},
     tip20::{ITIP20, TIP20Error, TIP20Token},
+    zone_factory::zone_portal_slots::IS_SEQUENCER,
 };
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_zone_contracts::{IZoneOutbox, Withdrawal, ZoneOutboxError, ZoneOutboxEvent};
 use zone_primitives::constants::{
-    MAX_WITHDRAWAL_GAS_LIMIT, PORTAL_IS_SEQUENCER_SLOT, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
+    MAX_WITHDRAWAL_GAS_LIMIT, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
 };
 
 use crate::{
@@ -67,7 +68,7 @@ impl ZoneOutbox {
         if caller == Address::ZERO {
             return Ok(());
         }
-        let membership_slot = caller.mapping_slot(PORTAL_IS_SEQUENCER_SLOT.into());
+        let membership_slot = caller.mapping_slot(IS_SEQUENCER);
         if self.read_portal_slot(l1, membership_slot.into())? == U256::ZERO {
             return Err(ZoneOutboxError::only_sequencer().into());
         }

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -38,8 +38,7 @@ impl Harness {
         let mut ctx = test_context();
         let token = tempo_precompiles::PATH_USD_ADDRESS;
         let l1 = MockL1Reader::default();
-        let sequencer_membership_slot =
-            keccak256((SEQUENCER, PORTAL_IS_SEQUENCER_SLOT).abi_encode());
+        let sequencer_membership_slot = keccak256((SEQUENCER, IS_SEQUENCER).abi_encode());
         l1.insert(
             PORTAL,
             sequencer_membership_slot.into(),
@@ -237,7 +236,7 @@ fn outbox_reads_injected_l1_state_at_tempo_checkpoint() -> eyre::Result<()> {
         harness.l1.storage_requests(),
         vec![(
             PORTAL,
-            keccak256((SEQUENCER, PORTAL_IS_SEQUENCER_SLOT).abi_encode()),
+            keccak256((SEQUENCER, IS_SEQUENCER).abi_encode()),
             ANCHOR
         ),]
     );

--- a/crates/precompiles/src/storage.rs
+++ b/crates/precompiles/src/storage.rs
@@ -7,8 +7,8 @@ use core::{cell::Cell, fmt};
 use alloy_primitives::{Address, B256, keccak256};
 use alloy_sol_types::SolValue;
 use revm::{context::result::AnyError, precompile::PrecompileError};
+use tempo_precompiles::zone_factory::zone_portal_slots::IS_SEQUENCER;
 use thiserror::Error;
-use zone_primitives::constants::PORTAL_IS_SEQUENCER_SLOT;
 
 pub(crate) use tempo_precompiles::storage::*;
 
@@ -124,7 +124,7 @@ impl<P: L1StorageReader> L1State<P> {
         account: Address,
         block_number: u64,
     ) -> Result<bool, L1StateError> {
-        let slot = keccak256((account, PORTAL_IS_SEQUENCER_SLOT).abi_encode());
+        let slot = keccak256((account, IS_SEQUENCER).abi_encode());
         Ok(self.read_l1_storage(self.portal_address, slot, block_number)? != B256::ZERO)
     }
 }

--- a/crates/precompiles/src/test_utils/l1_reader.rs
+++ b/crates/precompiles/src/test_utils/l1_reader.rs
@@ -75,7 +75,7 @@ impl MockL1Reader {
         let slot = keccak256(
             (
                 account,
-                zone_primitives::constants::PORTAL_IS_SEQUENCER_SLOT,
+                tempo_precompiles::zone_factory::zone_portal_slots::IS_SEQUENCER,
             )
                 .abi_encode(),
         );

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -55,19 +55,6 @@ pub const ZONE_TIP20_FACTORY_ADDRESS: Address =
 /// Default zone token address (pathUSD TIP-20).
 pub const ZONE_TOKEN_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000000");
 
-/// ZonePortal storage slot 0: `admin` (address).
-pub const PORTAL_ADMIN_SLOT: B256 = B256::ZERO;
-
-/// ZonePortal storage slot 6: `_tokenConfigs` mapping.
-pub const PORTAL_TOKEN_CONFIGS_SLOT: B256 = B256::with_last_byte(6);
-
-/// ZonePortal storage slot 19: `isSequencer` (mapping(address => bool)).
-pub const PORTAL_IS_SEQUENCER_SLOT: B256 = {
-    let mut bytes = [0u8; 32];
-    bytes[31] = 19;
-    B256::new(bytes)
-};
-
 // ---------------------------------------------------------------------------
 //  Storage slot constants for the proof system
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- bump Tempo dependencies to the merge commit for tempoxyz/tempo#6923
- replace duplicated ZonePortal slot numbers with `zone_portal_slots` exports
- remove the redundant Zones-owned slot constants

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo check -p zone-precompiles -p tempo-zone-contracts -p zone-primitives --locked` *(blocked: GitHub returned HTTP 401 while fetching `alloy-evm`)*

Prompted by: @0xalpharush