### PR TITLE
perf(sequencer): reuse finalized batch metadata

### DIFF
--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -39,8 +39,8 @@ use crate::{
     abi::{self, IZoneOutbox, NO_QUEUE_INDEX, TempoState, ZoneInbox, ZonePortal},
     rpc::rpc_connection_config,
     settlement::{
-        BatchAnchorConfig, BatchData, BatchSubmitter, ZoneBlockSnapshot, fetch_finalized_batch,
-        fetch_finalized_batch_boundaries, log_query_ranges,
+        BatchAnchorConfig, BatchData, BatchSubmitter, FinalizedBatchLog, ZoneBlockSnapshot,
+        fetch_finalized_batch, fetch_finalized_batch_boundaries, log_query_ranges,
     },
     withdrawals::SharedWithdrawalStore,
 };
@@ -441,20 +441,21 @@ impl ZoneMonitor {
             boundary_count = boundaries.len(),
             from,
             to,
-            first_boundary = boundaries[0],
-            last_boundary = boundaries[boundaries.len() - 1],
+            first_boundary = boundaries[0].block_number,
+            last_boundary = boundaries[boundaries.len() - 1].block_number,
             "Submitting finalized zone batches"
         );
 
         for (idx, boundary) in boundaries.into_iter().enumerate() {
-            if boundary <= self.last_submitted_zone_block {
+            let boundary_block = boundary.block_number;
+            if boundary_block <= self.last_submitted_zone_block {
                 continue;
             }
             let range_start = self.last_submitted_zone_block + 1;
             info!(
                 batch = idx + 1,
                 zone_from = range_start,
-                zone_to = boundary,
+                zone_to = boundary_block,
                 "Submitting finalized zone batch"
             );
             let before_submit = self.last_submitted_zone_block;
@@ -462,7 +463,7 @@ impl ZoneMonitor {
             if self.last_submitted_zone_block <= before_submit {
                 warn!(
                     before_submit,
-                    boundary,
+                    boundary = boundary_block,
                     current_last_submitted = self.last_submitted_zone_block,
                     "Batch submission did not advance local state; stopping boundary walk"
                 );
@@ -474,8 +475,14 @@ impl ZoneMonitor {
     }
 
     /// Process one boundary-aligned finalized batch.
-    async fn process_finalized_batch(&mut self, from: u64, to: u64) -> Result<()> {
-        let finalized_batch = fetch_finalized_batch(&self.outbox, &self.provider, from, to).await?;
+    async fn process_finalized_batch(
+        &mut self,
+        from: u64,
+        boundary: FinalizedBatchLog,
+    ) -> Result<()> {
+        let to = boundary.block_number;
+        let finalized_batch =
+            fetch_finalized_batch(&self.outbox, &self.provider, from, &boundary).await?;
         let end_state = self.fetch_block_snapshot(to).await?;
 
         let expected_l2_index = self
@@ -512,6 +519,7 @@ impl ZoneMonitor {
             prev_deposit_number: self.prev_processed_deposit_number,
             next_deposit_number: end_state.processed_deposit_number,
             withdrawal_queue_hash: finalized_batch.finalized_hash,
+            withdrawal_batch_index: expected_l2_index,
         };
 
         self.submit_batch_with_retry(&batch_data, to, finalized_batch.withdrawals)
@@ -1201,6 +1209,7 @@ mod tests {
             prev_deposit_number: 0,
             next_deposit_number: 0,
             withdrawal_queue_hash: B256::ZERO,
+            withdrawal_batch_index: 8,
         };
 
         monitor

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -148,6 +148,8 @@ pub struct BatchData {
     pub next_deposit_number: u64,
     /// Withdrawal queue hash for this batch (`B256::ZERO` if no withdrawals).
     pub withdrawal_queue_hash: B256,
+    /// L2 withdrawal batch index validated against the portal before submission.
+    pub withdrawal_batch_index: u64,
 }
 
 struct SettlementAttestationInput<'a> {
@@ -378,6 +380,7 @@ impl BatchSubmitter {
         prev_block_hash = %batch.prev_block_hash,
         next_block_hash = %batch.next_block_hash,
         withdrawal_queue_hash = %batch.withdrawal_queue_hash,
+        withdrawal_batch_index = batch.withdrawal_batch_index,
     ))]
     pub async fn submit_batch(&self, batch: &BatchData) -> Result<ZonePortal::BatchSubmitted> {
         if !batch.withdrawal_queue_hash.is_zero() {
@@ -523,13 +526,6 @@ impl BatchSubmitter {
             "local sequencer signer {} is not active in the portal sequencer set",
             signer.address()
         );
-        let withdrawal_batch_index = self
-            .portal
-            .withdrawalBatchIndex()
-            .call()
-            .await?
-            .checked_add(1)
-            .ok_or_else(|| eyre::eyre!("portal withdrawal batch index overflow"))?;
         let verifier = self.portal.verifier().call().await?;
         let chain_id = self.l1_provider.get_chain_id().await?;
 
@@ -543,7 +539,7 @@ impl BatchSubmitter {
             zoneId: zone_id,
             sequencerSetVersion: sequencer_set_version,
             zoneHeight: U256::from(batch.zone_height),
-            withdrawalBatchIndex: U256::from(withdrawal_batch_index),
+            withdrawalBatchIndex: U256::from(batch.withdrawal_batch_index),
             verifier,
             tempoBlockNumber: batch.tempo_block_number,
             anchorBlockNumber: anchor_block_number,
@@ -1040,8 +1036,8 @@ struct RequestedWithdrawalLog {
 }
 
 #[derive(Debug, Clone)]
-struct FinalizedBatchLog {
-    block_number: u64,
+pub(crate) struct FinalizedBatchLog {
+    pub(crate) block_number: u64,
     tx_index: u64,
     log_index: u64,
     tx_hash: B256,
@@ -1057,74 +1053,38 @@ pub(crate) async fn fetch_finalized_batch_boundaries(
     outbox: &IZoneOutbox::IZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     from: u64,
     to: u64,
-) -> Result<Vec<u64>> {
+) -> Result<Vec<FinalizedBatchLog>> {
     if from > to {
         return Ok(Vec::new());
     }
 
-    let mut boundaries: Vec<_> = outbox
-        .BatchFinalized_filter()
-        .from_block(from)
-        .to_block(to)
-        .chunked()
-        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
-        .concurrent(2)
-        .query()
-        .await?
-        .into_iter()
-        .map(|(_, log)| log.block_number.unwrap_or(0))
-        .collect();
-
-    boundaries.sort_unstable();
-    boundaries.dedup();
+    let boundaries = fetch_finalized_batch_logs(outbox, from, to).await?;
+    if let Some(duplicate) = boundaries
+        .windows(2)
+        .find(|pair| pair[0].block_number == pair[1].block_number)
+    {
+        return Err(eyre::eyre!(
+            "zone block {} contains more than one BatchFinalized event",
+            duplicate[0].block_number
+        ));
+    }
     Ok(boundaries)
 }
 
 /// Fetch one finalized L2 withdrawal batch for a range ending at `to`.
 ///
-/// The submitted hash and index come from the batch's `BatchFinalized` event.
-/// Withdrawal structs are reconstructed from `WithdrawalRequested` logs since
-/// the immediately preceding batch boundary so the off-chain processor can
-/// service the portal queue.
+/// The submitted hash and index come from the supplied `BatchFinalized` event.
+/// Withdrawal structs are reconstructed from `WithdrawalRequested` logs in the
+/// supplied boundary-aligned range so the off-chain processor can service the
+/// portal queue.
 pub(crate) async fn fetch_finalized_batch(
     outbox: &IZoneOutbox::IZoneOutboxInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     zone_provider: &DynProvider<TempoNetwork>,
     from: u64,
-    to: u64,
+    target: &FinalizedBatchLog,
 ) -> Result<FinalizedBatch> {
-    let mut finalized_batches = fetch_finalized_batch_logs(outbox, from, to).await?;
-
-    if finalized_batches.is_empty() {
-        return Err(eyre::eyre!(
-            "range {from}..={to} does not contain a BatchFinalized boundary"
-        ));
-    }
-
-    finalized_batches.sort_by_key(|batch| (batch.block_number, batch.tx_index, batch.log_index));
-    let target_position = finalized_batches
-        .iter()
-        .rposition(|batch| batch.block_number == to)
-        .ok_or_else(|| {
-            eyre::eyre!("range {from}..={to} does not end on a BatchFinalized boundary")
-        })?;
-
-    if finalized_batches
-        .iter()
-        .filter(|batch| batch.block_number == to)
-        .count()
-        != 1
-    {
-        return Err(eyre::eyre!(
-            "zone block {to} contains more than one BatchFinalized event"
-        ));
-    }
-
-    let target = finalized_batches[target_position].clone();
-    let previous_boundary = finalized_batches[..target_position]
-        .last()
-        .map(|batch| batch.block_number)
-        .unwrap_or(from.saturating_sub(1));
-    let request_from = previous_boundary.saturating_add(1);
+    let to = target.block_number;
+    let request_from = from;
 
     let requests = if request_from <= to {
         fetch_requested_withdrawal_logs(outbox, request_from, to).await?
@@ -1193,7 +1153,12 @@ pub(crate) async fn fetch_slot_withdrawals(
     from: u64,
     to: u64,
 ) -> Result<Vec<abi::Withdrawal>> {
-    Ok(fetch_finalized_batch(outbox, zone_provider, from, to)
+    let boundaries = fetch_finalized_batch_boundaries(outbox, to, to).await?;
+    let target = boundaries
+        .into_iter()
+        .next()
+        .ok_or_else(|| eyre::eyre!("zone block {to} does not contain a BatchFinalized boundary"))?;
+    Ok(fetch_finalized_batch(outbox, zone_provider, from, &target)
         .await?
         .withdrawals)
 }


### PR DESCRIPTION
Carry each `BatchFinalized` log from the boundary scan into finalized-batch processing instead of querying the same event again. The duplicate-event check remains at the boundary scan.

Also read and validate `withdrawalBatchIndex` once, then include that value in `BatchData` for attestation signing. Together these remove one `eth_getLogs` and one `eth_call` per finalized batch.

The multi-withdrawal e2e flow passes with Alloy RPC debug logging, alongside the sequencer unit tests and clippy.

## PR stack

Review in order:

1. **#821 — this PR**
2. #823 — multicall portal metadata
3. #824 — sync L1 transaction submission