### PR TITLE
fix zone-unstable L1 runtime updater

### DIFF
--- a/.github/workflows/update-nextfork-zone-runtimes.yml
+++ b/.github/workflows/update-nextfork-zone-runtimes.yml
@@ -39,6 +39,6 @@ jobs:
 
       - name: Update changed runtimes
         env:
-          RPC_URL: http://zone-factory-hf-val-rpc-service.tail388b2e.ts.net:8545
+          RPC_URL: ${{ secrets.TEMPO_NEXTFORK_RPC_URL }}
           FACTORY_OWNER_PRIVATE_KEY: ${{ secrets.FACTORY_OWNER_PRIVATE_KEY }}
         run: scripts/update-nextfork-zone-runtimes.sh

--- a/.github/workflows/update-nextfork-zone-runtimes.yml
+++ b/.github/workflows/update-nextfork-zone-runtimes.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Update changed runtimes
         env:
           RPC_URL: ${{ secrets.TEMPO_NEXTFORK_RPC_URL }}
-          FACTORY_OWNER_PRIVATE_KEY: ${{ secrets.ZONE_FACTORY_OWNER_PRIVATE_KEY }}
+          FACTORY_OWNER_PRIVATE_KEY: ${{ secrets.FACTORY_OWNER_PRIVATE_KEY }}
         run: scripts/update-nextfork-zone-runtimes.sh

--- a/.github/workflows/update-nextfork-zone-runtimes.yml
+++ b/.github/workflows/update-nextfork-zone-runtimes.yml
@@ -1,4 +1,4 @@
-name: Update nextfork Zone runtimes
+name: Update zone-unstable L1 Zone runtimes
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: update-nextfork-zone-runtimes
+  group: update-zone-unstable-l1-zone-runtimes
   cancel-in-progress: false
 
 jobs:
@@ -22,6 +22,13 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3.3.0
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Install Foundry
         uses: tempoxyz/gh-actions/actions/setup-foundry@98b1081dcf34361b576aca2ab3041772708582ef
         with:
@@ -32,6 +39,6 @@ jobs:
 
       - name: Update changed runtimes
         env:
-          RPC_URL: ${{ secrets.TEMPO_NEXTFORK_RPC_URL }}
+          RPC_URL: http://zone-factory-hf-val-rpc-service.tail388b2e.ts.net:8545
           FACTORY_OWNER_PRIVATE_KEY: ${{ secrets.FACTORY_OWNER_PRIVATE_KEY }}
         run: scripts/update-nextfork-zone-runtimes.sh


### PR DESCRIPTION
## Summary

- connect the runtime updater job to Tailscale using the shared CI OAuth credentials
- read the `zone-factory-hf` validator RPC backing `zone-unstable` from `TEMPO_NEXTFORK_RPC_URL`
- wire the owner key to the existing `FACTORY_OWNER_PRIVATE_KEY` repository secret
- clarify the workflow display name and concurrency group

## Root cause

The workflow was pointed at the authenticated public RPC for the separate persistent `tempo-devnet-nextfork` environment, which returned HTTP 401. `zone-unstable` is backed by the `zone-factory-hf` L1 instead, whose healthy validator RPC is reachable over Tailscale; the follower RPC is currently unavailable.

The workflow also exported `FACTORY_OWNER_PRIVATE_KEY` from a nonexistent `ZONE_FACTORY_OWNER_PRIVATE_KEY` secret, leaving the key empty.

Failed run: https://github.com/tempoxyz/zones/actions/runs/29978685289/job/89115814144

## Required repository secrets

- `TS_OAUTH_CLIENT_ID`
- `TS_OAUTH_SECRET`
- `TEMPO_NEXTFORK_RPC_URL`
- `FACTORY_OWNER_PRIVATE_KEY`

The Tailscale credentials must permit `tag:ci` to reach the `zone-factory-hf` validator service.

## Validation

- `git diff --check origin/main...HEAD`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/update-nextfork-zone-runtimes.yml`
- live validator RPC returned chain ID `0x7a56`
- live native ZoneFactory owner resolved to `0xaF571FD4B3AD43a5807A5E58bFb25ea1aB327A14`