### PR TITLE
fix(rpc): allow raw transaction submission without auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The sequencer includes the withdrawal in the next batch submission to L1 and pro
 
 ### Querying the Private RPC
 
-Zone balances are private by default. Every RPC request must include a signed authorization token that proves you control the querying account.
+Zone balances are private by default. RPC requests must include a signed authorization token that proves you control the querying account, except `eth_sendRawTransaction`, whose signed transaction already authenticates the sender.
 
 `just zone-auth-token` reads `generated/<name>/zone.json` and signs a short-lived auth token:
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -129,9 +129,9 @@ async fn prune_filter_owners<Api: EthApiTypes + 'static>(
 ///   simulate from the authenticated account (`-32004` on mismatch,
 ///   auto-set when omitted); state overrides are rejected for
 ///   non-sequencer callers (`-32602`).
-/// - **Sender verification** — `eth_sendRawTransaction` checks that the
-///   recovered transaction sender matches the authenticated account
-///   (`-32003` on mismatch).
+/// - **Signed transaction submission** — `eth_sendRawTransaction` is accepted
+///   without an RPC authorization token; the transaction signature
+///   authenticates its sender.
 ///
 /// [`classify_method`]: zone_rpc::types::classify_method
 pub struct ZoneRpc<Api: EthApiTypes> {
@@ -552,10 +552,8 @@ where
         })
     }
 
-    fn send_raw_transaction(&self, data: Bytes, auth: AuthContext) -> BoxFut<'_> {
+    fn send_raw_transaction(&self, data: Bytes) -> BoxFut<'_> {
         Box::pin(async move {
-            zone_rpc::policy::verify_raw_tx_sender(&data, &auth)?;
-
             let hash = EthTransactions::send_raw_transaction(&self.eth.api, data)
                 .await
                 .map_err(internal)?;

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -128,9 +128,9 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `eth_sendRawTransaction(data)` — submits a signed transaction to the pool.
     ///
-    /// Verifies that the recovered tx sender matches the authenticated account;
-    /// rejects with `-32003` on mismatch.
-    fn send_raw_transaction(&self, data: Bytes, auth: AuthContext) -> BoxFut<'_>;
+    /// This method does not require an authorization token: the transaction
+    /// signature itself authenticates the sender.
+    fn send_raw_transaction(&self, data: Bytes) -> BoxFut<'_>;
 
     /// `eth_sendRawTransactionSync(data)` — submits a signed transaction and
     /// waits for inclusion, returning the receipt.
@@ -318,7 +318,7 @@ pub async fn dispatch(
 
         // Transaction preparation & submission
         "eth_fillTransaction" => handle_fill_transaction(id, raw, auth, api).await,
-        "eth_sendRawTransaction" => handle_send_raw_transaction(id, raw, auth, api).await,
+        "eth_sendRawTransaction" => handle_send_raw_transaction(id, raw, api).await,
         "eth_sendRawTransactionSync" => handle_send_raw_transaction_sync(id, raw, auth, api).await,
 
         // Log & filter queries
@@ -529,11 +529,10 @@ async fn handle_fill_transaction(
     )
 }
 
-/// Handle `eth_sendRawTransaction`. Sender verification is delegated to the API impl.
-async fn handle_send_raw_transaction(
+/// Handle `eth_sendRawTransaction`.
+pub(crate) async fn handle_send_raw_transaction(
     id: Value,
     raw: &str,
-    auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
     let (data,) = match parse_params::<(Bytes,)>(raw, &id, "expected [data]") {
@@ -544,7 +543,7 @@ async fn handle_send_raw_transaction(
     api_result(
         id,
         "eth_sendRawTransaction",
-        api.send_raw_transaction(data, auth.clone()).await,
+        api.send_raw_transaction(data).await,
     )
 }
 
@@ -782,7 +781,7 @@ mod tests {
         stub!(transaction_receipt, _hash: B256, _auth: AuthContext);
         stub!(call, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
         stub!(estimate_gas, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
-        stub!(send_raw_transaction, _data: Bytes, _auth: AuthContext);
+        stub!(send_raw_transaction, _data: Bytes);
         stub!(send_raw_transaction_sync, _data: Bytes, _auth: AuthContext);
         stub!(fill_transaction, _request: TempoTransactionRequest, _auth: AuthContext);
         stub!(get_logs, _filter: Filter, _auth: AuthContext);

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -36,6 +36,8 @@ use crate::{
     ws::handle_ws_upgrade,
 };
 
+const UNAUTHENTICATED_METHODS: &[&str] = &["eth_sendRawTransaction"];
+
 /// Maximum number of requests in a single JSON-RPC batch.
 pub(crate) const MAX_BATCH_SIZE: usize = 100;
 
@@ -175,6 +177,17 @@ async fn handle_rpc(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
+    let body_str = match std::str::from_utf8(&body) {
+        Ok(s) => s,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, "invalid UTF-8").into_response();
+        }
+    };
+
+    if let Some(result) = process_unauthenticated_rpc_text(body_str, state.api.as_ref()).await {
+        return result.into_response();
+    }
+
     let auth = match authenticate(&headers, &state.config, state.api.as_ref()).await {
         Ok(auth) => auth,
         Err(e) => {
@@ -186,16 +199,52 @@ async fn handle_rpc(
         }
     };
 
-    let body_str = match std::str::from_utf8(&body) {
-        Ok(s) => s,
-        Err(_) => {
-            return (StatusCode::BAD_REQUEST, "invalid UTF-8").into_response();
-        }
-    };
-
     process_rpc_text(body_str, &auth, state.api.as_ref())
         .await
         .into_response()
+}
+
+/// Dispatch a request without RPC authentication when every method in the
+/// payload is explicitly allowed to rely on its own cryptographic signature.
+async fn process_unauthenticated_rpc_text(text: &str, api: &dyn ZoneRpcApi) -> Option<RpcResult> {
+    let trimmed = text.trim_start();
+    if trimmed.starts_with('[') {
+        let requests = serde_json::from_str::<Vec<JsonRpcRequest>>(trimmed).ok()?;
+        if requests.is_empty()
+            || requests.len() > MAX_BATCH_SIZE
+            || requests
+                .iter()
+                .any(|req| !UNAUTHENTICATED_METHODS.contains(&req.method.as_str()))
+        {
+            return None;
+        }
+
+        let mut responses = Vec::with_capacity(requests.len());
+        for req in &requests {
+            responses.push(dispatch_unauthenticated_request(req, api).await);
+        }
+        Some(RpcResult::Batch(responses))
+    } else {
+        let request = serde_json::from_str::<JsonRpcRequest>(trimmed).ok()?;
+        if !UNAUTHENTICATED_METHODS.contains(&request.method.as_str()) {
+            return None;
+        }
+        Some(RpcResult::Single(
+            dispatch_unauthenticated_request(&request, api).await,
+        ))
+    }
+}
+
+async fn dispatch_unauthenticated_request(
+    req: &JsonRpcRequest,
+    api: &dyn ZoneRpcApi,
+) -> JsonRpcResponse {
+    let raw = req
+        .params
+        .as_deref()
+        .map(|params| params.get())
+        .unwrap_or("[]");
+    handlers::handle_send_raw_transaction(req.id.clone(), raw, api).await
 }
 
 /// Authenticate the request using the `X-Authorization-Token` header.
@@ -298,7 +347,7 @@ pub(crate) fn now_unix_seconds() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::authenticate_token;
+    use super::{RpcResult, authenticate_token, process_unauthenticated_rpc_text};
     use crate::{
         PrivateRpcConfig,
         auth::build_token_fields,
@@ -385,7 +434,7 @@ mod tests {
         stub!(transaction_receipt, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
         stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
         stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
-        stub!(send_raw_transaction, _a: Bytes, _c: crate::auth::AuthContext);
+        stub!(send_raw_transaction, _a: Bytes);
         stub!(send_raw_transaction_sync, _a: Bytes, _c: crate::auth::AuthContext);
         stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: crate::auth::AuthContext);
         stub!(get_logs, _a: alloy_rpc_types_eth::Filter, _c: crate::auth::AuthContext);
@@ -410,6 +459,48 @@ mod tests {
             max_auth_token_validity: crate::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
             zone_portal: PORTAL,
         }
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_does_not_require_rpc_authentication() {
+        let api = TestApi {
+            key_infos: Mutex::new(HashMap::new()),
+        };
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_sendRawTransaction",
+            "params": ["0x01"],
+            "id": 1
+        })
+        .to_string();
+
+        let result = process_unauthenticated_rpc_text(&request, &api)
+            .await
+            .expect("signed transaction submission should bypass RPC auth");
+        let RpcResult::Single(response) = result else {
+            panic!("expected a single response");
+        };
+        assert_eq!(response.id, serde_json::json!(1));
+    }
+
+    #[tokio::test]
+    async fn private_method_still_requires_rpc_authentication() {
+        let api = TestApi {
+            key_infos: Mutex::new(HashMap::new()),
+        };
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_getBalance",
+            "params": [Address::ZERO, "latest"],
+            "id": 1
+        })
+        .to_string();
+
+        assert!(
+            process_unauthenticated_rpc_text(&request, &api)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -133,7 +133,7 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(transaction_receipt, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
     stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
     stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
-    stub!(send_raw_transaction, _a: alloy_primitives::Bytes, _c: zone_rpc::auth::AuthContext);
+    stub!(send_raw_transaction, _a: alloy_primitives::Bytes);
     stub!(send_raw_transaction_sync, _a: alloy_primitives::Bytes, _c: zone_rpc::auth::AuthContext);
     stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: zone_rpc::auth::AuthContext);
     stub!(get_logs, _a: alloy_rpc_types_eth::Filter, _c: zone_rpc::auth::AuthContext);


### PR DESCRIPTION
## Summary
- allow `eth_sendRawTransaction` over HTTP without an RPC authorization token
- rely on the signed transaction to authenticate its sender
- preserve authentication for private RPC reads and all other scoped methods
- document the exception and add regression coverage

## Testing
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-rpc --lib` *(blocked: private `alloy-evm` git dependency returned HTTP 401 during fetch)*

Prompted by: @0xKitsune