### PR TITLE
fix(l1): bound precompile L1 reads to the observed head

### DIFF
--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -23,7 +23,7 @@ use tracing::{debug, info, warn};
 use zone_precompiles::{L1StateError, L1StorageReader};
 
 use super::cache::L1StateCache;
-use crate::rpc::rpc_connection_config;
+use crate::{L1BlockTracker, rpc::rpc_connection_config};
 
 /// Upper bound on the delay between synchronous cache-miss attempts.
 ///
@@ -52,7 +52,9 @@ pub struct L1StateProviderConfig {
     /// Interval between WebSocket reconnection attempts.
     /// Defaults to 100ms.
     pub retry_connection_interval: std::time::Duration,
-    /// Maximum number of synchronous RPC attempts per cache miss. `None` retries indefinitely.
+    /// Maximum attempts per synchronous wait, applied independently to each phase of a cache
+    /// miss: first waiting for the observed L1 head, then fetching over RPC. A caller setting
+    /// this to `n` can therefore wait up to `2n` times before failing. `None` waits indefinitely.
     pub max_sync_attempts: Option<NonZeroU32>,
 }
 
@@ -102,6 +104,10 @@ pub struct L1StateProvider {
     max_sync_attempts: Option<NonZeroU32>,
     /// Base delay for the synchronous cache-miss wait, shared with the transport retry layer.
     initial_backoff_ms: u64,
+    /// Independently observed L1 head, used to hold back reads above it.
+    ///
+    /// Unset for callers with no subscriber (tests, the no-L1 CLI fallback), which read unbounded.
+    head_bound: Option<L1BlockTracker>,
 }
 
 impl L1StateProvider {
@@ -151,6 +157,7 @@ impl L1StateProvider {
             runtime_handle,
             max_sync_attempts: config.max_sync_attempts,
             initial_backoff_ms: config.initial_backoff_ms,
+            head_bound: None,
         })
     }
 
@@ -171,7 +178,17 @@ impl L1StateProvider {
             runtime_handle,
             max_sync_attempts: config.max_sync_attempts,
             initial_backoff_ms: config.initial_backoff_ms,
+            head_bound: None,
         }
+    }
+
+    /// Hold synchronous reads back until `tracker` has independently observed the L1 block.
+    ///
+    /// Only production wires this; callers without a subscriber read unbounded.
+    #[must_use]
+    pub fn with_head_bound(mut self, tracker: L1BlockTracker) -> Self {
+        self.head_bound = Some(tracker);
+        self
     }
 
     /// Read a storage slot synchronously at a specific L1 block — cache first, RPC fallback.
@@ -187,9 +204,9 @@ impl L1StateProvider {
     /// therefore retries until the value is fetched, stalling block production rather than failing
     /// closed.
     ///
-    /// Rejecting a read that consensus can prove is out of range is a separate, sound check, but
-    /// it belongs *before* the request, compared against in-consensus state — not after it, by
-    /// classifying whatever the endpoint happened to return. That bound is tracked as follow-up.
+    /// Bounding the request is a separate, sound check, and it happens *before* the request in
+    /// [`await_observed_head`](Self::await_observed_head) rather than after it by classifying
+    /// whatever the endpoint happened to return.
     ///
     /// [`RetryBackoffLayer`] is the single retry policy: it classifies and backs off per request.
     /// This loop adds no classification of its own, only a capped delay between attempts so a
@@ -211,6 +228,10 @@ impl L1StateProvider {
         }
 
         warn!(%address, %slot, block_number, "L1 storage cache miss, fetching from RPC");
+
+        // Bound the request against independently observed L1 state before it reaches the
+        // transport, so an attacker-chosen block number cannot steer this node's RPC traffic.
+        self.await_observed_head(block_number)?;
 
         let mut attempt = 0u32;
         loop {
@@ -245,6 +266,75 @@ impl L1StateProvider {
                     warn!(%address, %slot, block_number, %rpc_err, ?elapsed, attempt, ?backoff, "L1 storage RPC fetch failed, stalling before retry");
                     std::thread::sleep(backoff);
                 }
+            }
+        }
+    }
+
+    /// Wait until the requested L1 block is at or below the independently observed head.
+    ///
+    /// A read above the local head is not evidence that the block is bogus — this node may simply
+    /// be behind — so it must never become a validity verdict. Waiting keeps the outcome the same
+    /// on every honest node: a lagging node catches up and proceeds, while a block number no
+    /// honest head ever reaches stalls without an `eth_getStorageAt` ever being issued. That is
+    /// what stops an attacker-chosen number from steering this node's RPC.
+    ///
+    /// A tracker that has observed nothing yet reads unbounded. `latest` is only populated once
+    /// the subscriber records its first block, so blocking before then would stall a node whose
+    /// subscriber has not made first contact. This is the weakest point of the bound: the first
+    /// Tempo import — the one read with no parent-hash or contiguity constraint — is also the one
+    /// most likely to run while the tracker is still cold. Closing that needs a startup ordering
+    /// guarantee between the subscriber and block execution, which is tracked separately.
+    ///
+    /// The wait is driven by the tracker's observation channel rather than a timer, so it wakes
+    /// the moment the head advances instead of after a backoff interval. Unlike the RPC retry
+    /// loop there is no remote endpoint to pace here — this only reads local process state.
+    fn await_observed_head(&self, block_number: u64) -> Result<()> {
+        let Some(tracker) = self.head_bound.as_ref() else {
+            return Ok(());
+        };
+        // Subscribe once for the whole wait so an observation recorded between checks still
+        // wakes us instead of being missed by a fresh subscribe.
+        let mut observations = tracker.subscribe_observations();
+
+        let mut waits = 0u32;
+        loop {
+            let Some(latest) = tracker.latest() else {
+                return Ok(());
+            };
+            if block_number <= latest.number {
+                if waits > 0 {
+                    info!(
+                        block_number,
+                        observed_head = latest.number,
+                        waits,
+                        "L1 head caught up to the requested block"
+                    );
+                }
+                return Ok(());
+            }
+
+            waits += 1;
+            if self
+                .max_sync_attempts
+                .is_some_and(|max_attempts| waits >= max_attempts.get())
+            {
+                return Err(eyre::eyre!(
+                    "L1 block {block_number} is above the observed head {} after {waits} attempts",
+                    latest.number
+                ));
+            }
+            warn!(
+                block_number,
+                observed_head = latest.number,
+                waits,
+                "L1 read is ahead of the observed head, waiting"
+            );
+            if tokio::task::block_in_place(|| self.runtime_handle.block_on(observations.changed()))
+                .is_err()
+            {
+                // The subscriber is gone, so nothing will advance the head; fall through and let
+                // the RPC layer decide rather than waiting forever.
+                return Ok(());
             }
         }
     }
@@ -332,6 +422,7 @@ impl L1StorageReader for L1StateProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_eips::NumHash;
 
     async fn test_reader(config: L1StateProviderConfig) -> L1StateProvider {
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -345,6 +436,92 @@ mod tests {
             provider,
             tokio::runtime::Handle::current(),
         )
+    }
+
+    /// Tracker whose contiguous observations run through `head`.
+    fn tracker_at(head: u64) -> L1BlockTracker {
+        let tracker = L1BlockTracker::default();
+        tracker.initialize_consumed_through(head.saturating_sub(1));
+        tracker
+            .record(NumHash::new(head, B256::repeat_byte(0xab)))
+            .expect("contiguous observation");
+        tracker
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reads_are_unbounded_without_an_observed_head() {
+        // No tracker at all: the no-L1 CLI fallback and tests must not block.
+        let unbounded = test_reader(L1StateProviderConfig::default()).await;
+        unbounded
+            .await_observed_head(u64::MAX)
+            .expect("an absent tracker imposes no bound");
+
+        // Tracker present but cold: blocking here would deadlock node startup.
+        let cold = test_reader(L1StateProviderConfig::default())
+            .await
+            .with_head_bound(L1BlockTracker::default());
+        cold.await_observed_head(u64::MAX)
+            .expect("an unobserved tracker imposes no bound");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reads_at_or_below_the_observed_head_proceed() {
+        let reader = test_reader(L1StateProviderConfig::default())
+            .await
+            .with_head_bound(tracker_at(10));
+
+        reader
+            .await_observed_head(10)
+            .expect("head itself is in range");
+        reader
+            .await_observed_head(3)
+            .expect("below head is in range");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reads_above_the_observed_head_wait_rather_than_reject() {
+        let tracker = tracker_at(10);
+        let reader = test_reader(L1StateProviderConfig::default())
+            .await
+            .with_head_bound(tracker.clone());
+
+        // A lagging node must not treat "ahead of my head" as invalid — it waits and proceeds.
+        let waiting = tokio::task::spawn_blocking(move || reader.await_observed_head(11));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !waiting.is_finished(),
+            "read above the head must not resolve early"
+        );
+
+        // The wait is observation-driven, so recording the block releases it immediately rather
+        // than after a backoff interval.
+        tracker
+            .record(NumHash::new(11, B256::repeat_byte(0xcd)))
+            .expect("contiguous observation");
+        tokio::time::timeout(Duration::from_secs(5), waiting)
+            .await
+            .expect("advancing the head must release the wait")
+            .expect("wait task must not panic")
+            .expect("block 11 is observed once recorded");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bounded_callers_fail_finitely_above_the_observed_head() {
+        let reader = test_reader(L1StateProviderConfig {
+            max_sync_attempts: Some(NonZeroU32::MIN),
+            ..Default::default()
+        })
+        .await
+        .with_head_bound(tracker_at(10));
+
+        let err = tokio::task::spawn_blocking(move || {
+            reader.get_storage(Address::ZERO, B256::ZERO, 5_000)
+        })
+        .await
+        .expect("storage task must not panic")
+        .expect_err("a bounded caller must give up above the head");
+        let message = err.to_string();
+        assert!(message.contains("above the observed head 10"), "{message}");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -68,6 +68,14 @@ impl L1BlockTracker {
         self.state.read().latest
     }
 
+    /// Subscribe to observation updates, which fire whenever a new L1 block is recorded.
+    ///
+    /// Lets a caller hold one subscription across a wait loop so an observation recorded between
+    /// checks still wakes it, rather than being missed by a fresh subscribe.
+    pub fn subscribe_observations(&self) -> tokio::sync::watch::Receiver<()> {
+        self.changed.subscribe()
+    }
+
     /// Return whether `number` fits inside the bounded follower lookahead window.
     pub fn has_capacity_for(&self, number: u64) -> bool {
         self.state.read().pruned_through.is_none_or(|consumed| {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1003,6 +1003,7 @@ where
             self.l1_state_provider_config.clone(),
             self.l1_state_cache.clone(),
             self.enabled_tokens.clone(),
+            self.l1_block_tracker.clone(),
         );
         let mut payload_factory = ZonePayloadFactory::new(self.withdrawal_batch_interval_blocks);
         if let Some(encryptor) = self.withdrawal_reveal_encryptor.clone() {
@@ -1066,19 +1067,24 @@ pub struct ZoneExecutorBuilder {
     l1_state_provider_config: L1StateProviderConfig,
     l1_state_cache: L1StateCache,
     enabled_tokens: EnabledTokenRegistry,
+    l1_block_tracker: L1BlockTracker,
 }
 
 impl ZoneExecutorBuilder {
     /// Create a zone executor builder with the shared L1 state cache.
+    ///
+    /// `l1_block_tracker` bounds precompile L1 reads to independently observed blocks.
     pub fn new(
         l1_state_provider_config: L1StateProviderConfig,
         l1_state_cache: L1StateCache,
         enabled_tokens: EnabledTokenRegistry,
+        l1_block_tracker: L1BlockTracker,
     ) -> Self {
         Self {
             l1_state_provider_config,
             l1_state_cache,
             enabled_tokens,
+            l1_block_tracker,
         }
     }
 }
@@ -1097,7 +1103,8 @@ where
             self.l1_state_cache,
             runtime_handle.clone(),
         )
-        .await?;
+        .await?
+        .with_head_bound(self.l1_block_tracker);
 
         let l1_chain_id = l1_provider.chain_id().await?;
         let tempo_chain_spec = tempo_chain_spec_for_l1(l1_chain_id)


### PR DESCRIPTION
Stacked on #725 — review that first; this PR's diff is the top commit only.

Holds a synchronous L1 storage read until the requested block is at or below the head this node has independently observed, so an attacker-chosen `header.number()` cannot steer its RPC traffic. No `eth_getStorageAt` is issued for a block the node has no reason to think exists.

## Why it waits instead of rejecting

A read above the local head is not evidence the block is bogus — this node may simply be behind — so it must not become a validity verdict. `L1StateError::StorageUnavailable` converts to `PrecompileError::FatalAny`, which aborts execution rather than reverting, so a verdict here would let a node with a lagging endpoint reject a block its peers accept.

Waiting keeps the outcome identical on every honest node: a lagging node catches up and proceeds, while a number no honest head ever reaches stalls. A malicious sequencer can already halt its own zone by not producing blocks, so a stall grants it nothing new.

This is the check that #725 removes `is_permanent_rpc_failure` in favour of, placed where it can be sound: before the request, against in-consensus state, rather than after it by classifying whatever the endpoint returned.

The wait is driven by `L1BlockTracker`'s observation channel rather than a timer, so it wakes the moment the head advances. Unlike the RPC retry loop there is no remote endpoint to pace here — this only reads local process state, so backoff would add latency for nothing.

## Known gap: cold tracker

The bound is skipped while the tracker has observed nothing, because `L1BlockTracker::latest` is only populated once the subscriber records its first block.

This is the weakest point of the guarantee, and worth being explicit about: the first Tempo import — the one read with no parent-hash or contiguity constraint, and therefore the one a hostile header would target — is also the most likely to run while the tracker is still cold, since `spawn_l1_subscriber` carries no readiness barrier against block execution. Closing it needs a startup ordering guarantee between the subscriber and the engine, which is out of scope here.

Only `get_storage` is gated, since that is the consensus path; `get_storage_async` has no non-test callers.

## Validation

- `cargo check`, `clippy`, `fmt` clean
- 119 unit tests pass, including a concurrency test asserting that a read above the head resolves once the tracker advances rather than erroring
- Integration and e2e suites were not run locally — relying on CI
