### PR TITLE
feat(multi-seq): recover a restarting leader before block production

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -5,7 +5,10 @@
 
 use crate::{
     ZoneEngine,
-    replication::{AttestationContext, broadcast_persisted_blocks, run_block_sync},
+    replication::{
+        AttestationContext, LeaderRecovery, after_leader_recovery, broadcast_persisted_blocks,
+        run_follower_block_sync, run_leader_block_sync,
+    },
     rpc::{ZoneRpc, ZoneRpcApi, rpc_connection_config, start_private_rpc},
     settlement_attestation::collect_leader_settlements,
     tx_forwarding::{forward_new_transactions, insert_forwarded_transactions, route_p2p_events},
@@ -167,6 +170,27 @@ pub struct ZoneSequencerAddOnsConfig {
     pub withdrawal_poll_interval: Duration,
     /// Gas and concurrency limits for withdrawal processing transactions.
     pub withdrawal_batch_limits: WithdrawalBatchLimits,
+}
+
+/// Read the sealed header at the local canonical head.
+fn latest_sealed_header<P>(provider: &P) -> eyre::Result<SealedHeader<TempoHeader>>
+where
+    P: BlockNumReader + HeaderProvider<Header = TempoHeader>,
+{
+    let number = provider.best_block_number()?;
+    provider
+        .sealed_header(number)?
+        .ok_or_else(|| eyre::eyre!("no header at zone head {number}"))
+}
+
+/// Leader-only wiring for the tasks that must wait out the leader's startup catch-up.
+struct LeaderStartup {
+    /// Released once the leader's startup catch-up has finished.
+    recovery: LeaderRecovery,
+    /// Outbound P2P commands, shared with the block-sync task.
+    commands: tokio::sync::mpsc::Sender<zone_p2p::P2pCommand>,
+    /// Signing and L1-validation context for settlement proposals.
+    attestation: AttestationContext,
 }
 
 /// Configuration for the Zone private RPC server extension.
@@ -513,6 +537,7 @@ where
             .as_ref()
             .filter(|config| config.role() == Role::Leader)
             .map(|_| AttestationStore::default());
+        let mut leader_recovery = None;
         if let Some(config) = self.p2p_config.take() {
             let l1_chain_id = l1_provider.get_chain_id().await?;
             let network_id = P2pNetworkId::new(l1_chain_id, self.portal_address);
@@ -535,7 +560,7 @@ where
                 l1_provider.clone(),
                 anchor_config,
             );
-            Self::launch_p2p(
+            let startup = Self::launch_p2p(
                 config,
                 network_id,
                 attestation,
@@ -546,12 +571,34 @@ where
                 self.l1_config.block_tracker.clone(),
                 self.deposit_queue.clone(),
             )?;
+
+            // A leader that restarted behind its peers must reach their tip before it broadcasts
+            // or settles anything — both would otherwise speak for a stale head.
+            if let Some(startup) = startup {
+                let provider = ctx.node.provider().clone();
+                task_executor.spawn_critical_task(
+                    "zone-p2p-block-broadcast",
+                    after_leader_recovery(
+                        startup.recovery.clone(),
+                        broadcast_persisted_blocks(provider.clone(), startup.commands.clone()),
+                    ),
+                );
+                // Only a leader can propose settlement attestations.
+                task_executor.spawn_critical_task(
+                    "zone-p2p-settlement-collection",
+                    after_leader_recovery(
+                        startup.recovery.clone(),
+                        collect_leader_settlements(provider, startup.commands, startup.attestation),
+                    ),
+                );
+                leader_recovery = Some(startup.recovery);
+            }
         }
 
         if let Some(ref config) = self.sequencer_config {
             let sequencer_addr = config.sequencer_signer.address();
             let sequencer_key = SecretKey::from(config.sequencer_signer.credential());
-            self.spawn_zone_engine(&ctx, sequencer_addr, sequencer_key)?;
+            self.spawn_zone_engine(&ctx, sequencer_addr, sequencer_key, leader_recovery);
         }
 
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
@@ -606,10 +653,9 @@ where
         engine: ConsensusEngineHandle<ZonePayloadTypes>,
         l1_block_tracker: L1BlockTracker,
         deposit_queue: DepositQueue,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Option<LeaderStartup>> {
         let local_ed25519_public_key = config.ed25519_public_key();
-        let leadership = config.leadership();
-        let role = leadership.role_of(&local_ed25519_public_key);
+        let role = config.leadership().role_of(&local_ed25519_public_key);
         // Subscribe before starting Commonware (and, importantly, before RPC launch) so a
         // follower cannot admit a transaction in a startup gap.
         let new_transactions = (role == Role::Follower).then(|| pool.new_transactions_listener());
@@ -622,12 +668,8 @@ where
             events,
         } = handle.into_parts();
 
-        let sync_events = match role {
+        let leader_startup = match role {
             Role::Leader => {
-                task_executor.spawn_critical_task(
-                    "zone-p2p-block-broadcast",
-                    broadcast_persisted_blocks(provider.clone(), commands.clone()),
-                );
                 let (sync_events_tx, sync_events) = tokio::sync::mpsc::channel(128);
                 let (transaction_events_tx, transaction_events) = tokio::sync::mpsc::channel(128);
                 task_executor.spawn_critical_task(
@@ -638,7 +680,25 @@ where
                     "zone-p2p-transaction-import",
                     insert_forwarded_transactions(pool, transaction_events),
                 );
-                sync_events
+                let (caught_up, recovered) = tokio::sync::watch::channel(false);
+                task_executor.spawn_critical_task(
+                    "zone-p2p-block-sync",
+                    run_leader_block_sync(
+                        provider,
+                        engine,
+                        sync_events,
+                        commands.clone(),
+                        l1_block_tracker,
+                        deposit_queue,
+                        attestation.clone(),
+                        caught_up,
+                    ),
+                );
+                Some(LeaderStartup {
+                    recovery: LeaderRecovery::new(recovered),
+                    commands,
+                    attestation,
+                })
             }
             Role::Follower => {
                 task_executor.spawn_critical_task(
@@ -649,30 +709,21 @@ where
                         commands.clone(),
                     ),
                 );
-                events
+                task_executor.spawn_critical_task(
+                    "zone-p2p-block-sync",
+                    run_follower_block_sync(
+                        provider,
+                        engine,
+                        events,
+                        commands,
+                        l1_block_tracker,
+                        deposit_queue,
+                        attestation,
+                    ),
+                );
+                None
             }
         };
-        task_executor.spawn_critical_task(
-            "zone-p2p-block-sync",
-            run_block_sync(
-                local_ed25519_public_key,
-                leadership,
-                provider.clone(),
-                engine,
-                sync_events,
-                commands.clone(),
-                l1_block_tracker,
-                deposit_queue,
-                attestation.clone(),
-            ),
-        );
-        if role == Role::Leader {
-            // Only a leader can propose settlement attestations
-            task_executor.spawn_critical_task(
-                "zone-p2p-settlement-collection",
-                collect_leader_settlements(provider, commands, attestation),
-            );
-        }
         task_executor.spawn_critical_with_graceful_shutdown_signal(
             "zone-p2p",
             |shutdown| async move {
@@ -707,7 +758,7 @@ where
                 }
             },
         );
-        Ok(())
+        Ok(leader_startup)
     }
 
     /// Seed the enabled-token registry from the zone's current L1 snapshot.
@@ -788,32 +839,52 @@ where
     }
 
     /// Spawn the [`ZoneEngine`] for L1-event-driven block production.
+    ///
+    /// A recovering leader must not build on — or forkchoice back to — the head it started with,
+    /// so the engine's parent header is read after `recovery` releases rather than at launch. The
+    /// wait cannot happen here: recovery imports blocks through the engine API, which reth only
+    /// starts serving once add-ons have finished launching.
     fn spawn_zone_engine(
         &self,
         ctx: &AddOnsContext<'_, N>,
         fee_recipient: Address,
         sequencer_key: SecretKey,
-    ) -> eyre::Result<()> {
-        let provider = ctx.node.provider();
-        let last_header = provider
-            .sealed_header(provider.best_block_number()?)?
-            .ok_or_else(|| eyre::eyre!("no latest block header"))?;
-        let engine = ZoneEngine::new(
-            provider.chain_spec(),
-            ctx.beacon_engine_handle.clone(),
-            ctx.node.payload_builder_handle().clone(),
-            self.deposit_queue.clone(),
-            self.l1_config.block_tracker.clone(),
-            last_header,
-            fee_recipient,
-            sequencer_key,
-            self.portal_address,
-        );
+        recovery: Option<LeaderRecovery>,
+    ) {
+        let provider = ctx.node.provider().clone();
+        let chain_spec = provider.chain_spec();
+        let engine_handle = ctx.beacon_engine_handle.clone();
+        let payload_builder = ctx.node.payload_builder_handle().clone();
+        let deposit_queue = self.deposit_queue.clone();
+        let block_tracker = self.l1_config.block_tracker.clone();
+        let portal_address = self.portal_address;
+
         ctx.node
             .task_executor()
-            .spawn_critical_task("zone-engine", engine.run());
+            .spawn_critical_task("zone-engine", async move {
+                if let Some(recovery) = recovery {
+                    recovery
+                        .wait()
+                        .await
+                        .expect("leader startup catch-up must finish before block production");
+                }
+                let last_header = latest_sealed_header(&provider)
+                    .expect("ZoneEngine requires a readable canonical zone head");
+                ZoneEngine::new(
+                    chain_spec,
+                    engine_handle,
+                    payload_builder,
+                    deposit_queue,
+                    block_tracker,
+                    last_header,
+                    fee_recipient,
+                    sequencer_key,
+                    portal_address,
+                )
+                .run()
+                .await
+            });
         info!(target: "reth::cli", "ZoneEngine spawned");
-        Ok(())
     }
 
     /// Launch the private RPC server.

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -18,10 +18,10 @@ use std::{
 };
 use tempo_alloy::TempoNetwork;
 use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 use zone_l1::{DepositQueue, L1BlockTracker, L1PortalEvents, TempoStateExt as _};
-use zone_p2p::{Leadership, P2pCommand, P2pEvent, P2pPeerId, Role};
+use zone_p2p::{P2pCommand, P2pEvent};
 use zone_payload::{
     ZonePayloadTypes,
     abi::{IZoneInbox, ZONE_INBOX_ADDRESS},
@@ -215,6 +215,14 @@ const MAX_PENDING_BLOCKS: usize = 128;
 const BACKFILL_PAGE_SIZE: u64 = 64;
 const BACKFILL_SERVE_QUEUE_CAPACITY: usize = 8;
 
+/// How long a restarting leader waits for any peer to answer its catch-up probe.
+///
+/// A leader that hears nothing cannot tell a fresh zone apart from unreachable followers, so it
+/// eventually starts producing blocks either way — the behaviour it had before startup recovery
+/// existed. The window is several times Commonware's dial interval and handshake timeout, so a
+/// follower that is actually running gets to answer first.
+const LEADER_CATCHUP_GRACE_PERIOD: Duration = Duration::from_secs(10);
+
 struct BackfillRequest {
     peer: zone_p2p::P2pPeerId,
     request_id: u64,
@@ -383,22 +391,88 @@ async fn serve_backfill_requests<P>(
     }
 }
 
-/// Run role-appropriate block replication.
+/// Barrier released once a leader's startup catch-up has produced a canonical head.
 ///
-/// Leaders are deliberately serve-only: [`ZoneEngine`](crate::ZoneEngine) is their sole
-/// chain-head writer. Leader recovery is deferred to a future startup recovery phase, before the
-/// zone engine starts. Followers serve catch-up requests and import live/backfilled blocks in
-/// canonical order.
-pub(crate) async fn run_block_sync<P>(
-    local_ed25519_public_key: P2pPeerId,
-    leadership: Leadership,
+/// Block production, block broadcast, and settlement proposals must all start from the recovered
+/// head rather than the one the process came up with. Recovery cannot be awaited during node
+/// launch: it imports blocks through the engine API, and reth only starts the consensus engine
+/// after add-ons finish launching. So each of those tasks waits on this barrier instead.
+#[derive(Debug, Clone)]
+pub(crate) struct LeaderRecovery(watch::Receiver<bool>);
+
+impl LeaderRecovery {
+    /// Creates the barrier from the receiving half of a catch-up signal.
+    pub(crate) const fn new(recovered: watch::Receiver<bool>) -> Self {
+        Self(recovered)
+    }
+
+    /// Wait until the leader's canonical head is safe to build on.
+    pub(crate) async fn wait(mut self) -> eyre::Result<()> {
+        self.0
+            .wait_for(|recovered| *recovered)
+            .await
+            .map(drop)
+            .map_err(|_| eyre::eyre!("leader block sync stopped before startup catch-up finished"))
+    }
+}
+
+/// Run `task` once the leader's startup catch-up has released `recovery`.
+pub(crate) async fn after_leader_recovery(
+    recovery: LeaderRecovery,
+    task: impl Future<Output = ()>,
+) {
+    match recovery.wait().await {
+        Ok(()) => task.await,
+        Err(err) => {
+            tracing::error!(target: "zone::p2p", %err, "Skipping leader task; startup catch-up never finished");
+        }
+    }
+}
+
+/// Tracks whether a restarting leader has learned enough to hand its head to block production.
+///
+/// The only authoritative source is a peer: a leader that lost its disk looks exactly like a
+/// leader starting a brand new zone. Once any peer answers, the advertised tip decides when
+/// recovery is finished, and the leader keeps catching up rather than forking the zone.
+#[derive(Debug, Default)]
+struct LeaderCatchUp {
+    heard_from_peer: bool,
+}
+
+impl LeaderCatchUp {
+    /// Record that an eligible peer answered the catch-up probe.
+    const fn observe_response(&mut self) {
+        self.heard_from_peer = true;
+    }
+
+    /// Whether the local head now matches everything peers have advertised.
+    const fn is_complete(&self, backfill_needed: bool) -> bool {
+        self.heard_from_peer && !backfill_needed
+    }
+
+    /// Whether an elapsed grace period ends recovery because no peer ever answered.
+    const fn may_start_unheard(&self) -> bool {
+        !self.heard_from_peer
+    }
+}
+
+/// Recover a restarted leader, then serve peer backfill requests.
+///
+/// Only followers are backfilled in steady state, so a leader that crashed or lost its disk has
+/// no other way back to the canonical chain. Recovery therefore runs before
+/// [`ZoneEngine`](crate::ZoneEngine) becomes the sole writer of the leader's head, importing peer
+/// blocks through the same validating path a follower uses. `caught_up` releases the tasks that
+/// need the recovered head; afterwards the leader is serve-only and never follows a peer chain
+/// head again.
+pub(crate) async fn run_leader_block_sync<P>(
     provider: P,
     engine: ConsensusEngineHandle<ZonePayloadTypes>,
-    events: mpsc::Receiver<P2pEvent>,
+    mut events: mpsc::Receiver<P2pEvent>,
     commands: mpsc::Sender<P2pCommand>,
     l1_block_tracker: L1BlockTracker,
     deposit_queue: DepositQueue,
     attestation: AttestationContext,
+    caught_up: watch::Sender<bool>,
 ) where
     P: BlockNumReader
         + BlockReader<Block = Block>
@@ -410,30 +484,173 @@ pub(crate) async fn run_block_sync<P>(
         + Sync
         + 'static,
 {
-    let role = leadership.role_of(&local_ed25519_public_key);
-    match role {
-        Role::Leader => run_leader_backfill_server(provider, events, commands, attestation).await,
-        Role::Follower => {
-            run_follower_block_sync(
-                provider,
-                engine,
-                events,
-                commands,
-                l1_block_tracker,
-                deposit_queue,
-                attestation,
-            )
-            .await
+    // Serving spans both phases: a peer even further behind than this leader must not have to
+    // wait for the leader's own recovery to finish.
+    let (backfill_requests, backfill_request_rx) = mpsc::channel(BACKFILL_SERVE_QUEUE_CAPACITY);
+    let mut backfill_server = BackfillServerTask(tokio::spawn(serve_backfill_requests(
+        provider.clone(),
+        commands.clone(),
+        backfill_request_rx,
+    )));
+
+    if let Err(err) = run_leader_catch_up(
+        &provider,
+        &engine,
+        &mut events,
+        &commands,
+        &l1_block_tracker,
+        &deposit_queue,
+        &backfill_requests,
+        &mut backfill_server,
+    )
+    .await
+    {
+        tracing::error!(target: "zone::p2p", %err, "Leader startup catch-up stopped");
+        return;
+    }
+    caught_up.send_replace(true);
+
+    run_leader_backfill_server(
+        provider,
+        events,
+        attestation,
+        backfill_requests,
+        backfill_server,
+    )
+    .await
+}
+
+/// Import canonical peer blocks until the leader's head is safe to hand to block production.
+///
+/// Returns once recovery is finished. An error means the runtime is going away, so the caller
+/// must not release the startup barrier.
+async fn run_leader_catch_up<P>(
+    provider: &P,
+    engine: &ConsensusEngineHandle<ZonePayloadTypes>,
+    events: &mut mpsc::Receiver<P2pEvent>,
+    commands: &mpsc::Sender<P2pCommand>,
+    l1_block_tracker: &L1BlockTracker,
+    deposit_queue: &DepositQueue,
+    backfill_requests: &mpsc::Sender<BackfillRequest>,
+    backfill_server: &mut BackfillServerTask,
+) -> eyre::Result<()>
+where
+    P: BlockNumReader
+        + BlockReader<Block = Block>
+        + HeaderProvider<Header = TempoHeader>
+        + StateProviderFactory
+        + ReceiptProvider
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let mut pending = BTreeMap::<u64, Vec<u8>>::new();
+    let mut backfill = BackfillProgress::new();
+    let mut catch_up = LeaderCatchUp::default();
+
+    let mut retry = tokio::time::interval(BACKFILL_RETRY_INTERVAL);
+    retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let grace = tokio::time::sleep(LEADER_CATCHUP_GRACE_PERIOD);
+    tokio::pin!(grace);
+
+    info!(target: "zone::p2p", head = ?local_head(provider), "Probing peers before leader block production");
+
+    loop {
+        if catch_up.is_complete(backfill.needed) {
+            info!(target: "zone::p2p", head = ?local_head(provider), "Leader startup catch-up complete");
+            return Ok(());
+        }
+
+        tokio::select! {
+            event = events.recv() => {
+                let Some(event) = event else {
+                    eyre::bail!("P2P event channel closed");
+                };
+                // Any backfill response proves a peer is answering, which both settles what
+                // recovery is waiting for and keeps the grace period open.
+                if matches!(
+                    event,
+                    P2pEvent::BackfillBlockReceived { .. } | P2pEvent::BackfillCompleted { .. }
+                ) {
+                    catch_up.observe_response();
+                    grace.as_mut().reset(tokio::time::Instant::now() + LEADER_CATCHUP_GRACE_PERIOD);
+                }
+                match event {
+                    P2pEvent::BackfillRequested { peer, request_id, start } => {
+                        queue_backfill_request(backfill_requests, peer, request_id, start);
+                    }
+                    P2pEvent::BackfillBlockReceived { block, .. } => {
+                        absorb_peer_block(
+                            provider,
+                            engine,
+                            l1_block_tracker,
+                            deposit_queue,
+                            &mut pending,
+                            &mut backfill,
+                            block,
+                        ).await;
+                    }
+                    P2pEvent::BackfillCompleted { peer, tip } => {
+                        let Some(best) = local_head(provider) else { continue };
+                        backfill.complete(tip, best, pending.first_key_value().map(|(&number, _)| number));
+                        debug!(target: "zone::p2p", %peer, best, tip, backfill_needed = backfill.needed, "Completed leader catch-up response page");
+                    }
+                    P2pEvent::Started { .. }
+                    | P2pEvent::BlockReceived { .. }
+                    | P2pEvent::TransactionReceived { .. }
+                    | P2pEvent::SettlementProposalReceived { .. }
+                    | P2pEvent::SettlementSignatureReceived { .. } => {
+                        // A recovering leader neither builds blocks nor settles, and it follows
+                        // peer heads only through the backfill it asked for.
+                        debug!(target: "zone::p2p", "Ignoring non-backfill event during leader startup catch-up");
+                    }
+                }
+            }
+            _ = retry.tick(), if backfill.needed => {
+                let Some(best) = local_head(provider) else { continue };
+                if let Some(command) = backfill.request(best) {
+                    commands.send(command).await.map_err(|_| eyre::eyre!("P2P command channel closed"))?;
+                }
+            }
+            () = &mut grace => {
+                let head = local_head(provider);
+                if catch_up.may_start_unheard() {
+                    warn!(
+                        target: "zone::p2p",
+                        ?head,
+                        grace_secs = LEADER_CATCHUP_GRACE_PERIOD.as_secs(),
+                        "No peer answered the leader catch-up probe; starting block production from the local head"
+                    );
+                    return Ok(());
+                }
+                // A peer did answer, so its tip is authoritative: keep retrying instead of
+                // forking the zone from a stale head.
+                warn!(
+                    target: "zone::p2p",
+                    ?head,
+                    target_tip = ?backfill.target_tip,
+                    "Leader startup catch-up is still waiting for peer blocks"
+                );
+                grace.as_mut().reset(tokio::time::Instant::now() + LEADER_CATCHUP_GRACE_PERIOD);
+            }
+            result = &mut backfill_server.0 => {
+                match result {
+                    Ok(()) => eyre::bail!("block backfill server stopped unexpectedly"),
+                    Err(err) => eyre::bail!("block backfill server task failed: {err}"),
+                }
+            }
         }
     }
 }
 
-/// Leader will serve follower backfill requests (without ever requesting or importing peer blocks).
+/// Leader will serve peer backfill requests (without ever requesting or importing peer blocks).
 async fn run_leader_backfill_server<P>(
     provider: P,
     mut events: mpsc::Receiver<P2pEvent>,
-    commands: mpsc::Sender<P2pCommand>,
     attestation: AttestationContext,
+    backfill_requests: mpsc::Sender<BackfillRequest>,
+    mut backfill_server: BackfillServerTask,
 ) where
     P: BlockNumReader
         + BlockReader<Block = Block>
@@ -444,13 +661,6 @@ async fn run_leader_backfill_server<P>(
         + Sync
         + 'static,
 {
-    let (backfill_requests, backfill_request_rx) = mpsc::channel(BACKFILL_SERVE_QUEUE_CAPACITY);
-    let mut backfill_server = BackfillServerTask(tokio::spawn(serve_backfill_requests(
-        provider.clone(),
-        commands,
-        backfill_request_rx,
-    )));
-
     loop {
         tokio::select! {
             event = events.recv() => {
@@ -461,9 +671,7 @@ async fn run_leader_backfill_server<P>(
                 match event {
                     P2pEvent::Started { .. } => {}
                     P2pEvent::BackfillRequested { peer, request_id, start } => {
-                        if let Err(err) = backfill_requests.try_send(BackfillRequest { peer, request_id, start }) {
-                            tracing::warn!(target: "zone::p2p", %err, start, queue_capacity = BACKFILL_SERVE_QUEUE_CAPACITY, "Dropped block backfill request because the serving queue is unavailable");
-                        }
+                        queue_backfill_request(&backfill_requests, peer, request_id, start);
                     }
                     P2pEvent::SettlementSignatureReceived { follower, signature } => {
                         let result = async {
@@ -517,7 +725,7 @@ async fn run_leader_backfill_server<P>(
 }
 
 /// Serve catch-up requests and import live/backfilled blocks in canonical order on a follower.
-async fn run_follower_block_sync<P>(
+pub(crate) async fn run_follower_block_sync<P>(
     provider: P,
     engine: ConsensusEngineHandle<ZonePayloadTypes>,
     mut events: mpsc::Receiver<P2pEvent>,
@@ -599,77 +807,28 @@ async fn run_follower_block_sync<P>(
                         }
                     }
                     P2pEvent::BackfillRequested { peer, request_id, start } => {
-                        if let Err(err) = backfill_requests.try_send(BackfillRequest { peer, request_id, start }) {
-                            tracing::warn!(target: "zone::p2p", %err, start, queue_capacity = BACKFILL_SERVE_QUEUE_CAPACITY, "Dropped block backfill request because the serving queue is unavailable");
-                        }
+                        queue_backfill_request(&backfill_requests, peer, request_id, start);
                     }
                     P2pEvent::BlockReceived { block, .. }
                     | P2pEvent::BackfillBlockReceived { block, .. } => {
-                        match encoded_block_number(&block) {
-                            Ok(number) => {
-                                inactivity
-                                    .as_mut()
-                                    .reset(tokio::time::Instant::now() + BLOCK_INACTIVITY_TIMEOUT);
-                                let best = match provider.best_block_number() {
-                                    Ok(best) => best,
-                                    Err(err) => {
-                                        tracing::error!(target: "zone::p2p", %err, "Failed reading local head");
-                                        continue;
-                                    }
-                                };
-                                if number <= best {
-                                    if let Err(err) = import_peer_block(
-                                        &provider,
-                                        &engine,
-                                        &l1_block_tracker,
-                                        &deposit_queue,
-                                        &block,
-                                    ).await {
-                                        tracing::error!(target: "zone::p2p", %err, "Rejected duplicate or conflicting peer block");
-                                    }
-                                    continue;
-                                }
-                                backfill.observe_block(number, best);
-                                if let Some(dropped) = buffer_pending_block(&mut pending, number, block) {
-                                    tracing::warn!(target: "zone::p2p", dropped, pending_limit = MAX_PENDING_BLOCKS, "Dropped far-future peer block because the pending block buffer is full");
-                                }
-                                if number > best.saturating_add(1) {
-                                    info!(target: "zone::p2p", local_head = best, received = number, "Detected zone block gap; requesting backfill");
-                                }
-                                if let Err(err) = drain_pending_blocks(
-                                    &provider,
-                                    &engine,
-                                    &l1_block_tracker,
-                                    &deposit_queue,
-                                    &mut pending,
-                                ).await {
-                                    tracing::error!(target: "zone::p2p", %err, "Rejected peer block while draining backfill");
-                                    backfill.needed = true;
-                                } else {
-                                    let best = match provider.best_block_number() {
-                                        Ok(best) => best,
-                                        Err(err) => {
-                                            tracing::error!(target: "zone::p2p", %err, "Failed reading local head after importing peer blocks");
-                                            continue;
-                                        }
-                                    };
-                                    backfill.refresh_after_import(
-                                        best,
-                                        pending.first_key_value().map(|(&number, _)| number),
-                                    );
-                                }
-                            }
-                            Err(err) => tracing::error!(target: "zone::p2p", %err, "Rejected malformed peer block"),
+                        // Only a well-formed block counts as peer liveness; a peer flooding
+                        // malformed frames must not suppress the inactivity probe.
+                        if absorb_peer_block(
+                            &provider,
+                            &engine,
+                            &l1_block_tracker,
+                            &deposit_queue,
+                            &mut pending,
+                            &mut backfill,
+                            block,
+                        ).await {
+                            inactivity
+                                .as_mut()
+                                .reset(tokio::time::Instant::now() + BLOCK_INACTIVITY_TIMEOUT);
                         }
                     }
                     P2pEvent::BackfillCompleted { peer, tip } => {
-                        let best = match provider.best_block_number() {
-                            Ok(best) => best,
-                            Err(err) => {
-                                tracing::error!(target: "zone::p2p", %err, "Failed reading local head after backfill response");
-                                continue;
-                            }
-                        };
+                        let Some(best) = local_head(&provider) else { continue };
                         backfill.complete(
                             tip,
                             best,
@@ -686,13 +845,7 @@ async fn run_follower_block_sync<P>(
                 }
             }
             _ = retry.tick(), if backfill.needed => {
-                let best = match provider.best_block_number() {
-                    Ok(best) => best,
-                    Err(err) => {
-                        tracing::error!(target: "zone::p2p", %err, "Failed reading local head for backfill request");
-                        continue;
-                    }
-                };
+                let Some(best) = local_head(&provider) else { continue };
 
                 // retry the backfill
                 if let Some(command) = backfill.request(best)
@@ -708,13 +861,7 @@ async fn run_follower_block_sync<P>(
                 inactivity
                     .as_mut()
                     .reset(tokio::time::Instant::now() + BLOCK_INACTIVITY_TIMEOUT);
-                let best = match provider.best_block_number() {
-                    Ok(best) => best,
-                    Err(err) => {
-                        tracing::error!(target: "zone::p2p", %err, "Failed reading local head for inactivity backfill probe");
-                        continue;
-                    }
-                };
+                let Some(best) = local_head(&provider) else { continue };
                 let command = backfill.probe_after_inactivity(best);
                 info!(target: "zone::p2p", best, "No peer block received recently; probing for backfill");
                 if commands.send(command).await.is_err() {
@@ -731,6 +878,94 @@ async fn run_follower_block_sync<P>(
             }
         }
     }
+}
+
+/// Read the local canonical head, logging and yielding `None` on a provider error.
+fn local_head<P: BlockNumReader>(provider: &P) -> Option<u64> {
+    provider
+        .best_block_number()
+        .inspect_err(|err| tracing::error!(target: "zone::p2p", %err, "Failed reading local head"))
+        .ok()
+}
+
+/// Hand one peer catch-up request to the serving worker, dropping it under backpressure.
+fn queue_backfill_request(
+    backfill_requests: &mpsc::Sender<BackfillRequest>,
+    peer: zone_p2p::P2pPeerId,
+    request_id: u64,
+    start: u64,
+) {
+    if let Err(err) = backfill_requests.try_send(BackfillRequest {
+        peer,
+        request_id,
+        start,
+    }) {
+        warn!(target: "zone::p2p", %err, start, queue_capacity = BACKFILL_SERVE_QUEUE_CAPACITY, "Dropped block backfill request because the serving queue is unavailable");
+    }
+}
+
+/// Absorb one received peer block, then import everything that is now contiguous with the head.
+///
+/// Shared by follower replication and leader startup catch-up: both import strictly in canonical
+/// order and both track the same backfill progress. Returns whether the frame decoded as a zone
+/// block, so callers can treat only well-formed blocks as peer liveness.
+async fn absorb_peer_block<P>(
+    provider: &P,
+    engine: &ConsensusEngineHandle<ZonePayloadTypes>,
+    l1_block_tracker: &L1BlockTracker,
+    deposit_queue: &DepositQueue,
+    pending: &mut BTreeMap<u64, Vec<u8>>,
+    backfill: &mut BackfillProgress,
+    block: Vec<u8>,
+) -> bool
+where
+    P: BlockNumReader
+        + HeaderProvider<Header = TempoHeader>
+        + StateProviderFactory
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let number = match encoded_block_number(&block) {
+        Ok(number) => number,
+        Err(err) => {
+            tracing::error!(target: "zone::p2p", %err, "Rejected malformed peer block");
+            return false;
+        }
+    };
+    let Some(best) = local_head(provider) else {
+        return true;
+    };
+
+    if number <= best {
+        if let Err(err) =
+            import_peer_block(provider, engine, l1_block_tracker, deposit_queue, &block).await
+        {
+            tracing::error!(target: "zone::p2p", %err, "Rejected duplicate or conflicting peer block");
+        }
+        return true;
+    }
+
+    backfill.observe_block(number, best);
+    if let Some(dropped) = buffer_pending_block(pending, number, block) {
+        warn!(target: "zone::p2p", dropped, pending_limit = MAX_PENDING_BLOCKS, "Dropped far-future peer block because the pending block buffer is full");
+    }
+    if number > best.saturating_add(1) {
+        info!(target: "zone::p2p", local_head = best, received = number, "Detected zone block gap; requesting backfill");
+    }
+
+    if let Err(err) =
+        drain_pending_blocks(provider, engine, l1_block_tracker, deposit_queue, pending).await
+    {
+        tracing::error!(target: "zone::p2p", %err, "Rejected peer block while draining backfill");
+        backfill.needed = true;
+        return true;
+    }
+    if let Some(best) = local_head(provider) {
+        backfill.refresh_after_import(best, pending.first_key_value().map(|(&number, _)| number));
+    }
+    true
 }
 
 async fn drain_pending_blocks<P>(
@@ -984,8 +1219,8 @@ mod tests {
     use futures::{StreamExt as _, stream};
 
     use super::{
-        BackfillProgress, EncodedPersistedBlock, MAX_PENDING_BLOCKS, PersistedBlockSource,
-        PersistedTip, broadcast_persisted_blocks, buffer_pending_block,
+        BackfillProgress, EncodedPersistedBlock, LeaderCatchUp, MAX_PENDING_BLOCKS,
+        PersistedBlockSource, PersistedTip, broadcast_persisted_blocks, buffer_pending_block,
     };
     use alloy_primitives::B256;
     use zone_p2p::P2pCommand;
@@ -1332,6 +1567,66 @@ mod tests {
                 start: LOCAL_HEAD + 1,
             })
         );
+    }
+
+    #[test]
+    fn leader_startup_needs_peer_evidence_before_declaring_itself_caught_up() {
+        let mut catch_up = LeaderCatchUp::default();
+
+        // A silent network is indistinguishable from a fresh zone, so nothing but the grace
+        // period can release a leader that has not heard from a peer.
+        assert!(!catch_up.is_complete(true));
+        assert!(!catch_up.is_complete(false));
+        assert!(catch_up.may_start_unheard());
+
+        // Once a peer answers, its advertised tip is authoritative.
+        catch_up.observe_response();
+        assert!(!catch_up.may_start_unheard());
+        assert!(!catch_up.is_complete(true));
+        assert!(catch_up.is_complete(false));
+    }
+
+    #[test]
+    fn leader_catch_up_ends_when_peers_advertise_the_local_head() {
+        const LOCAL_HEAD: u64 = 42;
+
+        let mut catch_up = LeaderCatchUp::default();
+        let mut backfill = BackfillProgress::new();
+        assert_eq!(
+            backfill.request(LOCAL_HEAD),
+            Some(P2pCommand::RequestBackfill {
+                start: LOCAL_HEAD + 1,
+            })
+        );
+
+        // A peer at the same height answers with an empty page.
+        catch_up.observe_response();
+        backfill.complete(LOCAL_HEAD, LOCAL_HEAD, None);
+        assert!(catch_up.is_complete(backfill.needed));
+    }
+
+    #[test]
+    fn leader_catch_up_keeps_importing_while_a_peer_is_ahead() {
+        const LOCAL_HEAD: u64 = 42;
+        const PEER_TIP: u64 = 108;
+
+        let mut catch_up = LeaderCatchUp::default();
+        let mut backfill = BackfillProgress::new();
+        catch_up.observe_response();
+        backfill.complete(PEER_TIP, LOCAL_HEAD, None);
+
+        // The leader is provably behind, so it must not start producing on the stale head.
+        assert!(!catch_up.is_complete(backfill.needed));
+        assert_eq!(
+            backfill.request(LOCAL_HEAD),
+            Some(P2pCommand::RequestBackfill {
+                start: LOCAL_HEAD + 1,
+            })
+        );
+
+        // Importing through the advertised tip ends recovery without another response page.
+        backfill.refresh_after_import(PEER_TIP, None);
+        assert!(catch_up.is_complete(backfill.needed));
     }
 
     #[test]

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -117,6 +117,20 @@ offline or a gap remains. Followers request blocks from the statically configure
 recovering leader requests blocks from the configured followers. Both roles can serve bounded
 64-block response pages from their persisted canonical chain.
 
+### Leader startup recovery
+
+A leader is the sole writer of its own canonical head once block production starts, so a leader
+that crashed — or came back with an empty disk — has to catch up *before* that happens. On
+startup a leader therefore runs one recovery phase in which it behaves like a follower: it asks
+its peers for the blocks it is missing and imports them through the same validating path. Block
+production, block broadcast, and settlement proposals all start afterwards, from the recovered
+head.
+
+Recovery ends as soon as the leader's head matches every tip its peers advertised. A leader that
+hears nothing cannot tell an unreachable peer set apart from a brand new zone, so it starts
+producing after a bounded grace period and logs that it did so. Once any peer *has* answered, its
+tip is authoritative: the leader keeps retrying rather than forking the zone from a stale head.
+
 Backfilled blocks use the same RLP representation and import path as live replicated blocks. A
 node buffers out-of-order arrivals, then re-executes and canonicalizes only the next block after
 its local head. Parent linkage, execution results, block hash, and forkchoice validation therefore


### PR DESCRIPTION
## What

Adds a startup recovery phase for multi-sequencer **leaders**, so a leader that crashed — or came
back with an empty disk — catches up to the canonical chain before it starts producing blocks.

From the multi-sequencer list in Slack (item 1):

> Leader catchup — Today only followers are backfilled, but if a leader crashes/loses disk, we
> don't have a way to backfill

## Why

`run_block_sync` put leaders in a deliberately serve-only mode, with the gap called out in a doc
comment (`Leader recovery is deferred to a future startup recovery phase, before the zone engine
starts`). The P2P layer already routes a leader's `RequestBackfill` to its followers and accepts
their responses — nothing on the node side ever asked.

The consequence isn't just a stalled node. `ZoneEngine` snapshots the persisted head at launch,
sends an FCU for it, and is the sole writer of the leader's canonical head from then on. A leader
restarting behind its followers would silently rebuild the zone from a stale head.

## How

`run_leader_block_sync` replaces the serve-only leader loop with two phases sharing one backfill
serving worker:

1. **Recovery** — the leader behaves like a follower: probes peers, buffers out-of-order arrivals,
   and imports through the existing `import_peer_block` path. Parent linkage, independent L1 anchor
   observation, execution, and forkchoice validation are all unchanged.
2. **Serve-only** — the previous behaviour, unchanged.

Completion is published on a `watch` barrier (`LeaderRecovery`). Three tasks wait on it, and each
reads the head *after* it releases:

- `ZoneEngine` — its parent header is now read inside the task rather than at launch, so a
  recovered leader never forkchoices back to the head it started with.
- `broadcast_persisted_blocks` — otherwise the leader would re-broadcast the entire backfilled
  chain to the peers it just got it from.
- `collect_leader_settlements` — otherwise it would propose settlements for a stale head.

Node launch itself does **not** wait on the barrier, and that ordering is load-bearing: recovery
imports blocks through the engine API, and reth only spawns the consensus engine *after*
`launch_add_ons` returns. Awaiting recovery during launch would deadlock. Followers are unaffected.

Termination rules live in `LeaderCatchUp`:

- Any peer answered and the local head covers every advertised tip → done.
- **No** peer answered within a 10s grace period → start anyway, with a loud warning. A silent
  network is indistinguishable from a brand new zone, and starting is what leaders did before this
  change.
- A peer answered with a higher tip → its tip is authoritative. The leader keeps retrying rather
  than forking the zone, even if that peer subsequently goes away.

Also extracted `absorb_peer_block` / `local_head` / `queue_backfill_request` so recovery and
follower replication share one import path instead of two copies of the buffer/drain/refresh logic.
That also collapses five repeated `match provider.best_block_number()` blocks in the follower loop.
The role dispatch `run_block_sync` performed now sits next to the other role-based task spawning in
`launch_p2p`.

## Trade-offs / follow-ups

- A leader whose peer advertised a higher tip and then disappeared will never start producing.
  That is intentional — producing on a stale head is worse — but it is a new way for a leader to be
  stuck. It logs its head and the target tip every grace period.
- RPC and the sequencer monitor still come up during recovery, so a recovering leader briefly
  serves a stale head over RPC. `submit_batch` cannot act on it: it blocks on a settlement quorum,
  and no proposal is broadcast until recovery finishes.
- Recovery reuses the existing 64-block response pages and the 1/s backfill request quota, so a
  full disk-loss resync runs at roughly 64 blocks/s. Fine for a crash-restart, slow for a
  from-genesis rebuild. Raising the page size affects followers too, so it belongs in its own
  change.

## Testing

- `cargo test -p zone-node --lib`, `cargo clippy -p zone-p2p -p zone-node --all-targets
  --all-features`, `cargo fmt --check`.
- `e2e::test_p2p_follower_tracks_leader_balance` — exercises leader startup with a real follower;
  recovery completes as soon as the follower answers, before block production.
- New unit tests: the `LeaderCatchUp` decision table, plus recovery-completion and still-behind
  cases against the existing `BackfillProgress` state machine.
- The wire-level leader→follower backfill path is already covered by
  `leader_broadcasts_blocks_to_followers` in `zone-p2p`.
- **Not covered:** a true "leader restarts with a wiped datadir" end-to-end test. The node test
  harness builds a fresh in-memory node per launch and has no relaunch-with-existing-state path, so
  that needs harness work I did not want to fold into this PR.
