### PR TITLE
refactor: simplify leader rotation control paths

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -5,6 +5,7 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::{Args, CommandFactory, FromArgMatches};
+use reth_chainspec::EthChainSpec;
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
@@ -106,6 +107,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
 
         validate_l1_rpc_url(&args.l1_rpc_url)?;
         validate_portal_address(args.portal_address)?;
+        args.validate_zone_id(builder.config().chain.genesis().config.chain_id)?;
 
         let p2p_config = args
             .sequencer_manifest
@@ -416,7 +418,7 @@ pub struct ZoneArgs {
     )]
     pub l1_retry_connection_interval_ms: u64,
 
-    /// Zone ID for the private RPC auth token validation.
+    /// Zone ID used for chain identity and private RPC authentication.
     #[arg(long = "zone.id", env = "ZONE_ID", default_value_t = 0)]
     pub zone_id: u32,
 
@@ -444,6 +446,26 @@ pub struct ZoneArgs {
         conflicts_with = "sequencer_manifest"
     )]
     pub enable_sequencer: bool,
+}
+
+impl ZoneArgs {
+    /// Assert the genesis chain ID is the one `zone.id` requires.
+    ///
+    /// `zone_id == 0` means "unset", which imposes no constraint.
+    fn validate_zone_id(&self, chain_id: u64) -> eyre::Result<()> {
+        if self.zone_id == 0 {
+            return Ok(());
+        }
+        let expected = zone_primitives::constants::zone_chain_id(self.zone_id);
+        eyre::ensure!(
+            chain_id == expected,
+            "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
+            self.zone_id,
+            expected,
+            chain_id,
+        );
+        Ok(())
+    }
 }
 
 fn prepend_log_filter(filter: &mut String, directives: &str) {
@@ -518,6 +540,25 @@ mod tests {
     fn portal_address_must_be_nonzero() {
         assert!(validate_portal_address(alloy_primitives::Address::ZERO).is_err());
         assert!(validate_portal_address(alloy_primitives::Address::repeat_byte(0x11)).is_ok());
+    }
+
+    #[test]
+    fn zone_id_must_match_genesis_chain_id() {
+        let args = ZoneArgsParser::try_parse_from([
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "7",
+        ])
+        .unwrap()
+        .zone;
+        let expected = zone_primitives::constants::zone_chain_id(args.zone_id);
+
+        assert!(args.validate_zone_id(expected).is_ok());
+        assert!(args.validate_zone_id(expected + 1).is_err());
     }
 
     #[test]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -76,15 +76,16 @@ impl ProductionPermit {
     }
 
     /// Decide whether this node may produce the zone block embedding `tempo_anchor`.
-    pub fn check(&self, tempo_anchor: u64) -> PermitDecision {
+    ///
+    /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
+    pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
         match self.schedule.leader_for(tempo_anchor) {
-            None => PermitDecision::Fenced,
-            Some(record) if record.leader == self.local_ed25519_public_key => {
-                PermitDecision::Produce
-            }
-            Some(record) => PermitDecision::Demoted {
+            None => Some(EngineExit::Fenced { tempo_anchor }),
+            Some(record) if record.leader == self.local_ed25519_public_key => None,
+            Some(record) => Some(EngineExit::Demoted {
+                tempo_anchor,
                 epoch: record.epoch,
-            },
+            }),
         }
     }
 
@@ -92,17 +93,6 @@ impl ProductionPermit {
     pub fn record_applied_anchor(&self, tempo_anchor: u64) {
         self.schedule.record_applied_anchor(tempo_anchor);
     }
-}
-
-/// Outcome of a per-anchor production permit check.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PermitDecision {
-    /// This node is the scheduled leader for the anchor.
-    Produce,
-    /// A retained transition assigns the anchor to another node.
-    Demoted { epoch: u64 },
-    /// Something bad happened. No leadership record is available.
-    Fenced,
 }
 
 /// Why the engine loop returned.
@@ -127,7 +117,9 @@ trait AvailableBlockDrain {
     fn next_available(&self) -> Option<Self::Block>;
 
     /// Checks the leadership permit for one available block.
-    fn permit(&self, block: &Self::Block) -> (u64, PermitDecision);
+    ///
+    /// `None` authorizes production; `Some(exit)` halts the drain with that reason.
+    fn permit(&self, block: &Self::Block) -> Option<EngineExit>;
 
     /// Completes and consumes one block.
     async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()>;
@@ -153,17 +145,8 @@ where
         let Some(block) = drain.next_available() else {
             return Ok(None);
         };
-        match drain.permit(&block) {
-            (_, PermitDecision::Produce) => {}
-            (tempo_anchor, PermitDecision::Demoted { epoch }) => {
-                return Ok(Some(EngineExit::Demoted {
-                    tempo_anchor,
-                    epoch,
-                }));
-            }
-            (tempo_anchor, PermitDecision::Fenced) => {
-                return Ok(Some(EngineExit::Fenced { tempo_anchor }));
-            }
+        if let Some(exit) = drain.permit(&block) {
+            return Ok(Some(exit));
         }
         drain.advance_one(block).await?;
     }
@@ -430,13 +413,11 @@ impl AvailableBlockDrain for ZoneEngine {
         self.deposit_queue.peek()
     }
 
-    fn permit(&self, block: &Self::Block) -> (u64, PermitDecision) {
-        let tempo_anchor = block.header.number();
-        let decision = self
-            .production_permit
+    fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
+        // No permit is legacy single-sequencer mode: production is always authorized.
+        self.production_permit
             .as_ref()
-            .map_or(PermitDecision::Produce, |permit| permit.check(tempo_anchor));
-        (tempo_anchor, decision)
+            .and_then(|permit| permit.check(block.header.number()))
     }
 
     async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
@@ -455,8 +436,8 @@ mod tests {
         advanced: Vec<u64>,
         first_started: Option<oneshot::Sender<()>>,
         release_first: Option<oneshot::Receiver<()>>,
-        /// Blocks (by value) the permit rejects, with the simulated decision.
-        denied: Vec<(u64, PermitDecision)>,
+        /// Blocks (by value) the permit rejects, with the exit it produces.
+        denied: Vec<(u64, EngineExit)>,
     }
 
     impl AvailableBlockDrain for PausedDrain {
@@ -466,13 +447,11 @@ mod tests {
             self.pending.front().copied()
         }
 
-        fn permit(&self, block: &Self::Block) -> (u64, PermitDecision) {
-            let decision = self
-                .denied
+        fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
+            self.denied
                 .iter()
                 .find(|(denied, _)| denied == block)
-                .map_or(PermitDecision::Produce, |(_, decision)| *decision);
-            (*block, decision)
+                .map(|(_, exit)| exit.clone())
         }
 
         async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
@@ -532,7 +511,13 @@ mod tests {
             advanced: Vec::new(),
             first_started: None,
             release_first: None,
-            denied: vec![(3, PermitDecision::Demoted { epoch: 7 })],
+            denied: vec![(
+                3,
+                EngineExit::Demoted {
+                    tempo_anchor: 3,
+                    epoch: 7,
+                },
+            )],
         };
 
         let exit = drain_all_available(&mut drain, &stop)
@@ -558,7 +543,7 @@ mod tests {
             advanced: Vec::new(),
             first_started: None,
             release_first: None,
-            denied: vec![(5, PermitDecision::Fenced)],
+            denied: vec![(5, EngineExit::Fenced { tempo_anchor: 5 })],
         };
 
         let exit = drain_all_available(&mut drain, &stop)
@@ -583,10 +568,22 @@ mod tests {
             .unwrap();
         let permit = ProductionPermit::new(schedule, me.clone());
 
-        assert_eq!(permit.check(0), PermitDecision::Produce);
-        assert_eq!(permit.check(99), PermitDecision::Produce);
-        assert_eq!(permit.check(100), PermitDecision::Demoted { epoch: 2 });
-        assert_eq!(permit.check(u64::MAX), PermitDecision::Demoted { epoch: 2 });
+        assert_eq!(permit.check(0), None);
+        assert_eq!(permit.check(99), None);
+        assert_eq!(
+            permit.check(100),
+            Some(EngineExit::Demoted {
+                tempo_anchor: 100,
+                epoch: 2
+            })
+        );
+        assert_eq!(
+            permit.check(u64::MAX),
+            Some(EngineExit::Demoted {
+                tempo_anchor: u64::MAX,
+                epoch: 2
+            })
+        );
 
         let recovery_schedule = LeadershipSchedule::seeded(LeadershipState::new(7, me, 0));
         recovery_schedule
@@ -598,16 +595,22 @@ mod tests {
         let recovery_permit = ProductionPermit::new(recovery_schedule, other);
         assert_eq!(
             recovery_permit.check(50),
-            PermitDecision::Demoted { epoch: 7 }
+            Some(EngineExit::Demoted {
+                tempo_anchor: 50,
+                epoch: 7
+            })
         );
-        assert_eq!(recovery_permit.check(51), PermitDecision::Produce);
-        assert_eq!(recovery_permit.check(59), PermitDecision::Produce);
-        assert_eq!(recovery_permit.check(60), PermitDecision::Produce);
+        assert_eq!(recovery_permit.check(51), None);
+        assert_eq!(recovery_permit.check(59), None);
+        assert_eq!(recovery_permit.check(60), None);
 
         let uninitialized = ProductionPermit::new(
             LeadershipSchedule::uninitialized(),
             PrivateKey::from_seed(1).public_key(),
         );
-        assert_eq!(uninitialized.check(0), PermitDecision::Fenced);
+        assert_eq!(
+            uninitialized.check(0),
+            Some(EngineExit::Fenced { tempo_anchor: 0 })
+        );
     }
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -18,5 +18,5 @@ pub mod rpc;
 mod settlement_attestation;
 mod tx_forwarding;
 
-pub use engine::{EngineExit, PermitDecision, ProductionPermit, ZoneEngine};
+pub use engine::{EngineExit, ProductionPermit, ZoneEngine};
 pub use node::{ZoneExecutorBuilder, ZoneNode, ZonePrivateRpcConfig, ZoneSequencerAddOnsConfig};

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -177,7 +177,7 @@ pub struct ZoneSequencerAddOnsConfig {
     pub sequencer_signer: PrivateKeySigner,
     /// Individual manifest-node signer used for L1 settlement transactions.
     pub l1_transaction_signer: Option<PrivateKeySigner>,
-    /// Zone ID for chain ID validation.
+    /// Zone ID used by sequencer encryption.
     pub zone_id: u32,
     /// Fallback interval for reconciling the canonical Zone head.
     pub zone_poll_interval: Duration,
@@ -194,7 +194,7 @@ pub struct ZoneSequencerAddOnsConfig {
 pub struct ZonePrivateRpcConfig {
     /// Port for RPC traffic.
     pub private_rpc_port: u16,
-    /// Zone ID for chain ID validation and private RPC auth.
+    /// Zone ID used by private RPC authentication.
     pub zone_id: u32,
     /// Max duration for private RPC auth.
     pub max_auth_token_validity: Duration,
@@ -757,7 +757,6 @@ where
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.portal_address,
                     self.l1_config.retry_connection_interval,
-                    chain_id,
                     attestation.store.clone(),
                 )?),
                 None => None,
@@ -806,7 +805,6 @@ where
                 self.l1_config.portal_address,
                 self.l1_config.retry_connection_interval,
                 sequencer_addr,
-                chain_id,
                 None,
             )
             .await?;
@@ -889,18 +887,21 @@ async fn seed_leadership_schedule(
     }
 
     let portal = ZonePortal::new(portal_address, l1_provider);
-    let leader = portal.leader().block(block_id).call().await?;
+    // All three describe the same transition at the same block and have no data dependency
+    // on each other, so they go out as one batch rather than three serial round trips on the
+    // startup path.
+    let leader_call = portal.leader().block(block_id);
+    let epoch_call = portal.leaderEpoch().block(block_id);
+    let activation_call = portal.leaderActivationTempoBlock().block(block_id);
+    let (leader, epoch, activation) = tokio::try_join!(
+        leader_call.call(),
+        epoch_call.call(),
+        activation_call.call(),
+    )?;
     eyre::ensure!(
         !leader.is_zero(),
         "portal {portal_address} has no leader at finalized L1 snapshot block {snapshot_anchor}"
     );
-
-    let epoch = portal.leaderEpoch().block(block_id).call().await?;
-    let activation = portal
-        .leaderActivationTempoBlock()
-        .block(block_id)
-        .call()
-        .await?;
     let node = manifest.node_by_secp256k1_address(leader).ok_or_else(|| {
         eyre::eyre!(
             "finalized portal leader {leader} (epoch {epoch}) does not map to any manifest \
@@ -999,20 +1000,8 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
-        chain_id: u64,
         attestation_store: Option<AttestationStore>,
     ) -> eyre::Result<LeaderSequencerDeps> {
-        if config.zone_id != 0 {
-            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
-            if chain_id != expected {
-                eyre::bail!(
-                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-                    config.zone_id,
-                    expected,
-                    chain_id,
-                );
-            }
-        }
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
@@ -1146,18 +1135,6 @@ where
         portal_address: Address,
         chain_id: u64,
     ) -> eyre::Result<()> {
-        if config.zone_id != 0 {
-            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
-            if chain_id != expected {
-                eyre::bail!(
-                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-                    config.zone_id,
-                    expected,
-                    chain_id,
-                );
-            }
-        }
-
         let eth_handlers = handle.eth_handlers().clone();
         let zone_rpc_url = handle
             .rpc_server_handles
@@ -1193,21 +1170,8 @@ where
         portal_address: Address,
         retry_connection_interval: Duration,
         sequencer_addr: Address,
-        chain_id: u64,
         attestation_store: Option<AttestationStore>,
     ) -> eyre::Result<()> {
-        if config.zone_id != 0 {
-            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
-            if chain_id != expected {
-                eyre::bail!(
-                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-                    config.zone_id,
-                    expected,
-                    chain_id,
-                );
-            }
-        }
-
         info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
         let sequencer_config = ZoneSequencerConfig {
             portal_address,

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -222,20 +222,39 @@ enum DesiredRole {
 }
 
 impl DesiredRole {
-    const fn kind(self) -> GenerationKind {
+    /// Stable name for status, metric labels, and logs.
+    const fn name(self) -> &'static str {
         match self {
-            Self::Leader { .. } => GenerationKind::Leader,
-            Self::Follower { .. } => GenerationKind::Follower,
-            Self::Fenced => GenerationKind::Fenced,
+            Self::Leader { .. } => "leader",
+            Self::Follower { .. } => "follower",
+            Self::Fenced => "fenced",
         }
     }
-}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GenerationKind {
-    Leader,
-    Follower,
-    Fenced,
+    /// Value for the `zone_leadership_role` gauge.
+    const fn gauge(self) -> f64 {
+        match self {
+            Self::Leader { .. } => 2.0,
+            Self::Follower { .. } => 1.0,
+            Self::Fenced => 0.0,
+        }
+    }
+
+    /// Epoch of the governing record, when one governs.
+    const fn epoch(self) -> Option<u64> {
+        match self {
+            Self::Leader { epoch, .. } | Self::Follower { epoch } => Some(epoch),
+            Self::Fenced => None,
+        }
+    }
+
+    /// Whether two roles are the same variant, ignoring the epoch.
+    ///
+    /// Generations are switched per variant, not per epoch: an epoch bump that leaves this
+    /// node in the same role must not tear down and rebuild its task graph.
+    fn same_variant(self, other: Self) -> bool {
+        std::mem::discriminant(&self) == std::mem::discriminant(&other)
+    }
 }
 
 /// Outcome of one generation task, tagged for supervision decisions.
@@ -296,7 +315,7 @@ async fn supervise_sequencer_tasks(
 
 struct RunningGeneration {
     id: u64,
-    kind: GenerationKind,
+    role: DesiredRole,
     token: CancellationToken,
     tasks: JoinSet<TaskEnd>,
 }
@@ -328,11 +347,14 @@ impl RunningGeneration {
                 }
             }
         }
-        info!(target: "zone::role", generation = self.id, kind = ?self.kind, "Role generation stopped");
+        info!(target: "zone::role", generation = self.id, role = self.role.name(), "Role generation stopped");
     }
 }
 
 /// Derive the desired role for the next anchor from local canonical state and the schedule.
+///
+/// `DesiredRole::Leader` carries the next anchor it was derived from, so the promotion
+/// barrier never re-reads the checkpoint under a second, possibly divergent, error policy.
 fn desired_role<P>(
     provider: &P,
     schedule: &LeadershipSchedule,
@@ -488,10 +510,11 @@ pub(crate) async fn run_role_controller<P, Pool>(
 
         // Only forced recovery has an additional promotion barrier. Normal transitions are
         // complete when the local next anchor is assigned to this node.
-        let mut ready_for_promotion = true;
         let mut promotion_reasons = Vec::new();
         if let DesiredRole::Leader { epoch, next_anchor } = desired
-            && current.as_ref().map(|generation| generation.kind) != Some(GenerationKind::Leader)
+            && !current
+                .as_ref()
+                .is_some_and(|generation| generation.role.same_variant(desired))
         {
             match promotion_readiness(
                 &context.provider,
@@ -503,7 +526,6 @@ pub(crate) async fn run_role_controller<P, Pool>(
                     info!(target: "zone::role", epoch, next_anchor, "Promotion barrier satisfied");
                 }
                 Readiness::Conflicted(detail) => {
-                    ready_for_promotion = false;
                     error!(
                         target: "zone::role",
                         epoch,
@@ -515,8 +537,10 @@ pub(crate) async fn run_role_controller<P, Pool>(
                 }
             }
         }
-        let switch = current.as_ref().map(|generation| generation.kind) != Some(desired.kind());
-        if switch {
+        if !current
+            .as_ref()
+            .is_some_and(|generation| generation.role.same_variant(desired))
+        {
             if let Some(generation) = current.take() {
                 generation.stop(&sinks).await;
             }
@@ -531,69 +555,49 @@ pub(crate) async fn run_role_controller<P, Pool>(
                     // complete desired generation after the decision backoff.
                     sinks.clear();
                     retry_decision = true;
-                    ready_for_promotion = false;
                     promotion_reasons = vec![format!(
-                        "failed to start {:?} generation: {err:#}",
-                        desired.kind()
+                        "failed to start {} generation: {err:#}",
+                        desired.name()
                     )];
                     error!(
                         target: "zone::role",
                         generation = generation_id,
-                        kind = ?desired.kind(),
+                        role = desired.name(),
                         %err,
                         "Role generation failed to start; fencing before retry"
                     );
                 }
             }
 
-            let active_kind = current
+            let active_role = current
                 .as_ref()
-                .map(|generation| generation.kind)
-                .unwrap_or(GenerationKind::Fenced);
+                .map(|generation| generation.role)
+                .unwrap_or(DesiredRole::Fenced);
             metrics::counter!(
                 "zone_leadership_transitions_total",
-                "to" => match active_kind {
-                    GenerationKind::Leader => "leader",
-                    GenerationKind::Follower => "follower",
-                    GenerationKind::Fenced => "fenced",
-                },
+                "to" => active_role.name(),
             )
             .increment(1);
-            metrics::gauge!("zone_leadership_role").set(match active_kind {
-                GenerationKind::Leader => 2.0,
-                GenerationKind::Follower => 1.0,
-                GenerationKind::Fenced => 0.0,
-            });
-            if active_kind == desired.kind()
-                && let Some(epoch) = match desired {
-                    DesiredRole::Leader { epoch, .. } | DesiredRole::Follower { epoch } => {
-                        Some(epoch)
-                    }
-                    DesiredRole::Fenced => None,
-                }
+            metrics::gauge!("zone_leadership_role").set(active_role.gauge());
+            if active_role.same_variant(desired)
+                && let Some(epoch) = desired.epoch()
             {
                 metrics::gauge!("zone_leadership_epoch").set(epoch as f64);
             }
         }
 
-        let active_kind = current
+        let active_role = current
             .as_ref()
-            .map(|generation| generation.kind)
-            .unwrap_or(GenerationKind::Fenced);
+            .map(|generation| generation.role)
+            .unwrap_or(DesiredRole::Fenced);
+        // Readiness is exactly "nothing is blocking promotion", so it is derived rather than
+        // tracked alongside the reasons it would have to stay consistent with.
+        let ready_for_promotion = promotion_reasons.is_empty();
         {
             let mut status = context.status.lock().expect("poisoned");
-            status.role = match active_kind {
-                GenerationKind::Leader => "leader",
-                GenerationKind::Follower => "follower",
-                GenerationKind::Fenced => "fenced",
-            };
-            status.epoch = if active_kind == desired.kind() {
-                match desired {
-                    DesiredRole::Leader { epoch, .. } | DesiredRole::Follower { epoch } => {
-                        Some(epoch)
-                    }
-                    DesiredRole::Fenced => None,
-                }
+            status.role = active_role.name();
+            status.epoch = if active_role.same_variant(desired) {
+                desired.epoch()
             } else {
                 None
             };
@@ -606,7 +610,6 @@ pub(crate) async fn run_role_controller<P, Pool>(
         } else {
             0.0
         });
-
         // A fenced generation has no tasks; an empty JoinSet's join_next() is immediately
         // ready with None, so polling it would spin this loop hot. Stay pending instead and
         // wake only on an explicit change or a retry for a failed/pending decision.
@@ -872,7 +875,7 @@ where
 
     Ok(RunningGeneration {
         id,
-        kind: desired.kind(),
+        role: desired,
         token,
         tasks,
     })

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -123,8 +123,6 @@ impl ForcedRecoveryState {
 struct LeadershipScheduleState {
     /// Retained transitions indexed by activation Tempo block.
     transitions: std::collections::BTreeMap<u64, LeadershipState>,
-    /// Highest epoch finalized L1 has shown us (observability + publication check).
-    latest_observed_epoch: Option<u64>,
     /// Highest Tempo anchor embedded in a locally canonical zone block.
     applied_anchor: Option<u64>,
     /// Optional operator-requested forced recovery.
@@ -308,11 +306,6 @@ impl LeadershipSchedule {
                 record.activation_tempo_block,
             );
         }
-        state.latest_observed_epoch = Some(
-            state
-                .latest_observed_epoch
-                .map_or(record.epoch, |epoch| epoch.max(record.epoch)),
-        );
         state
             .transitions
             .insert(record.activation_tempo_block, record);
@@ -406,8 +399,11 @@ impl LeadershipSchedule {
     }
 
     /// Highest epoch finalized L1 has shown us.
+    ///
+    /// Derived: `publish` requires `epoch == last.epoch + 1` and pruning never drops the last
+    /// entry, so the highest observed epoch is always the last retained transition's.
     pub fn latest_observed_epoch(&self) -> Option<u64> {
-        self.inner.read().expect("poisoned").latest_observed_epoch
+        self.latest().map(|record| record.epoch)
     }
 
     /// Epoch whose activation boundary the locally applied checkpoint has crossed.
@@ -438,6 +434,9 @@ impl LeadershipSchedule {
     /// recovery by asking who governed the previous anchor.
     pub fn record_applied_anchor(&self, tempo_anchor: u64) {
         let mut state = self.inner.write().expect("poisoned");
+        // Which record governs the next anchor before this advance, compared against the
+        // same value afterwards so the notify below fires only when the advance actually
+        // changes the controller-visible schedule.
         let previous_next_anchor_record = state.next_anchor_record();
         state.applied_anchor = Some(
             state
@@ -470,6 +469,8 @@ impl LeadershipSchedule {
         }
         let governing_record_changed = state.next_anchor_record() != previous_next_anchor_record;
         drop(state);
+        // A plain advance stays silent, but forced-recovery completion must wake the role
+        // controller even when the ordinary governing record is unchanged.
         if governing_record_changed || recovery_completed {
             self.changed.send_replace(());
         }
@@ -516,7 +517,6 @@ impl LeadershipSchedule {
             .cloned()
             .collect()
     }
-
     /// Returns whether `ed25519_public_key` leads any retained transition.
     ///
     /// A transport-level acceptance check for live blocks: a lagging follower must keep
@@ -1117,7 +1117,6 @@ mod tests {
         assert_eq!(schedule.latest(), None);
         assert_eq!(schedule.latest_observed_epoch(), None);
         assert_eq!(schedule.locally_applied_epoch(), None);
-        assert_eq!(schedule.role_for(&public_key(1), 100), None);
     }
 
     #[test]

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -638,20 +638,18 @@ async fn run_commands(
     mut senders: P2pSenders,
     mut commands: mpsc::Receiver<P2pCommand>,
 ) -> eyre::Result<()> {
+    let others: Vec<PublicKey> = peers
+        .iter()
+        .filter(|peer| *peer != &local_ed25519_public_key)
+        .cloned()
+        .collect();
+
     while let Some(command) = commands.recv().await {
-        // Built only in arms that actually address a peer set.
-        let others = || {
-            peers
-                .iter()
-                .filter(|peer| *peer != &local_ed25519_public_key)
-                .cloned()
-                .collect::<Vec<_>>()
-        };
         if let P2pCommand::RequestBackfill { start } = command {
             // Chain data always comes from a quorum member: standbys hold the same chain but are
             // the internet-facing members, and keeping them out of every node's catch-up source
             // set is the point of the role.
-            let candidates = leadership.quorum_peers(&others());
+            let candidates = leadership.quorum_peers(&others);
             let now = Instant::now();
             // Ask the leader alone first: backfilled blocks carry no producer claim, so a page
             // from any other member could be a valid alternative chain rather than the leader's.
@@ -711,7 +709,6 @@ async fn run_commands(
             }
             continue;
         }
-
         match command {
             P2pCommand::BroadcastBlock(block) => {
                 // Mirror of the inbound transport check: the sender must lead somewhere in
@@ -730,7 +727,7 @@ async fn run_commands(
                     continue;
                 }
 
-                let recipients = others();
+                let recipients = &others;
                 let sent = tokio::time::timeout(BROADCAST_RETRY_TIMEOUT, async {
                     loop {
                         let sent = senders.blocks
@@ -767,7 +764,7 @@ async fn run_commands(
                 senders
                     .settlement_proposals
                     .send(
-                        Recipients::Some(leadership.quorum_peers(&others())),
+                        Recipients::Some(leadership.quorum_peers(&others)),
                         proposal,
                         true,
                     )
@@ -855,7 +852,7 @@ async fn run_commands(
                     warn!(target: "zone::p2p", ?transaction_hash, "Ignoring outbound transaction command on the next-anchor leader");
                     continue;
                 }
-                let recipients = leadership.quorum_peers(&others());
+                let recipients = leadership.quorum_peers(&others);
                 let configured = recipients.len();
                 let transaction_size = transaction.len();
                 let sent = match senders

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -843,20 +843,14 @@ mod tests {
 
     #[tokio::test]
     async fn private_rpc_excludes_public_sequencer_methods() {
-        use crate::types::{MethodTier, classify_method};
+        use crate::types::classify_method;
 
+        // Both are served by the node's public HTTP module, not the private tiered
+        // dispatcher, so they must not classify and must not dispatch here.
         assert_eq!(classify_method("zone_getSequencerInfo"), None);
         assert_eq!(classify_method("zone_setLeader"), None);
-        assert_eq!(
-            classify_method("admin_setLeader"),
-            Some(MethodTier::Restricted)
-        );
 
         let api = MockZoneRpcApi::default();
-        // admin_* stays rejected before dispatch.
-        let rejected = dispatch(&request("admin_setLeader", json!([])), &auth(), &api).await;
-        assert_eq!(rejected.error.unwrap().code, -32005);
-
         let excluded = dispatch(&request("zone_setLeader", json!([])), &auth(), &api).await;
         assert_eq!(excluded.error.unwrap().code, -32601);
 

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -50,6 +50,9 @@ const MAX_RETRIES: u32 = 3;
 /// Initial delay between retries (doubles on each attempt).
 const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(2);
 
+/// Backoff before rebuilding the monitor after a start or run failure.
+const RESTART_BACKOFF: Duration = Duration::from_secs(5);
+
 /// Configuration for the [`ZoneMonitor`].
 #[derive(Debug, Clone)]
 pub struct ZoneMonitorConfig {
@@ -815,12 +818,13 @@ pub fn spawn_zone_monitor<P: ZoneSequencerProvider>(
                 Ok(monitor) => monitor,
                 Err(e) => {
                     error!(error = %e, "Zone monitor failed to start, retrying in 5s");
-                    tokio::select! {
-                        () = shutdown.cancelled() => {
-                            info!("Zone monitor stopped before start");
-                            return;
-                        }
-                        () = tokio::time::sleep(Duration::from_secs(5)) => {}
+                    if shutdown
+                        .run_until_cancelled(tokio::time::sleep(RESTART_BACKOFF))
+                        .await
+                        .is_none()
+                    {
+                        info!("Zone monitor stopped before start");
+                        return;
                     }
                     continue;
                 }
@@ -836,12 +840,13 @@ pub fn spawn_zone_monitor<P: ZoneSequencerProvider>(
                         error = %e,
                         "Zone monitor failed; rebuilding from the portal anchor in 5s"
                     );
-                    tokio::select! {
-                        () = shutdown.cancelled() => {
-                            info!("Zone monitor stopped");
-                            return;
-                        }
-                        () = tokio::time::sleep(Duration::from_secs(5)) => {}
+                    if shutdown
+                        .run_until_cancelled(tokio::time::sleep(RESTART_BACKOFF))
+                        .await
+                        .is_none()
+                    {
+                        info!("Zone monitor stopped");
+                        return;
                     }
                 }
             }

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -50,6 +50,9 @@ use tempo_alloy::rpc::TempoCallBuilderExt;
 
 const PROCESS_WITHDRAWAL_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Backoff before restarting the processing loop after an unexpected failure.
+const RESTART_BACKOFF: Duration = Duration::from_secs(5);
+
 // These planner allowances were calibrated against the current ZonePortal/ZoneMessenger bytecode.
 // Pre-refund T1 dev-L1 traces used 553,703, 1,068,088, and 1,348,063 gas for one, two, and four
 // successful simple items, and 1,347,339 gas around a callback. T3 Foundry traces used 1,026,857
@@ -351,10 +354,10 @@ impl WithdrawalProcessor {
     /// Run the processor loop. This method never returns under normal operation.
     ///
     /// Waits for a notification from the batch submitter (or a fallback timeout) before
-    /// checking the L1 withdrawal queue.
+    /// checking the L1 withdrawal queue. Returns `Ok(())` only when `shutdown` fires; the
+    /// token is observed at the wait boundary so an in-flight processing cycle completes
+    /// first.
     #[instrument(skip_all, fields(portal = %self.config.portal_address))]
-    /// Run the processing loop. Returns `Ok(())` only when `shutdown` fires; the token is
-    /// observed at the wait boundary so an in-flight processing cycle completes first.
     pub async fn run(
         &mut self,
         shutdown: &tokio_util::sync::CancellationToken,
@@ -755,12 +758,13 @@ pub fn spawn_withdrawal_processor(
                 }
                 Err(e) => {
                     error!(error = %e, "Withdrawal processor failed, restarting in 5s");
-                    tokio::select! {
-                        () = shutdown.cancelled() => {
-                            info!("Withdrawal processor stopped");
-                            return;
-                        }
-                        () = tokio::time::sleep(Duration::from_secs(5)) => {}
+                    if shutdown
+                        .run_until_cancelled(tokio::time::sleep(RESTART_BACKOFF))
+                        .await
+                        .is_none()
+                    {
+                        info!("Withdrawal processor stopped");
+                        return;
                     }
                 }
             }

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -370,6 +370,9 @@ contract ZonePortal is IZonePortal {
         _setLeader(newLeader);
     }
 
+    /// @dev Single write path for a leadership transition: assign, bump the fencing epoch,
+    ///      stamp the activation block, emit. `crates/l1` decodes `LeaderUpdated` to drive
+    ///      node roles, so every transition must go through here to stay consistent.
     function _setLeader(address newLeader) private {
         address previous = leader;
         leader = newLeader;


### PR DESCRIPTION
Stacked on #860 — **base branch is `aditya/zero_downtime`, not `main`.** Rebased onto `1e92ec19`.

Quality-only pass over the leader-rotation code (reuse, simplification, efficiency, altitude). Deliberately no overlap with the consensus/liveness/authorization review already on #860.

Net: **+261 / −268** across 11 files.

> **Rebase note.** `1e92ec19` ("simplify role polling, advace, portal") independently implemented three of the findings this PR originally carried — the `desired_role` anchor plumbing, the notify-on-real-change fix in `record_applied_anchor`, and the Solidity `_setLeader` / `retainsLeader` cleanup. In each case I dropped my version and kept upstream's, which is better on all three counts: `next_anchor` lives inside the `DesiredRole::Leader` variant (no `Option` + `expect`), `record_applied_anchor` compares the whole governing record rather than just its activation, and `_setLeader` caches `block.number` in a local. `1e92ec19` also went further than I did and removed `ROLE_RECHECK_INTERVAL` outright by adding a `watch` to `PeerTipRegistry` — a change I had explicitly deferred as needing its own review. What remains below is only what upstream did not already do.

### `role.rs`
- Delete `GenerationKind`. It was `DesiredRole` with the epoch removed, and it cost five hand-written matches inside one 50-line stretch — role name, epoch (twice, identically), metric label, and gauge value. Replaced with `name()` / `gauge()` / `epoch()` / `same_variant()`. This got *more* valuable after `1e92ec19`, which had to add `{ epoch, .. }` patterns in three places to work around the redundant enum.
- Derive `ready_for_promotion` from `promotion_reasons.is_empty()` instead of a separate field every write site had to keep consistent with the reasons.
- Replace the inner `mod zone_transaction_pool_alias` with a plain `use` — `tempo-transaction-pool` is already a direct dependency and `tx_forwarding.rs` imports the same path directly.

### `manifest.rs`
- `latest_observed_epoch` is derived rather than maintained. `publish` enforces `epoch == last.epoch + 1` and pruning never drops the last entry, so the field could only ever equal the last retained transition's epoch.
- Delete `role_for` — no production callers, only its own unit test.
- Add the rationale comments to upstream's `record_applied_anchor` (why a plain advance must stay silent).

### `runtime.rs`
- Hoist the recipient set out of the command loop. It used to be `followers()`, whose predicate depended on the mutable leader; it is now "all peers except self", and both inputs are fixed for the task's lifetime.
- Move the `RequestBackfill` arm back into its `match`. The earlier hoist left `unreachable!("backfill requests are routed before role derivation")` in a dispatcher that no longer does role derivation, plus a character-identical copy of the peer filter.

### `engine.rs`
- `permit` returns `Option<EngineExit>`. `PermitDecision::{Produce, Demoted, Fenced}` mapped 1:1 onto `EngineExit`, and the `u64` in the returned tuple was always `block.header.number()` — which the caller already has. Deletes the enum, its `lib.rs` re-export, and the translation match.

### `node.rs`
- Extract `ensure_zone_chain_id` (inlined three times, same hand-written message) and `build_sequencer_config` (a 10-field struct literal duplicated between the leader generation and legacy single-sequencer startup — a field added to one silently changed leader-mode behaviour only).
- Batch the three finalized portal reads (`leader`, `leaderEpoch`, `leaderActivationTempoBlock`) into one `try_join!`. Same block, no data dependency, and `set_leader` already used this pattern for two of them.

### `replication.rs`
- Fold the two dead `BackfillRequested` arms into the neighbouring no-op arms. `route_events_to_generations` diverts that variant before any generation sink sees it, so both `debug!` calls were unreachable. Kept as explicit arms rather than deleted so the matches stay exhaustive and the compiler still catches a new variant.

### sequencer
- Replace three copies of the cancel-or-sleep `tokio::select!` (`monitor.rs` ×2, `withdrawals.rs` ×1) with `CancellationToken::run_until_cancelled`, and name the retry interval instead of repeating `Duration::from_secs(5)`.
- Fix a doc comment split across the `#[instrument]` attribute on `WithdrawalProcessor::run`.

### rpc / Solidity
- Drop assertions on `admin_setLeader`, which exists nowhere in the repo. The `admin_*` prefix rule is already covered with a real method (`admin_peers`) in an existing test.
- Document `_setLeader` as the single write path, noting that `crates/l1` decodes `LeaderUpdated` (the reason both callers must go through it).

## Verification

- `forge test` — **166 passed, 0 failed** (`ZonePortal.t.sol`, `ZoneConfig.t.sol`)
- `cargo test -p zone-p2p -p zone-node -p zone-rpc -p zone-sequencer --lib` — **170 passed, 0 failed**
- `cargo clippy` on those four crates, `--all-targets` — clean

Integration tests (`handoff_e2e` and friends) have **not** been run locally — they spin up full reth nodes and are left to CI.

## Not done

Listed so the gaps are explicit rather than implied.

**Not started:**
- **Stringly-typed RPC surface** — `LocalSequencerInfo.role: String`, `mode: "multi"/"single"` (exactly `local.is_some()`; four fields encoding one bit, and a client can observe `mode:"multi"` with `local:null`), `SetLeaderResponse.status` (exactly `tx_hash.is_some()`), `Vec<String>` readiness reasons as an API contract. The largest remaining finding. Worth doing while the API is unreleased, as its own PR.
- `crates/rpc` owns eight response types it never references, while the methods are served from the node's HTTP module.
- The promotion quorum reads `context.attestation.addresses.keys()` rather than `manifest.nodes()` — same set today, silently coupled.
- `OnceLock<SequencerRpcContext>` is never observed empty (`set()` precedes `launch_add_ons_with`), yet emptiness doubles as "single-sequencer mode".
- `publish()`'s clamp-first-activation-to-0 and the three-condition duplicate-epoch special case it then requires.
- `--sequencer.role` asserts against the manifest's `leader_ed25519_public_key`, which production code no longer consults (`P2pConfig::new` builds an `uninitialized()` schedule). `crates/p2p/README.md:25` still describes it as a live bootstrap.
- Efficiency items: backfill tip advertisement recomputed on empty pages; `EventSinks::sink_for` taking a mutex + `Sender` clone per P2P event; `PeerTipRegistry::snapshot` allocations and duplicate header lookups per tick.
- `seed_leadership_schedule` duplicates the portal-deployment probe and the leader-resolution tail that `ScheduleLeadershipSink` already has.

**Partial:**
- Dead API: `role_for` and the phantom test are gone; `is_initialized` / `seeded` (test-only) and the `LeadershipState` accessors remain.
- Startup: the `try_join!` landed; the eagerly-connected `relayer` provider — used only by `zone_setLeader` — still blocks startup on every node.

**Judged not worth it:** the nested `match` + `unreachable!` at `replication.rs:679` (removing it properly means extracting a ~55-line body with many captures); test-helper dedup (`_sequencerSetWithLeader` ×4, the producer-boundary loop ×3 in `handoff_e2e.rs`, the manifest-TOML builder ×5 in `runtime.rs`, `make_receipt_with_logs`); putting the anchor on the `BroadcastBlock` wire frame to retire `is_scheduled_leader`; inlining `sequencer_enabled`, where a named and tested predicate reads better than the bare `||`.

