### PR TITLE
test: migrate Earn E2E to single-zone router

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/earn
-          ref: main
+          # Keep the external contracts in sync with the router API exercised by
+          # crates/node/tests/it/earn_zone_e2e.rs. Earn main removed this API in #126.
+          ref: 36ce683da968a4ff3a0bdd88090a8c701fedc962
           path: earn
           ssh-key: ${{ secrets.EARN_DEPLOY_KEY }}
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/earn
-          # Keep the external contracts in sync with the router API exercised by
-          # crates/node/tests/it/earn_zone_e2e.rs. Earn main removed this API in #126.
-          ref: 36ce683da968a4ff3a0bdd88090a8c701fedc962
+          ref: main
           path: earn
           ssh-key: ${{ secrets.EARN_DEPLOY_KEY }}
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,13 @@ jobs:
       - uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef
         with:
           toolchain: stable
-      # sccache avoids recompiling dependencies, while this cache also keeps the
-      # final linked workspace test binaries that sccache cannot cache.
+      # sccache avoids recompiling dependencies. Do not cache the linked test
+      # target: the nextest archive already preserves it for the test shards,
+      # and duplicating the ~15 GB target can exhaust runner disk during save.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: test-build
-          cache-workspace-crates: true
+          cache-targets: false
           cache-on-failure: true
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:

--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -57,28 +57,20 @@ alloy_sol_types::sol! {
 
     struct FixedFeeRecipient {
         address account;
-        uint96 rate;
+        uint16 rateBps;
     }
 
     struct ExcessReturnFee {
         bool enabled;
         address account;
-        uint96 annualTargetRate;
-        uint96 excessFeeRate;
+        uint16 annualTargetRateBps;
+        uint16 excessFeeRateBps;
     }
 
     struct FeeConfig {
         uint8 fixedFeeCount;
         FixedFeeRecipient[4] fixedFees;
         ExcessReturnFee excess;
-    }
-
-    struct EarnFeesInit {
-        address administrator;
-        address guardian;
-        uint96 fixedFeeCap;
-        uint96 excessFeeCap;
-        FeeConfig initialConfig;
     }
 
     struct EarnEncryptedDepositPayload {
@@ -109,7 +101,7 @@ alloy_sol_types::sol! {
         address engine;
         address owner;
         EarnVaultControls controls;
-        EarnFeesInit fees;
+        FeeConfig fees;
     }
 
     #[sol(rpc)]
@@ -380,23 +372,17 @@ impl EarnZoneFixture {
         )
         .await?;
 
-        let fees = EarnFeesInit {
-            administrator: Address::ZERO,
-            guardian: Address::ZERO,
-            fixedFeeCap: Default::default(),
-            excessFeeCap: Default::default(),
-            initialConfig: FeeConfig {
-                fixedFeeCount: 0,
-                fixedFees: std::array::from_fn(|_| FixedFeeRecipient {
-                    account: Address::ZERO,
-                    rate: Default::default(),
-                }),
-                excess: ExcessReturnFee {
-                    enabled: false,
-                    account: Address::ZERO,
-                    annualTargetRate: Default::default(),
-                    excessFeeRate: Default::default(),
-                },
+        let fees = FeeConfig {
+            fixedFeeCount: 0,
+            fixedFees: std::array::from_fn(|_| FixedFeeRecipient {
+                account: Address::ZERO,
+                rateBps: 0,
+            }),
+            excess: ExcessReturnFee {
+                enabled: false,
+                account: Address::ZERO,
+                annualTargetRateBps: 0,
+                excessFeeRateBps: 0,
             },
         };
         let params = EarnDeployParams {
@@ -454,6 +440,8 @@ impl EarnZoneFixture {
             .abi_encode(),
         )
         .await?;
+        let authority_provider = l1.dev_provider();
+        let authority = DemoTokenAuthority::new(token_authority, &authority_provider);
         let unwrap_role = authority.UNWRAPPER_ROLE().call().await?;
         let receipt = authority
             .grantRole(unwrap_role, router)
@@ -747,16 +735,6 @@ impl EarnZoneFixture {
             min_earn_shares: 0,
             min_output_amount,
         })
-    }
-
-    async fn assert_router_empty(&self) -> eyre::Result<()> {
-        for token in [self.vault_asset, self.alternate_asset, self.earn_share] {
-            eyre::ensure!(
-                self.l1.balance_of(token, self.router).await? == U256::ZERO,
-                "SingleZoneEarnRouter retained token {token}"
-            );
-        }
-        Ok(())
     }
 
     async fn assert_private_return(

--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -27,7 +27,6 @@ const AMOUNT: u128 = 1_000_000;
 const REWARD_AMOUNT: u128 = AMOUNT / 10;
 const PUBLIC_USER_BALANCE: u128 = 50_000_000;
 const PRIVATE_FEE_BALANCE: u128 = 10_000_000;
-const DEX_LIQUIDITY: u128 = 300_000_000;
 const TOKEN_SUPPLY: u128 = 1_000_000_000;
 // Match Earn's current callback budget.
 const CALLBACK_GAS_LIMIT: u64 = 10_000_000;
@@ -90,13 +89,7 @@ alloy_sol_types::sol! {
         bytes16 tag;
     }
 
-    enum EarnDestination {
-        Zone,
-        Public
-    }
-
-    struct EarnZoneDelivery {
-        address portal;
+    struct EarnZoneReturn {
         uint256 keyIndex;
         EarnEncryptedDepositPayload encrypted;
         address refundRecipient;
@@ -104,14 +97,11 @@ alloy_sol_types::sol! {
 
     struct EarnCallbackData {
         EarnFlow flow;
-        address earnVault;
-        EarnDestination destination;
-        address outputToken;
         uint128 minVaultAssets;
         uint128 minEarnShares;
         uint128 minOutputAmount;
         bytes32 actionId;
-        bytes destinationData;
+        EarnZoneReturn zoneReturn;
     }
 
     struct EarnDeployParams {
@@ -181,25 +171,18 @@ alloy_sol_types::sol! {
     }
 
     #[sol(rpc)]
-    contract UniversalEarnRouter {
-        function deposit(address earnVault, uint256 assets, uint256 minEarnShares, address recipient)
-            external
-            returns (uint256 earnShares);
-        function depositToZone(
-            address earnVault,
-            uint256 assets,
-            uint256 minEarnShares,
-            EarnZoneDelivery delivery
-        ) external returns (uint256 earnShares, bytes32 zoneDepositHash);
-        function redeem(address earnVault, uint256 earnShares, uint256 minAssets, address recipient)
-            external
-            returns (uint256 assets);
-        function redeemToZone(
-            address earnVault,
-            uint256 earnShares,
-            uint256 minAssets,
-            EarnZoneDelivery delivery
-        ) external returns (uint256 assets, bytes32 zoneDepositHash);
+    contract SingleZoneEarnRouter {
+        constructor(uint32 allowedZoneId_, address earnVault_, address privateAsset_, address tokenAuthority_);
+    }
+
+    #[sol(rpc)]
+    contract DemoTokenAuthority {
+        constructor(address reserveToken, address administrator);
+        function BRIDGE_ECOSYSTEM_CONTRACT_ROLE() external view returns (bytes32);
+        function UNWRAPPER_ROLE() external view returns (bytes32);
+        function grantRole(bytes32 role, address account) external;
+        function mintBridgeEcosystem(address stablecoin, address receiver, uint256 amount) external;
+        function setTxnMintLimit(address stablecoin, uint256 limit) external;
     }
 
     #[sol(rpc)]
@@ -266,16 +249,83 @@ impl EarnZoneFixture {
         reth_tracing::init_test_tracing();
 
         let l1 = L1TestNode::start().await?;
+        let reserve_asset = l1
+            .create_tip20("Earn Reserve USD", "erUSD", B256::with_last_byte(0xE0))
+            .await?;
         let vault_asset = l1
-            .create_tip20("Earn Vault USD", "evUSD", B256::with_last_byte(0xE1))
+            .create_tip20_with_quote(
+                "Earn Vault USD",
+                "evUSD",
+                reserve_asset,
+                B256::with_last_byte(0xE1),
+            )
             .await?;
         let alternate_asset = l1
-            .create_tip20("Earn Alternate USD", "eaUSD", B256::with_last_byte(0xE2))
+            .create_tip20_with_quote(
+                "Earn Alternate USD",
+                "eaUSD",
+                reserve_asset,
+                B256::with_last_byte(0xE2),
+            )
             .await?;
-        l1.mint_tip20(vault_asset, l1.dev_address(), TOKEN_SUPPLY)
+        let token_authority = deploy_contract(
+            &l1,
+            "DemoTokenAuthority",
+            DemoTokenAuthority::constructorCall {
+                reserveToken: reserve_asset,
+                administrator: l1.dev_address(),
+            }
+            .abi_encode(),
+        )
+        .await?;
+        let provider = l1.dev_provider();
+        let authority = DemoTokenAuthority::new(token_authority, &provider);
+        use tempo_contracts::precompiles::IRolesAuth;
+        use tempo_precompiles::tip20::ISSUER_ROLE;
+        for token in [reserve_asset, vault_asset, alternate_asset] {
+            let receipt = IRolesAuth::new(token, &provider)
+                .grantRole(*ISSUER_ROLE, token_authority)
+                .send()
+                .await?
+                .get_receipt()
+                .await?;
+            eyre::ensure!(
+                receipt.status(),
+                "granting TokenAuthority issuer role failed"
+            );
+        }
+        for token in [vault_asset, alternate_asset] {
+            let receipt = authority
+                .setTxnMintLimit(token, U256::from(TOKEN_SUPPLY))
+                .send()
+                .await?
+                .get_receipt()
+                .await?;
+            eyre::ensure!(receipt.status(), "setting TokenAuthority limit failed");
+        }
+        let bridge_role = authority.BRIDGE_ECOSYSTEM_CONTRACT_ROLE().call().await?;
+        let receipt = authority
+            .grantRole(bridge_role, l1.dev_address())
+            .send()
+            .await?
+            .get_receipt()
             .await?;
-        l1.mint_tip20(alternate_asset, l1.dev_address(), TOKEN_SUPPLY)
-            .await?;
+        eyre::ensure!(
+            receipt.status(),
+            "granting TokenAuthority bridge role failed"
+        );
+        for token in [vault_asset, alternate_asset] {
+            let receipt = authority
+                .mintBridgeEcosystem(token, l1.dev_address(), U256::from(TOKEN_SUPPLY))
+                .send()
+                .await?
+                .get_receipt()
+                .await?;
+            eyre::ensure!(
+                receipt.status(),
+                "minting reserve-backed test assets failed"
+            );
+        }
 
         let portal = l1.deploy_zone().await?;
         let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal).await?;
@@ -388,7 +438,30 @@ impl EarnZoneFixture {
             .await?;
         eyre::ensure!(receipt.status(), "initializing the Earn engine failed");
 
-        let router = deploy_contract(&l1, "UniversalEarnRouter", Vec::new()).await?;
+        let zone_id = ZonePortal::new(portal, l1.provider())
+            .zoneId()
+            .call()
+            .await?;
+        let router = deploy_contract(
+            &l1,
+            "SingleZoneEarnRouter",
+            SingleZoneEarnRouter::constructorCall {
+                allowedZoneId_: zone_id,
+                earnVault_: earn_vault,
+                privateAsset_: alternate_asset,
+                tokenAuthority_: token_authority,
+            }
+            .abi_encode(),
+        )
+        .await?;
+        let unwrap_role = authority.UNWRAPPER_ROLE().call().await?;
+        let receipt = authority
+            .grantRole(unwrap_role, router)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(receipt.status(), "authorizing Earn router failed");
         let router_block = l1.set_zone_gateway_on_portal(portal, router, true).await?;
         zone.wait_for_l2_tempo_finalized(router_block, E2E_TIMEOUT)
             .await?;
@@ -431,17 +504,6 @@ impl EarnZoneFixture {
         l1.enable_token_on_portal(portal, vault_asset).await?;
         l1.enable_token_on_portal(portal, alternate_asset).await?;
         l1.enable_token_on_portal(portal, earn_share).await?;
-
-        l1.create_dex_pair(vault_asset).await?;
-        l1.create_dex_pair(alternate_asset).await?;
-        l1.place_dex_bid_order(vault_asset, DEX_LIQUIDITY, 0)
-            .await?;
-        l1.place_dex_ask_order(vault_asset, DEX_LIQUIDITY, 0)
-            .await?;
-        l1.place_dex_bid_order(alternate_asset, DEX_LIQUIDITY, 0)
-            .await?;
-        l1.place_dex_ask_order(alternate_asset, DEX_LIQUIDITY, 0)
-            .await?;
 
         let configured_at = l1.provider().get_block_number().await?;
         zone.wait_for_l2_tempo_finalized(configured_at, E2E_TIMEOUT)
@@ -620,7 +682,6 @@ impl EarnZoneFixture {
     async fn callback_data(
         &self,
         flow: EarnFlow,
-        output_token: Address,
         recipient: Address,
         refund_recipient: Address,
         limits: EarnLimits,
@@ -630,37 +691,29 @@ impl EarnZoneFixture {
             .encrypt_deposit_for_portal(self.portal, recipient, B256::ZERO)
             .await?;
         let action_id = keccak256(encrypted.ciphertext.as_ref());
-        let destination_data = EarnZoneDelivery {
-            portal: self.portal,
+        let zone_return = EarnZoneReturn {
             keyIndex: key_index,
             encrypted: map_encrypted_payload(encrypted),
             refundRecipient: refund_recipient,
-        }
-        .abi_encode()
-        .into();
+        };
         Ok(EarnCallbackData {
             flow,
-            earnVault: self.earn_vault,
-            destination: EarnDestination::Zone,
-            outputToken: output_token,
             minVaultAssets: limits.min_vault_assets,
             minEarnShares: limits.min_earn_shares,
             minOutputAmount: limits.min_output_amount,
             actionId: action_id,
-            destinationData: destination_data,
+            zoneReturn: zone_return,
         }
         .abi_encode()
         .into())
     }
 
-    async fn deposit_limits(&self, input_token: Address, amount: u128) -> eyre::Result<EarnLimits> {
-        let expected_vault_assets = if input_token == self.vault_asset {
-            amount
-        } else {
-            self.l1
-                .quote_dex_swap_exact_amount_in(input_token, self.vault_asset, amount)
-                .await?
-        };
+    async fn deposit_limits(
+        &self,
+        _input_token: Address,
+        amount: u128,
+    ) -> eyre::Result<EarnLimits> {
+        let expected_vault_assets = amount;
         let min_vault_assets = minimum_output(expected_vault_assets);
         let expected_earn_shares = EarnVault::new(self.earn_vault, self.l1.provider())
             .convertEngineSharesToEarnShares(U256::from(min_vault_assets))
@@ -687,19 +740,8 @@ impl EarnZoneFixture {
             .await?;
         let min_vault_assets =
             minimum_output(u256_to_u128(expected_vault_assets, "Earn redeem preview")?);
-        let min_output_amount = if output_token == self.vault_asset {
-            min_vault_assets
-        } else {
-            minimum_output(
-                self.l1
-                    .quote_dex_swap_exact_amount_in(
-                        self.vault_asset,
-                        output_token,
-                        min_vault_assets,
-                    )
-                    .await?,
-            )
-        };
+        let _ = output_token;
+        let min_output_amount = min_vault_assets;
         Ok(EarnLimits {
             min_vault_assets,
             min_earn_shares: 0,
@@ -707,270 +749,14 @@ impl EarnZoneFixture {
         })
     }
 
-    fn public_callback_data(
-        &self,
-        flow: EarnFlow,
-        output_token: Address,
-        recipient: Address,
-        limits: EarnLimits,
-    ) -> Bytes {
-        EarnCallbackData {
-            flow,
-            earnVault: self.earn_vault,
-            destination: EarnDestination::Public,
-            outputToken: output_token,
-            minVaultAssets: limits.min_vault_assets,
-            minEarnShares: limits.min_earn_shares,
-            minOutputAmount: limits.min_output_amount,
-            actionId: keccak256((recipient, output_token).abi_encode()),
-            destinationData: recipient.abi_encode().into(),
-        }
-        .abi_encode()
-        .into()
-    }
-
     async fn assert_router_empty(&self) -> eyre::Result<()> {
         for token in [self.vault_asset, self.alternate_asset, self.earn_share] {
             eyre::ensure!(
                 self.l1.balance_of(token, self.router).await? == U256::ZERO,
-                "UniversalEarnRouter retained token {token}"
+                "SingleZoneEarnRouter retained token {token}"
             );
         }
         Ok(())
-    }
-
-    async fn enable_public_callback_destinations(&self) -> eyre::Result<()> {
-        // Closed-access portals require every callback to append a return deposit. Earn's public
-        // matrix destinations intentionally leave the Zone system, so mirror upstream's open Zone
-        // environment for only those paths.
-        let block = self
-            .l1
-            .set_access_mode_on_portal(self.portal, false)
-            .await?;
-        self.zone
-            .wait_for_l2_tempo_finalized(block, E2E_TIMEOUT)
-            .await?;
-        Ok(())
-    }
-
-    async fn deposit_public_to_private(&self, recipient: Address) -> eyre::Result<u128> {
-        let provider = self.user.l1_provider();
-        let limits = self.deposit_limits(self.vault_asset, AMOUNT).await?;
-        let private_before = self.zone.balance_of(self.earn_share, recipient).await?;
-        let public_before = self
-            .l1
-            .balance_of(self.earn_share, self.user.address())
-            .await?;
-        let receipt = ITIP20::new(self.vault_asset, provider)
-            .approve(self.router, U256::from(AMOUNT))
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "public deposit router approval failed");
-
-        let (key_index, encrypted) = self
-            .l1
-            .encrypt_deposit_for_portal(self.portal, recipient, B256::ZERO)
-            .await?;
-        let delivery = EarnZoneDelivery {
-            portal: self.portal,
-            keyIndex: key_index,
-            encrypted: map_encrypted_payload(encrypted),
-            refundRecipient: self.user.address(),
-        };
-        let receipt = UniversalEarnRouter::new(self.router, provider)
-            .depositToZone(
-                self.earn_vault,
-                U256::from(AMOUNT),
-                U256::from(limits.min_earn_shares),
-                delivery,
-            )
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "public-to-private Earn deposit failed");
-
-        let private_after = self
-            .zone
-            .wait_for_balance(
-                self.earn_share,
-                recipient,
-                private_before + U256::from(1),
-                E2E_TIMEOUT,
-            )
-            .await?;
-        assert_eq!(
-            self.l1
-                .balance_of(self.earn_share, self.user.address())
-                .await?,
-            public_before,
-            "public-to-private deposit left EarnShare on the caller"
-        );
-        self.assert_router_empty().await?;
-        u256_to_u128(
-            private_after - private_before,
-            "EarnShare returned by public-to-private deposit",
-        )
-    }
-
-    async fn deposit_private_to_public(&mut self, recipient: Address) -> eyre::Result<u128> {
-        self.enable_public_callback_destinations().await?;
-        self.encrypted_entry(self.vault_asset, AMOUNT).await?;
-        let before = self.l1.balance_of(self.earn_share, recipient).await?;
-        let limits = self.deposit_limits(self.vault_asset, AMOUNT).await?;
-        let data = self.public_callback_data(EarnFlow::Deposit, self.earn_share, recipient, limits);
-        self.user
-            .withdraw_token_with(
-                self.vault_asset,
-                WithdrawalArgs {
-                    amount: AMOUNT,
-                    to: Some(self.router),
-                    memo: B256::ZERO,
-                    gas_limit: CALLBACK_GAS_LIMIT,
-                    zone_fallback_recipient: Some(self.user.address()),
-                    data,
-                    reveal_to: Bytes::new(),
-                },
-            )
-            .await?;
-        let after = self
-            .l1
-            .wait_for_balance(
-                self.earn_share,
-                recipient,
-                before + U256::from(1),
-                E2E_TIMEOUT,
-            )
-            .await?;
-        self.assert_router_empty().await?;
-        u256_to_u128(
-            after - before,
-            "EarnShare returned by private-to-public deposit",
-        )
-    }
-
-    async fn mint_public_earn(&self) -> eyre::Result<u128> {
-        let provider = self.user.l1_provider();
-        let limits = self.deposit_limits(self.vault_asset, AMOUNT).await?;
-        let receipt = ITIP20::new(self.vault_asset, provider)
-            .approve(self.router, U256::from(AMOUNT))
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "public Earn deposit approval failed");
-        let before = self
-            .l1
-            .balance_of(self.earn_share, self.user.address())
-            .await?;
-        let receipt = UniversalEarnRouter::new(self.router, provider)
-            .deposit(
-                self.earn_vault,
-                U256::from(AMOUNT),
-                U256::from(limits.min_earn_shares),
-                self.user.address(),
-            )
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "public Earn deposit failed");
-        let after = self
-            .l1
-            .balance_of(self.earn_share, self.user.address())
-            .await?;
-        self.assert_router_empty().await?;
-        u256_to_u128(after - before, "public Earn deposit")
-    }
-
-    async fn redeem_public_to_private(&self, recipient: Address) -> eyre::Result<u128> {
-        let earn_shares = self.mint_public_earn().await?;
-        let limits = self.redeem_limits(earn_shares, self.vault_asset).await?;
-        let provider = self.user.l1_provider();
-        let receipt = ITIP20::new(self.earn_share, provider)
-            .approve(self.router, U256::from(earn_shares))
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "public Earn redeem approval failed");
-
-        let private_before = self.zone.balance_of(self.vault_asset, recipient).await?;
-        let (key_index, encrypted) = self
-            .l1
-            .encrypt_deposit_for_portal(self.portal, recipient, B256::ZERO)
-            .await?;
-        let delivery = EarnZoneDelivery {
-            portal: self.portal,
-            keyIndex: key_index,
-            encrypted: map_encrypted_payload(encrypted),
-            refundRecipient: self.user.address(),
-        };
-        let receipt = UniversalEarnRouter::new(self.router, provider)
-            .redeemToZone(
-                self.earn_vault,
-                U256::from(earn_shares),
-                U256::from(limits.min_vault_assets),
-                delivery,
-            )
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "public-to-private Earn redeem failed");
-        let private_after = self
-            .zone
-            .wait_for_balance(
-                self.vault_asset,
-                recipient,
-                private_before + U256::from(1),
-                E2E_TIMEOUT,
-            )
-            .await?;
-        self.assert_router_empty().await?;
-        u256_to_u128(
-            private_after - private_before,
-            "assets returned by public-to-private redeem",
-        )
-    }
-
-    async fn redeem_private_to_public(&mut self, recipient: Address) -> eyre::Result<u128> {
-        let user = self.user.address();
-        let earn_shares = self.zone_deposit(self.vault_asset, user).await?;
-        self.enable_public_callback_destinations().await?;
-        let before = self.l1.balance_of(self.vault_asset, recipient).await?;
-        let limits = self.redeem_limits(earn_shares, self.vault_asset).await?;
-        let data = self.public_callback_data(EarnFlow::Redeem, self.vault_asset, recipient, limits);
-        self.user
-            .withdraw_token_with(
-                self.earn_share,
-                WithdrawalArgs {
-                    amount: earn_shares,
-                    to: Some(self.router),
-                    memo: B256::ZERO,
-                    gas_limit: CALLBACK_GAS_LIMIT,
-                    zone_fallback_recipient: Some(user),
-                    data,
-                    reveal_to: Bytes::new(),
-                },
-            )
-            .await?;
-        let after = self
-            .l1
-            .wait_for_balance(
-                self.vault_asset,
-                recipient,
-                before + U256::from(1),
-                E2E_TIMEOUT,
-            )
-            .await?;
-        self.assert_router_empty().await?;
-        u256_to_u128(
-            after - before,
-            "assets returned by private-to-public redeem",
-        )
     }
 
     async fn assert_private_return(
@@ -1077,13 +863,7 @@ impl EarnZoneFixture {
         let portal_before = self.l1.balance_of(self.earn_share, self.portal).await?;
         let limits = self.deposit_limits(input_token, AMOUNT).await?;
         let data = self
-            .callback_data(
-                EarnFlow::Deposit,
-                self.earn_share,
-                recipient,
-                self.user.address(),
-                limits,
-            )
+            .callback_data(EarnFlow::Deposit, recipient, self.user.address(), limits)
             .await?;
         self.user
             .withdraw_token_with(
@@ -1161,13 +941,7 @@ impl EarnZoneFixture {
             .call()
             .await?;
         let data = self
-            .callback_data(
-                EarnFlow::Deposit,
-                self.earn_share,
-                recipient,
-                self.user.address(),
-                limits,
-            )
+            .callback_data(EarnFlow::Deposit, recipient, self.user.address(), limits)
             .await?;
         let callback_gas_limit = CALLBACK_GAS_LIMIT;
         self.user
@@ -1263,7 +1037,6 @@ impl EarnZoneFixture {
         let data = self
             .callback_data(
                 EarnFlow::Deposit,
-                self.earn_share,
                 recipient,
                 self.user.address(),
                 EarnLimits::default(),
@@ -1364,13 +1137,7 @@ impl EarnZoneFixture {
         let portal_before = self.l1.balance_of(output_token, self.portal).await?;
         let limits = self.redeem_limits(shares, output_token).await?;
         let data = self
-            .callback_data(
-                EarnFlow::Redeem,
-                output_token,
-                recipient,
-                account.address(),
-                limits,
-            )
+            .callback_data(EarnFlow::Redeem, recipient, account.address(), limits)
             .await?;
         account
             .withdraw_token_with(
@@ -1655,7 +1422,7 @@ fn ensure_gas_headroom(gas_used: u64, gas_limit: u64, operation: &str) -> eyre::
 async fn zone_deposit_direct() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
-    let shares = fixture.zone_deposit(fixture.vault_asset, user).await?;
+    let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
     assert_eq!(shares, AMOUNT, "direct Zone deposit was not 1:1");
     Ok(())
 }
@@ -1664,7 +1431,9 @@ async fn zone_deposit_direct() -> eyre::Result<()> {
 async fn zone_deposit_third_party_recipient() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let recipient = fixture.l1.signer_at(3).address();
-    let shares = fixture.zone_deposit(fixture.vault_asset, recipient).await?;
+    let shares = fixture
+        .zone_deposit(fixture.alternate_asset, recipient)
+        .await?;
     assert_eq!(shares, AMOUNT, "third-party Zone deposit was not 1:1");
     Ok(())
 }
@@ -1673,9 +1442,9 @@ async fn zone_deposit_third_party_recipient() -> eyre::Result<()> {
 async fn zone_redeem_direct() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
-    let shares = fixture.zone_deposit(fixture.vault_asset, user).await?;
+    let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
     let output = fixture
-        .zone_redeem(shares, fixture.vault_asset, user)
+        .zone_redeem(shares, fixture.alternate_asset, user)
         .await?;
     assert_eq!(output, AMOUNT, "direct Zone lifecycle was not 1:1");
     Ok(())
@@ -1686,16 +1455,16 @@ async fn zone_redeem_third_party_recipient() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
     let recipient = fixture.l1.signer_at(3).address();
-    let shares = fixture.zone_deposit(fixture.vault_asset, user).await?;
+    let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
     let output = fixture
-        .zone_redeem(shares, fixture.vault_asset, recipient)
+        .zone_redeem(shares, fixture.alternate_asset, recipient)
         .await?;
     assert_eq!(output, AMOUNT, "third-party Zone lifecycle was not 1:1");
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn zone_lifecycle_swapped() -> eyre::Result<()> {
+async fn zone_lifecycle_converted() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
     let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
@@ -1708,7 +1477,7 @@ async fn zone_lifecycle_swapped() -> eyre::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn zone_swap_slippage_bounces() -> eyre::Result<()> {
+async fn zone_conversion_slippage_bounces() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
 
@@ -1729,13 +1498,13 @@ async fn zone_swap_slippage_bounces() -> eyre::Result<()> {
 async fn controls_pause_blocks_entry_but_preserves_exits() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
-    let shares = fixture.zone_deposit(fixture.vault_asset, user).await?;
+    let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
     fixture.set_deposits_paused(true).await?;
     fixture
-        .zone_deposit_expect_callback_bounce(fixture.vault_asset, user, EarnLimits::default())
+        .zone_deposit_expect_callback_bounce(fixture.alternate_asset, user, EarnLimits::default())
         .await?;
     let output = fixture
-        .zone_redeem(shares, fixture.vault_asset, user)
+        .zone_redeem(shares, fixture.alternate_asset, user)
         .await?;
     assert_eq!(output, AMOUNT, "deposit pause blocked a private exit");
     fixture.set_deposits_paused(false).await?;
@@ -1749,7 +1518,7 @@ async fn zone_ineligible_private_deposit_bounces() -> eyre::Result<()> {
     fixture.allow_zone_account(outsider).await?;
     fixture.set_access_eligibility(outsider, false).await?;
     fixture
-        .zone_deposit_expect_recipient_bounce(fixture.vault_asset, outsider)
+        .zone_deposit_expect_recipient_bounce(fixture.alternate_asset, outsider)
         .await
 }
 
@@ -1760,7 +1529,7 @@ async fn zone_ineligible_private_transfer_blocked() -> eyre::Result<()> {
     let outsider = fixture.l1.signer_at(3).address();
     fixture.allow_zone_account(outsider).await?;
     fixture.set_access_eligibility(outsider, false).await?;
-    let user_shares = fixture.zone_deposit(fixture.vault_asset, user).await?;
+    let user_shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
     let user_before = fixture.zone.balance_of(fixture.earn_share, user).await?;
     let outsider_before = fixture
         .zone
@@ -1792,7 +1561,7 @@ async fn zone_ineligible_private_transfer_blocked() -> eyre::Result<()> {
         "rejected private transfer changed the recipient balance"
     );
     let output = fixture
-        .zone_redeem(user_shares, fixture.vault_asset, user)
+        .zone_redeem(user_shares, fixture.alternate_asset, user)
         .await?;
     assert_eq!(output, AMOUNT, "eligible holder cleanup was not 1:1");
     Ok(())
@@ -1811,7 +1580,9 @@ async fn zone_removed_private_holder_can_exit() -> eyre::Result<()> {
         .deposit(PRIVATE_FEE_BALANCE, E2E_TIMEOUT, &fixture.zone)
         .await?;
     fixture.set_access_eligibility(outsider, true).await?;
-    let outsider_shares = fixture.zone_deposit(fixture.vault_asset, outsider).await?;
+    let outsider_shares = fixture
+        .zone_deposit(fixture.alternate_asset, outsider)
+        .await?;
     assert!(
         outsider_shares > 0,
         "eligible private outsider received no EarnShare"
@@ -1821,7 +1592,7 @@ async fn zone_removed_private_holder_can_exit() -> eyre::Result<()> {
         .zone_redeem_as(
             &mut outsider_account,
             outsider_shares,
-            fixture.vault_asset,
+            fixture.alternate_asset,
             outsider,
         )
         .await?;
@@ -1844,7 +1615,7 @@ async fn zone_removed_private_holder_can_exit() -> eyre::Result<()> {
 async fn zone_rewards_private_holder() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
-    let shares = fixture.zone_deposit(fixture.vault_asset, user).await?;
+    let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
     assert!(shares > 1, "private reward setup minted too few shares");
 
     let private_after_entry = fixture.zone.balance_of(fixture.earn_share, user).await?;
@@ -1928,7 +1699,7 @@ async fn zone_rewards_private_holder() -> eyre::Result<()> {
     let first_shares = shares / 2;
     let second_shares = shares - first_shares;
     let first_output = fixture
-        .zone_redeem(first_shares, fixture.vault_asset, user)
+        .zone_redeem(first_shares, fixture.alternate_asset, user)
         .await?;
     assert!(
         first_output > 0,
@@ -1942,7 +1713,7 @@ async fn zone_rewards_private_holder() -> eyre::Result<()> {
     );
 
     let second_output = fixture
-        .zone_redeem(second_shares, fixture.vault_asset, user)
+        .zone_redeem(second_shares, fixture.alternate_asset, user)
         .await?;
     assert_eq!(
         first_output + second_output,
@@ -1958,84 +1729,6 @@ async fn zone_rewards_private_holder() -> eyre::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn matrix_deposit_public_private_self() -> eyre::Result<()> {
-    let fixture = EarnZoneFixture::start().await?;
-    let amount = fixture
-        .deposit_public_to_private(fixture.user.address())
-        .await?;
-    assert!(amount > 0, "public deposit produced no private EarnShare");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_deposit_public_private_third_party() -> eyre::Result<()> {
-    let fixture = EarnZoneFixture::start().await?;
-    let amount = fixture
-        .deposit_public_to_private(fixture.l1.signer_at(3).address())
-        .await?;
-    assert!(amount > 0, "public deposit produced no private EarnShare");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_deposit_private_public_self() -> eyre::Result<()> {
-    let mut fixture = EarnZoneFixture::start().await?;
-    let amount = fixture
-        .deposit_private_to_public(fixture.user.address())
-        .await?;
-    assert!(amount > 0, "private deposit produced no public EarnShare");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_deposit_private_public_third_party() -> eyre::Result<()> {
-    let mut fixture = EarnZoneFixture::start().await?;
-    let recipient = fixture.l1.signer_at(3).address();
-    let amount = fixture.deposit_private_to_public(recipient).await?;
-    assert!(amount > 0, "private deposit produced no public EarnShare");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_redeem_public_private_self() -> eyre::Result<()> {
-    let fixture = EarnZoneFixture::start().await?;
-    let amount = fixture
-        .redeem_public_to_private(fixture.user.address())
-        .await?;
-    assert!(amount > 0, "public redeem produced no private assets");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_redeem_public_private_third_party() -> eyre::Result<()> {
-    let fixture = EarnZoneFixture::start().await?;
-    let amount = fixture
-        .redeem_public_to_private(fixture.l1.signer_at(3).address())
-        .await?;
-    assert!(amount > 0, "public redeem produced no private assets");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_redeem_private_public_self() -> eyre::Result<()> {
-    let mut fixture = EarnZoneFixture::start().await?;
-    let amount = fixture
-        .redeem_private_to_public(fixture.user.address())
-        .await?;
-    assert!(amount > 0, "private redeem produced no public assets");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_redeem_private_public_third_party() -> eyre::Result<()> {
-    let mut fixture = EarnZoneFixture::start().await?;
-    let recipient = fixture.l1.signer_at(3).address();
-    let amount = fixture.redeem_private_to_public(recipient).await?;
-    assert!(amount > 0, "private redeem produced no public assets");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn migration_existing_vault_shares_to_zone() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
@@ -2043,7 +1736,7 @@ async fn migration_existing_vault_shares_to_zone() -> eyre::Result<()> {
     let earn_shares = fixture.migrate_existing_vault_shares().await?;
     assert_eq!(earn_shares, AMOUNT, "venue-share migration was not 1:1");
     let output = fixture
-        .zone_redeem(earn_shares, fixture.vault_asset, user)
+        .zone_redeem(earn_shares, fixture.alternate_asset, user)
         .await?;
     assert_eq!(output, AMOUNT, "migrated EarnShare did not redeem 1:1");
     Ok(())

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1875,9 +1875,22 @@ impl L1TestNode {
         symbol: &str,
         salt: B256,
     ) -> eyre::Result<Address> {
+        use tempo_precompiles::PATH_USD_ADDRESS;
+        self.create_tip20_with_quote(name, symbol, PATH_USD_ADDRESS, salt)
+            .await
+    }
+
+    /// Create a new TIP-20 token with an explicit quote token.
+    pub(crate) async fn create_tip20_with_quote(
+        &self,
+        name: &str,
+        symbol: &str,
+        quote_token: Address,
+        salt: B256,
+    ) -> eyre::Result<Address> {
         use alloy_sol_types::SolEvent;
         use tempo_contracts::precompiles::ITIP20Factory;
-        use tempo_precompiles::{PATH_USD_ADDRESS, TIP20_FACTORY_ADDRESS};
+        use tempo_precompiles::TIP20_FACTORY_ADDRESS;
 
         let provider = self.dev_provider();
         let factory = ITIP20Factory::new(TIP20_FACTORY_ADDRESS, &provider);
@@ -1886,7 +1899,7 @@ impl L1TestNode {
                 name.to_string(),
                 symbol.to_string(),
                 "USD".to_string(),
-                PATH_USD_ADDRESS,
+                quote_token,
                 self.dev_address(),
                 salt,
             )


### PR DESCRIPTION
## Summary
- migrate Zone Earn E2E coverage from the removed `UniversalEarnRouter` to `SingleZoneEarnRouter`
- build a reserve-backed `DemoTokenAuthority` fixture and authorize the router
- remove public-routing matrix cases that the replacement API intentionally does not support
- align the fixture with current `earn@main`: direct `FeeConfig` factory input and explicit `uint16` BPS fields
- refresh the TokenAuthority provider before the late router-role grant so its nonce is current
- continue tracking `earn@main` instead of pinning a deleted API

## Validation
- `cargo +nightly-2026-02-21 fmt --all --check`
- `cargo +nightly-2026-02-21 clippy --all-targets --all-features --locked`
- current Zones and Earn Solidity artifacts built locally
- full Earn integration module: 12/12 passed
- `git diff --check`

Prompted by: aditya