### PR TITLE
fix(ci): remove oversized test workspace cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,6 @@ jobs:
       - uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef
         with:
           toolchain: stable
-      # sccache avoids recompiling dependencies, while this cache also keeps the
-      # final linked workspace test binaries that sccache cannot cache.
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: test-build
-          cache-workspace-crates: true
-          cache-on-failure: true
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: nextest@0.9.124


### PR DESCRIPTION
## Summary

- remove the 17.6 GB workspace Rust cache from `build-test-artifacts`
- retain the existing `sccache`, Solidity cache, test archive, and parallel test shards

## Why

Recent runs spend roughly 7 minutes restoring and another 7 minutes saving the workspace cache, while rebuilding the test archive takes about 1.5 minutes.

## Measured impact

- this PR: [`build test artifacts` completed in 4m12s](https://github.com/tempoxyz/zones/actions/runs/30350258163/job/90245800932)
- latest `main` run: [`build test artifacts` completed in 17m30s](https://github.com/tempoxyz/zones/actions/runs/30290798528/job/90059808686)
- median of the five latest successful `main` runs: 9m58s

This PR is 13m18s faster than the latest `main` run and 5m46s faster than the recent median (58% reduction).

## Validation

- parsed `.github/workflows/test.yml` with PyYAML
- `git diff --check`
- `build test artifacts` completed successfully in CI

Prompted by: @grandizzy