### PR TITLE
fix(sequencer): preserve withdrawal preimages

### DIFF
--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -303,9 +303,9 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
     /// Rebuild the in-memory withdrawal store from authoritative chain state.
     ///
     /// The L1 portal only stores queue hashes, so the monitor reconstructs the
-    /// pending withdrawal payloads from L1 + zone-L2 events and replaces the
-    /// local store with that result. Used during startup and after a portal
-    /// resync when local withdrawal data may be stale or missing.
+    /// pending withdrawal payloads from L1 + zone-L2 events and merges them
+    /// into the local store. Observations never remove local preimages; only
+    /// confirmed processing may prune them.
     async fn restore_pending_withdrawals_from_chain(&self) -> Result<()> {
         let pending = match self
             .batch_submitter
@@ -326,11 +326,13 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
 
         let mut store = self.withdrawal_store.lock();
         let (previous_slots, previous_first_slot, previous_last_slot) = store.summary();
-        store.replace_batches(pending);
+        store.merge_batches(pending).map_err(|slot| {
+            eyre::eyre!("restored withdrawals conflict with local preimages for slot {slot}")
+        })?;
         let reconciled_slots = store.batch_count();
         drop(store);
 
-        if reconciled_slots > 0 {
+        if restored_withdrawals > 0 {
             info!(
                 previous_slots,
                 previous_first_slot,
@@ -342,13 +344,6 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                 "Restored pending withdrawals from chain"
             );
             self.withdrawal_notify.notify_one();
-        } else if previous_slots > 0 {
-            info!(
-                previous_slots,
-                previous_first_slot,
-                previous_last_slot,
-                "Cleared stale withdrawal batches after restoring pending withdrawals from chain"
-            );
         }
 
         Ok(())
@@ -706,21 +701,9 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
         if let Some(store) = &self.config.attestation_store {
             store.remove_submitted(last_submitted_zone_block);
         }
-        if let Err(e) = self.restore_pending_withdrawals_from_chain().await {
-            let (stale_store_batches, stale_store_first_slot, stale_store_last_slot) = {
-                let mut store = self.withdrawal_store.lock();
-                let summary = store.summary();
-                store.replace_batches(Default::default());
-                summary
-            };
-            error!(
-                error = %e,
-                stale_store_batches,
-                stale_store_first_slot,
-                stale_store_last_slot,
-                "Failed to restore pending withdrawals during portal resync; cleared local withdrawal store"
-            );
-        }
+        self.restore_pending_withdrawals_from_chain()
+            .await
+            .wrap_err("failed to restore pending withdrawals during portal resync")?;
 
         Ok(last_submitted_zone_block)
     }
@@ -1021,6 +1004,10 @@ mod tests {
             abi_encode_u64(7),
             abi_encode_u64(7),
         ]));
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(7),
+            abi_encode_u64(7),
+        ]));
 
         let mut monitor = test_monitor(l1.clone(), zone);
 
@@ -1033,7 +1020,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repair_missing_withdrawal_slot_resyncs_portal_and_rebuilds_withdrawal_store() {
+    async fn repair_missing_withdrawal_slot_preserves_store_on_empty_observation() {
         let l1 = Asserter::new();
         let portal_hash = B256::from(U256::from(7).to_be_bytes::<32>());
         let confirmed_zone_block = 42;
@@ -1041,6 +1028,10 @@ mod tests {
         let zone = mock_zone_provider(portal_hash, confirmed_zone_block, confirmed_deposit_hash);
 
         l1.push_success(&abi_encode_b256(portal_hash));
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(7),
+            abi_encode_u64(7),
+        ]));
         l1.push_success(&abi_encode_multicall(vec![
             abi_encode_u64(7),
             abi_encode_u64(7),
@@ -1065,14 +1056,15 @@ mod tests {
         monitor.repair_missing_withdrawal_slot().await;
 
         let store = monitor.withdrawal_store.lock();
-        assert_eq!(store.batch_count(), 0);
+        assert_eq!(store.batch_count(), 1);
+        assert!(store.has_batch(3));
         assert_eq!(monitor.prev_zone_block_hash, portal_hash);
         assert_eq!(monitor.last_submitted_zone_block, confirmed_zone_block);
         assert_eq!(monitor.prev_processed_deposit_hash, confirmed_deposit_hash);
     }
 
     #[tokio::test]
-    async fn resync_clears_stale_withdrawal_store_when_restore_fails() {
+    async fn resync_preserves_withdrawal_store_when_restore_fails() {
         let l1 = Asserter::new();
         let portal_hash = B256::from(U256::from(7).to_be_bytes::<32>());
         let confirmed_zone_block = 42;
@@ -1099,14 +1091,64 @@ mod tests {
             },
         );
 
-        let anchor = monitor.resync_from_portal().await.unwrap();
+        let error = monitor.resync_from_portal().await.unwrap_err();
 
-        assert_eq!(anchor, confirmed_zone_block);
+        assert!(
+            error
+                .to_string()
+                .contains("failed to restore pending withdrawals during portal resync")
+        );
         let store = monitor.withdrawal_store.lock();
-        assert_eq!(store.batch_count(), 0);
+        assert_eq!(store.batch_count(), 1);
+        assert!(store.has_batch(3));
         assert_eq!(monitor.prev_zone_block_hash, portal_hash);
         assert_eq!(monitor.last_submitted_zone_block, confirmed_zone_block);
         assert_eq!(monitor.prev_processed_deposit_hash, confirmed_deposit_hash);
+    }
+
+    #[tokio::test]
+    async fn resync_preserves_withdrawal_store_on_false_empty_observation() {
+        let l1 = Asserter::new();
+        let portal_hash = B256::from(U256::from(7).to_be_bytes::<32>());
+        let confirmed_zone_block = 42;
+        let confirmed_deposit_hash = B256::repeat_byte(0x33);
+        let zone = mock_zone_provider(portal_hash, confirmed_zone_block, confirmed_deposit_hash);
+
+        l1.push_success(&abi_encode_b256(portal_hash));
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(7),
+            abi_encode_u64(7),
+        ]));
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(6),
+            abi_encode_u64(7),
+        ]));
+
+        let mut monitor = test_monitor(l1.clone(), zone);
+        monitor.withdrawal_store.lock().add_withdrawal(
+            3,
+            abi::Withdrawal {
+                token: Address::repeat_byte(0x10),
+                senderTag: B256::repeat_byte(0x11),
+                to: Address::repeat_byte(0x12),
+                amount: 100,
+                memo: B256::ZERO,
+                gasLimit: 0,
+                fallbackNonce: 1,
+                callbackData: Default::default(),
+                encryptedSender: Default::default(),
+            },
+        );
+
+        let error = monitor.resync_from_portal().await.unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("withdrawal queue changed during restore"),
+            "unexpected error: {error:#}"
+        );
+        let store = monitor.withdrawal_store.lock();
+        assert_eq!(store.batch_count(), 1);
+        assert!(store.has_batch(3));
     }
 
     #[tokio::test]
@@ -1119,6 +1161,10 @@ mod tests {
 
         l1.push_success(&abi_encode_b256(portal_hash));
         l1.push_success(&abi_encode_b256(portal_hash));
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(7),
+            abi_encode_u64(7),
+        ]));
         l1.push_success(&abi_encode_multicall(vec![
             abi_encode_u64(7),
             abi_encode_u64(7),
@@ -1165,6 +1211,10 @@ mod tests {
 
         l1.push_success(&abi_encode_b256(portal_hash));
         l1.push_success(&abi_encode_b256(portal_hash));
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(7),
+            abi_encode_u64(7),
+        ]));
         l1.push_success(&abi_encode_multicall(vec![
             abi_encode_u64(7),
             abi_encode_u64(7),

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -1063,7 +1063,23 @@ impl BatchSubmitter {
         // Step 1: read pending slot range from the L1 portal.
         let (head, tail) = self.read_portal_withdrawal_queue_bounds().await?;
 
-        if head >= tail {
+        if head > tail {
+            eyre::bail!(
+                "invalid withdrawal queue bounds during restore: head {head} exceeds tail {tail}"
+            );
+        }
+
+        if head == tail {
+            let (head2, tail2) = self.read_portal_withdrawal_queue_bounds().await?;
+            if head2 != head || tail2 != tail {
+                eyre::bail!(
+                    "withdrawal queue changed during restore ({}..{} -> {}..{}), retry on next startup",
+                    head,
+                    tail,
+                    head2,
+                    tail2
+                );
+            }
             info!(head, tail, "No pending withdrawals to restore");
             return Ok(BTreeMap::new());
         }
@@ -1264,13 +1280,11 @@ fn resolve_pending_slots(
 /// `current_slot_hash`. Returns `Some(0)` if no withdrawals have been processed,
 /// `Some(n)` if n have been processed (n remaining), or `None` if no match is
 /// found.
-///
-/// Also checks `offset == len` (all consumed, hash chain = `B256::ZERO`).
 pub(crate) fn find_processed_offset(
     withdrawals: &[abi::Withdrawal],
     current_slot_hash: B256,
 ) -> Option<usize> {
-    for offset in 0..=withdrawals.len() {
+    for offset in 0..withdrawals.len() {
         let hash = abi::Withdrawal::queue_hash(&withdrawals[offset..]);
         if hash == current_slot_hash {
             return Some(offset);
@@ -2123,11 +2137,10 @@ mod tests {
     }
 
     #[test]
-    fn find_offset_all_processed() {
+    fn find_offset_rejects_empty_suffix() {
         let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
         let withdrawals = vec![w0];
-        // B256::ZERO = queue_hash(&[]), meaning all withdrawals have been consumed.
-        assert_eq!(find_processed_offset(&withdrawals, B256::ZERO), Some(1));
+        assert_eq!(find_processed_offset(&withdrawals, B256::ZERO), None);
     }
 
     #[test]
@@ -2316,7 +2329,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_single_slot_fully_processed() {
+    fn resolve_rejects_zero_pending_head_slot() {
         let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
         let withdrawals = vec![w0];
         let full_hash = abi::Withdrawal::queue_hash(&withdrawals);
@@ -2326,10 +2339,8 @@ mod tests {
         let mut slot_withdrawals = BTreeMap::new();
         slot_withdrawals.insert(5, withdrawals);
 
-        // B256::ZERO = queue_hash(&[]), all consumed. find_processed_offset returns
-        // Some(1) (offset == len), so remaining is empty and slot is not stored.
-        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO).unwrap();
-        assert!(result.is_empty());
+        let result = resolve_pending_slots(5, 6, &events, &slot_withdrawals, B256::ZERO);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -189,9 +189,27 @@ impl WithdrawalStore {
         self.batches.insert(batch_index, withdrawals);
     }
 
-    /// Replace the entire store with an authoritative set of pending batches.
-    pub(crate) fn replace_batches(&mut self, batches: BTreeMap<u64, Vec<abi::Withdrawal>>) {
-        self.batches = batches;
+    /// Merge verified batches without removing preimages omitted by the observed queue range.
+    pub(crate) fn merge_batches(
+        &mut self,
+        batches: BTreeMap<u64, Vec<abi::Withdrawal>>,
+    ) -> Result<(), u64> {
+        for (&slot, withdrawals) in &batches {
+            if let Some(existing) = self.batches.get(&slot)
+                && !existing.ends_with(withdrawals)
+                && !withdrawals.ends_with(existing)
+            {
+                return Err(slot);
+            }
+        }
+
+        for (slot, withdrawals) in batches {
+            let existing = self.batches.entry(slot).or_default();
+            if withdrawals.len() > existing.len() {
+                *existing = withdrawals;
+            }
+        }
+        Ok(())
     }
 
     /// Get all withdrawals for a batch.
@@ -207,6 +225,19 @@ impl WithdrawalStore {
     /// Remove slots that the portal head has already passed.
     fn remove_before(&mut self, batch_index: u64) {
         self.batches.retain(|&index, _| index >= batch_index);
+    }
+
+    /// Remove processed slots only when the portal head advanced exactly past the attempted slot.
+    fn prune_after_confirmed_processing(
+        &mut self,
+        processed_slot: u64,
+        confirmed_head: u64,
+    ) -> bool {
+        if processed_slot.checked_add(1) != Some(confirmed_head) {
+            return false;
+        }
+        self.remove_before(confirmed_head);
+        true
     }
 
     pub fn has_batch(&self, batch_index: u64) -> bool {
@@ -411,7 +442,6 @@ impl WithdrawalProcessor {
                 );
                 return Ok(());
             }
-            self.store.lock().remove_before(head_val);
             let StoreSnapshot {
                 batch_count: store_batch_count,
                 first_slot: store_first_slot,
@@ -505,13 +535,8 @@ impl WithdrawalProcessor {
 
             let remaining = &withdrawals[offset..];
             if remaining.is_empty() {
-                // Defensive: queue_hash never produces B256::ZERO for a pending head
-                // slot, but if it happens drop the stale batch and wait for the portal.
-                warn!(
-                    slot = head_val,
-                    "Head slot fully processed but head not advanced"
-                );
-                self.store.lock().remove_batch(head_val);
+                error!(slot = head_val, "Pending head slot has an empty queue hash");
+                self.repair_notify.notify_one();
                 return Ok(());
             }
 
@@ -535,11 +560,39 @@ impl WithdrawalProcessor {
 
             match outcome {
                 SubmitOutcome::Confirmed => {
-                    self.store.lock().remove_batch(head_val);
+                    let (confirmed_head, confirmed_tail): (U256, U256) = self
+                        .provider
+                        .multicall()
+                        .add(self.portal.withdrawalQueueHead())
+                        .add(self.portal.withdrawalQueueTail())
+                        .aggregate()
+                        .await?;
+                    let confirmed_head: u64 = confirmed_head
+                        .try_into()
+                        .map_err(|_| eyre::eyre!("confirmed head overflow"))?;
+                    let confirmed_tail: u64 = confirmed_tail
+                        .try_into()
+                        .map_err(|_| eyre::eyre!("confirmed tail overflow"))?;
+
+                    let pruned = confirmed_head <= confirmed_tail
+                        && self
+                            .store
+                            .lock()
+                            .prune_after_confirmed_processing(head_val, confirmed_head);
+                    if !pruned {
+                        warn!(
+                            slot = head_val,
+                            confirmed_head,
+                            confirmed_tail,
+                            "Portal head did not advance exactly past processed slot; retaining preimages"
+                        );
+                        self.repair_notify.notify_one();
+                        return Ok(());
+                    }
                     info!(
                         slot = head_val,
                         count = remaining.len(),
-                        "Slot fully processed and removed from store"
+                        "Slot fully processed and obsolete preimages removed"
                     );
                 }
                 SubmitOutcome::Retry => {
@@ -1122,7 +1175,19 @@ mod tests {
     }
 
     #[test]
-    fn store_replace_batches_reconciles_authoritative_view() {
+    fn false_advanced_head_does_not_prune_withdrawal_preimages() {
+        let mut store = WithdrawalStore::new();
+        let withdrawal = test_withdrawal(Address::repeat_byte(0x42), 100);
+        store.add_batch(5, vec![withdrawal.clone()]);
+        store.add_batch(6, vec![withdrawal]);
+
+        assert!(!store.prune_after_confirmed_processing(6, 6));
+        assert!(store.has_batch(5));
+        assert!(store.has_batch(6));
+    }
+
+    #[test]
+    fn store_merge_batches_preserves_unobserved_preimages() {
         let mut store = WithdrawalStore::new();
         let addr = address!("0x0000000000000000000000000000000000000042");
 
@@ -1133,13 +1198,13 @@ mod tests {
         reconciled.insert(5, vec![test_withdrawal(addr, 500)]);
         reconciled.insert(6, vec![test_withdrawal(addr, 600)]);
 
-        store.replace_batches(reconciled);
+        store.merge_batches(reconciled).unwrap();
 
-        assert!(!store.has_batch(0));
-        assert!(!store.has_batch(9));
+        assert!(store.has_batch(0));
+        assert!(store.has_batch(9));
         assert!(store.has_batch(5));
         assert!(store.has_batch(6));
-        assert_eq!(store.batch_count(), 2);
+        assert_eq!(store.batch_count(), 4);
     }
 
     fn abi_encode_b256(value: B256) -> Bytes {
@@ -1254,6 +1319,68 @@ mod tests {
                 .is_err()
         );
         assert!(store.lock().has_batch(5));
+        assert!(l1.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_queue_preserves_preimage_on_false_empty_observation() {
+        let l1 = Asserter::new();
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(6),
+            abi_encode_u64(6),
+        ]));
+
+        let store = SharedWithdrawalStore::new();
+        store.lock().add_batch(
+            5,
+            vec![test_withdrawal(
+                address!("0x0000000000000000000000000000000000000042"),
+                100,
+            )],
+        );
+
+        let repair_notify = Arc::new(Notify::new());
+        let mut processor = test_processor(l1.clone(), store.clone(), repair_notify.clone());
+
+        processor.process_queue().await.unwrap();
+
+        assert!(store.lock().has_batch(5));
+        assert!(
+            timeout(Duration::from_millis(50), repair_notify.notified())
+                .await
+                .is_err()
+        );
+        assert!(l1.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_queue_zero_slot_hash_preserves_preimage_and_requests_repair() {
+        let l1 = Asserter::new();
+        l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(5),
+            abi_encode_u64(6),
+        ]));
+        l1.push_success(&abi_encode_u64(0));
+        l1.push_success(&abi_encode_b256(B256::ZERO));
+
+        let store = SharedWithdrawalStore::new();
+        store.lock().add_batch(
+            5,
+            vec![test_withdrawal(
+                address!("0x0000000000000000000000000000000000000042"),
+                100,
+            )],
+        );
+
+        let repair_notify = Arc::new(Notify::new());
+        let mut processor = test_processor(l1.clone(), store.clone(), repair_notify.clone());
+
+        processor.process_queue().await.unwrap();
+
+        assert!(store.lock().has_batch(5));
+        timeout(Duration::from_millis(50), repair_notify.notified())
+            .await
+            .expect("zero pending slot hash should request repair");
         assert!(l1.read_q().is_empty());
     }
 }


### PR DESCRIPTION
Closes [ZONE-189](https://linear.app/tempoxyz/issue/ZONE-189/t3-037-unvalidated-portal-observations-prune-withdrawal-preimages).

## Summary

- retain withdrawal preimages until successful processing is corroborated by an exact Portal head advance
- reject zero pending-slot hashes and inconsistent queue observations
- merge verified resync data without deleting omitted local preimages

## Why

Provider observations can be transiently stale or incorrect. Treating them as authoritative allowed false empty ranges or zero slot hashes to delete the only local preimage for a still-pending withdrawal queue head. This change makes destructive pruning exclusive to confirmed processing while repair and resync paths fail closed.