### PR TITLE
feat(sequencer): use canonical notifications for zone monitor

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -344,11 +344,11 @@ pub struct ZoneArgs {
     )]
     pub sequencer_role: Option<Role>,
 
-    /// How often (in seconds) the zone monitor polls for new L2 blocks.
+    /// How often (in seconds) the zone monitor polls for new L2 blocks as a recovery fallback.
     #[arg(
         long = "zone.poll-interval-secs",
         env = "ZONE_POLL_INTERVAL_SECS",
-        default_value_t = 1
+        default_value_t = 30
     )]
     pub zone_poll_interval_secs: u64,
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -13,6 +13,7 @@ use crate::{
 use alloy_primitives::Address;
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
+use futures::StreamExt;
 use k256::SecretKey;
 use reth_chainspec::EthChainSpec;
 use reth_eth_wire_types::primitives::BasicNetworkPrimitives;
@@ -31,8 +32,8 @@ use reth_node_builder::{
         PayloadValidatorBuilder, RethRpcAddOns, RpcAddOns,
     },
 };
-use reth_primitives_traits::SealedHeader;
-use reth_provider::ChainSpecProvider;
+use reth_primitives_traits::{Block as _, SealedHeader};
+use reth_provider::{CanonStateSubscriptions, ChainSpecProvider};
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
 use reth_storage_api::{
@@ -877,7 +878,16 @@ where
         let l1_transaction_signer = config
             .l1_transaction_signer
             .unwrap_or(config.sequencer_signer);
-        let seq_handle = spawn_zone_sequencer(sequencer_config, l1_transaction_signer).await;
+        let zone_head_notifications =
+            Box::pin(handle.node.provider().canonical_state_stream().filter_map(
+                |notification| async move { notification.tip_checked().map(|tip| tip.number()) },
+            ));
+        let seq_handle = spawn_zone_sequencer(
+            sequencer_config,
+            l1_transaction_signer,
+            zone_head_notifications,
+        )
+        .await;
         info!(target: "reth::cli", "Sequencer tasks spawned");
 
         // Critical task — node shuts down if either exits.

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3161,7 +3161,14 @@ pub(crate) async fn spawn_sequencer_with_config(
         attestation_store: None,
     };
 
-    zone_sequencer::spawn_zone_sequencer(config, sequencer_signer).await
+    use futures::StreamExt;
+
+    use reth_primitives_traits::Block as _;
+
+    let zone_head_notifications = Box::pin(zone.subscribe_to_canonical_state().filter_map(
+        |notification| async move { notification.tip_checked().map(|tip| tip.number()) },
+    ));
+    zone_sequencer::spawn_zone_sequencer(config, sequencer_signer, zone_head_notifications).await
 }
 
 /// Start a local zone node with an L1Fixture already seeded for `seed_blocks` blocks.

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -3,12 +3,13 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use std::{sync::Arc, time::Duration};
+use std::{pin::Pin, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_transport::TransportResult;
+use futures::Stream;
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 use tokio::sync::Notify;
 
@@ -34,6 +35,9 @@ pub use withdrawals::{
     MAX_WITHDRAWAL_BATCH_GAS, SharedWithdrawalStore, WithdrawalBatchLimits,
     WithdrawalProcessorConfig, WithdrawalStore,
 };
+
+/// In-process notifications carrying the latest Zone canonical block number.
+pub type ZoneHeadNotifications = Pin<Box<dyn Stream<Item = u64> + Send>>;
 
 use crate::rpc::rpc_connection_config;
 
@@ -65,7 +69,7 @@ pub struct ZoneSequencerConfig {
     pub tempo_state_address: Address,
     /// Zone L2 RPC URL.
     pub zone_rpc_url: String,
-    /// How often the zone monitor polls for new L2 blocks.
+    /// How often the zone monitor polls for new L2 blocks as a recovery fallback.
     pub zone_poll_interval: Duration,
     /// Number of zone blocks between empty withdrawal batch boundaries / L1 submissions.
     pub batch_interval_blocks: u64,
@@ -97,6 +101,7 @@ pub struct ZoneSequencerHandle {
 pub async fn spawn_zone_sequencer(
     config: ZoneSequencerConfig,
     signer: PrivateKeySigner,
+    zone_head_notifications: ZoneHeadNotifications,
 ) -> ZoneSequencerHandle {
     let sequencer_address = signer.address();
     // Build a single shared L1 provider with the sequencer wallet.
@@ -146,6 +151,7 @@ pub async fn spawn_zone_sequencer(
         monitor_config,
         l1_provider,
         signer,
+        zone_head_notifications,
         withdrawal_store,
         withdrawal_notify,
         withdrawal_repair_notify,

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -29,6 +29,7 @@ use alloy_rpc_client::RpcClient;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_transport::layers::RetryBackoffLayer;
 use eyre::{Result, WrapErr};
+use futures::StreamExt;
 use tempo_alloy::TempoNetwork;
 use tokio::sync::Notify;
 use tracing::{error, info, instrument, warn};
@@ -36,7 +37,7 @@ use tracing::{error, info, instrument, warn};
 use alloy_sol_types::{ContractError, SolInterface as _};
 
 use crate::{
-    AttestationStore,
+    AttestationStore, ZoneHeadNotifications,
     abi::{self, IZoneInbox, IZoneOutbox, NO_QUEUE_INDEX, TempoState, ZonePortal},
     rpc::rpc_connection_config,
     settlement::{
@@ -74,7 +75,7 @@ pub struct ZoneMonitorConfig {
     pub zone_rpc_url: String,
     /// Interval between WebSocket reconnection attempts for the zone RPC client.
     pub retry_connection_interval: Duration,
-    /// How often to poll the zone L2 for new blocks (cheap RPC call).
+    /// How often to poll the zone L2 for new blocks if a canonical-chain notification is missed.
     pub poll_interval: Duration,
     /// Number of zone blocks between empty withdrawal batch boundaries.
     ///
@@ -262,7 +263,8 @@ impl ZoneMonitor {
 
     /// Run the monitor loop. This method never returns under normal operation.
     ///
-    /// Polls the zone L2 frequently (`poll_interval`) but only submits a batch
+    /// Wakes on canonical-chain notifications, with `poll_interval` as a recovery fallback, but
+    /// only submits a batch
     /// to L1 when:
     /// - Enough new zone blocks have accumulated to cross an empty-batch
     ///   boundary (`batch_interval_blocks`), OR
@@ -271,7 +273,7 @@ impl ZoneMonitor {
         outbox = %self.config.outbox_address,
         inbox = %self.config.inbox_address,
     ))]
-    pub async fn run(&mut self) -> Result<()> {
+    pub async fn run(&mut self, zone_heads: &mut ZoneHeadNotifications) -> Result<()> {
         info!(
             zone_rpc = %self.config.zone_rpc_url,
             batch_interval_blocks = self.config.batch_interval_blocks,
@@ -279,19 +281,21 @@ impl ZoneMonitor {
             "Zone monitor started"
         );
 
-        let mut poll = tokio::time::interval(self.config.poll_interval);
+        let mut fallback_poll = tokio::time::interval(self.config.poll_interval);
 
         loop {
-            tokio::select! {
-                _ = poll.tick() => {}
+            let latest_zone_block = tokio::select! {
+                _ = fallback_poll.tick() => {
+                    let Ok(latest_zone_block) = self.provider.get_block_number().await else {
+                        continue;
+                    };
+                    latest_zone_block
+                }
+                Some(latest_zone_block) = zone_heads.next() => latest_zone_block,
                 _ = self.repair_notify.notified() => {
                     self.repair_missing_withdrawal_slot().await;
                     continue;
                 }
-            }
-
-            let Ok(latest_zone_block) = self.provider.get_block_number().await else {
-                continue;
             };
             self.record_observed_zone_block(latest_zone_block);
             if latest_zone_block <= self.last_submitted_zone_block {
@@ -920,6 +924,7 @@ pub fn spawn_zone_monitor(
     config: ZoneMonitorConfig,
     l1_provider: DynProvider<TempoNetwork>,
     signer: PrivateKeySigner,
+    mut zone_head_notifications: ZoneHeadNotifications,
     withdrawal_store: SharedWithdrawalStore,
     withdrawal_notify: Arc<Notify>,
     repair_notify: Arc<Notify>,
@@ -945,7 +950,7 @@ pub fn spawn_zone_monitor(
         };
 
         loop {
-            if let Err(e) = monitor.run().await {
+            if let Err(e) = monitor.run(&mut zone_head_notifications).await {
                 error!(error = %e, "Zone monitor failed, restarting in 5s");
                 tokio::time::sleep(Duration::from_secs(5)).await;
             }

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -616,7 +616,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |
 | `--block.interval-ms` | 250 | Block building interval |
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |
-| `--zone.poll-interval-secs` | 1 | How often (seconds) the zone monitor polls for new L2 blocks |
+| `--zone.poll-interval-secs` | 30 | Recovery polling interval; normal operation uses in-process canonical-chain notifications |
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |
 | `--withdrawal-max-batch-gas` | 10000000 | Maximum planned gas for one `processWithdrawals` transaction (up to 20000000); an oversized FIFO head is still sent alone |
 | `--withdrawal-max-in-flight-batches` | 8 | Maximum ordered withdrawal transactions kept concurrently in flight |


### PR DESCRIPTION
## Summary
- wake the zone monitor from in-process canonical-chain notifications
- use the notification tip directly instead of polling `eth_blockNumber` on every block
- retain a 30-second RPC poll as recovery and document the new behavior

## Validation
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo check -p zone-sequencer -p zone-node` *(blocked locally: sandbox receives HTTP 401 fetching pinned `alloy-rs/evm` git dependency)*

Prompted by: @Rjected