### PR TITLE
fix(sequencer): avoid Tempo fee history requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13716,6 +13716,7 @@ dependencies = [
  "schnellru",
  "serde_json",
  "tempo-alloy",
+ "tempo-chainspec",
  "tempo-primitives",
  "tempo-zone-contracts",
  "tokio",

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # tempo
 tempo-alloy.workspace = true
+tempo-chainspec.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
 
 # reth

--- a/crates/sequencer/src/encryption_key.rs
+++ b/crates/sequencer/src/encryption_key.rs
@@ -35,6 +35,8 @@ pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
 
     let receipt = ZonePortal::new(portal, provider)
         .setSequencerEncryptionKey(x, y_parity, pop_v, pop_r, pop_s)
+        .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
+        .max_priority_fee_per_gas(0)
         .send()
         .await?
         .get_receipt()

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -35,6 +35,13 @@ pub use withdrawals::{
 
 use crate::rpc::rpc_connection_config;
 
+/// Conservative Tempo L1 fee cap for sequencer transactions.
+///
+/// T1's fixed base fee is above both T0's fixed fee and T7's dynamic base-fee cap, so setting it
+/// explicitly avoids an `eth_feeHistory` request while remaining valid across those regimes.
+pub(crate) const TEMPO_L1_MAX_FEE_PER_GAS: u128 =
+    tempo_chainspec::constants::gas::TEMPO_T1_BASE_FEE as u128;
+
 /// Configuration for all zone sequencer background tasks.
 #[derive(Debug, Clone)]
 pub struct ZoneSequencerConfig {

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -450,6 +450,8 @@ impl BatchSubmitter {
                 vec![signature],
             )
             .nonce_key(SUBMIT_BATCH_NONCE_KEY)
+            .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
+            .max_priority_fee_per_gas(0)
             .send()
             .await?;
 

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -602,6 +602,8 @@ impl WithdrawalProcessor {
                     .processWithdrawals(batch_withdrawals, remaining_queue)
                     .nonce_key(PROCESS_WITHDRAWAL_NONCE_KEY)
                     .nonce(nonce)
+                    .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
+                    .max_priority_fee_per_gas(0)
                     .gas(batch.gas_limit);
 
                 let pending = tokio::time::timeout(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT, call.send())


### PR DESCRIPTION
Configure sequencer-owned Tempo L1 writes with the known T1 fee cap and zero priority fee.

The T1 fee is above both the T0 fixed base fee and the T7 dynamic base-fee cap, so transactions remain valid while Alloy no longer needs an `eth_feeHistory` request before batch submission, withdrawal processing, or encryption-key registration.