### PR TITLE
feat: leverage upstream `StorageOps` and `Handler`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,16 +45,6 @@ jobs:
         with:
           tool: nextest@0.9.124
 
-      - name: Generate updated lockfile
-        run: cargo update
-
-      - name: Upload updated lockfile
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: generated-lockfile
-          path: Cargo.lock
-          retention-days: 1
-
       - name: Install Foundry
         uses: tempoxyz/gh-actions/actions/setup-foundry@98b1081dcf34361b576aca2ab3041772708582ef
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,17 @@ jobs:
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: nextest@0.9.124
+
+      - name: Generate updated lockfile
+        run: cargo update
+
+      - name: Upload updated lockfile
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: generated-lockfile
+          path: Cargo.lock
+          retention-days: 1
+
       - name: Install Foundry
         uses: tempoxyz/gh-actions/actions/setup-foundry@98b1081dcf34361b576aca2ab3041772708582ef
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7229,7 +7229,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7256,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7289,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7309,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7322,7 +7322,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7416,7 +7416,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7483,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7497,7 +7497,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7510,7 +7510,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7535,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7564,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7590,7 +7590,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7620,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7684,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7708,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7743,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7770,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7793,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7820,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7906,7 +7906,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7924,7 +7924,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7940,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7963,7 +7963,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7974,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8064,7 +8064,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "clap",
  "eyre",
@@ -8087,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8119,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8132,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8162,7 +8162,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8176,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8186,7 +8186,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8211,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8231,7 +8231,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8249,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8281,7 +8281,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8319,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8333,7 +8333,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "serde",
  "serde_json",
@@ -8343,7 +8343,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8369,7 +8369,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bytes",
  "futures",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -8406,7 +8406,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bindgen",
  "cc",
@@ -8415,7 +8415,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "futures",
  "libc",
@@ -8429,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8438,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8452,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8510,7 +8510,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8535,7 +8535,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8574,7 +8574,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8588,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8605,7 +8605,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8629,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8697,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8752,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8825,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8849,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bytes",
  "eyre",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8885,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8909,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8944,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9035,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9078,7 +9078,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9093,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9200,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9243,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9341,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9437,7 +9437,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9516,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9550,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9565,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9608,7 +9608,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9629,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9645,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "clap",
  "eyre",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9691,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9734,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11173,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11212,7 +11212,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11248,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11260,7 +11260,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11295,7 +11295,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11307,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11367,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11405,7 +11405,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11425,7 +11425,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11448,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11459,7 +11459,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11491,7 +11491,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11514,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
+source = "git+https://github.com/tempoxyz/tempo?rev=e180fc17046c1b270315d83bb0b22c5057a9cc73#e180fc17046c1b270315d83bb0b22c5057a9cc73"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
+checksum = "7bdf7932042b511ad4ad67f7eeac896df62439ac91a8c516d678b79cbe3f9c27"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -151,14 +151,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5c8b5baa015ef1d07a33983794e1539cce36954846a9bc6e1050d8a1ebf9b7"
+checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -189,15 +189,15 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+checksum = "e8421a5ee9019b6d89f92935d0f8facd9f6ca088b41d7cc47244a02ccde4545f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -235,7 +235,7 @@ dependencies = [
  "crc",
  "rand 0.8.7",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -266,7 +266,7 @@ dependencies = [
  "rand 0.8.7",
  "serde",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -281,14 +281,14 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -312,16 +312,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ddd5c63a05ac3274143ed0589e129119206f65cf094d2e727499da23efae8"
+checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -339,15 +339,15 @@ dependencies = [
  "auto_impl",
  "derive_more",
  "revm",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -386,24 +386,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
+checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-network"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
+checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -422,14 +422,14 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
+checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -509,7 +509,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa5976a77e32a63152e937fa90d0dae1f8142b41a9a99a6386d6ea58934cfa6"
+checksum = "71044e076a7c243454619e36279fc4654bc1ff846fbf666663ef574388859c84"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
+checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
+checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3279cb55f7069c2fb1dbcd9ab2c6e79a02d63c92fd0b850addea0a3715d6b05f"
+checksum = "980671fae7bff5ab0ae2d0bfe5c97e42cda103fece106f8d0e584a41c789fc7c"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f89d27756bf3effdac25d07692724e840ce90ca1ff956a6b47dd2ae1612f597"
+checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
+checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81133671b8da58169589aac996f3c4da23bbdee85b13ecee7098065f3eae718a"
+checksum = "d22759d1d0e79082a5a06f75dc45bf55dfedbb4ac9890da1f179d85a5d2f32f7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -657,16 +657,16 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tree_hash",
  "tree_hash_derive",
 ]
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e9c1f9ac81c56b2d96901201db7eb95c4e9fc3c21237a4690f8c652aa62089"
+checksum = "7b918cbaadbdcffa4ed64840a5ecbde80a6476ab23adc8c5c8ae6feec081058c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1f682c4881aa7000ac7cc86d7aeeb3b09836a77a90b329820140233651aeea"
+checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -714,14 +714,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c635f0c45a871b55c276653e3838d1687d86282eeaf3d83a1914e02563b3f2"
+checksum = "b04a8f30a439c995d71ab999d56a828dcbe4d90b4f012419832779e60acf86af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -734,23 +734,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796729a4e1783904c6040f11a503c4d55ddb16f69dc199ad15e50c4ad039f371"
+checksum = "a12cafc0ee2290122ec4e069bb0f2389a356f4b5414f2e82de8288049c2bc98a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533c450895de79eb581875bfc317d1a239ae71aba79e20ee158fa153268f163"
+checksum = "157eec8f8661e6e70e3749c0a4d918a8831f0b0fc152aed60c0de457faca420b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
+checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -782,14 +782,14 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c880813cd26bd1ddf8c2236e31295896efd1fcc5cc761d8894ae894503aeea53"
+checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -800,7 +800,7 @@ dependencies = [
  "coins-bip39",
  "k256",
  "rand 0.8.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zeroize",
 ]
 
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
+checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -892,7 +892,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
@@ -902,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
+checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24422d5159996688b0c094babf1969cb0197d453902da483711c92c1624fea2"
+checksum = "e7b51470da19d0ed256bb3cf31042cceca3ce01714a9ca76624fc71a999f6a27"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bea36621cd4e4f06c1243e556b32fdc9c4db7b9b09b72a95a87383c0ffcc625"
+checksum = "e67177a75a6e8a44f39ccbbc64a3e3a70186ef401d7313285b56735d4285aa34"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -971,15 +971,15 @@ dependencies = [
  "proptest-derive 0.7.0",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1054,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "approx"
@@ -1518,13 +1518,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1573,9 +1573,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -1733,7 +1733,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1804,9 +1804,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -1874,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
 dependencies = [
  "cc",
  "glob",
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1993,9 +1993,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -2055,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2088,9 +2088,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -2192,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2214,14 +2214,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2335,7 +2335,7 @@ dependencies = [
  "commonware-runtime",
  "commonware-utils",
  "prometheus-client",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -2350,7 +2350,7 @@ dependencies = [
  "paste",
  "rand 0.8.7",
  "rand_chacha 0.3.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2371,7 +2371,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "reed-solomon-simd",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2400,7 +2400,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_distr",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -2433,7 +2433,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "x25519-dalek",
  "zeroize",
 ]
@@ -2494,7 +2494,7 @@ dependencies = [
  "rand 0.8.7",
  "rand_core 0.6.4",
  "rand_distr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -2524,7 +2524,7 @@ dependencies = [
  "futures",
  "prometheus-client",
  "rand 0.8.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -2557,7 +2557,7 @@ dependencies = [
  "rayon",
  "sha2 0.10.9",
  "sysinfo 0.37.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.32.1",
@@ -2583,7 +2583,7 @@ dependencies = [
  "futures-util",
  "prometheus-client",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zstd",
 ]
@@ -2602,7 +2602,7 @@ dependencies = [
  "futures",
  "rand 0.8.7",
  "rand_core 0.6.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "x25519-dalek",
  "zeroize",
 ]
@@ -2626,7 +2626,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.8.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "zeroize",
 ]
@@ -2900,7 +2900,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -3128,7 +3128,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3418,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -3582,9 +3582,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fastrlp"
@@ -3754,9 +3754,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3769,9 +3769,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3779,15 +3779,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3796,15 +3796,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3813,15 +3813,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -3835,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3939,7 +3939,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -3947,9 +3947,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-net"
@@ -4135,9 +4135,9 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -4196,7 +4196,7 @@ dependencies = [
  "ipnet",
  "jni 0.22.4",
  "rand 0.10.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4218,7 +4218,7 @@ dependencies = [
  "rand 0.10.2",
  "ring",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "url",
@@ -4246,7 +4246,7 @@ dependencies = [
  "serde",
  "smallvec",
  "system-configuration",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4353,9 +4353,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4570,12 +4570,13 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
 dependencies = [
  "archery",
  "bitmaps",
+ "equivalent",
  "imbl-sized-chunks",
  "rand_core 0.9.5",
  "rand_xoshiro",
@@ -4677,7 +4678,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -4791,11 +4792,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.32"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -4804,11 +4806,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.32"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4842,7 +4854,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -4944,7 +4956,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier 0.5.3",
  "soketto",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -4972,7 +4984,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tower",
@@ -4997,7 +5009,7 @@ dependencies = [
  "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "url",
@@ -5035,7 +5047,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5052,7 +5064,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5122,7 +5134,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5185,7 +5197,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -5197,9 +5209,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "left-right"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+checksum = "8bc015ded5d9b3054dbbdb63332cdd6ee42352ccef19e911e25117490e2f48ee"
 dependencies = [
  "crossbeam-utils",
  "loom",
@@ -5208,15 +5220,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",
@@ -5254,7 +5266,7 @@ dependencies = [
  "multihash",
  "prost",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zeroize",
 ]
@@ -5313,7 +5325,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5528,7 +5540,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5730,7 +5742,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -5748,7 +5760,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5909,7 +5921,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5966,7 +5978,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -5980,7 +5992,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -6023,7 +6035,7 @@ dependencies = [
  "opentelemetry_sdk 0.31.0",
  "prost",
  "reqwest 0.12.28",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -6040,7 +6052,7 @@ dependencies = [
  "opentelemetry_sdk 0.32.1",
  "prost",
  "reqwest 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tonic-types",
@@ -6090,7 +6102,7 @@ dependencies = [
  "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -6108,7 +6120,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6244,9 +6256,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -6433,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -6576,9 +6588,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -6589,7 +6601,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "flate2",
  "procfs-core",
@@ -6602,7 +6614,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "chrono",
  "hex",
 ]
@@ -6638,7 +6650,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
  "rand_chacha 0.9.0",
@@ -6748,7 +6760,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -6771,7 +6783,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6793,9 +6805,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -6963,7 +6975,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "compact_str",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
@@ -6972,7 +6984,7 @@ dependencies = [
  "palette",
  "serde",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -6996,7 +7008,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.17.1",
  "indoc",
  "instability",
@@ -7016,7 +7028,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -7057,7 +7069,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -7085,29 +7097,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7117,9 +7129,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -7217,7 +7229,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7244,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7277,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7297,7 +7309,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7310,7 +7322,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7394,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7404,7 +7416,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7415,7 +7427,7 @@ dependencies = [
  "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tikv-jemalloc-sys",
  "tikv-jemallocator",
 ]
@@ -7455,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7471,7 +7483,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7479,13 +7491,13 @@ dependencies = [
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7498,7 +7510,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7523,7 +7535,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7545,14 +7557,14 @@ dependencies = [
  "strum 0.27.2",
  "sysinfo 0.38.4",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7578,7 +7590,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7601,14 +7613,14 @@ dependencies = [
  "reth-trie-db",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7623,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7639,7 +7651,7 @@ dependencies = [
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7648,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7664,7 +7676,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-peers",
  "secp256k1 0.30.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -7672,7 +7684,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7687,7 +7699,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7696,7 +7708,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7721,7 +7733,7 @@ dependencies = [
  "reth-tasks",
  "reth-testing-utils",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7731,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7748,7 +7760,7 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7758,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7781,7 +7793,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7801,14 +7813,14 @@ dependencies = [
  "reth-storage-api",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7823,6 +7835,7 @@ dependencies = [
  "indexmap 2.14.0",
  "metrics",
  "moka",
+ "parking_lot",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -7855,7 +7868,7 @@ dependencies = [
  "reth-trie-sparse",
  "revm",
  "schnellru",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -7863,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7893,7 +7906,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7905,13 +7918,13 @@ dependencies = [
  "ethereum_ssz_derive",
  "sha2 0.10.9",
  "snap",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7927,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7950,18 +7963,18 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
  "reth-storage-errors",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7979,7 +7992,7 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "snap",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7989,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8005,13 +8018,13 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8051,7 +8064,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -8074,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8090,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8100,13 +8113,13 @@ dependencies = [
  "reth-payload-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8119,7 +8132,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8149,7 +8162,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8163,7 +8176,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8173,7 +8186,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8198,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8218,7 +8231,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8236,20 +8249,20 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8268,7 +8281,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8297,7 +8310,7 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "rmp-serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8306,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8320,17 +8333,17 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8356,7 +8369,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "futures",
@@ -8365,7 +8378,7 @@ dependencies = [
  "jsonrpsee",
  "pin-project",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8376,9 +8389,9 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "crossbeam-queue",
  "dashmap",
@@ -8386,14 +8399,14 @@ dependencies = [
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bindgen",
  "cc",
@@ -8402,9 +8415,10 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures",
+ "libc",
  "metrics",
  "metrics-derive",
  "reth-primitives-traits",
@@ -8415,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8424,13 +8438,13 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures-util",
  "if-addrs",
  "reqwest 0.13.4",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -8438,7 +8452,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8486,7 +8500,7 @@ dependencies = [
  "serde",
  "smallvec",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -8496,7 +8510,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8513,7 +8527,7 @@ dependencies = [
  "reth-network-types",
  "reth-tokio-util",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -8521,7 +8535,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8545,14 +8559,14 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "enr",
  "secp256k1 0.30.0",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "url",
 ]
@@ -8560,7 +8574,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8574,7 +8588,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8583,7 +8597,7 @@ dependencies = [
  "memmap2",
  "reth-fs-util",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zstd",
 ]
@@ -8591,7 +8605,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8615,7 +8629,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8697,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8727,7 +8741,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "toml",
  "tracing",
  "url",
@@ -8738,7 +8752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8787,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8800,7 +8814,7 @@ dependencies = [
  "reth-transaction-pool",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.28.0",
@@ -8811,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8835,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "eyre",
@@ -8859,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8871,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8895,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8907,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8923,14 +8937,14 @@ dependencies = [
  "reth-trie-common",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8967,13 +8981,13 @@ dependencies = [
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9021,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9040,7 +9054,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tokio-util",
  "rustc-hash",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -9048,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9057,14 +9071,14 @@ dependencies = [
  "reth-codecs",
  "serde",
  "strum 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9079,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9146,7 +9160,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9156,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9186,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9218,7 +9232,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tower",
@@ -9229,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9243,13 +9257,13 @@ dependencies = [
  "reth-evm",
  "reth-primitives-traits",
  "reth-rpc-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9272,7 +9286,7 @@ dependencies = [
  "reth-tasks",
  "reth-transaction-pool",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -9280,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9327,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9368,7 +9382,7 @@ dependencies = [
  "revm-inspectors",
  "schnellru",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9378,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9392,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9417,13 +9431,13 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-signer",
  "reth-primitives-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9466,7 +9480,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-db",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -9474,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9494,7 +9508,7 @@ dependencies = [
  "reth-static-file",
  "reth-static-file-types",
  "reth-tokio-util",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -9502,7 +9516,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9536,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9551,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9577,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9588,13 +9602,13 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9605,7 +9619,7 @@ dependencies = [
  "pin-project",
  "rayon",
  "reth-metrics",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "thread-priority",
  "tokio",
  "tracing",
@@ -9615,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9631,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9641,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -9659,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9677,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9685,7 +9699,7 @@ dependencies = [
  "alloy-rlp",
  "aquamarine",
  "auto_impl",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "futures-util",
  "imbl",
  "metrics",
@@ -9711,7 +9725,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9720,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9772,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9791,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9808,14 +9822,14 @@ dependencies = [
  "reth-trie",
  "reth-trie-sparse",
  "revm",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -9934,7 +9948,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -9989,7 +10003,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -10049,7 +10063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "nonmax",
  "revm-bytecode",
  "revm-primitives",
@@ -10243,7 +10257,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -10280,9 +10294,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -10326,7 +10340,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs 1.0.8",
+ "webpki-root-certs 1.0.9",
  "windows-sys 0.61.2",
 ]
 
@@ -10413,9 +10427,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -10508,7 +10522,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -10557,9 +10571,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -10567,29 +10581,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -10644,7 +10658,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -10830,7 +10844,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -10873,9 +10887,9 @@ dependencies = [
 
 [[package]]
 name = "snap"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -11029,6 +11043,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-solidity"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11094,7 +11119,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -11148,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11187,7 +11212,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11211,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11223,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11235,7 +11260,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11263,14 +11288,14 @@ dependencies = [
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-revm",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11282,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11332,7 +11357,7 @@ dependencies = [
  "tempo-primitives",
  "tempo-revm",
  "tempo-transaction-pool",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "url",
  "vergen",
@@ -11342,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11380,7 +11405,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11400,12 +11425,12 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy",
  "alloy-evm",
  "alloy-primitives",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "commonware-codec",
  "commonware-cryptography",
  "derive_more",
@@ -11416,14 +11441,14 @@ dependencies = [
  "tempo-contracts",
  "tempo-precompiles-macros",
  "tempo-primitives",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11434,7 +11459,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11466,7 +11491,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11482,14 +11507,14 @@ dependencies = [
  "tempo-contracts",
  "tempo-precompiles",
  "tempo-primitives",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=6b6f12d052bd96039e0a8aa5b02a25fcae0f9335#6b6f12d052bd96039e0a8aa5b02a25fcae0f9335"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11519,7 +11544,7 @@ dependencies = [
  "tempo-precompiles",
  "tempo-primitives",
  "tempo-revm",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -11595,11 +11620,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -11615,13 +11640,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -11630,7 +11655,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2e834949be5111506bb252643498af1514f600d9e1dceedaa42afae155b67f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "libc",
  "log",
@@ -11689,9 +11714,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -11711,9 +11736,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -11756,9 +11781,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -11773,9 +11798,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11794,9 +11819,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -11835,14 +11860,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -11895,9 +11921,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -11984,7 +12010,7 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -12039,7 +12065,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing-subscriber 0.3.23",
 ]
@@ -12264,7 +12290,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
@@ -12281,7 +12307,7 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -12434,9 +12460,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -12662,14 +12688,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.8",
+ "webpki-root-certs 1.0.9",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -12680,14 +12706,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -13220,7 +13246,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -13288,18 +13314,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13426,7 +13452,7 @@ dependencies = [
  "tempo-primitives",
  "tempo-revm",
  "tempo-zone-contracts",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "zone-chainspec",
  "zone-l1",
@@ -13472,7 +13498,6 @@ dependencies = [
  "tracing",
  "url",
  "zone-precompiles",
- "zone-primitives",
 ]
 
 [[package]]
@@ -13542,7 +13567,7 @@ dependencies = [
  "tempo-revm",
  "tempo-transaction-pool",
  "tempo-zone-contracts",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tokio-util",
@@ -13576,7 +13601,7 @@ dependencies = [
  "eyre",
  "metrics",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "toml",
@@ -13648,7 +13673,7 @@ dependencies = [
  "tempo-precompiles-macros",
  "tempo-primitives",
  "tempo-zone-contracts",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zone-primitives",
 ]
@@ -13688,7 +13713,7 @@ dependencies = [
  "tempo-alloy",
  "tempo-contracts",
  "tempo-primitives",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,13 +3308,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3468,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -7268,7 +7268,6 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.5",
- "rayon",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -7276,7 +7275,6 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
- "reth-tasks",
  "reth-trie",
  "reth-trie-sparse",
  "revm",
@@ -7859,11 +7857,11 @@ dependencies = [
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
+ "reth-storage-overlay",
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
  "reth-trie-common",
- "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "revm",
@@ -8195,6 +8193,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more",
+ "fixed-cache",
  "futures-util",
  "metrics",
  "rayon",
@@ -8481,6 +8480,7 @@ dependencies = [
  "reth-eth-wire-types",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
+ "reth-evm",
  "reth-evm-ethereum",
  "reth-fs-util",
  "reth-metrics",
@@ -8682,11 +8682,11 @@ dependencies = [
  "reth-rpc-layer",
  "reth-stages",
  "reth-static-file",
+ "reth-storage-overlay",
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9020,6 +9020,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-storage-overlay",
  "reth-tasks",
  "reth-tokio-util",
  "reth-trie",
@@ -9606,6 +9607,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-storage-overlay"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "metrics",
+ "parking_lot",
+ "rayon",
+ "reth-chain-state",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-tasks",
+ "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
+ "tracing",
+]
+
+[[package]]
 name = "reth-tasks"
 version = "2.4.1"
 source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
@@ -9789,11 +9816,8 @@ version = "2.4.1"
 source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
- "metrics",
- "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,25 +94,25 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
@@ -128,38 +128,38 @@ zone-rpc = { path = "crates/rpc" }
 zone-sequencer = { path = "crates/sequencer" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400", features = [
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 revm = { version = "41.0.0", features = [
   "optional_fee_charge",
 ], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,25 +94,25 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "6b6f12d052bd96039e0a8aa5b02a25fcae0f9335", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "e180fc17046c1b270315d83bb0b22c5057a9cc73", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
@@ -128,38 +128,38 @@ zone-rpc = { path = "crates/rpc" }
 zone-sequencer = { path = "crates/sequencer" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", features = [
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
 revm = { version = "41.0.0", features = [
   "optional_fee_charge",
 ], default-features = false }

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -51,7 +51,6 @@ serde = { workspace = true, features = ["derive"] }
 tokio.workspace = true
 tracing.workspace = true
 url = "2"
-zone-primitives.workspace = true
 
 [dev-dependencies]
 alloy-rlp.workspace = true

--- a/crates/l1/src/state/prefetch.rs
+++ b/crates/l1/src/state/prefetch.rs
@@ -4,35 +4,100 @@
 //! before payload construction starts. This module turns that data into bounded waves of exact-L1
 //! storage reads so the payload builder normally observes cache hits instead of serial RPC calls.
 
-use super::L1StateProvider;
-use alloy_primitives::{Address, B256, U256, keccak256};
+use super::{L1StateProvider, provider::StorageSlot};
+use alloy_primitives::{Address, B256, U256};
 use eyre::{Result, WrapErr as _};
 use std::{
     collections::{HashMap, HashSet},
     time::Instant,
 };
-use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 use tempo_precompiles::{
-    storage::StorageKey as _,
-    tip403_registry::{
-        ALLOW_ALL_POLICY_ID, PolicyType, REJECT_ALL_POLICY_ID, TIP403Registry,
-        tip403_registry_slots,
-    },
+    error::TempoPrecompileError,
+    receive_policy_guard::RecoveryMode,
+    storage::{Handler, Storable, StorageOps},
+    tip403_registry::{ALLOW_ALL_POLICY_ID, PolicyType, REJECT_ALL_POLICY_ID, TIP403Registry},
+    zone_factory::ZonePortalStorage,
 };
 use tempo_primitives::TempoAddressExt as _;
 use tempo_zone_contracts::ZONE_INBOX_ADDRESS;
 use tracing::info;
-use zone_primitives::constants::{
-    PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, PORTAL_ENCRYPTION_KEYS_SLOT,
-};
 
-type StorageSlot = (Address, B256);
-type StorageValues = HashMap<StorageSlot, B256>;
+/// Immutable raw words returned by exactly one completed prefetch wave.
+///
+/// Values are decoded through their generated typed slots. Reads never fall back to the provider
+/// cache, so an incomplete dependency wave fails visibly instead of silently decoding as zero.
+struct StorageValues(HashMap<StorageSlot, B256>);
+
+impl StorageValues {
+    fn read<T: Storable>(&self, handler: &impl Handler<T>) -> Result<T> {
+        let slot = handler.as_slot();
+        let storage = AccountValues {
+            address: slot.address(),
+            words: &self.0,
+        };
+        T::load(&storage, slot.slot(), slot.ctx()).map_err(|error| {
+            let StorageSlot(address, raw_slot) = (slot.address(), slot.slot()).into();
+            eyre::eyre!(
+                "failed to decode {} from prefetched storage at {address}[{raw_slot}]: {error}",
+                std::any::type_name::<T>(),
+            )
+        })
+    }
+}
+
+/// Read-only [`StorageOps`] view of one account in a wave's fetched values.
+///
+/// [`StorageOps::load`] receives only a slot number, so typed decoding binds the slot's account in
+/// this adapter before calling [`Storable::load`].
+struct AccountValues<'a> {
+    address: Address,
+    words: &'a HashMap<StorageSlot, B256>,
+}
+
+impl StorageOps for AccountValues<'_> {
+    fn load(&self, slot: U256) -> tempo_precompiles::Result<U256> {
+        let raw_slot = B256::from(slot.to_be_bytes::<32>());
+        self.words
+            .get(&StorageSlot(self.address, raw_slot))
+            .copied()
+            .map(Into::into)
+            .ok_or_else(|| {
+                TempoPrecompileError::Fatal(format!(
+                    "prefetch wave is missing storage word {}[{raw_slot}]",
+                    self.address
+                ))
+            })
+    }
+
+    fn store(&mut self, slot: U256, _value: U256) -> tempo_precompiles::Result<()> {
+        Err(TempoPrecompileError::Fatal(format!(
+            "attempted to write through read-only prefetched storage at {}[{}]",
+            self.address, slot
+        )))
+    }
+}
+
+/// Deduplicated raw storage words required by one value-dependent prefetch wave.
+///
+/// Inserting a typed handler expands every contiguous word described by [`Storable::SLOTS`].
+/// Packed fields naturally collapse to one [`StorageSlot`] through the underlying [`HashSet`].
+#[derive(Default)]
+struct PrefetchSlots(HashSet<StorageSlot>);
+
+impl PrefetchSlots {
+    /// Schedule every raw word occupied by a typed value.
+    fn insert<T: Storable>(&mut self, handler: &impl Handler<T>) {
+        let slot = handler.as_slot();
+        for offset in 0..T::SLOTS {
+            self.0
+                .insert((slot.address(), slot.slot() + U256::from(offset)).into());
+        }
+    }
+}
 
 /// Hardfork-sensitive controls for deposit storage prefetching.
 #[derive(Debug, Clone, Copy)]
 pub struct DepositPrefetchConfig {
-    receive_policies: bool,
     registry_token_policies: bool,
     concurrency: usize,
 }
@@ -40,21 +105,11 @@ pub struct DepositPrefetchConfig {
 impl DepositPrefetchConfig {
     /// Create a configuration for the hardforks active in the zone block being prepared and the
     /// operator's maximum number of concurrent L1 requests.
-    pub const fn new(
-        receive_policies: bool,
-        registry_token_policies: bool,
-        concurrency: usize,
-    ) -> Self {
+    pub const fn new(registry_token_policies: bool, concurrency: usize) -> Self {
         Self {
-            receive_policies,
             registry_token_policies,
             concurrency,
         }
-    }
-
-    #[cfg(test)]
-    const fn all() -> Self {
-        Self::new(true, true, 4)
     }
 }
 
@@ -106,7 +161,7 @@ impl DepositPrefetchPlan {
     }
 
     pub(crate) fn add_mint(&mut self, token: Address, recipient: Address) {
-        // T9 and T6 both follow T3, where these recipients fail validation before policy reads.
+        // Zones start at T7, after T3 made these recipients fail validation before policy reads.
         if recipient.is_zero() || recipient.is_tip20() {
             return;
         }
@@ -155,9 +210,8 @@ impl DepositPrefetchPlan {
             .prefetch_wave(provider, root_slots, config.concurrency, &mut all_slots)
             .await?;
 
-        let token_policies = self.registered_token_policies(&roots, config);
-        let policy_and_receive_slots =
-            self.policy_and_receive_slots(&roots, &token_policies, config);
+        let token_policies = self.registered_token_policies(&roots, config)?;
+        let policy_and_receive_slots = self.policy_and_receive_slots(&roots, &token_policies)?;
         let policy_and_receive = self
             .prefetch_wave(
                 provider,
@@ -167,7 +221,7 @@ impl DepositPrefetchPlan {
             )
             .await?;
 
-        let mint_policy_slots = self.mint_policy_slots(&token_policies, &policy_and_receive);
+        let mint_policy_slots = self.mint_policy_slots(&token_policies, &policy_and_receive)?;
         let mint_policies = self
             .prefetch_wave(
                 provider,
@@ -178,7 +232,7 @@ impl DepositPrefetchPlan {
             .await?;
 
         let compound_subpolicy_slots =
-            self.compound_subpolicy_slots(&token_policies, &policy_and_receive, &mint_policies);
+            self.compound_subpolicy_slots(&token_policies, &policy_and_receive, &mint_policies)?;
         self.prefetch_wave(
             provider,
             compound_subpolicy_slots,
@@ -201,14 +255,15 @@ impl DepositPrefetchPlan {
     async fn prefetch_wave(
         &self,
         provider: &L1StateProvider,
-        slots: HashSet<StorageSlot>,
+        slots: PrefetchSlots,
         concurrency: usize,
         all_slots: &mut HashSet<StorageSlot>,
     ) -> Result<StorageValues> {
-        all_slots.extend(slots.iter().copied());
+        all_slots.extend(slots.0.iter().copied());
         provider
-            .prefetch_storage(slots, self.block_number, concurrency)
+            .prefetch_storage(slots.0, self.block_number, concurrency)
             .await
+            .map(StorageValues)
             .wrap_err_with(|| {
                 format!(
                     "failed to prefetch deposit L1 state at block {}",
@@ -217,268 +272,144 @@ impl DepositPrefetchPlan {
             })
     }
 
-    fn root_slots(&self, config: DepositPrefetchConfig) -> Result<HashSet<StorageSlot>> {
-        let mut slots = HashSet::new();
+    fn root_slots(&self, config: DepositPrefetchConfig) -> Result<PrefetchSlots> {
+        let registry = TIP403Registry::new();
+        let mut wave = PrefetchSlots::default();
         if !self.portal.is_zero() {
-            slots.insert((self.portal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT));
-            for &key_index in &self.encryption_key_indices {
-                let (x, metadata) = encryption_key_slots(key_index)?;
-                slots.extend([(self.portal, x), (self.portal, metadata)]);
+            let portal = ZonePortalStorage::new(self.portal);
+            wave.insert(&portal.current_deposit_queue_hash);
+            for &index in &self.encryption_key_indices {
+                let index = usize::try_from(index).wrap_err_with(|| {
+                    format!("Portal encryption key index exceeds usize: {index}")
+                })?;
+                wave.insert(&portal.encryption_keys[index]);
             }
         }
-
         for &token in &self.enabled_tokens {
-            slots.insert(token_policy_binding_slot(token));
+            wave.insert(&registry.token_transfer_policies[token]);
         }
         if config.registry_token_policies {
             for &token in &self.deposit_tokens {
-                slots.insert(token_policy_binding_slot(token));
+                wave.insert(&registry.token_transfer_policies[token]);
             }
         }
-        if config.receive_policies {
-            for mint in &self.mints {
-                slots.insert(receive_policy_config_slot(mint.recipient));
-            }
+        for mint in &self.mints {
+            wave.insert(&registry.receive_policies[mint.recipient].config);
         }
-        Ok(slots)
+        Ok(wave)
     }
 
     fn registered_token_policies(
         &self,
         roots: &StorageValues,
         config: DepositPrefetchConfig,
-    ) -> HashMap<Address, u64> {
+    ) -> Result<HashMap<Address, u64>> {
         if !config.registry_token_policies {
-            return HashMap::new();
+            return Ok(HashMap::new());
         }
-
-        self.deposit_tokens
-            .iter()
-            .filter_map(|&token| {
-                let value = roots.get(&token_policy_binding_slot(token))?;
-                decode_token_policy_binding(*value).map(|policy_id| (token, policy_id))
-            })
-            .collect()
+        let mut result = HashMap::new();
+        let registry = TIP403Registry::new();
+        for &token in &self.deposit_tokens {
+            let transfer_policy = roots.read(&registry.token_transfer_policies[token])?;
+            if transfer_policy.is_set {
+                result.insert(token, transfer_policy.policy_id);
+            }
+        }
+        Ok(result)
     }
 
     fn policy_and_receive_slots(
         &self,
         roots: &StorageValues,
         token_policies: &HashMap<Address, u64>,
-        config: DepositPrefetchConfig,
-    ) -> HashSet<StorageSlot> {
-        let mut slots = HashSet::new();
-        if token_policies
-            .values()
-            .any(|&policy_id| !is_builtin_policy(policy_id))
-        {
-            slots.insert(policy_counter_slot());
-            slots.extend(
-                token_policies
-                    .values()
-                    .copied()
-                    .filter(|&policy_id| !is_builtin_policy(policy_id))
-                    .map(policy_base_slot),
-            );
-        }
-
-        if config.receive_policies {
-            for mint in &self.mints {
-                let Some(value) = roots.get(&receive_policy_config_slot(mint.recipient)) else {
-                    continue;
-                };
-                let Some(receive) = decode_receive_policy(*value) else {
-                    continue;
-                };
-                if !is_builtin_policy(receive.token_filter_id) {
-                    slots.insert(policy_member_slot(receive.token_filter_id, mint.token));
-                }
-                if !is_builtin_policy(receive.sender_policy_id) {
-                    slots.insert(policy_member_slot(
-                        receive.sender_policy_id,
-                        ZONE_INBOX_ADDRESS,
-                    ));
-                }
-                if receive.has_third_party_recovery {
-                    slots.insert(receive_policy_recovery_slot(mint.recipient));
-                }
+    ) -> Result<PrefetchSlots> {
+        let registry = TIP403Registry::new();
+        let mut slots = PrefetchSlots::default();
+        if token_policies.values().any(|id| !is_builtin_policy(*id)) {
+            slots.insert(&registry.policy_id_counter);
+            for &id in token_policies
+                .values()
+                .filter(|id| !is_builtin_policy(**id))
+            {
+                slots.insert(&registry.policy_records[id].base);
             }
         }
-        slots
+        for mint in &self.mints {
+            let receive = &registry.receive_policies[mint.recipient];
+            let config = roots.read(&receive.config)?;
+            if !config.has_receive_policy {
+                continue;
+            }
+            if !is_builtin_policy(config.token_filter_id) {
+                slots.insert(&registry.policy_set[config.token_filter_id][mint.token]);
+            }
+            if !is_builtin_policy(config.sender_policy_id) {
+                slots.insert(&registry.policy_set[config.sender_policy_id][ZONE_INBOX_ADDRESS]);
+            }
+            if config.recovery_mode == RecoveryMode::ThirdParty {
+                slots.insert(&receive.recovery_address);
+            }
+        }
+        Ok(slots)
     }
 
     fn mint_policy_slots(
         &self,
         token_policies: &HashMap<Address, u64>,
-        policy_values: &StorageValues,
-    ) -> HashSet<StorageSlot> {
-        let mut slots = HashSet::new();
-        for (&token, &policy_id) in token_policies {
-            if is_builtin_policy(policy_id) {
+        values: &StorageValues,
+    ) -> Result<PrefetchSlots> {
+        let registry = TIP403Registry::new();
+        let mut slots = PrefetchSlots::default();
+        for (&token, &id) in token_policies {
+            if is_builtin_policy(id) {
                 continue;
             }
-            let Some(base) = policy_values.get(&policy_base_slot(policy_id)) else {
-                continue;
-            };
-            if decode_policy_type(*base) == PolicyType::COMPOUND as u8 {
-                slots.insert(policy_compound_slot(policy_id));
+            if values.read(&registry.policy_records[id].base)?.policy_type
+                == PolicyType::COMPOUND as u8
+            {
+                slots.insert(&registry.policy_records[id].compound);
             } else {
-                // Simple authorization reads membership before validating the stored policy type.
-                slots.extend(
-                    self.mints
-                        .iter()
-                        .filter(|mint| mint.token == token)
-                        .map(|mint| policy_member_slot(policy_id, mint.recipient)),
-                );
+                for mint in self.mints.iter().filter(|mint| mint.token == token) {
+                    slots.insert(&registry.policy_set[id][mint.recipient]);
+                }
             }
         }
-        slots
+        Ok(slots)
     }
 
     fn compound_subpolicy_slots(
         &self,
         token_policies: &HashMap<Address, u64>,
-        policy_values: &StorageValues,
-        mint_policy_values: &StorageValues,
-    ) -> HashSet<StorageSlot> {
-        let mut slots = HashSet::new();
-        for (&token, &policy_id) in token_policies {
-            let Some(base) = policy_values.get(&policy_base_slot(policy_id)) else {
-                continue;
-            };
-            if decode_policy_type(*base) != PolicyType::COMPOUND as u8 {
+        policies: &StorageValues,
+        compounds: &StorageValues,
+    ) -> Result<PrefetchSlots> {
+        let registry = TIP403Registry::new();
+        let mut slots = PrefetchSlots::default();
+        for (&token, &id) in token_policies {
+            if is_builtin_policy(id)
+                || policies
+                    .read(&registry.policy_records[id].base)?
+                    .policy_type
+                    != PolicyType::COMPOUND as u8
+            {
                 continue;
             }
-            let Some(compound) = mint_policy_values.get(&policy_compound_slot(policy_id)) else {
-                continue;
-            };
-            let mint_policy_id = decode_compound_mint_policy(*compound);
-            if !is_builtin_policy(mint_policy_id) {
-                slots.insert(policy_base_slot(mint_policy_id));
-                slots.extend(
-                    self.mints
-                        .iter()
-                        .filter(|mint| mint.token == token)
-                        .map(|mint| policy_member_slot(mint_policy_id, mint.recipient)),
-                );
+            let mint_id = compounds
+                .read(&registry.policy_records[id].compound)?
+                .mint_recipient_policy_id;
+            if !is_builtin_policy(mint_id) {
+                slots.insert(&registry.policy_records[mint_id].base);
+                for mint in self.mints.iter().filter(|mint| mint.token == token) {
+                    slots.insert(&registry.policy_set[mint_id][mint.recipient]);
+                }
             }
         }
-        slots
+        Ok(slots)
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ReceivePolicy {
-    sender_policy_id: u64,
-    token_filter_id: u64,
-    has_third_party_recovery: bool,
-}
-
-fn registry_slot(slot: U256) -> StorageSlot {
-    (
-        TIP403_REGISTRY_ADDRESS,
-        B256::from(slot.to_be_bytes::<32>()),
-    )
-}
-
-fn token_policy_binding_slot(token: Address) -> StorageSlot {
-    registry_slot(TIP403Registry::new().token_transfer_policies[token].base_slot())
-}
-
-fn policy_counter_slot() -> StorageSlot {
-    registry_slot(TIP403Registry::new().policy_id_counter.slot())
-}
-
-fn policy_base_slot(policy_id: u64) -> StorageSlot {
-    registry_slot(
-        TIP403Registry::new().policy_records[policy_id]
-            .base
-            .base_slot(),
-    )
-}
-
-fn policy_compound_slot(policy_id: u64) -> StorageSlot {
-    registry_slot(
-        TIP403Registry::new().policy_records[policy_id]
-            .compound
-            .base_slot(),
-    )
-}
-
-fn policy_member_slot(policy_id: u64, account: Address) -> StorageSlot {
-    registry_slot(TIP403Registry::new().policy_set[policy_id][account].slot())
-}
-
-fn receive_policy_config_slot(recipient: Address) -> StorageSlot {
-    registry_slot(recipient.mapping_slot(tip403_registry_slots::RECEIVE_POLICIES))
-}
-
-fn receive_policy_recovery_slot(recipient: Address) -> StorageSlot {
-    registry_slot(
-        recipient
-            .mapping_slot(tip403_registry_slots::RECEIVE_POLICIES)
-            .wrapping_add(U256::ONE),
-    )
-}
-
-fn encryption_key_slots(key_index: U256) -> Result<(B256, B256)> {
-    let base: U256 = keccak256(PORTAL_ENCRYPTION_KEYS_SLOT.as_slice()).into();
-    let x = key_index
-        .checked_mul(U256::from(2))
-        .and_then(|offset| base.checked_add(offset))
-        .ok_or_else(|| eyre::eyre!("Portal encryption key slot overflow for index {key_index}"))?;
-    let metadata = x
-        .checked_add(U256::ONE)
-        .ok_or_else(|| eyre::eyre!("Portal encryption key metadata slot overflow"))?;
-    Ok((
-        B256::from(x.to_be_bytes::<32>()),
-        B256::from(metadata.to_be_bytes::<32>()),
-    ))
-}
-
-fn is_builtin_policy(policy_id: u64) -> bool {
-    matches!(policy_id, REJECT_ALL_POLICY_ID | ALLOW_ALL_POLICY_ID)
-}
-
-/// TIP-1092 packs `{ uint64 policyId; bool isSet; }` from the low-order byte upward.
-fn decode_token_policy_binding(value: B256) -> Option<u64> {
-    let value = U256::from_be_bytes(value.0);
-    let is_set = packed_u8(value, 64) != 0;
-    is_set.then(|| packed_u64(value, 0))
-}
-
-/// `PolicyData.policy_type` is the low-order byte of its packed storage slot.
-fn decode_policy_type(value: B256) -> u8 {
-    packed_u8(U256::from_be_bytes(value.0), 0)
-}
-
-/// `CompoundPolicyData` packs sender, recipient, then mint-recipient `uint64` policy IDs.
-fn decode_compound_mint_policy(value: B256) -> u64 {
-    packed_u64(U256::from_be_bytes(value.0), 128)
-}
-
-/// Decode the fields needed to derive reads from a packed TIP-1028 receive-policy configuration.
-///
-/// Layout, from the low-order byte: `bool`, sender `uint64`, sender type `uint8`, token-filter
-/// `uint64`, token-filter type `uint8`, and recovery-mode `uint8`.
-fn decode_receive_policy(value: B256) -> Option<ReceivePolicy> {
-    let value = U256::from_be_bytes(value.0);
-    if (value & U256::from(u8::MAX)) == U256::ZERO {
-        return None;
-    }
-    Some(ReceivePolicy {
-        sender_policy_id: packed_u64(value, 8),
-        token_filter_id: packed_u64(value, 80),
-        has_third_party_recovery: packed_u8(value, 152) == 2,
-    })
-}
-
-fn packed_u8(value: U256, shift: usize) -> u8 {
-    ((value >> shift) & U256::from(u8::MAX)).to::<u8>()
-}
-
-fn packed_u64(value: U256, shift: usize) -> u64 {
-    ((value >> shift) & U256::from(u64::MAX)).to::<u64>()
+fn is_builtin_policy(id: u64) -> bool {
+    matches!(id, REJECT_ALL_POLICY_ID | ALLOW_ALL_POLICY_ID)
 }
 
 #[cfg(test)]
@@ -486,182 +417,34 @@ mod tests {
     use super::*;
     use alloy_primitives::address;
 
-    const PORTAL: Address = address!("1000000000000000000000000000000000000001");
     const TOKEN: Address = address!("20c0000000000000000000000000000000000001");
-    const ENABLED_TOKEN: Address = address!("20c0000000000000000000000000000000000002");
-    const RECIPIENT: Address = address!("3000000000000000000000000000000000000001");
-    const VIRTUAL_RECIPIENT: Address = address!("01020304fdfdfdfdfdfdfdfdfdfd010203040506");
 
     #[test]
-    fn root_slots_are_deduplicated_across_deposits() -> Result<()> {
-        let mut plan = DepositPrefetchPlan::new(7, PORTAL);
-        plan.add_enabled_token(TOKEN);
-        plan.add_mint(TOKEN, RECIPIENT);
-        plan.add_mint(TOKEN, RECIPIENT);
-        plan.add_encryption_key(U256::from(4));
-        plan.add_encryption_key(U256::from(4));
-
-        let slots = plan.root_slots(DepositPrefetchConfig::all())?;
-        let (key_x, key_metadata) = encryption_key_slots(U256::from(4))?;
-        assert_eq!(slots.len(), 5);
-        assert!(slots.contains(&(PORTAL, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT)));
-        assert!(slots.contains(&(PORTAL, key_x)));
-        assert!(slots.contains(&(PORTAL, key_metadata)));
-        assert!(slots.contains(&token_policy_binding_slot(TOKEN)));
-        assert!(slots.contains(&receive_policy_config_slot(RECIPIENT)));
+    fn packed_typed_fields_deduplicate_and_decode() -> Result<()> {
+        let registry = TIP403Registry::new();
+        let handler = &registry.token_transfer_policies[TOKEN];
+        let mut wave = PrefetchSlots::default();
+        wave.insert(&handler.policy_id);
+        wave.insert(&handler.is_set);
+        assert_eq!(wave.0.len(), 1);
+        let raw = U256::from(42) | (U256::ONE << 64usize);
+        let values = StorageValues(HashMap::from([(
+            (handler.policy_id.address(), handler.policy_id.slot()).into(),
+            B256::from(raw.to_be_bytes::<32>()),
+        )]));
+        let binding = values.read(handler)?;
+        assert_eq!(binding.policy_id, 42);
+        assert!(binding.is_set);
         Ok(())
     }
 
     #[test]
-    fn root_slots_follow_receive_and_registry_policy_hardforks() -> Result<()> {
-        let mut plan = DepositPrefetchPlan::new(7, PORTAL);
-        plan.add_enabled_token(ENABLED_TOKEN);
-        plan.add_mint(TOKEN, RECIPIENT);
-
-        let before_t6_t9 = plan.root_slots(DepositPrefetchConfig::new(false, false, 4))?;
-        assert_eq!(
-            before_t6_t9,
-            HashSet::from([
-                (PORTAL, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT),
-                token_policy_binding_slot(ENABLED_TOKEN),
-            ])
-        );
-
-        let at_t6 = plan.root_slots(DepositPrefetchConfig::new(true, false, 4))?;
-        assert_eq!(
-            at_t6,
-            HashSet::from([
-                (PORTAL, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT),
-                token_policy_binding_slot(ENABLED_TOKEN),
-                receive_policy_config_slot(RECIPIENT),
-            ])
-        );
-
-        let at_t9 = plan.root_slots(DepositPrefetchConfig::new(true, true, 4))?;
-        assert_eq!(
-            at_t9,
-            HashSet::from([
-                (PORTAL, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT),
-                token_policy_binding_slot(ENABLED_TOKEN),
-                token_policy_binding_slot(TOKEN),
-                receive_policy_config_slot(RECIPIENT),
-            ])
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn packed_policy_values_drive_dependent_slots() {
-        let binding: U256 = U256::from(42) | (U256::ONE << 64usize);
-        assert_eq!(
-            decode_token_policy_binding(B256::from(binding.to_be_bytes::<32>())),
-            Some(42)
-        );
-        assert_eq!(decode_token_policy_binding(B256::ZERO), None);
-
-        let compound: U256 =
-            U256::from(2) | (U256::from(3) << 64usize) | (U256::from(77) << 128usize);
-        assert_eq!(
-            decode_compound_mint_policy(B256::from(compound.to_be_bytes::<32>())),
-            77
-        );
-    }
-
-    #[test]
-    fn packed_receive_policy_drives_memberships_and_recovery() {
-        let sender_policy_id = 11u64;
-        let token_filter_id = 12u64;
-        let packed: U256 = U256::ONE
-            | (U256::from(sender_policy_id) << 8usize)
-            | (U256::from(1) << 72usize)
-            | (U256::from(token_filter_id) << 80usize)
-            | (U256::from(1) << 144usize)
-            | (U256::from(2) << 152usize);
-
-        assert_eq!(
-            decode_receive_policy(B256::from(packed.to_be_bytes::<32>())),
-            Some(ReceivePolicy {
-                sender_policy_id,
-                token_filter_id,
-                has_third_party_recovery: true,
-            })
-        );
-        assert_eq!(decode_receive_policy(B256::ZERO), None);
-    }
-
-    #[test]
-    fn policy_values_expand_into_every_dependent_wave() {
-        let outer_policy_id = 42u64;
-        let mint_policy_id = 77u64;
-        let sender_policy_id = 11u64;
-        let token_filter_id = 12u64;
-
-        let mut plan = DepositPrefetchPlan::new(7, PORTAL);
-        plan.add_mint(TOKEN, RECIPIENT);
-
-        let binding =
-            B256::from((U256::from(outer_policy_id) | (U256::ONE << 64usize)).to_be_bytes::<32>());
-        let receive = B256::from(
-            (U256::ONE
-                | (U256::from(sender_policy_id) << 8usize)
-                | (U256::from(1u8) << 72usize)
-                | (U256::from(token_filter_id) << 80usize)
-                | (U256::from(1u8) << 144usize)
-                | (U256::from(2u8) << 152usize))
-                .to_be_bytes::<32>(),
-        );
-        let roots = StorageValues::from([
-            (token_policy_binding_slot(TOKEN), binding),
-            (receive_policy_config_slot(RECIPIENT), receive),
-        ]);
-
-        let token_policies = plan.registered_token_policies(&roots, DepositPrefetchConfig::all());
-        assert_eq!(token_policies.get(&TOKEN), Some(&outer_policy_id));
-
-        let second_wave =
-            plan.policy_and_receive_slots(&roots, &token_policies, DepositPrefetchConfig::all());
-        assert!(second_wave.contains(&policy_counter_slot()));
-        assert!(second_wave.contains(&policy_base_slot(outer_policy_id)));
-        assert!(second_wave.contains(&policy_member_slot(token_filter_id, TOKEN)));
-        assert!(second_wave.contains(&policy_member_slot(sender_policy_id, ZONE_INBOX_ADDRESS)));
-        assert!(second_wave.contains(&receive_policy_recovery_slot(RECIPIENT)));
-
-        let compound_base = B256::from(U256::from(PolicyType::COMPOUND as u8).to_be_bytes::<32>());
-        let second_values =
-            StorageValues::from([(policy_base_slot(outer_policy_id), compound_base)]);
-        let third_wave = plan.mint_policy_slots(&token_policies, &second_values);
-        assert_eq!(
-            third_wave,
-            HashSet::from([policy_compound_slot(outer_policy_id)])
-        );
-
-        let compound = B256::from((U256::from(mint_policy_id) << 128usize).to_be_bytes::<32>());
-        let third_values = StorageValues::from([(policy_compound_slot(outer_policy_id), compound)]);
-        let fourth_wave =
-            plan.compound_subpolicy_slots(&token_policies, &second_values, &third_values);
-        assert_eq!(
-            fourth_wave,
-            HashSet::from([
-                policy_base_slot(mint_policy_id),
-                policy_member_slot(mint_policy_id, RECIPIENT),
-            ])
-        );
-
-        let mut unresolved_recipient = DepositPrefetchPlan::new(7, PORTAL);
-        unresolved_recipient.add_mint(TOKEN, VIRTUAL_RECIPIENT);
-        assert_eq!(
-            unresolved_recipient.mint_policy_slots(&token_policies, &second_values),
-            HashSet::from([policy_compound_slot(outer_policy_id)]),
-            "compound data remains token-derived when the effective recipient is Zone-local"
-        );
-        assert_eq!(
-            unresolved_recipient.compound_subpolicy_slots(
-                &token_policies,
-                &second_values,
-                &third_values,
-            ),
-            HashSet::from([policy_base_slot(mint_policy_id)]),
-            "the sub-policy base remains derivable, but its membership does not"
+    fn missing_typed_value_is_an_error() {
+        let registry = TIP403Registry::new();
+        assert!(
+            StorageValues(HashMap::new())
+                .read(&registry.policy_id_counter)
+                .is_err()
         );
     }
 }

--- a/crates/l1/src/state/prefetch.rs
+++ b/crates/l1/src/state/prefetch.rs
@@ -81,7 +81,7 @@ impl StorageOps for AccountValues<'_> {
 ///
 /// Inserting a typed handler expands every contiguous word described by [`Storable::SLOTS`].
 /// Packed fields naturally collapse to one [`StorageSlot`] through the underlying [`HashSet`].
-#[derive(Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 struct PrefetchSlots(HashSet<StorageSlot>);
 
 impl PrefetchSlots {
@@ -560,7 +560,7 @@ mod tests {
         );
 
         let built_in = HashMap::from([(TOKEN, ALLOW_ALL_POLICY_ID)]);
-        let no_mints = DepositPrefetchPlan::new(7, PORTAL).0;
+        let no_mints = DepositPrefetchPlan::new(7, PORTAL);
         assert!(
             no_mints
                 .policy_and_receive_slots(&StorageValues(HashMap::new()), &built_in)?

--- a/crates/l1/src/state/prefetch.rs
+++ b/crates/l1/src/state/prefetch.rs
@@ -85,6 +85,11 @@ impl StorageOps for AccountValues<'_> {
 struct PrefetchSlots(HashSet<StorageSlot>);
 
 impl PrefetchSlots {
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Schedule every raw word occupied by a typed value.
     fn insert<T: Storable>(&mut self, handler: &impl Handler<T>) {
         let slot = handler.as_slot();

--- a/crates/l1/src/state/prefetch.rs
+++ b/crates/l1/src/state/prefetch.rs
@@ -111,6 +111,11 @@ impl DepositPrefetchConfig {
             concurrency,
         }
     }
+
+    #[cfg(test)]
+    const fn all() -> Self {
+        Self::new(true, 4)
+    }
 }
 
 /// One deposit mint whose effective recipient is derivable before payload construction.
@@ -417,24 +422,151 @@ mod tests {
     use super::*;
     use alloy_primitives::address;
 
+    const PORTAL: Address = address!("1000000000000000000000000000000000000001");
     const TOKEN: Address = address!("20c0000000000000000000000000000000000001");
+    const ENABLED_TOKEN: Address = address!("20c0000000000000000000000000000000000002");
+    const RECIPIENT: Address = address!("3000000000000000000000000000000000000001");
+    const VIRTUAL_RECIPIENT: Address = address!("01020304fdfdfdfdfdfdfdfdfdfd010203040506");
+
+    fn storage_slot<T: Storable>(handler: &impl Handler<T>) -> StorageSlot {
+        let slot = handler.as_slot();
+        (slot.address(), slot.slot()).into()
+    }
+
+    fn stored_word<T: Storable>(handler: &impl Handler<T>, value: U256) -> (StorageSlot, B256) {
+        (storage_slot(handler), value.into())
+    }
+
+    fn values<T: Storable>(handler: &impl Handler<T>, value: U256) -> StorageValues {
+        StorageValues(HashMap::from([stored_word(handler, value)]))
+    }
 
     #[test]
-    fn packed_typed_fields_deduplicate_and_decode() -> Result<()> {
+    fn root_slots_are_deduplicated_across_deposits() -> Result<()> {
+        let mut plan = DepositPrefetchPlan::new(7, PORTAL);
+        plan.add_enabled_token(TOKEN);
+        plan.add_mint(TOKEN, RECIPIENT);
+        plan.add_mint(TOKEN, RECIPIENT);
+        plan.add_encryption_key(U256::from(4));
+        plan.add_encryption_key(U256::from(4));
+
+        let slots = plan.root_slots(DepositPrefetchConfig::all())?.0;
+        let registry = TIP403Registry::new();
+        let portal = ZonePortalStorage::new(PORTAL);
+        assert_eq!(slots.len(), 5);
+        assert!(slots.contains(&storage_slot(&portal.current_deposit_queue_hash)));
+        let encryption_key = &portal.encryption_keys[4];
+        let encryption_slot = encryption_key.as_slot();
+        for offset in 0..2 {
+            assert!(
+                slots.contains(
+                    &(
+                        encryption_slot.address(),
+                        encryption_slot.slot() + U256::from(offset)
+                    )
+                        .into()
+                )
+            );
+        }
+        assert!(slots.contains(&storage_slot(&registry.token_transfer_policies[TOKEN])));
+        assert!(slots.contains(&storage_slot(&registry.receive_policies[RECIPIENT].config)));
+        Ok(())
+    }
+
+    #[test]
+    fn root_slots_follow_registry_policy_hardfork() -> Result<()> {
+        let mut plan = DepositPrefetchPlan::new(7, PORTAL);
+        plan.add_enabled_token(ENABLED_TOKEN);
+        plan.add_mint(TOKEN, RECIPIENT);
+        let registry = TIP403Registry::new();
+
+        let before_t9 = plan.root_slots(DepositPrefetchConfig::new(false, 4))?.0;
+        assert_eq!(before_t9.len(), 3);
+        assert!(before_t9.contains(&storage_slot(
+            &registry.token_transfer_policies[ENABLED_TOKEN]
+        )));
+        assert!(!before_t9.contains(&storage_slot(&registry.token_transfer_policies[TOKEN])));
+        assert!(before_t9.contains(&storage_slot(&registry.receive_policies[RECIPIENT].config)));
+
+        let at_t9 = plan.root_slots(DepositPrefetchConfig::all())?.0;
+        assert_eq!(at_t9.len(), 4);
+        assert!(at_t9.contains(&storage_slot(&registry.token_transfer_policies[TOKEN])));
+        Ok(())
+    }
+
+    #[test]
+    fn policy_values_expand_into_every_dependent_wave() -> Result<()> {
+        let outer_policy_id = 42;
+        let mint_policy_id = 77;
+        let sender_policy_id = 11;
+        let token_filter_id = 12;
         let registry = TIP403Registry::new();
         let handler = &registry.token_transfer_policies[TOKEN];
-        let mut wave = PrefetchSlots::default();
-        wave.insert(&handler.policy_id);
-        wave.insert(&handler.is_set);
-        assert_eq!(wave.0.len(), 1);
-        let raw = U256::from(42) | (U256::ONE << 64usize);
-        let values = StorageValues(HashMap::from([(
-            (handler.policy_id.address(), handler.policy_id.slot()).into(),
-            B256::from(raw.to_be_bytes::<32>()),
-        )]));
-        let binding = values.read(handler)?;
-        assert_eq!(binding.policy_id, 42);
-        assert!(binding.is_set);
+        let receive = &registry.receive_policies[RECIPIENT];
+        let outer = &registry.policy_records[outer_policy_id];
+        let mint = &registry.policy_records[mint_policy_id];
+        let mut plan = DepositPrefetchPlan::new(7, PORTAL);
+        plan.add_mint(TOKEN, RECIPIENT);
+
+        let binding_value = U256::from(outer_policy_id) | (U256::ONE << 64usize);
+        let receive_value = U256::ONE
+            | (U256::from(sender_policy_id) << 8usize)
+            | (U256::from(1) << 72usize)
+            | (U256::from(token_filter_id) << 80usize)
+            | (U256::from(1) << 144usize)
+            | (U256::from(RecoveryMode::ThirdParty as u8) << 152usize);
+        let roots = StorageValues(HashMap::from([
+            stored_word(handler, binding_value),
+            stored_word(&receive.config, receive_value),
+        ]));
+        let token_policies =
+            plan.registered_token_policies(&roots, DepositPrefetchConfig::all())?;
+        assert_eq!(token_policies.get(&TOKEN), Some(&outer_policy_id));
+
+        let second = plan.policy_and_receive_slots(&roots, &token_policies)?.0;
+        for slot in [
+            storage_slot(&registry.policy_id_counter),
+            storage_slot(&outer.base),
+            storage_slot(&registry.policy_set[token_filter_id][TOKEN]),
+            storage_slot(&registry.policy_set[sender_policy_id][ZONE_INBOX_ADDRESS]),
+            storage_slot(&receive.recovery_address),
+        ] {
+            assert!(second.contains(&slot));
+        }
+
+        let p_values = values(&outer.base, U256::from(PolicyType::COMPOUND as u8));
+        let third = plan.mint_policy_slots(&token_policies, &p_values)?.0;
+        assert_eq!(third, HashSet::from([storage_slot(&outer.compound)]));
+
+        let c_values = values(&outer.compound, U256::from(mint_policy_id) << 128usize);
+        let fourth = plan.compound_subpolicy_slots(&token_policies, &p_values, &c_values)?;
+        assert_eq!(
+            fourth.0,
+            HashSet::from([
+                storage_slot(&mint.base),
+                storage_slot(&registry.policy_set[mint_policy_id][RECIPIENT]),
+            ])
+        );
+
+        let mut unresolved = DepositPrefetchPlan::new(7, PORTAL);
+        unresolved.add_mint(TOKEN, VIRTUAL_RECIPIENT);
+        assert_eq!(
+            unresolved.mint_policy_slots(&token_policies, &p_values)?,
+            PrefetchSlots(HashSet::from([storage_slot(&outer.compound)]))
+        );
+        assert_eq!(
+            unresolved.compound_subpolicy_slots(&token_policies, &p_values, &c_values)?,
+            PrefetchSlots(HashSet::from([storage_slot(&mint.base)]))
+        );
+
+        let built_in = HashMap::from([(TOKEN, ALLOW_ALL_POLICY_ID)]);
+        let no_mints = DepositPrefetchPlan::new(7, PORTAL).0;
+        assert!(
+            no_mints
+                .policy_and_receive_slots(&StorageValues(HashMap::new()), &built_in)?
+                .is_empty()
+        );
+        assert!(no_mints.mint_policy_slots(&built_in, &p_values)?.is_empty());
         Ok(())
     }
 

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -29,7 +29,7 @@ use super::cache::L1StateCache;
 use crate::rpc::rpc_connection_config;
 
 /// One type-erased L1 storage word, keyed by account and raw slot.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct StorageSlot(pub(super) Address, pub(super) B256);
 
 impl From<(Address, U256)> for StorageSlot {

--- a/crates/l1/src/state/provider.rs
+++ b/crates/l1/src/state/provider.rs
@@ -28,6 +28,16 @@ use zone_precompiles::{L1StateError, L1StorageReader};
 use super::cache::L1StateCache;
 use crate::rpc::rpc_connection_config;
 
+/// One type-erased L1 storage word, keyed by account and raw slot.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct StorageSlot(pub(super) Address, pub(super) B256);
+
+impl From<(Address, U256)> for StorageSlot {
+    fn from((address, slot): (Address, U256)) -> Self {
+        Self(address, slot.into())
+    }
+}
+
 /// Configuration for the [`L1StateProvider`].
 #[derive(Debug, Clone)]
 pub struct L1StateProviderConfig {
@@ -249,19 +259,19 @@ impl L1StateProvider {
     ///
     /// Requests are deduplicated before dispatch and bounded by `concurrency`, so callers can move
     /// predictable read latency out of synchronous EVM execution without issuing an unbounded RPC
-    /// burst. Returned values are keyed by `(address, slot)` for value-dependent prefetch planning.
-    pub(crate) async fn prefetch_storage(
+    /// burst. Returned values retain their storage keys for value-dependent prefetch planning.
+    pub(super) async fn prefetch_storage(
         &self,
-        slots: impl IntoIterator<Item = (Address, B256)>,
+        slots: impl IntoIterator<Item = StorageSlot>,
         block_number: u64,
         concurrency: usize,
-    ) -> Result<HashMap<(Address, B256), B256>> {
+    ) -> Result<HashMap<StorageSlot, B256>> {
         let slots: HashSet<_> = slots.into_iter().collect();
         stream::iter(slots)
-            .map(|(address, slot)| async move {
-                self.get_storage_async(address, slot, block_number)
+            .map(|slot @ StorageSlot(address, key)| async move {
+                self.get_storage_async(address, key, block_number)
                     .await
-                    .map(|value| ((address, slot), value))
+                    .map(|value| (slot, value))
             })
             .buffer_unordered(concurrency.max(1))
             .try_collect()

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -145,7 +145,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             // Replicate only durable blocks. Persist every block immediately so followers can
             // acknowledge each block without waiting for Reth's in-memory buffer to fill.
             builder.config_mut().engine.persistence_threshold = 0;
-            builder.config_mut().engine.memory_block_buffer_target = 0;
+            builder.config_mut().engine.memory_block_buffer_target = Some(0);
         }
         let should_sequence_blocks = sequencer_enabled(args.enable_sequencer, manifest_role);
         let sequencer_signer = if should_sequence_blocks || manifest_mode {

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -244,7 +244,6 @@ impl ZoneEngine {
     async fn prepare_l1_block(&self, l1_block: L1BlockDeposits) -> eyre::Result<PreparedL1Block> {
         let timestamp = l1_block.header.timestamp();
         let prefetch_config = DepositPrefetchConfig::new(
-            self.chain_spec.is_t6_active_at_timestamp(timestamp),
             self.chain_spec.is_t9_active_at_timestamp(timestamp),
             self.l1_fetch_concurrency,
         );

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1151,7 +1151,7 @@ impl ZoneTestNode {
                 c.network.discovery.disable_discovery = true;
                 if p2p_enabled {
                     c.engine.persistence_threshold = 0;
-                    c.engine.memory_block_buffer_target = 0;
+                    c.engine.memory_block_buffer_target = Some(0);
                 }
                 c
             });


### PR DESCRIPTION
this PR updates https://github.com/tempoxyz/zones/pull/851 to leverage upstream `StorageOps` and `Handler` abstractions to make deposit-state prefetching fully typed and remove duplicated storage-layout logic.

> [!NOTE]
> depends on https://github.com/tempoxyz/tempo/pull/6983 which requires a reth bump