### PR TITLE
Remove unsafe L1 genesis block-number override

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -287,7 +287,6 @@ zone-up name reset="false" profile="dev" args="":
                       --chain "$GENESIS_JSON" \
                       --l1.rpc-url "${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}" \
                       --l1.portal-address "$PORTAL" \
-                      --l1.genesis-block-number "$ANCHOR_BLOCK" \
                       --zone.id "$ZONE_ID" \
                       --http \
                       --http.addr 0.0.0.0 \
@@ -914,7 +913,6 @@ deploy-zone name token="" access_enforced="false" gateway_enforced="false":
                       --chain "$OUTPUT/genesis.json" \
                       --l1.rpc-url "$L1_RPC" \
                       --l1.portal-address "$PORTAL" \
-                      --l1.genesis-block-number "$ANCHOR_BLOCK" \
                       --zone.id "$ZONE_ID" \
                       --http \
                       --http.addr 0.0.0.0 \

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -261,8 +261,6 @@ pub struct L1SubscriberConfig {
     pub l1_rpc_url: String,
     /// ZonePortal contract address on L1.
     pub portal_address: Address,
-    /// Optional genesis Tempo block number used to backfill a fresh zone.
-    pub genesis_tempo_block_number: Option<u64>,
     /// Shared registry of tokens enabled for this zone.
     pub enabled_tokens: crate::state::EnabledTokenRegistry,
     /// Shared L1 state cache. The subscriber updates the cache anchor on each
@@ -535,38 +533,21 @@ impl L1Subscriber {
 
     /// Determine the starting block number for backfill.
     ///
-    /// Uses the zone's local `tempoBlockNumber` as the primary starting point —
-    /// this is the authoritative source for where the zone left off. Falls back
-    /// to the CLI genesis override when the zone hasn't processed any blocks
-    /// yet. Without either checkpoint, live subscription starts at the L1 tip.
-    pub(crate) async fn resolve_start_block(&self) -> eyre::Result<Option<u64>> {
-        // The zone's local state is the authoritative source for where to
-        // resume. This avoids the bug where the portal's
-        // lastSyncedTempoBlockNumber runs ahead of local zone state.
+    /// The zone's persisted `tempoBlockNumber` is the authoritative source for
+    /// where ingestion resumes.
+    pub(crate) fn resolve_start_block(&self) -> eyre::Result<u64> {
         let local_tempo_block_number = self.local_state.latest_tempo_block_number()?;
-        if local_tempo_block_number > 0 {
-            info!(local_tempo_block_number, "Resuming from local zone state");
-            return Ok(Some(local_tempo_block_number + 1));
-        }
-
-        if let Some(genesis) = self.config.genesis_tempo_block_number {
-            info!(genesis, "Using CLI genesis block number override");
-            return Ok(Some(genesis + 1));
-        }
-
-        warn!(
-            "No local Tempo checkpoint or genesis block override — skipping backfill. \
-             Set --l1.genesis-block-number to backfill from the correct block."
+        eyre::ensure!(
+            local_tempo_block_number > 0,
+            "zone genesis is not anchored to an L1 block"
         );
-        Ok(None)
+        info!(local_tempo_block_number, "Resuming from local zone state");
+        Ok(local_tempo_block_number + 1)
     }
 
     /// Resolve the first L1 block that has not already been ingested.
-    pub(crate) async fn next_block_to_sync(
-        &self,
-        l1_provider: &impl Provider<TempoNetwork>,
-    ) -> eyre::Result<u64> {
-        let resolved = self.resolve_start_block().await?;
+    pub(crate) fn next_block_to_sync(&self) -> eyre::Result<u64> {
+        let resolved = self.resolve_start_block()?;
         let queued = self
             .deposit_sink
             .last_enqueued()
@@ -577,29 +558,18 @@ impl L1Subscriber {
             .latest()
             .map(|last| last.number.saturating_add(1));
 
-        let next = resolved.into_iter().chain(queued).chain(observed).max();
-        match next {
-            Some(next) => {
-                // Only the persisted zone checkpoint proves consumption.
-                // Queue and observation cursors are fetch high-water marks.
-                if let Some(resolved) = resolved {
-                    self.config
-                        .block_tracker
-                        .initialize_consumed_through(resolved.saturating_sub(1));
-                }
-                Ok(next)
-            }
-            None => {
-                let next = self
-                    .finalized_block_number(l1_provider)
-                    .await?
-                    .saturating_add(1);
-                self.config
-                    .block_tracker
-                    .initialize_consumed_through(next.saturating_sub(1));
-                Ok(next)
-            }
-        }
+        let next = [Some(resolved), queued, observed]
+            .into_iter()
+            .flatten()
+            .max()
+            .expect("resolved checkpoint is always present");
+
+        // Only the persisted zone checkpoint proves consumption.
+        // Queue and observation cursors are fetch high-water marks.
+        self.config
+            .block_tracker
+            .initialize_consumed_through(resolved.saturating_sub(1));
+        Ok(next)
     }
 
     /// Return the block number referenced by the L1 `finalized` tag.
@@ -661,7 +631,7 @@ impl L1Subscriber {
         S: Stream<Item = eyre::Result<()>> + Send,
     {
         let mut triggers = Box::pin(triggers);
-        let mut next_block = self.next_block_to_sync(l1_provider).await?;
+        let mut next_block = self.next_block_to_sync()?;
 
         // Subscribe before the initial sync so a head published while catching
         // up remains queued as another trigger.

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -281,7 +281,7 @@ pub struct L1SubscriberConfig {
 }
 
 pub(crate) trait LocalTempoCheckpointReader: Send + Sync {
-    fn latest_tempo_block_number(&self) -> eyre::Result<u64>;
+    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash>;
 }
 
 /// Optional sink for finalized deposit-bearing L1 blocks.
@@ -322,9 +322,9 @@ impl<P> LocalTempoCheckpointReader for ProviderLocalTempoCheckpointReader<P>
 where
     P: StateProviderFactory + Clone + Send + Sync + 'static,
 {
-    fn latest_tempo_block_number(&self) -> eyre::Result<u64> {
+    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash> {
         let state = self.provider.latest()?;
-        Ok(state.tempo_block_number()?)
+        Ok(state.tempo_num_hash()?)
     }
 }
 
@@ -533,14 +533,16 @@ impl L1Subscriber {
 
     /// Determine the starting block number for backfill.
     ///
-    /// The zone's persisted `tempoBlockNumber` is the authoritative source for
-    /// where ingestion resumes.
+    /// The zone's persisted Tempo checkpoint is the authoritative source for
+    /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
+    /// block-zero genesis from the unanchored template.
     pub(crate) fn resolve_start_block(&self) -> eyre::Result<u64> {
-        let local_tempo_block_number = self.local_state.latest_tempo_block_number()?;
+        let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
         eyre::ensure!(
-            local_tempo_block_number > 0,
+            local_checkpoint.hash != B256::ZERO,
             "zone genesis is not anchored to an L1 block"
         );
+        let local_tempo_block_number = local_checkpoint.number;
         info!(local_tempo_block_number, "Resuming from local zone state");
         Ok(local_tempo_block_number + 1)
     }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -130,23 +130,34 @@ fn make_deposit(amount: u128) -> L1Deposit {
 }
 
 struct SequenceLocalTempoCheckpointReader {
-    values: Mutex<VecDeque<u64>>,
-    last_value: u64,
+    values: Mutex<VecDeque<NumHash>>,
+    last_value: NumHash,
 }
 
 impl SequenceLocalTempoCheckpointReader {
     fn new(values: impl Into<VecDeque<u64>>) -> Self {
-        let values = values.into();
+        let values = values
+            .into()
+            .into_iter()
+            .map(|number| NumHash::new(number, B256::with_last_byte(1)))
+            .collect::<VecDeque<_>>();
         let last_value = values.back().copied().unwrap_or_default();
         Self {
             values: Mutex::new(values),
             last_value,
         }
     }
+
+    fn unanchored() -> Self {
+        Self {
+            values: Mutex::new(VecDeque::from([NumHash::default()])),
+            last_value: NumHash::default(),
+        }
+    }
 }
 
 impl LocalTempoCheckpointReader for SequenceLocalTempoCheckpointReader {
-    fn latest_tempo_block_number(&self) -> eyre::Result<u64> {
+    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash> {
         let mut values = self.values.lock();
         Ok(values.pop_front().unwrap_or(self.last_value))
     }
@@ -703,8 +714,14 @@ fn test_resolve_start_block_reads_live_local_state_each_time() {
 }
 
 #[test]
-fn test_resolve_start_block_rejects_unanchored_genesis() {
+fn test_resolve_start_block_accepts_block_zero_with_nonzero_hash() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    assert_eq!(subscriber.resolve_start_block().unwrap(), 1);
+}
+
+#[test]
+fn test_resolve_start_block_rejects_unanchored_genesis() {
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::unanchored()));
     assert!(
         subscriber
             .resolve_start_block()

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -152,17 +152,13 @@ impl LocalTempoCheckpointReader for SequenceLocalTempoCheckpointReader {
     }
 }
 
-fn test_subscriber(
-    local_state: Arc<dyn LocalTempoCheckpointReader>,
-    genesis_tempo_block_number: Option<u64>,
-) -> L1Subscriber {
+fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscriber {
     let portal_address = address!("0x0000000000000000000000000000000000000ABC");
 
     L1Subscriber {
         config: L1SubscriberConfig {
             l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
             portal_address,
-            genesis_tempo_block_number,
             enabled_tokens: crate::state::EnabledTokenRegistry::default(),
             l1_state_cache: crate::L1StateCache::new(),
             block_tracker: L1BlockTracker::default(),
@@ -177,11 +173,8 @@ fn test_subscriber(
     }
 }
 
-fn test_observer(
-    local_state: Arc<dyn LocalTempoCheckpointReader>,
-    genesis_tempo_block_number: Option<u64>,
-) -> L1Subscriber {
-    let mut subscriber = test_subscriber(local_state, genesis_tempo_block_number);
+fn test_observer(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscriber {
+    let mut subscriber = test_subscriber(local_state);
     subscriber.config.retain_observations = false;
     subscriber.deposit_sink = DepositSink::Observer;
     subscriber
@@ -360,7 +353,7 @@ fn l1_block_tracker_rejects_first_observation_above_persisted_successor() {
 
 #[test]
 fn subscriber_applies_state_and_records_observation() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let header = make_test_header(10);
     let sealed = seal(header);
     let anchor = sealed.num_hash();
@@ -647,10 +640,7 @@ fn assert_tempo_header_rejected(input: &[u8]) {
 
 #[test]
 fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
-    let subscriber = test_subscriber(
-        Arc::new(SequenceLocalTempoCheckpointReader::new([0])),
-        Some(0),
-    );
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
     let slot = B256::with_last_byte(1);
     let value = B256::with_last_byte(2);
     let stable_account = address!("0x0000000000000000000000000000000000000ABC");
@@ -703,40 +693,30 @@ fn deposit_hash_chain(previous_hash: B256, deposits: &[L1Deposit]) -> B256 {
     })
 }
 
-#[tokio::test]
-async fn test_resolve_start_block_reads_live_local_state_each_time() {
-    let subscriber = test_subscriber(
-        Arc::new(SequenceLocalTempoCheckpointReader::new(VecDeque::from([
-            10, 11,
-        ]))),
-        None,
-    );
-    assert_eq!(subscriber.resolve_start_block().await.unwrap(), Some(11));
-    assert_eq!(subscriber.resolve_start_block().await.unwrap(), Some(12));
+#[test]
+fn test_resolve_start_block_reads_live_local_state_each_time() {
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new(
+        VecDeque::from([10, 11]),
+    )));
+    assert_eq!(subscriber.resolve_start_block().unwrap(), 11);
+    assert_eq!(subscriber.resolve_start_block().unwrap(), 12);
 }
 
-#[tokio::test]
-async fn test_resolve_start_block_falls_back_to_genesis_override_when_local_state_is_zero() {
-    let subscriber = test_subscriber(
-        Arc::new(SequenceLocalTempoCheckpointReader::new(VecDeque::from([0]))),
-        Some(42),
+#[test]
+fn test_resolve_start_block_rejects_unanchored_genesis() {
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    assert!(
+        subscriber
+            .resolve_start_block()
+            .unwrap_err()
+            .to_string()
+            .contains("zone genesis is not anchored to an L1 block")
     );
-    assert_eq!(subscriber.resolve_start_block().await.unwrap(), Some(43));
-}
-
-#[tokio::test]
-async fn test_resolve_start_block_skips_backfill_without_checkpoint() {
-    let subscriber = test_subscriber(
-        Arc::new(SequenceLocalTempoCheckpointReader::new(VecDeque::from([0]))),
-        None,
-    );
-
-    assert_eq!(subscriber.resolve_start_block().await.unwrap(), None);
 }
 
 #[tokio::test]
 async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
@@ -780,7 +760,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
 
 #[tokio::test]
 async fn observer_advances_caches_without_retaining_deposit_blocks() {
-    let subscriber = test_observer(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let subscriber = test_observer(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let cached_address = address!("0x0000000000000000000000000000000000000ABC");
     let cached_slot = B256::with_last_byte(1);
     let cached_value = B256::with_last_byte(2);
@@ -834,10 +814,7 @@ async fn observer_advances_caches_without_retaining_deposit_blocks() {
 
 #[tokio::test]
 async fn test_head_triggers_falls_back_to_http_block_filter() {
-    let subscriber = test_subscriber(
-        Arc::new(SequenceLocalTempoCheckpointReader::new([10])),
-        None,
-    );
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
     let asserter = Asserter::new();
     let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
         .connect_mocked_client(asserter.clone())
@@ -858,10 +835,7 @@ async fn test_head_triggers_falls_back_to_http_block_filter() {
 
 #[tokio::test]
 async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
-    let subscriber = test_subscriber(
-        Arc::new(SequenceLocalTempoCheckpointReader::new([10])),
-        None,
-    );
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
@@ -930,10 +904,7 @@ fn test_push_log_decodes_bounce_back_as_regular_deposit() {
 
 #[test]
 fn confirmed_token_enabled_event_updates_registry() {
-    let subscriber = test_subscriber(
-        Arc::new(SequenceLocalTempoCheckpointReader::new(VecDeque::from([0]))),
-        None,
-    );
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
     let token = address!("0x20c0000000000000000000000000000000000001");
     let events = L1PortalEvents {
         enabled_tokens: vec![EnabledToken {
@@ -1547,7 +1518,7 @@ fn corrupt_recognized_portal_log(portal: Address) -> Log {
 
 #[test]
 fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
 
     // A recognized topic0 with garbage payload must fence the whole block, never be skipped.
@@ -1579,7 +1550,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
 
 #[tokio::test]
 async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
     let DepositSink::Queue(queue) = subscriber.deposit_sink.clone() else {
         panic!("test subscriber must retain deposits");
@@ -1635,8 +1606,7 @@ impl LeadershipSink for RecordingLeadershipSink {
 
 #[tokio::test]
 async fn sync_applies_leadership_transition_before_enqueueing_the_activation_block() {
-    let mut subscriber =
-        test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
     let DepositSink::Queue(queue) = subscriber.deposit_sink.clone() else {
         panic!("test subscriber must retain deposits");
@@ -1685,8 +1655,7 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
 
 #[tokio::test]
 async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition() {
-    let mut subscriber =
-        test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])), None);
+    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
     let DepositSink::Queue(queue) = subscriber.deposit_sink.clone() else {
         panic!("test subscriber must retain deposits");

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -166,7 +166,6 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         let mut node = ZoneNode::new(
             args.l1_rpc_url,
             args.portal_address,
-            args.l1_genesis_block_number,
             args.l1_fetch_concurrency,
             Duration::from_millis(args.l1_retry_connection_interval_ms),
         )
@@ -385,10 +384,6 @@ pub struct ZoneArgs {
         value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
     )]
     pub withdrawal_max_in_flight_batches: usize,
-
-    /// Genesis Tempo L1 block number override.
-    #[arg(long = "l1.genesis-block-number", env = "L1_GENESIS_BLOCK_NUMBER")]
-    pub l1_genesis_block_number: Option<u64>,
 
     /// Maximum number of concurrent L1 receipt fetches.
     #[arg(

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -413,8 +413,6 @@ mod command {
                 &self.l1_rpc_url,
                 "--l1.portal-address",
                 &provisioned.portal.to_string(),
-                "--l1.genesis-block-number",
-                &provisioned.anchor_block_number.to_string(),
                 "--zone.id",
                 &provisioned.zone_id.to_string(),
                 "--http",

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -224,7 +224,6 @@ impl ZoneNode {
     pub fn new(
         l1_rpc_url: String,
         portal_address: Address,
-        genesis_tempo_block_number: Option<u64>,
         l1_fetch_concurrency: usize,
         retry_connection_interval: Duration,
     ) -> Self {
@@ -236,7 +235,6 @@ impl ZoneNode {
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
             portal_address,
-            genesis_tempo_block_number,
             enabled_tokens: enabled_tokens.clone(),
             l1_state_cache: l1_state_cache.clone(),
             block_tracker: l1_block_tracker.clone(),
@@ -519,11 +517,7 @@ where
         // leadership transition.
         if let Some(p2p) = self.p2p_config.as_ref() {
             let schedule = p2p.leadership();
-            let snapshot_anchor = if tempo_block_number > 0 {
-                tempo_block_number
-            } else {
-                self.l1_config.genesis_tempo_block_number.unwrap_or(0)
-            };
+            let snapshot_anchor = tempo_block_number;
             seed_leadership_schedule(
                 &l1_provider,
                 self.portal_address,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -934,7 +934,7 @@ impl ZoneTestNode {
 
     /// Start a zone node pointing at a real L1 WebSocket URL.
     pub(crate) async fn start(l1_ws_url: String, portal_address: Address) -> eyre::Result<Self> {
-        Self::launch(l1_ws_url, portal_address, None, next_unique_chain_id()).await
+        Self::launch(l1_ws_url, portal_address, next_unique_chain_id()).await
     }
 
     /// Start a zone node connected to a real L1, generating genesis from the L1's
@@ -946,14 +946,12 @@ impl ZoneTestNode {
         l1_ws_url: &url::Url,
         portal_address: Address,
     ) -> eyre::Result<Self> {
-        let (genesis, genesis_block_number) =
-            build_l1_anchored_genesis(l1_http_url, portal_address).await?;
+        let (genesis, _) = build_l1_anchored_genesis(l1_http_url, portal_address).await?;
 
         let signer = l1_dev_signer();
         Self::launch_with_genesis(
             l1_ws_url.to_string(),
             portal_address,
-            Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
             signer,
@@ -968,14 +966,13 @@ impl ZoneTestNode {
         portal_address: Address,
         block_number: u64,
     ) -> eyre::Result<Self> {
-        let (genesis, genesis_block_number) =
+        let (genesis, _) =
             build_l1_anchored_genesis_at_block(l1_http_url, portal_address, block_number).await?;
 
         let signer = l1_dev_signer();
         Self::launch_with_genesis_and_withdrawal_batch_interval(
             l1_ws_url.to_string(),
             portal_address,
-            Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
             signer,
@@ -992,14 +989,12 @@ impl ZoneTestNode {
         portal_address: Address,
         withdrawal_batch_interval_blocks: u64,
     ) -> eyre::Result<Self> {
-        let (genesis, genesis_block_number) =
-            build_l1_anchored_genesis(l1_http_url, portal_address).await?;
+        let (genesis, _) = build_l1_anchored_genesis(l1_http_url, portal_address).await?;
 
         let signer = l1_dev_signer();
         Self::launch_with_genesis_and_withdrawal_batch_interval(
             l1_ws_url.to_string(),
             portal_address,
-            Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
             signer,
@@ -1021,7 +1016,7 @@ impl ZoneTestNode {
         portal_address: Address,
         genesis_block_number: u64,
     ) -> eyre::Result<Self> {
-        let (genesis, genesis_block_number) =
+        let (genesis, _) =
             build_l1_anchored_genesis_at_block(l1_http_url, portal_address, genesis_block_number)
                 .await?;
 
@@ -1029,7 +1024,6 @@ impl ZoneTestNode {
         Self::launch_with_genesis(
             l1_ws_url.to_string(),
             portal_address,
-            Some(genesis_block_number),
             next_unique_chain_id(),
             Some(genesis),
             signer,
@@ -1047,7 +1041,6 @@ impl ZoneTestNode {
         Self::launch(
             DUMMY_L1_URL.to_string(),
             Address::ZERO,
-            None,
             next_unique_chain_id(),
         )
         .await
@@ -1058,7 +1051,7 @@ impl ZoneTestNode {
     /// Useful for running multiple zone nodes in a single test — each needs
     /// a unique chain ID to avoid datadir collisions.
     pub(crate) async fn start_local_with_chain_id(chain_id: u64) -> eyre::Result<Self> {
-        Self::launch(DUMMY_L1_URL.to_string(), Address::ZERO, None, chain_id).await
+        Self::launch(DUMMY_L1_URL.to_string(), Address::ZERO, chain_id).await
     }
 
     pub(crate) async fn start_local_with_p2p(
@@ -1070,7 +1063,6 @@ impl ZoneTestNode {
         Self::launch_with_genesis_and_withdrawal_batch_interval(
             l1_rpc_url,
             Address::ZERO,
-            None,
             next_unique_chain_id(),
             None,
             signer,
@@ -1084,7 +1076,6 @@ impl ZoneTestNode {
     async fn launch(
         l1_ws_url: String,
         portal_address: Address,
-        genesis_tempo_block_number: Option<u64>,
         chain_id: u64,
     ) -> eyre::Result<Self> {
         // Generate a throwaway signer for tests that don't use encrypted deposits.
@@ -1093,7 +1084,6 @@ impl ZoneTestNode {
         Self::launch_with_genesis_and_withdrawal_batch_interval(
             l1_ws_url,
             portal_address,
-            genesis_tempo_block_number,
             chain_id,
             None,
             signer,
@@ -1107,7 +1097,6 @@ impl ZoneTestNode {
     async fn launch_with_genesis(
         l1_ws_url: String,
         portal_address: Address,
-        genesis_tempo_block_number: Option<u64>,
         chain_id: u64,
         custom_genesis: Option<Genesis>,
         sequencer_signer: alloy_signer_local::PrivateKeySigner,
@@ -1115,7 +1104,6 @@ impl ZoneTestNode {
         Self::launch_with_genesis_and_withdrawal_batch_interval(
             l1_ws_url,
             portal_address,
-            genesis_tempo_block_number,
             chain_id,
             custom_genesis,
             sequencer_signer,
@@ -1130,7 +1118,6 @@ impl ZoneTestNode {
     async fn launch_with_genesis_and_withdrawal_batch_interval(
         l1_ws_url: String,
         portal_address: Address,
-        genesis_tempo_block_number: Option<u64>,
         chain_id: u64,
         custom_genesis: Option<Genesis>,
         sequencer_signer: alloy_signer_local::PrivateKeySigner,
@@ -1156,7 +1143,6 @@ impl ZoneTestNode {
         let mut zone_node = ZoneNode::new(
             l1_ws_url,
             portal_address,
-            genesis_tempo_block_number,
             4,
             std::time::Duration::from_millis(100),
         )
@@ -3511,7 +3497,6 @@ pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2
             ZoneTestNode::launch_with_genesis_and_withdrawal_batch_interval(
                 l1_rpc_url.clone(),
                 Address::ZERO,
-                None,
                 chain_id,
                 Some(genesis.clone()),
                 sequencer_signers[index].clone(),
@@ -4119,7 +4104,6 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
     let zone = ZoneTestNode::launch(
         DUMMY_L1_URL.to_string(),
         Address::ZERO,
-        None,
         next_unique_chain_id(),
     )
     .await?;

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -609,7 +609,6 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--l1.genesis-block-number` | (from zone.json) | L1 block when the zone was created |
 | `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` (mainnet) or `1424310000 + (zone_id % 723173648)` (testnet). |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |


### PR DESCRIPTION
Removes the `--l1.genesis-block-number` / `L1_GENESIS_BLOCK_NUMBER` bootstrap override and its config wiring.

The L1 subscriber now derives its starting height exclusively from the checkpoint persisted in Zone state. An unanchored genesis is rejected instead of trusting an operator-supplied block number or silently starting at the RPC finalized tip.

Breaking impact:
- remove `--l1.genesis-block-number` from launch commands
- `L1_GENESIS_BLOCK_NUMBER` is no longer recognized
- regenerate Zone genesis files that do not embed an L1 checkpoint

Validation:
- `cargo test -p zone-l1 --lib`
- `cargo test -p zone-node --lib`
- `cargo check --workspace --all-targets`
- `cargo clippy -p zone-l1 --all-targets -- -D warnings`
- `git diff --check`