### PR TITLE
feat(verifier): bind zone height to proof interface

### DIFF
--- a/.github/workflows/sync-tempo-zone-runtimes.yml
+++ b/.github/workflows/sync-tempo-zone-runtimes.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           forge inspect ZonePortal deployedBytecode > "$RUNNER_TEMP/ZonePortal"
           forge inspect ZoneMessenger deployedBytecode > "$RUNNER_TEMP/ZoneMessenger"
+          forge inspect Verifier deployedBytecode > "$RUNNER_TEMP/Verifier"
 
       - name: Mint Tempo pull request token
         id: app-token
@@ -63,6 +64,7 @@ jobs:
           python3 zones/scripts/sync-tempo-zone-runtimes.py \
             --runtime "ZonePortal=$RUNNER_TEMP/ZonePortal" \
             --runtime "ZoneMessenger=$RUNNER_TEMP/ZoneMessenger" \
+            --runtime "Verifier=$RUNNER_TEMP/Verifier" \
             --tempo-file tempo/crates/contracts/src/zones.rs \
             --presto tempo/crates/chainspec/src/genesis/presto.json \
             --zones-sha "$GITHUB_SHA" \
@@ -101,7 +103,7 @@ jobs:
             title="chore(contracts): sync Zone runtimes"
           fi
           printf \
-            "Syncs the embedded ZonePortal and ZoneMessenger runtimes with [tempoxyz/zones@%s](https://github.com/tempoxyz/zones/commit/%s).\n" \
+            "Syncs the embedded ZonePortal, ZoneMessenger, and Verifier runtimes with [tempoxyz/zones@%s](https://github.com/tempoxyz/zones/commit/%s).\n" \
             "$ZONES_SHA" "$ZONES_SHA" > "$RUNNER_TEMP/runtimes-pr-body.md"
 
           pr=$(gh pr list \

--- a/scripts/sync-tempo-zone-runtimes.py
+++ b/scripts/sync-tempo-zone-runtimes.py
@@ -9,6 +9,7 @@ from pathlib import Path
 CONSTANTS = {
     "ZonePortal": "ZONE_PORTAL_RUNTIME",
     "ZoneMessenger": "ZONE_MESSENGER_RUNTIME",
+    "Verifier": "ZONE_VERIFIER_RUNTIME",
 }
 
 

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -394,13 +394,15 @@ interface IVerifier {
     ///      3. If anchorBlockNumber == tempoBlockNumber: zone's hash matches anchorBlockHash
     ///      4. If anchorBlockNumber > tempoBlockNumber: ancestry chain from tempoBlockNumber to anchorBlockNumber
     ///      5. ZoneOutbox.lastBatch().withdrawalBatchIndex == expectedWithdrawalBatchIndex
-    ///      6. ZoneOutbox.lastBatch().withdrawalQueueHash matches withdrawalQueueHash
-    ///      7. Deposit processing is correct (validated via Tempo state read inside proof)
+    ///      6. Final proven Zone block number == expectedZoneHeight
+    ///      7. ZoneOutbox.lastBatch().withdrawalQueueHash matches withdrawalQueueHash
+    ///      8. Deposit processing is correct (validated via Tempo state read inside proof)
     /// @param zoneId Unique identifier of the zone whose batch is being verified
     /// @param tempoBlockNumber Block zone committed to (from TempoState)
     /// @param anchorBlockNumber Block whose hash is verified (tempoBlockNumber or recent block)
     /// @param anchorBlockHash Hash of anchorBlockNumber (from EIP-2935)
     /// @param expectedWithdrawalBatchIndex Expected batch index (portal.withdrawalBatchIndex + 1)
+    /// @param expectedZoneHeight Expected final Zone block number (portal nextZoneHeight)
     /// @param blockTransition Zone block hash transition
     /// @param depositQueueTransition Deposit queue processing transition
     /// @param withdrawalQueueHash Withdrawal queue hash chain for this batch (0 if none)
@@ -412,6 +414,7 @@ interface IVerifier {
         uint64 anchorBlockNumber,
         bytes32 anchorBlockHash,
         uint64 expectedWithdrawalBatchIndex,
+        uint256 expectedZoneHeight,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
         bytes32 withdrawalQueueHash,

--- a/specs/ref-impls/src/tempo/Verifier.sol
+++ b/specs/ref-impls/src/tempo/Verifier.sol
@@ -16,6 +16,7 @@ contract Verifier is IVerifier {
         uint64,
         bytes32,
         uint64,
+        uint256,
         BlockTransition calldata,
         DepositQueueTransition calldata,
         bytes32,

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -1214,6 +1214,7 @@ contract ZonePortal is IZonePortal {
                 anchorBlockNumber,
                 anchorBlockHash,
                 withdrawalBatchIndex + 1,
+                nextZoneHeight,
                 blockTransition,
                 depositQueueTransition,
                 withdrawalQueueHash,

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 5301,
+      "astId": 5303,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5304,
+      "astId": 5306,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5306,
+      "astId": 5308,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -25,7 +25,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5308,
+      "astId": 5310,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5311,
+      "astId": 5313,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5314,
+      "astId": 5316,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5317,
+      "astId": 5319,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -57,7 +57,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5320,
+      "astId": 5322,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5323,
+      "astId": 5325,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "bouncebackGas",
       "offset": 24,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5328,
+      "astId": 5330,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
@@ -81,15 +81,15 @@
       "type": "t_array(t_struct(EncryptionKeyEntry)2654_storage)dyn_storage"
     },
     {
-      "astId": 5334,
+      "astId": 5336,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
       "slot": "6",
-      "type": "t_mapping(t_address,t_struct(TokenConfig)3083_storage)"
+      "type": "t_mapping(t_address,t_struct(TokenConfig)3085_storage)"
     },
     {
-      "astId": 5338,
+      "astId": 5340,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5345,
+      "astId": 5347,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -105,15 +105,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 5349,
+      "astId": 5351,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
       "slot": "9",
-      "type": "t_struct(WithdrawalQueue)4975_storage"
+      "type": "t_struct(WithdrawalQueue)4977_storage"
     },
     {
-      "astId": 5352,
+      "astId": 5354,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 5355,
+      "astId": 5357,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5358,
+      "astId": 5360,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5361,
+      "astId": 5363,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5364,
+      "astId": 5366,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -153,7 +153,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5366,
+      "astId": 5368,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5368,
+      "astId": 5370,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 20,
@@ -169,7 +169,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5371,
+      "astId": 5373,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerSetVersion",
       "offset": 21,
@@ -177,7 +177,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5373,
+      "astId": 5375,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerThreshold",
       "offset": 29,
@@ -185,7 +185,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 5375,
+      "astId": 5377,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneHeight",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5378,
+      "astId": 5380,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_sequencers",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5382,
+      "astId": 5384,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "isSequencer",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 5387,
+      "astId": 5389,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "role",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_mapping(t_address,t_enum(Role)2497)"
     },
     {
-      "astId": 5390,
+      "astId": 5392,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isAccessEnforced",
       "offset": 0,
@@ -225,7 +225,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5392,
+      "astId": 5394,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isGatewayEnforced",
       "offset": 1,
@@ -233,7 +233,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5395,
+      "astId": 5397,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enforcementModesPadding",
       "offset": 2,
@@ -241,7 +241,7 @@
       "type": "t_uint240"
     },
     {
-      "astId": 5398,
+      "astId": 5400,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "maxTempoGasRate",
       "offset": 0,
@@ -249,7 +249,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5401,
+      "astId": 5403,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leader",
       "offset": 0,
@@ -257,7 +257,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5404,
+      "astId": 5406,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderEpoch",
       "offset": 20,
@@ -265,7 +265,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5407,
+      "astId": 5409,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderActivationTempoBlock",
       "offset": 0,
@@ -327,12 +327,12 @@
       "numberOfBytes": "32",
       "value": "t_mapping(t_address,t_uint128)"
     },
-    "t_mapping(t_address,t_struct(TokenConfig)3083_storage)": {
+    "t_mapping(t_address,t_struct(TokenConfig)3085_storage)": {
       "encoding": "mapping",
       "key": "t_address",
       "label": "mapping(address => struct TokenConfig)",
       "numberOfBytes": "32",
-      "value": "t_struct(TokenConfig)3083_storage"
+      "value": "t_struct(TokenConfig)3085_storage"
     },
     "t_mapping(t_address,t_uint128)": {
       "encoding": "mapping",
@@ -384,13 +384,13 @@
         }
       ]
     },
-    "t_struct(TokenConfig)3083_storage": {
+    "t_struct(TokenConfig)3085_storage": {
       "encoding": "inplace",
       "label": "struct TokenConfig",
       "numberOfBytes": "32",
       "members": [
         {
-          "astId": 3080,
+          "astId": 3082,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "enabled",
           "offset": 0,
@@ -398,7 +398,7 @@
           "type": "t_bool"
         },
         {
-          "astId": 3082,
+          "astId": 3084,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "depositsActive",
           "offset": 1,
@@ -407,13 +407,13 @@
         }
       ]
     },
-    "t_struct(WithdrawalQueue)4975_storage": {
+    "t_struct(WithdrawalQueue)4977_storage": {
       "encoding": "inplace",
       "label": "struct WithdrawalQueue",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 4968,
+          "astId": 4970,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "head",
           "offset": 0,
@@ -421,7 +421,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4970,
+          "astId": 4972,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "tail",
           "offset": 0,
@@ -429,7 +429,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4974,
+          "astId": 4976,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "slots",
           "offset": 0,

--- a/specs/ref-impls/test/mocks/MockVerifier.sol
+++ b/specs/ref-impls/test/mocks/MockVerifier.sol
@@ -19,6 +19,7 @@ contract MockVerifier is IVerifier {
         uint64, // anchorBlockNumber
         bytes32, // anchorBlockHash
         uint64, // expectedWithdrawalBatchIndex
+        uint256, // expectedZoneHeight
         BlockTransition calldata,
         DepositQueueTransition calldata,
         bytes32, // withdrawalQueueHash

--- a/specs/ref-impls/test/tempo/Verifier.t.sol
+++ b/specs/ref-impls/test/tempo/Verifier.t.sol
@@ -18,6 +18,7 @@ contract VerifierTest is Test {
             1,
             bytes32("anchor"),
             1,
+            1,
             BlockTransition({ prevBlockHash: bytes32("prev"), nextBlockHash: bytes32("next") }),
             DepositQueueTransition({
                 prevProcessedHash: bytes32(0),

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { StdPrecompiles } from "tempo-std/StdPrecompiles.sol";
+import { ISignatureVerifier } from "tempo-std/interfaces/ISignatureVerifier.sol";
 import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 import { ITIP403Registry } from "tempo-std/interfaces/ITIP403Registry.sol";
 
@@ -1662,6 +1663,61 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.blockHash(), newStateRoot);
         assertEq(portal.withdrawalBatchIndex(), 1);
         assertEq(portal.lastSyncedTempoBlockNumber(), uint64(block.number - 1));
+    }
+
+    function test_submitBatch_passesZoneHeightToVerifier() public {
+        vm.roll(block.number + 1);
+
+        uint64 tempoBlockNumber = uint64(block.number - 1);
+        BlockTransition memory blockTransition = BlockTransition({
+            prevBlockHash: portal.blockHash(), nextBlockHash: keccak256("next block")
+        });
+        DepositQueueTransition memory depositQueueTransition = DepositQueueTransition({
+            prevProcessedHash: bytes32(0),
+            nextProcessedHash: bytes32(0),
+            prevDepositNumber: 0,
+            nextDepositNumber: 0
+        });
+        uint256 nextZoneHeight = 42;
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = hex"01";
+        vm.mockCall(
+            address(StdPrecompiles.SIGNATURE_VERIFIER),
+            abi.encodeWithSelector(ISignatureVerifier.recover.selector),
+            abi.encode(sequencer)
+        );
+
+        vm.expectCall(
+            ZONE_VERIFIER_ADDRESS,
+            abi.encodeCall(
+                IVerifier.verify,
+                (
+                    testZoneId,
+                    tempoBlockNumber,
+                    tempoBlockNumber,
+                    getBlockHash(tempoBlockNumber),
+                    1,
+                    nextZoneHeight,
+                    blockTransition,
+                    depositQueueTransition,
+                    bytes32(0),
+                    bytes(""),
+                    bytes("")
+                )
+            )
+        );
+
+        portal.submitBatch(
+            tempoBlockNumber,
+            0,
+            blockTransition,
+            depositQueueTransition,
+            bytes32(0),
+            "",
+            "",
+            nextZoneHeight,
+            signatures
+        );
     }
 
     function test_submitBatch_emitsAssignedWithdrawalQueueIndex() public {

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1040,7 +1040,7 @@ It takes a complete witness of zone blocks and their dependencies, executes EVM 
 
 The witness contains everything needed to re-execute the batch:
 
-- **PublicInputs**: `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. These are the values the portal passes to the verifier and the proof must be consistent with. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `zone_id`. The bootstrap batch has to continue through at least one non-genesis block.
+- **PublicInputs**: `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `expected_zone_height`, `sequencer`. These are the values the portal passes to the verifier and the proof must be consistent with. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `zone_id`. The bootstrap batch has to continue through at least one non-genesis block.
 - **BatchWitness**: the public inputs, the previous batch's canonical Tempo header (absent for the bootstrap proof), the zone blocks to execute, the initial zone state, Tempo state proofs, and Tempo ancestry headers (for ancestry validation).
 - **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `beneficiary`, `protocol_version`, `tempo_header_rlp` (required for every non-genesis block), `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
 - **ZoneStateWitness**: the initial zone state root, a deduplicated pool of zone-state trie nodes, and decoded account / storage reads needed to bootstrap execution. Only accounts and storage slots accessed during execution are included. Missing witness data must produce an error, not default to zero, to prevent the prover from omitting non-zero state.
@@ -1054,7 +1054,7 @@ flowchart TB
     subgraph BW["BatchWitness"]
         direction TB
 
-        PI["PublicInputs<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>sequencer"]
+        PI["PublicInputs<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>expected_zone_height<br/>sequencer"]
 
         PH["TempoHeader<br/>canonical Tempo fields"]
 
@@ -1139,6 +1139,9 @@ pub struct PublicInputs {
 
     /// Expected withdrawal batch index (passed by portal as withdrawalBatchIndex + 1)
     pub expected_withdrawal_batch_index: u64,
+
+    /// Expected final Zone block number (passed by portal as nextZoneHeight)
+    pub expected_zone_height: U256,
 
     /// Registered sequencer (passed by portal; zone block beneficiary must match)
     pub sequencer: Address,
@@ -1316,6 +1319,7 @@ The state transition function produces:
 | Field | Description |
 |-------|-------------|
 | `block_transition` | `prev_block_hash` to `next_block_hash` covering all blocks in the batch |
+| `zone_height` | Block number of the final executed Zone block |
 | `deposit_queue_transition` | Deposit queue progress from the previous `(processed_hash, deposit_number)` pair to the next `(processed_hash, deposit_number)` pair |
 | `withdrawal_queue_hash` | Hash chain of withdrawals finalized in this batch (`0` if none) |
 | `last_batch_commitment` | `withdrawal_batch_index` read from `ZoneOutbox.lastBatch` |
@@ -1358,7 +1362,7 @@ The stateless execution function must reject the witness on any failed check, mi
     Require `TempoState.tempoBlockNumber == public_inputs.tempo_block_number`. If `anchor_block_number == tempo_block_number`, require `TempoState.tempoBlockHash == anchor_block_hash`. Otherwise, verify the parent-hash chain from `tempo_block_number` to `anchor_block_number` using `tempo_ancestry_headers`, ending at `anchor_block_hash`. This check also applies to the bootstrap proof because its required non-genesis block imports Tempo.
 
 12. **Return the batch outputs.**
-    Set `block_transition.prev_block_hash = initial_prev_block_hash` and `block_transition.next_block_hash = prev_block_hash` after the final block. Set `deposit_queue_transition.prev_processed_hash` and `deposit_queue_transition.prev_deposit_number` to the values captured before executing the batch, and set `deposit_queue_transition.next_processed_hash` and `deposit_queue_transition.next_deposit_number` to the final inbox processed hash and processed deposit number. Set `withdrawal_queue_hash` and `last_batch_commitment.withdrawal_batch_index` from the final `ZoneOutbox.lastBatch` state.
+    Set `block_transition.prev_block_hash = initial_prev_block_hash` and `block_transition.next_block_hash = prev_block_hash` after the final block. Set `zone_height` to the final executed block header's number and require `U256::from(zone_height) == public_inputs.expected_zone_height`. Set `deposit_queue_transition.prev_processed_hash` and `deposit_queue_transition.prev_deposit_number` to the values captured before executing the batch, and set `deposit_queue_transition.next_processed_hash` and `deposit_queue_transition.next_deposit_number` to the final inbox processed hash and processed deposit number. Set `withdrawal_queue_hash` and `last_batch_commitment.withdrawal_batch_index` from the final `ZoneOutbox.lastBatch` state.
 
 ### Tempo State Proofs
 
@@ -1424,6 +1428,7 @@ interface IVerifier {
         uint64 anchorBlockNumber,
         bytes32 anchorBlockHash,
         uint64 expectedWithdrawalBatchIndex,
+        uint256 expectedZoneHeight,
         BlockTransition calldata blockTransition,
         DepositQueueTransition calldata depositQueueTransition,
         bytes32 withdrawalQueueHash,
@@ -1433,7 +1438,7 @@ interface IVerifier {
 }
 ```
 
-The portal passes its `zoneId`, computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)), and passes them alongside the portal's current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex`. The `verifierConfig` and `proof` are opaque to the portal. Sequencer authorization is enforced separately by the portal's versioned threshold certificate.
+The portal passes its `zoneId`, computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)), passes its current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex`, and passes the submitted `nextZoneHeight` as `expectedZoneHeight`. The verifier must bind `expectedZoneHeight` to the final Zone block number proven by the batch. The `verifierConfig` and `proof` are opaque to the portal. Sequencer authorization is enforced separately by the portal's versioned threshold certificate.
 
 ### Anchor Block Validation
 
@@ -1450,14 +1455,15 @@ If `recentTempoBlockNumber` is greater than `tempoBlockNumber`, the portal looks
 The proof must validate:
 
 1. The state transition from `prevBlockHash` to `nextBlockHash` is correct.
-2. The zone committed to `tempoBlockNumber` via `TempoState`.
-3. The zone's `tempoBlockHash` matches `anchorBlockHash` (direct), or the parent-hash chain from `tempoBlockNumber` to `anchorBlockNumber` is valid (ancestry).
-4. `ZoneOutbox.lastBatch().withdrawalBatchIndex` equals `expectedWithdrawalBatchIndex`.
-5. `ZoneOutbox.lastBatch().withdrawalQueueHash` matches the submitted `withdrawalQueueHash`.
-6. Every non-genesis zone block `beneficiary` is an active member of the versioned sequencer set committed by the settlement certificate; the genesis block must match the canonical header in full.
-7. Deposit processing is correct: deposits are processed oldest-first and contiguously from `prevProcessedHash`, `nextProcessedHash` equals the post-state `ZoneInbox.processedDepositQueueHash`, `nextDepositNumber` equals the post-state processed deposit number, and the proof shows `nextProcessedHash` equals the portal's `currentDepositQueueHash` read from Tempo state.
+2. The final proven Zone block number equals `expectedZoneHeight`.
+3. The zone committed to `tempoBlockNumber` via `TempoState`.
+4. The zone's `tempoBlockHash` matches `anchorBlockHash` (direct), or the parent-hash chain from `tempoBlockNumber` to `anchorBlockNumber` is valid (ancestry).
+5. `ZoneOutbox.lastBatch().withdrawalBatchIndex` equals `expectedWithdrawalBatchIndex`.
+6. `ZoneOutbox.lastBatch().withdrawalQueueHash` matches the submitted `withdrawalQueueHash`.
+7. Every non-genesis zone block `beneficiary` is an active member of the versioned sequencer set committed by the settlement certificate; the genesis block must match the canonical header in full.
+8. Deposit processing is correct: deposits are processed oldest-first and contiguously from `prevProcessedHash`, `nextProcessedHash` equals the post-state `ZoneInbox.processedDepositQueueHash`, `nextDepositNumber` equals the post-state processed deposit number, and the proof shows `nextProcessedHash` equals the portal's `currentDepositQueueHash` read from Tempo state.
 
-For the first proof, requirement 1 specifically means a transition from `prevBlockHash == 0` through the canonical zone genesis block derived from `zoneId` to the final non-genesis block of a batch containing at least two blocks. That batch's first Tempo import makes requirement 3 applicable immediately and includes the non-zero portal sequencer storage proof described above.
+For the first proof, requirement 1 specifically means a transition from `prevBlockHash == 0` through the canonical zone genesis block derived from `zoneId` to the final non-genesis block of a batch containing at least two blocks. That batch's first Tempo import makes requirement 4 applicable immediately and includes the non-zero portal sequencer storage proof described above.
 
 ## Zone Precompiles
 


### PR DESCRIPTION
Adds the submitted Zone height to the verifier-facing settlement inputs so a proving backend can bind the Portal's persisted height to the batch's final block number.

It:

- passes `nextZoneHeight` from `ZonePortal` as `IVerifier.expectedZoneHeight`;
- defines `expected_zone_height` and `BatchOutput.zone_height` in the proving specification;
- extends the Tempo runtime sync to stage the changed Portal and Verifier together; and
- adds an exact-calldata regression test for the Portal-to-verifier call.

The current verifier remains a permissive stub, so enforcement begins when a proving backend validates the documented equality. The coordinated runtime update is required because the new parameter changes the `verify` selector.

Closes CYCLOPS-553