### PR TITLE
test: expand zone fuzz and symbolic coverage on Tempo T9

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"
-      MIN_LINES: "88"
-      MIN_BRANCHES: "60"
+      MIN_LINES: "92"
+      MIN_BRANCHES: "70"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -176,6 +176,7 @@ jobs:
       - name: Forge coverage (zone specs)
         working-directory: specs/ref-impls
         run: |
+          set -o pipefail
           "$GITHUB_WORKSPACE/foundry/target/release/forge" coverage \
             --ir-minimum --match-path "test/**" --exclude-tests --report summary | tee coverage.txt
           {

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,32 +19,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-
     cargo build --profile ${RUST_PROFILE} \
         --bin tempo-xtask
 
-# Build the same pinned, Tempo-patched Foundry used by the Specs workflow.
-FROM rust:1.96-bookworm@sha256:5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc AS foundry
-ARG TEMPO_FOUNDRY_REF=18a5d71d6ab621433145e5ea86dfe3dbace0763a
-ARG FOUNDRY_REF=6902a96211da7bcc3d9c4d8e97910ac5c9d5d2c6
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang cmake git libssl-dev pkg-config \
-    && rm -rf /var/lib/apt/lists/*
-RUN git init /tempo \
-    && git -C /tempo remote add origin https://github.com/tempoxyz/tempo.git \
-    && git -C /tempo fetch --depth=1 origin "${TEMPO_FOUNDRY_REF}" \
-    && git -C /tempo checkout --detach FETCH_HEAD \
-    && git init /foundry \
-    && git -C /foundry remote add origin https://github.com/foundry-rs/foundry.git \
-    && git -C /foundry fetch --depth=1 origin "${FOUNDRY_REF}" \
-    && git -C /foundry checkout --detach FETCH_HEAD
-RUN /tempo/scripts/foundry-patch.sh /tempo /foundry
-RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=foundry-cargo-registry \
-    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked,id=foundry-cargo-git \
-    cd /foundry \
-    && cargo build --bin forge --bin cast --profile release --no-default-features
-
 # Solidity ref-impls compiled for shared runtimes, routers, and zone genesis artifacts.
 # Requires the specs/ref-impls/lib submodules to be checked out.
 FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS solidity
-COPY --from=foundry /foundry/target/release/forge /usr/local/bin/forge
-COPY --from=foundry /foundry/target/release/cast /usr/local/bin/cast
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://foundry.paradigm.xyz | bash \
+    && /root/.foundry/bin/foundryup --install nightly
+ENV PATH="/root/.foundry/bin:${PATH}"
 WORKDIR /app/specs/ref-impls
 COPY specs/ref-impls .
 RUN forge build --skip test
@@ -71,7 +54,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/${RUST_PROFILE}/tempo-xtask /usr/local/bin/tempo-xtask
-COPY --from=solidity /usr/local/bin/cast /usr/local/bin/cast
+COPY --from=solidity /root/.foundry/bin/cast /usr/local/bin/cast
 COPY --from=solidity /app/specs/ref-impls/out /app/specs/ref-impls/out
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/tempo-xtask"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,32 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-
     cargo build --profile ${RUST_PROFILE} \
         --bin tempo-xtask
 
+# Build the same pinned, Tempo-patched Foundry used by the Specs workflow.
+FROM rust:1.96-bookworm@sha256:5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc AS foundry
+ARG TEMPO_FOUNDRY_REF=18a5d71d6ab621433145e5ea86dfe3dbace0763a
+ARG FOUNDRY_REF=6902a96211da7bcc3d9c4d8e97910ac5c9d5d2c6
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang cmake git libssl-dev pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+RUN git init /tempo \
+    && git -C /tempo remote add origin https://github.com/tempoxyz/tempo.git \
+    && git -C /tempo fetch --depth=1 origin "${TEMPO_FOUNDRY_REF}" \
+    && git -C /tempo checkout --detach FETCH_HEAD \
+    && git init /foundry \
+    && git -C /foundry remote add origin https://github.com/foundry-rs/foundry.git \
+    && git -C /foundry fetch --depth=1 origin "${FOUNDRY_REF}" \
+    && git -C /foundry checkout --detach FETCH_HEAD
+RUN /tempo/scripts/foundry-patch.sh /tempo /foundry
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=foundry-cargo-registry \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked,id=foundry-cargo-git \
+    cd /foundry \
+    && cargo build --bin forge --bin cast --profile release --no-default-features
+
 # Solidity ref-impls compiled for shared runtimes, routers, and zone genesis artifacts.
 # Requires the specs/ref-impls/lib submodules to be checked out.
 FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS solidity
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl git \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://foundry.paradigm.xyz | bash \
-    && /root/.foundry/bin/foundryup
-ENV PATH="/root/.foundry/bin:${PATH}"
+COPY --from=foundry /foundry/target/release/forge /usr/local/bin/forge
+COPY --from=foundry /foundry/target/release/cast /usr/local/bin/cast
 WORKDIR /app/specs/ref-impls
 COPY specs/ref-impls .
 RUN forge build --skip test
@@ -54,7 +71,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     jq \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/${RUST_PROFILE}/tempo-xtask /usr/local/bin/tempo-xtask
-COPY --from=solidity /root/.foundry/bin/cast /usr/local/bin/cast
+COPY --from=solidity /usr/local/bin/cast /usr/local/bin/cast
 COPY --from=solidity /app/specs/ref-impls/out /app/specs/ref-impls/out
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/tempo-xtask"]

--- a/specs/ref-impls/foundry.toml
+++ b/specs/ref-impls/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-hardfork = "tempo:T3"
+hardfork = "tempo:T9"
 solc_version = "0.8.35"
 
 # layout and file system

--- a/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
+++ b/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
@@ -385,6 +385,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         );
     }
 
+    /// @notice Verifies an exact-input quote equals the output delivered through the router.
     /// @dev TODO: Enable once https://github.com/tempoxyz/tempo/pull/6614 is included in Forge.
     function test_swapOutputMatchesQuote() public {
         vm.skip(true, "Tempo #6614: exact-input quotes still round per tick instead of per order");
@@ -407,6 +408,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         assertEq(mockPortal2.lastDepositAmount(), quote);
     }
 
+    /// @notice Swapped value is conserved across the real DEX, router, and target portal.
     function testFuzz_swapDeposit_conservesBalancesAndQueuesDeposit(
         bool encrypted,
         bytes32 metadata,
@@ -450,6 +452,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         assertNotEq(mockPortal2.currentDepositQueueHash(), hashBefore);
     }
 
+    /// @notice DEX slippage and downstream portal rejection revert every swap and deposit mutation.
     function testFuzz_swapDeposit_failureIsAtomic(bool portalRejects, bool encrypted) public {
         uint128 quote = exchange.quoteSwapExactAmountIn(address(pathUSD), address(token1), AMOUNT);
         mockPortal2.setRejectDeposits(portalRejects);

--- a/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
+++ b/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
@@ -14,38 +14,6 @@ import { BaseTest } from "../BaseTest.t.sol";
 import { IStablecoinDEX } from "tempo-std/interfaces/IStablecoinDEX.sol";
 import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 
-contract MockStablecoinDEXForRouter {
-
-    uint128 public nextAmountOut;
-    bool public shouldRevert;
-
-    function setNextAmountOut(uint128 _amountOut) external {
-        nextAmountOut = _amountOut;
-    }
-
-    function setShouldRevert(bool _shouldRevert) external {
-        shouldRevert = _shouldRevert;
-    }
-
-    function swapExactAmountIn(
-        address tokenIn,
-        address tokenOut,
-        uint128 amountIn,
-        uint128 minAmountOut
-    )
-        external
-        returns (uint128 amountOut)
-    {
-        if (shouldRevert || nextAmountOut < minAmountOut) {
-            revert IStablecoinDEX.InsufficientOutput();
-        }
-        ITIP20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
-        amountOut = nextAmountOut;
-        ITIP20(tokenOut).mint(msg.sender, amountOut);
-    }
-
-}
-
 contract MockZoneFactoryForRouter {
 
     mapping(address => bool) public portalMap;
@@ -72,6 +40,8 @@ contract MockZoneFactoryForRouter {
 
 contract MockZonePortalForRouter {
 
+    error DepositsRejected();
+
     mapping(address => bool) public enabledTokens;
 
     address public lastDepositRecipient;
@@ -84,6 +54,13 @@ contract MockZonePortalForRouter {
     uint256 public lastEncryptedKeyIndex;
     address public lastEncryptedBouncebackRecipient;
     bool public encryptedDepositCalled;
+    uint256 public depositCount;
+    bytes32 public currentDepositQueueHash;
+    bool public rejectDeposits;
+
+    function setRejectDeposits(bool reject) external {
+        rejectDeposits = reject;
+    }
 
     function enableToken(address _token) external {
         enabledTokens[_token] = true;
@@ -103,13 +80,20 @@ contract MockZonePortalForRouter {
         external
         returns (bytes32)
     {
+        if (rejectDeposits) revert DepositsRejected();
         ITIP20(_token).transferFrom(msg.sender, address(this), amount);
         lastDepositRecipient = to;
         lastDepositBouncebackRecipient = tempoRefundRecipient;
         lastDepositAmount = amount;
         lastDepositMemo = memo;
         depositCalled = true;
-        return bytes32(0);
+        ++depositCount;
+        currentDepositQueueHash = keccak256(
+            abi.encode(
+                currentDepositQueueHash, false, _token, to, amount, memo, tempoRefundRecipient
+            )
+        );
+        return currentDepositQueueHash;
     }
 
     function depositEncrypted(
@@ -122,12 +106,19 @@ contract MockZonePortalForRouter {
         external
         returns (bytes32)
     {
+        if (rejectDeposits) revert DepositsRejected();
         ITIP20(_token).transferFrom(msg.sender, address(this), amount);
         lastEncryptedAmount = amount;
         lastEncryptedKeyIndex = keyIndex;
         lastEncryptedBouncebackRecipient = tempoRefundRecipient;
         encryptedDepositCalled = true;
-        return bytes32(0);
+        ++depositCount;
+        currentDepositQueueHash = keccak256(
+            abi.encode(
+                currentDepositQueueHash, true, _token, amount, keyIndex, tempoRefundRecipient
+            )
+        );
+        return currentDepositQueueHash;
     }
 
 }
@@ -135,7 +126,6 @@ contract MockZonePortalForRouter {
 contract SwapAndDepositRouterTest is BaseTest {
 
     SwapAndDepositRouter public router;
-    MockStablecoinDEXForRouter public mockDEX;
     MockZoneFactoryForRouter public mockFactory;
     MockZonePortalForRouter public mockPortal;
     MockZonePortalForRouter public mockPortal2;
@@ -145,16 +135,17 @@ contract SwapAndDepositRouterTest is BaseTest {
     address public sourcePortal = address(0x501);
     address public refundBurner = address(0xb000000000000000000000000000000000000123);
     uint128 public constant AMOUNT = 1000e6;
+    uint256 internal constant FRAGMENTED_ORDERS = 2;
+    uint128[] internal liquidityOrderIds;
 
     function setUp() public override {
         super.setUp();
 
-        mockDEX = new MockStablecoinDEXForRouter();
         mockFactory = new MockZoneFactoryForRouter();
         mockPortal = new MockZonePortalForRouter();
         mockPortal2 = new MockZonePortalForRouter();
 
-        router = new SwapAndDepositRouter(address(mockDEX), address(mockFactory));
+        router = new SwapAndDepositRouter(address(exchange), address(mockFactory));
 
         mockFactory.setSourcePortal(SOURCE_ZONE_ID, sourcePortal);
         mockFactory.setPortal(address(mockPortal), true);
@@ -169,12 +160,52 @@ contract SwapAndDepositRouterTest is BaseTest {
         vm.stopPrank();
 
         vm.prank(sequencer);
-        token1.grantRole(_ISSUER_ROLE, sequencer);
-        vm.prank(sequencer);
-        token1.mint(address(router), AMOUNT * 10);
+        token1.grantRole(_ISSUER_ROLE, admin);
+        _seedFragmentedLiquidity();
+    }
 
-        vm.prank(sequencer);
-        token1.grantRole(_ISSUER_ROLE, address(mockDEX));
+    function _seedFragmentedLiquidity() internal {
+        uint128 perOrder = exchange.MIN_ORDER_AMOUNT() * 5 + 3;
+        exchange.createPair(address(token1));
+        vm.prank(admin);
+        token1.mint(bob, uint256(perOrder) * FRAGMENTED_ORDERS * 2);
+        vm.prank(bob);
+        token1.approve(address(exchange), type(uint256).max);
+        int16 spacing = exchange.TICK_SPACING();
+        for (uint256 i; i < FRAGMENTED_ORDERS; ++i) {
+            int16 tick = int16(int256(i + 1)) * spacing;
+            vm.prank(bob);
+            liquidityOrderIds.push(exchange.place(address(token1), perOrder, false, tick));
+            vm.prank(bob);
+            liquidityOrderIds.push(exchange.place(address(token1), perOrder, false, tick));
+        }
+    }
+
+    function _dexStateHash() internal view returns (bytes32 stateHash) {
+        bytes32 key = exchange.pairKey(address(token1), address(pathUSD));
+        (address base, address quote, int16 bestBid, int16 bestAsk) = exchange.books(key);
+        stateHash = keccak256(
+            abi.encode(
+                exchange.nextOrderId(),
+                exchange.balanceOf(bob, address(pathUSD)),
+                exchange.balanceOf(bob, address(token1)),
+                base,
+                quote,
+                bestBid,
+                bestAsk
+            )
+        );
+        int16 spacing = exchange.TICK_SPACING();
+        for (uint256 i; i < liquidityOrderIds.length; ++i) {
+            int16 tick = int16(int256(i / 2 + 1)) * spacing;
+            (uint128 head, uint128 tail, uint128 liquidity) =
+                exchange.getTickLevel(address(token1), tick, false);
+            stateHash = keccak256(
+                abi.encode(
+                    stateHash, exchange.getOrder(liquidityOrderIds[i]), head, tail, liquidity
+                )
+            );
+        }
     }
 
     function _buildPlaintextData(
@@ -289,11 +320,8 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_plaintextDeposit_withSwap() public {
-        uint128 swapOut = 990e6;
-        mockDEX.setNextAmountOut(swapOut);
-
         bytes memory data = _buildPlaintextData(
-            address(token1), address(mockPortal2), alice, refundBurner, bytes32("swap"), 900e6
+            address(token1), address(mockPortal2), alice, refundBurner, bytes32("swap"), 0
         );
 
         vm.prank(ZONE_MESSENGER_ADDRESS);
@@ -305,7 +333,7 @@ contract SwapAndDepositRouterTest is BaseTest {
         assertTrue(mockPortal2.depositCalled());
         assertEq(mockPortal2.lastDepositRecipient(), alice);
         assertEq(mockPortal2.lastDepositBouncebackRecipient(), refundBurner);
-        assertEq(mockPortal2.lastDepositAmount(), swapOut);
+        assertGt(mockPortal2.lastDepositAmount(), 0);
         assertEq(mockPortal2.lastDepositMemo(), bytes32("swap"));
     }
 
@@ -327,13 +355,9 @@ contract SwapAndDepositRouterTest is BaseTest {
     }
 
     function test_encryptedDeposit_withSwap() public {
-        uint128 swapOut = 950e6;
-        mockDEX.setNextAmountOut(swapOut);
-
         EncryptedDepositPayload memory payload = _defaultEncryptedPayload();
-        bytes memory data = _buildEncryptedData(
-            address(token1), address(mockPortal2), 1, payload, refundBurner, 900e6
-        );
+        bytes memory data =
+            _buildEncryptedData(address(token1), address(mockPortal2), 1, payload, refundBurner, 0);
 
         vm.prank(ZONE_MESSENGER_ADDRESS);
         bytes4 ret = router.onWithdrawalReceived(
@@ -342,16 +366,16 @@ contract SwapAndDepositRouterTest is BaseTest {
 
         assertEq(ret, IWithdrawalReceiver.onWithdrawalReceived.selector);
         assertTrue(mockPortal2.encryptedDepositCalled());
-        assertEq(mockPortal2.lastEncryptedAmount(), swapOut);
+        assertGt(mockPortal2.lastEncryptedAmount(), 0);
         assertEq(mockPortal2.lastEncryptedKeyIndex(), 1);
         assertEq(mockPortal2.lastEncryptedBouncebackRecipient(), refundBurner);
     }
 
     function test_swapSlippageReverts() public {
-        mockDEX.setNextAmountOut(800e6);
+        uint128 quote = exchange.quoteSwapExactAmountIn(address(pathUSD), address(token1), AMOUNT);
 
         bytes memory data = _buildPlaintextData(
-            address(token1), address(mockPortal2), alice, refundBurner, bytes32("slip"), 900e6
+            address(token1), address(mockPortal2), alice, refundBurner, bytes32("slip"), quote + 1
         );
 
         vm.prank(ZONE_MESSENGER_ADDRESS);
@@ -359,6 +383,99 @@ contract SwapAndDepositRouterTest is BaseTest {
         router.onWithdrawalReceived(
             SOURCE_ZONE_ID, sourcePortal, senderTag, address(pathUSD), AMOUNT, data
         );
+    }
+
+    function testFuzz_swapDeposit_conservesBalancesAndQueuesDeposit(
+        bool encrypted,
+        bytes32 metadata,
+        uint256 keyIndex
+    )
+        public
+    {
+        uint256 routerInBefore = pathUSD.balanceOf(address(router));
+        uint256 dexInBefore = pathUSD.balanceOf(address(exchange));
+        uint256 dexOutBefore = token1.balanceOf(address(exchange));
+        uint256 portalOutBefore = token1.balanceOf(address(mockPortal2));
+        bytes32 hashBefore = mockPortal2.currentDepositQueueHash();
+
+        bytes memory data = encrypted
+            ? _buildEncryptedData(
+                address(token1),
+                address(mockPortal2),
+                keyIndex,
+                _defaultEncryptedPayload(),
+                refundBurner,
+                0
+            )
+            : _buildPlaintextData(
+                address(token1), address(mockPortal2), alice, refundBurner, metadata, 0
+            );
+        vm.prank(ZONE_MESSENGER_ADDRESS);
+        bytes4 result = router.onWithdrawalReceived(
+            SOURCE_ZONE_ID, sourcePortal, senderTag, address(pathUSD), AMOUNT, data
+        );
+        uint128 amountOut =
+            encrypted ? mockPortal2.lastEncryptedAmount() : mockPortal2.lastDepositAmount();
+
+        assertEq(result, IWithdrawalReceiver.onWithdrawalReceived.selector);
+        assertGt(amountOut, 0);
+        assertEq(pathUSD.balanceOf(address(router)), routerInBefore - AMOUNT);
+        assertEq(pathUSD.balanceOf(address(exchange)), dexInBefore + AMOUNT);
+        assertEq(token1.balanceOf(address(exchange)), dexOutBefore - amountOut);
+        assertEq(token1.balanceOf(address(mockPortal2)), portalOutBefore + amountOut);
+        assertEq(token1.balanceOf(address(router)), 0);
+        assertEq(mockPortal2.depositCount(), 1);
+        assertNotEq(mockPortal2.currentDepositQueueHash(), hashBefore);
+    }
+
+    function testFuzz_swapDeposit_failureIsAtomic(bool portalRejects, bool encrypted) public {
+        uint128 quote = exchange.quoteSwapExactAmountIn(address(pathUSD), address(token1), AMOUNT);
+        mockPortal2.setRejectDeposits(portalRejects);
+        uint128 minAmountOut = portalRejects ? 0 : quote + 1;
+        bytes memory data = encrypted
+            ? _buildEncryptedData(
+                address(token1),
+                address(mockPortal2),
+                17,
+                _defaultEncryptedPayload(),
+                refundBurner,
+                minAmountOut
+            )
+            : _buildPlaintextData(
+                address(token1),
+                address(mockPortal2),
+                alice,
+                refundBurner,
+                bytes32("rollback"),
+                minAmountOut
+            );
+        uint256[4] memory balances = [
+            pathUSD.balanceOf(address(router)),
+            pathUSD.balanceOf(address(exchange)),
+            token1.balanceOf(address(exchange)),
+            token1.balanceOf(address(mockPortal2))
+        ];
+        bytes32 hashBefore = mockPortal2.currentDepositQueueHash();
+        bytes32 dexStateBefore = _dexStateHash();
+
+        vm.prank(ZONE_MESSENGER_ADDRESS);
+        vm.expectRevert(
+            portalRejects
+                ? MockZonePortalForRouter.DepositsRejected.selector
+                : IStablecoinDEX.InsufficientOutput.selector
+        );
+        router.onWithdrawalReceived(
+            SOURCE_ZONE_ID, sourcePortal, senderTag, address(pathUSD), AMOUNT, data
+        );
+
+        assertEq(pathUSD.balanceOf(address(router)), balances[0]);
+        assertEq(pathUSD.balanceOf(address(exchange)), balances[1]);
+        assertEq(token1.balanceOf(address(exchange)), balances[2]);
+        assertEq(token1.balanceOf(address(mockPortal2)), balances[3]);
+        assertEq(token1.balanceOf(address(router)), 0);
+        assertEq(mockPortal2.depositCount(), 0);
+        assertEq(mockPortal2.currentDepositQueueHash(), hashBefore);
+        assertEq(_dexStateHash(), dexStateBefore);
     }
 
 }

--- a/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
+++ b/specs/ref-impls/test/tempo/SwapAndDepositRouter.t.sol
@@ -385,6 +385,28 @@ contract SwapAndDepositRouterTest is BaseTest {
         );
     }
 
+    /// @dev TODO: Enable once https://github.com/tempoxyz/tempo/pull/6614 is included in Forge.
+    function test_swapOutputMatchesQuote() public {
+        vm.skip(true, "Tempo #6614: exact-input quotes still round per tick instead of per order");
+
+        uint128 quote = exchange.quoteSwapExactAmountIn(address(pathUSD), address(token1), AMOUNT);
+        bytes memory data = _buildPlaintextData(
+            address(token1),
+            address(mockPortal2),
+            alice,
+            refundBurner,
+            bytes32("quote parity"),
+            quote
+        );
+
+        vm.prank(ZONE_MESSENGER_ADDRESS);
+        router.onWithdrawalReceived(
+            SOURCE_ZONE_ID, sourcePortal, senderTag, address(pathUSD), AMOUNT, data
+        );
+
+        assertEq(mockPortal2.lastDepositAmount(), quote);
+    }
+
     function testFuzz_swapDeposit_conservesBalancesAndQueuesDeposit(
         bool encrypted,
         bytes32 metadata,

--- a/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
@@ -315,6 +315,7 @@ contract ZoneMessengerTest is BaseTest {
         );
     }
 
+    /// @notice Only the matching portal and gateway can relay, and every callback failure rolls back.
     function testFuzz_relayMessage_authorizationAndCallbackRollbackMatrix(
         bool factoryPortalCaller,
         bool matchingZone,

--- a/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import {
     IWithdrawalReceiver,
+    IZoneFactory,
     IZonePortal,
     MAX_WITHDRAWAL_CALLBACK_GAS,
     Role,
@@ -14,21 +15,6 @@ import { ZoneMessenger } from "../../src/tempo/ZoneMessenger.sol";
 import { BaseTest } from "../BaseTest.t.sol";
 import { MockZoneToken } from "../mocks/MockZoneToken.sol";
 import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
-
-contract MockZoneFactoryForMessenger {
-
-    mapping(uint32 => ZoneInfo) internal _zones;
-
-    function setPortal(uint32 zoneId, address portal) external {
-        _zones[zoneId].zoneId = zoneId;
-        _zones[zoneId].portal = portal;
-    }
-
-    function zones(uint32 id) external view returns (ZoneInfo memory) {
-        return _zones[id];
-    }
-
-}
 
 contract AcceptingWithdrawalReceiver is IWithdrawalReceiver {
 
@@ -134,7 +120,7 @@ contract ZoneMessengerTest is BaseTest {
     uint32 internal constant OTHER_ZONE_ID = 2;
     uint64 internal constant CALLBACK_GAS_LIMIT = MAX_WITHDRAWAL_CALLBACK_GAS;
 
-    MockZoneFactoryForMessenger public messengerFactory;
+    IZoneFactory public messengerFactory;
     ZoneMessenger public messenger;
     MockZoneToken public zoneToken;
 
@@ -144,10 +130,17 @@ contract ZoneMessengerTest is BaseTest {
 
     function setUp() public override {
         super.setUp();
-        vm.etch(ZONE_FACTORY_ADDRESS, type(MockZoneFactoryForMessenger).runtimeCode);
-        messengerFactory = MockZoneFactoryForMessenger(ZONE_FACTORY_ADDRESS);
-        messengerFactory.setPortal(ZONE_ID, portal);
-        messengerFactory.setPortal(OTHER_ZONE_ID, otherPortal);
+        messengerFactory = IZoneFactory(ZONE_FACTORY_ADDRESS);
+        vm.mockCall(
+            ZONE_FACTORY_ADDRESS,
+            abi.encodeWithSelector(IZoneFactory.zones.selector, ZONE_ID),
+            abi.encode(_zoneInfo(ZONE_ID, portal))
+        );
+        vm.mockCall(
+            ZONE_FACTORY_ADDRESS,
+            abi.encodeWithSelector(IZoneFactory.zones.selector, OTHER_ZONE_ID),
+            abi.encode(_zoneInfo(OTHER_ZONE_ID, otherPortal))
+        );
 
         vm.etch(ZONE_MESSENGER_ADDRESS, type(ZoneMessenger).runtimeCode);
         messenger = ZoneMessenger(ZONE_MESSENGER_ADDRESS);
@@ -156,6 +149,19 @@ contract ZoneMessengerTest is BaseTest {
         );
         zoneToken = new MockZoneToken("Zone USD", "zUSD");
         zoneToken.setMinter(address(this), true);
+    }
+
+    function _zoneInfo(
+        uint32 zoneId,
+        address zonePortal
+    )
+        internal
+        pure
+        returns (ZoneInfo memory info)
+    {
+        info.zoneId = zoneId;
+        info.portal = zonePortal;
+        info.sequencers = new address[](0);
     }
 
     function _mockTransfer(address target, uint128 amount, bool result) internal {

--- a/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneMessenger.t.sol
@@ -80,6 +80,54 @@ contract RejectingWithdrawalReceiver is IWithdrawalReceiver {
 
 }
 
+contract MatrixWithdrawalReceiver is IWithdrawalReceiver {
+
+    bytes4 internal immutable _selector;
+    uint256 public calls;
+    bytes32 public callbackHash;
+
+    constructor(bytes4 selector) {
+        _selector = selector;
+    }
+
+    function onWithdrawalReceived(
+        uint32 zoneId,
+        address sourcePortal,
+        bytes32 senderTag,
+        address token,
+        uint128 amount,
+        bytes calldata data
+    )
+        external
+        returns (bytes4)
+    {
+        ++calls;
+        callbackHash = keccak256(abi.encode(zoneId, sourcePortal, senderTag, token, amount, data));
+        return _selector;
+    }
+
+}
+
+contract MatrixTransferToken {
+
+    mapping(address => uint256) public balanceOf;
+    bool internal immutable _result;
+
+    constructor(address owner, uint256 amount, bool result) {
+        balanceOf[owner] = amount;
+        _result = result;
+    }
+
+    function transfer(address target, uint256 amount) external returns (bool) {
+        if (!_result) return false;
+        require(balanceOf[msg.sender] >= amount);
+        balanceOf[msg.sender] -= amount;
+        balanceOf[target] += amount;
+        return true;
+    }
+
+}
+
 contract ZoneMessengerTest is BaseTest {
 
     uint32 internal constant ZONE_ID = 1;
@@ -259,6 +307,63 @@ contract ZoneMessengerTest is BaseTest {
             50_000,
             _callback()
         );
+    }
+
+    function testFuzz_relayMessage_authorizationAndCallbackRollbackMatrix(
+        bool factoryPortalCaller,
+        bool matchingZone,
+        bool callbackGateway,
+        bool transferResult,
+        bytes4 callbackSelector,
+        bytes calldata data
+    )
+        public
+    {
+        MatrixWithdrawalReceiver receiver = new MatrixWithdrawalReceiver(callbackSelector);
+        uint128 amount = 17;
+        MatrixTransferToken matrixToken =
+            new MatrixTransferToken(address(messenger), amount, transferResult);
+        address caller = factoryPortalCaller ? portal : alice;
+        uint32 zoneId = matchingZone ? ZONE_ID : OTHER_ZONE_ID;
+        vm.mockCall(
+            caller, abi.encodeWithSelector(IZonePortal.isGatewayOpen.selector), abi.encode(false)
+        );
+        vm.mockCall(
+            caller,
+            abi.encodeWithSelector(IZonePortal.role.selector, address(receiver)),
+            abi.encode(callbackGateway ? Role.CallbackGateway : Role.None)
+        );
+
+        bool authorized = caller == portal && zoneId == ZONE_ID;
+        bool succeeds = authorized && callbackGateway && transferResult
+            && callbackSelector == IWithdrawalReceiver.onWithdrawalReceived.selector;
+        vm.prank(caller);
+        if (!succeeds) vm.expectRevert();
+        messenger.relayMessage(
+            zoneId,
+            address(matrixToken),
+            bytes32("matrix"),
+            address(receiver),
+            amount,
+            CALLBACK_GAS_LIMIT,
+            data
+        );
+
+        assertEq(matrixToken.balanceOf(address(messenger)), succeeds ? 0 : amount);
+        assertEq(matrixToken.balanceOf(address(receiver)), succeeds ? amount : 0);
+        assertEq(receiver.calls(), succeeds ? 1 : 0);
+        if (succeeds) {
+            assertEq(
+                receiver.callbackHash(),
+                keccak256(
+                    abi.encode(
+                        zoneId, caller, bytes32("matrix"), address(matrixToken), amount, data
+                    )
+                )
+            );
+        } else {
+            assertEq(receiver.callbackHash(), bytes32(0));
+        }
     }
 
 }

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -191,47 +191,6 @@ contract ReentrantWithdrawalReceiver is IWithdrawalReceiver {
 
 }
 
-/// @dev Keeps the twelve-argument portal initializer encoder out of the already-large proxy test.
-contract ZonePortalInitializationForwarder {
-
-    function initialize(
-        address target,
-        uint32 id,
-        address initialToken,
-        address portalMessenger,
-        address portalAdmin,
-        address sequencer,
-        address portalVerifier
-    )
-        external
-    {
-        address[] memory accounts = new address[](2);
-        accounts[0] = portalAdmin;
-        accounts[1] = sequencer;
-        address[] memory gateways = new address[](1);
-        gateways[0] = portalMessenger;
-        address[] memory sequencers = new address[](1);
-        sequencers[0] = sequencer;
-
-        ZonePortal(target)
-            .initialize(
-                id,
-                initialToken,
-                true,
-                true,
-                accounts,
-                gateways,
-                portalMessenger,
-                portalAdmin,
-                sequencers,
-                1,
-                portalVerifier,
-                ""
-            );
-    }
-
-}
-
 contract ZonePortalProxyStorageTest is Test {
 
     function _emptyAddresses() internal pure returns (address[] memory values) {
@@ -297,8 +256,6 @@ contract ZonePortalProxyStorageTest is Test {
         );
         vm.etch(proxyA, runtime);
         vm.etch(proxyB, runtime);
-        ZonePortalInitializationForwarder forwarder = new ZonePortalInitializationForwarder();
-        vm.etch(ZONE_FACTORY_ADDRESS, address(forwarder).code);
 
         address messengerA = makeAddr("messenger A");
         address messengerB = makeAddr("messenger B");
@@ -430,15 +387,30 @@ contract ZonePortalProxyStorageTest is Test {
     )
         internal
     {
-        ZonePortalInitializationForwarder(ZONE_FACTORY_ADDRESS)
+        address portalAdmin = makeAddr(string.concat("admin ", vm.toString(id)));
+        address sequencer = makeAddr(string.concat("sequencer ", vm.toString(id)));
+        address[] memory accounts = new address[](2);
+        accounts[0] = portalAdmin;
+        accounts[1] = sequencer;
+        address[] memory gateways = new address[](1);
+        gateways[0] = portalMessenger;
+        address[] memory sequencers = new address[](1);
+        sequencers[0] = sequencer;
+
+        ZonePortal(target)
             .initialize(
-                target,
                 id,
                 initialToken,
+                true,
+                true,
+                accounts,
+                gateways,
                 portalMessenger,
-                makeAddr(string.concat("admin ", vm.toString(id))),
-                makeAddr(string.concat("sequencer ", vm.toString(id))),
-                portalVerifier
+                portalAdmin,
+                sequencers,
+                1,
+                portalVerifier,
+                ""
             );
     }
 

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -4515,6 +4515,229 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.depositCount(), iterations);
     }
 
+    /// @notice Every rejected regular deposit leaves escrow, fees, and queue state untouched.
+    function testFuzz_deposit_rejectionIsAtomic(uint128 amount, uint8 failure) public {
+        failure = uint8(bound(failure, 0, 2));
+        vm.fee(1e12);
+        _setZoneGasRate(1);
+        _setBouncebackGas(300_000);
+        uint128 minimum = portal.calculateDepositFee() + portal.calculateBouncebackFee();
+        amount = failure == 0
+            ? uint128(bound(amount, 0, minimum - 1))
+            : uint128(bound(amount, minimum, 1000e6));
+
+        uint256 aliceBalance = pathUSD.balanceOf(alice);
+        uint256 adminBalance = pathUSD.balanceOf(admin);
+        uint256 portalBalance = pathUSD.balanceOf(address(portal));
+        bytes32 queueHash = portal.currentDepositQueueHash();
+        uint64 depositCount = portal.depositCount();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), failure == 1 ? amount - 1 : amount);
+        if (failure == 0) {
+            vm.expectRevert(IZonePortal.DepositTooSmall.selector);
+        } else if (failure == 1) {
+            vm.expectRevert();
+        } else {
+            vm.stopPrank();
+            vm.prank(admin);
+            portal.pauseDeposits(address(pathUSD));
+            vm.startPrank(alice);
+            vm.expectRevert(IZonePortal.DepositsNotActive.selector);
+        }
+        portal.deposit(address(pathUSD), bob, amount, bytes32("atomic"), bob);
+        vm.stopPrank();
+
+        assertEq(pathUSD.balanceOf(alice), aliceBalance);
+        assertEq(pathUSD.balanceOf(admin), adminBalance);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBalance);
+        assertEq(portal.currentDepositQueueHash(), queueHash);
+        assertEq(portal.depositCount(), depositCount);
+    }
+
+    /// @notice Invalid encrypted payload/key combinations cannot partially collect or enqueue.
+    function testFuzz_depositEncrypted_validationIsAtomic(
+        uint8 failure,
+        uint16 ciphertextLength
+    )
+        public
+    {
+        failure = uint8(bound(failure, 0, 5));
+        _setEncKeyWithPoP(ENC_KEY_1);
+        uint256 secondKeyBlock = block.number + 2;
+        vm.roll(secondKeyBlock);
+        _setEncKeyWithPoP(ENC_KEY_2);
+
+        EncryptedDepositPayload memory payload = _makeEncryptedPayload();
+        uint256 keyIndex = 1;
+        if (failure == 0) payload.ephemeralPubkeyYParity = uint8(bound(ciphertextLength, 0, 255));
+        if (failure == 0) {
+            vm.assume(
+                payload.ephemeralPubkeyYParity != 0x02 && payload.ephemeralPubkeyYParity != 0x03
+            );
+        }
+        if (failure == 1) payload.ephemeralPubkeyX = bytes32(0);
+        if (failure == 2) {
+            uint256 length = bound(ciphertextLength, 0, 128);
+            vm.assume(length != 64);
+            payload.ciphertext = new bytes(length);
+        }
+        if (failure == 3) keyIndex = 2 + uint256(ciphertextLength);
+        if (failure == 4) {
+            keyIndex = 0;
+            vm.roll(secondKeyBlock + ENCRYPTION_KEY_GRACE_PERIOD);
+        }
+        if (failure == 5) keyIndex = type(uint256).max;
+
+        uint256 aliceBalance = pathUSD.balanceOf(alice);
+        uint256 adminBalance = pathUSD.balanceOf(admin);
+        uint256 portalBalance = pathUSD.balanceOf(address(portal));
+        bytes32 queueHash = portal.currentDepositQueueHash();
+        uint64 depositCount = portal.depositCount();
+
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+        if (failure <= 1) {
+            vm.expectRevert(IZonePortal.InvalidEphemeralPubkey.selector);
+        } else if (failure == 2) {
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    IZonePortal.InvalidCiphertextLength.selector, payload.ciphertext.length, 64
+                )
+            );
+        } else if (failure == 4) {
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    IZonePortal.EncryptionKeyExpired.selector, 0, uint64(1), uint64(secondKeyBlock)
+                )
+            );
+        } else {
+            vm.expectRevert(
+                abi.encodeWithSelector(IZonePortal.InvalidEncryptionKeyIndex.selector, keyIndex)
+            );
+        }
+        portal.depositEncrypted(address(pathUSD), 1000e6, keyIndex, payload, alice);
+        vm.stopPrank();
+
+        assertEq(pathUSD.balanceOf(alice), aliceBalance);
+        assertEq(pathUSD.balanceOf(admin), adminBalance);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBalance);
+        assertEq(portal.currentDepositQueueHash(), queueHash);
+        assertEq(portal.depositCount(), depositCount);
+    }
+
+    /// @notice Malformed deposit transitions reject the whole batch before settlement state changes.
+    function testFuzz_submitBatch_invalidDepositTransitionIsAtomic(uint8 failure) public {
+        failure = uint8(bound(failure, 0, 2));
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+        portal.deposit(address(pathUSD), bob, 1000e6, bytes32("batch"), bob);
+        vm.stopPrank();
+
+        if (failure == 1) {
+            bytes32 previousBlockHash = portal.blockHash();
+            vm.roll(block.number + 1);
+            _submitBatch(
+                portal,
+                uint64(block.number - 1),
+                0,
+                BlockTransition({
+                    prevBlockHash: previousBlockHash, nextBlockHash: keccak256("valid")
+                }),
+                DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: portal.currentDepositQueueHash(),
+                    prevDepositNumber: 0,
+                    nextDepositNumber: 1
+                }),
+                bytes32(0),
+                "",
+                ""
+            );
+        }
+
+        DepositQueueTransition memory transition = DepositQueueTransition({
+            prevProcessedHash: failure == 1 ? portal.currentDepositQueueHash() : bytes32(0),
+            nextProcessedHash: portal.currentDepositQueueHash(),
+            prevDepositNumber: failure == 0 ? 1 : 0,
+            nextDepositNumber: failure == 2 ? 2 : 0
+        });
+        if (failure == 1) {
+            transition.prevDepositNumber = 1;
+            transition.nextDepositNumber = 0;
+        }
+        bytes32 oldBlockHash = portal.blockHash();
+        uint256 oldBatchIndex = portal.withdrawalBatchIndex();
+        uint256 oldTail = portal.withdrawalQueueTail();
+        uint64 oldProcessedNumber = portal.lastProcessedDepositNumber();
+        vm.roll(block.number + 1);
+
+        vm.expectRevert(IZonePortal.InvalidDepositTransition.selector);
+        _submitBatch(
+            portal,
+            uint64(block.number - 1),
+            0,
+            BlockTransition({ prevBlockHash: oldBlockHash, nextBlockHash: keccak256("invalid") }),
+            transition,
+            keccak256("withdrawals"),
+            "",
+            ""
+        );
+
+        assertEq(portal.blockHash(), oldBlockHash);
+        assertEq(portal.withdrawalBatchIndex(), oldBatchIndex);
+        assertEq(portal.withdrawalQueueTail(), oldTail);
+        assertEq(portal.lastProcessedDepositNumber(), oldProcessedNumber);
+    }
+
+    /// @notice Invalid withdrawal data or suffix hashes cannot partially dequeue a slot.
+    function testFuzz_processWithdrawals_invalidDequeueIsAtomic(
+        bytes32 mutation,
+        bool badSuffix
+    )
+        public
+    {
+        vm.assume(mutation != bytes32(0));
+        Withdrawal memory withdrawal =
+            _withdrawal(address(pathUSD), alice, bob, 1, bytes32("valid"), 0, alice, "");
+        bytes32 withdrawalHash = keccak256(abi.encode(withdrawal, EMPTY_SENTINEL));
+        vm.roll(block.number + 1);
+        _submitBatch(
+            portal,
+            uint64(block.number - 1),
+            0,
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("queued")
+            }),
+            DepositQueueTransition({
+                    prevProcessedHash: bytes32(0),
+                    nextProcessedHash: bytes32(0),
+                    prevDepositNumber: 0,
+                    nextDepositNumber: 0
+                }),
+            withdrawalHash,
+            "",
+            ""
+        );
+
+        uint256 head = portal.withdrawalQueueHead();
+        uint256 tail = portal.withdrawalQueueTail();
+        if (!badSuffix) withdrawal.memo ^= mutation;
+        bytes32 remainingQueue = badSuffix ? mutation : bytes32(0);
+
+        vm.expectRevert(WithdrawalQueueLib.InvalidWithdrawalHash.selector);
+        portal.processWithdrawals(_singleWithdrawal(withdrawal), remainingQueue);
+
+        assertEq(portal.withdrawalQueueHead(), head);
+        assertEq(portal.withdrawalQueueTail(), tail);
+
+        // A subsequent valid dequeue proves the failed call did not alter the head slot hash.
+        Withdrawal memory validWithdrawal =
+            _withdrawal(address(pathUSD), alice, bob, 1, bytes32("valid"), 0, alice, "");
+        portal.processWithdrawals(_singleWithdrawal(validWithdrawal), bytes32(0));
+        assertEq(portal.withdrawalQueueHead(), head + 1);
+    }
+
     /// @notice Key lookup returns the latest encryption key active at the query block.
     function testFuzz_encryptionKeyAtBlock(
         uint16 gap1,

--- a/specs/ref-impls/test/zone/ZoneInbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneInbox.t.sol
@@ -62,6 +62,14 @@ contract RefundCallForwarder {
 /// @notice Tests for ZoneInbox covering edge cases
 contract ZoneInboxTest is Test {
 
+    struct MixedBatchExpectations {
+        bytes32 queueHash;
+        uint256 decryptionIndex;
+        uint256 acceptedValue;
+        uint256 bouncedValue;
+        uint256 parkedValue;
+    }
+
     ZoneConfig public config;
     ZoneInbox public inbox;
     MockZoneToken public zoneToken;
@@ -1453,11 +1461,7 @@ contract ZoneInboxTest is Test {
         }
         QueuedDeposit[] memory deposits = new QueuedDeposit[](count);
         DecryptionData[] memory decs = new DecryptionData[](decryptionCount);
-        uint256 decIndex;
-        bytes32 expectedHash;
-        uint256 acceptedValue;
-        uint256 bouncedValue;
-        uint256 parkedValue;
+        MixedBatchExpectations memory expected;
 
         for (uint256 i = 0; i < count; i++) {
             uint128 amount = uint128((i + 1) * 1e6);
@@ -1470,9 +1474,10 @@ contract ZoneInboxTest is Test {
                 qd.depositData = abi.encode(ed);
                 qd.rejected = kind == 3;
                 deposits[i] = qd;
-                expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, expectedHash));
+                expected.queueHash =
+                    keccak256(abi.encode(DepositType.Encrypted, ed, expected.queueHash));
                 if (kind != 3) {
-                    decs[decIndex++] = DecryptionData({
+                    decs[expected.decryptionIndex++] = DecryptionData({
                         sharedSecret: bytes32(i + 1),
                         sharedSecretYParity: 0x02,
                         cpProof: ChaumPedersenProof({
@@ -1480,8 +1485,8 @@ contract ZoneInboxTest is Test {
                         })
                     });
                 }
-                if (kind == 1) acceptedValue += amount;
-                else bouncedValue += amount;
+                if (kind == 1) expected.acceptedValue += amount;
+                else expected.bouncedValue += amount;
             } else {
                 bool parked = kind == 6;
                 address token = kind == 5 || parked ? address(failedToken) : address(zoneToken);
@@ -1497,10 +1502,11 @@ contract ZoneInboxTest is Test {
                 deposits[i] = QueuedDeposit({
                     depositType: DepositType.Regular, depositData: abi.encode(d), rejected: rejected
                 });
-                expectedHash = keccak256(abi.encode(DepositType.Regular, d, expectedHash));
-                if (kind == 0) acceptedValue += amount;
-                else if (parked) parkedValue += amount;
-                else bouncedValue += amount;
+                expected.queueHash =
+                    keccak256(abi.encode(DepositType.Regular, d, expected.queueHash));
+                if (kind == 0) expected.acceptedValue += amount;
+                else if (parked) expected.parkedValue += amount;
+                else expected.bouncedValue += amount;
             }
 
             if (kind == 2 || kind == 3 || kind == 4 || kind == 5) {
@@ -1518,18 +1524,21 @@ contract ZoneInboxTest is Test {
         }
 
         tempoState.setMockStorageValue(
-            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expected.queueHash
         );
         vm.prank(sequencer);
         inbox.advanceTempo("", deposits, decs, new EnabledToken[](0));
 
-        assertEq(inbox.processedDepositQueueHash(), expectedHash);
+        assertEq(inbox.processedDepositQueueHash(), expected.queueHash);
         assertEq(inbox.processedDepositNumber(), count);
-        assertEq(zoneToken.totalSupply(), acceptedValue);
+        assertEq(zoneToken.totalSupply(), expected.acceptedValue);
         assertEq(failedToken.totalSupply(), 0);
         vm.prank(fallbackRecipient);
-        assertEq(inbox.refunds(address(failedToken), fallbackRecipient), parkedValue);
-        assertEq(zoneToken.totalSupply() + bouncedValue + parkedValue, _sumMixedAmounts(count));
+        assertEq(inbox.refunds(address(failedToken), fallbackRecipient), expected.parkedValue);
+        assertEq(
+            zoneToken.totalSupply() + expected.bouncedValue + expected.parkedValue,
+            _sumMixedAmounts(count)
+        );
     }
 
     function _sumMixedAmounts(uint256 count) internal pure returns (uint256) {

--- a/specs/ref-impls/test/zone/ZoneInbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneInbox.t.sol
@@ -821,22 +821,51 @@ contract ZoneInboxTest is Test {
         // Set up encryption key
         _setupEncryptionKeyMock(0, keccak256("seq-key"), 0x03);
 
-        // Build encrypted deposit but provide NO decryption data
+        // Process a regular deposit before reaching an encrypted deposit with no decryption data.
+        // The regular mint must roll back along with the queue progression.
+        Deposit memory regular = Deposit({
+            token: address(zoneToken),
+            sender: alice,
+            to: bob,
+            amount: 100e6,
+            tempoRefundRecipient: bob,
+            memo: bytes32("before missing")
+        });
         (QueuedDeposit memory qd,) = _makeEncryptedDeposit(alice, 1000e6, 0);
 
-        // We need to set the current hash to something - doesn't matter since we expect revert
+        bytes32 regularHash = keccak256(abi.encode(DepositType.Regular, regular, bytes32(0)));
         tempoState.setMockStorageValue(
-            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, keccak256("whatever")
+            mockPortal,
+            PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
+            keccak256(
+                abi.encode(
+                    DepositType.Encrypted,
+                    abi.decode(qd.depositData, (EncryptedDeposit)),
+                    regularHash
+                )
+            )
         );
 
-        QueuedDeposit[] memory deposits = new QueuedDeposit[](1);
-        deposits[0] = qd;
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](2);
+        deposits[0] = QueuedDeposit({
+            depositType: DepositType.Regular, depositData: abi.encode(regular), rejected: false
+        });
+        deposits[1] = qd;
 
         DecryptionData[] memory emptyDecs = new DecryptionData[](0);
+
+        bytes32 hashBefore = inbox.processedDepositQueueHash();
+        uint64 numberBefore = inbox.processedDepositNumber();
+        uint256 supplyBefore = zoneToken.totalSupply();
 
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.MissingDecryptionData.selector);
         inbox.advanceTempo("", deposits, emptyDecs, new EnabledToken[](0));
+
+        assertEq(inbox.processedDepositQueueHash(), hashBefore);
+        assertEq(inbox.processedDepositNumber(), numberBefore);
+        assertEq(zoneToken.totalSupply(), supplyBefore);
+        assertEq(zoneToken.balanceOf(bob), 0);
     }
 
     function test_advanceTempo_extraDecryptionData() public {
@@ -869,9 +898,17 @@ contract ZoneInboxTest is Test {
             cpProof: ChaumPedersenProof({ s: bytes32(uint256(1)), c: bytes32(uint256(2)) })
         });
 
+        bytes32 hashBefore = inbox.processedDepositQueueHash();
+        uint64 numberBefore = inbox.processedDepositNumber();
+        uint256 supplyBefore = zoneToken.totalSupply();
+
         vm.prank(sequencer);
         vm.expectRevert(IZoneInbox.ExtraDecryptionData.selector);
         inbox.advanceTempo("", deposits, decs, new EnabledToken[](0));
+
+        assertEq(inbox.processedDepositQueueHash(), hashBefore);
+        assertEq(inbox.processedDepositNumber(), numberBefore);
+        assertEq(zoneToken.totalSupply(), supplyBefore);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1378,6 +1415,125 @@ contract ZoneInboxTest is Test {
         uint128 encryptedRecipientRefunds = inbox.refunds(address(zoneToken), encryptedRecipient);
         uint256 parkedRefunds = uint256(bobRefunds) + encryptedRecipientRefunds;
         assertEq(zoneToken.totalSupply() + parkedRefunds, netCredited);
+    }
+
+    /// @notice A shuffled batch containing every processing outcome advances every queue item once
+    ///         while conserving its value between zone supply, Tempo bounce-backs, and refunds.
+    function testFuzz_advanceTempo_shuffledMixedBatchConservesValue(
+        bytes32 seed,
+        uint8 rawExtra
+    )
+        public
+    {
+        uint256 count = 7 + bound(rawExtra, 0, 5);
+        uint8[] memory kinds = new uint8[](count);
+        for (uint256 i = 0; i < count; i++) {
+            // The first seven guarantee dense mixed coverage; extras fuzz all outcomes.
+            kinds[i] = i < 7 ? uint8(i) : uint8(uint256(keccak256(abi.encode(seed, i))) % 7);
+        }
+        for (uint256 i = count - 1; i > 0; i--) {
+            uint256 j = uint256(keccak256(abi.encode(seed, i, "shuffle"))) % (i + 1);
+            (kinds[i], kinds[j]) = (kinds[j], kinds[i]);
+        }
+
+        MockZoneToken failedToken = new MockZoneToken("Failed USD", "fUSD");
+        address encryptedRecipient = address(0x500);
+        address fallbackRecipient = address(0x501);
+        _setupEncryptionKeyMock(0, keccak256("mixed-key"), 0x03);
+        _setupPrecompileMocks(encryptedRecipient, bytes32("mixed"));
+        vm.mockCall(
+            ZONE_OUTBOX,
+            abi.encodeWithSelector(IZoneOutbox.consumeFallbackRecipient.selector),
+            abi.encode(fallbackRecipient)
+        );
+
+        uint256 decryptionCount;
+        for (uint256 i = 0; i < count; i++) {
+            if (kinds[i] == 1 || kinds[i] == 4) decryptionCount++;
+        }
+        QueuedDeposit[] memory deposits = new QueuedDeposit[](count);
+        DecryptionData[] memory decs = new DecryptionData[](decryptionCount);
+        uint256 decIndex;
+        bytes32 expectedHash;
+        uint256 acceptedValue;
+        uint256 bouncedValue;
+        uint256 parkedValue;
+
+        for (uint256 i = 0; i < count; i++) {
+            uint128 amount = uint128((i + 1) * 1e6);
+            uint8 kind = kinds[i];
+            if (kind == 1 || kind == 3 || kind == 4) {
+                address token = kind == 4 ? address(failedToken) : address(zoneToken);
+                (QueuedDeposit memory qd, EncryptedDeposit memory ed) =
+                    _makeEncryptedDeposit(alice, amount, 0);
+                ed.token = token;
+                qd.depositData = abi.encode(ed);
+                qd.rejected = kind == 3;
+                deposits[i] = qd;
+                expectedHash = keccak256(abi.encode(DepositType.Encrypted, ed, expectedHash));
+                if (kind != 3) {
+                    decs[decIndex++] = DecryptionData({
+                        sharedSecret: bytes32(i + 1),
+                        sharedSecretYParity: 0x02,
+                        cpProof: ChaumPedersenProof({
+                            s: bytes32(uint256(1)), c: bytes32(uint256(2))
+                        })
+                    });
+                }
+                if (kind == 1) acceptedValue += amount;
+                else bouncedValue += amount;
+            } else {
+                bool parked = kind == 6;
+                address token = kind == 5 || parked ? address(failedToken) : address(zoneToken);
+                Deposit memory d = Deposit({
+                    token: token,
+                    sender: alice,
+                    to: parked ? address(uint160(uint64(i + 1))) : bob,
+                    amount: amount,
+                    tempoRefundRecipient: parked ? address(0) : bob,
+                    memo: bytes32(i)
+                });
+                bool rejected = kind == 2;
+                deposits[i] = QueuedDeposit({
+                    depositType: DepositType.Regular, depositData: abi.encode(d), rejected: rejected
+                });
+                expectedHash = keccak256(abi.encode(DepositType.Regular, d, expectedHash));
+                if (kind == 0) acceptedValue += amount;
+                else if (parked) parkedValue += amount;
+                else bouncedValue += amount;
+            }
+
+            if (kind == 2 || kind == 3 || kind == 4 || kind == 5) {
+                address bounceToken =
+                    kind == 4 || kind == 5 ? address(failedToken) : address(zoneToken);
+                address refundRecipient = kind == 3 || kind == 4 ? alice : bob;
+                vm.expectCall(
+                    ZONE_OUTBOX,
+                    abi.encodeCall(
+                        IZoneOutbox.enqueueDepositBounceBack, (bounceToken, amount, refundRecipient)
+                    ),
+                    1
+                );
+            }
+        }
+
+        tempoState.setMockStorageValue(
+            mockPortal, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, expectedHash
+        );
+        vm.prank(sequencer);
+        inbox.advanceTempo("", deposits, decs, new EnabledToken[](0));
+
+        assertEq(inbox.processedDepositQueueHash(), expectedHash);
+        assertEq(inbox.processedDepositNumber(), count);
+        assertEq(zoneToken.totalSupply(), acceptedValue);
+        assertEq(failedToken.totalSupply(), 0);
+        vm.prank(fallbackRecipient);
+        assertEq(inbox.refunds(address(failedToken), fallbackRecipient), parkedValue);
+        assertEq(zoneToken.totalSupply() + bouncedValue + parkedValue, _sumMixedAmounts(count));
+    }
+
+    function _sumMixedAmounts(uint256 count) internal pure returns (uint256) {
+        return count * (count + 1) * 1e6 / 2;
     }
 
 }

--- a/specs/ref-impls/test/zone/ZoneOutbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneOutbox.t.sol
@@ -1438,6 +1438,7 @@ contract ZoneOutboxTest is Test {
         assertEq(_pendingWithdrawalsCount(), 0);
     }
 
+    /// @notice A withdrawal records exact fields while burning its amount and advancing indices.
     function testFuzz_requestWithdrawal_exactBurnPendingIndexAndFallbackNonce(
         uint128 rawAmount,
         uint128 rawRate,
@@ -1482,6 +1483,7 @@ contract ZoneOutboxTest is Test {
         assertEq(outbox.consumeFallbackRecipient(1), fallbackRecipient);
     }
 
+    /// @notice Every withdrawal validation branch rejects without burning or advancing state.
     function testFuzz_requestWithdrawal_rejectionMatrixIsAtomic(uint8 rawCase) public {
         uint8 rejectionCase = uint8(bound(rawCase, 0, 5));
         bytes memory data;
@@ -1542,6 +1544,7 @@ contract ZoneOutboxTest is Test {
         assertEq(outbox.lastFallbackNonce(), nonceBefore);
     }
 
+    /// @notice Finalized sender tags bind both the withdrawal sender and current zone transaction.
     function testFuzz_finalizeWithdrawalBatch_senderTagBindsSenderAndCurrentTxHash(
         address sender,
         bytes32 memo
@@ -1563,6 +1566,7 @@ contract ZoneOutboxTest is Test {
         assertEq(expected.senderTag, keccak256(abi.encodePacked(sender, txContext.txHashFor(1))));
     }
 
+    /// @notice Invalid withdrawal and encrypted-sender counts leave the pending batch unchanged.
     function testFuzz_finalizeWithdrawalBatch_shapeRejectionIsAtomic(
         uint8 rawCase,
         uint8 rawWrongLength

--- a/specs/ref-impls/test/zone/ZoneOutbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneOutbox.t.sol
@@ -1438,4 +1438,180 @@ contract ZoneOutboxTest is Test {
         assertEq(_pendingWithdrawalsCount(), 0);
     }
 
+    function testFuzz_requestWithdrawal_exactBurnPendingIndexAndFallbackNonce(
+        uint128 rawAmount,
+        uint128 rawRate,
+        uint64 rawGasLimit,
+        bytes32 memo,
+        address fallbackRecipient
+    )
+        public
+    {
+        vm.assume(fallbackRecipient != address(0));
+        uint128 rate = uint128(bound(rawRate, 0, 500));
+        uint64 gasLimit = uint64(bound(rawGasLimit, 0, outbox.MAX_WITHDRAWAL_GAS_LIMIT()));
+        uint128 fee = uint128(50_000 + gasLimit) * rate;
+        uint128 amount = uint128(bound(rawAmount, 0, zoneToken.balanceOf(alice) - fee));
+        address recipient = gasLimit == 0 ? bob : callbackTarget;
+        bytes memory data = gasLimit == 0 ? bytes("") : bytes("opaque");
+
+        vm.prank(sequencer);
+        outbox.setTempoGasRate(rate);
+        uint256 balanceBefore = zoneToken.balanceOf(alice);
+        uint256 supplyBefore = zoneToken.totalSupply();
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), amount + fee);
+        outbox.requestWithdrawal(
+            address(zoneToken), recipient, amount, memo, gasLimit, fallbackRecipient, data
+        );
+        vm.stopPrank();
+
+        assertEq(zoneToken.balanceOf(alice), balanceBefore - amount - fee);
+        assertEq(zoneToken.totalSupply(), supplyBefore - amount - fee);
+        assertEq(outbox.nextWithdrawalIndex(), 1);
+        assertEq(outbox.lastFallbackNonce(), 1);
+        PendingWithdrawal[] memory pending = _getPendingWithdrawals();
+        assertEq(pending.length, 1);
+        assertEq(pending[0].sender, alice);
+        assertEq(pending[0].txHash, txContext.txHashFor(1));
+        assertEq(pending[0].amount, amount);
+        assertEq(pending[0].gasLimit, gasLimit);
+        assertEq(pending[0].fallbackNonce, 1);
+        vm.prank(ZONE_INBOX);
+        assertEq(outbox.consumeFallbackRecipient(1), fallbackRecipient);
+    }
+
+    function testFuzz_requestWithdrawal_rejectionMatrixIsAtomic(uint8 rawCase) public {
+        uint8 rejectionCase = uint8(bound(rawCase, 0, 5));
+        bytes memory data;
+        address recipient = bob;
+        address fallbackRecipient = alice;
+        uint64 gasLimit;
+
+        if (rejectionCase == 0) {
+            gasLimit = outbox.MAX_WITHDRAWAL_GAS_LIMIT() + 1;
+        } else if (rejectionCase == 1) {
+            data = new bytes(outbox.MAX_CALLBACK_DATA_SIZE() + 1);
+        } else if (rejectionCase == 2) {
+            fallbackRecipient = address(0);
+        } else if (rejectionCase == 3) {
+            recipient = callbackTarget;
+        } else if (rejectionCase == 4) {
+            gasLimit = 1;
+        } else {
+            vm.prank(sequencer);
+            outbox.setMaxWithdrawalsPerBlock(1);
+            vm.startPrank(alice);
+            zoneToken.approve(address(outbox), 2);
+            outbox.requestWithdrawal(address(zoneToken), bob, 1, bytes32(0), 0, alice, "");
+            vm.stopPrank();
+        }
+
+        uint256 balanceBefore = zoneToken.balanceOf(alice);
+        uint256 supplyBefore = zoneToken.totalSupply();
+        uint256 pendingBefore = _pendingWithdrawalsCount();
+        uint64 indexBefore = outbox.nextWithdrawalIndex();
+        uint64 nonceBefore = outbox.lastFallbackNonce();
+
+        bytes memory expectedError;
+        if (rejectionCase == 0) {
+            expectedError = abi.encodeWithSelector(ZoneOutbox.GasLimitTooHigh.selector);
+        } else if (rejectionCase == 1) {
+            expectedError = abi.encodeWithSelector(ZoneOutbox.CallbackDataTooLarge.selector);
+        } else if (rejectionCase == 2) {
+            expectedError = abi.encodeWithSelector(ZoneOutbox.InvalidFallbackRecipient.selector);
+        } else if (rejectionCase == 3 || rejectionCase == 4) {
+            expectedError = abi.encodeWithSelector(IZonePortal.InvalidCallbackTarget.selector);
+        } else {
+            expectedError = abi.encodeWithSelector(ZoneOutbox.TooManyWithdrawalsThisBlock.selector);
+        }
+
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 500e6);
+        vm.expectRevert(expectedError);
+        outbox.requestWithdrawal(
+            address(zoneToken), recipient, 500e6, bytes32(0), gasLimit, fallbackRecipient, data
+        );
+        vm.stopPrank();
+
+        assertEq(zoneToken.balanceOf(alice), balanceBefore);
+        assertEq(zoneToken.totalSupply(), supplyBefore);
+        assertEq(_pendingWithdrawalsCount(), pendingBefore);
+        assertEq(outbox.nextWithdrawalIndex(), indexBefore);
+        assertEq(outbox.lastFallbackNonce(), nonceBefore);
+    }
+
+    function testFuzz_finalizeWithdrawalBatch_senderTagBindsSenderAndCurrentTxHash(
+        address sender,
+        bytes32 memo
+    )
+        public
+    {
+        vm.assume(sender != address(0) && sender.code.length == 0);
+        vm.assume(sender != ZONE_INBOX && sender != ZONE_TX_CONTEXT);
+        zoneToken.mint(sender, 1);
+
+        vm.startPrank(sender);
+        zoneToken.approve(address(outbox), 1);
+        outbox.requestWithdrawal(address(zoneToken), bob, 1, memo, 0, sender, "");
+        vm.stopPrank();
+
+        Withdrawal memory expected = _withdrawal(1, sender, bob, 1, memo, 0, sender, "");
+        bytes32 expectedHash = keccak256(abi.encode(expected, EMPTY_SENTINEL));
+        assertEq(_finalizeWithdrawalBatch(1), expectedHash);
+        assertEq(expected.senderTag, keccak256(abi.encodePacked(sender, txContext.txHashFor(1))));
+    }
+
+    function testFuzz_finalizeWithdrawalBatch_shapeRejectionIsAtomic(
+        uint8 rawCase,
+        uint8 rawWrongLength
+    )
+        public
+    {
+        vm.startPrank(alice);
+        zoneToken.approve(address(outbox), 2);
+        outbox.requestWithdrawal(address(zoneToken), bob, 1, bytes32("plain"), 0, alice, "");
+        outbox.requestWithdrawal(
+            address(zoneToken), bob, 1, bytes32("private"), 0, alice, "", _validRevealTo()
+        );
+        vm.stopPrank();
+
+        uint8 rejectionCase = uint8(bound(rawCase, 0, 2));
+        uint256 count = 2;
+        bytes[] memory encryptedSenders;
+        bytes memory expectedError;
+        if (rejectionCase == 0) {
+            count = 3;
+            encryptedSenders = new bytes[](3);
+            expectedError = abi.encodeWithSelector(ZoneOutbox.InvalidWithdrawalCount.selector, 3, 2);
+        } else if (rejectionCase == 1) {
+            encryptedSenders = new bytes[](1);
+            expectedError =
+                abi.encodeWithSelector(ZoneOutbox.InvalidEncryptedSenderCount.selector, 1, 2);
+        } else {
+            encryptedSenders = new bytes[](2);
+            uint256 wrongLength = bound(rawWrongLength, 1, 112);
+            encryptedSenders[1] = new bytes(wrongLength);
+            expectedError = abi.encodeWithSelector(
+                ZoneOutbox.InvalidEncryptedSenderLength.selector, wrongLength, 113
+            );
+        }
+
+        LastBatch memory beforeBatch = outbox.lastBatch();
+        uint64 timestampBefore = outbox.lastFinalizedTimestamp();
+        vm.expectRevert(expectedError);
+        vm.prank(sequencer);
+        outbox.finalizeWithdrawalBatch(count, uint64(block.number), encryptedSenders);
+
+        LastBatch memory afterBatch = outbox.lastBatch();
+        assertEq(afterBatch.withdrawalQueueHash, beforeBatch.withdrawalQueueHash);
+        assertEq(afterBatch.withdrawalBatchIndex, beforeBatch.withdrawalBatchIndex);
+        assertEq(outbox.lastFinalizedTimestamp(), timestampBefore);
+        assertEq(_pendingWithdrawalsCount(), 2);
+        PendingWithdrawal[] memory pending = _getPendingWithdrawals();
+        assertEq(pending[0].memo, bytes32("plain"));
+        assertEq(pending[1].memo, bytes32("private"));
+    }
+
 }

--- a/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
+++ b/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
@@ -316,6 +316,7 @@ contract EncryptionGraceSymbolic is Test {
         h = new EncryptionGraceHarness();
     }
 
+    /// @notice Production key validity changes exactly at the superseding key's grace boundary.
     function check_encryptionGraceExpiresAtExactBoundary(
         uint64 activation,
         uint256 currentBlock
@@ -331,6 +332,7 @@ contract EncryptionGraceSymbolic is Test {
         assertEq(valid, currentBlock < expiry);
     }
 
+    /// @notice An overflowing grace-period calculation reverts without altering key history.
     function check_encryptionGraceAdditionCannotWrap(uint64 activation) external {
         vm.assume(activation > type(uint64).max - ENCRYPTION_KEY_GRACE_PERIOD);
         h.setTwoKeys(activation);
@@ -341,6 +343,7 @@ contract EncryptionGraceSymbolic is Test {
         assertEq(h.encryptionKeyAt(1).activationBlock, activation);
     }
 
+    /// @notice Production key lookup accepts stored indices and safely rejects all others.
     function check_encryptionKeyIndexRange(uint256 index) external {
         h.setTwoKeys(1);
         (bool valid, uint64 expiry) = h.isEncryptionKeyValid(index);

--- a/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
+++ b/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import { ENCRYPTION_KEY_GRACE_PERIOD, EncryptionKeyEntry } from "../../src/interfaces/IZone.sol";
 import { EncryptedDepositLib } from "../../src/libraries/EncryptedDeposit.sol";
 import {
     WITHDRAWAL_QUEUE_CAPACITY,
     WithdrawalQueue,
     WithdrawalQueueLib
 } from "../../src/libraries/WithdrawalQueueLib.sol";
+import { ZonePortal } from "../../src/tempo/ZonePortal.sol";
 import { ZonePortalTest } from "../tempo/ZonePortal.t.sol";
 import { ZoneOutboxTest } from "./ZoneOutbox.t.sol";
 import { Test } from "forge-std/Test.sol";
@@ -28,6 +30,29 @@ import { Test } from "forge-std/Test.sol";
 ///         Inherits ZonePortalTest to reuse its concrete setUp (a real ZonePortal deployed via
 ///         ZoneFactory, with separate portal admin and sequencer roles).
 contract ZonePortalSymbolic is ZonePortalTest {
+
+    /// @notice At the configured maximum rate the deposit fee still fits the uint128 return
+    ///         type. The rate is concrete so the solver only has to establish a cast boundary,
+    ///         not a multiplication of two symbolic values.
+    function check_depositFeeAtRateCapFitsCast() external {
+        uint128 rate = portal.MAX_GAS_FEE_RATE();
+        vm.prank(admin);
+        portal.setZoneGasRate(rate);
+
+        uint256 wideFee = uint256(portal.FIXED_DEPOSIT_GAS()) * rate;
+        assertLe(wideFee, type(uint128).max);
+        assertEq(portal.calculateDepositFee(), uint128(wideFee));
+    }
+
+    /// @notice The bounce-back ceil-division is still exactly representable at the uint128 cast
+    ///         boundary. Both factors are concrete to keep this out of nonlinear arithmetic.
+    function check_bouncebackFeeAtUint128CastBoundary() external {
+        vm.prank(admin);
+        portal.setBouncebackGas(1);
+        vm.fee(uint256(type(uint128).max) * 1e12);
+
+        assertEq(portal.calculateBouncebackFee(), type(uint128).max);
+    }
 
     /// @notice Deposit fee never overflows uint128 for any rate within the enforced cap, so
     ///         `calculateDepositFee` cannot revert. Proven over all 2^128 rate values.
@@ -80,6 +105,10 @@ contract WithdrawalQueueHarness {
 
     function tail() external view returns (uint256) {
         return q.tail;
+    }
+
+    function slot(uint256 index) external view returns (bytes32) {
+        return q.slots[index];
     }
 
     function length() external view returns (uint256) {
@@ -184,12 +213,42 @@ contract WithdrawalQueueSymbolic is Test {
         qh.enqueue(h);
     }
 
+    /// @notice A non-full queue at the maximum tail cannot wrap, and the failed enqueue is atomic.
+    function check_enqueueAtMaxTailRevertsWithoutMutation(bytes32 h) external {
+        vm.assume(h != bytes32(0));
+        uint256 tail = type(uint256).max;
+        uint256 head = tail - qh.capacity() + 1;
+        uint256 slotIndex = tail % qh.capacity();
+        qh.setHeadTail(head, tail);
+        bytes32 slotBefore = qh.slot(slotIndex);
+
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        qh.enqueue(h);
+
+        assertEq(qh.head(), head);
+        assertEq(qh.tail(), tail);
+        assertEq(qh.slot(slotIndex), slotBefore);
+    }
+
 }
 
 /// @title ZoneOutbox symbolic properties
 /// @notice Symbolic checks for the zone→Tempo withdrawal fee arithmetic. Inherits ZoneOutboxTest
 ///         to reuse its concrete setUp (real ZoneOutbox + ZoneConfig, `sequencer` authorized).
 contract ZoneOutboxSymbolic is ZoneOutboxTest {
+
+    /// @notice At both callback-gas boundaries the fee fits uint128 and the cast is lossless at
+    ///         the maximum configured rate.
+    function check_withdrawalFeeCastFitsAtGasBoundaries(bool useMaximum) external {
+        uint64 gasLimit = useMaximum ? outbox.MAX_WITHDRAWAL_GAS_LIMIT() : 0;
+        uint128 rate = config.maxTempoGasRate();
+        vm.prank(sequencer);
+        outbox.setTempoGasRate(rate);
+
+        uint256 wideFee = uint256(outbox.WITHDRAWAL_BASE_GAS() + gasLimit) * rate;
+        assertLe(wideFee, type(uint128).max);
+        assertEq(outbox.calculateWithdrawalFee(gasLimit), uint128(wideFee));
+    }
 
     /// @notice The withdrawal fee `(WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate` never
     ///         overflows uint128, so `calculateWithdrawalFee` cannot revert. Verifies the
@@ -228,6 +287,70 @@ contract ZoneOutboxSymbolic is ZoneOutboxTest {
         try outbox.calculateWithdrawalFee(gasLimit) returns (uint128) {
             fail(); // an over-cap gas limit must never produce a fee
         } catch { }
+    }
+
+}
+
+/// @notice Exposes production ZonePortal key-history storage setup to the symbolic properties.
+contract EncryptionGraceHarness is ZonePortal {
+
+    function setTwoKeys(uint64 supersedingActivation) external {
+        delete _encryptionKeys;
+        _encryptionKeys.push(
+            EncryptionKeyEntry({ x: bytes32(uint256(1)), yParity: 0x02, activationBlock: 0 })
+        );
+        _encryptionKeys.push(
+            EncryptionKeyEntry({
+                x: bytes32(uint256(2)), yParity: 0x03, activationBlock: supersedingActivation
+            })
+        );
+    }
+
+}
+
+contract EncryptionGraceSymbolic is Test {
+
+    EncryptionGraceHarness internal h;
+
+    function setUp() public {
+        h = new EncryptionGraceHarness();
+    }
+
+    function check_encryptionGraceExpiresAtExactBoundary(
+        uint64 activation,
+        uint256 currentBlock
+    )
+        external
+    {
+        vm.assume(activation <= type(uint64).max - ENCRYPTION_KEY_GRACE_PERIOD);
+        h.setTwoKeys(activation);
+        vm.roll(currentBlock);
+
+        (bool valid, uint64 expiry) = h.isEncryptionKeyValid(0);
+        assertEq(expiry, uint256(activation) + ENCRYPTION_KEY_GRACE_PERIOD);
+        assertEq(valid, currentBlock < expiry);
+    }
+
+    function check_encryptionGraceAdditionCannotWrap(uint64 activation) external {
+        vm.assume(activation > type(uint64).max - ENCRYPTION_KEY_GRACE_PERIOD);
+        h.setTwoKeys(activation);
+
+        try h.isEncryptionKeyValid(0) returns (bool, uint64) {
+            fail();
+        } catch { }
+        assertEq(h.encryptionKeyAt(1).activationBlock, activation);
+    }
+
+    function check_encryptionKeyIndexRange(uint256 index) external {
+        h.setTwoKeys(1);
+        (bool valid, uint64 expiry) = h.isEncryptionKeyValid(index);
+        if (index >= 2) {
+            assertFalse(valid);
+            assertEq(expiry, 0);
+        } else if (index == 1) {
+            assertTrue(valid);
+            assertEq(expiry, 0);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

- add fuzz coverage for Portal deposit validation and settlement transitions, Outbox withdrawal creation and finalization, Inbox mixed batches, Messenger authorization rollback, and router conservation/rollback against the real StablecoinDEX fixture
- add solver-friendly symbolic properties for production fee arithmetic, withdrawal queue boundaries, encryption-key validity, and encrypted plaintext packing
- move the Forge suite to `tempo:T9` and align native-factory fixtures with the current Tempo storage layout
- install upstream Foundry nightly in Docker so T9 Solidity artifacts build consistently with the existing Forge Build job
- track the StablecoinDEX fragmented-order quote mismatch as a skipped regression test pending tempoxyz/tempo#6614
- aise the production coverage gates to 92% lines and 70% branches

## Validation

- exact `forge coverage --ir-minimum --match-path 'test/**' --exclude-tests --report summary`: 667 passed, 1 intentionally skipped
- production coverage gate: 92.45% lines and 70.97% branches
- new fuzz properties passed 1,000-run fixed-seed stress tests
- 19 symbolic properties passed with Z3 and no incomplete paths

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: George