### PR TITLE
fix(precompiles): don't leak user balance on reverts

### DIFF
--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -28,14 +28,7 @@
 extern crate alloc;
 
 pub mod error;
-use alloy_sol_types::SolError;
 pub use error::{Result, ZonePrecompileError, ZoneResult};
-
-alloy_sol_types::sol! {
-    /// Returned instead of the upstream balance error for delegated transfers, which must not
-    /// reveal the source account's balance to the spender.
-    error InsufficientBalance();
-}
 
 pub mod aes_gcm;
 pub mod chaum_pedersen;
@@ -72,6 +65,7 @@ pub use zone_fee_manager::{ZONE_FEE_MANAGER_ADDRESS, ZoneFeeManager};
 
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Address;
+use alloy_sol_types::SolError;
 use tempo_precompiles::{
     Precompile as _,
     tip20::{ITIP20::InsufficientBalance as TIP20InsufficientBalance, TIP20Token},
@@ -125,10 +119,10 @@ pub fn create_tip20_precompile<P>(
 where
     P: L1StorageReader,
 {
-    // Transforms internal reverts into generic InsufficientBalance errors
-    let anonymize = |mut res: revm::precompile::PrecompileOutput| {
+    // Redacts TIP20 transfer from reverts that reveal user balances to the spender.
+    let redact = |mut res: revm::precompile::PrecompileOutput| {
         if res.bytes.starts_with(&TIP20InsufficientBalance::SELECTOR) {
-            res.bytes = InsufficientBalance {}.abi_encode().into();
+            res.bytes = crate::ztip20::InsufficientBalance {}.abi_encode().into();
         }
         res
     };
@@ -140,7 +134,7 @@ where
         move |data, caller| {
             TIP20Token::from_address_unchecked(address)
                 .call(data, caller)
-                .map(anonymize)
+                .map(redact)
         },
     )
 }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -28,7 +28,14 @@
 extern crate alloc;
 
 pub mod error;
+use alloy_sol_types::SolError;
 pub use error::{Result, ZonePrecompileError, ZoneResult};
+
+alloy_sol_types::sol! {
+    /// Returned instead of the upstream balance error for delegated transfers, which must not
+    /// reveal the source account's balance to the spender.
+    error InsufficientBalance();
+}
 
 pub mod aes_gcm;
 pub mod chaum_pedersen;
@@ -65,7 +72,11 @@ pub use zone_fee_manager::{ZONE_FEE_MANAGER_ADDRESS, ZoneFeeManager};
 
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::Address;
-use tempo_precompiles::{Precompile as _, tip20::TIP20Token, tip403_registry::TIP403Registry};
+use tempo_precompiles::{
+    Precompile as _,
+    tip20::{ITIP20::InsufficientBalance as TIP20InsufficientBalance, TIP20Token},
+    tip403_registry::TIP403Registry,
+};
 
 /// Creates the zone-native fee manager precompile.
 pub fn create_zone_fee_manager_precompile(env: &ZonePrecompileEnv) -> DynPrecompile {
@@ -114,11 +125,23 @@ pub fn create_tip20_precompile<P>(
 where
     P: L1StorageReader,
 {
+    // Transforms internal reverts into generic InsufficientBalance errors
+    let anonymize = |mut res: revm::precompile::PrecompileOutput| {
+        if res.bytes.starts_with(&TIP20InsufficientBalance::SELECTOR) {
+            res.bytes = InsufficientBalance {}.abi_encode().into();
+        }
+        res
+    };
+
     execution::create_precompile(
         "TIP20Token",
         env,
         ztip20::TIP20Rules::new(l1),
-        move |data, caller| TIP20Token::from_address_unchecked(address).call(data, caller),
+        move |data, caller| {
+            TIP20Token::from_address_unchecked(address)
+                .call(data, caller)
+                .map(anonymize)
+        },
     )
 }
 

--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -22,6 +22,11 @@ use crate::{
     storage::{L1State, L1StorageReader},
 };
 
+alloy_sol_types::sol! {
+    /// Returned instead of the upstream balance error that reveal the user balance to the spender.
+    error InsufficientBalance();
+}
+
 /// Fixed gas charged for TIP20 transfer and approval selectors on the zone.
 ///
 /// A constant charge hides storage-dependent execution costs that could reveal whether a recipient
@@ -563,7 +568,7 @@ mod tests {
         assert!(result.is_revert());
         assert_eq!(
             result.bytes,
-            Bytes::from(crate::InsufficientBalance {}.abi_encode())
+            Bytes::from(InsufficientBalance {}.abi_encode())
         );
         assert_eq!(harness.balance_of(harness.alice)?, U256::from(1_000_000u64));
 

--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -134,7 +134,7 @@ mod tests {
     use super::*;
     use alloy::primitives::{Address, Bytes, U256, address};
     use alloy_evm::precompiles::DynPrecompile;
-    use alloy_sol_types::{SolCall, SolInterface};
+    use alloy_sol_types::{SolCall, SolError, SolInterface};
     use revm::precompile::PrecompileResult;
     use tempo_contracts::precompiles::TIP20Error;
     use tempo_precompiles::{
@@ -528,6 +528,44 @@ mod tests {
         )?;
         assert!(outbox_burn.is_success());
         assert_eq!(harness.balance_of(ZONE_OUTBOX_ADDRESS)?, U256::ZERO);
+
+        Ok(())
+    }
+
+    #[test]
+    fn transfer_from_insufficient_balance_does_not_reveal_the_source_balance() -> eyre::Result<()> {
+        let mut harness = PrecompileHarness::new()?;
+        harness.call(
+            harness.alice,
+            ITIP20::approveCall {
+                spender: harness.spender,
+                amount: U256::from(1_000_001u64),
+            }
+            .abi_encode()
+            .into(),
+            TIP20_FIXED_TRANSFER_GAS,
+            false,
+        )?;
+
+        let result = harness.call(
+            harness.spender,
+            ITIP20::transferFromCall {
+                from: harness.alice,
+                to: harness.bob,
+                amount: U256::from(1_000_001u64),
+            }
+            .abi_encode()
+            .into(),
+            TIP20_FIXED_TRANSFER_GAS,
+            false,
+        )?;
+
+        assert!(result.is_revert());
+        assert_eq!(
+            result.bytes,
+            Bytes::from(crate::InsufficientBalance {}.abi_encode())
+        );
+        assert_eq!(harness.balance_of(harness.alice)?, U256::from(1_000_000u64));
 
         Ok(())
     }


### PR DESCRIPTION
ref: `ZONE-104`

this PR redacts the user balance from a tip20 transfer from `InsufficientBalance(from, to, balance)` error