### PR TITLE
test: use upgraded Tempo ZoneFactory in zone tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11148,7 +11148,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11187,7 +11187,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11222,8 +11222,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11234,8 +11234,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11270,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11281,8 +11281,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11341,8 +11341,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11379,8 +11379,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11399,8 +11399,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11422,8 +11422,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11434,7 +11434,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11465,8 +11465,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11488,8 +11488,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e#6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=a55a6395567f529f03fa88bc457584fa8ed89af8#a55a6395567f529f03fa88bc457584fa8ed89af8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,25 +94,25 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "6a639b7cd452b6444c3cdbcdc8fac61bd18aee8e", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "a55a6395567f529f03fa88bc457584fa8ed89af8", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }

--- a/crates/node/tests/it/demo_cross_zone.rs
+++ b/crates/node/tests/it/demo_cross_zone.rs
@@ -31,7 +31,6 @@ const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 ///
 /// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime and router artifacts.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_cross_zone_send() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -509,7 +509,6 @@ async fn test_many_concurrent_withdrawals_are_batched() -> eyre::Result<()> {
 /// An open zone has no account allowlist: an unlisted account can complete the full
 /// L1 deposit -> L2 mint -> L2 withdrawal -> L1 release loop.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_open_mode_unlisted_account_roundtrip() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -739,7 +738,6 @@ async fn test_closed_mode_rejects_unlisted_deposit_and_withdrawal_recipient() ->
 
 /// Account and gateway enforcement can be changed independently without rewriting either set.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_access_and_gateway_modes_are_mutable_and_independent() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -898,7 +896,6 @@ async fn test_queued_plain_withdrawal_bounces_after_recipient_revocation() -> ey
 /// gateway is revoked before L1 processing. The callback bounces, and the next
 /// plain withdrawal proves the failed head did not block the FIFO.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_queued_callback_bounces_after_gateway_revocation() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1002,7 +999,6 @@ async fn test_queued_callback_bounces_after_gateway_revocation() -> eyre::Result
 ///
 /// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime and router artifacts.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1132,7 +1128,6 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
 /// The refund must go to the Tempo refund recipient encoded in the router payload,
 /// not to the encrypted recipient and not to the router contract.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_cross_zone_encrypted_router_tempo_refund_recipient() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1246,7 +1241,6 @@ async fn test_cross_zone_encrypted_router_tempo_refund_recipient() -> eyre::Resu
 ///  4. Deposit BetaUSD back into the same zone.
 ///  5. Verify AlphaUSD was consumed and BetaUSD was minted.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
@@ -1349,7 +1343,6 @@ async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
 /// Deposits for BetaUSD are paused on the target portal so the router callback
 /// reverts and the original AlphaUSD withdrawal bounces back to the sender.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_failure()
 -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -1449,7 +1442,6 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
 /// encrypted payload and key index, a target-portal deposit failure must revert
 /// the callback and bounce the original token back to the sender.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires upgraded Tempo native ZoneFactory ABI; re-enable after tempo#6934"]
 async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_failure()
 -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -38,7 +38,7 @@ use tempo_chainspec::{
     spec::{TEMPO_T0_BASE_FEE, TempoChainSpec},
 };
 use tempo_contracts::precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, ITIP20, IZoneFactory as LegacyZoneFactory, TIP403_REGISTRY_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, ITIP20, TIP403_REGISTRY_ADDRESS,
     account_keychain::IAccountKeychain::{
         IAccountKeychainInstance, KeyRestrictions, SignatureType as KeyInfoSignatureType,
     },
@@ -263,6 +263,24 @@ fn install_native_zone_factory(genesis: &mut Genesis, owner: Address) -> eyre::R
             .with_nonce(Some(1))
             .with_code(Some(forge_deployed_bytecode("ZoneMessenger")?)),
     );
+
+    // The native factory requires the initial token's TIP-403 policy binding to exist.
+    let token_policy_slot = keccak256(
+        (
+            PATH_USD_ADDRESS,
+            tip403_registry_slots::TOKEN_TRANSFER_POLICIES,
+        )
+            .abi_encode(),
+    );
+    let packed_policy = U256::from(ALLOW_ALL_POLICY_ID) | (U256::ONE << u64::BITS);
+    genesis
+        .alloc
+        .entry(TIP403_REGISTRY_ADDRESS)
+        .or_default()
+        .storage
+        .get_or_insert_default()
+        .insert(token_policy_slot, B256::from(packed_policy.to_be_bytes()));
+
     Ok(())
 }
 
@@ -1561,13 +1579,17 @@ impl L1TestNode {
         config: ZoneCreationConfig,
     ) -> eyre::Result<Address> {
         use tempo_precompiles::PATH_USD_ADDRESS;
-        use tempo_zone_contracts::ZonePortal;
+        use tempo_zone_contracts::ZoneFactory;
 
         let l1_provider = self.dev_provider();
-        let create_zone = LegacyZoneFactory::createZoneCall {
-            params: LegacyZoneFactory::CreateZoneParams {
+        let create_zone = ZoneFactory::createZoneCall {
+            params: ZoneFactory::CreateZoneParams {
                 admin,
                 initialToken: PATH_USD_ADDRESS,
+                accessMode: config.access_mode,
+                gatewayMode: config.gateway_mode,
+                allowedAccounts: config.allowed_accounts,
+                zoneGateways: config.zone_gateways,
                 sequencers: vec![sequencer],
                 threshold: 1,
                 rpcUrl: String::new(),
@@ -1588,60 +1610,10 @@ impl L1TestNode {
             .inner
             .logs()
             .iter()
-            .find_map(|log| LegacyZoneFactory::ZoneCreated::decode_log(&log.inner).ok())
+            .find_map(|log| ZoneFactory::ZoneCreated::decode_log(&log.inner).ok())
             .ok_or_else(|| eyre::eyre!("ZoneCreated event not found"))?;
 
-        let portal_address = zone_created.portal;
-        let admin_provider = if admin == self.dev_address() {
-            self.dev_provider()
-        } else if admin == self.admin_address() {
-            self.admin_provider()
-        } else {
-            return Err(eyre::eyre!(
-                "test helper cannot configure portal for unknown admin {admin}"
-            ));
-        };
-        let portal = ZonePortal::new(portal_address, &admin_provider);
-        for account in config.allowed_accounts {
-            let receipt = portal
-                .setAllowedAccount(account, true)
-                .send()
-                .await?
-                .get_receipt()
-                .await?;
-            eyre::ensure!(receipt.status(), "setting initial portal member failed");
-        }
-        for gateway in config.zone_gateways {
-            let receipt = portal
-                .setGateway(gateway, true)
-                .send()
-                .await?
-                .get_receipt()
-                .await?;
-            eyre::ensure!(receipt.status(), "setting initial portal gateway failed");
-        }
-        let receipt = portal
-            .setAccessMode(config.access_mode)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(
-            receipt.status(),
-            "setting initial portal access mode failed"
-        );
-        let receipt = portal
-            .setGatewayMode(config.gateway_mode)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(
-            receipt.status(),
-            "setting initial portal gateway mode failed"
-        );
-
-        Ok(portal_address)
+        Ok(zone_created.portal)
     }
 
     /// Deploy the SwapAndDepositRouter contract on L1 from the Foundry artifact.


### PR DESCRIPTION
## Summary

- pin Tempo dependencies to tempoxyz/tempo#6934 head `ad787cfef40c566ae2bce1c2a540d098eed87682`
- use the current Tempo `FeeTokenResolver` API
- pass the complete boolean enforcement config and initial allowlists through the native `ZoneFactory.createZone` call
- seed the required initial-token TIP-403 binding in test genesis
- remove all nine temporary factory-test ignores and the post-creation portal configuration shim

## Stack

- Base: #810
- Tempo dependency: tempoxyz/tempo#6934

## Validation

- `forge build` in `specs/ref-impls`
- `cargo fmt --all -- --check`
- `cargo clippy -p zone-evm -p zone-node --all-targets -- -D warnings`
- nine factory-dependent integration tests via `cargo nextest run`: 9 passed, 0 failed
