### PR TITLE
feat(xtask): multi-sequencer set support in create-zone

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -157,6 +157,7 @@ crate::sol! {
 
         event RoleUpdated(address indexed account, Role prev, Role next);
         event EnforcementModesUpdated(bool accessMode, bool gatewayMode);
+        event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers);
 
         // -- Errors --
 
@@ -184,6 +185,7 @@ crate::sol! {
         function setRole(address account, Role role) external;
         function setAllowedAccount(address account, bool allowed) external;
         function setGateway(address account, bool allowed) external;
+        function setSequencerSet(address[] calldata newSequencers, uint8 newThreshold) external;
         function verifier() external view returns (address);
         function sequencerSetVersion() external view returns (uint64);
         function sequencerThreshold() external view returns (uint8);

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -14,7 +14,9 @@ use eyre::{WrapErr as _, eyre};
 use std::path::PathBuf;
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
-use tempo_zone_contracts::{ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactory};
+use tempo_zone_contracts::{
+    ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactory, ZonePortal,
+};
 use zone_primitives::constants::zone_chain_id;
 
 use crate::zone_utils::MODERATO_ZONE_FACTORY;
@@ -54,9 +56,21 @@ pub(crate) struct CreateZone {
     #[arg(long = "allowed-account")]
     allowed_accounts: Vec<Address>,
 
-    /// Sequencer address that will operate the zone.
-    #[arg(long)]
-    sequencer: Address,
+    /// Sequencer address that will operate the zone. Repeat for a
+    /// multi-sequencer set; the first address is the leader.
+    ///
+    /// A multi-sequencer set is installed via a post-creation `setSequencerSet`
+    /// call so the on-chain `sequencerSetVersion` becomes non-zero, which the
+    /// P2P manifest requires. That call must be signed by the zone admin, so
+    /// `--private-key` must be the admin key when more than one sequencer is
+    /// given.
+    #[arg(long = "sequencer", required = true)]
+    sequencers: Vec<Address>,
+
+    /// Number of sequencer signatures required for a settlement attestation
+    /// quorum. Must be between 1 and the number of sequencers.
+    #[arg(long, default_value_t = 1)]
+    threshold: u8,
 
     /// Admin address that controls token enablement and deposit pause/resume.
     /// Pass the sequencer address explicitly when both roles should use the same key.
@@ -85,13 +99,51 @@ pub(crate) struct CreateZone {
     specs_out: PathBuf,
 }
 
+/// Mirrors `ZonePortal.MAX_SEQUENCERS` for a fast client-side error.
+const MAX_SEQUENCERS: usize = 8;
+
 impl CreateZone {
     pub(crate) async fn run(self) -> eyre::Result<()> {
+        let leader = *self
+            .sequencers
+            .first()
+            .ok_or_else(|| eyre!("at least one --sequencer is required"))?;
+        if self.sequencers.len() > MAX_SEQUENCERS {
+            return Err(eyre!(
+                "at most {MAX_SEQUENCERS} sequencers are supported, got {}",
+                self.sequencers.len()
+            ));
+        }
+        for (i, sequencer) in self.sequencers.iter().enumerate() {
+            if sequencer.is_zero() {
+                return Err(eyre!("sequencer address must not be zero"));
+            }
+            if self.sequencers[..i].contains(sequencer) {
+                return Err(eyre!("duplicate sequencer address {sequencer}"));
+            }
+        }
+        if self.threshold == 0 || usize::from(self.threshold) > self.sequencers.len() {
+            return Err(eyre!(
+                "threshold must be between 1 and the number of sequencers ({}), got {}",
+                self.sequencers.len(),
+                self.threshold
+            ));
+        }
+
         let key_str = self
             .private_key
             .strip_prefix("0x")
             .unwrap_or(&self.private_key);
         let signer: PrivateKeySigner = key_str.parse()?;
+        let signer_address = signer.address();
+        if self.sequencers.len() > 1 && signer_address != self.admin {
+            return Err(eyre!(
+                "multi-sequencer creation requires --private-key to be the admin key \
+                 ({}) so the sequencer set can be installed via setSequencerSet, \
+                 but the key resolves to {signer_address}",
+                self.admin
+            ));
+        }
         let wallet = EthereumWallet::from(signer);
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
@@ -117,12 +169,18 @@ impl CreateZone {
         let anchor_hash = keccak256(&genesis_header_rlp);
 
         println!("Admin: {}", self.admin);
-        println!("Sequencer: {}", self.sequencer);
+        println!("Sequencers: {:?}", self.sequencers);
+        println!("Threshold: {}", self.threshold);
 
         println!(
             "Creating zone on L1 via ZoneFactory at {}...",
             self.zone_factory
         );
+        // The native factory initializes the portal at `sequencerSetVersion` 0,
+        // but the P2P manifest (and follower attestation checks) require a
+        // non-zero version. Create the zone with a 1-of-1 leader set, then
+        // install the full set via `setSequencerSet`, which bumps the version
+        // to 1. Single-sequencer zones keep the legacy 1-of-1 set at version 0.
         let receipt = factory
             .createZone(ZoneFactory::CreateZoneParams {
                 initialToken: self.initial_token,
@@ -131,7 +189,7 @@ impl CreateZone {
                 allowedAccounts: self.allowed_accounts.clone(),
                 zoneGateways: self.zone_gateways.clone(),
                 admin: self.admin,
-                sequencers: vec![self.sequencer],
+                sequencers: vec![leader],
                 threshold: 1,
                 rpcUrl: self.rpc_url.clone(),
             })
@@ -159,6 +217,27 @@ impl CreateZone {
         let portal = event.portal;
         let chain_id = zone_chain_id(zone_id);
 
+        let portal_contract = ZonePortal::new(portal, &provider);
+        if self.sequencers.len() > 1 {
+            println!(
+                "Installing {}-of-{} sequencer set via setSequencerSet...",
+                self.threshold,
+                self.sequencers.len()
+            );
+            let receipt = portal_contract
+                .setSequencerSet(self.sequencers.clone(), self.threshold)
+                .send_sync()
+                .await?;
+            if !receipt.status() {
+                return Err(eyre!(
+                    "setSequencerSet transaction reverted (tx: {:?})",
+                    receipt.transaction_hash
+                ));
+            }
+        }
+        let sequencer_set_version = portal_contract.sequencerSetVersion().call().await?;
+        println!("Sequencer set version: {sequencer_set_version}");
+
         println!(
             "Using pre-creation block {} (hash: {anchor_hash}) as genesis anchor",
             anchor_header.inner.number
@@ -175,7 +254,7 @@ impl CreateZone {
             default_fee_token: self.initial_token,
             tempo_genesis_header_rlp: Some(header_rlp_hex),
             admin: self.admin,
-            sequencer: Some(self.sequencer),
+            sequencer: Some(leader),
             specs_out: self.specs_out.clone(),
             with_createx: true,
             with_safe_deployer: true,
@@ -195,7 +274,10 @@ impl CreateZone {
             "zoneGateways": self.zone_gateways.iter().map(ToString::to_string).collect::<Vec<_>>(),
             "allowedAccounts": self.allowed_accounts.iter().map(ToString::to_string).collect::<Vec<_>>(),
             "admin": format!("{}", self.admin),
-            "sequencer": format!("{}", self.sequencer),
+            "sequencer": format!("{leader}"),
+            "sequencers": self.sequencers.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            "sequencerThreshold": self.threshold,
+            "sequencerSetVersion": sequencer_set_version,
             "tempoAnchorBlock": anchor_header.inner.number,
             "zoneFactory": format!("{}", self.zone_factory),
             "rpcUrl": self.rpc_url,
@@ -216,7 +298,9 @@ impl CreateZone {
         println!("  Access enforcement: {}", self.access_mode);
         println!("  Gateway enforcement: {}", self.gateway_mode);
         println!("  Admin: {}", self.admin);
-        println!("  Sequencer: {}", self.sequencer);
+        println!("  Sequencers: {:?}", self.sequencers);
+        println!("  Threshold: {}", self.threshold);
+        println!("  Sequencer set version: {sequencer_set_version}");
         println!("  ZoneFactory: {}", self.zone_factory);
         if !self.rpc_url.is_empty() {
             println!("  RPC URL: {}", self.rpc_url);


### PR DESCRIPTION
## Motivation

Standing up a multi-sequencer zone (e.g. 3 nodes, 2-of-3 attestation quorum) currently isn't possible through `create-zone`: it hard-codes `sequencers: [sequencer], threshold: 1`.

There is also a version mismatch that would break attestations even with a multi set installed at creation: the native factory initializes portals at `sequencerSetVersion = 0`, but the P2P manifest [rejects version 0](https://github.com/tempoxyz/zones/blob/main/crates/p2p/src/manifest.rs) and followers refuse attestation requests whose version doesn't match the manifest.

## Solution

- `--sequencer` is now repeatable (first address is the leader) and `--threshold` is added (default 1). Existing single-sequencer invocations are unchanged, including the version-0 legacy behavior.
- For multi-sequencer sets, `create-zone` creates the zone with a 1-of-1 leader set, then installs the full set via `setSequencerSet`, which bumps the on-chain version to 1 — matching a manifest with `sequencer_set_version = 1`. Fails fast when `--private-key` is not the admin key, since `setSequencerSet` is `onlyAdmin`.
- Client-side validation mirrors the portal: max 8 sequencers, unique, non-zero, `1 <= threshold <= len`.
- Adds `setSequencerSet` + `SequencerSetUpdated` to the `ZonePortal` bindings.
- `zone.json` gains `sequencers`, `sequencerThreshold`, `sequencerSetVersion` (keeps `sequencer` = leader for downstream tooling).

Fixing genesis to land at version 1 instead would require changes to the embedded portal runtime + native init in tempoxyz/tempo and a hardfork rollout; the two-step flow here is self-contained.

## Deployment note

`setSequencerSet` only exists in portal runtimes from tempo `83982c7` (#6952) onward — L1 devnets must run an image at least that new for the multi-sequencer path.

## PR Checklist

- [x] Compiles, clippy and fmt clean
- [ ] Untested against a live chain (xtask has no test harness)