### PR TITLE
fix(l1): validate finalized parent continuity

### DIFF
--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -574,6 +574,37 @@ impl L1Subscriber {
         Ok(next)
     }
 
+    /// Resolve the latest L1 anchor already admitted by local state or this subscriber.
+    fn latest_ingested_anchor(&self) -> eyre::Result<NumHash> {
+        let mut latest = self.local_state.latest_tempo_checkpoint()?;
+        eyre::ensure!(
+            latest.hash != B256::ZERO,
+            "zone genesis is not anchored to an L1 block"
+        );
+
+        for candidate in [
+            self.deposit_sink.last_enqueued(),
+            self.config.block_tracker.latest(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if candidate.number > latest.number {
+                latest = candidate;
+            } else if candidate.number == latest.number {
+                eyre::ensure!(
+                    candidate.hash == latest.hash,
+                    "conflicting ingested L1 anchors at height {}: {} and {}",
+                    latest.number,
+                    latest.hash,
+                    candidate.hash
+                );
+            }
+        }
+
+        Ok(latest)
+    }
+
     /// Return the block number referenced by the L1 `finalized` tag.
     async fn finalized_block_number(
         &self,
@@ -662,6 +693,18 @@ impl L1Subscriber {
     ) -> eyre::Result<()> {
         use futures::stream;
 
+        let mut parent = self.latest_ingested_anchor()?;
+        let expected_from = parent
+            .number
+            .checked_add(1)
+            .ok_or_else(|| eyre::eyre!("finalized L1 block number overflow"))?;
+        eyre::ensure!(
+            from == expected_from,
+            "finalized L1 backfill must continue after block {} at {}, received start {from}",
+            parent.number,
+            parent.hash
+        );
+
         let concurrency = self.config.l1_fetch_concurrency.max(1);
         let subscriber_metrics = self.subscriber_metrics.clone();
         let block_tracker = self.config.block_tracker.clone();
@@ -720,6 +763,21 @@ impl L1Subscriber {
 
         while let Some((header, receipts)) = fetched.try_next().await? {
             let block_number = header.number();
+            let expected_block_number = parent
+                .number
+                .checked_add(1)
+                .ok_or_else(|| eyre::eyre!("finalized L1 block number overflow"))?;
+            eyre::ensure!(
+                block_number == expected_block_number,
+                "non-contiguous finalized L1 header: expected height {expected_block_number}, received {block_number}"
+            );
+            eyre::ensure!(
+                header.parent_hash() == parent.hash,
+                "finalized L1 parent mismatch at height {block_number}: expected {}, received {}",
+                parent.hash,
+                header.parent_hash()
+            );
+
             // Decoding fails closed: a decode failure of a recognized portal log aborts this
             // block before anything is enqueued or any cache advances. Ingestion halts here (fenced)
             // instead of continuing under a partial event view.
@@ -774,6 +832,7 @@ impl L1Subscriber {
             if !self.config.retain_observations {
                 self.config.block_tracker.prune_through(anchor.number);
             }
+            parent = anchor;
             processed += 1;
 
             if processed.is_multiple_of(100) {

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -395,13 +395,7 @@ fn subscriber_applies_state_and_records_observation() {
 }
 
 fn make_test_header(number: u64) -> TempoHeader {
-    TempoHeader {
-        inner: Header {
-            number,
-            ..Default::default()
-        },
-        ..Default::default()
-    }
+    make_chained_header(number, B256::with_last_byte(1))
 }
 
 /// Create a header that chains to the given parent.
@@ -825,6 +819,83 @@ async fn observer_advances_caches_without_retaining_deposit_blocks() {
     assert!(
         matches!(subscriber.deposit_sink, DepositSink::Observer),
         "an observer must not accumulate finalized blocks in a deposit queue"
+    );
+    assert!(asserter.read_q().is_empty());
+}
+
+#[tokio::test]
+async fn finalized_backfill_rejects_a_first_header_disconnected_from_local_state() {
+    let subscriber = test_observer(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let asserter = Asserter::new();
+    let l1_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
+    let disconnected = make_chained_header(10, B256::with_last_byte(0xee));
+
+    asserter.push_success(&Some(header_response(disconnected.clone())));
+    push_header_and_empty_receipts(&asserter, disconnected);
+
+    let error = subscriber
+        .sync_finalized_once(&l1_provider, 10)
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("finalized L1 parent mismatch at height 10")
+    );
+    assert_eq!(
+        subscriber.config.block_tracker.latest(),
+        None,
+        "a disconnected first header must not advance follower observations"
+    );
+    assert!(asserter.read_q().is_empty());
+}
+
+#[tokio::test]
+async fn finalized_backfill_stops_at_a_disconnected_successor_and_recovers() {
+    let subscriber = test_observer(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let asserter = Asserter::new();
+    let l1_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
+    let header_10 = make_test_header(10);
+    let header_10_hash = header_hash(&header_10);
+    let disconnected_11 = make_chained_header(11, B256::with_last_byte(0xee));
+
+    asserter.push_success(&Some(header_response(disconnected_11.clone())));
+    push_header_and_empty_receipts(&asserter, header_10.clone());
+    push_header_and_empty_receipts(&asserter, disconnected_11);
+
+    let error = subscriber
+        .sync_finalized_once(&l1_provider, 10)
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("finalized L1 parent mismatch at height 11")
+    );
+    assert_eq!(
+        subscriber.config.block_tracker.latest(),
+        Some(NumHash::new(10, header_10_hash)),
+        "the valid prefix should remain available as the retry boundary"
+    );
+
+    let canonical_11 = make_chained_header(11, header_10_hash);
+    let canonical_11_hash = header_hash(&canonical_11);
+    asserter.push_success(&Some(header_response(canonical_11.clone())));
+    push_header_and_empty_receipts(&asserter, canonical_11);
+
+    assert_eq!(
+        subscriber
+            .sync_finalized_once(&l1_provider, 11)
+            .await
+            .unwrap(),
+        12
+    );
+    assert_eq!(
+        subscriber.config.block_tracker.latest(),
+        Some(NumHash::new(11, canonical_11_hash))
     );
     assert!(asserter.read_q().is_empty());
 }


### PR DESCRIPTION
This PR rejects disconnected finalized L1 headers before advancing subscriber state, preserving parent-hash continuity across backfill.

Closes ZONE-136