### PR TITLE
fix(deps): update Reth sparse trie proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7217,7 +7217,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7244,7 +7244,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7277,7 +7277,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7297,7 +7297,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7310,7 +7310,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7394,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7404,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7485,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7498,7 +7498,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7523,7 +7523,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7552,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7578,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7608,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7623,7 +7623,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7648,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7758,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7781,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7808,7 +7808,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7893,7 +7893,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7911,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7927,7 +7927,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7961,7 +7961,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8011,7 +8011,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8051,7 +8051,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -8074,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8106,7 +8106,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8119,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8149,7 +8149,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8163,7 +8163,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8173,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8236,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8249,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8268,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8320,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "serde",
  "serde_json",
@@ -8330,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8356,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "futures",
@@ -8376,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -8393,7 +8393,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bindgen",
  "cc",
@@ -8402,7 +8402,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures",
  "metrics",
@@ -8415,7 +8415,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8424,7 +8424,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8496,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8545,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8560,7 +8560,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8574,7 +8574,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8591,7 +8591,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8615,7 +8615,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8738,7 +8738,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8787,7 +8787,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8811,7 +8811,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8835,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "eyre",
@@ -8859,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8871,7 +8871,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8907,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8930,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8973,7 +8973,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9021,7 +9021,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9048,7 +9048,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9079,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9156,7 +9156,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9186,7 +9186,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9229,7 +9229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9249,7 +9249,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9280,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9327,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9423,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9474,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9551,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9577,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9615,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9631,7 +9631,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9641,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -9659,7 +9659,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9720,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9791,7 +9791,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,38 +128,38 @@ zone-rpc = { path = "crates/rpc" }
 zone-sequencer = { path = "crates/sequencer" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400", features = [
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 revm = { version = "41.0.0", features = [
   "optional_fee_charge",
 ], default-features = false }


### PR DESCRIPTION
## Summary
- update all Reth workspace dependencies from `01d3400` to `84f4c98`
- include the partial-proof fixes from paradigmxyz/reth#26421 and paradigmxyz/reth#26471
- prevent reused anchored sparse tries from deriving roots from stale database branch masks

## Incident context
Zone sequencers running `01d3400` repeatedly computed incorrect sparse-trie roots and fell back to serial computation. The first observed mismatch was block 416105, where the database tip was block 416102 and the reused sparse trie covered the in-memory continuation.

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo metadata --locked --offline --no-deps --format-version 1`
- `cargo check -p zone-node --locked --offline` could not run because the sandbox lacked the already-pinned `alloy-rs/evm` Git checkout and outbound Git authentication returned 401

Prompted by: @legion2002