### PR TITLE
docs: fix broken Zone spec link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Zones are private blockchains anchored to [Tempo](https://github.com/tempoxyz/tempo) *(currently available in testnet only),* with native support for confidential balances and transactions. Zones inherit compliance via TIP403 policies from Tempo and support interoperability with Tempo for moving assets in and out of Zones.
 
-You can get started today by [deploying a Zone](#getting-started) on Tempo testnet, reading the [Zones documentation](https://docs.tempo.xyz/guide/private-zones), or exploring the [Zone spec](specs/ref-impls/zone_spec.md).
+You can get started today by [deploying a Zone](#getting-started) on Tempo testnet, reading the [Zones documentation](https://docs.tempo.xyz/guide/private-zones), or exploring the [Zone spec](specs/spec.md).
 
 <br>
 


### PR DESCRIPTION
The README's intro links the Zone spec to `specs/ref-impls/zone_spec.md`, which doesn't exist, so the link 404s.

The Zone specification is `specs/spec.md` ("Tempo Zones"). I pointed the link there rather than at `specs/ref-impls/README.md`, since that document covers the Solidity precompile specs and fuzz tests rather than the Zone spec itself.

One-line change; this is the only `zone_spec` reference in the repo.