### PR TITLE
fix(test): sync Earn deploy params

### DIFF
--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -126,6 +126,7 @@ alloy_sol_types::sol! {
         address owner;
         EarnVaultControls controls;
         FeeConfig fees;
+        uint64 transferPolicyId;
     }
 
     #[sol(rpc)]
@@ -375,6 +376,7 @@ impl EarnZoneFixture {
                 migrationMode: EngineMigrationMode::OperatorEnabled,
             },
             fees,
+            transferPolicyId: 0,
         };
 
         let provider = l1.dev_provider();


### PR DESCRIPTION
## Summary
- sync the Earn factory deploy tuple with the new `transferPolicyId` field
- retain the default always-allow policy for existing Earn zone scenarios

## Validation
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- full local test build unavailable because sandbox git dependency fetches return 401

Prompted by: @0xrusowsky