### PR TITLE
feat: add Grafana dashboard for multisequencer zones

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,43 @@
+# Grafana dashboards
+
+## `zone-multisequencer.json`
+
+Dashboard illustrating a multi-node zone sequencer set (leader + followers),
+built against the metrics exposed by the zone node's reth metrics endpoint
+(`--metrics`, port 6060 in the `tempo-zone` Helm chart).
+
+Sections:
+
+- **Sequencer set overview** — nodes reporting, leader head, follower
+  replication lag (`reth_blockchain_tree_canonical_chain_height` per pod),
+  block production rate.
+- **Leader → L1 settlement** — `reth_tempo_zone_monitor_*`: observed vs
+  submitted zone blocks, submission lag, batch submit rate/latency/size,
+  withdrawals per batch, failure counters.
+- **L1 ingestion (all nodes)** — `reth_tempo_zone_l1_subscriber_*`: L1 lag,
+  latest L1 block seen, fetch failures/reconnects, deposit events.
+- **Withdrawal processor** — `reth_tempo_zone_withdrawal_processor_*`.
+- **Zone P2P** — `reth_zone_p2p_*` counters (transactions forwarded to the
+  leader, role-invalid drops). These counters only appear after the first
+  event, so panels may show "no data" on a quiet zone.
+- **Node vitals** — CPU, memory, uptime per pod.
+
+### Importing
+
+Import the JSON via Grafana → Dashboards → Import and pick a Prometheus
+datasource. The dashboard is parameterized by `namespace` and `pod` labels,
+e.g. namespace `tempo-zone-unstable-multiseq` with pods
+`zone-unstable-multiseq-leader-0`, `zone-unstable-multiseq-follower-a-0`,
+`zone-unstable-multiseq-follower-b-0`.
+
+### Prerequisite: scraping
+
+The dashboard assumes the zone pods' metrics port (`reth-metrics`, 6060) is
+scraped by Prometheus with standard Kubernetes labels (`namespace`, `pod`).
+The `tempo-zone` chart does not ship a `PodMonitor` yet, so one must exist in
+the target cluster for panels to populate.
+
+Known gaps (candidates for new metrics): leader→follower block streaming,
+settlement attestation requests/quorum, and sequencer-set version are not yet
+instrumented, so the dashboard illustrates replication via per-node chain
+height rather than attestation activity.

--- a/grafana/zone-multisequencer.json
+++ b/grafana/zone-multisequencer.json
@@ -1,0 +1,517 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping zone node metrics (reth metrics port)",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "title": "Tempo Zone — Multisequencer",
+  "uid": "tempo-zone-multiseq",
+  "description": "Illustrates a multi-node zone sequencer set: leader block production, follower replication lag, leader-to-L1 batch settlement, L1 ingestion on every node, withdrawal processing, and node vitals. Metrics come from each node's reth metrics endpoint (port 6060).",
+  "tags": ["tempo", "zones", "multisequencer"],
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "10s",
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      },
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(reth_blockchain_tree_canonical_chain_height, namespace)",
+        "current": { "selected": true, "text": "tempo-zone-unstable-multiseq", "value": "tempo-zone-unstable-multiseq" },
+        "definition": "label_values(reth_blockchain_tree_canonical_chain_height, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1
+      },
+      {
+        "name": "pod",
+        "label": "Pod",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\"}, pod)",
+        "current": { "selected": true, "text": ["All"], "value": ["$__all"] },
+        "definition": "label_values(reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Sequencer set overview",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Sequencer nodes reporting",
+      "description": "Number of zone nodes currently exposing metrics. Expect leader + followers (e.g. 3 for a 2-of-3 set).",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "green", "value": 3 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Leader head",
+      "description": "Highest canonical block on the leader.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 5, "x": 4, "y": 1 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\",pod=~\".*-leader-.*\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Max follower lag",
+      "description": "Blocks the slowest follower is behind the leader head. Should hover near 0 when block streaming is healthy.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 5, "x": 9, "y": 1 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(scalar(max(reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\",pod=~\".*-leader-.*\"})) - reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\",pod=~\".*-follower-.*\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Zone → L1 submission lag",
+      "description": "Zone blocks produced but not yet submitted to the portal on L1 (leader batch submitter).",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 5, "x": 14, "y": 1 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(reth_tempo_zone_monitor_zone_to_l1_submission_lag_blocks{namespace=\"$namespace\"})",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 240 },
+              { "color": "red", "value": 600 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "type": "stat",
+      "title": "Batch submit failures / resyncs",
+      "description": "Anomaly counters on the leader: failed batch submissions, resyncs from portal, withdrawal-store restore failures. All should stay at 0.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 4, "w": 5, "x": 19, "y": 1 },
+      "targets": [
+        { "refId": "A", "expr": "max(reth_tempo_zone_monitor_batch_submit_failure_total{namespace=\"$namespace\"})", "legendFormat": "submit failures", "instant": true },
+        { "refId": "B", "expr": "max(reth_tempo_zone_monitor_resync_from_portal_total{namespace=\"$namespace\"})", "legendFormat": "portal resyncs", "instant": true },
+        { "refId": "C", "expr": "max(reth_tempo_zone_monitor_withdrawal_store_restore_failure_total{namespace=\"$namespace\"})", "legendFormat": "store restore failures", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Canonical chain height by node",
+      "description": "Leader and followers should track each other. Diverging lines mean block streaming or execution is falling behind on a follower.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\",pod=~\"$pod\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 0, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Follower replication lag (blocks behind leader)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 5 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "scalar(max(reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\",pod=~\".*-leader-.*\"})) - reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\",pod=~\".*-follower-.*\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Block production rate",
+      "description": "Blocks per second derived from canonical height. All nodes should show the same rate.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 5 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "deriv(reth_blockchain_tree_canonical_chain_height{namespace=\"$namespace\",pod=~\"$pod\"}[2m])",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "row",
+      "title": "Leader → L1 settlement",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Zone blocks: observed vs submitted to L1",
+      "description": "Leader batch submitter: highest zone block observed vs highest zone block included in a batch accepted on L1.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 14 },
+      "targets": [
+        { "refId": "A", "expr": "max(reth_tempo_zone_monitor_latest_zone_block_observed{namespace=\"$namespace\"})", "legendFormat": "observed" },
+        { "refId": "B", "expr": "max(reth_tempo_zone_monitor_latest_zone_block_submitted_to_l1{namespace=\"$namespace\"})", "legendFormat": "submitted to L1" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 0, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Zone → L1 submission lag",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 14 },
+      "targets": [
+        { "refId": "A", "expr": "max(reth_tempo_zone_monitor_zone_to_l1_submission_lag_blocks{namespace=\"$namespace\"})", "legendFormat": "lag (blocks)" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Batch submissions per minute",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 14 },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(reth_tempo_zone_monitor_batch_submit_success_total{namespace=\"$namespace\"}[$__rate_interval])) * 60", "legendFormat": "success" },
+        { "refId": "B", "expr": "sum(rate(reth_tempo_zone_monitor_batch_submit_retry_total{namespace=\"$namespace\"}[$__rate_interval])) * 60", "legendFormat": "retry" },
+        { "refId": "C", "expr": "sum(rate(reth_tempo_zone_monitor_batch_submit_failure_total{namespace=\"$namespace\"}[$__rate_interval])) * 60", "legendFormat": "failure" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "cpm", "custom": { "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "failure" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] },
+          { "matcher": { "id": "byName", "options": "retry" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }] },
+          { "matcher": { "id": "byName", "options": "success" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Batch submit latency",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 22 },
+      "targets": [
+        { "refId": "A", "expr": "max(reth_tempo_zone_monitor_batch_submit_latency_seconds{namespace=\"$namespace\",quantile=\"0.5\"})", "legendFormat": "p50" },
+        { "refId": "B", "expr": "max(reth_tempo_zone_monitor_batch_submit_latency_seconds{namespace=\"$namespace\",quantile=\"0.99\"})", "legendFormat": "p99" },
+        { "refId": "C", "expr": "sum(rate(reth_tempo_zone_monitor_batch_submit_latency_seconds_sum{namespace=\"$namespace\"}[15m])) / sum(rate(reth_tempo_zone_monitor_batch_submit_latency_seconds_count{namespace=\"$namespace\"}[15m]))", "legendFormat": "avg (15m)" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "fillOpacity": 0, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Batch size (blocks per batch)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 22 },
+      "targets": [
+        { "refId": "A", "expr": "max(reth_tempo_zone_monitor_batch_size_blocks{namespace=\"$namespace\",quantile=\"0.5\"})", "legendFormat": "p50" },
+        { "refId": "B", "expr": "sum(rate(reth_tempo_zone_monitor_batch_size_blocks_sum{namespace=\"$namespace\"}[15m])) / sum(rate(reth_tempo_zone_monitor_batch_size_blocks_count{namespace=\"$namespace\"}[15m]))", "legendFormat": "avg (15m)" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Withdrawals per batch",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 22 },
+      "targets": [
+        { "refId": "A", "expr": "max(reth_tempo_zone_monitor_withdrawals_per_batch{namespace=\"$namespace\",quantile=\"0.5\"})", "legendFormat": "p50" },
+        { "refId": "B", "expr": "max(reth_tempo_zone_monitor_withdrawals_per_batch{namespace=\"$namespace\",quantile=\"1\"})", "legendFormat": "max" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "row",
+      "title": "L1 ingestion (all nodes)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "L1 subscriber lag by node",
+      "description": "How many L1 blocks behind each node's L1 subscriber is. Every node (leader and followers) follows L1 independently.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 31 },
+      "targets": [
+        { "refId": "A", "expr": "reth_tempo_zone_l1_subscriber_current_l1_lag_blocks{namespace=\"$namespace\",pod=~\"$pod\"}", "legendFormat": "{{pod}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Latest L1 block seen by node",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 31 },
+      "targets": [
+        { "refId": "A", "expr": "reth_tempo_zone_l1_subscriber_latest_l1_block_seen{namespace=\"$namespace\",pod=~\"$pod\"}", "legendFormat": "{{pod}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 0, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "L1 subscriber errors",
+      "description": "Fetch failures and websocket reconnects per node. Sustained increases indicate L1 RPC trouble.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 31 },
+      "targets": [
+        { "refId": "A", "expr": "rate(reth_tempo_zone_l1_subscriber_fetch_failures{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]) * 60", "legendFormat": "{{pod}} fetch failures" },
+        { "refId": "B", "expr": "rate(reth_tempo_zone_l1_subscriber_reconnects{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]) * 60", "legendFormat": "{{pod}} reconnects" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "cpm", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Deposit events observed",
+      "description": "Regular and encrypted deposit events ingested from L1, per node. Nodes should agree.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 39 },
+      "targets": [
+        { "refId": "A", "expr": "reth_tempo_zone_l1_subscriber_regular_deposit_events{namespace=\"$namespace\",pod=~\"$pod\"}", "legendFormat": "{{pod}} regular" },
+        { "refId": "B", "expr": "reth_tempo_zone_l1_subscriber_encrypted_deposit_events{namespace=\"$namespace\",pod=~\"$pod\"}", "legendFormat": "{{pod}} encrypted" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 0, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Private RPC auth failures",
+      "description": "Failed authentications against the private (sequencer-to-sequencer) RPC, per node.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 39 },
+      "targets": [
+        { "refId": "A", "expr": "rate(reth_tempo_zone_private_rpc_auth_failures_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]) * 60", "legendFormat": "{{pod}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "cpm", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "row",
+      "title": "Withdrawal processor (leader)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 47 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Withdrawals processed / confirmed / failed / reverted",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(reth_tempo_zone_withdrawal_processor_withdrawals_processed_total{namespace=\"$namespace\"}[$__rate_interval])) * 60", "legendFormat": "processed" },
+        { "refId": "B", "expr": "sum(rate(reth_tempo_zone_withdrawal_processor_withdrawals_confirmed_total{namespace=\"$namespace\"}[$__rate_interval])) * 60", "legendFormat": "confirmed" },
+        { "refId": "C", "expr": "sum(rate(reth_tempo_zone_withdrawal_processor_withdrawals_failed_total{namespace=\"$namespace\"}[$__rate_interval])) * 60", "legendFormat": "failed" },
+        { "refId": "D", "expr": "sum(rate(reth_tempo_zone_withdrawal_processor_withdrawals_reverted_total{namespace=\"$namespace\"}[$__rate_interval])) * 60", "legendFormat": "reverted" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "cpm", "custom": { "fillOpacity": 10, "showPoints": "never" } },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "failed" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] },
+          { "matcher": { "id": "byName", "options": "reverted" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Portal withdrawal queue",
+      "description": "Head/tail of the portal withdrawal queue and pending slots awaiting processing.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "targets": [
+        { "refId": "A", "expr": "max(reth_tempo_zone_withdrawal_processor_portal_queue_head{namespace=\"$namespace\"})", "legendFormat": "head" },
+        { "refId": "B", "expr": "max(reth_tempo_zone_withdrawal_processor_portal_queue_tail{namespace=\"$namespace\"})", "legendFormat": "tail" },
+        { "refId": "C", "expr": "max(reth_tempo_zone_withdrawal_processor_portal_queue_pending_slots{namespace=\"$namespace\"})", "legendFormat": "pending slots" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "none", "custom": { "fillOpacity": 0, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "row",
+      "title": "Zone P2P (leader ↔ followers)",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Transactions forwarded to leader",
+      "description": "Transactions the leader received from followers over zone P2P (followers forward RPC transactions to the leader). Counter only appears after the first forwarded transaction.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 57 },
+      "targets": [
+        { "refId": "A", "expr": "rate(reth_zone_p2p_transactions_received_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]) * 60", "legendFormat": "{{pod}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "cpm", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "P2P anomalies",
+      "description": "Role-invalid messages dropped and transaction sends attempted with no known leader. Counters only appear after the first event; flat 0 / no data is healthy.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 57 },
+      "targets": [
+        { "refId": "A", "expr": "rate(reth_zone_p2p_role_invalid_messages_dropped_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]) * 60", "legendFormat": "{{pod}} role-invalid dropped" },
+        { "refId": "B", "expr": "rate(reth_zone_p2p_transaction_sends_without_leader_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval]) * 60", "legendFormat": "{{pod}} sends w/o leader" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "cpm", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "row",
+      "title": "Node vitals",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 65 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "CPU usage by node",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 66 },
+      "targets": [
+        { "refId": "A", "expr": "rate(reth_process_cpu_seconds_total{namespace=\"$namespace\",pod=~\"$pod\"}[$__rate_interval])", "legendFormat": "{{pod}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Resident memory by node",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 66 },
+      "targets": [
+        { "refId": "A", "expr": "reth_process_resident_memory_bytes{namespace=\"$namespace\",pod=~\"$pod\"}", "legendFormat": "{{pod}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "fillOpacity": 10, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Process uptime by node",
+      "description": "Drops to zero indicate restarts.",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 66 },
+      "targets": [
+        { "refId": "A", "expr": "time() - reth_process_start_time_seconds{namespace=\"$namespace\",pod=~\"$pod\"}", "legendFormat": "{{pod}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "fillOpacity": 0, "showPoints": "never" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] }, "tooltip": { "mode": "multi" } }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `grafana/zone-multisequencer.json` (+ README) — a Grafana dashboard illustrating a running multi-node zone sequencer set, built against the live metrics of `zone-unstable-multiseq` (leader + 2 followers, 2-of-3).

### Panels
- **Sequencer set overview**: nodes reporting, leader head, follower replication lag and block production rate from `reth_blockchain_tree_canonical_chain_height` per pod
- **Leader → L1 settlement**: `reth_tempo_zone_monitor_*` — observed vs submitted zone blocks, submission lag, batch submit rate/latency/size, withdrawals per batch, failure/resync counters
- **L1 ingestion (all nodes)**: `reth_tempo_zone_l1_subscriber_*` — L1 lag, latest L1 block seen, fetch failures/reconnects, deposit events
- **Withdrawal processor**: `reth_tempo_zone_withdrawal_processor_*`
- **Zone P2P**: `reth_zone_p2p_*` (tx forwarding to leader, role-invalid drops) — these counters only appear after the first event
- **Node vitals**: CPU / memory / uptime per pod

Templated on datasource, `namespace` (default `tempo-zone-unstable-multiseq`) and `pod`.

### Notes
- Metric names verified against live metric dumps from `zone-unstable-multiseq-leader-0` and `follower-a-0` (port 6060).
- Panels populate once the pods' `reth-metrics` port is scraped; the `tempo-zone` chart has no PodMonitor yet — follow-up in helm-charts/dev-infra.
- No dedicated metrics exist yet for block streaming / attestation quorum / sequencer-set version, so replication health is shown via per-node chain height.