### PR TITLE
fix(rpc): bound restricted method metric labels

### DIFF
--- a/crates/rpc/src/metrics.rs
+++ b/crates/rpc/src/metrics.rs
@@ -49,7 +49,34 @@ pub(crate) struct ZoneProviderMetrics {
 pub(crate) fn canonical_method_label(method: &str) -> &str {
     match classify_method(method) {
         Some(_) if method.starts_with("admin_") => "admin_*",
+        Some(_) if method.starts_with("debug_") => "debug_*",
+        Some(_) if method.starts_with("txpool_") => "txpool_*",
         Some(_) => method,
         None => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_method_label;
+
+    #[test]
+    fn canonicalizes_restricted_wildcard_method_families() {
+        for (method, expected) in [
+            ("admin_trace_0", "admin_*"),
+            ("admin_trace_1", "admin_*"),
+            ("debug_trace_0", "debug_*"),
+            ("debug_trace_1", "debug_*"),
+            ("txpool_content_0", "txpool_*"),
+            ("txpool_content_1", "txpool_*"),
+        ] {
+            assert_eq!(canonical_method_label(method), expected);
+        }
+    }
+
+    #[test]
+    fn preserves_known_methods_and_buckets_unknown_methods() {
+        assert_eq!(canonical_method_label("eth_call"), "eth_call");
+        assert_eq!(canonical_method_label("missing_method"), "unknown");
     }
 }


### PR DESCRIPTION
Currently private RPC records metrics before checking method authorization. Rejected `debug_*` and `txpool_*` requests are included in RPC metrics using caller-controlled method names.

This PR groups these restricted methods under fixed `debug_*` and `txpool_*` labels, matching the existing `admin_*` behavior. This prevents rejected requests from creating a new metric label for each method name while preserving existing labels for known methods.

Closes ZONE-142.