### PR TITLE
feat(multi-seq): add an rpc-only follower role

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13570,7 +13570,6 @@ dependencies = [
  "commonware-runtime",
  "commonware-utils",
  "const-hex",
- "derive_more",
  "eyre",
  "metrics",
  "serde",

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -199,8 +199,8 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 },
             });
         }
-        if manifest_role == Some(Role::Follower) {
-            info!(target: "reth::cli", "Starting in follower mode");
+        if let Some(role) = manifest_role.filter(|role| role.follows_leader()) {
+            info!(target: "reth::cli", %role, "Starting without block production");
         }
         if let Some(config) = p2p_config {
             node = node.with_p2p(config);
@@ -336,6 +336,8 @@ pub struct ZoneArgs {
     pub p2p_bypass_ip_check: bool,
 
     /// (Optional) Checked against the role derived from the manifest.
+    ///
+    /// One of `leader`, `follower`, or `rpc-follower`.
     #[arg(
         long = "sequencer.role",
         env = "SEQUENCER_ROLE",
@@ -452,8 +454,7 @@ fn prepend_log_filter(filter: &mut String, directives: &str) {
 
 fn sequencer_enabled(cli_flag: bool, manifest_role: Option<Role>) -> bool {
     match manifest_role {
-        Some(Role::Leader) => true,
-        Some(Role::Follower) => false,
+        Some(role) => role == Role::Leader,
         None => cli_flag,
     }
 }
@@ -738,8 +739,32 @@ mod tests {
     fn manifest_role_is_authoritative_for_sequencer_startup() {
         assert!(sequencer_enabled(false, Some(Role::Leader)));
         assert!(!sequencer_enabled(true, Some(Role::Follower)));
+        assert!(!sequencer_enabled(true, Some(Role::RpcFollower)));
         assert!(sequencer_enabled(true, None));
         assert!(!sequencer_enabled(false, None));
+    }
+
+    #[test]
+    fn sequencer_role_argument_accepts_the_rpc_follower_spelling() {
+        let parsed = ZoneArgsParser::try_parse_from([
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sequencer-key",
+            "0x01",
+            "--sequencer.manifest",
+            "zone.toml",
+            "--p2p.key",
+            "node.key",
+            "--secp256k1.key",
+            "node-secp256k1.key",
+            "--sequencer.role",
+            "rpc-follower",
+        ])
+        .unwrap();
+        assert_eq!(parsed.zone.sequencer_role, Some(Role::RpcFollower));
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -612,7 +612,9 @@ where
         let role = leadership.role_of(&local_ed25519_public_key);
         // Subscribe before starting Commonware (and, importantly, before RPC launch) so a
         // follower cannot admit a transaction in a startup gap.
-        let new_transactions = (role == Role::Follower).then(|| pool.new_transactions_listener());
+        let new_transactions = role
+            .follows_leader()
+            .then(|| pool.new_transactions_listener());
         let handle = spawn_p2p(config, network_id)?;
         let zone_p2p::P2pHandleParts {
             shutdown: shutdown_token,
@@ -640,7 +642,9 @@ where
                 );
                 sync_events
             }
-            Role::Follower => {
+            // An RPC-only follower replicates and forwards exactly like a quorum follower; it
+            // simply never receives a settlement proposal to sign.
+            Role::Follower | Role::RpcFollower => {
                 task_executor.spawn_critical_task(
                     "zone-p2p-transaction-forward",
                     forward_new_transactions(

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -413,7 +413,9 @@ pub(crate) async fn run_block_sync<P>(
     let role = leadership.role_of(&local_ed25519_public_key);
     match role {
         Role::Leader => run_leader_backfill_server(provider, events, commands, attestation).await,
-        Role::Follower => {
+        // An RPC-only follower imports the same chain through the same path; the P2P layer keeps
+        // settlement proposals away from it, so it never signs.
+        Role::Follower | Role::RpcFollower => {
             run_follower_block_sync(
                 provider,
                 engine,

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -22,7 +22,6 @@ commonware-runtime = { workspace = true, features = ["external"] }
 commonware-utils.workspace = true
 
 const-hex.workspace = true
-derive_more.workspace = true
 eyre.workspace = true
 metrics.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -14,10 +14,20 @@ behavior.
 - The **leader** runs the existing block-production and L1-settlement tasks in
   addition to the P2P network.
 - A **follower** joins the P2P network and receives blocks from the leader, validating and importing the blocks and sending a signed block hash back to the leader
+- An **rpc-follower** replicates and validates exactly like a follower, but never signs a
+  settlement attestation and is not registered with `ZonePortal`. It is a hot standby for public
+  RPC: it serves reads from its own imported chain and forwards transactions to the leader, so
+  neither the leader nor a quorum follower has to be exposed to the internet. Mark one with
+  `rpc_only = true` on its manifest node.
+
+Because rpc-followers are outside the on-chain quorum, they neither raise nor lower the signature
+threshold. The manifest therefore still requires at least three *quorum* nodes, and the leader
+cannot be `rpc_only`.
 
 The manifest is authoritative. The (optional) `--sequencer.role` CLI argument is
-only an assertion checked against the manifest. There is no automatic election or promotion.
- 
+only an assertion checked against the manifest — `leader`, `follower`, or `rpc-follower`. There is
+no automatic election or promotion.
+
 
 ## Commonware network
 
@@ -37,7 +47,7 @@ or endpoint is accidentally reused.
 
 ## Manifest example
 
-The manifest is TOML and must contain at least three nodes. The following shows
+The manifest is TOML and must contain at least three quorum nodes. The following shows
 the configuration shape:
 
 ```toml
@@ -62,11 +72,21 @@ name = "follower-b"
 ed25519_public_key = "0xfb..."
 secp256k1_address = "0x3333333333333333333333333333333333333333"
 address = "follower-b.zone.internal:9200"
+
+[[nodes]]
+name = "public-rpc"
+ed25519_public_key = "0xrpc..."
+secp256k1_address = "0x4444444444444444444444444444444444444444"
+address = "public-rpc.zone.internal:9200"
+rpc_only = true
 ```
+
+`rpc_only` defaults to `false`, so existing manifests keep their current meaning.
 
 The manifest loader validates that:
 
-- there are at least three nodes;
+- there are at least three quorum nodes (nodes without `rpc_only`);
+- the leader is not `rpc_only`;
 - node names, Ed25519 public keys, and secp256k1 addresses are unique;
 - every address has a non-zero port;
 - `leader_ed25519_public_key` identifies one of the nodes;
@@ -114,8 +134,9 @@ authentication remains enforced.
 
 Every node probes for missing blocks when P2P starts and retries while its eligible peers are
 offline or a gap remains. Followers request blocks from the statically configured leader. A
-recovering leader requests blocks from the configured followers. Both roles can serve bounded
-64-block response pages from their persisted canonical chain.
+recovering leader requests blocks from any replica. An rpc-follower requests from the leader *or*
+a quorum follower, so a leader outage does not stall the node that serves public reads. Every role
+can serve bounded 64-block response pages from its persisted canonical chain.
 
 Backfilled blocks use the same RLP representation and import path as live replicated blocks. A
 node buffers out-of-order arrivals, then re-executes and canonicalizes only the next block after
@@ -126,8 +147,9 @@ canonical.
 ## Transaction forwarding
 
 Commonware carries blocks, catch-up traffic, and transactions on independent authenticated
-channels. A follower sends canonical EIP-2718 transaction bytes only to the configured leader,
-and the leader accepts transaction messages only from manifest members with the follower role.
+channels. A follower — quorum or rpc-only — sends canonical EIP-2718 transaction bytes only to the
+configured leader, and the leader accepts transaction messages only from manifest members that
+follow its chain.
 
 This permits public RPC to be exposed on followers while keeping the leader's RPC private. The
 leader decodes and validates every forwarded transaction again, and it alone selects and orders

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -3,6 +3,7 @@ use std::{
     fmt,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::Path,
+    sync::Arc,
 };
 
 use alloy_primitives::Address as EthereumAddress;
@@ -10,18 +11,66 @@ use commonware_codec::DecodeExt as _;
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_p2p::{Address, Ingress};
 use commonware_utils::Hostname;
-use derive_more::{Display, FromStr};
 use serde::Deserialize;
 
+/// Minimum number of nodes that must be registered for the on-chain settlement quorum.
+const MIN_QUORUM_NODES: usize = 3;
+
 /// The role assigned to a node by the manifest.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, FromStr)]
-#[display(rename_all = "lowercase")]
-#[from_str(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
     /// Builds blocks and runs the existing sequencer settlement tasks.
     Leader,
-    /// Runs without block production, follows `Leader`s blocks
+    /// Runs without block production, follows `Leader`s blocks, and signs settlement
+    /// attestations for the on-chain quorum.
     Follower,
+    /// Follows `Leader`s blocks without joining the on-chain quorum.
+    ///
+    /// A hot standby for public RPC: it imports and serves the same chain and forwards
+    /// transactions to the leader, but never signs a settlement attestation. That keeps the
+    /// leader and the quorum followers off the internet without changing the quorum.
+    RpcFollower,
+}
+
+impl Role {
+    /// Whether this role replicates the leader's chain instead of producing blocks.
+    pub const fn follows_leader(self) -> bool {
+        matches!(self, Self::Follower | Self::RpcFollower)
+    }
+
+    /// Whether this role signs settlement attestations for the on-chain quorum.
+    pub const fn in_quorum(self) -> bool {
+        matches!(self, Self::Leader | Self::Follower)
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Leader => "leader",
+            Self::Follower => "follower",
+            Self::RpcFollower => "rpc-follower",
+        }
+    }
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for Role {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "leader" => Ok(Self::Leader),
+            "follower" => Ok(Self::Follower),
+            "rpc-follower" => Ok(Self::RpcFollower),
+            other => Err(format!(
+                "expected `leader`, `follower`, or `rpc-follower`, got `{other}`"
+            )),
+        }
+    }
 }
 
 /// Shared bootstrap leadership record for a zone node.
@@ -60,16 +109,27 @@ pub struct LeadershipState {
     pub leader: PublicKey,
     /// First block where the leader can become active.
     pub start_block: u64,
+    /// Members that replicate the chain without joining the on-chain quorum.
+    ///
+    /// Shared rather than copied: routing consults this on every P2P command.
+    rpc_followers: Arc<BTreeSet<PublicKey>>,
 }
 
 impl LeadershipState {
-    /// Creates a leadership record.
-    pub const fn new(epoch: u64, leader: PublicKey, start_block: u64) -> Self {
+    /// Creates a leadership record whose members all belong to the quorum.
+    pub fn new(epoch: u64, leader: PublicKey, start_block: u64) -> Self {
         Self {
             epoch,
             leader,
             start_block,
+            rpc_followers: Arc::default(),
         }
+    }
+
+    /// Marks the members that replicate the chain without joining the on-chain quorum.
+    pub fn with_rpc_followers(mut self, rpc_followers: BTreeSet<PublicKey>) -> Self {
+        self.rpc_followers = Arc::new(rpc_followers);
+        self
     }
 
     /// Monotonically increasing fencing epoch.
@@ -96,6 +156,8 @@ impl LeadershipState {
     pub fn role_of(&self, ed25519_public_key: &PublicKey) -> Role {
         if ed25519_public_key == &self.leader {
             Role::Leader
+        } else if self.rpc_followers.contains(ed25519_public_key) {
+            Role::RpcFollower
         } else {
             Role::Follower
         }
@@ -177,6 +239,7 @@ pub struct ManifestNode {
     ed25519_public_key: PublicKey,
     secp256k1_address: EthereumAddress,
     address: ManifestAddress,
+    rpc_only: bool,
 }
 
 impl ManifestNode {
@@ -199,6 +262,11 @@ impl ManifestNode {
     pub const fn address(&self) -> &ManifestAddress {
         &self.address
     }
+
+    /// Whether this node serves RPC without joining the on-chain settlement quorum.
+    pub const fn is_rpc_only(&self) -> bool {
+        self.rpc_only
+    }
 }
 
 /// A parsed and intrinsically validated zone manifest.
@@ -216,9 +284,6 @@ impl ZoneManifest {
         let raw: RawManifest = toml::from_str(input).map_err(ManifestError::Toml)?;
         if raw.sequencer_set_version == 0 {
             return Err(ManifestError::InvalidSequencerSetVersion);
-        }
-        if raw.nodes.len() < 3 {
-            return Err(ManifestError::TooFewNodes(raw.nodes.len()));
         }
 
         let leader_ed25519_public_key =
@@ -267,11 +332,15 @@ impl ZoneManifest {
                         address: raw_node.address.clone(),
                         reason,
                     })?;
+            if raw_node.rpc_only && ed25519_public_key == leader_ed25519_public_key {
+                return Err(ManifestError::RpcOnlyLeader(raw_node.name));
+            }
             nodes.push(ManifestNode {
                 name: raw_node.name,
                 ed25519_public_key,
                 secp256k1_address,
                 address,
+                rpc_only: raw_node.rpc_only,
             });
         }
 
@@ -279,6 +348,13 @@ impl ZoneManifest {
             return Err(ManifestError::LeaderEd25519PublicKeyNotFound(
                 leader_ed25519_public_key.to_string(),
             ));
+        }
+
+        // RPC-only members are not registered with `ZonePortal`, so they cannot make up for a
+        // quorum that is too small to settle.
+        let quorum_nodes = nodes.iter().filter(|node| !node.rpc_only).count();
+        if quorum_nodes < MIN_QUORUM_NODES {
+            return Err(ManifestError::TooFewQuorumNodes(quorum_nodes));
         }
 
         Ok(Self {
@@ -356,12 +432,23 @@ impl ZoneManifest {
 
     /// Static leadership record used for the lifetime of the process.
     pub fn bootstrap_leadership(&self) -> LeadershipState {
-        LeadershipState::new(0, self.leader_ed25519_public_key.clone(), 0)
+        LeadershipState::new(0, self.leader_ed25519_public_key.clone(), 0).with_rpc_followers(
+            self.nodes
+                .iter()
+                .filter(|node| node.rpc_only)
+                .map(|node| node.ed25519_public_key.clone())
+                .collect(),
+        )
     }
 
     /// All nodes in the static peer set.
     pub fn nodes(&self) -> &[ManifestNode] {
         &self.nodes
+    }
+
+    /// Nodes registered with `ZonePortal` for the on-chain settlement quorum.
+    pub fn quorum_nodes(&self) -> impl Iterator<Item = &ManifestNode> {
+        self.nodes.iter().filter(|node| !node.rpc_only)
     }
 
     /// Returns whether an Ed25519 key belongs to the manifest's static peer set.
@@ -402,6 +489,9 @@ struct RawManifestNode {
     ed25519_public_key: String,
     secp256k1_address: String,
     address: String,
+    /// Serve RPC as a hot standby without joining the on-chain settlement quorum.
+    #[serde(default)]
+    rpc_only: bool,
 }
 
 fn parse_ed25519_public_key(field: &str, encoded: &str) -> Result<PublicKey, ManifestError> {
@@ -433,8 +523,13 @@ pub enum ManifestError {
     #[error("invalid sequencer manifest TOML")]
     Toml(#[source] toml::de::Error),
 
-    #[error("sequencer manifest must contain at least 3 nodes, found {0}")]
-    TooFewNodes(usize),
+    #[error(
+        "sequencer manifest must contain at least {MIN_QUORUM_NODES} quorum nodes (nodes without `rpc_only`), found {0}"
+    )]
+    TooFewQuorumNodes(usize),
+
+    #[error("sequencer manifest leader `{0}` cannot be `rpc_only`")]
+    RpcOnlyLeader(String),
 
     #[error("sequencer manifest node names must not be empty")]
     EmptyNodeName,
@@ -490,7 +585,7 @@ pub enum ManifestError {
 mod tests {
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
-    use super::{ManifestError, Role, ZoneManifest};
+    use super::{MIN_QUORUM_NODES, ManifestError, Role, ZoneManifest};
 
     fn ed25519_public_key(seed: u64) -> String {
         let key = PrivateKey::from_seed(seed).public_key();
@@ -502,13 +597,21 @@ mod tests {
     }
 
     fn manifest(leader: u64, nodes: &[(u64, &str, &str)]) -> String {
+        let quorum = nodes
+            .iter()
+            .map(|(key, name, address)| (*key, *name, *address, false))
+            .collect::<Vec<_>>();
+        manifest_with_rpc_only(leader, &quorum)
+    }
+
+    fn manifest_with_rpc_only(leader: u64, nodes: &[(u64, &str, &str, bool)]) -> String {
         let mut value = format!(
             "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n",
             ed25519_public_key(leader)
         );
-        for (key, name, address) in nodes {
+        for (key, name, address, rpc_only) in nodes {
             value.push_str(&format!(
-                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\nrpc_only = {rpc_only}\n",
                 ed25519_public_key(*key),
                 secp256k1_address(*key),
             ));
@@ -565,9 +668,109 @@ mod tests {
             .split_once("\n```")
             .expect("README closes the TOML manifest example");
 
+        // The example uses placeholder keys, so only its shape can be checked.
         let manifest: super::RawManifest = toml::from_str(example).unwrap();
         assert_eq!(manifest.zone_id, 7);
-        assert_eq!(manifest.nodes.len(), 3);
+        assert_eq!(manifest.nodes.len(), 4);
+        assert_eq!(
+            manifest.nodes.iter().filter(|node| !node.rpc_only).count(),
+            MIN_QUORUM_NODES
+        );
+    }
+
+    #[test]
+    fn rpc_only_nodes_replicate_without_joining_the_quorum() {
+        let input = manifest_with_rpc_only(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200", false),
+                (2, "follower-a", "127.0.0.1:9201", false),
+                (3, "follower-b", "127.0.0.1:9202", false),
+                (4, "public-rpc", "127.0.0.1:9203", true),
+            ],
+        );
+        let manifest = ZoneManifest::parse(&input).unwrap();
+        let leader = PrivateKey::from_seed(1).public_key();
+        let follower = PrivateKey::from_seed(2).public_key();
+        let rpc_follower = PrivateKey::from_seed(4).public_key();
+        let leadership = manifest.bootstrap_leadership();
+
+        assert_eq!(leadership.role_of(&leader), Role::Leader);
+        assert_eq!(leadership.role_of(&follower), Role::Follower);
+        assert_eq!(leadership.role_of(&rpc_follower), Role::RpcFollower);
+
+        // The RPC standby replicates, but the on-chain quorum is unchanged by its presence.
+        assert!(Role::RpcFollower.follows_leader());
+        assert!(!Role::RpcFollower.in_quorum());
+        assert_eq!(manifest.nodes().len(), 4);
+        assert_eq!(manifest.quorum_nodes().count(), 3);
+        assert!(
+            manifest
+                .quorum_nodes()
+                .all(|node| node.ed25519_public_key() != &rpc_follower)
+        );
+
+        assert_eq!(
+            manifest
+                .validate_node(
+                    7,
+                    &rpc_follower,
+                    secp256k1_address(4).parse().unwrap(),
+                    Some(Role::RpcFollower),
+                )
+                .unwrap(),
+            Role::RpcFollower
+        );
+        assert!(matches!(
+            manifest.validate_node(
+                7,
+                &rpc_follower,
+                secp256k1_address(4).parse().unwrap(),
+                Some(Role::Follower),
+            ),
+            Err(ManifestError::RoleMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_topologies_that_would_shrink_the_quorum() {
+        // Four nodes, but only two of them can sign a settlement.
+        let thin_quorum = manifest_with_rpc_only(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200", false),
+                (2, "follower", "127.0.0.1:9201", false),
+                (3, "public-rpc-a", "127.0.0.1:9202", true),
+                (4, "public-rpc-b", "127.0.0.1:9203", true),
+            ],
+        );
+        assert!(matches!(
+            ZoneManifest::parse(&thin_quorum),
+            Err(ManifestError::TooFewQuorumNodes(2))
+        ));
+
+        // A leader cannot opt out of the quorum it settles for.
+        let rpc_only_leader = manifest_with_rpc_only(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200", true),
+                (2, "follower-a", "127.0.0.1:9201", false),
+                (3, "follower-b", "127.0.0.1:9202", false),
+            ],
+        );
+        assert!(matches!(
+            ZoneManifest::parse(&rpc_only_leader),
+            Err(ManifestError::RpcOnlyLeader(_))
+        ));
+    }
+
+    #[test]
+    fn role_round_trips_through_its_cli_and_manifest_spelling() {
+        for role in [Role::Leader, Role::Follower, Role::RpcFollower] {
+            assert_eq!(role.to_string().parse::<Role>().unwrap(), role);
+        }
+        assert_eq!("rpc-follower".parse::<Role>().unwrap(), Role::RpcFollower);
+        assert!("rpc_follower".parse::<Role>().is_err());
     }
 
     #[test]
@@ -581,7 +784,7 @@ mod tests {
         );
         assert!(matches!(
             ZoneManifest::parse(&too_small),
-            Err(ManifestError::TooFewNodes(2))
+            Err(ManifestError::TooFewQuorumNodes(2))
         ));
 
         let duplicate = manifest(

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -18,7 +18,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    Leadership, P2pNetworkId, Role, ZoneManifest,
+    Leadership, LeadershipState, P2pNetworkId, Role, ZoneManifest,
     identity::{Ed25519Identity, Secp256k1Identity},
     network::{
         self, BACKFILL_REQUEST_CHANNEL, BACKFILL_RESPONSE_CHANNEL, BLOCK_BACKLOG, BLOCK_CHANNEL,
@@ -202,11 +202,13 @@ impl P2pConfig {
         self.secp256k1_identity.signer()
     }
 
-    /// Expected attestation address for every peer.
+    /// Expected attestation address for every quorum peer.
+    ///
+    /// RPC-only members are deliberately absent: they never sign, so a signature claiming to come
+    /// from one has no registered address to match and is rejected.
     pub fn block_attestation_addresses(&self) -> HashMap<PublicKey, EthereumAddress> {
         self.manifest
-            .nodes()
-            .iter()
+            .quorum_nodes()
             .map(|node| (node.ed25519_public_key().clone(), node.secp256k1_address()))
             .collect()
     }
@@ -572,17 +574,10 @@ async fn run_commands(
     mut commands: mpsc::Receiver<P2pCommand>,
 ) -> eyre::Result<()> {
     while let Some(command) = commands.recv().await {
-        let (role, leader) = local_role_and_leader(&leadership, &local_ed25519_public_key);
-        // Built only in arms that actually address a peer set — forwarding a transaction must
-        // not allocate one. Keeping routing derived from the shared record also leaves one
-        // decision point for the future handoff implementation.
-        let followers = || {
-            peers
-                .iter()
-                .filter(|peer| *peer != &leader)
-                .cloned()
-                .collect::<Vec<_>>()
-        };
+        // Peer sets are built only in the arms that actually address one — forwarding a
+        // transaction must not allocate one. Deriving them from the shared record also leaves a
+        // single routing decision point for the future handoff implementation.
+        let (role, record) = local_leadership(&leadership, &local_ed25519_public_key);
         match command {
             P2pCommand::BroadcastBlock(block) => {
                 if role != Role::Leader {
@@ -595,14 +590,15 @@ async fn run_commands(
                     continue;
                 }
 
-                let followers = followers();
+                // Every replica needs the block, including RPC-only standbys.
+                let replicas = replicas(&record, &peers);
                 let sent = tokio::time::timeout(BROADCAST_RETRY_TIMEOUT, async {
                     loop {
                         let sent = senders.blocks
-                            .send(Recipients::Some(followers.clone()), block.clone(), true)
+                            .send(Recipients::Some(replicas.clone()), block.clone(), true)
                             .await
                             .map_err(|err| eyre::eyre!("failed broadcasting zone block: {err}"))?;
-                        if !sent.is_empty() || followers.is_empty() {
+                        if !sent.is_empty() || replicas.is_empty() {
                             return Ok::<_, eyre::Report>(sent);
                         }
                         debug!(target: "zone::p2p", "No followers are connected; retrying canonical block broadcast");
@@ -616,8 +612,8 @@ async fn run_commands(
                         continue;
                     }
                 };
-                if sent.len() != followers.len() {
-                    debug!(target: "zone::p2p", connected = sent.len(), configured = followers.len(), "Some followers are not connected; block was not sent to them");
+                if sent.len() != replicas.len() {
+                    debug!(target: "zone::p2p", connected = sent.len(), configured = replicas.len(), "Some followers are not connected; block was not sent to them");
                 }
             }
 
@@ -626,32 +622,36 @@ async fn run_commands(
                     warn!(target: "zone::p2p", "Ignoring settlement proposal command on follower");
                     continue;
                 }
+                // Only quorum members sign, so only they are asked.
                 senders
                     .settlement_proposals
-                    .send(Recipients::Some(followers()), proposal, true)
+                    .send(
+                        Recipients::Some(quorum_followers(&record, &peers)),
+                        proposal,
+                        true,
+                    )
                     .await
                     .wrap_err("failed broadcasting settlement proposal")?;
             }
 
             P2pCommand::SendSettlementSignature(signature) => {
                 if role != Role::Follower {
-                    warn!(target: "zone::p2p", "Ignoring settlement signature command on leader");
+                    warn!(target: "zone::p2p", %role, "Ignoring settlement signature command from a node outside the quorum");
                     continue;
                 }
                 senders
                     .settlement_signatures
-                    .send(Recipients::Some(vec![leader.clone()]), signature, true)
+                    .send(
+                        Recipients::Some(vec![record.leader.clone()]),
+                        signature,
+                        true,
+                    )
                     .await
                     .wrap_err("failed sending settlement signature")?;
             }
 
             P2pCommand::RequestBackfill { start } => {
-                let backfill_peers = match role {
-                    // A recovering leader can backfill from all followers.
-                    Role::Leader => followers(),
-                    // A recovering follower can backfill from the canonical leader.
-                    Role::Follower => vec![leader.clone()],
-                };
+                let backfill_peers = backfill_peers(&record, role, &peers);
                 let now = Instant::now();
                 let request = {
                     backfill_job
@@ -721,11 +721,12 @@ async fn run_commands(
                 transaction_hash,
                 transaction,
             } => {
-                if role != Role::Follower {
+                if !role.follows_leader() {
                     metrics::counter!("zone_p2p_role_invalid_messages_dropped_total").increment(1);
                     warn!(target: "zone::p2p", ?transaction_hash, "Ignoring outbound transaction command on leader");
                     continue;
                 }
+                let leader = &record.leader;
                 let sent = match senders
                     .transactions
                     .send(
@@ -757,12 +758,55 @@ async fn run_commands(
     Err(eyre::eyre!("P2P command channel closed unexpectedly"))
 }
 
-fn local_role_and_leader(
+/// Snapshot the leadership record together with this node's role under it.
+fn local_leadership(
     leadership: &Leadership,
     local_ed25519_public_key: &PublicKey,
-) -> (Role, PublicKey) {
+) -> (Role, LeadershipState) {
     let record = leadership.current();
-    (record.role_of(local_ed25519_public_key), record.leader)
+    (record.role_of(local_ed25519_public_key), record)
+}
+
+/// Peers that replicate the leader's blocks: every member except the leader.
+fn replicas(record: &LeadershipState, peers: &[PublicKey]) -> Vec<PublicKey> {
+    peers
+        .iter()
+        .filter(|peer| **peer != record.leader)
+        .cloned()
+        .collect()
+}
+
+/// Peers that sign settlement attestations: quorum members except the leader.
+fn quorum_followers(record: &LeadershipState, peers: &[PublicKey]) -> Vec<PublicKey> {
+    peers
+        .iter()
+        .filter(|peer| record.role_of(peer) == Role::Follower)
+        .cloned()
+        .collect()
+}
+
+/// Whether `peer` may serve block backfill to a local node holding `role`.
+///
+/// One predicate drives both sending requests and admitting responses, so the two cannot drift.
+fn serves_backfill_for(record: &LeadershipState, role: Role, peer: &PublicKey) -> bool {
+    match role {
+        // A recovering leader can backfill from any replica.
+        Role::Leader => peer != &record.leader,
+        // A follower's only authoritative source is the leader.
+        Role::Follower => peer == &record.leader,
+        // An RPC standby exists for when the leader is unavailable, so it also catches up from
+        // the quorum followers — they hold the same chain and are not exposed to the internet.
+        Role::RpcFollower => record.role_of(peer).in_quorum(),
+    }
+}
+
+/// Peers eligible to answer a local node's block backfill requests.
+fn backfill_peers(record: &LeadershipState, role: Role, peers: &[PublicKey]) -> Vec<PublicKey> {
+    peers
+        .iter()
+        .filter(|peer| serves_backfill_for(record, role, peer))
+        .cloned()
+        .collect()
 }
 
 async fn run_receivers(
@@ -787,9 +831,9 @@ async fn run_receivers(
             // Got a block
             result = blocks.recv() => {
                 let (peer, bytes) = result.map_err(|err| eyre::eyre!("block channel receive failed: {err}"))?;
-                let (role, leader) =
-                    local_role_and_leader(&leadership, &local_ed25519_public_key);
-                if role == Role::Leader || peer != leader {
+                let (role, record) =
+                    local_leadership(&leadership, &local_ed25519_public_key);
+                if role == Role::Leader || peer != record.leader {
                     warn!(target: "zone::p2p", %peer, "Ignoring live block from non-leader");
                     continue;
                 }
@@ -799,9 +843,10 @@ async fn run_receivers(
             // Got a settlement proposal at a batch boundary
             result = settlement_proposals.recv() => {
                 let (peer, bytes) = result.wrap_err("settlement proposal channel receive failed")?;
-                let (role, leader) =
-                    local_role_and_leader(&leadership, &local_ed25519_public_key);
-                if role != Role::Follower || peer != leader {
+                let (role, record) =
+                    local_leadership(&leadership, &local_ed25519_public_key);
+                // Only quorum followers sign; an RPC standby drops the proposal here.
+                if role != Role::Follower || peer != record.leader {
                     warn!(target: "zone::p2p", %peer, "Ignoring settlement proposal from ineligible peer");
                     continue;
                 }
@@ -811,9 +856,9 @@ async fn run_receivers(
             // Got a response from a follower to the settlement proposal
             result = settlement_signatures.recv() => {
                 let (peer, bytes) = result.wrap_err("settlement signature channel receive failed")?;
-                let (role, leader) =
-                    local_role_and_leader(&leadership, &local_ed25519_public_key);
-                if role != Role::Leader || peer == leader {
+                let (role, record) =
+                    local_leadership(&leadership, &local_ed25519_public_key);
+                if role != Role::Leader || record.role_of(&peer) != Role::Follower {
                     warn!(target: "zone::p2p", %peer, "Ignoring settlement signature from ineligible peer");
                     continue;
                 }
@@ -835,10 +880,9 @@ async fn run_receivers(
             // Got backfill response (for an existing request)
             result = backfill_responses.recv() => {
                 let (peer, bytes) = result.map_err(|err| eyre::eyre!("backfill response receive failed: {err}"))?;
-                let (role, leader) =
-                    local_role_and_leader(&leadership, &local_ed25519_public_key);
-                let eligible = match role { Role::Leader => peer != leader, Role::Follower => peer == leader };
-                if !eligible {
+                let (role, record) =
+                    local_leadership(&leadership, &local_ed25519_public_key);
+                if !serves_backfill_for(&record, role, &peer) {
                     warn!(target: "zone::p2p", %peer, "Ignoring backfill response from ineligible peer");
                     continue;
                 }
@@ -886,10 +930,11 @@ async fn run_receivers(
             // Got a transaction forwarded by an authenticated follower.
             result = transactions.recv() => {
                 let (peer, bytes) = result.map_err(|err| eyre::eyre!("transaction channel receive failed: {err}"))?;
-                let (role, leader) =
-                    local_role_and_leader(&leadership, &local_ed25519_public_key);
+                let (role, record) =
+                    local_leadership(&leadership, &local_ed25519_public_key);
+                // Any replica may forward, including an RPC-only standby serving public RPC.
                 if role != Role::Leader
-                    || peer == leader
+                    || !record.role_of(&peer).follows_leader()
                     || !manifest.contains_ed25519_public_key(&peer)
                 {
                     metrics::counter!("zone_p2p_role_invalid_messages_dropped_total").increment(1);
@@ -923,11 +968,11 @@ mod tests {
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
     use super::{
-        BACKFILL_RESPONSE_TIMEOUT, BackfillJob, P2pCommand, P2pConfig, P2pEvent, spawn_p2p,
-        validate_ip_check_configuration,
+        BACKFILL_RESPONSE_TIMEOUT, BackfillJob, P2pCommand, P2pConfig, P2pEvent, backfill_peers,
+        quorum_followers, replicas, spawn_p2p, validate_ip_check_configuration,
     };
     use crate::{
-        P2pNetworkId, ZoneManifest,
+        P2pNetworkId, Role, ZoneManifest,
         identity::{Ed25519Identity, Secp256k1Identity},
         network::MAX_MESSAGE_SIZE,
     };
@@ -980,6 +1025,22 @@ mod tests {
         assert!(lifecycle.complete(&peer, replacement_id, expired_at));
     }
 
+    /// Drain events for `duration`, failing if any of them satisfies `forbidden`.
+    async fn assert_no_event_matching(
+        events: &mut tokio::sync::mpsc::Receiver<P2pEvent>,
+        duration: Duration,
+        context: &str,
+        forbidden: impl Fn(&P2pEvent) -> bool,
+    ) {
+        let result = tokio::time::timeout(duration, async {
+            while let Some(event) = events.recv().await {
+                assert!(!forbidden(&event), "{context}");
+            }
+        })
+        .await;
+        assert!(result.is_err(), "{context}: event channel closed");
+    }
+
     async fn assert_no_backfill_response_events(
         events: &mut tokio::sync::mpsc::Receiver<P2pEvent>,
         duration: Duration,
@@ -1003,6 +1064,57 @@ mod tests {
         assert!(
             result.is_err(),
             "{context}: event channel closed while checking for unsolicited backfill response"
+        );
+    }
+
+    #[test]
+    fn peer_sets_keep_rpc_only_members_out_of_the_quorum() {
+        let identities = [1_u64, 2, 3, 4].map(ed25519_identity);
+        let mut input = format!(
+            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
+        );
+        for (index, identity) in identities.iter().enumerate() {
+            let rpc_only = index == 3;
+            input.push_str(&format!(
+                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"127.0.0.1:{}\"\nrpc_only = {rpc_only}\n",
+                const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
+                secp256k1_identity(index as u64 + 1).address(),
+                9200 + index,
+            ));
+        }
+        let manifest = ZoneManifest::parse(&input).unwrap();
+        let record = manifest.bootstrap_leadership();
+        let peers = identities
+            .iter()
+            .map(|identity| identity.ed25519_public_key())
+            .collect::<Vec<_>>();
+        let [leader, follower_a, follower_b, rpc] = peers.clone().try_into().unwrap();
+
+        // Blocks reach every replica; only quorum followers are asked to sign.
+        assert_eq!(
+            replicas(&record, &peers),
+            vec![follower_a.clone(), follower_b.clone(), rpc.clone()]
+        );
+        assert_eq!(
+            quorum_followers(&record, &peers),
+            vec![follower_a.clone(), follower_b.clone()]
+        );
+
+        // A recovering leader accepts any replica; a quorum follower only trusts the leader.
+        assert_eq!(
+            backfill_peers(&record, Role::Leader, &peers),
+            vec![follower_a.clone(), follower_b.clone(), rpc]
+        );
+        assert_eq!(
+            backfill_peers(&record, Role::Follower, &peers),
+            vec![leader.clone()]
+        );
+        // The RPC standby exists for when the leader is unavailable, so it also catches up from
+        // the quorum followers — but never from another RPC standby.
+        assert_eq!(
+            backfill_peers(&record, Role::RpcFollower, &peers),
+            vec![leader, follower_a, follower_b]
         );
     }
 
@@ -1436,6 +1548,179 @@ mod tests {
         })
         .await
         .expect("leader did not receive requested backfill completion");
+
+        for handle in handles {
+            tokio::time::timeout(Duration::from_secs(10), handle.shutdown())
+                .await
+                .expect("P2P runtime did not stop")
+                .expect("P2P runtime failed");
+        }
+    }
+
+    /// An RPC-only member replicates and forwards like any follower, but stays outside the
+    /// settlement quorum in both directions.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_only_follower_replicates_but_never_settles() {
+        const LEADER: usize = 0;
+        const QUORUM_FOLLOWER: usize = 1;
+        const QUORUM_FOLLOWER_B: usize = 2;
+        const RPC_FOLLOWER: usize = 3;
+
+        let addresses = [
+            available_address(),
+            available_address(),
+            available_address(),
+            available_address(),
+        ];
+        let identities = [21_u64, 22, 23, 24].map(ed25519_identity);
+        let mut input = format!(
+            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            const_hex::encode_prefixed(identities[LEADER].ed25519_public_key().as_ref())
+        );
+        for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
+            input.push_str(&format!(
+                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\nrpc_only = {}\n",
+                const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
+                secp256k1_identity(index as u64 + 21).address(),
+                index == RPC_FOLLOWER,
+            ));
+        }
+        let manifest = Arc::new(ZoneManifest::parse(&input).unwrap());
+        let rpc_follower_peer = identities[RPC_FOLLOWER].ed25519_public_key();
+        let mut handles = identities
+            .into_iter()
+            .zip(addresses)
+            .enumerate()
+            .map(|(index, (identity, listen))| {
+                spawn_p2p(
+                    P2pConfig {
+                        manifest: manifest.clone(),
+                        ed25519_identity: identity,
+                        secp256k1_identity: secp256k1_identity(index as u64 + 21),
+                        listen,
+                        bypass_ip_check: false,
+                        leadership: crate::Leadership::new(manifest.bootstrap_leadership()),
+                    },
+                    P2pNetworkId::new(1, address!("1111111111111111111111111111111111111111")),
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let leader_commands = handles[LEADER].parts.as_ref().unwrap().commands.clone();
+        let rpc_commands = handles[RPC_FOLLOWER]
+            .parts
+            .as_ref()
+            .unwrap()
+            .commands
+            .clone();
+
+        // Commonware drops messages for peers that have not handshaked yet, so each phase
+        // repeats its command until the expected peer observes it.
+        fn repeat(
+            commands: tokio::sync::mpsc::Sender<P2pCommand>,
+            command: P2pCommand,
+        ) -> tokio::task::JoinHandle<()> {
+            tokio::spawn(async move {
+                loop {
+                    commands.send(command.clone()).await.unwrap();
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            })
+        }
+
+        // Replication reaches every replica, including the RPC standby: it serves reads from its
+        // own imported chain. Waiting for all three also establishes the full mesh.
+        let block = vec![0xf8, 0x01, 0x80];
+        let broadcaster = repeat(
+            leader_commands.clone(),
+            P2pCommand::BroadcastBlock(block.clone()),
+        );
+        for index in [QUORUM_FOLLOWER, QUORUM_FOLLOWER_B, RPC_FOLLOWER] {
+            tokio::time::timeout(Duration::from_secs(15), async {
+                loop {
+                    if let Some(P2pEvent::BlockReceived {
+                        block: received, ..
+                    }) = handles[index].events_mut().recv().await
+                    {
+                        assert_eq!(received, block);
+                        return;
+                    }
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("node-{index} did not receive the leader's block"));
+        }
+        broadcaster.abort();
+
+        // Settlement proposals go only to the quorum.
+        let proposal = vec![0x10, 0x20];
+        let proposer = repeat(
+            leader_commands.clone(),
+            P2pCommand::BroadcastSettlementProposal(proposal.clone()),
+        );
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                if let Some(P2pEvent::SettlementProposalReceived {
+                    proposal: received, ..
+                }) = handles[QUORUM_FOLLOWER].events_mut().recv().await
+                {
+                    assert_eq!(received, proposal);
+                    return;
+                }
+            }
+        })
+        .await
+        .expect("quorum follower did not receive the settlement proposal");
+        // Proposals keep flowing through this window, so the standby has every chance to leak one.
+        assert_no_event_matching(
+            handles[RPC_FOLLOWER].events_mut(),
+            Duration::from_secs(2),
+            "RPC-only follower was asked to sign a settlement",
+            |event| matches!(event, P2pEvent::SettlementProposalReceived { .. }),
+        )
+        .await;
+        proposer.abort();
+
+        // ...and a signature from outside the quorum never reaches the leader. The receiving
+        // guard is covered by `peer_sets_keep_rpc_only_members_out_of_the_quorum`; here the
+        // command is dropped before it is ever sent.
+        rpc_commands
+            .send(P2pCommand::SendSettlementSignature(vec![0x30, 0x40]))
+            .await
+            .unwrap();
+
+        // Transaction forwarding still works: public RPC submissions must reach the leader.
+        let transaction_hash = B256::with_last_byte(7);
+        let transaction = vec![0x76, 0x07];
+        let forwarder = repeat(
+            rpc_commands.clone(),
+            P2pCommand::ForwardTransaction {
+                transaction_hash,
+                transaction: transaction.clone(),
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                match handles[LEADER].events_mut().recv().await {
+                    Some(P2pEvent::SettlementSignatureReceived { follower, .. }) => {
+                        panic!("leader accepted a settlement signature from {follower}")
+                    }
+                    Some(P2pEvent::TransactionReceived {
+                        follower_ed25519_public_key,
+                        transaction: received,
+                    }) => {
+                        assert_eq!(follower_ed25519_public_key, rpc_follower_peer);
+                        assert_eq!(received, transaction);
+                        return;
+                    }
+                    Some(_) => {}
+                    None => panic!("leader event channel closed"),
+                }
+            }
+        })
+        .await
+        .expect("leader did not receive the RPC-only follower's forwarded transaction");
+        forwarder.abort();
 
         for handle in handles {
             tokio::time::timeout(Duration::from_secs(10), handle.shutdown())


### PR DESCRIPTION
## What

Adds a third multi-sequencer role: an **rpc-only follower** that replicates and serves the zone's
chain without joining the on-chain settlement quorum.

From the multi-sequencer list in Slack (item 3):

> Add a new type of "rpc-only" follower that doesn't participate in the on chain quorum but serves
> as a hot-standby that can serve RPC requests so we don't expose the leader/follower to the
> internet.

## Why

Right now every manifest member is either the block producer or a quorum signer, so exposing
public RPC means exposing a node whose availability or compromise has consensus consequences. An
rpc-only member gives you a node that is safe to put on the internet: it holds and validates the
same chain, so reads are served locally, and writes are forwarded to the leader over the existing
authenticated channel.

## How

A manifest node marked `rpc_only = true` resolves to `Role::RpcFollower`. The field defaults to
`false`, so existing manifests are unchanged.

What an rpc-only member does, and does not, do:

| | leader | follower | rpc-follower |
|---|---|---|---|
| produces blocks | ✅ | — | — |
| imports replicated blocks | — | ✅ | ✅ |
| serves backfill to peers | ✅ | ✅ | ✅ |
| forwards transactions to the leader | — | ✅ | ✅ |
| receives settlement proposals | — | ✅ | — |
| signs settlement attestations | ✅ | ✅ | — |
| registered with `ZonePortal` | ✅ | ✅ | — |

Consequences that fell out of that:

- **The quorum is unchanged by how many standbys you run.** They are excluded from
  `block_attestation_addresses`, so a signature claiming to come from one has no registered
  address to match. The on-chain threshold comes from the portal, so nothing about settlement
  moves. The manifest minimum is now three *quorum* nodes rather than three nodes, and the leader
  cannot be `rpc_only`.
- **A standby backfills from the quorum followers too, not just the leader.** It exists to keep
  serving reads when the leader is unavailable, so tying its catch-up to the leader alone would
  defeat the point. It will not backfill from another standby.
- **Routing is one decision point per direction.** `replicas`, `quorum_followers`, and
  `serves_backfill_for` replace the inline `followers()` closure and the inline eligibility match,
  so sending a backfill request and admitting its response can no longer disagree about who is
  eligible.
- `Role` gained `follows_leader()` and `in_quorum()` predicates so call sites ask what they mean
  rather than enumerating variants. `Display`/`FromStr` are now hand-written to spell the new
  variant `rpc-follower` (derive_more's `rename_all = "lowercase"` would have produced
  `rpcfollower`); `derive_more` is no longer a `zone-p2p` dependency.

## Deployment note

An rpc-only node still needs its own Ed25519 and secp256k1 keys and a manifest entry, but its
secp256k1 address **must not** be registered with `ZonePortal` — registering it would add a signer
the zone never collects a signature from.

## Trade-offs / follow-ups

- `xtask create-zone` does not yet know how to generate a manifest with an rpc-only member; its
  output stays valid because `rpc_only` defaults to false. Worth a follow-up once the shape
  settles.
- An rpc-only node still loads a secp256k1 signer it never uses. Making the attestation signer
  optional per role is a wider refactor than this change warrants.
- Promotion/demotion (`#844`) does not yet know about this role. Since leadership is still static,
  a standby can't be promoted; that has to be handled when the handoff protocol lands.

## Testing

- `cargo test -p zone-p2p --lib`, `cargo test -p zone-node --lib`,
  `cargo clippy --workspace --all-targets`, `cargo fmt --check`.
- New `rpc_only_follower_replicates_but_never_settles` spins up a real four-node Commonware mesh
  and asserts the standby receives live blocks, is *not* sent a settlement proposal, cannot get a
  signature to the leader, and *can* get a forwarded transaction there.
- New unit tests: role derivation and quorum membership from a manifest; rejection of a topology
  whose quorum is too small and of an `rpc_only` leader; the peer-set routing table for all three
  roles; `Role` string round-trip; `--sequencer.role rpc-follower` parsing; `sequencer_enabled`.
