### PR TITLE
feat(sequencer): add shadow prover validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13946,9 +13946,13 @@ dependencies = [
  "parking_lot",
  "proptest",
  "reth-chain-state",
+ "reth-evm",
  "reth-metrics",
+ "reth-primitives-traits",
  "reth-provider",
+ "reth-revm",
  "reth-storage-api",
+ "reth-trie-common",
  "schnellru",
  "serde_json",
  "tempo-alloy",
@@ -13959,6 +13963,9 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tracing",
+ "zone-evm",
+ "zone-l1",
+ "zone-spf",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13946,13 +13946,10 @@ dependencies = [
  "parking_lot",
  "proptest",
  "reth-chain-state",
- "reth-evm",
  "reth-metrics",
  "reth-primitives-traits",
  "reth-provider",
- "reth-revm",
  "reth-storage-api",
- "reth-trie-common",
  "schnellru",
  "serde_json",
  "tempo-alloy",
@@ -13965,6 +13962,7 @@ dependencies = [
  "tracing",
  "zone-evm",
  "zone-l1",
+ "zone-rpc",
  "zone-spf",
 ]
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -40,14 +40,14 @@ reth-ethereum = { workspace = true, features = [
   "node",
   "cli",
 ], optional = true }
+reth-evm.workspace = true
 reth-node-api.workspace = true
 reth-node-builder.workspace = true
 reth-payload-builder.workspace = true
 reth-payload-primitives.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
-reth-evm.workspace = true
-reth-revm.workspace = true
+reth-revm = { workspace = true, features = ["witness"] }
 reth-rpc.workspace = true
 reth-rpc-builder.workspace = true
 reth-rpc-eth-api.workspace = true

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -171,6 +171,10 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         } else {
             None
         };
+        eyre::ensure!(
+            !args.enable_prover || should_sequence_blocks,
+            "--sequencer.enable-prover requires a promotable sequencer node"
+        );
         let additional_decryption_keys =
             load_decryption_keys(args.deposit_decryption_keys_file.as_deref()).await?;
 
@@ -216,6 +220,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                     max_batch_gas: args.withdrawal_max_batch_gas,
                     max_in_flight_batches: args.withdrawal_max_in_flight_batches,
                 },
+                enable_prover: args.enable_prover,
             });
         }
         if let Some(config) = p2p_config {
@@ -498,6 +503,10 @@ pub struct ZoneArgs {
         conflicts_with = "sequencer_manifest"
     )]
     pub enable_sequencer: bool,
+
+    /// Validate finalized batch candidates with the SPF without changing settlement.
+    #[arg(long = "sequencer.enable-prover", env = "SEQUENCER_ENABLE_PROVER")]
+    pub enable_prover: bool,
 }
 
 impl ZoneArgs {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -88,7 +88,8 @@ use zone_payload::{
 use zone_rpc::ZoneDebugApiServer;
 use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
-    ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer_with_prover,
+    ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer,
+    spawn_zone_sequencer_with_prover,
 };
 
 /// Returns a known Tempo chain spec for an L1 chain ID.
@@ -690,14 +691,11 @@ where
         }
 
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
-        let prover_config = self
+        let prover_settings = self
             .sequencer_config
             .as_ref()
             .filter(|config| config.enable_prover)
-            .map(|config| ShadowProverConfig {
-                zone_id: config.zone_id,
-                evm_config: ctx.node.evm_config().clone(),
-            });
+            .map(|config| (config.zone_id, ctx.node.evm_config().clone()));
         let provider = ctx.node.provider().clone();
         let zone_provider = provider.clone();
         let pool = ctx.node.pool().clone();
@@ -730,6 +728,11 @@ where
                 Ok(())
             })
             .await?;
+        let prover_config = prover_settings.map(|(zone_id, evm_config)| ShadowProverConfig {
+            zone_id,
+            evm_config,
+            debug_api: ZoneDebugApi::new(handle.eth_handlers().api.clone()),
+        });
 
         Self::launch_redacted_rpc(
             self.redacted_rpc_config,
@@ -1092,14 +1095,14 @@ where
     }
 
     /// Build the leader-generation sequencer dependencies (activated only while leader).
-    fn build_leader_sequencer_deps(
+    fn build_leader_sequencer_deps<A>(
         config: ZoneSequencerAddOnsConfig,
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
         attestation_store: AttestationStore,
-        prover_config: Option<ShadowProverConfig>,
-    ) -> eyre::Result<LeaderSequencerDeps> {
+        prover_config: Option<ShadowProverConfig<A>>,
+    ) -> eyre::Result<LeaderSequencerDeps<A>> {
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
@@ -1295,7 +1298,7 @@ where
 
     /// Launch sequencer background tasks: batch submission, withdrawal processing,
     /// and engine shutdown hook.
-    async fn launch_sequencer_tasks(
+    async fn launch_sequencer_tasks<A>(
         config: ZoneSequencerAddOnsConfig,
         handle: &<Self as NodeAddOns<N>>::Handle,
         zone_provider: N::Provider,
@@ -1305,8 +1308,11 @@ where
         retry_connection_interval: Duration,
         sequencer_addr: Address,
         attestation_store: Option<AttestationStore>,
-        prover_config: Option<ShadowProverConfig>,
-    ) -> eyre::Result<()> {
+        prover_config: Option<ShadowProverConfig<A>>,
+    ) -> eyre::Result<()>
+    where
+        A: ZoneDebugApiServer + Send + Sync + 'static,
+    {
         info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
@@ -1323,14 +1329,28 @@ where
         let l1_transaction_signer = config
             .l1_transaction_signer
             .unwrap_or(config.sequencer_signer);
-        let seq_handle = spawn_zone_sequencer_with_prover(
-            sequencer_config,
-            l1_transaction_signer,
-            zone_provider,
-            prover_config,
-            tokio_util::sync::CancellationToken::new(),
-        )
-        .await;
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let seq_handle = match prover_config {
+            Some(prover_config) => {
+                spawn_zone_sequencer_with_prover(
+                    sequencer_config,
+                    l1_transaction_signer,
+                    zone_provider,
+                    prover_config,
+                    shutdown,
+                )
+                .await
+            }
+            None => {
+                spawn_zone_sequencer(
+                    sequencer_config,
+                    l1_transaction_signer,
+                    zone_provider,
+                    shutdown,
+                )
+                .await
+            }
+        };
         info!(target: "reth::cli", "Sequencer tasks spawned");
 
         // Critical task — node shuts down if either exits.

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1325,13 +1325,13 @@ where
         let l1_transaction_signer = config
             .l1_transaction_signer
             .unwrap_or(config.sequencer_signer);
-        let shutdown = tokio_util::sync::CancellationToken::new();
+        // Legacy single-sequencer mode: the tasks run for the process lifetime.
         let seq_handle = spawn_zone_sequencer(
             sequencer_config,
             l1_transaction_signer,
             zone_provider,
             prover_config,
-            shutdown,
+            tokio_util::sync::CancellationToken::new(),
         )
         .await;
         info!(target: "reth::cli", "Sequencer tasks spawned");

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -14,7 +14,7 @@ use crate::{
         run_role_controller,
     },
     rpc::{
-        OperatorZoneApi, SequencerRpcContext, ZoneApiServer as _, ZoneDebugApi, ZoneRpc,
+        NodeZoneDebugApi, OperatorZoneApi, SequencerRpcContext, ZoneApiServer as _, ZoneRpc,
         ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config, start_redacted_rpc,
     },
 };
@@ -85,11 +85,10 @@ use zone_payload::{
     DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, WithdrawalRevealEncryptor, ZonePayloadAttributes,
     ZonePayloadFactory, ZonePayloadTypes,
 };
-use zone_rpc::ZoneDebugApiServer;
+use zone_rpc::ZoneDebugApiRpcServer;
 use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
     ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer,
-    spawn_zone_sequencer_with_prover,
 };
 
 /// Returns a known Tempo chain spec for an L1 chain ID.
@@ -718,7 +717,7 @@ where
                     .modules
                     .merge_configured(operator_zone_api.into_rpc())?;
                 container.modules.merge_configured(
-                    ZoneDebugApi::new(container.registry.eth_api().clone()).into_rpc(),
+                    NodeZoneDebugApi::new(container.registry.eth_api().clone()).into_rpc(),
                 )?;
                 container.modules.merge_http(operator_zone_rpc_module(
                     portal_address,
@@ -731,7 +730,7 @@ where
         let prover_config = prover_settings.map(|(zone_id, evm_config)| ShadowProverConfig {
             zone_id,
             evm_config,
-            debug_api: ZoneDebugApi::new(handle.eth_handlers().api.clone()),
+            debug_api: Arc::new(NodeZoneDebugApi::new(handle.eth_handlers().api.clone())),
         });
 
         Self::launch_redacted_rpc(
@@ -1095,14 +1094,14 @@ where
     }
 
     /// Build the leader-generation sequencer dependencies (activated only while leader).
-    fn build_leader_sequencer_deps<A>(
+    fn build_leader_sequencer_deps(
         config: ZoneSequencerAddOnsConfig,
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
         attestation_store: AttestationStore,
-        prover_config: Option<ShadowProverConfig<A>>,
-    ) -> eyre::Result<LeaderSequencerDeps<A>> {
+        prover_config: Option<ShadowProverConfig>,
+    ) -> eyre::Result<LeaderSequencerDeps> {
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
@@ -1298,7 +1297,7 @@ where
 
     /// Launch sequencer background tasks: batch submission, withdrawal processing,
     /// and engine shutdown hook.
-    async fn launch_sequencer_tasks<A>(
+    async fn launch_sequencer_tasks(
         config: ZoneSequencerAddOnsConfig,
         handle: &<Self as NodeAddOns<N>>::Handle,
         zone_provider: N::Provider,
@@ -1308,11 +1307,8 @@ where
         retry_connection_interval: Duration,
         sequencer_addr: Address,
         attestation_store: Option<AttestationStore>,
-        prover_config: Option<ShadowProverConfig<A>>,
-    ) -> eyre::Result<()>
-    where
-        A: ZoneDebugApiServer + Send + Sync + 'static,
-    {
+        prover_config: Option<ShadowProverConfig>,
+    ) -> eyre::Result<()> {
         info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
@@ -1330,27 +1326,14 @@ where
             .l1_transaction_signer
             .unwrap_or(config.sequencer_signer);
         let shutdown = tokio_util::sync::CancellationToken::new();
-        let seq_handle = match prover_config {
-            Some(prover_config) => {
-                spawn_zone_sequencer_with_prover(
-                    sequencer_config,
-                    l1_transaction_signer,
-                    zone_provider,
-                    prover_config,
-                    shutdown,
-                )
-                .await
-            }
-            None => {
-                spawn_zone_sequencer(
-                    sequencer_config,
-                    l1_transaction_signer,
-                    zone_provider,
-                    shutdown,
-                )
-                .await
-            }
-        };
+        let seq_handle = spawn_zone_sequencer(
+            sequencer_config,
+            l1_transaction_signer,
+            zone_provider,
+            prover_config,
+            shutdown,
+        )
+        .await;
         info!(target: "reth::cli", "Sequencer tasks spawned");
 
         // Critical task — node shuts down if either exits.

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -87,8 +87,8 @@ use zone_payload::{
 };
 use zone_rpc::ZoneDebugApiServer;
 use zone_sequencer::{
-    AttestationStore, BatchAnchorConfig, WithdrawalBatchLimits, ZoneSequencerConfig,
-    attestation::AttestationDomain, spawn_zone_sequencer,
+    AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
+    ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer_with_prover,
 };
 
 /// Returns a known Tempo chain spec for an L1 chain ID.
@@ -178,6 +178,8 @@ pub struct ZoneSequencerAddOnsConfig {
     pub withdrawal_poll_interval: Duration,
     /// Gas and concurrency limits for withdrawal processing transactions.
     pub withdrawal_batch_limits: WithdrawalBatchLimits,
+    /// Run the SPF over finalized candidates in detached, observational mode.
+    pub enable_prover: bool,
 }
 
 /// Configuration for the Zone redacted RPC server extension.
@@ -688,6 +690,14 @@ where
         }
 
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
+        let prover_config = self
+            .sequencer_config
+            .as_ref()
+            .filter(|config| config.enable_prover)
+            .map(|config| ShadowProverConfig {
+                zone_id: config.zone_id,
+                evm_config: ctx.node.evm_config().clone(),
+            });
         let provider = ctx.node.provider().clone();
         let zone_provider = provider.clone();
         let pool = ctx.node.pool().clone();
@@ -761,6 +771,7 @@ where
                     self.l1_config.portal_address,
                     self.l1_config.retry_connection_interval,
                     attestation.store.clone(),
+                    prover_config.clone(),
                 )?),
                 None => None,
             };
@@ -812,6 +823,7 @@ where
                 self.l1_config.retry_connection_interval,
                 sequencer_addr,
                 None,
+                prover_config,
             )
             .await?;
         }
@@ -1086,6 +1098,7 @@ where
         portal_address: Address,
         retry_connection_interval: Duration,
         attestation_store: AttestationStore,
+        prover_config: Option<ShadowProverConfig>,
     ) -> eyre::Result<LeaderSequencerDeps> {
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
@@ -1102,6 +1115,7 @@ where
         Ok(LeaderSequencerDeps {
             config,
             sequencer_config,
+            prover_config,
         })
     }
 
@@ -1291,6 +1305,7 @@ where
         retry_connection_interval: Duration,
         sequencer_addr: Address,
         attestation_store: Option<AttestationStore>,
+        prover_config: Option<ShadowProverConfig>,
     ) -> eyre::Result<()> {
         info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
         let sequencer_config = ZoneSequencerConfig {
@@ -1308,11 +1323,11 @@ where
         let l1_transaction_signer = config
             .l1_transaction_signer
             .unwrap_or(config.sequencer_signer);
-        // Legacy single-sequencer mode: the tasks run for the process lifetime.
-        let seq_handle = spawn_zone_sequencer(
+        let seq_handle = spawn_zone_sequencer_with_prover(
             sequencer_config,
             l1_transaction_signer,
             zone_provider,
+            prover_config,
             tokio_util::sync::CancellationToken::new(),
         )
         .await;

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -35,8 +35,8 @@ use zone_p2p::{
 };
 use zone_payload::ZonePayloadTypes;
 use zone_sequencer::{
-    ZoneSequencerConfig, ZoneSequencerHandle, ZoneSequencerProvider, resolve_portal_zone_anchor,
-    spawn_zone_sequencer,
+    ShadowProverConfig, ZoneSequencerConfig, ZoneSequencerHandle, ZoneSequencerProvider,
+    resolve_portal_zone_anchor, spawn_zone_sequencer, spawn_zone_sequencer_with_prover,
 };
 use zone_transaction_pool_alias::TempoPooledTransaction;
 
@@ -110,6 +110,7 @@ pub type SharedRoleStatus = Arc<std::sync::Mutex<RoleStatus>>;
 pub(crate) struct LeaderSequencerDeps {
     pub config: ZoneSequencerAddOnsConfig,
     pub sequencer_config: ZoneSequencerConfig,
+    pub prover_config: Option<ShadowProverConfig>,
 }
 
 /// Sinks for the long-lived P2P event demultiplexer.
@@ -936,12 +937,14 @@ where
                 .clone()
                 .unwrap_or_else(|| sequencer.config.sequencer_signer.clone());
             let zone_provider = context.provider.clone();
+            let prover_config = sequencer.prover_config.clone();
             let sequencer_token = token.clone();
             tasks.spawn(async move {
-                let handle = spawn_zone_sequencer(
+                let handle = spawn_zone_sequencer_with_prover(
                     sequencer_config,
                     signer,
                     zone_provider,
+                    prover_config,
                     sequencer_token.clone(),
                 )
                 .await;

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -34,10 +34,9 @@ use zone_p2p::{
     P2pPeerId,
 };
 use zone_payload::ZonePayloadTypes;
-use zone_rpc::ZoneDebugApiServer;
 use zone_sequencer::{
     ShadowProverConfig, ZoneSequencerConfig, ZoneSequencerHandle, ZoneSequencerProvider,
-    resolve_portal_zone_anchor, spawn_zone_sequencer, spawn_zone_sequencer_with_prover,
+    resolve_portal_zone_anchor, spawn_zone_sequencer,
 };
 use zone_transaction_pool_alias::TempoPooledTransaction;
 
@@ -65,7 +64,7 @@ const GENERATION_RESTART_BACKOFF: Duration = Duration::from_millis(500);
 const GENERATION_EVENT_BACKLOG: usize = 128;
 
 /// Everything a role generation needs to start its tasks.
-pub(crate) struct RoleControllerContext<P, Pool, A> {
+pub(crate) struct RoleControllerContext<P, Pool> {
     pub local_ed25519_public_key: P2pPeerId,
     pub schedule: LeadershipSchedule,
     pub provider: P,
@@ -82,7 +81,7 @@ pub(crate) struct RoleControllerContext<P, Pool, A> {
     pub portal_address: Address,
     /// Sequencer resources constructed unconditionally at startup; activation is gated by
     /// the leader generation. `None` means this node can never lead.
-    pub sequencer: Option<LeaderSequencerDeps<A>>,
+    pub sequencer: Option<LeaderSequencerDeps>,
     /// Tip evidence advertised by peers via backfill completions.
     pub peer_tips: PeerTipRegistry,
     /// Live role/readiness snapshot shared with the status RPC.
@@ -108,10 +107,10 @@ pub struct RoleStatus {
 pub type SharedRoleStatus = Arc<std::sync::Mutex<RoleStatus>>;
 
 /// Leader-only background task dependencies (batch submission, withdrawal processing).
-pub(crate) struct LeaderSequencerDeps<A> {
+pub(crate) struct LeaderSequencerDeps {
     pub config: ZoneSequencerAddOnsConfig,
     pub sequencer_config: ZoneSequencerConfig,
-    pub prover_config: Option<ShadowProverConfig<A>>,
+    pub prover_config: Option<ShadowProverConfig>,
 }
 
 /// Sinks for the long-lived P2P event demultiplexer.
@@ -509,8 +508,8 @@ where
 /// role by the next-anchor rule, and switches role generations.
 /// Observation alone never switches roles — the trigger is consumption progress reaching
 /// the boundary, which this loop tracks by re-reading the local Tempo checkpoint.
-pub(crate) async fn run_role_controller<P, Pool, A>(
-    context: RoleControllerContext<P, Pool, A>,
+pub(crate) async fn run_role_controller<P, Pool>(
+    context: RoleControllerContext<P, Pool>,
     sinks: EventSinks,
 ) where
     P: BlockNumReader
@@ -525,7 +524,6 @@ pub(crate) async fn run_role_controller<P, Pool, A>(
         + Sync
         + 'static,
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
-    A: ZoneDebugApiServer + Clone + Send + Sync + 'static,
 {
     let mut schedule_changes = context.schedule.subscribe();
 
@@ -731,8 +729,8 @@ pub(crate) async fn run_role_controller<P, Pool, A>(
     }
 }
 
-async fn start_generation<P, Pool, A>(
-    context: &RoleControllerContext<P, Pool, A>,
+async fn start_generation<P, Pool>(
+    context: &RoleControllerContext<P, Pool>,
     sinks: &EventSinks,
     desired: DesiredRole,
     id: u64,
@@ -750,7 +748,6 @@ where
         + Sync
         + 'static,
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
-    A: ZoneDebugApiServer + Clone + Send + Sync + 'static,
 {
     let token = CancellationToken::new();
     let mut tasks = JoinSet::new();
@@ -943,27 +940,14 @@ where
             let prover_config = sequencer.prover_config.clone();
             let sequencer_token = token.clone();
             tasks.spawn(async move {
-                let handle = match prover_config {
-                    Some(prover_config) => {
-                        spawn_zone_sequencer_with_prover(
-                            sequencer_config,
-                            signer,
-                            zone_provider,
-                            prover_config,
-                            sequencer_token.clone(),
-                        )
-                        .await
-                    }
-                    None => {
-                        spawn_zone_sequencer(
-                            sequencer_config,
-                            signer,
-                            zone_provider,
-                            sequencer_token.clone(),
-                        )
-                        .await
-                    }
-                };
+                let handle = spawn_zone_sequencer(
+                    sequencer_config,
+                    signer,
+                    zone_provider,
+                    prover_config,
+                    sequencer_token.clone(),
+                )
+                .await;
                 supervise_sequencer_tasks(handle, sequencer_token).await
             });
 
@@ -990,9 +974,9 @@ where
         .ok_or_else(|| eyre::eyre!("no latest block header"))
 }
 
-fn build_engine<P, Pool, A>(
-    context: &RoleControllerContext<P, Pool, A>,
-    sequencer: &LeaderSequencerDeps<A>,
+fn build_engine<P, Pool>(
+    context: &RoleControllerContext<P, Pool>,
+    sequencer: &LeaderSequencerDeps,
     last_header: SealedHeader<TempoHeader>,
 ) -> ZoneEngine
 where

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -34,9 +34,10 @@ use zone_p2p::{
     P2pPeerId,
 };
 use zone_payload::ZonePayloadTypes;
+use zone_rpc::ZoneDebugApiServer;
 use zone_sequencer::{
     ShadowProverConfig, ZoneSequencerConfig, ZoneSequencerHandle, ZoneSequencerProvider,
-    resolve_portal_zone_anchor, spawn_zone_sequencer_with_prover,
+    resolve_portal_zone_anchor, spawn_zone_sequencer, spawn_zone_sequencer_with_prover,
 };
 use zone_transaction_pool_alias::TempoPooledTransaction;
 
@@ -64,7 +65,7 @@ const GENERATION_RESTART_BACKOFF: Duration = Duration::from_millis(500);
 const GENERATION_EVENT_BACKLOG: usize = 128;
 
 /// Everything a role generation needs to start its tasks.
-pub(crate) struct RoleControllerContext<P, Pool> {
+pub(crate) struct RoleControllerContext<P, Pool, A> {
     pub local_ed25519_public_key: P2pPeerId,
     pub schedule: LeadershipSchedule,
     pub provider: P,
@@ -81,7 +82,7 @@ pub(crate) struct RoleControllerContext<P, Pool> {
     pub portal_address: Address,
     /// Sequencer resources constructed unconditionally at startup; activation is gated by
     /// the leader generation. `None` means this node can never lead.
-    pub sequencer: Option<LeaderSequencerDeps>,
+    pub sequencer: Option<LeaderSequencerDeps<A>>,
     /// Tip evidence advertised by peers via backfill completions.
     pub peer_tips: PeerTipRegistry,
     /// Live role/readiness snapshot shared with the status RPC.
@@ -107,10 +108,10 @@ pub struct RoleStatus {
 pub type SharedRoleStatus = Arc<std::sync::Mutex<RoleStatus>>;
 
 /// Leader-only background task dependencies (batch submission, withdrawal processing).
-pub(crate) struct LeaderSequencerDeps {
+pub(crate) struct LeaderSequencerDeps<A> {
     pub config: ZoneSequencerAddOnsConfig,
     pub sequencer_config: ZoneSequencerConfig,
-    pub prover_config: Option<ShadowProverConfig>,
+    pub prover_config: Option<ShadowProverConfig<A>>,
 }
 
 /// Sinks for the long-lived P2P event demultiplexer.
@@ -508,8 +509,8 @@ where
 /// role by the next-anchor rule, and switches role generations.
 /// Observation alone never switches roles — the trigger is consumption progress reaching
 /// the boundary, which this loop tracks by re-reading the local Tempo checkpoint.
-pub(crate) async fn run_role_controller<P, Pool>(
-    context: RoleControllerContext<P, Pool>,
+pub(crate) async fn run_role_controller<P, Pool, A>(
+    context: RoleControllerContext<P, Pool, A>,
     sinks: EventSinks,
 ) where
     P: BlockNumReader
@@ -524,6 +525,7 @@ pub(crate) async fn run_role_controller<P, Pool>(
         + Sync
         + 'static,
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
+    A: ZoneDebugApiServer + Clone + Send + Sync + 'static,
 {
     let mut schedule_changes = context.schedule.subscribe();
 
@@ -729,8 +731,8 @@ pub(crate) async fn run_role_controller<P, Pool>(
     }
 }
 
-async fn start_generation<P, Pool>(
-    context: &RoleControllerContext<P, Pool>,
+async fn start_generation<P, Pool, A>(
+    context: &RoleControllerContext<P, Pool, A>,
     sinks: &EventSinks,
     desired: DesiredRole,
     id: u64,
@@ -748,6 +750,7 @@ where
         + Sync
         + 'static,
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
+    A: ZoneDebugApiServer + Clone + Send + Sync + 'static,
 {
     let token = CancellationToken::new();
     let mut tasks = JoinSet::new();
@@ -940,14 +943,27 @@ where
             let prover_config = sequencer.prover_config.clone();
             let sequencer_token = token.clone();
             tasks.spawn(async move {
-                let handle = spawn_zone_sequencer_with_prover(
-                    sequencer_config,
-                    signer,
-                    zone_provider,
-                    prover_config,
-                    sequencer_token.clone(),
-                )
-                .await;
+                let handle = match prover_config {
+                    Some(prover_config) => {
+                        spawn_zone_sequencer_with_prover(
+                            sequencer_config,
+                            signer,
+                            zone_provider,
+                            prover_config,
+                            sequencer_token.clone(),
+                        )
+                        .await
+                    }
+                    None => {
+                        spawn_zone_sequencer(
+                            sequencer_config,
+                            signer,
+                            zone_provider,
+                            sequencer_token.clone(),
+                        )
+                        .await
+                    }
+                };
                 supervise_sequencer_tasks(handle, sequencer_token).await
             });
 
@@ -974,9 +990,9 @@ where
         .ok_or_else(|| eyre::eyre!("no latest block header"))
 }
 
-fn build_engine<P, Pool>(
-    context: &RoleControllerContext<P, Pool>,
-    sequencer: &LeaderSequencerDeps,
+fn build_engine<P, Pool, A>(
+    context: &RoleControllerContext<P, Pool, A>,
+    sequencer: &LeaderSequencerDeps<A>,
     last_header: SealedHeader<TempoHeader>,
 ) -> ZoneEngine
 where

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -36,7 +36,7 @@ use zone_p2p::{
 use zone_payload::ZonePayloadTypes;
 use zone_sequencer::{
     ShadowProverConfig, ZoneSequencerConfig, ZoneSequencerHandle, ZoneSequencerProvider,
-    resolve_portal_zone_anchor, spawn_zone_sequencer, spawn_zone_sequencer_with_prover,
+    resolve_portal_zone_anchor, spawn_zone_sequencer_with_prover,
 };
 use zone_transaction_pool_alias::TempoPooledTransaction;
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -57,22 +57,18 @@ use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
 use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
 use zone_evm::ZoneEvmConfig;
 use zone_p2p::{LeadershipSchedule, PeerTip, ZoneManifest};
-use zone_rpc::types::{TempoStorageRead as RpcTempoStorageRead, ZoneExecutionWitness};
 use zone_rpc::{
     auth::AuthContext,
     types::{
         ActiveLeaderInfo, AuthorizationTokenInfoResponse, BoxEyreFut, BoxFut, JsonRpcError,
         LocalSequencerInfo, PeerTipInfo, SequencerInfoResponse, SequencerPeerInfo,
-        SequencerProgress, SequencerReadiness, SetLeaderResponse, ZoneInfoResponse, internal,
+        SequencerProgress, SequencerReadiness, SetLeaderResponse,
+        TempoStorageRead as RpcTempoStorageRead, ZoneExecutionWitness, ZoneInfoResponse, internal,
         raw_null, raw_zero, to_raw,
     },
 };
 
 use crate::{replication::PeerTipRegistry, role::SharedRoleStatus};
-
-fn operator_rpc_error(error: JsonRpcError) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(error.code as i32, error.message, error.data)
-}
 
 /// Multi-sequencer handles for the sequencer RPC methods.
 ///
@@ -225,18 +221,18 @@ where
 
 /// Zone-specific debug API backed directly by the node's full `EthApi`.
 #[derive(Clone)]
-pub(crate) struct ZoneDebugApi<E> {
+pub(crate) struct NodeZoneDebugApi<E> {
     eth_api: E,
 }
 
-impl<E> ZoneDebugApi<E> {
+impl<E> NodeZoneDebugApi<E> {
     pub(crate) const fn new(eth_api: E) -> Self {
         Self { eth_api }
     }
 }
 
 #[jsonrpsee::core::async_trait]
-impl<E> ZoneDebugApiServer for ZoneDebugApi<E>
+impl<E> ZoneDebugApi for NodeZoneDebugApi<E>
 where
     E: FullEthApi<Evm = ZoneEvmConfig, Primitives = TempoPrimitives>,
 {
@@ -290,6 +286,10 @@ where
             .await
             .map_err(|error| operator_rpc_error(internal(error)))
     }
+}
+
+fn operator_rpc_error(error: JsonRpcError) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(error.code as i32, error.message, error.data)
 }
 
 async fn zone_tokens(

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -57,18 +57,22 @@ use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
 use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
 use zone_evm::ZoneEvmConfig;
 use zone_p2p::{LeadershipSchedule, PeerTip, ZoneManifest};
+use zone_rpc::types::{TempoStorageRead as RpcTempoStorageRead, ZoneExecutionWitness};
 use zone_rpc::{
     auth::AuthContext,
     types::{
         ActiveLeaderInfo, AuthorizationTokenInfoResponse, BoxEyreFut, BoxFut, JsonRpcError,
         LocalSequencerInfo, PeerTipInfo, SequencerInfoResponse, SequencerPeerInfo,
-        SequencerProgress, SequencerReadiness, SetLeaderResponse,
-        TempoStorageRead as RpcTempoStorageRead, ZoneExecutionWitness, ZoneInfoResponse, internal,
+        SequencerProgress, SequencerReadiness, SetLeaderResponse, ZoneInfoResponse, internal,
         raw_null, raw_zero, to_raw,
     },
 };
 
 use crate::{replication::PeerTipRegistry, role::SharedRoleStatus};
+
+fn operator_rpc_error(error: JsonRpcError) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(error.code as i32, error.message, error.data)
+}
 
 /// Multi-sequencer handles for the sequencer RPC methods.
 ///
@@ -219,7 +223,7 @@ where
     Ok(module)
 }
 
-/// Zone-specific debug API.
+/// Zone-specific debug API backed directly by the node's full `EthApi`.
 #[derive(Clone)]
 pub(crate) struct ZoneDebugApi<E> {
     eth_api: E,
@@ -286,10 +290,6 @@ where
             .await
             .map_err(|error| operator_rpc_error(internal(error)))
     }
-}
-
-fn operator_rpc_error(error: JsonRpcError) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(error.code as i32, error.message, error.data)
 }
 
 async fn zone_tokens(

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -219,7 +219,7 @@ where
     Ok(module)
 }
 
-/// Zone-specific debug API backed directly by the node's full `EthApi`.
+/// Zone-specific debug API.
 #[derive(Clone)]
 pub(crate) struct NodeZoneDebugApi<E> {
     eth_api: E,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1285,6 +1285,7 @@ impl ZoneTestNode {
                     batch_anchor_config: Default::default(),
                     withdrawal_poll_interval: Duration::from_secs(5),
                     withdrawal_batch_limits: Default::default(),
+                    enable_prover: false,
                 });
         }
         // Multi-sequencer nodes run the real role controller, which owns the engine; the

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -594,6 +594,7 @@ where
                 config,
                 signer,
                 provider,
+                None,
                 tokio_util::sync::CancellationToken::new(),
             )
             .await

--- a/crates/rpc/src/debug.rs
+++ b/crates/rpc/src/debug.rs
@@ -5,13 +5,36 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 use crate::types::ZoneExecutionWitness;
 
-/// Debug methods that extend reth's standard execution-witness API for Zones.
+/// In-process Zone debug API contract.
+#[jsonrpsee::core::async_trait]
+pub trait ZoneDebugApi: Send + Sync {
+    /// Replays a Zone block and returns its execution witness and Tempo L1 storage reads.
+    async fn zone_execution_witness(
+        &self,
+        block: BlockNumberOrTag,
+    ) -> RpcResult<ZoneExecutionWitness>;
+}
+
+/// JSON-RPC transport adapter for [`ZoneDebugApi`].
 #[rpc(server, namespace = "debug")]
-pub trait ZoneDebugApi {
+pub trait ZoneDebugApiRpc {
     /// Replays a Zone block and returns its execution witness and Tempo L1 storage reads.
     #[method(name = "zoneExecutionWitness")]
     async fn zone_execution_witness(
         &self,
         block: BlockNumberOrTag,
     ) -> RpcResult<ZoneExecutionWitness>;
+}
+
+#[jsonrpsee::core::async_trait]
+impl<T> ZoneDebugApiRpcServer for T
+where
+    T: ZoneDebugApi + 'static,
+{
+    async fn zone_execution_witness(
+        &self,
+        block: BlockNumberOrTag,
+    ) -> RpcResult<ZoneExecutionWitness> {
+        ZoneDebugApi::zone_execution_witness(self, block).await
+    }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -21,7 +21,7 @@ pub mod types;
 mod ws;
 
 pub use config::RedactedRpcConfig;
-pub use debug::ZoneDebugApiServer;
+pub use debug::{ZoneDebugApi, ZoneDebugApiRpcServer};
 pub use handlers::ZoneRpcApi;
 pub use provider::{ZoneProvider, ZoneProviderConfig};
 pub use server::start_redacted_rpc;

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -16,11 +16,18 @@ tempo-alloy.workspace = true
 tempo-chainspec.workspace = true
 tempo-primitives.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
+zone-evm.workspace = true
+zone-l1.workspace = true
+zone-spf.workspace = true
 
 # reth
 reth-chain-state.workspace = true
+reth-evm.workspace = true
 reth-metrics.workspace = true
+reth-primitives-traits.workspace = true
+reth-revm = { workspace = true, features = ["witness"] }
 reth-storage-api.workspace = true
+reth-trie-common.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -18,16 +18,14 @@ tempo-primitives.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
 zone-evm.workspace = true
 zone-l1.workspace = true
+zone-rpc.workspace = true
 zone-spf.workspace = true
 
 # reth
 reth-chain-state.workspace = true
-reth-evm.workspace = true
 reth-metrics.workspace = true
 reth-primitives-traits.workspace = true
-reth-revm = { workspace = true, features = ["witness"] }
 reth-storage-api.workspace = true
-reth-trie-common.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -145,6 +145,9 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     prover_config: Option<ShadowProverConfig>,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> ZoneSequencerHandle {
+    // Build a single shared L1 provider with the sequencer wallet.
+    // Both the batch submitter (inside the zone monitor) and the withdrawal
+    // processor use this provider, ensuring nonces are tracked in one place.
     let l1_provider = connect_l1_provider(
         &config.l1_rpc_url,
         config.retry_connection_interval,

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -31,7 +31,7 @@ pub mod withdrawals;
 
 pub use attestation::AttestationStore;
 pub use encryption_key::register_encryption_key;
-pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState, spawn_zone_monitor};
+pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState};
 pub use prover::ShadowProverConfig;
 pub use settlement::{
     BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, resolve_portal_zone_anchor,
@@ -164,24 +164,6 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
             l1_provider.clone(),
         )
     });
-    spawn_zone_sequencer_tasks(
-        config,
-        signer,
-        zone_provider,
-        l1_provider,
-        shadow_prover,
-        shutdown,
-    )
-}
-
-fn spawn_zone_sequencer_tasks<P: ZoneSequencerProvider>(
-    config: ZoneSequencerConfig,
-    signer: PrivateKeySigner,
-    zone_provider: P,
-    l1_provider: DynProvider<TempoNetwork>,
-    shadow_prover: Option<prover::ShadowProver>,
-    shutdown: tokio_util::sync::CancellationToken,
-) -> ZoneSequencerHandle {
     let sequencer_address = signer.address();
 
     let withdrawal_store: SharedWithdrawalStore = Default::default();
@@ -217,7 +199,7 @@ fn spawn_zone_sequencer_tasks<P: ZoneSequencerProvider>(
         withdrawal_notify,
         withdrawal_repair_notify,
     );
-    let monitor_handle = monitor::spawn_zone_monitor_with_prover(
+    let monitor_handle = monitor::spawn_zone_monitor(
         monitor_config,
         zone_provider,
         l1_provider,

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -10,7 +10,7 @@ use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_transport::TransportResult;
 use reth_chain_state::CanonStateSubscriptions;
-use reth_storage_api::BlockReader;
+use reth_storage_api::{BlockReader, StateProviderFactory};
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope};
 use tokio::sync::Notify;
@@ -24,6 +24,7 @@ mod encryption_key;
 mod metrics;
 pub mod monitor;
 pub mod nonce_keys;
+mod prover;
 mod rpc;
 pub mod settlement;
 pub mod withdrawals;
@@ -31,6 +32,7 @@ pub mod withdrawals;
 pub use attestation::AttestationStore;
 pub use encryption_key::register_encryption_key;
 pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState, spawn_zone_monitor};
+pub use prover::ShadowProverConfig;
 pub use settlement::{
     BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, resolve_portal_zone_anchor,
 };
@@ -54,6 +56,7 @@ pub trait ZoneSequencerProvider:
         Transaction = TempoTxEnvelope,
         Receipt = TempoReceipt,
     > + CanonStateSubscriptions<Primitives = TempoPrimitives>
+    + StateProviderFactory
     + Clone
     + Send
     + Sync
@@ -68,6 +71,7 @@ impl<T> ZoneSequencerProvider for T where
             Transaction = TempoTxEnvelope,
             Receipt = TempoReceipt,
         > + CanonStateSubscriptions<Primitives = TempoPrimitives>
+        + StateProviderFactory
         + Clone
         + Send
         + Sync
@@ -138,6 +142,20 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     zone_provider: P,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> ZoneSequencerHandle {
+    spawn_zone_sequencer_with_prover(config, signer, zone_provider, None, shutdown).await
+}
+
+/// Spawn all zone sequencer background tasks with optional shadow SPF validation.
+///
+/// Shadow validation is observational: candidates are queued without delaying or changing L1
+/// settlement, and any prover failure is reported only through logs.
+pub async fn spawn_zone_sequencer_with_prover<P: ZoneSequencerProvider>(
+    config: ZoneSequencerConfig,
+    signer: PrivateKeySigner,
+    zone_provider: P,
+    prover_config: Option<ShadowProverConfig>,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> ZoneSequencerHandle {
     let sequencer_address = signer.address();
     // Build a single shared L1 provider with the sequencer wallet.
     // Both the batch submitter (inside the zone monitor) and the withdrawal
@@ -170,6 +188,15 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
         batch_anchor_config: config.batch_anchor_config,
         attestation_store: config.attestation_store,
     };
+    let shadow_prover = prover_config.map(|prover_config| {
+        prover::spawn_shadow_prover(
+            prover_config,
+            monitor_config.portal_address,
+            monitor_config.batch_anchor_config,
+            zone_provider.clone(),
+            l1_provider.clone(),
+        )
+    });
 
     let withdrawal_handle = withdrawals::spawn_withdrawal_processor(
         withdrawal_config,
@@ -184,12 +211,13 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
         withdrawal_notify,
         withdrawal_repair_notify,
     );
-    let monitor_handle = spawn_zone_monitor(
+    let monitor_handle = monitor::spawn_zone_monitor_with_prover(
         monitor_config,
         zone_provider,
         l1_provider,
         signer,
         monitor_shared_state,
+        shadow_prover,
         shutdown,
     );
 

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -130,6 +130,8 @@ pub struct ZoneSequencerHandle {
 ///   submission.
 /// - **Withdrawal processor** — polls the ZonePortal withdrawal queue on Tempo L1 and calls
 ///   `processWithdrawals` for each pending withdrawal.
+/// - **Shadow prover** — when `prover_config` is set, validates finalized batch candidates
+///   observationally without delaying or changing settlement.
 ///
 /// Both tasks share a single L1 provider and nonce manager to prevent signing/nonce contention
 /// when submitting concurrent L1 transactions.
@@ -140,6 +142,7 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     config: ZoneSequencerConfig,
     signer: PrivateKeySigner,
     zone_provider: P,
+    prover_config: Option<ShadowProverConfig>,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> ZoneSequencerHandle {
     let l1_provider = connect_l1_provider(
@@ -149,48 +152,21 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     )
     .await
     .expect("valid L1 RPC URL");
-    spawn_zone_sequencer_tasks(config, signer, zone_provider, l1_provider, None, shutdown)
-}
-
-/// Spawn all zone sequencer background tasks with shadow SPF validation.
-///
-/// Shadow validation is observational: candidates are queued without delaying or changing L1
-/// settlement, and any prover failure is reported only through logs.
-pub async fn spawn_zone_sequencer_with_prover<P, A>(
-    config: ZoneSequencerConfig,
-    signer: PrivateKeySigner,
-    zone_provider: P,
-    prover_config: ShadowProverConfig<A>,
-    shutdown: tokio_util::sync::CancellationToken,
-) -> ZoneSequencerHandle
-where
-    P: ZoneSequencerProvider,
-    A: zone_rpc::ZoneDebugApiServer + Send + Sync + 'static,
-{
-    // Build a single shared L1 provider with the sequencer wallet.
-    // Both the batch submitter (inside the zone monitor) and the withdrawal
-    // processor use this provider, ensuring nonces are tracked in one place.
-    let l1_provider = connect_l1_provider(
-        &config.l1_rpc_url,
-        config.retry_connection_interval,
-        signer.clone(),
-    )
-    .await
-    .expect("valid L1 RPC URL");
-
-    let shadow_prover = prover::spawn_shadow_prover(
-        prover_config,
-        config.portal_address,
-        config.batch_anchor_config,
-        zone_provider.clone(),
-        l1_provider.clone(),
-    );
+    let shadow_prover = prover_config.map(|prover_config| {
+        prover::spawn_shadow_prover(
+            prover_config,
+            config.portal_address,
+            config.batch_anchor_config,
+            zone_provider.clone(),
+            l1_provider.clone(),
+        )
+    });
     spawn_zone_sequencer_tasks(
         config,
         signer,
         zone_provider,
         l1_provider,
-        Some(shadow_prover),
+        shadow_prover,
         shutdown,
     )
 }

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -142,21 +142,31 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     zone_provider: P,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> ZoneSequencerHandle {
-    spawn_zone_sequencer_with_prover(config, signer, zone_provider, None, shutdown).await
+    let l1_provider = connect_l1_provider(
+        &config.l1_rpc_url,
+        config.retry_connection_interval,
+        signer.clone(),
+    )
+    .await
+    .expect("valid L1 RPC URL");
+    spawn_zone_sequencer_tasks(config, signer, zone_provider, l1_provider, None, shutdown)
 }
 
-/// Spawn all zone sequencer background tasks with optional shadow SPF validation.
+/// Spawn all zone sequencer background tasks with shadow SPF validation.
 ///
 /// Shadow validation is observational: candidates are queued without delaying or changing L1
 /// settlement, and any prover failure is reported only through logs.
-pub async fn spawn_zone_sequencer_with_prover<P: ZoneSequencerProvider>(
+pub async fn spawn_zone_sequencer_with_prover<P, A>(
     config: ZoneSequencerConfig,
     signer: PrivateKeySigner,
     zone_provider: P,
-    prover_config: Option<ShadowProverConfig>,
+    prover_config: ShadowProverConfig<A>,
     shutdown: tokio_util::sync::CancellationToken,
-) -> ZoneSequencerHandle {
-    let sequencer_address = signer.address();
+) -> ZoneSequencerHandle
+where
+    P: ZoneSequencerProvider,
+    A: zone_rpc::ZoneDebugApiServer + Send + Sync + 'static,
+{
     // Build a single shared L1 provider with the sequencer wallet.
     // Both the batch submitter (inside the zone monitor) and the withdrawal
     // processor use this provider, ensuring nonces are tracked in one place.
@@ -167,6 +177,33 @@ pub async fn spawn_zone_sequencer_with_prover<P: ZoneSequencerProvider>(
     )
     .await
     .expect("valid L1 RPC URL");
+
+    let shadow_prover = prover::spawn_shadow_prover(
+        prover_config,
+        config.portal_address,
+        config.batch_anchor_config,
+        zone_provider.clone(),
+        l1_provider.clone(),
+    );
+    spawn_zone_sequencer_tasks(
+        config,
+        signer,
+        zone_provider,
+        l1_provider,
+        Some(shadow_prover),
+        shutdown,
+    )
+}
+
+fn spawn_zone_sequencer_tasks<P: ZoneSequencerProvider>(
+    config: ZoneSequencerConfig,
+    signer: PrivateKeySigner,
+    zone_provider: P,
+    l1_provider: DynProvider<TempoNetwork>,
+    shadow_prover: Option<prover::ShadowProver>,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> ZoneSequencerHandle {
+    let sequencer_address = signer.address();
 
     let withdrawal_store: SharedWithdrawalStore = Default::default();
     let withdrawal_notify = Arc::new(Notify::new());
@@ -188,16 +225,6 @@ pub async fn spawn_zone_sequencer_with_prover<P: ZoneSequencerProvider>(
         batch_anchor_config: config.batch_anchor_config,
         attestation_store: config.attestation_store,
     };
-    let shadow_prover = prover_config.map(|prover_config| {
-        prover::spawn_shadow_prover(
-            prover_config,
-            monitor_config.portal_address,
-            monitor_config.batch_anchor_config,
-            zone_provider.clone(),
-            l1_provider.clone(),
-        )
-    });
-
     let withdrawal_handle = withdrawals::spawn_withdrawal_processor(
         withdrawal_config,
         l1_provider.clone(),

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -37,6 +37,7 @@ use alloy_sol_types::{ContractError, SolInterface as _};
 use crate::{
     AttestationStore, ZoneSequencerProvider,
     abi::{self, NO_QUEUE_INDEX, ZonePortal},
+    prover::ShadowProver,
     resolve_portal_zone_anchor,
     settlement::{
         BatchAnchorConfig, BatchData, BatchSubmitter, FinalizedBatchLog, ZoneBlockSnapshot,
@@ -133,6 +134,8 @@ pub struct ZoneMonitor<P: ZoneSequencerProvider> {
     prev_zone_block_hash: B256,
     /// Most recent canonical zone block observed from the node.
     latest_observed_zone_block: u64,
+    /// Detached, observational SPF worker.
+    shadow_prover: Option<ShadowProver>,
 }
 
 impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
@@ -157,6 +160,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             withdrawal_store,
             withdrawal_notify,
             repair_notify,
+            None,
         )
         .await
     }
@@ -169,6 +173,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
         withdrawal_store: SharedWithdrawalStore,
         withdrawal_notify: Arc<Notify>,
         repair_notify: Arc<Notify>,
+        shadow_prover: Option<ShadowProver>,
     ) -> Result<Self> {
         let metrics = crate::metrics::ZoneMonitorMetrics::default();
         let mut batch_submitter = BatchSubmitter::with_optional_signer_and_anchor_config(
@@ -225,6 +230,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             prev_processed_deposit_number,
             prev_zone_block_hash,
             latest_observed_zone_block: last_submitted_zone_block,
+            shadow_prover,
         };
 
         // Restore pending withdrawal data from zone L2 events so the
@@ -463,6 +469,9 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             withdrawal_batch_index: finalized_batch.finalized_index,
         };
 
+        if let Some(prover) = &self.shadow_prover {
+            prover.try_enqueue(from, to, batch_data.clone());
+        }
         self.submit_batch_with_retry(&batch_data, to, finalized_batch.withdrawals)
             .await
     }
@@ -778,26 +787,46 @@ pub fn spawn_zone_monitor<P: ZoneSequencerProvider>(
     shared_state: ZoneMonitorSharedState,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
+    spawn_zone_monitor_with_prover(
+        config,
+        zone_provider,
+        l1_provider,
+        signer,
+        shared_state,
+        None,
+        shutdown,
+    )
+}
+
+pub(crate) fn spawn_zone_monitor_with_prover<P: ZoneSequencerProvider>(
+    config: ZoneMonitorConfig,
+    zone_provider: P,
+    l1_provider: DynProvider<TempoNetwork>,
+    signer: PrivateKeySigner,
+    shared_state: ZoneMonitorSharedState,
+    shadow_prover: Option<ShadowProver>,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
     let ZoneMonitorSharedState {
         withdrawal_store,
         withdrawal_notify,
         repair_notify,
     } = shared_state;
-
     tokio::spawn(async move {
         loop {
             if shutdown.is_cancelled() {
                 info!("Zone monitor stopped before start");
                 return;
             }
-            let mut monitor = match ZoneMonitor::new(
+            let mut monitor = match ZoneMonitor::new_with_provider(
                 config.clone(),
                 zone_provider.clone(),
                 l1_provider.clone(),
-                signer.clone(),
+                Some(signer.clone()),
                 withdrawal_store.clone(),
                 withdrawal_notify.clone(),
                 repair_notify.clone(),
+                shadow_prover.clone(),
             )
             .await
             {
@@ -959,6 +988,7 @@ mod tests {
             prev_processed_deposit_number: 0,
             prev_zone_block_hash: B256::repeat_byte(0xbb),
             latest_observed_zone_block: 50,
+            shadow_prover: None,
         }
     }
 
@@ -985,6 +1015,7 @@ mod tests {
             SharedWithdrawalStore::new(),
             Arc::new(Notify::new()),
             Arc::new(Notify::new()),
+            None,
         )
         .await
         {

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -780,26 +780,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
 /// boundaries to the ZonePortal on Tempo L1. Local state only advances on successful submission.
 ///
 /// The `l1_provider` must already include the sequencer wallet for signing L1 transactions.
-pub fn spawn_zone_monitor<P: ZoneSequencerProvider>(
-    config: ZoneMonitorConfig,
-    zone_provider: P,
-    l1_provider: DynProvider<TempoNetwork>,
-    signer: PrivateKeySigner,
-    shared_state: ZoneMonitorSharedState,
-    shutdown: tokio_util::sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
-    spawn_zone_monitor_with_prover(
-        config,
-        zone_provider,
-        l1_provider,
-        signer,
-        shared_state,
-        None,
-        shutdown,
-    )
-}
-
-pub(crate) fn spawn_zone_monitor_with_prover<P: ZoneSequencerProvider>(
+pub(crate) fn spawn_zone_monitor<P: ZoneSequencerProvider>(
     config: ZoneMonitorConfig,
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -165,6 +165,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
         .await
     }
 
+    #[expect(clippy::too_many_arguments)]
     async fn new_with_provider(
         config: ZoneMonitorConfig,
         provider: P,

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
+    sync::Arc,
     time::Instant,
 };
 
@@ -25,7 +26,7 @@ use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{debug, error, info};
 use zone_evm::ZoneEvmConfig;
 use zone_l1::TempoStateExt as _;
-use zone_rpc::{ZoneDebugApiServer, types::TempoStorageRead};
+use zone_rpc::{ZoneDebugApi, types::TempoStorageRead};
 use zone_spf::{
     BatchOutput, BatchWitness, PublicInputs, SpfConfig, TempoStateWitness, ZoneBlock,
     ZoneStateWitness, prove_zone_batch,
@@ -41,16 +42,16 @@ type L1Reads = BTreeMap<u64, BTreeMap<Address, BTreeSet<B256>>>;
 
 /// Node-owned inputs required to validate canonical Zone blocks with the SPF.
 #[derive(Clone)]
-pub struct ShadowProverConfig<A> {
+pub struct ShadowProverConfig {
     /// Zone identifier bound into SPF public inputs.
     pub zone_id: u32,
     /// The exact EVM configuration used by the node.
     pub evm_config: ZoneEvmConfig,
     /// In-process Zone debug API used to generate execution witnesses.
-    pub debug_api: A,
+    pub debug_api: Arc<dyn ZoneDebugApi>,
 }
 
-impl<A> fmt::Debug for ShadowProverConfig<A> {
+impl fmt::Debug for ShadowProverConfig {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ShadowProverConfig")
@@ -80,8 +81,8 @@ struct ValidationStats {
     tempo_state_nodes: usize,
 }
 
-struct ProverContext<P, A> {
-    config: ShadowProverConfig<A>,
+struct ProverContext<P> {
+    config: ShadowProverConfig,
     portal: Address,
     anchor_config: BatchAnchorConfig,
     zone_provider: P,
@@ -102,17 +103,13 @@ struct Anchor {
     ancestry_headers: Vec<Bytes>,
 }
 
-pub(crate) fn spawn_shadow_prover<P, A>(
-    config: ShadowProverConfig<A>,
+pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
+    config: ShadowProverConfig,
     portal: Address,
     anchor_config: BatchAnchorConfig,
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,
-) -> ShadowProver
-where
-    P: ZoneSequencerProvider,
-    A: ZoneDebugApiServer + Send + Sync + 'static,
-{
+) -> ShadowProver {
     info!(
         target: "zone::sequencer::prover",
         zone_id = config.zone_id,
@@ -190,14 +187,10 @@ impl ShadowProver {
     }
 }
 
-async fn validate_candidate<P, A>(
-    context: &ProverContext<P, A>,
+async fn validate_candidate<P: ZoneSequencerProvider>(
+    context: &ProverContext<P>,
     job: &ProverJob,
-) -> Result<ValidationStats>
-where
-    P: ZoneSequencerProvider,
-    A: ZoneDebugApiServer + Send + Sync + 'static,
-{
+) -> Result<ValidationStats> {
     ensure!(
         job.batch.zone_height == job.to,
         "candidate zone height {} does not match range end {}",
@@ -227,7 +220,7 @@ where
     .context("Zone input worker panicked")??;
 
     let (zone_state_witness, tempo_reads) =
-        zone_witnesses(&context.config.debug_api, from, to).await?;
+        zone_witnesses(context.config.debug_api.as_ref(), from, to).await?;
 
     let initial_tempo_header = tempo_header(&context.l1_provider, zone_inputs.initial_tempo_number)
         .await
@@ -472,14 +465,11 @@ fn decode_tempo_header(encoded: &[u8]) -> Result<TempoHeader> {
     Ok(header)
 }
 
-async fn zone_witnesses<A>(
-    debug_api: &A,
+async fn zone_witnesses(
+    debug_api: &dyn ZoneDebugApi,
     from: u64,
     to: u64,
-) -> Result<(ZoneStateWitness, Vec<(u64, TempoStorageRead)>)>
-where
-    A: ZoneDebugApiServer + Send + Sync + 'static,
-{
+) -> Result<(ZoneStateWitness, Vec<(u64, TempoStorageRead)>)> {
     let results = stream::iter(from..=to)
         .map(|number| async move {
             let started = Instant::now();

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -1,6 +1,10 @@
 //! Detached, observational SPF validation for finalized batch candidates.
 
-use std::{collections::BTreeMap, time::Instant};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    time::Instant,
+};
 
 use alloy_consensus::{BlockHeader as _, Sealable as _, Transaction as _};
 use alloy_eips::{BlockId, eip2718::Encodable2718 as _};
@@ -10,11 +14,8 @@ use alloy_rlp::Decodable as _;
 use alloy_rpc_types_eth::BlockNumberOrTag;
 use alloy_sol_types::SolCall as _;
 use eyre::{Context as _, OptionExt as _, Result, bail, ensure};
-use reth_evm::{ConfigureEvm as _, execute::Executor as _};
+use futures::{StreamExt as _, TryStreamExt as _, stream};
 use reth_primitives_traits::RecoveredBlock;
-use reth_revm::{State, database::StateProviderDatabase, witness::ExecutionWitnessRecord};
-use reth_storage_api::StateProofProvider as _;
-use reth_trie_common::ExecutionWitnessMode;
 use tempo_alloy::TempoNetwork;
 use tempo_primitives::{Block, TempoHeader};
 use tempo_zone_contracts::{
@@ -24,23 +25,40 @@ use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{debug, error, info};
 use zone_evm::ZoneEvmConfig;
 use zone_l1::TempoStateExt as _;
+use zone_rpc::{ZoneDebugApiServer, types::TempoStorageRead};
 use zone_spf::{
-    BatchOutput, BatchWitness, Error as SpfError, PublicInputs, SpfConfig, TempoStateWitness,
-    ZoneBlock, ZoneStateWitness, prove_zone_batch,
+    BatchOutput, BatchWitness, PublicInputs, SpfConfig, TempoStateWitness, ZoneBlock,
+    ZoneStateWitness, prove_zone_batch,
 };
 
 use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider};
 
 /// Number of candidates allowed to wait behind the active validation.
 const SHADOW_PROVER_QUEUE_CAPACITY: usize = 2;
+const RPC_CONCURRENCY: usize = 8;
 
-/// Node-owned inputs required to faithfully re-execute canonical Zone blocks.
-#[derive(Debug, Clone)]
-pub struct ShadowProverConfig {
+type L1Reads = BTreeMap<u64, BTreeMap<Address, BTreeSet<B256>>>;
+
+/// Node-owned inputs required to validate canonical Zone blocks with the SPF.
+#[derive(Clone)]
+pub struct ShadowProverConfig<A> {
     /// Zone identifier bound into SPF public inputs.
     pub zone_id: u32,
     /// The exact EVM configuration used by the node.
     pub evm_config: ZoneEvmConfig,
+    /// In-process Zone debug API used to generate execution witnesses.
+    pub debug_api: A,
+}
+
+impl<A> fmt::Debug for ShadowProverConfig<A> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ShadowProverConfig")
+            .field("zone_id", &self.zone_id)
+            .field("evm_config", &self.evm_config)
+            .field("debug_api", &"<in-process>")
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -58,13 +76,12 @@ struct ProverJob {
 #[derive(Debug)]
 struct ValidationStats {
     witness_bytes: usize,
-    tempo_proof_rounds: usize,
     zone_state_nodes: usize,
     tempo_state_nodes: usize,
 }
 
-struct ProverContext<P> {
-    config: ShadowProverConfig,
+struct ProverContext<P, A> {
+    config: ShadowProverConfig<A>,
     portal: Address,
     anchor_config: BatchAnchorConfig,
     zone_provider: P,
@@ -74,7 +91,7 @@ struct ProverContext<P> {
 struct ZoneInputs {
     parent_header: TempoHeader,
     blocks: Vec<ZoneBlock>,
-    state_witness: ZoneStateWitness,
+    checkpoint_by_zone_block: BTreeMap<u64, u64>,
     initial_tempo_number: u64,
     initial_tempo_hash: B256,
 }
@@ -85,13 +102,17 @@ struct Anchor {
     ancestry_headers: Vec<Bytes>,
 }
 
-pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
-    config: ShadowProverConfig,
+pub(crate) fn spawn_shadow_prover<P, A>(
+    config: ShadowProverConfig<A>,
     portal: Address,
     anchor_config: BatchAnchorConfig,
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,
-) -> ShadowProver {
+) -> ShadowProver
+where
+    P: ZoneSequencerProvider,
+    A: ZoneDebugApiServer + Send + Sync + 'static,
+{
     info!(
         target: "zone::sequencer::prover",
         zone_id = config.zone_id,
@@ -122,7 +143,6 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                         witness_bytes = stats.witness_bytes,
                         zone_state_nodes = stats.zone_state_nodes,
                         tempo_state_nodes = stats.tempo_state_nodes,
-                        tempo_proof_rounds = stats.tempo_proof_rounds,
                         "Shadow prover validated finalized batch candidate"
                     );
                 }
@@ -170,10 +190,14 @@ impl ShadowProver {
     }
 }
 
-async fn validate_candidate<P: ZoneSequencerProvider>(
-    context: &ProverContext<P>,
+async fn validate_candidate<P, A>(
+    context: &ProverContext<P, A>,
     job: &ProverJob,
-) -> Result<ValidationStats> {
+) -> Result<ValidationStats>
+where
+    P: ZoneSequencerProvider,
+    A: ZoneDebugApiServer + Send + Sync + 'static,
+{
     ensure!(
         job.batch.zone_height == job.to,
         "candidate zone height {} does not match range end {}",
@@ -186,7 +210,6 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         job.batch.prev_block_hash
     );
     let zone_provider = context.zone_provider.clone();
-    let evm_config = context.config.evm_config.clone();
     let from = job.from;
     let to = job.to;
     let expected_prev_hash = job.batch.prev_block_hash;
@@ -194,7 +217,6 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     let zone_inputs = tokio::task::spawn_blocking(move || {
         build_zone_inputs(
             &zone_provider,
-            &evm_config,
             from,
             to,
             expected_prev_hash,
@@ -202,7 +224,10 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         )
     })
     .await
-    .context("Zone witness worker panicked")??;
+    .context("Zone input worker panicked")??;
+
+    let (zone_state_witness, tempo_reads) =
+        zone_witnesses(&context.config.debug_api, from, to).await?;
 
     let initial_tempo_header = tempo_header(&context.l1_provider, zone_inputs.initial_tempo_number)
         .await
@@ -236,7 +261,11 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     )
     .await?;
 
-    let mut witness = BatchWitness {
+    let reads = collect_l1_reads(tempo_reads, &zone_inputs.checkpoint_by_zone_block)?;
+    let tempo_state_witness =
+        tempo_state_witness(&context.l1_provider, &initial_tempo_header, reads).await?;
+
+    let witness = BatchWitness {
         public_inputs: PublicInputs {
             zone_id: context.config.zone_id,
             portal: context.portal,
@@ -247,55 +276,22 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         },
         parent_header: zone_inputs.parent_header,
         zone_blocks: zone_inputs.blocks,
-        zone_state_witness: zone_inputs.state_witness,
-        tempo_state_witness: TempoStateWitness {
-            initial_tempo_header_rlp: Bytes::from(alloy_rlp::encode(&initial_tempo_header)),
-            node_pool: Vec::new(),
-        },
+        zone_state_witness,
+        tempo_state_witness,
         tempo_ancestry_headers: anchor.ancestry_headers,
     };
 
     let spf_config = SpfConfig::new(context.config.evm_config.chain_spec().clone());
-    let mut requested_reads = std::collections::BTreeSet::new();
-    let mut tempo_proof_rounds = 0usize;
-    let output = loop {
-        let config = spf_config.clone();
-        let attempt = witness.clone();
-        let result = tokio::task::spawn_blocking(move || prove_zone_batch(&config, attempt))
-            .await
-            .context("SPF worker panicked")?;
-        match result {
-            Ok(output) => break output,
-            Err(SpfError::MissingTempoStorage {
-                account,
-                slot,
-                block_number,
-            }) => {
-                ensure!(
-                    requested_reads.insert((block_number, account, slot)),
-                    "SPF repeatedly requested Tempo storage {account}[{slot}] at block {block_number}"
-                );
-                tempo_proof_rounds += 1;
-                debug!(
-                    target: "zone::sequencer::prover",
-                    tempo_block = block_number,
-                    %account,
-                    %slot,
-                    "Shadow prover fetching missing Tempo storage proof"
-                );
-                let nodes =
-                    tempo_proof_nodes(&context.l1_provider, block_number, account, slot).await?;
-                merge_nodes(&mut witness.tempo_state_witness.node_pool, nodes);
-            }
-            Err(err) => return Err(err).context("SPF rejected generated witness"),
-        }
-    };
+    let attempt = witness.clone();
+    let output = tokio::task::spawn_blocking(move || prove_zone_batch(&spf_config, attempt))
+        .await
+        .context("SPF worker panicked")?
+        .context("SPF rejected generated witness")?;
 
     compare_output(&output, &job.batch, witness.parent_header.hash_slow())?;
 
     Ok(ValidationStats {
         witness_bytes: witness_size(&witness),
-        tempo_proof_rounds,
         zone_state_nodes: witness.zone_state_witness.node_pool.len(),
         tempo_state_nodes: witness.tempo_state_witness.node_pool.len(),
     })
@@ -303,7 +299,6 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
 
 fn build_zone_inputs<P: ZoneSequencerProvider>(
     provider: &P,
-    evm_config: &ZoneEvmConfig,
     from: u64,
     to: u64,
     expected_prev_hash: B256,
@@ -345,8 +340,7 @@ fn build_zone_inputs<P: ZoneSequencerProvider>(
 
     let mut expected_parent = parent_hash;
     let mut extracted = Vec::with_capacity(recovered.len());
-    let mut state_nodes = BTreeMap::new();
-    let mut bytecodes = BTreeMap::new();
+    let mut checkpoint_by_zone_block = BTreeMap::new();
     for (offset, block) in recovered.iter().enumerate() {
         let number = from + offset as u64;
         ensure!(
@@ -367,14 +361,10 @@ fn build_zone_inputs<P: ZoneSequencerProvider>(
             "recovered Zone block {number} is not canonical"
         );
 
-        let (nodes, codes) = execution_witness_for_block(provider, evm_config, block)?;
-        for node in nodes {
-            state_nodes.entry(keccak256(&node)).or_insert(node);
-        }
-        for code in codes {
-            bytecodes.entry(keccak256(&code)).or_insert(code);
-        }
-        extracted.push(extract_zone_block(block)?);
+        let extracted_block = extract_zone_block(block)?;
+        let checkpoint = decode_tempo_header(&extracted_block.tempo_header_rlp)?.number();
+        checkpoint_by_zone_block.insert(number, checkpoint);
+        extracted.push(extracted_block);
         expected_parent = canonical_hash;
     }
     ensure!(
@@ -385,49 +375,10 @@ fn build_zone_inputs<P: ZoneSequencerProvider>(
     Ok(ZoneInputs {
         parent_header,
         blocks: extracted,
-        state_witness: ZoneStateWitness {
-            node_pool: state_nodes.into_values().collect(),
-            bytecodes: bytecodes.into_values().collect(),
-        },
+        checkpoint_by_zone_block,
         initial_tempo_number: initial_tempo.number,
         initial_tempo_hash: initial_tempo.hash,
     })
-}
-
-fn execution_witness_for_block<P: ZoneSequencerProvider>(
-    provider: &P,
-    evm_config: &ZoneEvmConfig,
-    block: &RecoveredBlock<Block>,
-) -> Result<(Vec<Bytes>, Vec<Bytes>)> {
-    let state_provider = provider.state_by_block_hash(block.parent_hash())?;
-    let mut state = State::builder()
-        .with_database(StateProviderDatabase::new(&state_provider))
-        .with_bundle_update()
-        .build();
-    let executor = evm_config.executor(&mut state);
-    let mut record = ExecutionWitnessRecord::default();
-    executor
-        .execute_with_state_closure(block, |executed| {
-            record.record_executed_state(executed, ExecutionWitnessMode::default());
-        })
-        .map_err(|err| eyre::eyre!("re-execute canonical Zone block {}: {err}", block.number()))?;
-
-    if record
-        .lowest_block_number
-        .is_some_and(|lowest| lowest < block.number().saturating_sub(1))
-    {
-        bail!(
-            "Zone block {} reads an older BLOCKHASH, which the SPF witness cannot represent",
-            block.number()
-        );
-    }
-
-    let nodes = state_provider.witness(
-        Default::default(),
-        record.hashed_state,
-        ExecutionWitnessMode::default(),
-    )?;
-    Ok((nodes, record.codes))
 }
 
 fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
@@ -521,6 +472,135 @@ fn decode_tempo_header(encoded: &[u8]) -> Result<TempoHeader> {
     Ok(header)
 }
 
+async fn zone_witnesses<A>(
+    debug_api: &A,
+    from: u64,
+    to: u64,
+) -> Result<(ZoneStateWitness, Vec<(u64, TempoStorageRead)>)>
+where
+    A: ZoneDebugApiServer + Send + Sync + 'static,
+{
+    let results = stream::iter(from..=to)
+        .map(|number| async move {
+            let started = Instant::now();
+            debug!(
+                target: "zone::sequencer::prover",
+                zone_block = number,
+                "Requesting Zone execution witness"
+            );
+            let witness = debug_api
+                .zone_execution_witness(BlockNumberOrTag::Number(number))
+                .await
+                .map_err(|error| eyre::eyre!(error.to_string()))
+                .wrap_err_with(|| {
+                    format!("debug_zoneExecutionWitness for Zone block {number}")
+                })?;
+            if witness.execution_witness.headers.len() > 1 {
+                bail!(
+                    "Zone block {number} reads an older BLOCKHASH, which the current SPF witness cannot represent"
+                );
+            }
+            debug!(
+                target: "zone::sequencer::prover",
+                zone_block = number,
+                state_nodes = witness.execution_witness.state.len(),
+                bytecodes = witness.execution_witness.codes.len(),
+                ancestor_headers = witness.execution_witness.headers.len(),
+                tempo_storage_reads = witness.tempo_reads.len(),
+                elapsed_ms = started.elapsed().as_millis(),
+                "Received Zone execution witness"
+            );
+            Ok::<_, eyre::Report>((number, witness))
+        })
+        .buffer_unordered(RPC_CONCURRENCY)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let mut state = BTreeMap::new();
+    let mut codes = BTreeMap::new();
+    let mut tempo_reads = Vec::new();
+    for (number, witness) in results {
+        for node in witness.execution_witness.state {
+            state.entry(keccak256(&node)).or_insert(node);
+        }
+        for code in witness.execution_witness.codes {
+            codes.entry(keccak256(&code)).or_insert(code);
+        }
+        tempo_reads.extend(witness.tempo_reads.into_iter().map(|read| (number, read)));
+    }
+
+    Ok((
+        ZoneStateWitness {
+            node_pool: state.into_values().collect(),
+            bytecodes: codes.into_values().collect(),
+        },
+        tempo_reads,
+    ))
+}
+
+fn collect_l1_reads(
+    tempo_reads: Vec<(u64, TempoStorageRead)>,
+    checkpoints: &BTreeMap<u64, u64>,
+) -> Result<L1Reads> {
+    let mut reads = L1Reads::new();
+    for (zone_block, read) in tempo_reads {
+        let checkpoint = checkpoints.get(&zone_block).copied().ok_or_eyre(format!(
+            "missing Tempo checkpoint for Zone block {zone_block}"
+        ))?;
+        reads
+            .entry(checkpoint)
+            .or_default()
+            .entry(read.account)
+            .or_default()
+            .insert(read.slot);
+    }
+    Ok(reads)
+}
+
+async fn tempo_state_witness(
+    provider: &DynProvider<TempoNetwork>,
+    initial_header: &TempoHeader,
+    reads: L1Reads,
+) -> Result<TempoStateWitness> {
+    let requests = reads
+        .into_iter()
+        .flat_map(|(block, accounts)| {
+            accounts.into_iter().map(move |(account, slots)| {
+                (block, account, slots.into_iter().collect::<Vec<_>>())
+            })
+        })
+        .collect::<Vec<_>>();
+    let proofs = stream::iter(requests)
+        .map(|(block, account, slots)| async move {
+            let proof = provider
+                .get_proof(account, slots)
+                .block_id(BlockId::number(block))
+                .await
+                .wrap_err_with(|| format!("eth_getProof for {account} at Tempo block {block}"))?;
+            Ok::<_, eyre::Report>(proof)
+        })
+        .buffer_unordered(RPC_CONCURRENCY)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let mut nodes = BTreeMap::new();
+    for proof in proofs {
+        for node in proof.account_proof {
+            nodes.entry(keccak256(&node)).or_insert(node);
+        }
+        for storage in proof.storage_proof {
+            for node in storage.proof {
+                nodes.entry(keccak256(&node)).or_insert(node);
+            }
+        }
+    }
+
+    Ok(TempoStateWitness {
+        initial_tempo_header_rlp: Bytes::from(alloy_rlp::encode(initial_header)),
+        node_pool: nodes.into_values().collect(),
+    })
+}
+
 async fn tempo_header(provider: &DynProvider<TempoNetwork>, number: u64) -> Result<TempoHeader> {
     provider
         .get_block_by_number(BlockNumberOrTag::Number(number))
@@ -571,39 +651,6 @@ async fn resolve_anchor(
         hash: expected_parent,
         ancestry_headers,
     })
-}
-
-async fn tempo_proof_nodes(
-    provider: &DynProvider<TempoNetwork>,
-    block_number: u64,
-    account: Address,
-    slot: B256,
-) -> Result<Vec<Bytes>> {
-    let proof = provider
-        .get_proof(account, vec![slot])
-        .block_id(BlockId::number(block_number))
-        .await
-        .wrap_err_with(|| {
-            format!("eth_getProof for {account}[{slot}] at Tempo block {block_number}")
-        })?;
-    Ok(proof
-        .account_proof
-        .into_iter()
-        .chain(
-            proof
-                .storage_proof
-                .into_iter()
-                .flat_map(|storage| storage.proof),
-        )
-        .collect())
-}
-
-fn merge_nodes(target: &mut Vec<Bytes>, additional: Vec<Bytes>) {
-    let mut nodes = BTreeMap::new();
-    for node in target.drain(..).chain(additional) {
-        nodes.entry(keccak256(&node)).or_insert(node);
-    }
-    *target = nodes.into_values().collect();
 }
 
 fn compare_output(output: &BatchOutput, batch: &BatchData, expected_prev_hash: B256) -> Result<()> {

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -180,6 +180,11 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         job.batch.zone_height,
         job.to
     );
+    ensure!(
+        job.from != 1 || job.batch.prev_block_hash.is_zero(),
+        "first Zone batch must use the zero portal prev_block_hash sentinel, found {}",
+        job.batch.prev_block_hash
+    );
     let zone_provider = context.zone_provider.clone();
     let evm_config = context.config.evm_config.clone();
     let from = job.from;
@@ -288,7 +293,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         }
     };
 
-    compare_output(&output, &job.batch)?;
+    compare_output(&output, &job.batch, witness.parent_header.hash_slow())?;
 
     Ok(ValidationStats {
         witness_bytes: witness_size(&witness),
@@ -312,12 +317,25 @@ fn build_zone_inputs<P: ZoneSequencerProvider>(
     let parent_header = provider
         .header_by_number(from - 1)?
         .ok_or_eyre(format!("canonical Zone parent {} not found", from - 1))?;
-    ensure!(
-        parent_header.hash_slow() == expected_prev_hash,
-        "candidate parent hash changed: expected {expected_prev_hash}, found {}",
-        parent_header.hash_slow()
-    );
-    let parent_state = provider.state_by_block_hash(expected_prev_hash)?;
+    let parent_hash = parent_header.hash_slow();
+    // ZonePortal uses zero as its pre-genesis sentinel. SPF receives the real
+    // canonical hash of block 0 as the parent of block 1 instead.
+    if from == 1 {
+        ensure!(
+            expected_prev_hash.is_zero(),
+            "first Zone batch must use the zero portal prev_block_hash sentinel, found {expected_prev_hash}"
+        );
+        ensure!(
+            !parent_hash.is_zero(),
+            "canonical Zone block 0 hash must be non-zero"
+        );
+    } else {
+        ensure!(
+            parent_hash == expected_prev_hash,
+            "candidate parent hash changed: expected {expected_prev_hash}, found {parent_hash}"
+        );
+    }
+    let parent_state = provider.state_by_block_hash(parent_hash)?;
     let initial_tempo = parent_state.tempo_num_hash()?;
 
     let recovered = provider.recovered_block_range(from..=to)?;
@@ -327,7 +345,7 @@ fn build_zone_inputs<P: ZoneSequencerProvider>(
         recovered.len()
     );
 
-    let mut expected_parent = expected_prev_hash;
+    let mut expected_parent = parent_hash;
     let mut extracted = Vec::with_capacity(recovered.len());
     let mut state_nodes = BTreeMap::new();
     let mut bytecodes = BTreeMap::new();
@@ -585,12 +603,12 @@ fn merge_nodes(target: &mut Vec<Bytes>, additional: Vec<Bytes>) {
     *target = nodes.into_values().collect();
 }
 
-fn compare_output(output: &BatchOutput, batch: &BatchData) -> Result<()> {
+fn compare_output(output: &BatchOutput, batch: &BatchData, expected_prev_hash: B256) -> Result<()> {
     ensure!(
-        output.block_transition.prevBlockHash == batch.prev_block_hash,
-        "previous Zone block commitment mismatch: SPF {}, candidate {}",
+        output.block_transition.prevBlockHash == expected_prev_hash,
+        "previous Zone block commitment mismatch: SPF {}, canonical parent {}",
         output.block_transition.prevBlockHash,
-        batch.prev_block_hash
+        expected_prev_hash
     );
     ensure!(
         output.block_transition.nextBlockHash == batch.next_block_hash,

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -217,10 +217,8 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
 
     let final_tempo_header = zone_inputs
         .blocks
-        .iter()
-        .rev()
-        .find_map(|block| block.tempo_header_rlp.as_deref())
-        .map(|header| decode_tempo_header(header))
+        .last()
+        .map(|block| decode_tempo_header(&block.tempo_header_rlp))
         .transpose()?
         .unwrap_or_else(|| initial_tempo_header.clone());
     ensure!(
@@ -496,6 +494,11 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
         }
     }
 
+    let tempo_header_rlp = tempo_header_rlp.ok_or_eyre(format!(
+        "no advanceTempo call in Zone block {}",
+        header.number()
+    ))?;
+
     Ok(ZoneBlock {
         number: header.number(),
         parent_hash: header.parent_hash(),
@@ -670,10 +673,7 @@ fn witness_size(witness: &BatchWitness) -> usize {
             .zone_blocks
             .iter()
             .map(|block| {
-                block
-                    .tempo_header_rlp
-                    .as_ref()
-                    .map_or(0, |bytes| bytes.len())
+                block.tempo_header_rlp.len()
                     + block
                         .transactions
                         .iter()

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -20,7 +20,7 @@ use tempo_primitives::{Block, TempoHeader};
 use tempo_zone_contracts::{
     IZoneInbox as ZoneInbox, IZoneOutbox as ZoneOutbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
 };
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, error::TrySendError};
 use tracing::{debug, error, info};
 use zone_evm::ZoneEvmConfig;
 use zone_l1::TempoStateExt as _;
@@ -160,7 +160,11 @@ impl ShadowProver {
                 prev_block_hash = %batch.prev_block_hash,
                 next_block_hash = %batch.next_block_hash,
                 error = %err,
-                "Shadow prover queue unavailable; skipping finalized batch candidate"
+                "Shadow prover queue {}; skipping finalized batch candidate",
+                match err {
+                    TrySendError::Full(_) => "full",
+                    TrySendError::Closed(_) => "unavailable",
+                },
             );
         }
     }

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -1,0 +1,662 @@
+//! Detached, observational SPF validation for finalized batch candidates.
+
+use std::{collections::BTreeMap, time::Instant};
+
+use alloy_consensus::{BlockHeader as _, Sealable as _, Transaction as _};
+use alloy_eips::{BlockId, eip2718::Encodable2718 as _};
+use alloy_primitives::{Address, B256, Bytes, keccak256};
+use alloy_provider::{DynProvider, Provider as _};
+use alloy_rlp::Decodable as _;
+use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_sol_types::SolCall as _;
+use eyre::{Context as _, OptionExt as _, Result, bail, ensure};
+use reth_evm::{ConfigureEvm as _, execute::Executor as _};
+use reth_primitives_traits::RecoveredBlock;
+use reth_revm::{State, database::StateProviderDatabase, witness::ExecutionWitnessRecord};
+use reth_storage_api::StateProofProvider as _;
+use reth_trie_common::ExecutionWitnessMode;
+use tempo_alloy::TempoNetwork;
+use tempo_primitives::{Block, TempoHeader};
+use tempo_zone_contracts::{
+    IZoneInbox as ZoneInbox, IZoneOutbox as ZoneOutbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
+};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info};
+use zone_evm::ZoneEvmConfig;
+use zone_l1::TempoStateExt as _;
+use zone_spf::{
+    BatchOutput, BatchWitness, Error as SpfError, PublicInputs, SpfConfig, TempoStateWitness,
+    ZoneBlock, ZoneStateWitness, prove_zone_batch,
+};
+
+use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider};
+
+/// Number of candidates allowed to wait behind the active validation.
+const SHADOW_PROVER_QUEUE_CAPACITY: usize = 2;
+
+/// Node-owned inputs required to faithfully re-execute canonical Zone blocks.
+#[derive(Debug, Clone)]
+pub struct ShadowProverConfig {
+    /// Zone identifier bound into SPF public inputs.
+    pub zone_id: u32,
+    /// The exact EVM configuration used by the node.
+    pub evm_config: ZoneEvmConfig,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ShadowProver {
+    sender: mpsc::Sender<ProverJob>,
+}
+
+#[derive(Debug)]
+struct ProverJob {
+    from: u64,
+    to: u64,
+    batch: BatchData,
+}
+
+#[derive(Debug)]
+struct ValidationStats {
+    witness_bytes: usize,
+    tempo_proof_rounds: usize,
+    zone_state_nodes: usize,
+    tempo_state_nodes: usize,
+}
+
+struct ProverContext<P> {
+    config: ShadowProverConfig,
+    portal: Address,
+    anchor_config: BatchAnchorConfig,
+    zone_provider: P,
+    l1_provider: DynProvider<TempoNetwork>,
+}
+
+struct ZoneInputs {
+    parent_header: TempoHeader,
+    blocks: Vec<ZoneBlock>,
+    state_witness: ZoneStateWitness,
+    initial_tempo_number: u64,
+    initial_tempo_hash: B256,
+}
+
+struct Anchor {
+    number: u64,
+    hash: B256,
+    ancestry_headers: Vec<Bytes>,
+}
+
+pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
+    config: ShadowProverConfig,
+    portal: Address,
+    anchor_config: BatchAnchorConfig,
+    zone_provider: P,
+    l1_provider: DynProvider<TempoNetwork>,
+) -> ShadowProver {
+    info!(
+        target: "zone::sequencer::prover",
+        zone_id = config.zone_id,
+        queue_capacity = SHADOW_PROVER_QUEUE_CAPACITY,
+        "Shadow prover enabled"
+    );
+    let (sender, mut receiver) = mpsc::channel(SHADOW_PROVER_QUEUE_CAPACITY);
+    let context = ProverContext {
+        config,
+        portal,
+        anchor_config,
+        zone_provider,
+        l1_provider,
+    };
+
+    tokio::spawn(async move {
+        while let Some(job) = receiver.recv().await {
+            let started = Instant::now();
+            match validate_candidate(&context, &job).await {
+                Ok(stats) => {
+                    info!(
+                        target: "zone::sequencer::prover",
+                        zone_from = job.from,
+                        zone_to = job.to,
+                        prev_block_hash = %job.batch.prev_block_hash,
+                        next_block_hash = %job.batch.next_block_hash,
+                        elapsed_ms = started.elapsed().as_millis(),
+                        witness_bytes = stats.witness_bytes,
+                        zone_state_nodes = stats.zone_state_nodes,
+                        tempo_state_nodes = stats.tempo_state_nodes,
+                        tempo_proof_rounds = stats.tempo_proof_rounds,
+                        "Shadow prover validated finalized batch candidate"
+                    );
+                }
+                Err(err) => {
+                    error!(
+                        target: "zone::sequencer::prover",
+                        zone_from = job.from,
+                        zone_to = job.to,
+                        prev_block_hash = %job.batch.prev_block_hash,
+                        next_block_hash = %job.batch.next_block_hash,
+                        elapsed_ms = started.elapsed().as_millis(),
+                        error = %err,
+                        "Shadow prover failed to validate finalized batch candidate"
+                    );
+                }
+            }
+        }
+    });
+
+    ShadowProver { sender }
+}
+
+impl ShadowProver {
+    /// Queue a candidate without waiting for validation or queue capacity.
+    pub(crate) fn try_enqueue(&self, from: u64, to: u64, batch: BatchData) {
+        if let Err(err) = self.sender.try_send(ProverJob {
+            from,
+            to,
+            batch: batch.clone(),
+        }) {
+            error!(
+                target: "zone::sequencer::prover",
+                zone_from = from,
+                zone_to = to,
+                prev_block_hash = %batch.prev_block_hash,
+                next_block_hash = %batch.next_block_hash,
+                error = %err,
+                "Shadow prover queue unavailable; skipping finalized batch candidate"
+            );
+        }
+    }
+}
+
+async fn validate_candidate<P: ZoneSequencerProvider>(
+    context: &ProverContext<P>,
+    job: &ProverJob,
+) -> Result<ValidationStats> {
+    ensure!(
+        job.batch.zone_height == job.to,
+        "candidate zone height {} does not match range end {}",
+        job.batch.zone_height,
+        job.to
+    );
+    let zone_provider = context.zone_provider.clone();
+    let evm_config = context.config.evm_config.clone();
+    let from = job.from;
+    let to = job.to;
+    let expected_prev_hash = job.batch.prev_block_hash;
+    let expected_next_hash = job.batch.next_block_hash;
+    let zone_inputs = tokio::task::spawn_blocking(move || {
+        build_zone_inputs(
+            &zone_provider,
+            &evm_config,
+            from,
+            to,
+            expected_prev_hash,
+            expected_next_hash,
+        )
+    })
+    .await
+    .context("Zone witness worker panicked")??;
+
+    let initial_tempo_header = tempo_header(&context.l1_provider, zone_inputs.initial_tempo_number)
+        .await
+        .context("fetch initial Tempo checkpoint")?;
+    ensure!(
+        initial_tempo_header.hash_slow() == zone_inputs.initial_tempo_hash,
+        "parent Zone state commits Tempo block {} hash {}, but L1 returned {}",
+        zone_inputs.initial_tempo_number,
+        zone_inputs.initial_tempo_hash,
+        initial_tempo_header.hash_slow()
+    );
+
+    let final_tempo_header = zone_inputs
+        .blocks
+        .iter()
+        .rev()
+        .find_map(|block| block.tempo_header_rlp.as_deref())
+        .map(|header| decode_tempo_header(header))
+        .transpose()?
+        .unwrap_or_else(|| initial_tempo_header.clone());
+    ensure!(
+        final_tempo_header.number() == job.batch.tempo_block_number,
+        "candidate Tempo block is {}, but the final advanceTempo header is {}",
+        job.batch.tempo_block_number,
+        final_tempo_header.number()
+    );
+
+    let anchor = resolve_anchor(
+        &context.l1_provider,
+        final_tempo_header.number(),
+        final_tempo_header.hash_slow(),
+        context.anchor_config,
+    )
+    .await?;
+
+    let mut witness = BatchWitness {
+        public_inputs: PublicInputs {
+            zone_id: context.config.zone_id,
+            portal: context.portal,
+            tempo_block_number: final_tempo_header.number(),
+            anchor_block_number: anchor.number,
+            anchor_block_hash: anchor.hash,
+            expected_withdrawal_batch_index: job.batch.withdrawal_batch_index,
+        },
+        parent_header: zone_inputs.parent_header,
+        zone_blocks: zone_inputs.blocks,
+        zone_state_witness: zone_inputs.state_witness,
+        tempo_state_witness: TempoStateWitness {
+            initial_tempo_header_rlp: Bytes::from(alloy_rlp::encode(&initial_tempo_header)),
+            node_pool: Vec::new(),
+        },
+        tempo_ancestry_headers: anchor.ancestry_headers,
+    };
+
+    let spf_config = SpfConfig::new(context.config.evm_config.chain_spec().clone());
+    let mut requested_reads = std::collections::BTreeSet::new();
+    let mut tempo_proof_rounds = 0usize;
+    let output = loop {
+        let config = spf_config.clone();
+        let attempt = witness.clone();
+        let result = tokio::task::spawn_blocking(move || prove_zone_batch(&config, attempt))
+            .await
+            .context("SPF worker panicked")?;
+        match result {
+            Ok(output) => break output,
+            Err(SpfError::MissingTempoStorage {
+                account,
+                slot,
+                block_number,
+            }) => {
+                ensure!(
+                    requested_reads.insert((block_number, account, slot)),
+                    "SPF repeatedly requested Tempo storage {account}[{slot}] at block {block_number}"
+                );
+                tempo_proof_rounds += 1;
+                debug!(
+                    target: "zone::sequencer::prover",
+                    tempo_block = block_number,
+                    %account,
+                    %slot,
+                    "Shadow prover fetching missing Tempo storage proof"
+                );
+                let nodes =
+                    tempo_proof_nodes(&context.l1_provider, block_number, account, slot).await?;
+                merge_nodes(&mut witness.tempo_state_witness.node_pool, nodes);
+            }
+            Err(err) => return Err(err).context("SPF rejected generated witness"),
+        }
+    };
+
+    compare_output(&output, &job.batch)?;
+
+    Ok(ValidationStats {
+        witness_bytes: witness_size(&witness),
+        tempo_proof_rounds,
+        zone_state_nodes: witness.zone_state_witness.node_pool.len(),
+        tempo_state_nodes: witness.tempo_state_witness.node_pool.len(),
+    })
+}
+
+fn build_zone_inputs<P: ZoneSequencerProvider>(
+    provider: &P,
+    evm_config: &ZoneEvmConfig,
+    from: u64,
+    to: u64,
+    expected_prev_hash: B256,
+    expected_next_hash: B256,
+) -> Result<ZoneInputs> {
+    ensure!(from > 0, "SPF batch cannot start at Zone genesis");
+    ensure!(from <= to, "invalid Zone batch range {from}..={to}");
+
+    let parent_header = provider
+        .header_by_number(from - 1)?
+        .ok_or_eyre(format!("canonical Zone parent {} not found", from - 1))?;
+    ensure!(
+        parent_header.hash_slow() == expected_prev_hash,
+        "candidate parent hash changed: expected {expected_prev_hash}, found {}",
+        parent_header.hash_slow()
+    );
+    let parent_state = provider.state_by_block_hash(expected_prev_hash)?;
+    let initial_tempo = parent_state.tempo_num_hash()?;
+
+    let recovered = provider.recovered_block_range(from..=to)?;
+    ensure!(
+        recovered.len() == (to - from + 1) as usize,
+        "canonical Zone range {from}..={to} returned {} blocks",
+        recovered.len()
+    );
+
+    let mut expected_parent = expected_prev_hash;
+    let mut extracted = Vec::with_capacity(recovered.len());
+    let mut state_nodes = BTreeMap::new();
+    let mut bytecodes = BTreeMap::new();
+    for (offset, block) in recovered.iter().enumerate() {
+        let number = from + offset as u64;
+        ensure!(
+            block.number() == number,
+            "canonical Zone range returned block {} at expected height {number}",
+            block.number()
+        );
+        ensure!(
+            block.parent_hash() == expected_parent,
+            "Zone block {number} parent changed: expected {expected_parent}, found {}",
+            block.parent_hash()
+        );
+        let canonical_hash = provider
+            .block_hash(number)?
+            .ok_or_eyre(format!("canonical Zone block {number} has no hash"))?;
+        ensure!(
+            block.hash() == canonical_hash,
+            "recovered Zone block {number} is not canonical"
+        );
+
+        let (nodes, codes) = execution_witness_for_block(provider, evm_config, block)?;
+        for node in nodes {
+            state_nodes.entry(keccak256(&node)).or_insert(node);
+        }
+        for code in codes {
+            bytecodes.entry(keccak256(&code)).or_insert(code);
+        }
+        extracted.push(extract_zone_block(block)?);
+        expected_parent = canonical_hash;
+    }
+    ensure!(
+        expected_parent == expected_next_hash,
+        "candidate tip hash changed: expected {expected_next_hash}, found {expected_parent}"
+    );
+
+    Ok(ZoneInputs {
+        parent_header,
+        blocks: extracted,
+        state_witness: ZoneStateWitness {
+            node_pool: state_nodes.into_values().collect(),
+            bytecodes: bytecodes.into_values().collect(),
+        },
+        initial_tempo_number: initial_tempo.number,
+        initial_tempo_hash: initial_tempo.hash,
+    })
+}
+
+fn execution_witness_for_block<P: ZoneSequencerProvider>(
+    provider: &P,
+    evm_config: &ZoneEvmConfig,
+    block: &RecoveredBlock<Block>,
+) -> Result<(Vec<Bytes>, Vec<Bytes>)> {
+    let state_provider = provider.state_by_block_hash(block.parent_hash())?;
+    let mut state = State::builder()
+        .with_database(StateProviderDatabase::new(&state_provider))
+        .with_bundle_update()
+        .build();
+    let executor = evm_config.executor(&mut state);
+    let mut record = ExecutionWitnessRecord::default();
+    executor
+        .execute_with_state_closure(block, |executed| {
+            record.record_executed_state(executed, ExecutionWitnessMode::default());
+        })
+        .map_err(|err| eyre::eyre!("re-execute canonical Zone block {}: {err}", block.number()))?;
+
+    if record
+        .lowest_block_number
+        .is_some_and(|lowest| lowest < block.number().saturating_sub(1))
+    {
+        bail!(
+            "Zone block {} reads an older BLOCKHASH, which the SPF witness cannot represent",
+            block.number()
+        );
+    }
+
+    let nodes = state_provider.witness(
+        Default::default(),
+        record.hashed_state,
+        ExecutionWitnessMode::default(),
+    )?;
+    Ok((nodes, record.codes))
+}
+
+fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
+    let header = block.header();
+    let mut tempo_header_rlp = None;
+    let mut deposits = Vec::new();
+    let mut decryptions = Vec::new();
+    let mut enabled_tokens = Vec::new();
+    let mut finalize_count = None;
+    let mut finalize_encrypted_senders = Vec::new();
+    let mut user_transactions = Vec::new();
+
+    for transaction in &block.body().transactions {
+        if !transaction.is_system_tx() {
+            user_transactions.push(Bytes::from(transaction.encoded_2718()));
+            continue;
+        }
+
+        match transaction.to() {
+            Some(to) if to == ZONE_INBOX_ADDRESS => {
+                ensure!(
+                    tempo_header_rlp.is_none(),
+                    "Zone block {} contains multiple advanceTempo calls",
+                    header.number()
+                );
+                let call = ZoneInbox::advanceTempoCall::abi_decode(transaction.input())
+                    .wrap_err_with(|| {
+                        format!("decode advanceTempo in Zone block {}", header.number())
+                    })?;
+                decode_tempo_header(&call.header).wrap_err_with(|| {
+                    format!("decode Tempo checkpoint in Zone block {}", header.number())
+                })?;
+                tempo_header_rlp = Some(call.header);
+                deposits = call.deposits;
+                decryptions = call.decryptions;
+                enabled_tokens = call.enabledTokens;
+            }
+            Some(to) if to == ZONE_OUTBOX_ADDRESS => {
+                ensure!(
+                    finalize_count.is_none(),
+                    "Zone block {} contains multiple finalizeWithdrawalBatch calls",
+                    header.number()
+                );
+                let call = ZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(transaction.input())
+                    .wrap_err_with(|| {
+                        format!(
+                            "decode finalizeWithdrawalBatch in Zone block {}",
+                            header.number()
+                        )
+                    })?;
+                ensure!(
+                    call.blockNumber == header.number(),
+                    "finalization in Zone block {} declares block {}",
+                    header.number(),
+                    call.blockNumber
+                );
+                finalize_count = Some(call.count);
+                finalize_encrypted_senders = call.encryptedSenders;
+            }
+            target => bail!(
+                "unsupported system transaction target {target:?} in Zone block {}",
+                header.number()
+            ),
+        }
+    }
+
+    Ok(ZoneBlock {
+        number: header.number(),
+        parent_hash: header.parent_hash(),
+        timestamp: header.timestamp(),
+        beneficiary: header.beneficiary(),
+        tempo_header_rlp,
+        deposits,
+        decryptions,
+        enabled_tokens,
+        finalize_withdrawal_batch_count: finalize_count,
+        finalize_withdrawal_batch_encrypted_senders: finalize_encrypted_senders,
+        transactions: user_transactions,
+    })
+}
+
+fn decode_tempo_header(encoded: &[u8]) -> Result<TempoHeader> {
+    let mut input = encoded;
+    let header = TempoHeader::decode(&mut input).context("decode Tempo header RLP")?;
+    ensure!(input.is_empty(), "Tempo header RLP has trailing bytes");
+    Ok(header)
+}
+
+async fn tempo_header(provider: &DynProvider<TempoNetwork>, number: u64) -> Result<TempoHeader> {
+    provider
+        .get_block_by_number(BlockNumberOrTag::Number(number))
+        .await?
+        .map(|block| block.header.as_ref().clone())
+        .ok_or_eyre(format!("Tempo block {number} not found"))
+}
+
+async fn resolve_anchor(
+    provider: &DynProvider<TempoNetwork>,
+    checkpoint_number: u64,
+    checkpoint_hash: B256,
+    config: BatchAnchorConfig,
+) -> Result<Anchor> {
+    let tip = provider.get_block_number().await?;
+    ensure!(
+        checkpoint_number < tip,
+        "Tempo checkpoint {checkpoint_number} is not yet confirmed behind tip {tip}"
+    );
+    let gap = tip - checkpoint_number;
+    if gap < config.effective_window() {
+        return Ok(Anchor {
+            number: checkpoint_number,
+            hash: checkpoint_hash,
+            ancestry_headers: Vec::new(),
+        });
+    }
+
+    let anchor_number = tip.saturating_sub(config.safety_margin());
+    ensure!(
+        anchor_number > checkpoint_number,
+        "Tempo ancestry anchor {anchor_number} does not follow checkpoint {checkpoint_number}"
+    );
+    let mut expected_parent = checkpoint_hash;
+    let mut ancestry_headers = Vec::with_capacity((anchor_number - checkpoint_number) as usize);
+    for number in checkpoint_number + 1..=anchor_number {
+        let header = tempo_header(provider, number).await?;
+        ensure!(
+            header.parent_hash() == expected_parent,
+            "Tempo ancestry broke at block {number}: expected parent {expected_parent}, found {}",
+            header.parent_hash()
+        );
+        expected_parent = header.hash_slow();
+        ancestry_headers.push(Bytes::from(alloy_rlp::encode(&header)));
+    }
+    Ok(Anchor {
+        number: anchor_number,
+        hash: expected_parent,
+        ancestry_headers,
+    })
+}
+
+async fn tempo_proof_nodes(
+    provider: &DynProvider<TempoNetwork>,
+    block_number: u64,
+    account: Address,
+    slot: B256,
+) -> Result<Vec<Bytes>> {
+    let proof = provider
+        .get_proof(account, vec![slot])
+        .block_id(BlockId::number(block_number))
+        .await
+        .wrap_err_with(|| {
+            format!("eth_getProof for {account}[{slot}] at Tempo block {block_number}")
+        })?;
+    Ok(proof
+        .account_proof
+        .into_iter()
+        .chain(
+            proof
+                .storage_proof
+                .into_iter()
+                .flat_map(|storage| storage.proof),
+        )
+        .collect())
+}
+
+fn merge_nodes(target: &mut Vec<Bytes>, additional: Vec<Bytes>) {
+    let mut nodes = BTreeMap::new();
+    for node in target.drain(..).chain(additional) {
+        nodes.entry(keccak256(&node)).or_insert(node);
+    }
+    *target = nodes.into_values().collect();
+}
+
+fn compare_output(output: &BatchOutput, batch: &BatchData) -> Result<()> {
+    ensure!(
+        output.block_transition.prevBlockHash == batch.prev_block_hash,
+        "previous Zone block commitment mismatch: SPF {}, candidate {}",
+        output.block_transition.prevBlockHash,
+        batch.prev_block_hash
+    );
+    ensure!(
+        output.block_transition.nextBlockHash == batch.next_block_hash,
+        "next Zone block commitment mismatch: SPF {}, candidate {}",
+        output.block_transition.nextBlockHash,
+        batch.next_block_hash
+    );
+    ensure!(
+        output.deposit_queue_transition.prevProcessedHash == batch.prev_processed_deposit_hash,
+        "previous deposit hash mismatch: SPF {}, candidate {}",
+        output.deposit_queue_transition.prevProcessedHash,
+        batch.prev_processed_deposit_hash
+    );
+    ensure!(
+        output.deposit_queue_transition.nextProcessedHash == batch.next_processed_deposit_hash,
+        "next deposit hash mismatch: SPF {}, candidate {}",
+        output.deposit_queue_transition.nextProcessedHash,
+        batch.next_processed_deposit_hash
+    );
+    ensure!(
+        output.deposit_queue_transition.prevDepositNumber == batch.prev_deposit_number,
+        "previous deposit number mismatch: SPF {}, candidate {}",
+        output.deposit_queue_transition.prevDepositNumber,
+        batch.prev_deposit_number
+    );
+    ensure!(
+        output.deposit_queue_transition.nextDepositNumber == batch.next_deposit_number,
+        "next deposit number mismatch: SPF {}, candidate {}",
+        output.deposit_queue_transition.nextDepositNumber,
+        batch.next_deposit_number
+    );
+    ensure!(
+        output.withdrawal_queue_hash == batch.withdrawal_queue_hash,
+        "withdrawal queue hash mismatch: SPF {}, candidate {}",
+        output.withdrawal_queue_hash,
+        batch.withdrawal_queue_hash
+    );
+    ensure!(
+        output.last_batch_commitment.withdrawal_batch_index == batch.withdrawal_batch_index,
+        "withdrawal batch index mismatch: SPF {}, candidate {}",
+        output.last_batch_commitment.withdrawal_batch_index,
+        batch.withdrawal_batch_index
+    );
+    Ok(())
+}
+
+fn witness_size(witness: &BatchWitness) -> usize {
+    witness
+        .zone_state_witness
+        .node_pool
+        .iter()
+        .chain(&witness.zone_state_witness.bytecodes)
+        .chain(&witness.tempo_state_witness.node_pool)
+        .chain(&witness.tempo_ancestry_headers)
+        .map(|bytes| bytes.len())
+        .sum::<usize>()
+        + witness.tempo_state_witness.initial_tempo_header_rlp.len()
+        + witness
+            .zone_blocks
+            .iter()
+            .map(|block| {
+                block
+                    .tempo_header_rlp
+                    .as_ref()
+                    .map_or(0, |bytes| bytes.len())
+                    + block
+                        .transactions
+                        .iter()
+                        .map(|bytes| bytes.len())
+                        .sum::<usize>()
+            })
+            .sum::<usize>()
+}


### PR DESCRIPTION
Adds opt-in shadow SPF validation for sequencers via `--sequencer.enable-prover`. Finalized batch candidates are sent to a detached worker that builds the Zone and Tempo witnesses, runs `zone-spf`, and compares the resulting commitments against the candidate submitted for settlement.

Validation is observational and non-blocking: prover failures or queue saturation are logged without affecting settlement.