### PR TITLE
fix(precompiles): disable channel reserve on zones

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -54,9 +54,9 @@ use tempo_payload_types::TempoExecutionData;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PrecompileEnv,
     RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    account_keychain::AccountKeychain, error::Result as TempoResult, nonce::NonceManager,
-    receive_policy_guard::ReceivePolicyGuard, storage::actions::StorageActions,
-    tip20::is_tip20_prefix,
+    TIP20_CHANNEL_RESERVE_ADDRESS, account_keychain::AccountKeychain, error::Result as TempoResult,
+    nonce::NonceManager, receive_policy_guard::ReceivePolicyGuard,
+    storage::actions::StorageActions, tip20::is_tip20_prefix,
 };
 use tempo_primitives::{
     Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType,
@@ -118,6 +118,7 @@ where
             Some(ZoneTokenFactory::create(&env))
         });
         precompiles.apply_precompile(&TIP_FEE_MANAGER_ADDRESS, |_| None);
+        precompiles.apply_precompile(&TIP20_CHANNEL_RESERVE_ADDRESS, |_| None);
         let fee_env = env.clone();
         precompiles.apply_precompile(&ZONE_FEE_MANAGER_ADDRESS, move |_| {
             Some(create_zone_fee_manager_precompile(&fee_env))

--- a/crates/node/tests/it/precompiles.rs
+++ b/crates/node/tests/it/precompiles.rs
@@ -1,6 +1,8 @@
 //! Tests for zone-specific precompile availability.
 
-use tempo_precompiles::PATH_USD_ADDRESS;
+use alloy_primitives::B256;
+use tempo_contracts::precompiles::ITIP20ChannelReserve;
+use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS};
 
 use crate::utils::{
     DEFAULT_TIMEOUT, STABLECOIN_DEX_ADDRESS, TestStablecoinDEX, start_local_zone_with_fixture,
@@ -26,6 +28,27 @@ async fn test_dex_disabled_on_zone() -> eyre::Result<()> {
     assert!(
         result.is_err(),
         "StablecoinDEX should be disabled on zones — createPair must revert"
+    );
+
+    Ok(())
+}
+
+/// The TIP-20 channel reserve precompile should be disabled on zones.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_channel_reserve_disabled_on_zone() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
+
+    fixture.inject_empty_block(zone.deposit_queue());
+    zone.wait_for_tempo_block_number(1, DEFAULT_TIMEOUT).await?;
+
+    let reserve = ITIP20ChannelReserve::new(TIP20_CHANNEL_RESERVE_ADDRESS, zone.provider());
+    let result = reserve.getChannelState(B256::ZERO).call().await;
+
+    assert!(
+        result.is_err(),
+        "TIP-20 channel reserve should be disabled on zones"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- remove the inherited TIP-20 channel reserve precompile from the Zone EVM
- add an integration regression test for channel reserve availability

## Validation
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-node --test it test_channel_reserve_disabled_on_zone --no-run` *(blocked: Cargo git fetch receives HTTP 401 for the pinned `alloy-evm` revision)*

Prompted by: @0xKitsune