### PR TITLE
[WIP] feat(l1): version cache by verified storage roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13458,6 +13458,7 @@ dependencies = [
  "reth-provider",
  "reth-storage-api",
  "reth-tasks",
+ "schnellru",
  "serde",
  "serde_json",
  "tempo-alloy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13446,6 +13446,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
+ "alloy-trie",
  "const-hex",
  "derive_more",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ alloy-signer = "2.1.0"
 alloy-signer-local = "2.1.0"
 alloy-sol-types = { version = "1.6.0", default-features = false }
 alloy-transport = "2.1.0"
+alloy-trie = { version = "0.9.5", default-features = false }
 
 # commonware
 commonware-codec = "=2026.4.0"

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -45,6 +45,7 @@ futures.workspace = true
 k256.workspace = true
 metrics.workspace = true
 parking_lot.workspace = true
+schnellru.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -33,10 +33,12 @@ alloy-eips.workspace = true
 alloy-network.workspace = true
 alloy-primitives.workspace = true
 alloy-provider = { workspace = true, features = ["ws"] }
+alloy-rlp.workspace = true
 alloy-rpc-client.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-sol-types.workspace = true
 alloy-transport.workspace = true
+alloy-trie.workspace = true
 
 # misc
 derive_more = { workspace = true, features = ["deref"] }
@@ -52,6 +54,5 @@ tracing.workspace = true
 url = "2"
 
 [dev-dependencies]
-alloy-rlp.workspace = true
 const-hex.workspace = true
 serde_json.workspace = true

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -169,7 +169,7 @@ impl L1StateCacheInner {
     }
 
     /// Clears cached state and establishes a new contiguous receipt-coverage baseline.
-    pub fn reset(&mut self, floor: u64) {
+    fn reset(&mut self, floor: u64) {
         self.slots.clear();
         self.invalidations.clear();
         self.invalidation_count = 0;

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -121,16 +121,28 @@ impl L1StateCacheInner {
             .get(&(address, slot))?
             .range(..=block_number)
             .next_back()?;
-        let invalidated = self
+
+        // On exact match, just return the value
+        if cached_block == block_number {
+            return Some(value);
+        }
+
+        // If we didn't yet process the requested block, we can't use the cached value
+        if block_number > *self.coverage.end() {
+            return None;
+        }
+
+        // If there was an invalidation between cached and requested block, we can't use the cached value
+        if self
             .invalidations
             .get(&address)
             .and_then(|blocks| blocks.range(..=block_number).next_back())
-            .is_some_and(|&invalidated_at| invalidated_at > cached_block);
+            .is_some_and(|&invalidated_at| invalidated_at > cached_block)
+        {
+            return None;
+        }
 
-        let is_exact = cached_block == block_number;
-        let can_inherit = block_number <= *self.coverage.end() && !invalidated;
-        let is_cache_valid = cached_block >= *self.coverage.start() && (is_exact || can_inherit);
-        is_cache_valid.then_some(value)
+        Some(value)
     }
 
     /// Sets a storage slot value in the forward cache at the given block number.
@@ -156,44 +168,53 @@ impl L1StateCacheInner {
         debug_assert!(inserted, "trimmed slot history must fit cache capacity");
     }
 
-    /// Prevents values populated before the current contiguous receipt-coverage baseline from
-    /// entering the forward cache. Initialized at startup and rebased after a coverage reset.
-    pub fn initialize_floor(&mut self, block_number: u64) {
-        let floor = (*self.coverage.start()).max(block_number);
-        self.coverage = floor..=*self.coverage.end();
+    /// Clears cached state and establishes a new contiguous receipt-coverage baseline.
+    pub fn reset(&mut self, floor: u64) {
+        self.slots.clear();
+        self.invalidations.clear();
+        self.invalidation_count = 0;
+        self.coverage = floor..=floor;
     }
 
-    /// Returns the non-advancing cache floor.
-    pub fn block_floor(&self) -> u64 {
-        *self.coverage.start()
-    }
-
-    /// Invalidates inherited values for `address` starting at `block_number`.
-    pub fn invalidate(&mut self, address: Address, block_number: u64) {
-        let inserted = self
-            .invalidations
-            .entry(address)
-            .or_default()
-            .insert(block_number);
-        self.invalidation_count += usize::from(inserted);
-
-        if self.invalidation_count > self.max_invalidations {
+    /// Records mutation barriers and publishes receipt coverage for one finalized block.
+    ///
+    /// Coverage only advances one block at a time. A duplicate, skipped, or out-of-order block
+    /// invalidates the cache's continuity assumptions, so cached state is cleared and `anchor`
+    /// becomes the new coverage floor.
+    pub fn invalidate_and_set_anchor(
+        &mut self,
+        anchor: u64,
+        invalidated_addresses: impl IntoIterator<Item = Address>,
+    ) {
+        if self.coverage.end().checked_add(1) != Some(anchor) {
             warn!(
-                block_number,
-                invalidation_capacity = self.max_invalidations,
-                "L1 state invalidation capacity reached; resetting cache coverage"
+                anchor,
+                previous_anchor = *self.coverage.end(),
+                "Non-contiguous L1 state cache update; resetting cache coverage"
             );
-            // The subscriber publishes this block's coverage after recording all of its barriers.
-            // Clearing here is safe because values below this block become inadmissible.
-            self.slots.clear();
-            self.invalidations.clear();
-            self.invalidation_count = 0;
-            self.initialize_floor(block_number);
+            self.reset(anchor);
+            return;
         }
-    }
 
-    /// Updates the latest contiguous block whose receipts have been processed.
-    pub fn update_anchor(&mut self, anchor: u64) {
+        for address in invalidated_addresses {
+            let inserted = self
+                .invalidations
+                .entry(address)
+                .or_default()
+                .insert(anchor);
+            self.invalidation_count += usize::from(inserted);
+
+            if self.invalidation_count > self.max_invalidations {
+                warn!(
+                    anchor,
+                    invalidation_capacity = self.max_invalidations,
+                    "L1 state invalidation capacity reached; resetting cache coverage"
+                );
+                self.reset(anchor);
+                return;
+            }
+        }
+
         self.coverage = *self.coverage.start()..=anchor;
     }
 
@@ -286,7 +307,9 @@ mod tests {
     const PORTAL: Address = address!("0x0000000000000000000000000000000000004242");
 
     fn cover_through(cache: &mut L1StateCacheInner, block_number: u64) {
-        cache.update_anchor(block_number);
+        while cache.anchor() < block_number {
+            cache.invalidate_and_set_anchor(cache.anchor() + 1, []);
+        }
     }
 
     #[test]
@@ -360,7 +383,8 @@ mod tests {
         let old = B256::with_last_byte(0x0a);
         let new = B256::with_last_byte(0x0b);
         cache.set(PORTAL, slot, 10, old);
-        cache.invalidate(PORTAL, 11);
+        cover_through(&mut cache, 10);
+        cache.invalidate_and_set_anchor(11, [PORTAL]);
         cover_through(&mut cache, 12);
 
         assert_eq!(cache.get(PORTAL, slot, 11), None);
@@ -375,7 +399,7 @@ mod tests {
     fn floor_rejects_historical_cache_admission() {
         let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
-        cache.initialize_floor(10);
+        cache.reset(10);
         cache.set(PORTAL, slot, 9, B256::with_last_byte(9));
         cover_through(&mut cache, 11);
 
@@ -394,10 +418,24 @@ mod tests {
     }
 
     #[test]
-    fn update_anchor() {
+    fn contiguous_update_advances_anchor() {
         let mut cache = L1StateCacheInner::new();
-        cache.update_anchor(42);
-        assert_eq!(cache.anchor(), 42);
+        cache.invalidate_and_set_anchor(1, []);
+        assert_eq!(cache.anchor(), 1);
+    }
+
+    #[test]
+    fn non_contiguous_update_resets_cache_at_new_floor() {
+        let mut cache = L1StateCacheInner::new();
+        let slot = B256::with_last_byte(1);
+        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
+
+        cache.invalidate_and_set_anchor(10, [PORTAL]);
+
+        assert_eq!(cache.anchor(), 10);
+        assert_eq!(*cache.coverage.start(), 10);
+        assert!(cache.invalidations.is_empty());
+        assert_eq!(cache.get(PORTAL, slot, 10), None);
     }
 
     #[test]
@@ -502,14 +540,12 @@ mod tests {
         let mut cache = L1StateCacheInner::with_limits(10, 1);
         let slot = B256::with_last_byte(1);
 
-        cache.initialize_floor(10);
+        cache.reset(10);
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
-        cache.invalidate(PORTAL, 11);
-        cover_through(&mut cache, 11);
-        cache.invalidate(PORTAL, 12);
-        cover_through(&mut cache, 12);
+        cache.invalidate_and_set_anchor(11, [PORTAL]);
+        cache.invalidate_and_set_anchor(12, [PORTAL]);
 
-        assert_eq!(cache.block_floor(), 12);
+        assert_eq!(*cache.coverage.start(), 12);
         assert_eq!(cache.invalidation_count, 0);
         assert!(cache.invalidations.is_empty());
         assert_eq!(cache.get(PORTAL, slot, 10), None);

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -1,4 +1,4 @@
-//! Block-versioned in-memory cache of Tempo L1 contract storage slots.
+//! Bounded block-versioned cache of Tempo L1 contract storage slots.
 //!
 //! The zone's `TempoState` precompile reads Tempo L1 storage at a **specific L1 block height**
 //! (the `tempoBlockNumber` the zone committed to via `TempoState.finalizeTempo()` on Zone L2).
@@ -8,29 +8,43 @@
 //! ## Storage model
 //!
 //! Each `(contract_address, slot_key)` pair maps to a [`BTreeMap<u64, B256>`] of
-//! `block_number → value`. A lookup for block N may inherit the most recent earlier value only
-//! when verified receipt coverage and mutation barriers prove that it remained current.
+//! `block_number → value`. Slot histories live in a weighted LRU whose capacity is measured in
+//! versions, with an additional per-slot version limit so LRU eviction cannot discard an
+//! arbitrarily large history at once. A lookup for block N may inherit the most recent earlier
+//! value only when verified receipt coverage and mutation barriers prove that it remained current.
 //!
 //! ## Write path
 //!
-//! - The [`L1Subscriber`](crate::l1::L1Subscriber) writes storage diffs for tracked contracts
-//!   as they arrive, tagged with the L1 tip block number.
+//! - The [`L1Subscriber`](crate::l1::L1Subscriber) records mutation barriers from finalized L1
+//!   receipts.
 //! - The [`L1StateProvider`](super::provider::L1StateProvider) writes RPC-fetched values on
 //!   cache miss, tagged with the block number that was requested.
 //!
-//! ## Reorg handling
+//! ## Capacity handling
 //!
-//! On reorgs the caller is expected to [`L1StateCacheInner::clear`] the entire cache and
-//! re-populate from the new canonical chain segment. There is no per-block rollback.
+//! Slot histories are evicted least-recently-used when their combined version count exceeds the
+//! configured capacity. Mutation barriers have a separate bound; reaching it resets the value and
+//! barrier caches at the current finalized block rather than retaining an unbounded history.
 
-use alloy_eips::NumHash;
 use alloy_primitives::{Address, B256};
 use derive_more::Deref;
 use parking_lot::RwLock;
+use schnellru::{Limiter, LruMap};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
+    ops::RangeInclusive,
     sync::Arc,
 };
+use tracing::warn;
+
+/// Maximum total number of block-versioned values retained by the L1 state cache.
+const DEFAULT_VERSION_CAPACITY: usize = 100_000;
+
+/// Maximum number of block-versioned values retained for any individual storage slot.
+const MAX_VERSIONS_PER_SLOT: usize = 1_000;
+
+/// Maximum number of mutation barriers retained before conservatively resetting the cache.
+const DEFAULT_INVALIDATION_CAPACITY: usize = 100_000;
 
 /// Thread-safe L1 state cache backed by an `Arc<RwLock<L1StateCacheInner>>`.
 #[derive(Debug, Clone, Deref, Default)]
@@ -41,9 +55,9 @@ pub struct L1StateCache {
 
 impl L1StateCache {
     /// Create a new cache tracking the given contract addresses.
-    pub fn new(tracked_contracts: HashSet<Address>) -> Self {
+    pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(L1StateCacheInner::new(tracked_contracts))),
+            inner: Arc::new(RwLock::new(L1StateCacheInner::new())),
         }
     }
 }
@@ -59,29 +73,40 @@ impl L1StateCache {
 /// and no log from the owning contract indicates a possible mutation. The non-advancing floor
 /// excludes historical reads from before the subscriber's contiguous observation range.
 ///
-/// The anchor tracks the latest L1 block whose receipts the
-/// [`L1Subscriber`](crate::l1::L1Subscriber) has processed, and is also used for reorg detection.
-#[derive(Debug, Default)]
+/// The coverage end tracks the latest finalized L1 block whose receipts the
+/// [`L1Subscriber`](crate::l1::L1Subscriber) has processed.
+#[derive(Debug)]
 pub struct L1StateCacheInner {
-    tracked_contracts: HashSet<Address>,
-    /// Per-slot value history: `(address, slot) → { block_number → value }`.
-    /// The `BTreeMap` enables efficient range lookups for "latest value at or before block N".
-    slots: HashMap<(Address, B256), BTreeMap<u64, B256>>,
+    /// Bounded per-slot value histories, promoted as a unit on access.
+    slots: LruMap<(Address, B256), BTreeMap<u64, B256>, ByVersionCount>,
     /// Per-address mutation barriers. A value at V cannot serve a read at N when a barrier exists
     /// in `(V, N]`.
     invalidations: HashMap<Address, BTreeSet<u64>>,
-    /// Initial canonical Zone L1 anchor. Values below it are never admitted to the forward cache.
-    block_floor: u64,
-    /// Latest contiguous L1 block whose receipts the subscriber has processed.
-    anchor: NumHash,
+    invalidation_count: usize,
+    max_invalidations: usize,
+    /// Contiguous receipt coverage: earliest usable value height through latest processed block.
+    coverage: RangeInclusive<u64>,
+}
+
+impl Default for L1StateCacheInner {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl L1StateCacheInner {
     /// Create a new cache tracking the given contract addresses.
-    pub fn new(tracked_contracts: HashSet<Address>) -> Self {
+    pub fn new() -> Self {
+        Self::with_limits(DEFAULT_VERSION_CAPACITY, DEFAULT_INVALIDATION_CAPACITY)
+    }
+
+    fn with_limits(max_versions: usize, max_invalidations: usize) -> Self {
         Self {
-            tracked_contracts,
-            ..Default::default()
+            slots: LruMap::new(ByVersionCount::new(max_versions)),
+            invalidations: HashMap::new(),
+            invalidation_count: 0,
+            max_invalidations,
+            coverage: 0..=0,
         }
     }
 
@@ -90,7 +115,7 @@ impl L1StateCacheInner {
     /// An exact-height value is always valid. A value inherited from an earlier height is returned
     /// only when the subscriber has processed receipts through `block_number` and no mutation
     /// barrier exists after the value was populated.
-    pub fn get(&self, address: Address, slot: B256, block_number: u64) -> Option<B256> {
+    pub fn get(&mut self, address: Address, slot: B256, block_number: u64) -> Option<B256> {
         let (&cached_block, &value) = self
             .slots
             .get(&(address, slot))?
@@ -103,8 +128,8 @@ impl L1StateCacheInner {
             .is_some_and(|&invalidated_at| invalidated_at > cached_block);
 
         let is_exact = cached_block == block_number;
-        let can_inherit = block_number <= self.anchor.number && !invalidated;
-        let is_cache_valid = cached_block >= self.block_floor && (is_exact || can_inherit);
+        let can_inherit = block_number <= *self.coverage.end() && !invalidated;
+        let is_cache_valid = cached_block >= *self.coverage.start() && (is_exact || can_inherit);
         is_cache_valid.then_some(value)
     }
 
@@ -113,68 +138,143 @@ impl L1StateCacheInner {
     /// Values below the initial canonical floor are deliberately not admitted, so historical
     /// reads cannot later be inherited by canonical execution.
     pub fn set(&mut self, address: Address, slot: B256, block_number: u64, value: B256) {
-        if block_number < self.block_floor {
+        if block_number < *self.coverage.start() {
             return;
         }
-        self.slots
-            .entry((address, slot))
-            .or_default()
-            .insert(block_number, value);
+
+        let key = (address, slot);
+        let mut history = self.slots.remove(&key).unwrap_or_default();
+        history.insert(block_number, value);
+
+        // Bound eviction granularity and prevent one hot slot from monopolizing the cache.
+        let max_history = MAX_VERSIONS_PER_SLOT.min(self.slots.limiter().max_versions());
+        while history.len() > max_history {
+            history.pop_first();
+        }
+
+        let inserted = self.slots.insert(key, history);
+        debug_assert!(inserted, "trimmed slot history must fit cache capacity");
     }
 
     /// Prevents values populated before the current contiguous receipt-coverage baseline from
     /// entering the forward cache. Initialized at startup and rebased after a coverage reset.
     pub fn initialize_floor(&mut self, block_number: u64) {
-        self.block_floor = self.block_floor.max(block_number);
+        let floor = (*self.coverage.start()).max(block_number);
+        self.coverage = floor..=*self.coverage.end();
     }
 
     /// Returns the non-advancing cache floor.
-    pub const fn block_floor(&self) -> u64 {
-        self.block_floor
+    pub fn block_floor(&self) -> u64 {
+        *self.coverage.start()
     }
 
     /// Invalidates inherited values for `address` starting at `block_number`.
     pub fn invalidate(&mut self, address: Address, block_number: u64) {
-        self.invalidations
+        let inserted = self
+            .invalidations
             .entry(address)
             .or_default()
             .insert(block_number);
+        self.invalidation_count += usize::from(inserted);
+
+        if self.invalidation_count > self.max_invalidations {
+            warn!(
+                block_number,
+                invalidation_capacity = self.max_invalidations,
+                "L1 state invalidation capacity reached; resetting cache coverage"
+            );
+            // The subscriber publishes this block's coverage after recording all of its barriers.
+            // Clearing here is safe because values below this block become inadmissible.
+            self.slots.clear();
+            self.invalidations.clear();
+            self.invalidation_count = 0;
+            self.initialize_floor(block_number);
+        }
     }
 
     /// Updates the latest contiguous block whose receipts have been processed.
-    pub fn update_anchor(&mut self, anchor: NumHash) {
-        self.anchor = anchor;
+    pub fn update_anchor(&mut self, anchor: u64) {
+        self.coverage = *self.coverage.start()..=anchor;
     }
 
-    /// Returns `true` if the given address is one of the tracked contracts.
-    pub fn is_tracked(&self, address: &Address) -> bool {
-        self.tracked_contracts.contains(address)
+    /// Returns the current anchor block.
+    pub fn anchor(&self) -> u64 {
+        *self.coverage.end()
     }
+}
 
-    /// Clears chain-derived data while retaining the tracked-contract set and initial floor.
-    pub fn clear(&mut self) {
-        self.slots.clear();
-        self.invalidations.clear();
-        self.anchor = NumHash::default();
-    }
+/// [`schnellru`] limiter which measures capacity by the number of versions in all slot histories.
+#[derive(Debug, Clone)]
+struct ByVersionCount {
+    max_versions: usize,
+    versions: usize,
+}
 
-    /// Remove all entries with block numbers strictly less than `min_block`.
-    ///
-    /// Retains at most one entry per slot below the threshold — the latest one — so that
-    /// lookups at `min_block` still have a baseline value.
-    pub fn prune_before(&mut self, min_block: u64) {
-        for history in self.slots.values_mut() {
-            let keep_from = history.range(..min_block).next_back().map(|(k, _)| *k);
-
-            if let Some(keep) = keep_from {
-                let to_remove: Vec<u64> = history.range(..keep).map(|(k, _)| *k).collect();
-                for k in to_remove {
-                    history.remove(&k);
-                }
-            }
+impl ByVersionCount {
+    fn new(max_versions: usize) -> Self {
+        assert!(max_versions > 0, "L1 state cache capacity must be non-zero");
+        Self {
+            max_versions,
+            versions: 0,
         }
+    }
 
-        self.slots.retain(|_, history| !history.is_empty());
+    const fn max_versions(&self) -> usize {
+        self.max_versions
+    }
+
+    #[cfg(test)]
+    const fn versions(&self) -> usize {
+        self.versions
+    }
+}
+
+impl<K> Limiter<K, BTreeMap<u64, B256>> for ByVersionCount {
+    type KeyToInsert<'a> = K;
+    type LinkType = u32;
+
+    fn is_over_the_limit(&self, _length: usize) -> bool {
+        self.versions > self.max_versions
+    }
+
+    fn on_insert(
+        &mut self,
+        _length: usize,
+        key: Self::KeyToInsert<'_>,
+        value: BTreeMap<u64, B256>,
+    ) -> Option<(K, BTreeMap<u64, B256>)> {
+        if value.len() > self.max_versions {
+            return None;
+        }
+        self.versions += value.len();
+        Some((key, value))
+    }
+
+    fn on_replace(
+        &mut self,
+        _length: usize,
+        _old_key: &mut K,
+        _new_key: Self::KeyToInsert<'_>,
+        old_value: &mut BTreeMap<u64, B256>,
+        new_value: &mut BTreeMap<u64, B256>,
+    ) -> bool {
+        if new_value.len() > self.max_versions {
+            return false;
+        }
+        self.versions = self.versions - old_value.len() + new_value.len();
+        true
+    }
+
+    fn on_removed(&mut self, _key: &mut K, value: &mut BTreeMap<u64, B256>) {
+        self.versions -= value.len();
+    }
+
+    fn on_cleared(&mut self) {
+        self.versions = 0;
+    }
+
+    fn on_grow(&mut self, _new_memory_usage: usize) -> bool {
+        true
     }
 }
 
@@ -186,18 +286,18 @@ mod tests {
     const PORTAL: Address = address!("0x0000000000000000000000000000000000004242");
 
     fn cover_through(cache: &mut L1StateCacheInner, block_number: u64) {
-        cache.update_anchor(NumHash::new(block_number, B256::with_last_byte(1)));
+        cache.update_anchor(block_number);
     }
 
     #[test]
     fn get_returns_none_for_missing_slot() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         assert_eq!(cache.get(PORTAL, B256::ZERO, 100), None);
     }
 
     #[test]
     fn set_and_get_at_same_block() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         let value = B256::with_last_byte(0xff);
 
@@ -207,7 +307,7 @@ mod tests {
 
     #[test]
     fn get_returns_latest_value_at_or_before_requested_block() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
@@ -234,7 +334,7 @@ mod tests {
 
     #[test]
     fn get_returns_none_before_earliest_entry() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
 
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0xff));
@@ -243,7 +343,7 @@ mod tests {
 
     #[test]
     fn inherited_value_requires_receipt_coverage() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         let value = B256::with_last_byte(0x0a);
         cache.set(PORTAL, slot, 10, value);
@@ -255,7 +355,7 @@ mod tests {
 
     #[test]
     fn invalidation_blocks_inheritance_until_refetched() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         let old = B256::with_last_byte(0x0a);
         let new = B256::with_last_byte(0x0b);
@@ -273,7 +373,7 @@ mod tests {
 
     #[test]
     fn floor_rejects_historical_cache_admission() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         cache.initialize_floor(10);
         cache.set(PORTAL, slot, 9, B256::with_last_byte(9));
@@ -288,54 +388,21 @@ mod tests {
     }
 
     #[test]
-    fn clear_removes_chain_data_and_preserves_floor() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-
-        cache.initialize_floor(90);
-        cache.set(PORTAL, B256::ZERO, 100, B256::with_last_byte(1));
-        cache.invalidate(PORTAL, 101);
-        cache.update_anchor(NumHash {
-            number: 100,
-            hash: B256::with_last_byte(0xab),
-        });
-
-        cache.clear();
-
-        assert_eq!(cache.get(PORTAL, B256::ZERO, 100), None);
-        assert!(cache.invalidations.is_empty());
-        assert_eq!(cache.anchor, NumHash::default());
-        assert_eq!(cache.block_floor(), 90);
-    }
-
-    #[test]
     fn anchor_defaults_to_zero() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        assert_eq!(cache.anchor, NumHash::default());
+        let cache = L1StateCacheInner::new();
+        assert_eq!(cache.anchor(), 0);
     }
 
     #[test]
     fn update_anchor() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        let hash = B256::with_last_byte(0xbe);
-        cache.update_anchor(NumHash { number: 42, hash });
-        assert_eq!(cache.anchor, NumHash { number: 42, hash });
-    }
-
-    #[test]
-    fn is_tracked_returns_true_for_portal() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        assert!(cache.is_tracked(&PORTAL));
-    }
-
-    #[test]
-    fn is_tracked_returns_false_for_unknown_address() {
-        let cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        assert!(!cache.is_tracked(&address!("0x0000000000000000000000000000000000000001")));
+        let mut cache = L1StateCacheInner::new();
+        cache.update_anchor(42);
+        assert_eq!(cache.anchor(), 42);
     }
 
     #[test]
     fn different_addresses_same_slot_are_independent() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
+        let mut cache = L1StateCacheInner::new();
         let addr_b = address!("0x0000000000000000000000000000000000004343");
         let slot = B256::with_last_byte(1);
 
@@ -353,29 +420,108 @@ mod tests {
     }
 
     #[test]
-    fn prune_keeps_baseline_entry() {
-        let mut cache = L1StateCacheInner::new(HashSet::from([PORTAL]));
-        let slot = B256::with_last_byte(1);
+    fn lru_evicts_the_least_recently_used_slot_history_by_version_weight() {
+        let mut cache = L1StateCacheInner::with_limits(3, 10);
+        let slot_a = B256::with_last_byte(1);
+        let slot_b = B256::with_last_byte(2);
+        let slot_c = B256::with_last_byte(3);
 
-        cache.set(PORTAL, slot, 5, B256::with_last_byte(0x05));
-        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
-        cache.set(PORTAL, slot, 20, B256::with_last_byte(0x14));
+        cache.set(PORTAL, slot_a, 10, B256::with_last_byte(0x0a));
+        cache.set(PORTAL, slot_b, 10, B256::with_last_byte(0x0b));
         cover_through(&mut cache, 20);
 
-        cache.prune_before(15);
+        // Keep A hot, then insert a two-version history for C. B is the oldest history and is
+        // evicted to keep the total version count at three.
+        assert_eq!(
+            cache.get(PORTAL, slot_a, 20),
+            Some(B256::with_last_byte(0x0a))
+        );
+        cache.set(PORTAL, slot_c, 10, B256::with_last_byte(0x0c));
+        cache.set(PORTAL, slot_c, 20, B256::with_last_byte(0x1c));
 
-        assert_eq!(cache.get(PORTAL, slot, 5), None);
+        assert_eq!(cache.slots.limiter().versions(), 3);
+        assert_eq!(cache.get(PORTAL, slot_b, 20), None);
         assert_eq!(
-            cache.get(PORTAL, slot, 10),
+            cache.get(PORTAL, slot_a, 20),
             Some(B256::with_last_byte(0x0a))
         );
         assert_eq!(
-            cache.get(PORTAL, slot, 15),
-            Some(B256::with_last_byte(0x0a))
+            cache.get(PORTAL, slot_c, 20),
+            Some(B256::with_last_byte(0x1c))
         );
+    }
+
+    #[test]
+    fn a_single_slot_history_cannot_exceed_the_version_capacity() {
+        let mut cache = L1StateCacheInner::with_limits(2, 10);
+        let slot = B256::with_last_byte(1);
+
+        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
+        cache.set(PORTAL, slot, 20, B256::with_last_byte(0x14));
+        cache.set(PORTAL, slot, 30, B256::with_last_byte(0x1e));
+        cover_through(&mut cache, 30);
+
+        assert_eq!(cache.slots.limiter().versions(), 2);
+        assert_eq!(cache.get(PORTAL, slot, 10), None);
         assert_eq!(
             cache.get(PORTAL, slot, 20),
             Some(B256::with_last_byte(0x14))
+        );
+        assert_eq!(
+            cache.get(PORTAL, slot, 30),
+            Some(B256::with_last_byte(0x1e))
+        );
+    }
+
+    #[test]
+    fn slot_history_retains_only_the_newest_versions() {
+        let mut cache = L1StateCacheInner::with_limits(MAX_VERSIONS_PER_SLOT + 1, 10);
+        let slot = B256::with_last_byte(1);
+
+        for block_number in 0..=MAX_VERSIONS_PER_SLOT as u64 {
+            cache.set(
+                PORTAL,
+                slot,
+                block_number,
+                B256::with_last_byte((block_number % 256) as u8),
+            );
+        }
+        cover_through(&mut cache, MAX_VERSIONS_PER_SLOT as u64);
+
+        assert_eq!(cache.slots.limiter().versions(), MAX_VERSIONS_PER_SLOT);
+        assert_eq!(cache.get(PORTAL, slot, 0), None);
+        assert_eq!(cache.get(PORTAL, slot, 1), Some(B256::with_last_byte(1)));
+        assert_eq!(
+            cache.get(PORTAL, slot, MAX_VERSIONS_PER_SLOT as u64),
+            Some(B256::with_last_byte((MAX_VERSIONS_PER_SLOT % 256) as u8))
+        );
+    }
+
+    #[test]
+    fn invalidation_capacity_resets_cache_at_the_new_coverage_floor() {
+        let mut cache = L1StateCacheInner::with_limits(10, 1);
+        let slot = B256::with_last_byte(1);
+
+        cache.initialize_floor(10);
+        cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
+        cache.invalidate(PORTAL, 11);
+        cover_through(&mut cache, 11);
+        cache.invalidate(PORTAL, 12);
+        cover_through(&mut cache, 12);
+
+        assert_eq!(cache.block_floor(), 12);
+        assert_eq!(cache.invalidation_count, 0);
+        assert!(cache.invalidations.is_empty());
+        assert_eq!(cache.get(PORTAL, slot, 10), None);
+
+        cache.set(PORTAL, slot, 11, B256::with_last_byte(0x0b));
+        assert_eq!(cache.get(PORTAL, slot, 11), None);
+
+        cache.set(PORTAL, slot, 12, B256::with_last_byte(0x0c));
+        cover_through(&mut cache, 13);
+        assert_eq!(
+            cache.get(PORTAL, slot, 13),
+            Some(B256::with_last_byte(0x0c))
         );
     }
 }

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -1,4 +1,4 @@
-//! Bounded block-versioned cache of Tempo L1 contract storage slots.
+//! Block-versioned in-memory cache of Tempo L1 contract storage slots.
 //!
 //! The zone's `TempoState` precompile reads Tempo L1 storage at a **specific L1 block height**
 //! (the `tempoBlockNumber` the zone committed to via `TempoState.finalizeTempo()` on Zone L2).
@@ -8,10 +8,9 @@
 //! ## Storage model
 //!
 //! Each `(contract_address, slot_key)` pair maps to a [`BTreeMap<u64, B256>`] of
-//! `block_number → value`. Slot histories live in a weighted LRU whose capacity is measured in
-//! versions, with an additional per-slot version limit so LRU eviction cannot discard an
-//! arbitrarily large history at once. A lookup for block N may inherit the most recent earlier
-//! value only when verified receipt coverage and mutation barriers prove that it remained current.
+//! `block_number → value`. Slot histories are bounded by both a weighted LRU and a per-slot limit.
+//! A lookup for block N may inherit the most recent earlier value only when verified receipt
+//! coverage and mutation barriers prove that it remained current.
 //!
 //! ## Write path
 //!
@@ -19,12 +18,6 @@
 //!   receipts.
 //! - The [`L1StateProvider`](super::provider::L1StateProvider) writes RPC-fetched values on
 //!   cache miss, tagged with the block number that was requested.
-//!
-//! ## Capacity handling
-//!
-//! Slot histories are evicted least-recently-used when their combined version count exceeds the
-//! configured capacity. Mutation barriers have a separate bound; reaching it resets the value and
-//! barrier caches at the current finalized block rather than retaining an unbounded history.
 
 use alloy_primitives::{Address, B256};
 use derive_more::Deref;
@@ -54,7 +47,7 @@ pub struct L1StateCache {
 }
 
 impl L1StateCache {
-    /// Create a new cache tracking the given contract addresses.
+    /// Create an empty cache.
     pub fn new() -> Self {
         Self {
             inner: Arc::new(RwLock::new(L1StateCacheInner::new())),
@@ -70,19 +63,17 @@ impl L1StateCache {
 /// the `tempoBlockNumber` it committed to, even if the L1 chain has since advanced.
 ///
 /// Inherited values are valid only when the subscriber has processed every intervening L1 block
-/// and no log from the owning contract indicates a possible mutation. The non-advancing floor
-/// excludes historical reads from before the subscriber's contiguous observation range.
-///
-/// The coverage end tracks the latest finalized L1 block whose receipts the
-/// [`L1Subscriber`](crate::l1::L1Subscriber) has processed.
+/// and no log from the owning contract indicates a possible mutation. The coverage range starts
+/// at the current floor and ends at the latest finalized block whose receipts were processed.
 #[derive(Debug)]
 pub struct L1StateCacheInner {
     /// Bounded per-slot value histories, promoted as a unit on access.
     slots: LruMap<(Address, B256), BTreeMap<u64, B256>, ByVersionCount>,
-    /// Per-address mutation barriers. A value at V cannot serve a read at N when a barrier exists
-    /// in `(V, N]`.
+    /// Per-address block heights that prevent reuse across possible mutations.
     invalidations: HashMap<Address, BTreeSet<u64>>,
+    /// Total number of retained mutation barriers.
     invalidation_count: usize,
+    /// Maximum number of mutation barriers retained before resetting.
     max_invalidations: usize,
     /// Contiguous receipt coverage: earliest usable value height through latest processed block.
     coverage: RangeInclusive<u64>,
@@ -95,7 +86,7 @@ impl Default for L1StateCacheInner {
 }
 
 impl L1StateCacheInner {
-    /// Create a new cache tracking the given contract addresses.
+    /// Create an empty cache.
     pub fn new() -> Self {
         Self::with_limits(DEFAULT_VERSION_CAPACITY, DEFAULT_INVALIDATION_CAPACITY)
     }
@@ -147,7 +138,7 @@ impl L1StateCacheInner {
 
     /// Sets a storage slot value in the forward cache at the given block number.
     ///
-    /// Values below the initial canonical floor are deliberately not admitted, so historical
+    /// Values below the current coverage floor are deliberately not admitted, so historical
     /// reads cannot later be inherited by canonical execution.
     pub fn set(&mut self, address: Address, slot: B256, block_number: u64, value: B256) {
         if block_number < *self.coverage.start() {
@@ -218,7 +209,7 @@ impl L1StateCacheInner {
         self.coverage = *self.coverage.start()..=anchor;
     }
 
-    /// Returns the current anchor block.
+    /// Returns the end of contiguous receipt coverage.
     pub fn anchor(&self) -> u64 {
         *self.coverage.end()
     }

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -208,11 +208,6 @@ impl L1StateCacheInner {
 
         self.coverage = *self.coverage.start()..=anchor;
     }
-
-    /// Returns the end of contiguous receipt coverage.
-    pub fn anchor(&self) -> u64 {
-        *self.coverage.end()
-    }
 }
 
 /// [`schnellru`] limiter which measures capacity by the number of versions in all slot histories.
@@ -298,8 +293,8 @@ mod tests {
     const PORTAL: Address = address!("0x0000000000000000000000000000000000004242");
 
     fn cover_through(cache: &mut L1StateCacheInner, block_number: u64) {
-        while cache.anchor() < block_number {
-            cache.invalidate_and_set_anchor(cache.anchor() + 1, []);
+        while *cache.coverage.end() < block_number {
+            cache.invalidate_and_set_anchor(*cache.coverage.end() + 1, []);
         }
     }
 
@@ -403,16 +398,16 @@ mod tests {
     }
 
     #[test]
-    fn anchor_defaults_to_zero() {
+    fn coverage_defaults_to_zero() {
         let cache = L1StateCacheInner::new();
-        assert_eq!(cache.anchor(), 0);
+        assert_eq!(*cache.coverage.end(), 0);
     }
 
     #[test]
-    fn contiguous_update_advances_anchor() {
+    fn contiguous_update_advances_coverage() {
         let mut cache = L1StateCacheInner::new();
         cache.invalidate_and_set_anchor(1, []);
-        assert_eq!(cache.anchor(), 1);
+        assert_eq!(*cache.coverage.end(), 1);
     }
 
     #[test]
@@ -423,7 +418,7 @@ mod tests {
 
         cache.invalidate_and_set_anchor(10, [PORTAL]);
 
-        assert_eq!(cache.anchor(), 10);
+        assert_eq!(*cache.coverage.end(), 10);
         assert_eq!(*cache.coverage.start(), 10);
         assert!(cache.invalidations.is_empty());
         assert_eq!(cache.get(PORTAL, slot, 10), None);

--- a/crates/l1/src/state/cache.rs
+++ b/crates/l1/src/state/cache.rs
@@ -9,13 +9,13 @@
 //!
 //! Each `(contract_address, slot_key)` pair maps to a [`BTreeMap<u64, B256>`] of
 //! `block_number → value`. Slot histories are bounded by both a weighted LRU and a per-slot limit.
-//! A lookup for block N may inherit the most recent earlier value only when verified receipt
-//! coverage and mutation barriers prove that it remained current.
+//! A lookup for block N may inherit the most recent earlier value only when verified account
+//! storage roots prove that the owning account remained unchanged.
 //!
 //! ## Write path
 //!
-//! - The [`L1Subscriber`](crate::l1::L1Subscriber) records mutation barriers from finalized L1
-//!   receipts.
+//! - The [`L1Subscriber`](crate::l1::L1Subscriber) verifies tracked account proofs against each
+//!   finalized header and records a mutation barrier whenever an account storage root changes.
 //! - The [`L1StateProvider`](super::provider::L1StateProvider) writes RPC-fetched values on
 //!   cache miss, tagged with the block number that was requested.
 
@@ -62,9 +62,9 @@ impl L1StateCache {
 /// i.e. the value that was current at that height. This allows the zone to read L1 state at
 /// the `tempoBlockNumber` it committed to, even if the L1 chain has since advanced.
 ///
-/// Inherited values are valid only when the subscriber has processed every intervening L1 block
-/// and no log from the owning contract indicates a possible mutation. The coverage range starts
-/// at the current floor and ends at the latest finalized block whose receipts were processed.
+/// Inherited values are valid only when the subscriber has authenticated the owning account's
+/// storage root at every intervening L1 block. The coverage range starts at the current floor and
+/// ends at the latest finalized block whose tracked account proofs were verified.
 #[derive(Debug)]
 pub struct L1StateCacheInner {
     /// Bounded per-slot value histories, promoted as a unit on access.
@@ -75,8 +75,16 @@ pub struct L1StateCacheInner {
     invalidation_count: usize,
     /// Maximum number of mutation barriers retained before resetting.
     max_invalidations: usize,
-    /// Contiguous receipt coverage: earliest usable value height through latest processed block.
+    /// Latest verified storage root and the first continuously observed block per account.
+    storage_roots: HashMap<Address, TrackedStorageRoot>,
+    /// Contiguous proof coverage: earliest usable value height through latest processed block.
     coverage: RangeInclusive<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TrackedStorageRoot {
+    root: B256,
+    first_observed: u64,
 }
 
 impl Default for L1StateCacheInner {
@@ -97,6 +105,7 @@ impl L1StateCacheInner {
             invalidations: HashMap::new(),
             invalidation_count: 0,
             max_invalidations,
+            storage_roots: HashMap::new(),
             coverage: 0..=0,
         }
     }
@@ -104,8 +113,8 @@ impl L1StateCacheInner {
     /// Returns the cached value for a storage slot at the given block number.
     ///
     /// An exact-height value is always valid. A value inherited from an earlier height is returned
-    /// only when the subscriber has processed receipts through `block_number` and no mutation
-    /// barrier exists after the value was populated.
+    /// only when the subscriber has verified the owning account's storage root through
+    /// `block_number` and no root-change barrier exists after the value was populated.
     pub fn get(&mut self, address: Address, slot: B256, block_number: u64) -> Option<B256> {
         let (&cached_block, &value) = self
             .slots
@@ -120,6 +129,13 @@ impl L1StateCacheInner {
 
         // If we didn't yet process the requested block, we can't use the cached value
         if block_number > *self.coverage.end() {
+            return None;
+        }
+
+        // Cross-height reuse is safe only for accounts whose storage roots have been observed
+        // continuously through the requested block. Untracked accounts remain exact-height-only.
+        let tracked_root = self.storage_roots.get(&address)?;
+        if block_number < tracked_root.first_observed {
             return None;
         }
 
@@ -159,24 +175,27 @@ impl L1StateCacheInner {
         debug_assert!(inserted, "trimmed slot history must fit cache capacity");
     }
 
-    /// Clears cached state and establishes a new contiguous receipt-coverage baseline.
+    /// Clears cached state and establishes a new contiguous proof-coverage baseline.
     fn reset(&mut self, floor: u64) {
         self.slots.clear();
         self.invalidations.clear();
         self.invalidation_count = 0;
+        self.storage_roots.clear();
         self.coverage = floor..=floor;
     }
 
-    /// Records mutation barriers and publishes receipt coverage for one finalized block.
+    /// Records verified account storage roots and publishes coverage for one finalized block.
     ///
     /// Coverage only advances one block at a time. A duplicate, skipped, or out-of-order block
     /// invalidates the cache's continuity assumptions, so cached state is cleared and `anchor`
-    /// becomes the new coverage floor.
-    pub fn invalidate_and_set_anchor(
+    /// becomes the new coverage floor. A changed storage root creates an address-level mutation
+    /// barrier. Accounts omitted from `storage_roots` are no longer eligible for inheritance.
+    pub fn set_anchor_with_storage_roots(
         &mut self,
         anchor: u64,
-        invalidated_addresses: impl IntoIterator<Item = Address>,
+        storage_roots: impl IntoIterator<Item = (Address, B256)>,
     ) {
+        let storage_roots = storage_roots.into_iter().collect::<HashMap<_, _>>();
         if self.coverage.end().checked_add(1) != Some(anchor) {
             warn!(
                 anchor,
@@ -184,7 +203,39 @@ impl L1StateCacheInner {
                 "Non-contiguous L1 state cache update; resetting cache coverage"
             );
             self.reset(anchor);
+            self.storage_roots
+                .extend(storage_roots.into_iter().map(|(address, root)| {
+                    (
+                        address,
+                        TrackedStorageRoot {
+                            root,
+                            first_observed: anchor,
+                        },
+                    )
+                }));
             return;
+        }
+
+        self.storage_roots
+            .retain(|address, _| storage_roots.contains_key(address));
+
+        let mut invalidated_addresses = Vec::new();
+        for (&address, &root) in &storage_roots {
+            match self.storage_roots.entry(address) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    if entry.get().root != root {
+                        entry.get_mut().root = root;
+                        invalidated_addresses.push(address);
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(TrackedStorageRoot {
+                        root,
+                        first_observed: anchor,
+                    });
+                    invalidated_addresses.push(address);
+                }
+            }
         }
 
         for address in invalidated_addresses {
@@ -202,6 +253,16 @@ impl L1StateCacheInner {
                     "L1 state invalidation capacity reached; resetting cache coverage"
                 );
                 self.reset(anchor);
+                self.storage_roots
+                    .extend(storage_roots.into_iter().map(|(address, root)| {
+                        (
+                            address,
+                            TrackedStorageRoot {
+                                root,
+                                first_observed: anchor,
+                            },
+                        )
+                    }));
                 return;
             }
         }
@@ -291,10 +352,11 @@ mod tests {
     use alloy_primitives::address;
 
     const PORTAL: Address = address!("0x0000000000000000000000000000000000004242");
+    const PORTAL_ROOT: B256 = B256::with_last_byte(0x42);
 
     fn cover_through(cache: &mut L1StateCacheInner, block_number: u64) {
         while *cache.coverage.end() < block_number {
-            cache.invalidate_and_set_anchor(*cache.coverage.end() + 1, []);
+            cache.set_anchor_with_storage_roots(*cache.coverage.end() + 1, [(PORTAL, PORTAL_ROOT)]);
         }
     }
 
@@ -351,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn inherited_value_requires_receipt_coverage() {
+    fn inherited_value_requires_verified_root_coverage() {
         let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         let value = B256::with_last_byte(0x0a);
@@ -363,6 +425,19 @@ mod tests {
     }
 
     #[test]
+    fn untracked_accounts_are_exact_height_only() {
+        let mut cache = L1StateCacheInner::new();
+        let untracked = address!("0x0000000000000000000000000000000000004343");
+        let slot = B256::with_last_byte(1);
+        let value = B256::with_last_byte(0x0a);
+        cache.set(untracked, slot, 10, value);
+        cover_through(&mut cache, 11);
+
+        assert_eq!(cache.get(untracked, slot, 10), Some(value));
+        assert_eq!(cache.get(untracked, slot, 11), None);
+    }
+
+    #[test]
     fn invalidation_blocks_inheritance_until_refetched() {
         let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
@@ -370,8 +445,9 @@ mod tests {
         let new = B256::with_last_byte(0x0b);
         cache.set(PORTAL, slot, 10, old);
         cover_through(&mut cache, 10);
-        cache.invalidate_and_set_anchor(11, [PORTAL]);
-        cover_through(&mut cache, 12);
+        let changed_root = B256::with_last_byte(0x43);
+        cache.set_anchor_with_storage_roots(11, [(PORTAL, changed_root)]);
+        cache.set_anchor_with_storage_roots(12, [(PORTAL, changed_root)]);
 
         assert_eq!(cache.get(PORTAL, slot, 11), None);
         assert_eq!(cache.get(PORTAL, slot, 12), None);
@@ -386,6 +462,7 @@ mod tests {
         let mut cache = L1StateCacheInner::new();
         let slot = B256::with_last_byte(1);
         cache.reset(10);
+        cache.set_anchor_with_storage_roots(10, [(PORTAL, PORTAL_ROOT)]);
         cache.set(PORTAL, slot, 9, B256::with_last_byte(9));
         cover_through(&mut cache, 11);
 
@@ -406,7 +483,7 @@ mod tests {
     #[test]
     fn contiguous_update_advances_coverage() {
         let mut cache = L1StateCacheInner::new();
-        cache.invalidate_and_set_anchor(1, []);
+        cache.set_anchor_with_storage_roots(1, [(PORTAL, PORTAL_ROOT)]);
         assert_eq!(*cache.coverage.end(), 1);
     }
 
@@ -416,7 +493,7 @@ mod tests {
         let slot = B256::with_last_byte(1);
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
 
-        cache.invalidate_and_set_anchor(10, [PORTAL]);
+        cache.set_anchor_with_storage_roots(10, [(PORTAL, PORTAL_ROOT)]);
 
         assert_eq!(*cache.coverage.end(), 10);
         assert_eq!(*cache.coverage.start(), 10);
@@ -528,8 +605,8 @@ mod tests {
 
         cache.reset(10);
         cache.set(PORTAL, slot, 10, B256::with_last_byte(0x0a));
-        cache.invalidate_and_set_anchor(11, [PORTAL]);
-        cache.invalidate_and_set_anchor(12, [PORTAL]);
+        cache.set_anchor_with_storage_roots(11, [(PORTAL, B256::with_last_byte(0x43))]);
+        cache.set_anchor_with_storage_roots(12, [(PORTAL, B256::with_last_byte(0x44))]);
 
         assert_eq!(*cache.coverage.start(), 12);
         assert_eq!(cache.invalidation_count, 0);
@@ -540,7 +617,7 @@ mod tests {
         assert_eq!(cache.get(PORTAL, slot, 11), None);
 
         cache.set(PORTAL, slot, 12, B256::with_last_byte(0x0c));
-        cover_through(&mut cache, 13);
+        cache.set_anchor_with_storage_roots(13, [(PORTAL, B256::with_last_byte(0x44))]);
         assert_eq!(
             cache.get(PORTAL, slot, 13),
             Some(B256::with_last_byte(0x0c))

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -176,7 +176,6 @@ impl L1StateProvider {
         {
             let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
-                debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);
             }
         }
@@ -231,7 +230,6 @@ impl L1StateProvider {
         {
             let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
-                debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);
             }
         }

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -174,7 +174,7 @@ impl L1StateProvider {
     /// docs).
     pub fn get_storage(&self, address: Address, slot: B256, block_number: u64) -> Result<B256> {
         {
-            let cache = self.cache.read();
+            let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
                 debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);
@@ -229,7 +229,7 @@ impl L1StateProvider {
         block_number: u64,
     ) -> Result<B256> {
         {
-            let cache = self.cache.read();
+            let mut cache = self.cache.write();
             if let Some(value) = cache.get(address, slot, block_number) {
                 debug!(%address, %slot, block_number, %value, "L1 storage cache hit");
                 return Ok(value);

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -361,7 +361,7 @@ impl L1Subscriber {
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
             let sealed = SealedHeader::seal_slow(header);
-            self.update_l1_state_anchor(block_number, sealed.hash(), &invalidated);
+            self.update_l1_state_anchor(block_number, &invalidated);
             self.deposit_queue.enqueue_sealed(sealed, events);
             enqueued += 1;
             self.subscriber_metrics.blocks_enqueued.increment(1);
@@ -478,7 +478,6 @@ impl L1Subscriber {
     pub(crate) fn update_l1_state_anchor(
         &self,
         number: u64,
-        hash: B256,
         invalidated_accounts: &HashSet<Address>,
     ) {
         let mut guard = self.config.l1_state_cache.write();
@@ -486,7 +485,7 @@ impl L1Subscriber {
             guard.invalidate(address, number);
         }
         // Publish receipt coverage only after every mutation barrier from this block is visible.
-        guard.update_anchor(NumHash::new(number, hash));
+        guard.update_anchor(number);
     }
 }
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -480,12 +480,10 @@ impl L1Subscriber {
         number: u64,
         invalidated_accounts: &HashSet<Address>,
     ) {
-        let mut guard = self.config.l1_state_cache.write();
-        for &address in invalidated_accounts {
-            guard.invalidate(address, number);
-        }
-        // Publish receipt coverage only after every mutation barrier from this block is visible.
-        guard.update_anchor(number);
+        self.config
+            .l1_state_cache
+            .write()
+            .invalidate_and_set_anchor(number, invalidated_accounts.iter().copied());
     }
 }
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,19 +1,10 @@
 use super::*;
-use std::collections::HashSet;
-use tempo_primitives::is_tip20_prefix;
+use std::collections::HashMap;
 
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
 const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
 
-type L1ProcessedEvents = (L1PortalEvents, HashSet<Address>);
-
-fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
-    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
-
-    (address == TIP403_REGISTRY_ADDRESS
-        || (is_tip20_prefix(address) && topic0 == Some(&TransferPolicyUpdate::SIGNATURE_HASH)))
-    .then_some(TIP403_REGISTRY_ADDRESS)
-}
+const TRACKED_ACCOUNT_COUNT: usize = 2;
 
 /// Configuration for the L1 subscriber.
 #[derive(Debug, Clone)]
@@ -304,6 +295,7 @@ impl L1Subscriber {
 
         let concurrency = self.config.l1_fetch_concurrency.max(1);
         let subscriber_metrics = self.subscriber_metrics.clone();
+        let portal_address = self.config.portal_address;
 
         let mut fetched = stream::iter(from..=to)
             .map(move |block_number| {
@@ -328,13 +320,25 @@ impl L1Subscriber {
                     let block = NumHash::new(block_number, block_hash);
                     let expected_receipts_root = header_resp.receipts_root();
                     let expected_logs_bloom = header_resp.logs_bloom();
-                    let receipts = fetch_and_verify_receipts_for_header(
-                        provider,
-                        block,
-                        expected_receipts_root,
-                        expected_logs_bloom,
+                    let state_root = header_resp.state_root();
+                    let tracked_accounts = [
+                        portal_address,
+                        tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS,
+                    ];
+                    let (receipts, storage_roots) = futures::try_join!(
+                        fetch_and_verify_receipts_for_header(
+                            provider,
+                            block,
+                            expected_receipts_root,
+                            expected_logs_bloom,
+                        ),
+                        fetch_and_verify_storage_roots(
+                            provider,
+                            block,
+                            state_root,
+                            tracked_accounts,
+                        ),
                     )
-                    .await
                     .inspect_err(|_| {
                         fetch_failures.increment(1);
                     })?;
@@ -347,7 +351,7 @@ impl L1Subscriber {
                         "Fetched and validated L1 block data"
                     );
                     let header = header_resp.inner.inner;
-                    Ok::<_, eyre::Report>((header, receipts))
+                    Ok::<_, eyre::Report>((header, receipts, storage_roots))
                 }
             })
             .buffered(concurrency);
@@ -355,13 +359,13 @@ impl L1Subscriber {
         let mut enqueued = 0u64;
         let backfill_start = std::time::Instant::now();
 
-        while let Some((header, receipts)) = fetched.try_next().await? {
+        while let Some((header, receipts, storage_roots)) = fetched.try_next().await? {
             let block_number = header.number();
-            let (events, invalidated) = self.extract_events(block_number, &receipts);
+            let events = self.extract_events(block_number, &receipts);
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
             let sealed = SealedHeader::seal_slow(header);
-            self.update_l1_state_anchor(block_number, &invalidated);
+            self.update_l1_state_anchor(block_number, storage_roots);
             self.deposit_queue.enqueue_sealed(sealed, events);
             enqueued += 1;
             self.subscriber_metrics.blocks_enqueued.increment(1);
@@ -408,35 +412,29 @@ impl L1Subscriber {
         self.follow_finalized(&provider, triggers).await
     }
 
-    /// Extract portal events and raw-cache mutation barriers from fetched receipts.
+    /// Extract portal events from fetched receipts.
     fn extract_events(
         &self,
         block_number: u64,
         receipts: &[tempo_alloy::rpc::TempoTransactionReceipt],
-    ) -> L1ProcessedEvents {
+    ) -> L1PortalEvents {
         let portal_address = self.config.portal_address;
         let mut portal_events = L1PortalEvents::default();
-        let mut invalidated = HashSet::new();
 
         for receipt in receipts {
             for log in receipt.logs() {
                 let address = log.address();
 
-                if address == portal_address {
-                    invalidated.insert(address);
-                    if let Err(e) = portal_events.push_log(log, block_number) {
-                        warn!(block_number, %e, "Failed to decode portal event from receipt");
-                    }
-                } else if let Some(address) =
-                    cache_invalidation_address(address, log.topics().first())
+                if address == portal_address
+                    && let Err(e) = portal_events.push_log(log, block_number)
                 {
-                    invalidated.insert(address);
+                    warn!(block_number, %e, "Failed to decode portal event from receipt");
                 }
             }
         }
 
         self.record_portal_event_metrics(&portal_events);
-        (portal_events, invalidated)
+        portal_events
     }
 
     fn record_seen_block(&self, block_number: u64, lag_blocks: u64) {
@@ -478,13 +476,76 @@ impl L1Subscriber {
     pub(crate) fn update_l1_state_anchor(
         &self,
         number: u64,
-        invalidated_accounts: &HashSet<Address>,
+        storage_roots: HashMap<Address, B256>,
     ) {
         self.config
             .l1_state_cache
             .write()
-            .invalidate_and_set_anchor(number, invalidated_accounts.iter().copied());
+            .set_anchor_with_storage_roots(number, storage_roots);
     }
+}
+
+/// Fetch and authenticate account storage roots against a finalized header's state root.
+async fn fetch_and_verify_storage_roots(
+    provider: &impl Provider<TempoNetwork>,
+    block: NumHash,
+    state_root: B256,
+    addresses: [Address; TRACKED_ACCOUNT_COUNT],
+) -> eyre::Result<HashMap<Address, B256>> {
+    use futures::stream;
+
+    stream::iter(addresses)
+        .map(|address| async move {
+            let proof = provider
+                .get_proof(address, Vec::new())
+                .block_id(BlockId::hash(block.hash))
+                .await
+                .map_err(|error| {
+                    eyre::eyre!(
+                        "failed to fetch account proof for {address} at block {} ({}): {error}",
+                        block.number,
+                        block.hash,
+                    )
+                })?;
+            let storage_root = verify_account_storage_root(state_root, address, &proof)?;
+            Ok::<_, eyre::Report>((address, storage_root))
+        })
+        .buffer_unordered(TRACKED_ACCOUNT_COUNT)
+        .try_collect()
+        .await
+}
+
+fn verify_account_storage_root(
+    state_root: B256,
+    address: Address,
+    proof: &alloy_rpc_types_eth::EIP1186AccountProofResponse,
+) -> eyre::Result<B256> {
+    use alloy_consensus::TrieAccount;
+    use alloy_trie::{Nibbles, proof::verify_proof};
+
+    eyre::ensure!(
+        proof.address == address,
+        "account proof address mismatch: requested {address}, got {}",
+        proof.address,
+    );
+
+    let account = TrieAccount {
+        nonce: proof.nonce,
+        balance: proof.balance,
+        storage_root: proof.storage_hash,
+        code_hash: proof.code_hash,
+    };
+    verify_proof(
+        state_root,
+        Nibbles::unpack(keccak256(address)),
+        Some(alloy_rlp::encode(account)),
+        &proof.account_proof,
+    )
+    .map_err(|error| {
+        eyre::eyre!("invalid account proof for {address} against state root {state_root}: {error}")
+    })?;
+
+    Ok(proof.storage_hash)
 }
 
 /// Fetch receipts for the L1 header by block hash and verify they match the
@@ -548,16 +609,41 @@ pub(crate) fn verify_receipts(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::address;
-    use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
+    use alloy_primitives::{Bytes, U256, address};
+    use alloy_rlp::Encodable as _;
+    use alloy_trie::{Nibbles, nodes::LeafNode};
 
     #[test]
-    fn token_policy_updates_invalidate_the_registry() {
-        let token = address!("20C0000000000000000000000000000000000999");
+    fn account_storage_root_is_authenticated_by_the_header_state_root() {
+        let address = address!("0x0000000000000000000000000000000000004242");
+        let storage_root = B256::with_last_byte(0x42);
+        let account = alloy_consensus::TrieAccount {
+            nonce: 1,
+            balance: U256::from(2),
+            storage_root,
+            code_hash: B256::with_last_byte(3),
+        };
+        let mut encoded_leaf = Vec::new();
+        LeafNode::new(
+            Nibbles::unpack(keccak256(address)),
+            alloy_rlp::encode(account),
+        )
+        .encode(&mut encoded_leaf);
+        let state_root = keccak256(&encoded_leaf);
+        let proof = alloy_rpc_types_eth::EIP1186AccountProofResponse {
+            address,
+            balance: account.balance,
+            code_hash: account.code_hash,
+            nonce: account.nonce,
+            storage_hash: account.storage_root,
+            account_proof: vec![Bytes::from(encoded_leaf)],
+            storage_proof: Vec::new(),
+        };
 
         assert_eq!(
-            cache_invalidation_address(token, Some(&TransferPolicyUpdate::SIGNATURE_HASH)),
-            Some(TIP403_REGISTRY_ADDRESS)
+            verify_account_storage_root(state_root, address, &proof).unwrap(),
+            storage_root,
         );
+        assert!(verify_account_storage_root(B256::with_last_byte(0xff), address, &proof).is_err());
     }
 }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -148,7 +148,7 @@ fn test_subscriber(
             l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
             portal_address,
             genesis_tempo_block_number,
-            l1_state_cache: crate::L1StateCache::new(HashSet::from([portal_address])),
+            l1_state_cache: crate::L1StateCache::new(),
             l1_fetch_concurrency: 1,
             retry_connection_interval: Duration::from_secs(1),
         },
@@ -435,23 +435,18 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
         .write()
         .set(stable_account, stable_slot, 10, stable_value);
 
-    let hash_10 = B256::with_last_byte(10);
-    subscriber.update_l1_state_anchor(10, hash_10, &HashSet::new());
+    subscriber.update_l1_state_anchor(10, &HashSet::new());
     assert_eq!(
         subscriber
             .config
             .l1_state_cache
-            .read()
+            .write()
             .get(TIP403_REGISTRY_ADDRESS, slot, 10),
         Some(value)
     );
 
-    subscriber.update_l1_state_anchor(
-        11,
-        B256::with_last_byte(11),
-        &HashSet::from([TIP403_REGISTRY_ADDRESS]),
-    );
-    let cache = subscriber.config.l1_state_cache.read();
+    subscriber.update_l1_state_anchor(11, &HashSet::from([TIP403_REGISTRY_ADDRESS]));
+    let mut cache = subscriber.config.l1_state_cache.write();
     assert_eq!(
         cache.get(stable_account, stable_slot, 11),
         Some(stable_value)

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -424,7 +424,11 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     let stable_account = address!("0x0000000000000000000000000000000000000ABC");
     let stable_slot = B256::with_last_byte(3);
     let stable_value = B256::with_last_byte(4);
-    subscriber.config.l1_state_cache.write().reset(9);
+    subscriber
+        .config
+        .l1_state_cache
+        .write()
+        .invalidate_and_set_anchor(9, []);
     subscriber
         .config
         .l1_state_cache

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -424,6 +424,7 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     let stable_account = address!("0x0000000000000000000000000000000000000ABC");
     let stable_slot = B256::with_last_byte(3);
     let stable_value = B256::with_last_byte(4);
+    subscriber.config.l1_state_cache.write().reset(9);
     subscriber
         .config
         .l1_state_cache

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1,13 +1,15 @@
 use super::*;
 use crate::abi::DepositType;
 use alloy_consensus::{Header, ReceiptWithBloom};
-use alloy_primitives::{Bloom, FixedBytes, address};
-use alloy_rpc_types_eth::{Header as RpcHeader, TransactionReceipt};
+use alloy_primitives::{Bloom, Bytes, FixedBytes, U256, address};
+use alloy_rlp::Encodable as _;
+use alloy_rpc_types_eth::{EIP1186AccountProofResponse, Header as RpcHeader, TransactionReceipt};
 use alloy_sol_types::SolEvent;
 use alloy_transport::mock::Asserter;
+use alloy_trie::{Nibbles, nodes::LeafNode};
 use serde::Deserialize;
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     time::Duration,
 };
 use tempo_alloy::rpc::{TempoHeaderResponse, TempoTransactionReceipt};
@@ -203,6 +205,37 @@ fn header_response(header: TempoHeader) -> TempoHeaderResponse {
 fn push_header_and_empty_receipts(asserter: &Asserter, header: TempoHeader) {
     asserter.push_success(&Some(header_response(header)));
     asserter.push_success(&Some(Vec::<TempoTransactionReceipt>::new()));
+}
+
+fn tracked_account_proof(address: Address) -> (B256, EIP1186AccountProofResponse) {
+    let account = alloy_consensus::TrieAccount {
+        nonce: 1,
+        balance: U256::from(2),
+        storage_root: B256::with_last_byte(3),
+        code_hash: B256::with_last_byte(4),
+    };
+    let mut encoded_leaf = Vec::new();
+    LeafNode::new(
+        Nibbles::unpack(keccak256(address)),
+        alloy_rlp::encode(account),
+    )
+    .encode(&mut encoded_leaf);
+    let state_root = keccak256(&encoded_leaf);
+    let proof = EIP1186AccountProofResponse {
+        address,
+        balance: account.balance,
+        code_hash: account.code_hash,
+        nonce: account.nonce,
+        storage_hash: account.storage_root,
+        account_proof: vec![Bytes::from(encoded_leaf)],
+        storage_proof: Vec::new(),
+    };
+    (state_root, proof)
+}
+
+fn push_account_proofs(asserter: &Asserter, proof: &EIP1186AccountProofResponse) {
+    asserter.push_success(proof);
+    asserter.push_success(proof);
 }
 
 fn make_test_receipt(
@@ -414,33 +447,27 @@ fn assert_tempo_header_rejected(input: &[u8]) {
 }
 
 #[test]
-fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
+fn update_l1_state_anchor_applies_storage_root_changes_before_publishing_coverage() {
     let subscriber = test_subscriber(
         Arc::new(SequenceLocalTempoCheckpointReader::new([0])),
         Some(0),
     );
     let slot = B256::with_last_byte(1);
     let value = B256::with_last_byte(2);
-    let stable_account = address!("0x0000000000000000000000000000000000000ABC");
-    let stable_slot = B256::with_last_byte(3);
-    let stable_value = B256::with_last_byte(4);
     subscriber
         .config
         .l1_state_cache
         .write()
-        .invalidate_and_set_anchor(9, []);
+        .set_anchor_with_storage_roots(9, [(TIP403_REGISTRY_ADDRESS, B256::with_last_byte(9))]);
     subscriber
         .config
         .l1_state_cache
         .write()
         .set(TIP403_REGISTRY_ADDRESS, slot, 10, value);
-    subscriber
-        .config
-        .l1_state_cache
-        .write()
-        .set(stable_account, stable_slot, 10, stable_value);
-
-    subscriber.update_l1_state_anchor(10, &HashSet::new());
+    subscriber.update_l1_state_anchor(
+        10,
+        HashMap::from([(TIP403_REGISTRY_ADDRESS, B256::with_last_byte(9))]),
+    );
     assert_eq!(
         subscriber
             .config
@@ -450,12 +477,11 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
         Some(value)
     );
 
-    subscriber.update_l1_state_anchor(11, &HashSet::from([TIP403_REGISTRY_ADDRESS]));
-    let mut cache = subscriber.config.l1_state_cache.write();
-    assert_eq!(
-        cache.get(stable_account, stable_slot, 11),
-        Some(stable_value)
+    subscriber.update_l1_state_anchor(
+        11,
+        HashMap::from([(TIP403_REGISTRY_ADDRESS, B256::with_last_byte(10))]),
     );
+    let mut cache = subscriber.config.l1_state_cache.write();
     assert_eq!(cache.get(TIP403_REGISTRY_ADDRESS, slot, 11), None);
 }
 
@@ -504,24 +530,35 @@ async fn test_resolve_start_block_skips_backfill_without_checkpoint() {
 
 #[tokio::test]
 async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let mut subscriber =
+        test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    // Use one address for both tracked accounts so this mocked-provider test can focus on finalized
+    // range synchronization while still serving authenticated account proofs.
+    subscriber.config.portal_address = TIP403_REGISTRY_ADDRESS;
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
 
-    let header_10 = make_test_header(10);
-    let header_11 = make_chained_header(11, header_hash(&header_10));
-    let header_12 = make_chained_header(12, header_hash(&header_11));
+    let (state_root, proof) = tracked_account_proof(TIP403_REGISTRY_ADDRESS);
+    let mut header_10 = make_test_header(10);
+    header_10.inner.state_root = state_root;
+    let mut header_11 = make_chained_header(11, header_hash(&header_10));
+    header_11.inner.state_root = state_root;
+    let mut header_12 = make_chained_header(12, header_hash(&header_11));
+    header_12.inner.state_root = state_root;
 
     // Initial sync through finalized block 10.
     asserter.push_success(&Some(header_response(header_10.clone())));
     push_header_and_empty_receipts(&asserter, header_10);
+    push_account_proofs(&asserter, &proof);
 
     // One newHeads notification wakes the subscriber. The finalized tag has
     // advanced by two blocks, so both missing blocks must be ingested.
     asserter.push_success(&Some(header_response(header_12.clone())));
     push_header_and_empty_receipts(&asserter, header_11);
+    push_account_proofs(&asserter, &proof);
     push_header_and_empty_receipts(&asserter, header_12);
+    push_account_proofs(&asserter, &proof);
 
     let err = subscriber
         .follow_finalized(

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -38,7 +38,7 @@ use reth_transaction_pool::{
     Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
 };
-use std::{collections::HashSet, num::NonZeroU32, sync::Arc, time::Duration};
+use std::{num::NonZeroU32, sync::Arc, time::Duration};
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
 use tempo_node::{
@@ -202,7 +202,7 @@ impl ZoneNode {
     ) -> Self {
         let deposit_queue = DepositQueue::default();
 
-        let l1_state_cache = L1StateCache::new(HashSet::from([portal_address]));
+        let l1_state_cache = L1StateCache::new();
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
             portal_address,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -33,7 +33,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::ChainSpecProvider;
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
-use reth_storage_api::{BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProviderFactory};
+use reth_storage_api::{BlockNumReader, EmptyBodyStorage, HeaderProvider};
 use reth_transaction_pool::{
     Pool, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
@@ -59,7 +59,7 @@ use tracing::{debug, info};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
-    DepositQueue, L1Subscriber, L1SubscriberConfig, TempoStateExt,
+    DepositQueue, L1Subscriber, L1SubscriberConfig,
     state::{L1StateCache, L1StateProvider, L1StateProviderConfig},
 };
 use zone_p2p::{P2pConfig, P2pNetworkId, Role, spawn_p2p};
@@ -436,14 +436,6 @@ where
     > as NodeAddOns<N>>::Handle;
 
     async fn launch_add_ons(mut self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
-        let sp = ctx.node.provider().latest()?;
-        let tempo_block_number = sp.tempo_block_number()?;
-        self.l1_config
-            .l1_state_cache
-            .write()
-            .reset(tempo_block_number);
-        info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber and reset cache");
-
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
                 &self.l1_config.l1_rpc_url,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -441,8 +441,8 @@ where
         self.l1_config
             .l1_state_cache
             .write()
-            .initialize_floor(tempo_block_number);
-        info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber and initialized cache");
+            .reset(tempo_block_number);
+        info!(target: "reth::cli", tempo_block_number, "Read local tempoBlockNumber for L1 subscriber and reset cache");
 
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3507,7 +3507,12 @@ pub(crate) struct L1Fixture {
     next_timestamp: u64,
     last_hash: B256,
     /// Raw L1 caches seeded by this fixture, updated with state implied by injected deposits.
-    caches: Mutex<Vec<L1StateCache>>,
+    caches: Mutex<Vec<FixtureL1Cache>>,
+}
+
+struct FixtureL1Cache {
+    handle: L1StateCache,
+    coverage_end: u64,
 }
 
 impl L1Fixture {
@@ -3586,12 +3591,14 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        while cache.anchor() < num_blocks {
-            let next_anchor = cache.anchor() + 1;
-            cache.invalidate_and_set_anchor(next_anchor, []);
+        for block_number in 1..=num_blocks {
+            cache.invalidate_and_set_anchor(block_number, []);
         }
         drop(cache);
-        self.caches.lock().unwrap().push(cache_handle.clone());
+        self.caches.lock().unwrap().push(FixtureL1Cache {
+            handle: cache_handle.clone(),
+            coverage_end: num_blocks,
+        });
     }
 
     /// Seed the absence of an address-level TIP-403 receive policy at the current Zone anchor.
@@ -3604,7 +3611,7 @@ impl L1Fixture {
         // TODO(rusowsky): make `ReceivePolicy` public upstream to use the handlers
         let receive_policy_slot = recipient.mapping_slot(tip403_registry_slots::RECEIVE_POLICIES);
         for cache in self.caches.lock().unwrap().iter() {
-            cache.write().set(
+            cache.handle.write().set(
                 TIP403_REGISTRY_ADDRESS,
                 B256::from(receive_policy_slot.to_be_bytes()),
                 block_number,
@@ -3623,7 +3630,7 @@ impl L1Fixture {
 
     fn seed_enabled_token_policy_state(&self, block_number: u64, tokens: &[EnabledToken]) {
         for cache in self.caches.lock().unwrap().iter() {
-            let mut cache = cache.write();
+            let mut cache = cache.handle.write();
             for token in tokens {
                 seed_raw_tip403_token_policy(
                     &mut cache,
@@ -3641,11 +3648,11 @@ impl L1Fixture {
     /// cross that horizon still need unchanged slots to inherit their last seeded value rather
     /// than falling back to the deliberately unavailable dummy L1 RPC.
     fn extend_cache_coverage(&self, block_number: u64) {
-        for cache in self.caches.lock().unwrap().iter() {
-            let mut cache = cache.write();
-            while cache.anchor() < block_number {
-                let next_anchor = cache.anchor() + 1;
-                cache.invalidate_and_set_anchor(next_anchor, []);
+        for cache in self.caches.lock().unwrap().iter_mut() {
+            let mut handle = cache.handle.write();
+            while cache.coverage_end < block_number {
+                cache.coverage_end += 1;
+                handle.invalidate_and_set_anchor(cache.coverage_end, []);
             }
         }
     }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3507,12 +3507,7 @@ pub(crate) struct L1Fixture {
     next_timestamp: u64,
     last_hash: B256,
     /// Raw L1 caches seeded by this fixture, updated with state implied by injected deposits.
-    caches: Mutex<Vec<FixtureL1Cache>>,
-}
-
-struct FixtureL1Cache {
-    handle: L1StateCache,
-    coverage_end: u64,
+    caches: Mutex<Vec<L1StateCache>>,
 }
 
 impl L1Fixture {
@@ -3591,14 +3586,8 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        for block_number in 1..=num_blocks {
-            cache.invalidate_and_set_anchor(block_number, []);
-        }
         drop(cache);
-        self.caches.lock().unwrap().push(FixtureL1Cache {
-            handle: cache_handle.clone(),
-            coverage_end: num_blocks,
-        });
+        self.caches.lock().unwrap().push(cache_handle.clone());
     }
 
     /// Seed the absence of an address-level TIP-403 receive policy at the current Zone anchor.
@@ -3611,7 +3600,7 @@ impl L1Fixture {
         // TODO(rusowsky): make `ReceivePolicy` public upstream to use the handlers
         let receive_policy_slot = recipient.mapping_slot(tip403_registry_slots::RECEIVE_POLICIES);
         for cache in self.caches.lock().unwrap().iter() {
-            cache.handle.write().set(
+            cache.write().set(
                 TIP403_REGISTRY_ADDRESS,
                 B256::from(receive_policy_slot.to_be_bytes()),
                 block_number,
@@ -3630,7 +3619,7 @@ impl L1Fixture {
 
     fn seed_enabled_token_policy_state(&self, block_number: u64, tokens: &[EnabledToken]) {
         for cache in self.caches.lock().unwrap().iter() {
-            let mut cache = cache.handle.write();
+            let mut cache = cache.write();
             for token in tokens {
                 seed_raw_tip403_token_policy(
                     &mut cache,
@@ -3638,21 +3627,6 @@ impl L1Fixture {
                     token.token,
                     ALLOW_ALL_POLICY_ID,
                 );
-            }
-        }
-    }
-
-    /// Extend the fixture caches' contiguous receipt coverage through a generated block.
-    ///
-    /// `seed_l1_cache` may seed only the blocks a test normally needs. Tests that subsequently
-    /// cross that horizon still need unchanged slots to inherit their last seeded value rather
-    /// than falling back to the deliberately unavailable dummy L1 RPC.
-    fn extend_cache_coverage(&self, block_number: u64) {
-        for cache in self.caches.lock().unwrap().iter_mut() {
-            let mut handle = cache.handle.write();
-            while cache.coverage_end < block_number {
-                cache.coverage_end += 1;
-                handle.invalidate_and_set_anchor(cache.coverage_end, []);
             }
         }
     }
@@ -3680,7 +3654,12 @@ impl L1Fixture {
         self.last_hash = keccak256(&rlp_buf);
         self.next_block_number += 1;
         self.next_timestamp += 1; // 1s per L1 block
-        self.extend_cache_coverage(number);
+
+        // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
+        // coverage the subscriber would publish before the engine consumes this block.
+        for cache in self.caches.lock().unwrap().iter() {
+            cache.write().invalidate_and_set_anchor(number, []);
+        }
 
         header
     }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3352,20 +3352,6 @@ impl PrivateRpcTestCtx {
         eyre::ensure!(receipt.status(), "revokeKey failed");
         Ok(())
     }
-
-    /// Query `zone_getDepositStatus` via the private RPC as a specific user.
-    pub(crate) async fn get_deposit_status_as_user(
-        &self,
-        tempo_block_number: u64,
-        signer: &alloy_signer_local::PrivateKeySigner,
-    ) -> eyre::Result<serde_json::Value> {
-        self.call_as_user(
-            "zone_getDepositStatus",
-            serde_json::json!([format!("0x{tempo_block_number:x}")]),
-            signer,
-        )
-        .await
-    }
 }
 
 async fn zone_chain_id(zone: &ZoneTestNode) -> eyre::Result<u64> {
@@ -3600,7 +3586,10 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        cache.update_anchor(num_blocks);
+        while cache.anchor() < num_blocks {
+            let next_anchor = cache.anchor() + 1;
+            cache.invalidate_and_set_anchor(next_anchor, []);
+        }
         drop(cache);
         self.caches.lock().unwrap().push(cache_handle.clone());
     }
@@ -3654,8 +3643,9 @@ impl L1Fixture {
     fn extend_cache_coverage(&self, block_number: u64) {
         for cache in self.caches.lock().unwrap().iter() {
             let mut cache = cache.write();
-            if block_number > cache.anchor() {
-                cache.update_anchor(block_number);
+            while cache.anchor() < block_number {
+                let next_anchor = cache.anchor() + 1;
+                cache.invalidate_and_set_anchor(next_anchor, []);
             }
         }
     }
@@ -3684,12 +3674,6 @@ impl L1Fixture {
         self.next_block_number += 1;
         self.next_timestamp += 1; // 1s per L1 block
         self.extend_cache_coverage(number);
-
-        // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
-        // coverage the subscriber would publish before the engine consumes this block.
-        for cache in self.caches.lock().unwrap().iter() {
-            cache.write().update_anchor(number);
-        }
 
         header
     }

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1,6 +1,5 @@
 use alloy::genesis::{Genesis, GenesisAccount};
 use alloy_consensus::Header;
-use alloy_eips::NumHash;
 use alloy_primitives::{Address, B256, U256, address, keccak256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rlp::Encodable;
@@ -309,7 +308,7 @@ pub(crate) fn seed_raw_tip403_policy(
     let registry = TIP403Registry::new();
     let counter_slot = registry.policy_id_counter.slot();
     let existing_next_policy_id = cache
-        .read()
+        .write()
         .get(TIP403_REGISTRY_ADDRESS, counter_slot.into(), block_number)
         .and_then(|value| U256::from_be_bytes(value.0).try_into().ok())
         .unwrap_or(2u64);
@@ -3353,6 +3352,20 @@ impl PrivateRpcTestCtx {
         eyre::ensure!(receipt.status(), "revokeKey failed");
         Ok(())
     }
+
+    /// Query `zone_getDepositStatus` via the private RPC as a specific user.
+    pub(crate) async fn get_deposit_status_as_user(
+        &self,
+        tempo_block_number: u64,
+        signer: &alloy_signer_local::PrivateKeySigner,
+    ) -> eyre::Result<serde_json::Value> {
+        self.call_as_user(
+            "zone_getDepositStatus",
+            serde_json::json!([format!("0x{tempo_block_number:x}")]),
+            signer,
+        )
+        .await
+    }
 }
 
 async fn zone_chain_id(zone: &ZoneTestNode) -> eyre::Result<u64> {
@@ -3587,10 +3600,7 @@ impl L1Fixture {
         // synthetic token permissive in RPC-free fixtures, matching the old policy-provider stub.
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
-        cache.update_anchor(NumHash {
-            number: num_blocks,
-            hash: B256::ZERO,
-        });
+        cache.update_anchor(num_blocks);
         drop(cache);
         self.caches.lock().unwrap().push(cache_handle.clone());
     }
@@ -3636,6 +3646,20 @@ impl L1Fixture {
         }
     }
 
+    /// Extend the fixture caches' contiguous receipt coverage through a generated block.
+    ///
+    /// `seed_l1_cache` may seed only the blocks a test normally needs. Tests that subsequently
+    /// cross that horizon still need unchanged slots to inherit their last seeded value rather
+    /// than falling back to the deliberately unavailable dummy L1 RPC.
+    fn extend_cache_coverage(&self, block_number: u64) {
+        for cache in self.caches.lock().unwrap().iter() {
+            let mut cache = cache.write();
+            if block_number > cache.anchor() {
+                cache.update_anchor(block_number);
+            }
+        }
+    }
+
     /// Build a [`TempoHeader`] for the next L1 block.
     fn next_header(&mut self) -> TempoHeader {
         let number = self.next_block_number;
@@ -3659,13 +3683,12 @@ impl L1Fixture {
         self.last_hash = keccak256(&rlp_buf);
         self.next_block_number += 1;
         self.next_timestamp += 1; // 1s per L1 block
+        self.extend_cache_coverage(number);
 
         // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
         // coverage the subscriber would publish before the engine consumes this block.
         for cache in self.caches.lock().unwrap().iter() {
-            cache
-                .write()
-                .update_anchor(NumHash::new(number, self.last_hash));
+            cache.write().update_anchor(number);
         }
 
         header

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3507,7 +3507,7 @@ pub(crate) struct L1Fixture {
     next_timestamp: u64,
     last_hash: B256,
     /// Raw L1 caches seeded by this fixture, updated with state implied by injected deposits.
-    caches: Mutex<Vec<L1StateCache>>,
+    caches: Mutex<Vec<(L1StateCache, Address)>>,
 }
 
 impl L1Fixture {
@@ -3587,7 +3587,10 @@ impl L1Fixture {
         seed_raw_tip403_token_policy(&mut cache, 0, Address::ZERO, ALLOW_ALL_POLICY_ID);
         seed_raw_tip403_token_policy(&mut cache, 0, PATH_USD_ADDRESS, ALLOW_ALL_POLICY_ID);
         drop(cache);
-        self.caches.lock().unwrap().push(cache_handle.clone());
+        self.caches
+            .lock()
+            .unwrap()
+            .push((cache_handle.clone(), portal_address));
     }
 
     /// Seed the absence of an address-level TIP-403 receive policy at the current Zone anchor.
@@ -3599,7 +3602,7 @@ impl L1Fixture {
     fn seed_no_receive_policy_at(&self, block_number: u64, recipient: Address) -> eyre::Result<()> {
         // TODO(rusowsky): make `ReceivePolicy` public upstream to use the handlers
         let receive_policy_slot = recipient.mapping_slot(tip403_registry_slots::RECEIVE_POLICIES);
-        for cache in self.caches.lock().unwrap().iter() {
+        for (cache, _) in self.caches.lock().unwrap().iter() {
             cache.write().set(
                 TIP403_REGISTRY_ADDRESS,
                 B256::from(receive_policy_slot.to_be_bytes()),
@@ -3618,7 +3621,7 @@ impl L1Fixture {
     }
 
     fn seed_enabled_token_policy_state(&self, block_number: u64, tokens: &[EnabledToken]) {
-        for cache in self.caches.lock().unwrap().iter() {
+        for (cache, _) in self.caches.lock().unwrap().iter() {
             let mut cache = cache.write();
             for token in tokens {
                 seed_raw_tip403_token_policy(
@@ -3655,10 +3658,16 @@ impl L1Fixture {
         self.next_block_number += 1;
         self.next_timestamp += 1; // 1s per L1 block
 
-        // Synthetic injection bypasses the subscriber, so publish the same verified-receipt
+        // Synthetic injection bypasses the subscriber, so publish the same verified-root
         // coverage the subscriber would publish before the engine consumes this block.
-        for cache in self.caches.lock().unwrap().iter() {
-            cache.write().invalidate_and_set_anchor(number, []);
+        for (cache, portal_address) in self.caches.lock().unwrap().iter() {
+            cache.write().set_anchor_with_storage_roots(
+                number,
+                [
+                    (*portal_address, B256::with_last_byte(1)),
+                    (TIP403_REGISTRY_ADDRESS, B256::with_last_byte(2)),
+                ],
+            );
         }
 
         header

--- a/crates/node/tests/l1_state_reader.rs
+++ b/crates/node/tests/l1_state_reader.rs
@@ -4,8 +4,6 @@
 //!
 //! Requires `L1_RPC_URL` env var or defaults to moderato RPC.
 
-use std::collections::HashSet;
-
 use alloy_primitives::{Address, B256, address};
 use alloy_provider::{Provider, ProviderBuilder};
 use tempo_alloy::TempoNetwork;
@@ -24,7 +22,7 @@ async fn make_provider() -> L1StateProvider {
         portal_address: ZONE_PORTAL,
         ..Default::default()
     };
-    let cache = L1StateCache::new(HashSet::from([ZONE_PORTAL]));
+    let cache = L1StateCache::new();
     let rt = tokio::runtime::Handle::current();
     L1StateProvider::new(config, cache, rt)
         .await
@@ -80,7 +78,7 @@ async fn l1_provider_caches_result() {
 
     assert_eq!(v1, v2, "cached and fresh values must match");
 
-    let cached = provider.cache().read().get(ZONE_PORTAL, B256::ZERO, block);
+    let cached = provider.cache().write().get(ZONE_PORTAL, B256::ZERO, block);
     assert_eq!(cached, Some(v1), "value should be in cache after read");
     println!("Cache hit verified for slot 0 at block {block}: {v1}");
 }
@@ -111,7 +109,7 @@ async fn l1_provider_reads_multiple_slots() {
     }
 
     // Slot 0 should be non-zero (contains init data)
-    let v0 = provider.cache().read().get(ZONE_PORTAL, B256::ZERO, block);
+    let v0 = provider.cache().write().get(ZONE_PORTAL, B256::ZERO, block);
     assert!(
         v0.is_some_and(|v| v != B256::ZERO),
         "slot 0 should be non-zero"


### PR DESCRIPTION
## Summary

- authenticate the ZonePortal and TIP-403 registry storage roots against each finalized header state root
- replace semantic event-based cache invalidation with address-level barriers derived from storage-root changes
- allow cross-height reuse only for continuously root-tracked accounts; all other witness reads remain exact-height-only
- retain receipt fetching and verification for portal deposit ingestion

This is stacked on #791 and is intended as a storage-root-based alternative to #803.

## Performance / WIP

This adds two concurrent `eth_getProof` requests per finalized L1 block (one for ZonePortal and one for TIP-403). Before taking this out of draft, we should benchmark provider overhead and confirm historical proof availability across the intended backfill window.

Using the global state root as the cache key would invalidate every cached account on every L1 state change. This instead uses the state root only to authenticate each account proof, then versions reuse by the individual account storage root.

## Validation

- `cargo test -p zone-l1 --locked`
- `cargo clippy -p zone-l1 --all-targets --locked -- -D warnings`
- `cargo check -p zone-node --tests --locked`
- `git diff --check`