### PR TITLE
perf(sequencer): use sync L1 transaction submission

### DIFF
--- a/crates/sequencer/src/encryption_key.rs
+++ b/crates/sequencer/src/encryption_key.rs
@@ -37,9 +37,7 @@ pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
         .setSequencerEncryptionKey(x, y_parity, pop_v, pop_r, pop_s)
         .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
         .max_priority_fee_per_gas(0)
-        .send()
-        .await?
-        .get_receipt()
+        .send_sync()
         .await?;
     let tx_hash = receipt.transaction_hash();
     eyre::ensure!(

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -469,52 +469,29 @@ impl BatchSubmitter {
             "Submitting batch to ZonePortal on L1"
         );
 
-        let pending = self
-            .portal
-            .submitBatch(
-                batch.tempo_block_number,
-                recent_tempo_block_number,
-                block_transition,
-                deposit_transition,
-                batch.withdrawal_queue_hash,
-                verifier_config,
-                Bytes::new(),
-                U256::from(batch.zone_height),
-                signatures,
-            )
-            .nonce_key(SUBMIT_BATCH_NONCE_KEY)
-            .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
-            .max_priority_fee_per_gas(0)
-            .send()
-            .await?;
+        let receipt = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            self.portal
+                .submitBatch(
+                    batch.tempo_block_number,
+                    recent_tempo_block_number,
+                    block_transition,
+                    deposit_transition,
+                    batch.withdrawal_queue_hash,
+                    verifier_config,
+                    Bytes::new(),
+                    U256::from(batch.zone_height),
+                    signatures,
+                )
+                .nonce_key(SUBMIT_BATCH_NONCE_KEY)
+                .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
+                .max_priority_fee_per_gas(0)
+                .send_sync(),
+        )
+        .await
+        .map_err(|_| eyre::eyre!("submitBatch sync submission timed out after 30 seconds"))??;
 
-        let tx_hash = *pending.tx_hash();
-        info!(
-            %tx_hash,
-            timeout_secs = 30,
-            required_confirmations = 1,
-            "submitBatch tx accepted by RPC; waiting for confirmation"
-        );
-
-        let receipt_result = pending
-            .with_required_confirmations(1)
-            .with_timeout(Some(std::time::Duration::from_secs(30)))
-            .get_receipt()
-            .await;
-
-        let receipt = match receipt_result {
-            Ok(receipt) => receipt,
-            Err(err) => {
-                warn!(
-                    %tx_hash,
-                    timeout_secs = 30,
-                    error = %err,
-                    "submitBatch tx was broadcast but receipt not obtained"
-                );
-                return Err(err.into());
-            }
-        };
-
+        let tx_hash = receipt.transaction_hash();
         if !receipt.status() {
             return Err(eyre::eyre!(
                 "submitBatch tx {tx_hash} was included but reverted on L1"

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -606,85 +606,67 @@ impl WithdrawalProcessor {
                     .max_priority_fee_per_gas(0)
                     .gas(batch.gas_limit);
 
-                let pending = tokio::time::timeout(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT, call.send())
-                    .await
-                    .map_err(|_| eyre::eyre!("processWithdrawals tx send timed out"))
-                    .and_then(|result| result.map_err(Into::into));
-
-                match pending {
-                    Ok(pending) => {
-                        let tx_hash = *pending.tx_hash();
-                        self.metrics
-                            .withdrawals_processed_total
-                            .increment(batch.len() as u64);
-                        self.metrics
-                            .withdrawals_per_batch
-                            .record(batch.len() as f64);
-
-                        in_flight.push(async move {
-                            let receipt = pending
-                                .with_timeout(Some(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT))
-                                .get_receipt()
-                                .await;
-                            (batch, nonce, tx_hash, remaining_queue, receipt)
-                        });
-                        submitted += 1;
-                    }
-                    Err(e) => {
-                        self.metrics
-                            .withdrawals_failed_total
-                            .increment(batch.len() as u64);
-                        error!(
-                            slot,
-                            nonce,
-                            start_index = absolute_start,
-                            withdrawal_count = batch.len(),
-                            error = %e,
-                            "processWithdrawals tx failed to send; queue will be reconciled and retried"
-                        );
-                        retry = true;
-                    }
-                }
+                in_flight.push(async move {
+                    let receipt =
+                        tokio::time::timeout(PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT, call.send_sync())
+                            .await
+                            .map_err(|_| {
+                                eyre::eyre!(
+                                    "processWithdrawals sync submission timed out after {} seconds",
+                                    PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT.as_secs()
+                                )
+                            })
+                            .and_then(|result| result.map_err(Into::into));
+                    (batch, nonce, remaining_queue, receipt)
+                });
+                submitted += 1;
             }
 
-            let Some((batch, nonce, tx_hash, remaining_queue, receipt)) = in_flight.next().await
-            else {
+            let Some((batch, nonce, remaining_queue, receipt)) = in_flight.next().await else {
                 break;
             };
 
             match receipt {
-                Ok(receipt) if receipt.status() => {
+                Ok(receipt) => {
+                    let tx_hash = receipt.transaction_hash();
                     self.metrics
-                        .withdrawals_confirmed_total
-                        .increment(batch.len() as u64);
-                    self.metrics.batches_confirmed_total.increment(1);
-                    info!(
-                        slot,
-                        nonce,
-                        %tx_hash,
-                        start_index = offset + batch.start,
-                        withdrawal_count = batch.len(),
-                        gas_used = receipt.gas_used,
-                        "✅ Withdrawal batch confirmed on L1"
-                    );
-                }
-                Ok(_) => {
-                    self.metrics
-                        .withdrawals_failed_total
+                        .withdrawals_processed_total
                         .increment(batch.len() as u64);
                     self.metrics
-                        .withdrawals_reverted_total
-                        .increment(batch.len() as u64);
-                    error!(
-                        slot,
-                        nonce,
-                        %tx_hash,
-                        start_index = offset + batch.start,
-                        withdrawal_count = batch.len(),
-                        expected_remaining_queue = %remaining_queue,
-                        "processWithdrawals tx reverted; queue will be reconciled and retried"
-                    );
-                    retry = true;
+                        .withdrawals_per_batch
+                        .record(batch.len() as f64);
+                    if receipt.status() {
+                        self.metrics
+                            .withdrawals_confirmed_total
+                            .increment(batch.len() as u64);
+                        self.metrics.batches_confirmed_total.increment(1);
+                        info!(
+                            slot,
+                            nonce,
+                            %tx_hash,
+                            start_index = offset + batch.start,
+                            withdrawal_count = batch.len(),
+                            gas_used = receipt.gas_used,
+                            "✅ Withdrawal batch confirmed on L1"
+                        );
+                    } else {
+                        self.metrics
+                            .withdrawals_failed_total
+                            .increment(batch.len() as u64);
+                        self.metrics
+                            .withdrawals_reverted_total
+                            .increment(batch.len() as u64);
+                        error!(
+                            slot,
+                            nonce,
+                            %tx_hash,
+                            start_index = offset + batch.start,
+                            withdrawal_count = batch.len(),
+                            expected_remaining_queue = %remaining_queue,
+                            "processWithdrawals tx reverted; queue will be reconciled and retried"
+                        );
+                        retry = true;
+                    }
                 }
                 Err(e) => {
                     self.metrics
@@ -693,7 +675,6 @@ impl WithdrawalProcessor {
                     error!(
                         slot,
                         nonce,
-                        %tx_hash,
                         start_index = offset + batch.start,
                         withdrawal_count = batch.len(),
                         expected_remaining_queue = %remaining_queue,


### PR DESCRIPTION
## Summary

- submit sequencer-owned L1 writes with Alloy’s native `send_sync()` path
- preserve fixed Tempo L1 fee configuration, the 30-second confirmation bound, and concurrent withdrawal submission
- return and inspect receipts directly from Tempo L1 instead of polling them client-side

## RPC impact

The multi-withdrawal e2e flow reduced sequencer receipt polling from 677 `eth_getTransactionReceipt` calls to zero. Each affected transaction now makes one `eth_sendRawTransactionSync` request (50 batch submissions and 65 withdrawal batches in the measured run).