### PR TITLE
feat: `--l1.verify-certificates`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "age"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43"
+dependencies = [
+ "age-core",
+ "base64 0.21.7",
+ "bech32",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hmac",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "nom",
+ "pin-project",
+ "rand 0.8.7",
+ "rust-embed",
+ "scrypt",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "age-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+dependencies = [
+ "base64 0.21.7",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hkdf",
+ "io_tee",
+ "nom",
+ "rand 0.8.7",
+ "secrecy",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +507,7 @@ dependencies = [
  "rand 0.9.5",
  "rapidhash",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "secp256k1 0.31.1",
  "serde",
  "sha3 0.11.0",
@@ -1091,6 +1134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "archery"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,7 +1801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn 2.0.119",
 ]
@@ -2456,7 +2517,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -2693,6 +2754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +2799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
 ]
 
 [[package]]
@@ -3148,7 +3224,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -3239,7 +3315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -3251,6 +3327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -3645,6 +3722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +3794,50 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4426,6 +4556,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4729,6 +4925,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
+
+[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4969,7 +5190,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.5",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6560,6 +6781,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6745,7 +6967,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -6767,7 +6989,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -7217,7 +7439,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7244,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7277,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7297,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7310,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7385,7 +7607,7 @@ dependencies = [
  "tar",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
  "zstd",
@@ -7394,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7404,7 +7626,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7455,7 +7677,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7464,14 +7686,14 @@ dependencies = [
  "reth-stages-types",
  "reth-static-file-types",
  "serde",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7485,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7498,7 +7720,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7523,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7541,7 +7763,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "strum 0.27.2",
  "sysinfo 0.38.4",
  "tempfile",
@@ -7552,7 +7774,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7578,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7608,7 +7830,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7623,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7648,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7672,7 +7894,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7696,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7731,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7758,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7781,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7808,7 +8030,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7823,6 +8045,7 @@ dependencies = [
  "indexmap 2.14.0",
  "metrics",
  "moka",
+ "parking_lot",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -7863,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7893,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7911,7 +8134,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7927,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7950,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7961,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7989,7 +8212,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8011,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8051,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -8074,7 +8297,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8090,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8106,20 +8329,20 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
  "alloy-primitives",
  "auto_impl",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8149,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8163,7 +8386,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8173,7 +8396,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8198,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8218,7 +8441,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8236,7 +8459,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8249,7 +8472,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8268,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8306,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8320,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "serde",
  "serde_json",
@@ -8330,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8356,7 +8579,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "futures",
@@ -8376,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -8393,7 +8616,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bindgen",
  "cc",
@@ -8402,9 +8625,10 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures",
+ "libc",
  "metrics",
  "metrics-derive",
  "reth-primitives-traits",
@@ -8415,7 +8639,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8424,7 +8648,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8438,7 +8662,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8480,7 +8704,7 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-transaction-pool",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
@@ -8496,7 +8720,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8521,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8545,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8560,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8574,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8591,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8615,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8683,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8728,7 +8952,7 @@ dependencies = [
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.18",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
  "vergen",
@@ -8738,7 +8962,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8787,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8811,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8835,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "eyre",
@@ -8859,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8871,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8895,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8907,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8930,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8973,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9021,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9039,7 +9263,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-tokio-util",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9048,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9064,7 +9288,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9079,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9156,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9186,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9229,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9249,7 +9473,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9280,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9327,7 +9551,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9378,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9392,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9423,7 +9647,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9474,7 +9698,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9502,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9516,7 +9740,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9536,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9551,7 +9775,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9577,7 +9801,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9594,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9615,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9631,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9641,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -9659,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9677,7 +9901,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9706,7 +9930,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "revm",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "schnellru",
  "serde",
  "serde_json",
@@ -9720,7 +9944,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9969,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9772,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -9791,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9815,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -10205,6 +10429,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.119",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10382,6 +10647,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10447,6 +10721,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10503,6 +10788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10524,6 +10818,21 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.3.0",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -10706,6 +11015,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -11148,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11187,7 +11507,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11209,9 +11529,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-consensus"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rlp",
+ "alloy-rpc-client",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-transport",
+ "axum",
+ "bytes",
+ "clap",
+ "commonware-broadcast",
+ "commonware-codec",
+ "commonware-consensus",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-p2p",
+ "commonware-parallel",
+ "commonware-resolver",
+ "commonware-runtime",
+ "commonware-storage",
+ "commonware-utils",
+ "eyre",
+ "futures",
+ "governor",
+ "indexmap 2.14.0",
+ "jiff",
+ "jsonrpsee",
+ "parking_lot",
+ "pin-project",
+ "prometheus-client",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "reth-consensus-common",
+ "reth-engine-primitives",
+ "reth-ethereum",
+ "reth-evm",
+ "reth-node-builder",
+ "reth-node-core",
+ "reth-primitives-traits",
+ "reth-provider",
+ "reth-revm",
+ "serde_json",
+ "tempo-alloy",
+ "tempo-chainspec",
+ "tempo-consensus-config",
+ "tempo-dkg-onchain-artifacts",
+ "tempo-node",
+ "tempo-payload-types",
+ "tempo-precompiles",
+ "tempo-primitives",
+ "tempo-telemetry-util",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "tempo-consensus-config"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
+dependencies = [
+ "age",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-math",
+ "const-hex",
+ "rand_core 0.6.4",
+ "secrecy",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11223,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11235,7 +11635,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11270,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11282,7 +11682,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11342,7 +11742,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11380,7 +11780,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11400,7 +11800,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11423,7 +11823,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11434,7 +11834,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11466,7 +11866,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11487,9 +11887,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-telemetry-util"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
+dependencies = [
+ "eyre",
+ "jiff",
+ "tracing",
+]
+
+[[package]]
 name = "tempo-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=5d4721043120d08e53e7dcfc35929c8312342f41#5d4721043120d08e53e7dcfc35929c8312342f41"
+source = "git+https://github.com/tempoxyz/tempo?rev=63ee158051cfcc98fca9567d8142d8a6d5070f4c#63ee158051cfcc98fca9567d8142d8a6d5070f4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11726,6 +12136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -11847,6 +12258,15 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -12286,6 +12706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.3",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12332,6 +12761,25 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
 
 [[package]]
 name = "unicase"
@@ -13365,6 +13813,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -13465,6 +13914,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-alloy",
+ "tempo-chainspec",
+ "tempo-consensus",
  "tempo-contracts",
  "tempo-primitives",
  "tempo-zone-contracts",
@@ -13580,7 +14031,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,25 +94,25 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "5d4721043120d08e53e7dcfc35929c8312342f41", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "63ee158051cfcc98fca9567d8142d8a6d5070f4c", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
@@ -128,38 +128,38 @@ zone-rpc = { path = "crates/rpc" }
 zone-sequencer = { path = "crates/sequencer" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400", features = [
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 revm = { version = "41.0.0", features = [
   "optional_fee_charge",
 ], default-features = false }

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -17,6 +17,8 @@ zone-precompiles = { workspace = true, features = ["std"] }
 
 # tempo
 tempo-alloy.workspace = true
+tempo-chainspec.workspace = true
+tempo-consensus.workspace = true
 tempo-contracts.workspace = true
 tempo-primitives.workspace = true
 

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -1,9 +1,7 @@
 //! L1 chain subscription and deposit extraction.
 //!
-//! Uses L1 block notifications to follow the finalized chain and extracts
-//! deposit events from the ZonePortal contract for each finalized block.
-//! WebSocket connections use `newHeads`; HTTP connections use block-filter
-//! polling.
+//! Verifies Tempo consensus certificates while following the finalized chain,
+//! then extracts deposit events from the ZonePortal contract for each block.
 //!
 //! The module is split into:
 //! - [`subscriber`] — the [`L1Subscriber`] background task and its config.
@@ -31,6 +29,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_storage_api::StateProviderFactory;
 use std::{pin::Pin, sync::Arc};
 use tempo_alloy::TempoNetwork;
+use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
 use tempo_primitives::TempoHeader;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -93,6 +92,21 @@ pub use subscriber::{
     L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
     MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS,
 };
+
+/// Returns the Tempo chain spec used for an L1 chain ID.
+///
+/// Tempo Anvil uses chain ID 31337 with the Tempo DEV hardfork schedule. Additional
+/// dev-schedule chain IDs can be listed in `ZONE_L1_DEV_CHAIN_IDS`.
+pub fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
+    chainspec_from_chain_id(chain_id).or_else(|| match chain_id {
+        1337 | 31337 => Some(DEV.clone()),
+        _ => std::env::var("ZONE_L1_DEV_CHAIN_IDS")
+            .ok()?
+            .split(',')
+            .any(|id| id.trim().parse() == Ok(chain_id))
+            .then(|| DEV.clone()),
+    })
+}
 
 #[cfg(test)]
 pub(crate) use queue::PendingDeposits;

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -1,7 +1,7 @@
 //! L1 chain subscription and deposit extraction.
 //!
-//! Verifies Tempo consensus certificates while following the finalized chain,
-//! then extracts deposit events from the ZonePortal contract for each block.
+//! Follows the finalized Tempo chain, optionally verifies consensus certificates,
+//! and extracts deposit events from the ZonePortal contract for each block.
 //!
 //! The module is split into:
 //! - [`subscriber`] — the [`L1Subscriber`] background task and its config.
@@ -29,7 +29,6 @@ use reth_primitives_traits::SealedHeader;
 use reth_storage_api::StateProviderFactory;
 use std::{pin::Pin, sync::Arc};
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
 use tempo_primitives::TempoHeader;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -92,21 +91,6 @@ pub use subscriber::{
     L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
     MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS,
 };
-
-/// Returns the Tempo chain spec used for an L1 chain ID.
-///
-/// Tempo Anvil uses chain ID 31337 with the Tempo DEV hardfork schedule. Additional
-/// dev-schedule chain IDs can be listed in `ZONE_L1_DEV_CHAIN_IDS`.
-pub fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
-    chainspec_from_chain_id(chain_id).or_else(|| match chain_id {
-        1337 | 31337 => Some(DEV.clone()),
-        _ => std::env::var("ZONE_L1_DEV_CHAIN_IDS")
-            .ok()?
-            .split(',')
-            .any(|id| id.trim().parse() == Ok(chain_id))
-            .then(|| DEV.clone()),
-    })
-}
 
 #[cfg(test)]
 pub(crate) use queue::PendingDeposits;

--- a/crates/l1/src/metrics.rs
+++ b/crates/l1/src/metrics.rs
@@ -2,16 +2,13 @@
 
 use reth_metrics::{
     Metrics,
-    metrics::{Counter, Gauge, Histogram},
+    metrics::{Counter, Gauge},
 };
 
 /// Metrics emitted by the L1 subscriber / deposit ingestion pipeline.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_zone_l1_subscriber")]
 pub(crate) struct L1SubscriberMetrics {
-    /// Duration of a backfill run in seconds.
-    pub backfill_duration_seconds: Histogram,
-
     /// Most recent finalized L1 block number observed by the subscriber.
     pub latest_l1_block_seen: Gauge,
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,6 +1,7 @@
 use super::*;
 use eyre::WrapErr as _;
 use std::collections::HashSet;
+use tempo_consensus::finalized_block_stream::{FinalizedBlockStream, FinalizedBlockStreamConfig};
 use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::is_tip20_prefix;
 
@@ -531,192 +532,164 @@ impl L1Subscriber {
         }
     }
 
-    /// Determine the starting block number for backfill.
-    ///
-    /// The zone's persisted Tempo checkpoint is the authoritative source for
-    /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
-    /// block-zero genesis from the unanchored template.
-    pub(crate) fn resolve_start_block(&self) -> eyre::Result<u64> {
+    /// Resolve the persisted L1 checkpoint.
+    pub(crate) fn resolve_start_block(&self) -> eyre::Result<NumHash> {
         let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
         eyre::ensure!(
             local_checkpoint.hash != B256::ZERO,
             "zone genesis is not anchored to an L1 block"
         );
-        let local_tempo_block_number = local_checkpoint.number;
-        info!(local_tempo_block_number, "Resuming from local zone state");
-        Ok(local_tempo_block_number + 1)
+        info!(
+            local_tempo_block_number = local_checkpoint.number,
+            "Resuming from local zone state"
+        );
+        Ok(local_checkpoint)
     }
 
-    /// Resolve the first L1 block that has not already been ingested.
-    pub(crate) fn next_block_to_sync(&self) -> eyre::Result<u64> {
+    /// Resolve the trusted block immediately before the next L1 block to ingest.
+    pub(crate) fn next_block_to_sync(&self) -> eyre::Result<NumHash> {
         let resolved = self.resolve_start_block()?;
-        let queued = self
-            .deposit_sink
-            .last_enqueued()
-            .map(|last| last.number.saturating_add(1));
-        let observed = self
-            .config
-            .block_tracker
-            .latest()
-            .map(|last| last.number.saturating_add(1));
+        let queued = self.deposit_sink.last_enqueued();
+        let observed = self.config.block_tracker.latest();
 
-        let next = [Some(resolved), queued, observed]
-            .into_iter()
-            .flatten()
-            .max()
-            .expect("resolved checkpoint is always present");
+        let mut start_after = resolved;
+        for candidate in [queued, observed].into_iter().flatten() {
+            if candidate.number == start_after.number {
+                eyre::ensure!(
+                    candidate.hash == start_after.hash,
+                    "conflicting trusted L1 hashes at block {}: {} and {}",
+                    start_after.number,
+                    start_after.hash,
+                    candidate.hash
+                );
+            }
+            if candidate.number > start_after.number {
+                start_after = candidate;
+            }
+        }
 
         // Only the persisted zone checkpoint proves consumption.
         // Queue and observation cursors are fetch high-water marks.
         self.config
             .block_tracker
-            .initialize_consumed_through(resolved.saturating_sub(1));
-        Ok(next)
-    }
-
-    /// Return the block number referenced by the L1 `finalized` tag.
-    async fn finalized_block_number(
-        &self,
-        l1_provider: &impl Provider<TempoNetwork>,
-    ) -> eyre::Result<u64> {
-        l1_provider
-            .get_header_by_number(BlockNumberOrTag::Finalized)
-            .await
-            .inspect_err(|_| self.subscriber_metrics.fetch_failures.increment(1))?
-            .map(|header| header.number())
-            .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
-    }
-
-    /// Synchronize all missing blocks through the current finalized L1 head.
-    ///
-    /// Callers provide the next block number and receive the next cursor after
-    /// a successful sync.
-    pub(crate) async fn sync_finalized_once(
-        &self,
-        l1_provider: &impl Provider<TempoNetwork>,
-        next_block: u64,
-    ) -> eyre::Result<u64> {
-        let finalized = self.finalized_block_number(l1_provider).await?;
-        if next_block > finalized {
-            self.record_seen_block(finalized, 0);
-            return Ok(next_block);
-        }
-
-        let blocks = finalized - next_block + 1;
-        self.record_seen_block(finalized, blocks);
+            .initialize_consumed_through(resolved.number);
         info!(
-            from = next_block,
-            to = finalized,
-            blocks,
-            "Synchronizing finalized L1 blocks"
+            number = start_after.number,
+            hash = %start_after.hash,
+            "Resuming verified finalized L1 stream from trusted checkpoint"
         );
-
-        let start = std::time::Instant::now();
-        self.backfill(l1_provider, next_block, finalized).await?;
-        self.subscriber_metrics
-            .backfill_duration_seconds
-            .record(start.elapsed().as_secs_f64());
-        self.subscriber_metrics.current_l1_lag_blocks.set(0.0);
-        Ok(finalized.saturating_add(1))
+        Ok(start_after)
     }
 
-    /// Follow finalized L1 using transport-specific head notifications as wakeups.
-    ///
-    /// Header contents are intentionally ignored. Canonical block selection is
-    /// always based on the `finalized` tag read by [`Self::sync_finalized_once`].
-    pub(crate) async fn follow_finalized<S>(
+    /// Follow the RPC's finalized tag without consensus-certificate verification.
+    pub(crate) fn rpc_finalized_headers<'a, S>(
+        &self,
+        provider: DynProvider<TempoNetwork>,
+        start_after: NumHash,
+        triggers: S,
+    ) -> Pin<Box<dyn Stream<Item = eyre::Result<SealedHeader<TempoHeader>>> + Send + 'a>>
+    where
+        S: Stream<Item = eyre::Result<()>> + Send + Unpin + 'a,
+    {
+        let subscriber_metrics = self.subscriber_metrics.clone();
+        let state = (provider, start_after, start_after.number, triggers, false);
+        Box::pin(futures::stream::try_unfold(
+            state,
+            move |(provider, cursor, mut latest_finalized, mut triggers, mut wait_for_trigger)| {
+                let subscriber_metrics = subscriber_metrics.clone();
+                async move {
+                    loop {
+                        if cursor.number >= latest_finalized {
+                            if wait_for_trigger && triggers.try_next().await?.is_none() {
+                                return Ok(None);
+                            }
+                            let response = provider
+                                .get_header_by_number(BlockNumberOrTag::Finalized)
+                                .await
+                                .inspect_err(|_| subscriber_metrics.fetch_failures.increment(1))?
+                                .ok_or_else(|| {
+                                    eyre::eyre!("L1 finalized block is not available")
+                                })?;
+                            let finalized = validate_header_response(response)?;
+                            wait_for_trigger = true;
+                            if finalized.number() <= cursor.number {
+                                continue;
+                            }
+                            latest_finalized = finalized.number();
+                        }
+
+                        let number = cursor
+                            .number
+                            .checked_add(1)
+                            .ok_or_else(|| eyre::eyre!("L1 block number overflow"))?;
+                        let response = provider
+                            .get_header_by_number(number.into())
+                            .await
+                            .inspect_err(|_| subscriber_metrics.fetch_failures.increment(1))?
+                            .ok_or_else(|| eyre::eyre!("L1 header not found for block {number}"))?;
+                        let header = validate_header_response(response)?;
+                        eyre::ensure!(
+                            header.number() == number,
+                            "L1 RPC returned block {} for requested block {number}",
+                            header.number()
+                        );
+                        eyre::ensure!(
+                            header.parent_hash() == cursor.hash,
+                            "L1 parent hash mismatch at block {number}: expected {}, got {}",
+                            cursor.hash,
+                            header.parent_hash()
+                        );
+                        let next = header.num_hash();
+                        return Ok(Some((
+                            header,
+                            (provider, next, latest_finalized, triggers, true),
+                        )));
+                    }
+                }
+            },
+        ))
+    }
+
+    /// Fetch receipt-authenticated data for finalized headers and apply it in order.
+    pub(crate) async fn follow_headers<S>(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-        triggers: S,
+        headers: S,
     ) -> eyre::Result<()>
     where
-        S: Stream<Item = eyre::Result<()>> + Send,
+        S: Stream<Item = eyre::Result<SealedHeader<TempoHeader>>> + Send,
     {
-        let mut triggers = Box::pin(triggers);
-        let mut next_block = self.next_block_to_sync()?;
-
-        // Subscribe before the initial sync so a head published while catching
-        // up remains queued as another trigger.
-        next_block = self.sync_finalized_once(l1_provider, next_block).await?;
-
-        while let Some(trigger) = triggers.next().await {
-            trigger?;
-            next_block = self.sync_finalized_once(l1_provider, next_block).await?;
-        }
-
-        Err(eyre::eyre!("L1 head notification stream ended"))
-    }
-
-    /// Backfill L1 blocks from `from..=to` with pipelined RPC fetching.
-    ///
-    /// Fetches headers and receipts for up to `l1_fetch_concurrency` blocks in
-    /// parallel, then processes them sequentially (event extraction and enqueue).
-    /// Receipts are fetched by the corresponding block
-    /// hash and validated against the header's receipts root before processing.
-    #[instrument(skip(self, l1_provider), fields(from, to))]
-    async fn backfill(
-        &self,
-        l1_provider: &impl Provider<TempoNetwork>,
-        from: u64,
-        to: u64,
-    ) -> eyre::Result<()> {
-        use futures::stream;
-
         let concurrency = self.config.l1_fetch_concurrency.max(1);
         let subscriber_metrics = self.subscriber_metrics.clone();
         let block_tracker = self.config.block_tracker.clone();
-
-        let mut fetched = stream::iter(from..=to)
-            .map(move |block_number| {
-                let provider = l1_provider;
+        let mut fetched = Box::pin(headers)
+            .map(move |header| {
                 let subscriber_metrics = subscriber_metrics.clone();
                 let block_tracker = block_tracker.clone();
                 async move {
-                    block_tracker.wait_for_capacity(block_number).await?;
+                    let header = header?;
+                    let block = header.num_hash();
+                    block_tracker.wait_for_capacity(block.number).await?;
                     let start = std::time::Instant::now();
-                    let fetch_failures = &subscriber_metrics.fetch_failures;
-                    let header_resp = async {
-                        provider
-                            .get_header_by_number(block_number.into())
-                            .await?
-                            .ok_or_else(|| {
-                                eyre::eyre!("L1 header not found for block {block_number}")
-                            })
-                    }
-                    .await
-                    .inspect_err(|_| {
-                        fetch_failures.increment(1);
-                    })?;
-                    let block_hash = header_resp.hash();
-                    let block = NumHash::new(block_number, block_hash);
-                    let expected_receipts_root = header_resp.receipts_root();
-                    let expected_logs_bloom = header_resp.logs_bloom();
                     let receipts = fetch_and_verify_receipts_for_header(
-                        provider,
+                        l1_provider,
                         block,
-                        expected_receipts_root,
-                        expected_logs_bloom,
+                        header.receipts_root(),
+                        header.logs_bloom(),
                     )
                     .await
-                    .inspect_err(|_| {
-                        fetch_failures.increment(1);
-                    })?;
-                    let elapsed = start.elapsed();
+                    .inspect_err(|_| subscriber_metrics.fetch_failures.increment(1))?;
                     debug!(
-                        block_number,
-                        %block_hash,
-                        elapsed_ms = elapsed.as_millis() as u64,
+                        block_number = block.number,
+                        block_hash = %block.hash,
+                        elapsed_ms = start.elapsed().as_millis() as u64,
                         receipts = receipts.len(),
-                        "Fetched and validated L1 block data"
+                        "Fetched and validated receipts for finalized L1 header"
                     );
-                    let header = header_resp.inner.inner;
                     Ok::<_, eyre::Report>((header, receipts))
                 }
             })
             .buffered(concurrency);
-
-        let mut processed = 0u64;
-        let backfill_start = std::time::Instant::now();
 
         while let Some((header, receipts)) = fetched.try_next().await? {
             let block_number = header.number();
@@ -729,10 +702,9 @@ impl L1Subscriber {
                         self.subscriber_metrics.decode_fence_failures.increment(1);
                         FencedIngestionError::new(block_number, "portal event decoding", err)
                     })?;
-            self.record_seen_block(block_number, to.saturating_sub(block_number));
+            self.record_seen_block(block_number, 0);
 
-            let sealed = SealedHeader::seal_slow(header);
-            let anchor = sealed.num_hash();
+            let anchor = header.num_hash();
             // Publish the leadership transition _before_ the activation block becomes
             // consumable.
             if let Some(sink) = &self.config.leadership_sink {
@@ -757,7 +729,7 @@ impl L1Subscriber {
             }
             let appended = self
                 .deposit_sink
-                .enqueue(sealed, events.clone())
+                .enqueue(header, events.clone())
                 .wrap_err_with(|| {
                     format!("unexpected discontinuity while enqueueing L1 block {block_number}")
                 })?;
@@ -774,49 +746,58 @@ impl L1Subscriber {
             if !self.config.retain_observations {
                 self.config.block_tracker.prune_through(anchor.number);
             }
-            processed += 1;
-
-            if processed.is_multiple_of(100) {
-                let elapsed = backfill_start.elapsed();
-                let blocks_per_sec = processed as f64 / elapsed.as_secs_f64().max(0.001);
-                info!(
-                    processed,
-                    current_block = block_number,
-                    target = to,
-                    remaining = to - block_number,
-                    blocks_per_sec = format!("{blocks_per_sec:.1}"),
-                    "Backfill progress"
-                );
-            }
         }
 
-        let elapsed = backfill_start.elapsed();
-        info!(
-            from,
-            to,
-            blocks = to - from + 1,
-            elapsed_ms = elapsed.as_millis() as u64,
-            "Backfill complete"
-        );
-        Ok(())
+        Err(eyre::eyre!("finalized L1 header stream ended"))
     }
 
     /// Run the L1 subscriber until an RPC operation fails.
     ///
-    /// The subscriber follows only the L1 `finalized` tag. WebSocket
-    /// `newHeads` or HTTP block-filter updates are used as wakeups; each
-    /// notification ingests the missing finalized range in order.
+    /// Finalized headers are authenticated through Tempo consensus certificates. Tempo Anvil
+    /// retains finalized-tag following because it does not run consensus.
     ///
     /// [`Self::spawn`] retries transient errors and treats deterministic finalized-block
     /// ingestion failures as fatal.
     pub async fn run(&self) -> eyre::Result<()> {
         let provider = self.connect().await?;
-        let triggers = self.head_triggers(&provider).await?;
-        info!(
-            portal = %self.config.portal_address,
-            "Following finalized L1 blocks"
-        );
-        self.follow_finalized(&provider, triggers).await
+        let chain_id = provider.get_chain_id().await?;
+        let chain_spec = tempo_chain_spec_for_l1(chain_id)
+            .ok_or_else(|| eyre::eyre!("unsupported parent Tempo chain ID {chain_id}"))?;
+        let start_after = self.next_block_to_sync()?;
+
+        let headers: Pin<
+            Box<dyn Stream<Item = eyre::Result<SealedHeader<TempoHeader>>> + Send + '_>,
+        > = if chain_id != 31337 {
+            let epoch_length = chain_spec.info.epoch_length().ok_or_else(|| {
+                eyre::eyre!("Tempo chain {chain_id} has no consensus epoch length")
+            })?;
+            let mut config = FinalizedBlockStreamConfig::new(
+                start_after.hash,
+                chain_spec.network_identity.clone(),
+                epoch_length,
+            );
+            config.fetch_concurrency = self.config.l1_fetch_concurrency.max(1);
+            let headers = FinalizedBlockStream::new(provider.clone(), config)
+                .await?
+                .map(|result| result.map_err(eyre::Report::new));
+            info!(
+                portal = %self.config.portal_address,
+                start_after_number = start_after.number,
+                start_after_hash = %start_after.hash,
+                "Following certificate-authenticated finalized L1 blocks"
+            );
+            Box::pin(headers)
+        } else {
+            warn!(
+                chain_id,
+                "Tempo Anvil does not expose consensus certificates; following the trusted \
+                 finalized RPC tag without certificate verification"
+            );
+            let triggers = self.head_triggers(&provider).await?;
+            self.rpc_finalized_headers(provider.clone(), start_after, triggers)
+        };
+
+        self.follow_headers(&provider, headers).await
     }
 
     /// Extract portal events and raw-cache mutation barriers from fetched receipts.
@@ -927,6 +908,21 @@ impl L1Subscriber {
             .lock()
             .invalidate_and_set_anchor(number, invalidated_accounts.iter().copied());
     }
+}
+
+fn validate_header_response(
+    response: tempo_alloy::rpc::TempoHeaderResponse,
+) -> eyre::Result<SealedHeader<TempoHeader>> {
+    let reported_hash = response.hash();
+    let header = SealedHeader::seal_slow(response.inner.inner);
+    eyre::ensure!(
+        header.hash() == reported_hash,
+        "L1 header {} reports hash {}, computed {}",
+        header.number(),
+        reported_hash,
+        header.hash()
+    );
+    Ok(header)
 }
 
 /// Fetch receipts for the L1 header by block hash and verify they match the

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,6 +1,7 @@
 use super::*;
 use eyre::WrapErr as _;
 use std::collections::HashSet;
+use tempo_chainspec::spec::chainspec_from_chain_id;
 use tempo_consensus::finalized_block_stream::{FinalizedBlockStream, FinalizedBlockStreamConfig};
 use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::is_tip20_prefix;
@@ -260,6 +261,10 @@ pub trait LeadershipSink: Send + Sync + std::fmt::Debug {
 pub struct L1SubscriberConfig {
     /// RPC URL of the L1 node (HTTP or WebSocket).
     pub l1_rpc_url: String,
+    /// Whether finalized L1 headers must be verified using Tempo consensus certificates.
+    pub verify_certificates: bool,
+    /// Consensus epoch length override for L1 chains without a built-in Tempo chain spec.
+    pub epoch_length: Option<std::num::NonZeroU64>,
     /// ZonePortal contract address on L1.
     pub portal_address: Address,
     /// Shared registry of tokens enabled for this zone.
@@ -753,27 +758,33 @@ impl L1Subscriber {
 
     /// Run the L1 subscriber until an RPC operation fails.
     ///
-    /// Finalized headers are authenticated through Tempo consensus certificates. Tempo Anvil
-    /// retains finalized-tag following because it does not run consensus.
+    /// When configured, finalized headers are authenticated through Tempo consensus
+    /// certificates. Otherwise, the subscriber trusts the RPC's finalized tag.
     ///
     /// [`Self::spawn`] retries transient errors and treats deterministic finalized-block
     /// ingestion failures as fatal.
     pub async fn run(&self) -> eyre::Result<()> {
         let provider = self.connect().await?;
-        let chain_id = provider.get_chain_id().await?;
-        let chain_spec = tempo_chain_spec_for_l1(chain_id)
-            .ok_or_else(|| eyre::eyre!("unsupported parent Tempo chain ID {chain_id}"))?;
         let start_after = self.next_block_to_sync()?;
 
         let headers: Pin<
             Box<dyn Stream<Item = eyre::Result<SealedHeader<TempoHeader>>> + Send + '_>,
-        > = if chain_id != 31337 {
-            let epoch_length = chain_spec.info.epoch_length().ok_or_else(|| {
-                eyre::eyre!("Tempo chain {chain_id} has no consensus epoch length")
-            })?;
+        > = if self.config.verify_certificates {
+            let chain_id = provider.get_chain_id().await?;
+            let chain_spec = chainspec_from_chain_id(chain_id);
+            let epoch_length = self
+                .config
+                .epoch_length
+                .or_else(|| chain_spec.as_ref()?.info.epoch_length())
+                .ok_or_else(|| {
+                    eyre::eyre!(
+                        "cannot determine the consensus epoch length for Tempo chain {chain_id}; \
+                         provide --l1.epoch-length"
+                    )
+                })?;
             let mut config = FinalizedBlockStreamConfig::new(
                 start_after.hash,
-                chain_spec.network_identity.clone(),
+                chain_spec.and_then(|spec| spec.network_identity.clone()),
                 epoch_length,
             );
             config.fetch_concurrency = self.config.l1_fetch_concurrency.max(1);
@@ -789,9 +800,8 @@ impl L1Subscriber {
             Box::pin(headers)
         } else {
             warn!(
-                chain_id,
-                "Tempo Anvil does not expose consensus certificates; following the trusted \
-                 finalized RPC tag without certificate verification"
+                "L1 consensus certificate verification is disabled; trusting the finalized RPC \
+                 tag"
             );
             let triggers = self.head_triggers(&provider).await?;
             self.rpc_finalized_headers(provider.clone(), start_after, triggers)

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -169,6 +169,8 @@ fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscr
     L1Subscriber {
         config: L1SubscriberConfig {
             l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
+            verify_certificates: false,
+            epoch_length: None,
             portal_address,
             enabled_tokens: crate::state::EnabledTokenRegistry::default(),
             l1_state_cache: crate::L1StateCache::new(),

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -709,14 +709,23 @@ fn test_resolve_start_block_reads_live_local_state_each_time() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new(
         VecDeque::from([10, 11]),
     )));
-    assert_eq!(subscriber.resolve_start_block().unwrap(), 11);
-    assert_eq!(subscriber.resolve_start_block().unwrap(), 12);
+    assert_eq!(
+        subscriber.resolve_start_block().unwrap(),
+        NumHash::new(10, B256::with_last_byte(1))
+    );
+    assert_eq!(
+        subscriber.resolve_start_block().unwrap(),
+        NumHash::new(11, B256::with_last_byte(1))
+    );
 }
 
 #[test]
 fn test_resolve_start_block_accepts_block_zero_with_nonzero_hash() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
-    assert_eq!(subscriber.resolve_start_block().unwrap(), 1);
+    assert_eq!(
+        subscriber.resolve_start_block().unwrap(),
+        NumHash::new(0, B256::with_last_byte(1))
+    );
 }
 
 #[test]
@@ -732,34 +741,65 @@ fn test_resolve_start_block_rejects_unanchored_genesis() {
 }
 
 #[tokio::test]
-async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() {
+async fn certificate_verified_headers_feed_the_existing_receipt_pipeline() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    subscriber
+        .config
+        .block_tracker
+        .initialize_consumed_through(9);
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
+    let header = seal(make_test_header(10));
+    let expected = header.num_hash();
+    asserter.push_success(&Some(Vec::<TempoTransactionReceipt>::new()));
+
+    let err = subscriber
+        .follow_headers(
+            &l1_provider,
+            futures::stream::iter([Ok::<_, eyre::Report>(header)]),
+        )
+        .await
+        .expect_err("finite header stream should end the subscriber");
+
+    assert!(err.to_string().contains("finalized L1 header stream ended"));
+    let DepositSink::Queue(queue) = &subscriber.deposit_sink else {
+        panic!("test subscriber must retain deposits");
+    };
+    assert_eq!(queue.last_enqueued(), Some(expected));
+    assert_eq!(subscriber.config.block_tracker.latest(), Some(expected));
+    assert!(asserter.read_q().is_empty());
+}
+
+#[tokio::test]
+async fn rpc_finalized_headers_feed_the_shared_ingestion_pipeline() {
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    subscriber
+        .config
+        .block_tracker
+        .initialize_consumed_through(9);
+    let asserter = Asserter::new();
+    let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_mocked_client(asserter.clone())
+        .erased();
 
     let header_10 = make_test_header(10);
     let header_11 = make_chained_header(11, header_hash(&header_10));
     let header_12 = make_chained_header(12, header_hash(&header_11));
-
-    // Initial sync through finalized block 10.
-    asserter.push_success(&Some(header_response(header_10.clone())));
-    push_header_and_empty_receipts(&asserter, header_10);
-
-    // One newHeads notification wakes the subscriber. The finalized tag has
-    // advanced by two blocks, so both missing blocks must be ingested.
     asserter.push_success(&Some(header_response(header_12.clone())));
+    push_header_and_empty_receipts(&asserter, header_10.clone());
     push_header_and_empty_receipts(&asserter, header_11);
     push_header_and_empty_receipts(&asserter, header_12);
 
+    let start_after = NumHash::new(9, header_10.parent_hash());
+    let headers = subscriber
+        .rpc_finalized_headers(l1_provider.clone(), start_after, futures::stream::pending())
+        .take(3);
     let err = subscriber
-        .follow_finalized(
-            &l1_provider,
-            futures::stream::iter([Ok::<_, eyre::Report>(())]),
-        )
+        .follow_headers(&l1_provider, headers)
         .await
-        .expect_err("finite trigger stream should end the subscriber");
-    assert!(err.to_string().contains("head notification stream ended"));
+        .expect_err("finite header stream should end the subscriber");
+    assert!(err.to_string().contains("finalized L1 header stream ended"));
 
     let DepositSink::Queue(queue) = &subscriber.deposit_sink else {
         panic!("test subscriber must retain deposits");
@@ -794,18 +834,23 @@ async fn observer_advances_caches_without_retaining_deposit_blocks() {
     let header_11 = make_chained_header(11, header_hash(&header_10));
     let header_12 = make_chained_header(12, header_hash(&header_11));
 
-    asserter.push_success(&Some(header_response(header_12.clone())));
-    push_header_and_empty_receipts(&asserter, header_10);
-    push_header_and_empty_receipts(&asserter, header_11);
-    push_header_and_empty_receipts(&asserter, header_12);
+    for _ in 0..3 {
+        asserter.push_success(&Some(Vec::<TempoTransactionReceipt>::new()));
+    }
+    subscriber
+        .config
+        .block_tracker
+        .initialize_consumed_through(9);
 
-    assert_eq!(
-        subscriber
-            .sync_finalized_once(&l1_provider, 10)
-            .await
-            .unwrap(),
-        13
-    );
+    let headers = [header_10, header_11, header_12]
+        .into_iter()
+        .map(seal)
+        .map(Ok::<_, eyre::Report>);
+    let err = subscriber
+        .follow_headers(&l1_provider, futures::stream::iter(headers))
+        .await
+        .expect_err("finite header stream should end the subscriber");
+    assert!(err.to_string().contains("finalized L1 header stream ended"));
 
     assert_eq!(
         subscriber
@@ -847,27 +892,6 @@ async fn test_head_triggers_falls_back_to_http_block_filter() {
         .expect("HTTP block filter stream should remain open");
 
     trigger.expect("HTTP block filter request should succeed");
-    assert!(asserter.read_q().is_empty());
-}
-
-#[tokio::test]
-async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
-    let asserter = Asserter::new();
-    let l1_provider =
-        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
-    asserter.push_success(&Some(header_response(make_test_header(10))));
-
-    let next = subscriber
-        .sync_finalized_once(&l1_provider, 11)
-        .await
-        .unwrap();
-
-    assert_eq!(next, 11);
-    let DepositSink::Queue(queue) = &subscriber.deposit_sink else {
-        panic!("test subscriber must retain deposits");
-    };
-    assert!(queue.drain().is_empty());
     assert!(asserter.read_q().is_empty());
 }
 
@@ -1582,12 +1606,13 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
-    asserter.push_success(&Some(header_response(header_10.clone())));
-    asserter.push_success(&Some(header_response(header_10)));
     asserter.push_success(&Some(vec![receipt]));
 
     let err = subscriber
-        .sync_finalized_once(&l1_provider, 10)
+        .follow_headers(
+            &l1_provider,
+            futures::stream::iter([Ok::<_, eyre::Report>(seal(header_10))]),
+        )
         .await
         .unwrap_err();
     assert!(is_fenced_ingestion_error(&err));
@@ -1645,17 +1670,16 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
-    asserter.push_success(&Some(header_response(header_10.clone())));
-    asserter.push_success(&Some(header_response(header_10.clone())));
     asserter.push_success(&Some(vec![receipt]));
 
-    assert_eq!(
-        subscriber
-            .sync_finalized_once(&l1_provider, 10)
-            .await
-            .unwrap(),
-        11
-    );
+    let err = subscriber
+        .follow_headers(
+            &l1_provider,
+            futures::stream::iter([Ok::<_, eyre::Report>(seal(header_10))]),
+        )
+        .await
+        .expect_err("finite header stream should end the subscriber");
+    assert!(err.to_string().contains("finalized L1 header stream ended"));
 
     let seen = sink.seen.lock();
     assert_eq!(seen.len(), 1);
@@ -1693,12 +1717,13 @@ async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition()
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
-    asserter.push_success(&Some(header_response(header_10.clone())));
-    asserter.push_success(&Some(header_response(header_10.clone())));
     asserter.push_success(&Some(vec![receipt]));
 
     let err = subscriber
-        .sync_finalized_once(&l1_provider, 10)
+        .follow_headers(
+            &l1_provider,
+            futures::stream::iter([Ok::<_, eyre::Report>(seal(header_10))]),
+        )
         .await
         .unwrap_err();
     assert!(err.to_string().contains("leadership transition"));

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -1,6 +1,6 @@
 //! Tempo Zone CLI.
 
-use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{net::SocketAddr, num::NonZeroU64, path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
@@ -185,6 +185,9 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 args.private_rpc_max_auth_token_validity_secs,
             ),
         });
+        if args.l1_verify_certificates {
+            node = node.with_l1_certificate_verification(args.l1_epoch_length);
+        }
 
         if should_sequence_blocks {
             let sequencer_signer = sequencer_signer
@@ -259,6 +262,20 @@ pub struct ZoneArgs {
     /// Certified Tempo follower WebSocket RPC URL for finalized L1 state, deposit events, and chain notifications.
     #[arg(long = "l1.rpc-url", env = "L1_RPC_URL")]
     pub l1_rpc_url: String,
+
+    /// Verify finalized L1 blocks using Tempo consensus certificates.
+    #[arg(long = "l1.verify-certificates", env = "L1_VERIFY_CERTIFICATES")]
+    pub l1_verify_certificates: bool,
+
+    /// Consensus epoch length for certificate verification.
+    ///
+    /// Required unless the L1 is Presto or Moderato, whose values are built in.
+    #[arg(
+        long = "l1.epoch-length",
+        env = "L1_EPOCH_LENGTH",
+        requires = "l1_verify_certificates"
+    )]
+    pub l1_epoch_length: Option<NonZeroU64>,
 
     /// ZonePortal contract address on L1.
     #[arg(long = "l1.portal-address", env = "L1_PORTAL_ADDRESS")]
@@ -802,5 +819,46 @@ mod tests {
     fn l1_rpc_url_rejects_non_websocket_schemes() {
         assert!(validate_l1_rpc_url("http://localhost:8545").is_err());
         assert!(validate_l1_rpc_url("https://rpc.moderato.tempo.xyz").is_err());
+    }
+
+    #[test]
+    fn l1_certificate_verification_is_opt_in() {
+        let common = [
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+        ];
+
+        let default = ZoneArgsParser::try_parse_from(common).unwrap();
+        assert!(!default.zone.l1_verify_certificates);
+        assert_eq!(default.zone.l1_epoch_length, None);
+
+        let enabled =
+            ZoneArgsParser::try_parse_from(common.into_iter().chain(["--l1.verify-certificates"]))
+                .unwrap();
+        assert!(enabled.zone.l1_verify_certificates);
+        assert_eq!(enabled.zone.l1_epoch_length, None);
+
+        let overridden = ZoneArgsParser::try_parse_from(common.into_iter().chain([
+            "--l1.verify-certificates",
+            "--l1.epoch-length",
+            "100",
+        ]))
+        .unwrap();
+        assert!(overridden.zone.l1_verify_certificates);
+        assert_eq!(
+            overridden.zone.l1_epoch_length,
+            std::num::NonZeroU64::new(100)
+        );
+
+        let error =
+            ZoneArgsParser::try_parse_from(common.into_iter().chain(["--l1.epoch-length", "100"]))
+                .unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
     }
 }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -142,7 +142,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             // Replicate only durable blocks. Persist every block immediately so followers can
             // acknowledge each block without waiting for Reth's in-memory buffer to fill.
             builder.config_mut().engine.persistence_threshold = 0;
-            builder.config_mut().engine.memory_block_buffer_target = 0;
+            builder.config_mut().engine.memory_block_buffer_target = Some(0);
         }
         // Every promotable node constructs all the sequencer resources: activation is gated at
         // runtime by the leadership schedule, so a quorum follower must be able to become a

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -52,7 +52,6 @@ use reth_transaction_pool::{
 };
 use std::{num::NonZeroU32, sync::Arc, time::Duration};
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
 use tempo_evm::TempoInvalidTransaction;
 use tempo_node::{
     DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoEthApiBuilder,
@@ -76,6 +75,7 @@ use zone_l1::{
     DepositQueue, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeaderTransition,
     LeadershipSink, TempoStateExt,
     state::{EnabledTokenRegistry, L1StateCache, L1StateProvider, L1StateProviderConfig},
+    tempo_chain_spec_for_l1,
 };
 use zone_p2p::{
     LeadershipSchedule, LeadershipState, P2pConfig, P2pNetworkId, ZoneManifest, spawn_p2p,
@@ -101,25 +101,6 @@ fn disable_simulation_methods(modules: &mut TransportRpcModules) {
     modules.remove_ws_methods(PUBLIC_SIMULATION_METHODS);
     modules.remove_ipc_methods(PUBLIC_SIMULATION_METHODS);
 }
-
-/// Returns a known Tempo chain spec for an L1 chain ID.
-///
-/// Tempo Anvil uses chain ID 31337 and the same hardfork schedule as Tempo DEV (1337).
-///
-/// Additional dev-schedule L1 chain IDs (devnets that activate all Tempo
-/// hardforks at genesis) can be allowed via the `ZONE_L1_DEV_CHAIN_IDS`
-/// environment variable as a comma-separated list.
-fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
-    chainspec_from_chain_id(chain_id).or_else(|| match chain_id {
-        1337 | 31337 => Some(DEV.clone()),
-        _ => std::env::var("ZONE_L1_DEV_CHAIN_IDS")
-            .ok()?
-            .split(',')
-            .any(|id| id.trim().parse() == Ok(chain_id))
-            .then(|| DEV.clone()),
-    })
-}
-
 /// Network primitives for Zone Nodes
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
@@ -1648,9 +1629,15 @@ mod tests {
 
     #[test]
     fn resolves_public_and_local_tempo_l1_specs() {
-        assert_eq!(tempo_chain_spec_for_l1(4217).unwrap().chain().id(), 4217);
-        assert_eq!(tempo_chain_spec_for_l1(42431).unwrap().chain().id(), 42431);
-        assert_eq!(tempo_chain_spec_for_l1(1337).unwrap().chain().id(), 1337);
+        let presto = tempo_chain_spec_for_l1(4217).unwrap();
+        assert_eq!(presto.chain().id(), 4217);
+        assert!(presto.network_identity.is_some());
+        let moderato = tempo_chain_spec_for_l1(42431).unwrap();
+        assert_eq!(moderato.chain().id(), 42431);
+        assert!(moderato.network_identity.is_some());
+        let dev = tempo_chain_spec_for_l1(1337).unwrap();
+        assert_eq!(dev.chain().id(), 1337);
+        assert!(dev.network_identity.is_none());
         assert_eq!(tempo_chain_spec_for_l1(31337).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -50,8 +50,13 @@ use reth_transaction_pool::{
     Pool, PoolTransaction, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
 };
-use std::{num::NonZeroU32, sync::Arc, time::Duration};
+use std::{
+    num::{NonZeroU32, NonZeroU64},
+    sync::Arc,
+    time::Duration,
+};
 use tempo_alloy::TempoNetwork;
+use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
 use tempo_evm::TempoInvalidTransaction;
 use tempo_node::{
     DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoEthApiBuilder,
@@ -75,7 +80,6 @@ use zone_l1::{
     DepositQueue, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeaderTransition,
     LeadershipSink, TempoStateExt,
     state::{EnabledTokenRegistry, L1StateCache, L1StateProvider, L1StateProviderConfig},
-    tempo_chain_spec_for_l1,
 };
 use zone_p2p::{
     LeadershipSchedule, LeadershipState, P2pConfig, P2pNetworkId, ZoneManifest, spawn_p2p,
@@ -101,6 +105,25 @@ fn disable_simulation_methods(modules: &mut TransportRpcModules) {
     modules.remove_ws_methods(PUBLIC_SIMULATION_METHODS);
     modules.remove_ipc_methods(PUBLIC_SIMULATION_METHODS);
 }
+
+/// Returns a known Tempo chain spec for an L1 chain ID.
+///
+/// Tempo Anvil uses chain ID 31337 and the same hardfork schedule as Tempo DEV (1337).
+///
+/// Additional dev-schedule L1 chain IDs (devnets that activate all Tempo
+/// hardforks at genesis) can be allowed via the `ZONE_L1_DEV_CHAIN_IDS`
+/// environment variable as a comma-separated list.
+fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
+    chainspec_from_chain_id(chain_id).or_else(|| match chain_id {
+        1337 | 31337 => Some(DEV.clone()),
+        _ => std::env::var("ZONE_L1_DEV_CHAIN_IDS")
+            .ok()?
+            .split(',')
+            .any(|id| id.trim().parse() == Ok(chain_id))
+            .then(|| DEV.clone()),
+    })
+}
+
 /// Network primitives for Zone Nodes
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
@@ -231,6 +254,8 @@ impl ZoneNode {
         let l1_block_tracker = L1BlockTracker::default();
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
+            verify_certificates: false,
+            epoch_length: None,
             portal_address,
             enabled_tokens: enabled_tokens.clone(),
             l1_state_cache: l1_state_cache.clone(),
@@ -299,6 +324,13 @@ impl ZoneNode {
     /// against the shared queue — such as test harnesses — must opt back into retention.
     pub fn with_external_deposit_consumer(mut self) -> Self {
         self.external_deposit_consumer = true;
+        self
+    }
+
+    /// Verify finalized L1 headers using Tempo consensus certificates.
+    pub fn with_l1_certificate_verification(mut self, epoch_length: Option<NonZeroU64>) -> Self {
+        self.l1_config.verify_certificates = true;
+        self.l1_config.epoch_length = epoch_length;
         self
     }
 
@@ -1629,15 +1661,9 @@ mod tests {
 
     #[test]
     fn resolves_public_and_local_tempo_l1_specs() {
-        let presto = tempo_chain_spec_for_l1(4217).unwrap();
-        assert_eq!(presto.chain().id(), 4217);
-        assert!(presto.network_identity.is_some());
-        let moderato = tempo_chain_spec_for_l1(42431).unwrap();
-        assert_eq!(moderato.chain().id(), 42431);
-        assert!(moderato.network_identity.is_some());
-        let dev = tempo_chain_spec_for_l1(1337).unwrap();
-        assert_eq!(dev.chain().id(), 1337);
-        assert!(dev.network_identity.is_none());
+        assert_eq!(tempo_chain_spec_for_l1(4217).unwrap().chain().id(), 4217);
+        assert_eq!(tempo_chain_spec_for_l1(42431).unwrap().chain().id(), 42431);
+        assert_eq!(tempo_chain_spec_for_l1(1337).unwrap().chain().id(), 1337);
         assert_eq!(tempo_chain_spec_for_l1(31337).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
 

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1236,7 +1236,7 @@ impl ZoneTestNode {
                 c.network.discovery.disable_discovery = true;
                 if p2p_enabled {
                     c.engine.persistence_threshold = 0;
-                    c.engine.memory_block_buffer_target = 0;
+                    c.engine.memory_block_buffer_target = Some(0);
                 }
                 c
             });

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -609,6 +609,8 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
+| `--l1.verify-certificates` | false | Verify finalized L1 blocks using Tempo consensus certificates |
+| `--l1.epoch-length` | Presto/Moderato chain spec | Consensus epoch length override; required for certificate verification on other L1 chains |
 | `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` (mainnet) or `1424310000 + (zone_id % 723173648)` (testnet). |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |


### PR DESCRIPTION
Builds on the L1 checkpoint changes merged in #886.

Adds certificate-authenticated finalized L1 header streaming to the Zone subscriber using `FinalizedBlockStream` from tempoxyz/tempo#6961.

Production Tempo chains verify consensus certificates before headers enter the existing receipt-verification and ingestion pipeline. Tempo Anvil keeps the finalized-tag path because it does not expose consensus certificates; both paths share the same downstream flow. Sync resumes from the Zone checkpoint committed as a Tempo block number/hash pair.

Also updates the Tempo and Reth revisions required by the finalized stream implementation.

Validation:
- `cargo test -p zone-l1 --lib`
- `cargo test -p zone-node --lib`
- `cargo check --workspace --all-targets`
- `cargo clippy -p zone-l1 --all-targets -- -D warnings`
- `git diff --check`