### PR TITLE
run Zones benchmark nightly

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -1,6 +1,9 @@
 name: Zones benchmark
 
 on:
+  schedule:
+    - cron: "45 2 * * *"
+
   workflow_dispatch:
     inputs:
       phase:
@@ -191,6 +194,7 @@ jobs:
   authorize:
     name: Resolve and authorize benchmark request
     if: >-
+      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository)
@@ -259,7 +263,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          INPUT_PHASE: ${{ inputs.phase }}
+          INPUT_PHASE: ${{ inputs.phase || 'neobank-full-journey' }}
           INPUT_ACCOUNTS: ${{ inputs.accounts || '100' }}
           INPUT_COUNT: ${{ inputs.count || '100' }}
           INPUT_TPS: ${{ inputs.tps || '20' }}

--- a/docs/ZONES_BENCHMARK.md
+++ b/docs/ZONES_BENCHMARK.md
@@ -724,8 +724,13 @@ never selects a public test mnemonic or a public/mainnet write endpoint. Its
 mnemonic file, Schelk snapshots, and private sender-auth map are outside the
 artifact tree; the sender-auth map is mode 0600 and deleted on exit.
 
-After the workflow exists on the default branch, dispatch it from the Actions
-UI or CLI and select the branch/ref to test. This example offers `1.2`
+After the workflow exists on the default branch, it runs the default
+`neobank-full-journey` benchmark nightly at 02:45 UTC with the defaults above.
+The scheduled event always uses the workflow and Zones revision from the default
+branch.
+
+To test another phase, load, or branch/ref, dispatch it from the Actions UI or
+CLI. This example offers `1.2`
 journeys/s with 13 in flight, just above the approximately `1.14` journeys/s
 observed at the prior 12-journey capacity point:
 


### PR DESCRIPTION
## What changed

- Schedule the Zones benchmark every night at 02:45 UTC.
- Allow scheduled events through the benchmark authorization job.
- Default input-less scheduled runs to `neobank-full-journey`.
- Document that scheduled runs use the default-branch workflow and Zones revision.

## Why

The benchmark harness in #742 currently supports manual dispatch and scoped PR validation, but has no periodic execution. This adds one reproducible nightly run using its existing production-shaped, runner-local L1 and Zone topology.

## Validation

- `actionlint .github/workflows/zones-benchmark.yml`
- `git diff --check`

Stacked on #742.