### PR TITLE
refactor: use Tempo ZoneFactory ABI export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11816,6 +11816,7 @@ dependencies = [
  "const-hex",
  "k256",
  "serde",
+ "tempo-contracts",
  "tokio",
  "zone-primitives",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa
 tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
 tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false, features = [
+  "rpc",
   "serde",
 ] }
 tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -14,6 +14,9 @@ workspace = true
 # zones
 zone-primitives = { workspace = true, default-features = false }
 
+# tempo
+tempo-contracts = { workspace = true, default-features = false }
+
 # alloy
 alloy-primitives = { workspace = true, default-features = false }
 alloy-sol-types = { workspace = true, default-features = false }
@@ -37,6 +40,7 @@ std = [
     "alloy-primitives/std",
     "alloy-sol-types/std",
     "serde?/std",
+    "tempo-contracts/std",
     "zone-primitives/std",
 ]
 serde = ["dep:serde", "alloy-primitives/serde"]

--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -1,70 +1,10 @@
 //! Native TIP-1091 `ZoneFactory` precompile ABI.
 
-use alloy_primitives::{Address, FixedBytes, address, fixed_bytes};
+use alloy_primitives::{FixedBytes, fixed_bytes};
 
-pub use ZoneFactory::ZoneInfo;
+pub use tempo_contracts::precompiles::zone_factory::{
+    IZoneFactory as ZoneFactory, ZONE_FACTORY_ADDRESS, ZONE_MESSENGER_ADDRESS,
+    ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneInfo,
+};
 
-/// Maximum number of sequencers in a Zone's active sequencer set.
-pub const MAX_SEQUENCERS: usize = 8;
-
-/// Protocol-managed ZoneFactory address defined by TIP-1091.
-pub const ZONE_FACTORY_ADDRESS: Address = address!("0x5aF2000000000000000000000000000000000000");
 pub const ZONE_PORTAL_PREFIX: FixedBytes<12> = fixed_bytes!("5AD000000000000000000000");
-pub const ZONE_PORTAL_IMPL_ADDRESS: Address =
-    address!("0x5AD1000000000000000000000000000000000000");
-pub const ZONE_VERIFIER_ADDRESS: Address = address!("0x5a56000000000000000000000000000000000000");
-pub const ZONE_MESSENGER_ADDRESS: Address = address!("0x5A4d000000000000000000000000000000000000");
-
-crate::sol! {
-    #[sol(abi)]
-    #[derive(Debug)]
-    contract ZoneFactory {
-        struct ZoneInfo {
-            uint32 zoneId;
-            address portal;
-            bool accessMode;
-            bool gatewayMode;
-            address admin;
-            address[] sequencers;
-            uint8 threshold;
-            address verifier;
-            string rpcUrl;
-        }
-        struct CreateZoneParams {
-            address initialToken;
-            bool accessMode;
-            bool gatewayMode;
-            address[] allowedAccounts;
-            address[] zoneGateways;
-            address admin;
-            address[] sequencers;
-            uint8 threshold;
-            string rpcUrl;
-        }
-        event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
-        event ZoneCreated(
-            uint32 indexed zoneId,
-            address indexed portal,
-            address initialToken,
-            bool accessMode,
-            bool gatewayMode,
-            address admin,
-            address[] sequencers,
-            uint8 threshold,
-            address verifier
-        );
-        error InvalidToken();
-        error NotOwner();
-        error InvalidAdmin();
-        error InvalidSequencerSet();
-        error InvalidClosedLoopConfig();
-        error DuplicateAllowedAccount();
-        error DuplicateZoneGateway();
-        function owner() external view returns (address);
-        function transferOwnership(address newOwner) external;
-        function createZone(CreateZoneParams calldata params) external returns (uint32 zoneId, address portal);
-        function zones(uint32 zoneId) external view returns (ZoneInfo memory);
-        function nextZoneId() external view returns (uint32);
-        function isZonePortal(address portal) external view returns (bool);
-    }
-}

--- a/crates/contracts/src/runtime/interfaces/IZone.sol
+++ b/crates/contracts/src/runtime/interfaces/IZone.sol
@@ -367,12 +367,13 @@ interface IZoneFactory {
     );
 
     error InvalidToken();
+    error TokenTransferPolicyNotSet();
+    error InvalidClosedLoopConfig();
     error NotOwner();
     error InvalidAdmin();
     error InvalidSequencerSet();
-    error InvalidClosedLoopConfig();
-    error DuplicateAllowedAccount();
-    error DuplicateZoneGateway();
+    error AlreadyInitialized();
+    error TokenMetadataTooLong();
 
     /// @notice Returns the account authorized to create zones.
     function owner() external view returns (address);

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -8,10 +8,11 @@
 use alloy_consensus::Sealable;
 use alloy_genesis::Genesis;
 use alloy_network::{EthereumWallet, ReceiptResponse as _};
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, Bytes, TxKind};
 use alloy_provider::{PendingTransactionBuilder, Provider, ProviderBuilder};
+use alloy_rpc_types_eth::TransactionRequest;
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::SolEvent;
+use alloy_sol_types::{SolCall, SolEvent};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::{ITIP20, PATH_USD_ADDRESS};
 use tempo_zone_contracts::{ZONE_FACTORY_ADDRESS, ZoneFactory};
@@ -96,8 +97,18 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
     }
     let factory_address = native_zone_factory(&l1_rpc_url, wallet).await?;
 
-    let factory = ZoneFactory::new(factory_address, &provider);
-    let factory_owner = factory.owner().call().await?;
+    let owner_call = ZoneFactory::ownerCall {};
+    let owner_output = provider
+        .call(
+            TransactionRequest {
+                to: Some(TxKind::Call(factory_address)),
+                input: Bytes::from(owner_call.abi_encode()).into(),
+                ..Default::default()
+            }
+            .into(),
+        )
+        .await?;
+    let factory_owner = ZoneFactory::ownerCall::abi_decode_returns(&owner_output)?._0;
     eyre::ensure!(
         factory_owner == dev_address,
         "ZoneFactory owner is {factory_owner}, but the configured dev key resolves to \
@@ -114,8 +125,8 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .inner
         .inner;
 
-    let receipt = factory
-        .createZone(ZoneFactory::CreateZoneParams {
+    let create_zone = ZoneFactory::createZoneCall {
+        params: ZoneFactory::CreateZoneParams {
             initialToken: initial_token,
             accessMode: !is_access_open,
             gatewayMode: is_gateway_enforced,
@@ -125,8 +136,17 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
             sequencers: vec![dev_address],
             threshold: 1,
             rpcUrl: rpc_url,
-        })
-        .send()
+        },
+    };
+    let receipt = provider
+        .send_transaction(
+            TransactionRequest {
+                to: Some(TxKind::Call(factory_address)),
+                input: Bytes::from(create_zone.abi_encode()).into(),
+                ..Default::default()
+            }
+            .into(),
+        )
         .await?
         .get_receipt()
         .await?;

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -108,7 +108,7 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
             .into(),
         )
         .await?;
-    let factory_owner = ZoneFactory::ownerCall::abi_decode_returns(&owner_output)?._0;
+    let factory_owner = ZoneFactory::ownerCall::abi_decode_returns(&owner_output)?;
     eyre::ensure!(
         factory_owner == dev_address,
         "ZoneFactory owner is {factory_owner}, but the configured dev key resolves to \

--- a/xtask/src/admin/snapshot.rs
+++ b/xtask/src/admin/snapshot.rs
@@ -11,12 +11,13 @@ use eyre::{Context as _, ensure, eyre};
 use futures::future::{join_all, try_join_all};
 use serde::{Deserialize, Serialize};
 use tempo_alloy::TempoNetwork;
-use tempo_zone_contracts::{ZoneFactory, ZonePortal};
+use tempo_zone_contracts::ZonePortal;
 use tokio::time::timeout;
 use zone_p2p::ZoneManifest;
 use zone_rpc::types::{SequencerInfoResponse, ZoneInfoResponse};
 
 use super::config::{EffectiveConfig, OperatorEndpoint, format_duration};
+use crate::zone_utils::zone_factory_info_at;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -191,11 +192,7 @@ where
     let block_number = finalized.number.to::<u64>();
     let block_id = BlockId::number(block_number);
 
-    let factory = ZoneFactory::new(factory_address, provider);
-    let factory_info = factory
-        .zones(expected_zone_id)
-        .block(block_id)
-        .call()
+    let factory_info = zone_factory_info_at(provider, factory_address, expected_zone_id, block_id)
         .await
         .wrap_err("failed resolving Zone through ZoneFactory")?;
     ensure!(

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -4,7 +4,7 @@
 
 use alloy::{
     network::{EthereumWallet, TransactionBuilder, primitives::ReceiptResponse},
-    primitives::{Address, Bytes, TxKind, address, keccak256},
+    primitives::{Address, Bytes, TxKind, address},
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -3,11 +3,12 @@
 #![allow(clippy::too_many_arguments)]
 
 use alloy::{
-    network::{EthereumWallet, primitives::ReceiptResponse},
-    primitives::{Address, address},
+    network::{EthereumWallet, TransactionBuilder, primitives::ReceiptResponse},
+    primitives::{Address, Bytes, TxKind, address, keccak256},
     providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
-    sol_types::SolEvent,
+    sol_types::{SolCall, SolEvent},
 };
 use alloy_rpc_types_eth::BlockId;
 use eyre::{WrapErr as _, ensure, eyre};
@@ -166,8 +167,6 @@ impl CreateZone {
             .connect(&self.l1_rpc_url)
             .await?;
 
-        let factory = ZoneFactory::new(self.zone_factory, &provider);
-
         println!("Verifier: {ZONE_VERIFIER_ADDRESS}");
         println!("Messenger: {ZONE_MESSENGER_ADDRESS}");
 
@@ -212,15 +211,16 @@ impl CreateZone {
             "Creating zone on L1 via ZoneFactory at {}...",
             self.zone_factory
         );
-        // Install the requested set in the factory transaction. A separate
-        // setSequencerSet call would leave the portal live as a temporary
-        // 1-of-1 settlement authority before the intended quorum is active.
-        // The portal bootstraps the first sequencer as the initial
-        // block-production leader (leaderEpoch 1); later transfers go through
-        // setLeader. The factory-installed set starts at version 0.
-        let receipt = factory
-            .createZone(self.factory_params())
-            .send_sync()
+        let create_zone = ZoneFactory::createZoneCall {
+            params: self.factory_params(),
+        };
+        let tx = TransactionRequest::default()
+            .with_kind(TxKind::Call(self.zone_factory))
+            .input(Bytes::from(create_zone.abi_encode()).into());
+        let receipt = provider
+            .send_transaction(tx.into())
+            .await?
+            .get_receipt()
             .await?;
         println!("Transaction confirmed in block {:?}", receipt.block_number);
         println!("Status: {}", receipt.status());

--- a/xtask/src/verify_closed_loop.rs
+++ b/xtask/src/verify_closed_loop.rs
@@ -8,11 +8,9 @@ use alloy_rpc_types_eth::BlockId;
 use eyre::{WrapErr as _, ensure};
 use std::collections::{BTreeMap, BTreeSet};
 use tempo_alloy::TempoNetwork;
-use tempo_zone_contracts::{
-    ZONE_FACTORY_ADDRESS, ZoneFactory, ZonePortal, ZonePortal::Role as PortalRole,
-};
+use tempo_zone_contracts::{ZONE_FACTORY_ADDRESS, ZonePortal, ZonePortal::Role as PortalRole};
 
-use crate::zone_utils::{find_zone_deployment_block, normalize_http_rpc};
+use crate::zone_utils::{find_zone_deployment_block, normalize_http_rpc, zone_factory_info_at};
 
 const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
 
@@ -102,12 +100,10 @@ impl VerifyClosedLoop {
             .await
             .wrap_err("failed reading Earn router configuration")?;
 
-        let zone = ZoneFactory::new(ZONE_FACTORY_ADDRESS, &provider)
-            .zones(zone_id)
-            .block(snapshot_block_id)
-            .call()
-            .await
-            .wrap_err("failed resolving Zone through ZoneFactory")?;
+        let zone =
+            zone_factory_info_at(&provider, ZONE_FACTORY_ADDRESS, zone_id, snapshot_block_id)
+                .await
+                .wrap_err("failed resolving Zone through ZoneFactory")?;
         ensure!(
             zone.portal != Address::ZERO,
             "router targets unknown Zone {zone_id}"

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -8,12 +8,10 @@ use alloy::{
 use eyre::{WrapErr as _, ensure};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP20 as TIP20Token;
-use tempo_zone_contracts::{
-    IZoneInbox, ZONE_FACTORY_ADDRESS, ZONE_INBOX_ADDRESS, ZoneFactory, ZonePortal,
-};
+use tempo_zone_contracts::{IZoneInbox, ZONE_FACTORY_ADDRESS, ZONE_INBOX_ADDRESS, ZonePortal};
 use zone_primitives::constants::zone_chain_id;
 
-use crate::zone_utils::normalize_http_rpc;
+use crate::zone_utils::{normalize_http_rpc, zone_factory_info_at, zone_factory_is_portal_at};
 
 const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
 
@@ -85,7 +83,6 @@ impl VerifyPortalBacking {
         let l1_block = BlockId::number(l1_snapshot);
         let zone_block = BlockId::number(zone_snapshot);
         let portal = ZonePortal::new(self.portal, &l1);
-        let factory = ZoneFactory::new(ZONE_FACTORY_ADDRESS, &l1);
         let l1_token = TIP20Token::new(self.token, &l1);
         let zone_token = TIP20Token::new(self.token, &zone);
         let inbox = IZoneInbox::new(ZONE_INBOX_ADDRESS, &zone);
@@ -99,8 +96,7 @@ impl VerifyPortalBacking {
             .add(portal.depositCount())
             .add(portal.lastProcessedDepositNumber())
             .add(portal.zoneId())
-            .add(portal.isTokenEnabled(self.token))
-            .add(factory.isZonePortal(self.portal));
+            .add(portal.isTokenEnabled(self.token));
         let zone_reads = zone
             .multicall()
             .block(zone_block)
@@ -116,18 +112,16 @@ impl VerifyPortalBacking {
                 l1_processed_deposits,
                 portal_zone_id,
                 token_enabled,
-                portal_registered,
             ),
             (zone_supply, zone_processed_deposits, inbox_portal),
         ) = tokio::try_join!(l1_reads.aggregate(), zone_reads.aggregate())
             .wrap_err("failed reading backing state")?;
 
-        let factory_zone = factory
-            .zones(portal_zone_id)
-            .block(l1_block)
-            .call()
-            .await
-            .wrap_err("failed reading ZoneFactory registration")?;
+        let (portal_registered, factory_zone) = tokio::try_join!(
+            zone_factory_is_portal_at(&l1, ZONE_FACTORY_ADDRESS, self.portal, l1_block,),
+            zone_factory_info_at(&l1, ZONE_FACTORY_ADDRESS, portal_zone_id, l1_block,),
+        )
+        .wrap_err("failed reading ZoneFactory registration")?;
         let expected_zone_chain_id =
             zone_chain_id(l1_chain_id, portal_zone_id).wrap_err("failed deriving Zone chain ID")?;
 

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -46,7 +46,7 @@ impl ZoneInfoCmd {
                         .into(),
                 )
                 .await?;
-            let next_zone_id = ZoneFactory::nextZoneIdCall::abi_decode_returns(&output)?._0;
+            let next_zone_id = ZoneFactory::nextZoneIdCall::abi_decode_returns(&output)?;
 
             let mut found = None;
             for id in 1..next_zone_id {
@@ -59,7 +59,7 @@ impl ZoneInfoCmd {
                             .into(),
                     )
                     .await?;
-                let info = ZoneFactory::zonesCall::abi_decode_returns(&output)?.info;
+                let info = ZoneFactory::zonesCall::abi_decode_returns(&output)?;
                 if info.portal == portal {
                     found = Some(id);
                     break;
@@ -81,7 +81,7 @@ impl ZoneInfoCmd {
                     .into(),
             )
             .await?;
-        let info = ZoneFactory::zonesCall::abi_decode_returns(&output)?.info;
+        let info = ZoneFactory::zonesCall::abi_decode_returns(&output)?;
         if info.portal == Address::ZERO {
             return Err(eyre!("zone {zone_id} does not exist"));
         }

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -1,6 +1,6 @@
 use alloy::{
     network::TransactionBuilder,
-    primitives::{Address, Bytes, TxKind, U256},
+    primitives::{Address, Bytes, TxKind},
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
     sol_types::SolCall,

--- a/xtask/src/zone_info.rs
+++ b/xtask/src/zone_info.rs
@@ -1,4 +1,10 @@
-use alloy::{primitives::Address, providers::ProviderBuilder};
+use alloy::{
+    network::TransactionBuilder,
+    primitives::{Address, Bytes, TxKind, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    sol_types::SolCall,
+};
 use eyre::eyre;
 use tempo_alloy::TempoNetwork;
 use tempo_zone_contracts::{ZONE_MESSENGER_ADDRESS, ZoneFactory};
@@ -28,16 +34,32 @@ impl ZoneInfoCmd {
             .connect(&self.l1_rpc_url)
             .await?;
 
-        let factory = ZoneFactory::new(self.zone_factory, &provider);
-
         let zone_id = if self.identifier.starts_with("0x") {
             // Look up by portal address — scan all zones
             let portal: Address = self.identifier.parse()?;
-            let next_zone_id = factory.nextZoneId().call().await?;
+            let call = ZoneFactory::nextZoneIdCall {};
+            let output = provider
+                .call(
+                    TransactionRequest::default()
+                        .with_kind(TxKind::Call(self.zone_factory))
+                        .input(Bytes::from(call.abi_encode()).into())
+                        .into(),
+                )
+                .await?;
+            let next_zone_id = ZoneFactory::nextZoneIdCall::abi_decode_returns(&output)?._0;
 
             let mut found = None;
             for id in 1..next_zone_id {
-                let info = factory.zones(id).call().await?;
+                let call = ZoneFactory::zonesCall { id };
+                let output = provider
+                    .call(
+                        TransactionRequest::default()
+                            .with_kind(TxKind::Call(self.zone_factory))
+                            .input(Bytes::from(call.abi_encode()).into())
+                            .into(),
+                    )
+                    .await?;
+                let info = ZoneFactory::zonesCall::abi_decode_returns(&output)?.info;
                 if info.portal == portal {
                     found = Some(id);
                     break;
@@ -50,7 +72,16 @@ impl ZoneInfoCmd {
                 .map_err(|_| eyre!("expected a zone ID (integer) or portal address (0x...)"))?
         };
 
-        let info = factory.zones(zone_id).call().await?;
+        let call = ZoneFactory::zonesCall { id: zone_id };
+        let output = provider
+            .call(
+                TransactionRequest::default()
+                    .with_kind(TxKind::Call(self.zone_factory))
+                    .input(Bytes::from(call.abi_encode()).into())
+                    .into(),
+            )
+            .await?;
+        let info = ZoneFactory::zonesCall::abi_decode_returns(&output)?.info;
         if info.portal == Address::ZERO {
             return Err(eyre!("zone {zone_id} does not exist"));
         }

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -1,10 +1,10 @@
 use alloy::{
     consensus::BlockHeader as _,
-    network::primitives::ReceiptResponse,
-    primitives::{Address, B256, U256, address},
+    network::{TransactionBuilder, primitives::ReceiptResponse},
+    primitives::{Address, B256, Bytes, TxKind, U256, address},
     providers::Provider,
-    rpc::types::Filter,
-    sol_types::SolEvent,
+    rpc::types::{BlockId, Filter, TransactionRequest},
+    sol_types::{SolCall, SolEvent},
 };
 use eyre::{WrapErr as _, eyre};
 use serde_json::Value;
@@ -14,7 +14,7 @@ use std::{
 };
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP20 as TIP20Token;
-use tempo_zone_contracts::{IZoneInbox, ZONE_FACTORY_ADDRESS, ZoneFactory, ZonePortal};
+use tempo_zone_contracts::{IZoneInbox, ZONE_FACTORY_ADDRESS, ZoneFactory, ZoneInfo, ZonePortal};
 
 /// Write a file that may contain key material with owner-only permissions on Unix.
 ///
@@ -58,23 +58,73 @@ const DEFAULT_WAIT_ATTEMPTS: usize = 120;
 const DEFAULT_WAIT_POLL: Duration = Duration::from_millis(500);
 const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
 
+pub(crate) async fn zone_factory_info_at<P: Provider<TempoNetwork>>(
+    provider: &P,
+    factory_address: Address,
+    zone_id: u32,
+    block_id: BlockId,
+) -> eyre::Result<ZoneInfo> {
+    let call = ZoneFactory::zonesCall { id: zone_id };
+    let output = provider
+        .call(
+            TransactionRequest::default()
+                .with_kind(TxKind::Call(factory_address))
+                .input(Bytes::from(call.abi_encode()).into())
+                .into(),
+        )
+        .block(block_id)
+        .await?;
+    Ok(ZoneFactory::zonesCall::abi_decode_returns(&output)?)
+}
+
+pub(crate) async fn zone_factory_is_portal_at<P: Provider<TempoNetwork>>(
+    provider: &P,
+    factory_address: Address,
+    portal: Address,
+    block_id: BlockId,
+) -> eyre::Result<bool> {
+    let call = ZoneFactory::isZonePortalCall { portal };
+    let output = provider
+        .call(
+            TransactionRequest::default()
+                .with_kind(TxKind::Call(factory_address))
+                .input(Bytes::from(call.abi_encode()).into())
+                .into(),
+        )
+        .block(block_id)
+        .await?;
+    Ok(ZoneFactory::isZonePortalCall::abi_decode_returns(&output)?)
+}
+
 pub(crate) async fn find_zone_deployment_block<P: Provider<TempoNetwork>>(
     provider: &P,
     zone_id: u32,
     portal: Address,
     snapshot_block: u64,
 ) -> eyre::Result<u64> {
-    let events = ZoneFactory::new(ZONE_FACTORY_ADDRESS, provider)
-        .ZoneCreated_filter()
-        .topic1(B256::from(U256::from(zone_id)))
-        .topic2(portal.into_word())
-        .from_block(0)
-        .to_block(snapshot_block)
-        .chunked()
-        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
-        .query()
-        .await
-        .wrap_err("failed scanning ZoneFactory ZoneCreated events")?;
+    let mut events = Vec::new();
+    for start in (0..=snapshot_block).step_by(LOG_QUERY_BLOCK_CHUNK as usize) {
+        let filter = Filter::new()
+            .address(ZONE_FACTORY_ADDRESS)
+            .event_signature(ZoneFactory::ZoneCreated::SIGNATURE_HASH)
+            .topic1(B256::from(U256::from(zone_id)))
+            .topic2(portal.into_word())
+            .from_block(start)
+            .to_block(
+                start
+                    .saturating_add(LOG_QUERY_BLOCK_CHUNK - 1)
+                    .min(snapshot_block),
+            );
+        for log in provider
+            .get_logs(&filter)
+            .await
+            .wrap_err("failed scanning ZoneFactory ZoneCreated events")?
+        {
+            if let Ok(event) = ZoneFactory::ZoneCreated::decode_log(&log.inner) {
+                events.push((event, log));
+            }
+        }
+    }
 
     eyre::ensure!(
         events.len() == 1,


### PR DESCRIPTION
## Summary

- replace the duplicated Zones `ZoneFactory` ABI with Tempo's canonical `IZoneFactory` export
- use the existing Tempo revision from `main` (`9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1`), which already contains tempoxyz/tempo#6934
- enable the `tempo-contracts` `rpc` feature and encode exported ABI calls at call sites that do not use provider-bound instances
- retain only the Zones-specific portal prefix locally

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo check -p tempo-zone-contracts -p tempo-xtask -p zone-node`
- GitHub Actions CI

Prompted by: @0xalpharush
