### PR TITLE
feat(precompiles): enable storage credits on zones

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -53,10 +53,10 @@ use tempo_evm::{
 use tempo_payload_types::TempoExecutionData;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PrecompileEnv,
-    RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    account_keychain::AccountKeychain, error::Result as TempoResult, nonce::NonceManager,
-    receive_policy_guard::ReceivePolicyGuard, storage::actions::StorageActions,
-    tip20::is_tip20_prefix,
+    RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, STORAGE_CREDITS_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, account_keychain::AccountKeychain, error::Result as TempoResult,
+    nonce::NonceManager, receive_policy_guard::ReceivePolicyGuard,
+    storage::actions::StorageActions, storage_credits::StorageCredits, tip20::is_tip20_prefix,
 };
 use tempo_primitives::{
     Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType,
@@ -139,6 +139,8 @@ where
                 Some(AccountKeychain::create_precompile(&tempo_env))
             } else if *address == RECEIVE_POLICY_GUARD_ADDRESS {
                 Some(ReceivePolicyGuard::create_precompile(&tempo_env))
+            } else if *address == STORAGE_CREDITS_ADDRESS {
+                Some(StorageCredits::create_precompile(&tempo_env))
             } else {
                 None
             }

--- a/crates/node/tests/it/precompiles.rs
+++ b/crates/node/tests/it/precompiles.rs
@@ -1,5 +1,7 @@
 //! Tests for zone-specific precompile availability.
 
+use alloy_primitives::Address;
+use tempo_contracts::precompiles::{IStorageCredits, STORAGE_CREDITS_ADDRESS};
 use tempo_precompiles::PATH_USD_ADDRESS;
 
 use crate::utils::{
@@ -26,6 +28,26 @@ async fn test_dex_disabled_on_zone() -> eyre::Result<()> {
     assert!(
         result.is_err(),
         "StablecoinDEX should be disabled on zones — createPair must revert"
+    );
+
+    Ok(())
+}
+
+/// The storage credits precompile should be available on zones.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_storage_credits_enabled_on_zone() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
+
+    fixture.inject_empty_block(zone.deposit_queue());
+    zone.wait_for_tempo_block_number(1, DEFAULT_TIMEOUT).await?;
+
+    let storage_credits = IStorageCredits::new(STORAGE_CREDITS_ADDRESS, zone.provider());
+    assert_eq!(
+        storage_credits.balanceOf(Address::ZERO).call().await?,
+        0,
+        "storage credits precompile should return an empty balance"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- register the Tempo storage credits precompile in the Zone EVM lookup
- add an integration test that verifies `balanceOf` is callable on a Zone

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-evm --lib` *(blocked: dependency fetch from `alloy-rs/evm` returned HTTP 401 in the sandbox)*

Prompted by: @0xKitsune