### PR TITLE
fix(rpc): make private fee quotes deterministic

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -37,7 +37,7 @@ use tempo_alloy::{
     TempoNetwork,
     rpc::{TempoCallBuilderExt as _, TempoHeaderResponse, TempoTransactionRequest},
 };
-use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
+use tempo_chainspec::spec::{TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE};
 use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     account_keychain::IAccountKeychain::{self, KeyInfo, getKeyCall},
@@ -670,7 +670,7 @@ where
     }
 
     fn gas_price(&self) -> BoxFut<'_> {
-        Box::pin(async move { to_raw(&U256::from(TEMPO_T0_BASE_FEE)) })
+        Box::pin(async move { to_raw(&U256::from(TEMPO_T1_BASE_FEE)) })
     }
 
     fn max_priority_fee_per_gas(&self) -> BoxFut<'_> {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -670,19 +670,11 @@ where
     }
 
     fn gas_price(&self) -> BoxFut<'_> {
-        Box::pin(async move {
-            let price = EthFees::gas_price(&self.eth.api).await.map_err(internal)?;
-            to_raw(&price)
-        })
+        Box::pin(async move { to_raw(&U256::from(TEMPO_T0_BASE_FEE)) })
     }
 
     fn max_priority_fee_per_gas(&self) -> BoxFut<'_> {
-        Box::pin(async move {
-            let fee = EthFees::suggested_priority_fee(&self.eth.api)
-                .await
-                .map_err(internal)?;
-            to_raw(&fee)
-        })
+        Box::pin(async move { to_raw(&U256::ZERO) })
     }
 
     fn fee_history(

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -25,7 +25,7 @@ use p256::ecdsa::SigningKey as P256SigningKey;
 use rand::thread_rng;
 use serde_json::{Value, json};
 use std::{collections::HashSet, time::Duration};
-use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
+use tempo_chainspec::spec::{TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE};
 use tempo_contracts::precompiles::{
     ITIP20 as ContractTip20,
     account_keychain::IAccountKeychain::SignatureType as KeyInfoSignatureType,
@@ -560,7 +560,7 @@ async fn test_public_methods() -> eyre::Result<()> {
     }
 
     for (method, expected) in [
-        ("eth_gasPrice", U256::from(TEMPO_T0_BASE_FEE)),
+        ("eth_gasPrice", U256::from(TEMPO_T1_BASE_FEE)),
         ("eth_maxPriorityFeePerGas", U256::ZERO),
     ] {
         for response in [

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -535,7 +535,7 @@ async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Public methods (blockNumber, chainId, gasPrice) work for both sequencer and users.
+/// Public methods work for both sequencer and users without leaking private fee activity.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_public_methods() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -543,7 +543,7 @@ async fn test_public_methods() -> eyre::Result<()> {
     let ctx = start_zone_with_private_rpc().await?;
     let user_signer = PrivateKeySigner::random();
 
-    for method in ["eth_blockNumber", "eth_chainId", "eth_gasPrice"] {
+    for method in ["eth_blockNumber", "eth_chainId"] {
         let seq_resp = ctx.call_as_sequencer(method, serde_json::json!([])).await?;
         assert!(
             seq_resp.get("result").is_some() && seq_resp.get("error").is_none(),
@@ -557,6 +557,18 @@ async fn test_public_methods() -> eyre::Result<()> {
             user_resp.get("result").is_some() && user_resp.get("error").is_none(),
             "user should succeed for {method}"
         );
+    }
+
+    for (method, expected) in [
+        ("eth_gasPrice", U256::from(TEMPO_T0_BASE_FEE)),
+        ("eth_maxPriorityFeePerGas", U256::ZERO),
+    ] {
+        for response in [
+            ctx.call_as_sequencer(method, json!([])).await?,
+            ctx.call_as_user(method, json!([]), &user_signer).await?,
+        ] {
+            assert_eq!(response["result"], json!(format!("{expected:#x}")));
+        }
     }
 
     Ok(())

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -916,6 +916,8 @@ The RPC uses a default-deny model. Any method not explicitly listed returns `-32
 
 **Allowed.** `eth_chainId`, `eth_blockNumber`, `eth_gasPrice`, `eth_maxPriorityFeePerGas`, `eth_feeHistory`, `eth_getBlockByNumber` and `eth_getBlockByHash` (without full transactions), `eth_syncing`, `eth_coinbase`, `net_version`, `net_listening`, `web3_clientVersion`, `web3_sha3`.
 
+Fee quotes are caller-independent: `eth_gasPrice` returns the fixed T0 gas price and `eth_maxPriorityFeePerGas` returns `0`.
+
 **Scoped.** Available to any authenticated caller but filtered to the caller's account:
 
 - `eth_getBalance`, `eth_getTransactionCount`: return `0x0` for non-self queries (no error, to avoid leaking account existence).

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -916,7 +916,7 @@ The RPC uses a default-deny model. Any method not explicitly listed returns `-32
 
 **Allowed.** `eth_chainId`, `eth_blockNumber`, `eth_gasPrice`, `eth_maxPriorityFeePerGas`, `eth_feeHistory`, `eth_getBlockByNumber` and `eth_getBlockByHash` (without full transactions), `eth_syncing`, `eth_coinbase`, `net_version`, `net_listening`, `web3_clientVersion`, `web3_sha3`.
 
-Fee quotes are caller-independent: `eth_gasPrice` returns the fixed T0 gas price and `eth_maxPriorityFeePerGas` returns `0`.
+Fee quotes are caller-independent: `eth_gasPrice` returns the fixed T1 gas price and `eth_maxPriorityFeePerGas` returns `0`.
 
 **Scoped.** Available to any authenticated caller but filtered to the caller's account:
 


### PR DESCRIPTION
## Summary

- return the fixed T1 gas price from eth_gasPrice
- return zero from eth_maxPriorityFeePerGas
- cover both sequencer and ordinary authenticated callers and document the policy

## Why

The private RPC delegated fee quotes to the Reth gas oracle, allowing recent private transaction tips to influence responses even though eth_feeHistory redacts the same activity. Zones do not accept priority fees, so these endpoints should return caller-independent values instead of sampling private blocks.

Fixes ZONE-195