### PR TITLE
fix(portal): cap deposits per Tempo block

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -178,6 +178,7 @@ crate::sol! {
         error PolicyForbids();
         error InvalidBouncebackRecipient();
         error TokenNotEnabled();
+        error DepositBlockCapacityExceeded(uint64 maximum);
         error InvalidCallbackTarget();
         error AccountNotAllowed(address account);
         error InvalidLeader();
@@ -221,6 +222,7 @@ crate::sol! {
         function calculateBouncebackFee() external view returns (uint128 fee);
         function depositCount() external view returns (uint64);
         function lastProcessedDepositNumber() external view returns (uint64);
+        function MAX_DEPOSITS_PER_TEMPO_BLOCK() external view returns (uint64);
         function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);
 
         // -- State-changing functions --
@@ -381,6 +383,7 @@ impl core::fmt::Display for ZonePortal::ZonePortalErrors {
             Self::PolicyForbids(_) => f.write_str("PolicyForbids"),
             Self::InvalidBouncebackRecipient(_) => f.write_str("InvalidBouncebackRecipient"),
             Self::TokenNotEnabled(_) => f.write_str("TokenNotEnabled"),
+            Self::DepositBlockCapacityExceeded(_) => f.write_str("DepositBlockCapacityExceeded"),
             Self::InvalidCallbackTarget(_) => f.write_str("InvalidCallbackTarget"),
             Self::AccountNotAllowed(_) => f.write_str("AccountNotAllowed"),
             Self::InvalidLeader(_) => f.write_str("InvalidLeader"),

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -5,11 +5,14 @@ use alloy_primitives::{Bytes, address, keccak256};
 use alloy_rlp::Encodable as _;
 use alloy_sol_types::{SolCall, SolError};
 use revm::precompile::PrecompileResult;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{
     PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    receive_policy_guard::ReceivePolicyGuard,
     storage::{ContractStorage, Handler, StorageCtx},
     test_util::TIP20Setup,
     tip20::{ITIP20, TIP20Token},
+    tip403_registry::{ALLOW_ALL_POLICY_ID, ITIP403Registry, REJECT_ALL_POLICY_ID, TIP403Registry},
     zone_factory::{ZonePortalStorage, zone_portal_slots},
 };
 use tempo_primitives::TempoHeader;
@@ -47,7 +50,16 @@ impl Harness {
     }
 
     fn with_l1(l1: MockL1Reader) -> eyre::Result<Self> {
+        Self::with_l1_and_spec(l1, TempoHardfork::default())
+    }
+
+    fn with_spec(spec: TempoHardfork) -> eyre::Result<Self> {
+        Self::with_l1_and_spec(MockL1Reader::default(), spec)
+    }
+
+    fn with_l1_and_spec(l1: MockL1Reader, spec: TempoHardfork) -> eyre::Result<Self> {
         let mut ctx = test_context();
+        ctx.cfg.spec = spec;
         let genesis_rlp = encode_header(&TempoHeader::default());
         let genesis_hash = keccak256(&genesis_rlp);
         {
@@ -56,6 +68,9 @@ impl Harness {
                 TempoState::new().initialize(&genesis_rlp)?;
                 ZoneInbox::new().initialize()?;
                 ZoneOutbox::new().initialize()?;
+                if spec.is_t6() {
+                    ReceivePolicyGuard::new().initialize()?;
+                }
                 TIP20Setup::path_usd(ALICE)
                     .with_issuer(ALICE)
                     .with_issuer(ZONE_INBOX_ADDRESS)
@@ -115,12 +130,21 @@ impl Harness {
     }
 
     fn call(&mut self, caller: Address, calldata: impl AsRef<[u8]>) -> PrecompileResult {
+        self.call_with_gas(caller, calldata, GAS)
+    }
+
+    fn call_with_gas(
+        &mut self,
+        caller: Address,
+        calldata: impl AsRef<[u8]>,
+        gas: u64,
+    ) -> PrecompileResult {
         call_precompile(
             &mut self.ctx,
             &self.precompile,
             caller,
             calldata.as_ref(),
-            GAS,
+            gas,
             false,
             ZONE_INBOX_ADDRESS,
             ZONE_INBOX_ADDRESS,
@@ -193,6 +217,101 @@ impl Harness {
         assert_eq!(pending[0].to, recipient);
         Ok(())
     }
+}
+
+fn worst_case_encrypted_deposit_block_gas(spec: TempoHardfork) -> eyre::Result<u64> {
+    const SYSTEM_GAS: u64 = 250_000_000;
+    const MAX_DEPOSITS_PER_TEMPO_BLOCK: usize = 640;
+
+    let mut harness = Harness::with_spec(spec)?;
+    {
+        let mut storage = test_storage_provider(&mut harness.ctx, u64::MAX, false);
+        StorageCtx::enter(&mut storage, || {
+            TIP403Registry::new().set_receive_policy(
+                BOB,
+                ITIP403Registry::setReceivePolicyCall {
+                    senderPolicyId: REJECT_ALL_POLICY_ID,
+                    tokenFilterId: ALLOW_ALL_POLICY_ID,
+                    recoveryAuthority: Address::ZERO,
+                },
+            )
+        })?;
+    }
+
+    let fixture = EncryptedDepositFixture::new();
+    let decrypted = fixture.decrypt().expect("fixture decrypts");
+    let info = crate::ecies::hkdf_info(&PORTAL, &fixture.key_index, &fixture.eph_pub_x);
+    let key = crate::ecies::hkdf_sha256(&decrypted.proof.shared_secret.0, b"ecies-aes-key", &info);
+    let plaintext = build_plaintext(&BOB, &fixture.memo);
+    let (ciphertext, nonce, tag) = encrypt_plaintext(&key, &plaintext);
+    let (sequencer_x, sequencer_y_parity) = compressed_x_and_parity(&fixture.seq_pub);
+    let base: U256 = keccak256(B256::from(zone_portal_slots::ENCRYPTION_KEYS)).into();
+    let slot_x = base + fixture.key_index * U256::from(2);
+    harness
+        .l1
+        .insert(PORTAL, slot_x, 1, U256::from_be_bytes(sequencer_x.0));
+    harness.l1.insert(
+        PORTAL,
+        slot_x + U256::ONE,
+        1,
+        U256::from(sequencer_y_parity),
+    );
+
+    let deposit = EncryptedDeposit {
+        token: PATH_USD_ADDRESS,
+        sender: ALICE,
+        amount: 1,
+        tempoRefundRecipient: ALICE,
+        keyIndex: fixture.key_index,
+        encrypted: tempo_zone_contracts::EncryptedDepositPayload {
+            ephemeralPubkeyX: fixture.eph_pub_x,
+            ephemeralPubkeyYParity: fixture.eph_pub_y_parity,
+            ciphertext: ciphertext.into(),
+            nonce: nonce.into(),
+            tag: tag.into(),
+        },
+    };
+    let decryption = DecryptionData {
+        sharedSecret: decrypted.proof.shared_secret,
+        sharedSecretYParity: decrypted.proof.shared_secret_y_parity,
+        cpProof: tempo_zone_contracts::ChaumPedersenProof {
+            s: decrypted.proof.cp_proof_s,
+            c: decrypted.proof.cp_proof_c,
+        },
+    };
+
+    let mut deposits = Vec::with_capacity(MAX_DEPOSITS_PER_TEMPO_BLOCK);
+    let mut decryptions = Vec::with_capacity(MAX_DEPOSITS_PER_TEMPO_BLOCK);
+    let mut head = B256::ZERO;
+    for _ in 0..MAX_DEPOSITS_PER_TEMPO_BLOCK {
+        head = keccak256((DepositType::Encrypted, deposit.clone(), head).abi_encode_params());
+        deposits.push(QueuedDeposit {
+            depositType: DepositType::Encrypted,
+            depositData: deposit.abi_encode().into(),
+        });
+        decryptions.push(decryption.clone());
+    }
+
+    harness.set_queue_hash(head);
+    let calldata = harness.advance_call(deposits, decryptions).abi_encode();
+    let output = harness.call_with_gas(Address::ZERO, calldata, SYSTEM_GAS)?;
+    assert!(output.is_success());
+    Ok(output.gas_used)
+}
+
+#[test]
+fn max_portal_deposit_block_fits_system_gas_budget() -> eyre::Result<()> {
+    const BUFFERED_GAS_LIMIT: u64 = 200_000_000;
+
+    for spec in [TempoHardfork::T7, TempoHardfork::T9] {
+        let gas_used = worst_case_encrypted_deposit_block_gas(spec)?;
+        eprintln!("max portal deposit block at {spec:?}: {gas_used} gas");
+        assert!(
+            gas_used <= BUFFERED_GAS_LIMIT,
+            "max deposit block used {gas_used} gas at {spec:?}"
+        );
+    }
+    Ok(())
 }
 
 #[test]

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -50,16 +50,8 @@ impl Harness {
     }
 
     fn with_l1(l1: MockL1Reader) -> eyre::Result<Self> {
-        Self::with_l1_and_spec(l1, TempoHardfork::default())
-    }
-
-    fn with_spec(spec: TempoHardfork) -> eyre::Result<Self> {
-        Self::with_l1_and_spec(MockL1Reader::default(), spec)
-    }
-
-    fn with_l1_and_spec(l1: MockL1Reader, spec: TempoHardfork) -> eyre::Result<Self> {
         let mut ctx = test_context();
-        ctx.cfg.spec = spec;
+        ctx.cfg.spec = TempoHardfork::T9;
         let genesis_rlp = encode_header(&TempoHeader::default());
         let genesis_hash = keccak256(&genesis_rlp);
         {
@@ -68,9 +60,7 @@ impl Harness {
                 TempoState::new().initialize(&genesis_rlp)?;
                 ZoneInbox::new().initialize()?;
                 ZoneOutbox::new().initialize()?;
-                if spec.is_t6() {
-                    ReceivePolicyGuard::new().initialize()?;
-                }
+                ReceivePolicyGuard::new().initialize()?;
                 TIP20Setup::path_usd(ALICE)
                     .with_issuer(ALICE)
                     .with_issuer(ZONE_INBOX_ADDRESS)
@@ -219,11 +209,11 @@ impl Harness {
     }
 }
 
-fn worst_case_encrypted_deposit_block_gas(spec: TempoHardfork) -> eyre::Result<u64> {
+fn worst_case_encrypted_deposit_block_gas() -> eyre::Result<u64> {
     const SYSTEM_GAS: u64 = 250_000_000;
     const MAX_DEPOSITS_PER_TEMPO_BLOCK: usize = 640;
 
-    let mut harness = Harness::with_spec(spec)?;
+    let mut harness = Harness::new()?;
     {
         let mut storage = test_storage_provider(&mut harness.ctx, u64::MAX, false);
         StorageCtx::enter(&mut storage, || {
@@ -303,14 +293,12 @@ fn worst_case_encrypted_deposit_block_gas(spec: TempoHardfork) -> eyre::Result<u
 fn max_portal_deposit_block_fits_system_gas_budget() -> eyre::Result<()> {
     const BUFFERED_GAS_LIMIT: u64 = 200_000_000;
 
-    for spec in [TempoHardfork::T7, TempoHardfork::T9] {
-        let gas_used = worst_case_encrypted_deposit_block_gas(spec)?;
-        eprintln!("max portal deposit block at {spec:?}: {gas_used} gas");
-        assert!(
-            gas_used <= BUFFERED_GAS_LIMIT,
-            "max deposit block used {gas_used} gas at {spec:?}"
-        );
-    }
+    let gas_used = worst_case_encrypted_deposit_block_gas()?;
+    eprintln!("max portal deposit block: {gas_used} gas");
+    assert!(
+        gas_used <= BUFFERED_GAS_LIMIT,
+        "max deposit block used {gas_used} gas"
+    );
     Ok(())
 }
 

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -1028,6 +1028,23 @@ mod tests {
     }
 
     #[test]
+    fn maximum_batch_fits_portal_bounceback_reserve() {
+        const PORTAL_BOUNCEBACK_RESERVE: usize = 20;
+
+        let withdrawals = simple_withdrawals(PORTAL_BOUNCEBACK_RESERVE);
+        let batches = build_withdrawal_batches(&withdrawals, MAX_WITHDRAWAL_BATCH_GAS);
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].len(), 19);
+        assert_eq!(batches[1].len(), 1);
+        assert!(
+            batches
+                .iter()
+                .all(|batch| batch.len() <= PORTAL_BOUNCEBACK_RESERVE)
+        );
+    }
+
+    #[test]
     fn oversized_withdrawal_is_a_singleton() {
         let mut withdrawals = simple_withdrawals(2);
         withdrawals[0].gasLimit = MAX_WITHDRAWAL_GAS_LIMIT;

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -360,7 +360,8 @@ interface IZoneTxContext {
 //   slot 21: _isAccessEnforced (bool) + _isGatewayEnforced (bool) [packed]
 //   slot 22: maxTempoGasRate (uint128)
 //   slot 23: leader (address) + leaderEpoch (uint64) [packed]
-//   slot 24: leaderActivationTempoBlock (uint64)
+//   slot 24: leaderActivationTempoBlock (uint64) + _depositCountBlock (uint64)
+//            + _depositsInCurrentBlock (uint64) [packed]
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via
@@ -640,6 +641,7 @@ interface IZonePortal {
     error InvalidCiphertextLength(uint256 actual, uint256 expected);
     error InvalidProofOfPossession();
     error DepositTooSmall();
+    error DepositBlockCapacityExceeded(uint64 maximum);
     error GasFeeRateTooHigh();
     error TokenNotEnabled();
     error DepositsNotActive();
@@ -680,6 +682,9 @@ interface IZonePortal {
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
+
+    /// @notice Maximum deposits accepted by this portal in one Tempo block.
+    function MAX_DEPOSITS_PER_TEMPO_BLOCK() external view returns (uint64);
 
     /// @notice Maximum callback gas accepted for withdrawals
     function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -55,6 +55,12 @@ contract ZonePortal is IZonePortal {
     ///      to adjust the zoneGasRate based on operational costs.
     uint64 public constant FIXED_DEPOSIT_GAS = 100_000;
 
+    /// @notice Maximum deposits that may be appended to this portal in one Tempo block.
+    /// @dev Across the T7 and T9 gas schedules, the worst measurement for 640 encrypted
+    ///      deposits is 185,613,414 of the 250,000,000 gas available to `advanceTempo`.
+    ///      This leaves 64,386,586 gas (25.75%) for fixed overhead and gas-cost variance.
+    uint64 public constant MAX_DEPOSITS_PER_TEMPO_BLOCK = 640;
+
     /// @notice Scale factor from 18-decimal Tempo gas prices to 6-decimal TIP-20 units
     uint256 internal constant TEMPO_BASE_FEE_SCALE = 1e12;
 
@@ -179,6 +185,10 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Tempo block number that recorded the most recent leader transition.
     uint64 public leaderActivationTempoBlock;
+
+    /// @dev Per-Tempo-block deposit admission counter. Appended for upgrade-safe storage layout.
+    uint64 internal _depositCountBlock;
+    uint64 internal _depositsInCurrentBlock;
 
     /*//////////////////////////////////////////////////////////////
                              INITIALIZATION
@@ -779,6 +789,18 @@ contract ZonePortal is IZonePortal {
         internal
         returns (uint64 thisDeposit)
     {
+        uint64 currentBlock = uint64(block.number);
+        if (_depositCountBlock != currentBlock) {
+            _depositCountBlock = currentBlock;
+            _depositsInCurrentBlock = 0;
+        }
+        if (_depositsInCurrentBlock >= MAX_DEPOSITS_PER_TEMPO_BLOCK) {
+            revert DepositBlockCapacityExceeded(MAX_DEPOSITS_PER_TEMPO_BLOCK);
+        }
+        unchecked {
+            ++_depositsInCurrentBlock;
+        }
+
         currentDepositQueueHash = newCurrentDepositQueueHash;
         thisDeposit = ++depositCount;
     }
@@ -1120,8 +1142,7 @@ contract ZonePortal is IZonePortal {
 
         bytes32 newCurrentDepositQueueHash =
             DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
-        currentDepositQueueHash = newCurrentDepositQueueHash;
-        uint64 thisDeposit = ++depositCount;
+        uint64 thisDeposit = _recordDeposit(newCurrentDepositQueueHash);
 
         emit WithdrawalBounceBack(
             newCurrentDepositQueueHash, fallbackNonce, _token, amount, thisDeposit

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -56,10 +56,14 @@ contract ZonePortal is IZonePortal {
     uint64 public constant FIXED_DEPOSIT_GAS = 100_000;
 
     /// @notice Maximum deposits that may be appended to this portal in one Tempo block.
-    /// @dev Across the T7 and T9 gas schedules, the worst measurement for 640 encrypted
-    ///      deposits is 185,613,414 of the 250,000,000 gas available to `advanceTempo`.
-    ///      This leaves 64,386,586 gas (25.75%) for fixed overhead and gas-cost variance.
+    /// @dev Under T9, processing 640 encrypted deposits uses 185,349,414 of the
+    ///      250,000,000 gas available to `advanceTempo`. This leaves 64,650,586 gas
+    ///      (25.86%) for fixed overhead and gas-cost variance.
     uint64 public constant MAX_DEPOSITS_PER_TEMPO_BLOCK = 640;
+
+    /// @dev Reserves enough capacity for one maximum-size sequencer withdrawal batch to bounce.
+    ///      The 20M batch gas ceiling fits at most 19 simple withdrawals (plus one slot of margin).
+    uint64 internal constant WITHDRAWAL_BOUNCEBACK_RESERVE = 20;
 
     /// @notice Scale factor from 18-decimal Tempo gas prices to 6-decimal TIP-20 units
     uint256 internal constant TEMPO_BASE_FEE_SCALE = 1e12;
@@ -785,7 +789,10 @@ contract ZonePortal is IZonePortal {
         }
     }
 
-    function _recordDeposit(bytes32 newCurrentDepositQueueHash)
+    function _recordDeposit(
+        bytes32 newCurrentDepositQueueHash,
+        uint64 maximum
+    )
         internal
         returns (uint64 thisDeposit)
     {
@@ -794,8 +801,8 @@ contract ZonePortal is IZonePortal {
             _depositCountBlock = currentBlock;
             _depositsInCurrentBlock = 0;
         }
-        if (_depositsInCurrentBlock >= MAX_DEPOSITS_PER_TEMPO_BLOCK) {
-            revert DepositBlockCapacityExceeded(MAX_DEPOSITS_PER_TEMPO_BLOCK);
+        if (_depositsInCurrentBlock >= maximum) {
+            revert DepositBlockCapacityExceeded(maximum);
         }
         unchecked {
             ++_depositsInCurrentBlock;
@@ -844,7 +851,9 @@ contract ZonePortal is IZonePortal {
 
         // Insert deposit into queue
         newCurrentDepositQueueHash = DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
-        uint64 thisDeposit = _recordDeposit(newCurrentDepositQueueHash);
+        uint64 thisDeposit = _recordDeposit(
+            newCurrentDepositQueueHash, MAX_DEPOSITS_PER_TEMPO_BLOCK - WITHDRAWAL_BOUNCEBACK_RESERVE
+        );
 
         emit DepositMade(
             newCurrentDepositQueueHash,
@@ -935,7 +944,9 @@ contract ZonePortal is IZonePortal {
         // Insert encrypted deposit into queue
         newCurrentDepositQueueHash =
             DepositQueueLib.enqueueEncrypted(currentDepositQueueHash, depositData);
-        uint64 thisDeposit = _recordDeposit(newCurrentDepositQueueHash);
+        uint64 thisDeposit = _recordDeposit(
+            newCurrentDepositQueueHash, MAX_DEPOSITS_PER_TEMPO_BLOCK - WITHDRAWAL_BOUNCEBACK_RESERVE
+        );
 
         emit EncryptedDepositMade(
             newCurrentDepositQueueHash,
@@ -1142,7 +1153,8 @@ contract ZonePortal is IZonePortal {
 
         bytes32 newCurrentDepositQueueHash =
             DepositQueueLib.enqueue(currentDepositQueueHash, depositData);
-        uint64 thisDeposit = _recordDeposit(newCurrentDepositQueueHash);
+        uint64 thisDeposit =
+            _recordDeposit(newCurrentDepositQueueHash, MAX_DEPOSITS_PER_TEMPO_BLOCK);
 
         emit WithdrawalBounceBack(
             newCurrentDepositQueueHash, fallbackNonce, _token, amount, thisDeposit

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 5301,
+      "astId": 5315,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5304,
+      "astId": 5318,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5306,
+      "astId": 5320,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -25,7 +25,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5308,
+      "astId": 5322,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5311,
+      "astId": 5325,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5314,
+      "astId": 5328,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5317,
+      "astId": 5331,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -57,7 +57,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5320,
+      "astId": 5334,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5323,
+      "astId": 5337,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "bouncebackGas",
       "offset": 24,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5328,
+      "astId": 5342,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_array(t_struct(EncryptionKeyEntry)2654_storage)dyn_storage"
     },
     {
-      "astId": 5334,
+      "astId": 5348,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_mapping(t_address,t_struct(TokenConfig)3083_storage)"
     },
     {
-      "astId": 5338,
+      "astId": 5352,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5345,
+      "astId": 5359,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -105,15 +105,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 5349,
+      "astId": 5363,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
       "slot": "9",
-      "type": "t_struct(WithdrawalQueue)4975_storage"
+      "type": "t_struct(WithdrawalQueue)4985_storage"
     },
     {
-      "astId": 5352,
+      "astId": 5366,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 5355,
+      "astId": 5369,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5358,
+      "astId": 5372,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5361,
+      "astId": 5375,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5364,
+      "astId": 5378,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -153,7 +153,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5366,
+      "astId": 5380,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5368,
+      "astId": 5382,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 20,
@@ -169,7 +169,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5371,
+      "astId": 5385,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerSetVersion",
       "offset": 21,
@@ -177,7 +177,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5373,
+      "astId": 5387,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerThreshold",
       "offset": 29,
@@ -185,7 +185,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 5375,
+      "astId": 5389,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneHeight",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5378,
+      "astId": 5392,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_sequencers",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5382,
+      "astId": 5396,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "isSequencer",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 5387,
+      "astId": 5401,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "role",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_mapping(t_address,t_enum(Role)2497)"
     },
     {
-      "astId": 5390,
+      "astId": 5404,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isAccessEnforced",
       "offset": 0,
@@ -225,7 +225,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5392,
+      "astId": 5406,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isGatewayEnforced",
       "offset": 1,
@@ -233,7 +233,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5395,
+      "astId": 5409,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enforcementModesPadding",
       "offset": 2,
@@ -241,7 +241,7 @@
       "type": "t_uint240"
     },
     {
-      "astId": 5398,
+      "astId": 5412,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "maxTempoGasRate",
       "offset": 0,
@@ -249,7 +249,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5401,
+      "astId": 5415,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leader",
       "offset": 0,
@@ -257,7 +257,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5404,
+      "astId": 5418,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderEpoch",
       "offset": 20,
@@ -265,10 +265,26 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5407,
+      "astId": 5421,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderActivationTempoBlock",
       "offset": 0,
+      "slot": "24",
+      "type": "t_uint64"
+    },
+    {
+      "astId": 5424,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "_depositCountBlock",
+      "offset": 8,
+      "slot": "24",
+      "type": "t_uint64"
+    },
+    {
+      "astId": 5426,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "_depositsInCurrentBlock",
+      "offset": 16,
       "slot": "24",
       "type": "t_uint64"
     }
@@ -407,13 +423,13 @@
         }
       ]
     },
-    "t_struct(WithdrawalQueue)4975_storage": {
+    "t_struct(WithdrawalQueue)4985_storage": {
       "encoding": "inplace",
       "label": "struct WithdrawalQueue",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 4968,
+          "astId": 4978,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "head",
           "offset": 0,
@@ -421,7 +437,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4970,
+          "astId": 4980,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "tail",
           "offset": 0,
@@ -429,7 +445,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4974,
+          "astId": 4984,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "slots",
           "offset": 0,

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 5315,
+      "astId": 5319,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5318,
+      "astId": 5322,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5320,
+      "astId": 5324,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -25,7 +25,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5322,
+      "astId": 5326,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5325,
+      "astId": 5329,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5328,
+      "astId": 5332,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5331,
+      "astId": 5335,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -57,7 +57,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5334,
+      "astId": 5338,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5337,
+      "astId": 5341,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "bouncebackGas",
       "offset": 24,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5342,
+      "astId": 5346,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_array(t_struct(EncryptionKeyEntry)2654_storage)dyn_storage"
     },
     {
-      "astId": 5348,
+      "astId": 5352,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_mapping(t_address,t_struct(TokenConfig)3083_storage)"
     },
     {
-      "astId": 5352,
+      "astId": 5356,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5359,
+      "astId": 5363,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 5363,
+      "astId": 5367,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_struct(WithdrawalQueue)4985_storage"
     },
     {
-      "astId": 5366,
+      "astId": 5370,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 5369,
+      "astId": 5373,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5372,
+      "astId": 5376,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5375,
+      "astId": 5379,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5378,
+      "astId": 5382,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -153,7 +153,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5380,
+      "astId": 5384,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5382,
+      "astId": 5386,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 20,
@@ -169,7 +169,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5385,
+      "astId": 5389,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerSetVersion",
       "offset": 21,
@@ -177,7 +177,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5387,
+      "astId": 5391,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerThreshold",
       "offset": 29,
@@ -185,7 +185,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 5389,
+      "astId": 5393,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneHeight",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5392,
+      "astId": 5396,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_sequencers",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5396,
+      "astId": 5400,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "isSequencer",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 5401,
+      "astId": 5405,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "role",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_mapping(t_address,t_enum(Role)2497)"
     },
     {
-      "astId": 5404,
+      "astId": 5408,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isAccessEnforced",
       "offset": 0,
@@ -225,7 +225,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5406,
+      "astId": 5410,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isGatewayEnforced",
       "offset": 1,
@@ -233,7 +233,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5409,
+      "astId": 5413,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enforcementModesPadding",
       "offset": 2,
@@ -241,7 +241,7 @@
       "type": "t_uint240"
     },
     {
-      "astId": 5412,
+      "astId": 5416,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "maxTempoGasRate",
       "offset": 0,
@@ -249,7 +249,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5415,
+      "astId": 5419,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leader",
       "offset": 0,
@@ -257,7 +257,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5418,
+      "astId": 5422,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderEpoch",
       "offset": 20,
@@ -265,7 +265,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5421,
+      "astId": 5425,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderActivationTempoBlock",
       "offset": 0,
@@ -273,7 +273,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5424,
+      "astId": 5428,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_depositCountBlock",
       "offset": 8,
@@ -281,7 +281,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5426,
+      "astId": 5430,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_depositsInCurrentBlock",
       "offset": 16,

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -1501,13 +1501,14 @@ contract ZonePortalTest is BaseTest {
 
     function test_deposit_enforcesPerTempoBlockCapAcrossDepositTypes() public {
         uint64 maximum = portal.MAX_DEPOSITS_PER_TEMPO_BLOCK();
+        uint64 maximumPublicDeposits = maximum - 20;
         assertEq(maximum, 640);
         _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 amount = 1;
         vm.startPrank(alice);
         pathUSD.approve(address(portal), uint256(maximum) + 2);
-        for (uint256 i; i < maximum - 1; ++i) {
+        for (uint256 i; i < maximumPublicDeposits - 1; ++i) {
             portal.deposit(address(pathUSD), bob, amount, bytes32(i), bob);
         }
         portal.depositEncrypted(address(pathUSD), amount, 0, _makeEncryptedPayload(), alice);
@@ -1515,15 +1516,17 @@ contract ZonePortalTest is BaseTest {
         bytes32 queueHashAtCapacity = portal.currentDepositQueueHash();
         uint256 aliceBalanceAtCapacity = pathUSD.balanceOf(alice);
         uint256 portalBalanceAtCapacity = pathUSD.balanceOf(address(portal));
-        assertEq(portal.depositCount(), maximum);
+        assertEq(portal.depositCount(), maximumPublicDeposits);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IZonePortal.DepositBlockCapacityExceeded.selector, maximum)
+            abi.encodeWithSelector(
+                IZonePortal.DepositBlockCapacityExceeded.selector, maximumPublicDeposits
+            )
         );
         portal.deposit(address(pathUSD), bob, amount, bytes32("over cap"), bob);
 
         assertEq(portal.currentDepositQueueHash(), queueHashAtCapacity);
-        assertEq(portal.depositCount(), maximum);
+        assertEq(portal.depositCount(), maximumPublicDeposits);
         assertEq(pathUSD.balanceOf(alice), aliceBalanceAtCapacity);
         assertEq(pathUSD.balanceOf(address(portal)), portalBalanceAtCapacity);
 
@@ -1531,10 +1534,10 @@ contract ZonePortalTest is BaseTest {
         portal.deposit(address(pathUSD), bob, amount, bytes32("next block"), bob);
         vm.stopPrank();
 
-        assertEq(portal.depositCount(), maximum + 1);
+        assertEq(portal.depositCount(), maximumPublicDeposits + 1);
     }
 
-    function test_withdrawalBounceBack_sharesPerTempoBlockDepositCap() public {
+    function test_withdrawalBounceBack_usesReservedBatchCapacityWithoutBlockingQueue() public {
         vm.startPrank(alice);
         pathUSD.approve(address(portal), 1000e6);
         portal.deposit(address(pathUSD), alice, 1000e6, bytes32("escrow"), alice);
@@ -1545,13 +1548,19 @@ contract ZonePortalTest is BaseTest {
             address(pathUSD),
             alice,
             address(gasConsumingReceiver),
-            500e6,
-            bytes32("payment"),
+            1,
+            bytes32("failed"),
             50_000,
             bob,
             ""
         );
-        bytes32 withdrawalHash = keccak256(abi.encode(withdrawal, EMPTY_SENTINEL));
+        uint256 reserve = 20;
+        Withdrawal[] memory withdrawals = new Withdrawal[](reserve);
+        bytes32 withdrawalHash = EMPTY_SENTINEL;
+        for (uint256 i = reserve; i > 0; --i) {
+            withdrawals[i - 1] = withdrawal;
+            withdrawalHash = keccak256(abi.encode(withdrawal, withdrawalHash));
+        }
 
         vm.roll(block.number + 1);
         _submitBatch(
@@ -1573,25 +1582,30 @@ contract ZonePortalTest is BaseTest {
         );
 
         uint64 maximum = portal.MAX_DEPOSITS_PER_TEMPO_BLOCK();
+        uint64 maximumPublicDeposits = maximum - uint64(reserve);
         vm.startPrank(alice);
         pathUSD.approve(address(portal), maximum);
-        for (uint256 i; i < maximum; ++i) {
+        for (uint256 i; i < maximumPublicDeposits; ++i) {
             portal.deposit(address(pathUSD), bob, 1, bytes32(i), bob);
         }
         vm.stopPrank();
 
-        bytes32 queueHashAtCapacity = portal.currentDepositQueueHash();
-        vm.expectRevert(
-            abi.encodeWithSelector(IZonePortal.DepositBlockCapacityExceeded.selector, maximum)
-        );
-        portal.processWithdrawals(_singleWithdrawal(withdrawal), bytes32(0));
-        assertEq(portal.currentDepositQueueHash(), queueHashAtCapacity);
-        assertEq(portal.withdrawalQueueHead(), 0);
+        bytes32 queueHashAtPublicCapacity = portal.currentDepositQueueHash();
+        portal.processWithdrawals(withdrawals, bytes32(0));
 
-        vm.roll(block.number + 1);
-        portal.processWithdrawals(_singleWithdrawal(withdrawal), bytes32(0));
-        assertTrue(portal.currentDepositQueueHash() != queueHashAtCapacity);
+        bytes32 queueHashAtCapacity = portal.currentDepositQueueHash();
+        assertTrue(queueHashAtCapacity != queueHashAtPublicCapacity);
+        assertEq(portal.depositCount(), maximum + 1);
         assertEq(portal.withdrawalQueueHead(), 1);
+        assertEq(portal.withdrawalQueueSlot(0), EMPTY_SENTINEL);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IZonePortal.DepositBlockCapacityExceeded.selector, maximumPublicDeposits
+            )
+        );
+        vm.prank(alice);
+        portal.deposit(address(pathUSD), bob, 1, bytes32("reserved"), bob);
     }
 
     function test_deposit_hashChainStructure() public {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -1499,6 +1499,101 @@ contract ZonePortalTest is BaseTest {
         assertEq(pathUSD.balanceOf(address(portal)), amount1 + amount2);
     }
 
+    function test_deposit_enforcesPerTempoBlockCapAcrossDepositTypes() public {
+        uint64 maximum = portal.MAX_DEPOSITS_PER_TEMPO_BLOCK();
+        assertEq(maximum, 640);
+        _setEncKeyWithPoP(ENC_KEY_1);
+
+        uint128 amount = 1;
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), uint256(maximum) + 2);
+        for (uint256 i; i < maximum - 1; ++i) {
+            portal.deposit(address(pathUSD), bob, amount, bytes32(i), bob);
+        }
+        portal.depositEncrypted(address(pathUSD), amount, 0, _makeEncryptedPayload(), alice);
+
+        bytes32 queueHashAtCapacity = portal.currentDepositQueueHash();
+        uint256 aliceBalanceAtCapacity = pathUSD.balanceOf(alice);
+        uint256 portalBalanceAtCapacity = pathUSD.balanceOf(address(portal));
+        assertEq(portal.depositCount(), maximum);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.DepositBlockCapacityExceeded.selector, maximum)
+        );
+        portal.deposit(address(pathUSD), bob, amount, bytes32("over cap"), bob);
+
+        assertEq(portal.currentDepositQueueHash(), queueHashAtCapacity);
+        assertEq(portal.depositCount(), maximum);
+        assertEq(pathUSD.balanceOf(alice), aliceBalanceAtCapacity);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBalanceAtCapacity);
+
+        vm.roll(block.number + 1);
+        portal.deposit(address(pathUSD), bob, amount, bytes32("next block"), bob);
+        vm.stopPrank();
+
+        assertEq(portal.depositCount(), maximum + 1);
+    }
+
+    function test_withdrawalBounceBack_sharesPerTempoBlockDepositCap() public {
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), 1000e6);
+        portal.deposit(address(pathUSD), alice, 1000e6, bytes32("escrow"), alice);
+        vm.stopPrank();
+
+        bytes32 processedDepositHash = portal.currentDepositQueueHash();
+        Withdrawal memory withdrawal = _withdrawal(
+            address(pathUSD),
+            alice,
+            address(gasConsumingReceiver),
+            500e6,
+            bytes32("payment"),
+            50_000,
+            bob,
+            ""
+        );
+        bytes32 withdrawalHash = keccak256(abi.encode(withdrawal, EMPTY_SENTINEL));
+
+        vm.roll(block.number + 1);
+        _submitBatch(
+            portal,
+            uint64(block.number - 1),
+            0,
+            BlockTransition({
+                prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("bounce-back-cap")
+            }),
+            DepositQueueTransition({
+                prevProcessedHash: bytes32(0),
+                nextProcessedHash: processedDepositHash,
+                prevDepositNumber: 0,
+                nextDepositNumber: 1
+            }),
+            withdrawalHash,
+            "",
+            ""
+        );
+
+        uint64 maximum = portal.MAX_DEPOSITS_PER_TEMPO_BLOCK();
+        vm.startPrank(alice);
+        pathUSD.approve(address(portal), maximum);
+        for (uint256 i; i < maximum; ++i) {
+            portal.deposit(address(pathUSD), bob, 1, bytes32(i), bob);
+        }
+        vm.stopPrank();
+
+        bytes32 queueHashAtCapacity = portal.currentDepositQueueHash();
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.DepositBlockCapacityExceeded.selector, maximum)
+        );
+        portal.processWithdrawals(_singleWithdrawal(withdrawal), bytes32(0));
+        assertEq(portal.currentDepositQueueHash(), queueHashAtCapacity);
+        assertEq(portal.withdrawalQueueHead(), 0);
+
+        vm.roll(block.number + 1);
+        portal.processWithdrawals(_singleWithdrawal(withdrawal), bytes32(0));
+        assertTrue(portal.currentDepositQueueHash() != queueHashAtCapacity);
+        assertEq(portal.withdrawalQueueHead(), 1);
+    }
+
     function test_deposit_hashChainStructure() public {
         // Verify the hash chain is built correctly: newest deposits wrap the outside
         uint128 amount = 1000e6;

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -437,6 +437,8 @@ currentDepositQueueHash = keccak256(abi.encode(DepositType.Regular, deposit, cur
 
 The newest deposit is always outermost, making onchain addition O(1). The zone tracks its own `processedDepositQueueHash` and `processedDepositNumber` in state. During `advanceTempo()`, the zone processes deposits oldest-first, rebuilding the hash chain and validating that the result matches `currentDepositQueueHash` read from Tempo state via `TempoState.readTempoStorageSlot()`.
 
+Each portal accepts at most `MAX_DEPOSITS_PER_TEMPO_BLOCK` deposits in one Tempo block. The cap applies to regular deposits, encrypted deposits, and withdrawal bounce-backs because all three append to the same queue. Once the cap is reached, further queue appends revert until the next Tempo block. This bounds the complete per-block deposit vector below the Zone's `advanceTempo()` system gas budget.
+
 `advanceTempo()` reads the portal's `currentDepositQueueHash` from Tempo state via `TempoState.readTempoStorageSlot()`. The call must process deposits through the current queue head: after rebuilding the hash chain, the resulting `processedDepositQueueHash` must equal the portal's `currentDepositQueueHash`.
 
 After a batch is accepted, the portal updates `lastSyncedTempoBlockNumber` to record how far Tempo state was synced, and updates `lastProcessedDepositNumber` from the proven `DepositQueueTransition`. Users should track deposit inclusion by deposit number: `DepositMade` and `EncryptedDepositMade` emit `depositNumber`, `ZoneInbox.TempoAdvanced` emits the inbox's `lastProcessedDepositNumber`, and `ZonePortal.BatchSubmitted` emits the accepted portal value. A deposit with number `N` is processed once `lastProcessedDepositNumber >= N`.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -437,7 +437,7 @@ currentDepositQueueHash = keccak256(abi.encode(DepositType.Regular, deposit, cur
 
 The newest deposit is always outermost, making onchain addition O(1). The zone tracks its own `processedDepositQueueHash` and `processedDepositNumber` in state. During `advanceTempo()`, the zone processes deposits oldest-first, rebuilding the hash chain and validating that the result matches `currentDepositQueueHash` read from Tempo state via `TempoState.readTempoStorageSlot()`.
 
-Each portal accepts at most `MAX_DEPOSITS_PER_TEMPO_BLOCK` deposits in one Tempo block. The cap applies to regular deposits, encrypted deposits, and withdrawal bounce-backs because all three append to the same queue. Once the cap is reached, further queue appends revert until the next Tempo block. This bounds the complete per-block deposit vector below the Zone's `advanceTempo()` system gas budget.
+Each portal accepts at most `MAX_DEPOSITS_PER_TEMPO_BLOCK` deposits in one Tempo block. The cap applies to regular deposits, encrypted deposits, and withdrawal bounce-backs because all three append to the same queue. Twenty slots are reserved for internal withdrawal bounce-backs, enough for one maximum-size sequencer withdrawal batch, so public deposits stop at `MAX_DEPOSITS_PER_TEMPO_BLOCK - 20`. This both bounds the complete per-block deposit vector below the Zone's `advanceTempo()` system gas budget and guarantees FIFO withdrawal progress under sustained public deposit load.
 
 `advanceTempo()` reads the portal's `currentDepositQueueHash` from Tempo state via `TempoState.readTempoStorageSlot()`. The call must process deposits through the current queue head: after rebuilding the hash chain, the resulting `processedDepositQueueHash` must equal the portal's `currentDepositQueueHash`.
 


### PR DESCRIPTION
## Summary
- cap each `ZonePortal` at 640 total deposit queue entries per Tempo block
- cap public regular/encrypted deposits at 620, reserving 20 slots for one complete withdrawal bounce-back batch
- add gas-budget, withdrawal-liveness, planner-bound, storage-layout, and portal behavior regression coverage

## Why
`advanceTempo` must atomically process every deposit emitted in one finalized Tempo block under the 250,000,000 gas system budget. Without admission control in the portal, an oversized block can make the next L1 advance unexecutable.

The internal reserve also prevents public deposits from consuming every queue slot before `processWithdrawals`: the official 20M-gas withdrawal batch can contain at most 19 simple withdrawals, so 20 reserved slots let at least one complete batch advance the FIFO under sustained public deposit load.

## Capacity calculation
The regression conservatively exercises 640 encrypted deposits whose recipients reject the transfer, including decryption and receive-policy handling. This is more expensive than the reachable maximum mix of 620 public deposits and 20 regular bounce-backs.

- T9 gas used: 185,349,414
- System budget: 250,000,000
- Headroom: 64,650,586 gas (25.86%)

The regression enforces a stricter 200,000,000-gas ceiling, preserving at least a 20% buffer.

## Validation
- `forge test --match-path test/tempo/ZonePortal.t.sol` — 169 passed
- `rustup run nightly cargo test -p zone-precompiles` — 120 passed
- `rustup run nightly cargo test -p zone-sequencer` — 62 passed
- regenerated and verified `ZonePortal` storage layout
- `forge build --sizes` — `ZonePortal` runtime 22,257 bytes, 2,319-byte margin
- formatting and diff checks passed

Linear: ZONE-167