### PR TITLE
fix: scope zone chain IDs by parent network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11553,8 +11553,8 @@ dependencies = [
  "tempo-revm",
  "tempo-zone-contracts",
  "tokio",
+ "zone-chainspec",
  "zone-precompiles",
- "zone-primitives",
  "zone-sequencer",
 ]
 
@@ -13401,6 +13401,7 @@ dependencies = [
  "reth-network-peers",
  "tempo-chainspec",
  "tempo-primitives",
+ "zone-primitives",
 ]
 
 [[package]]

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -11,6 +11,9 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+# zone
+zone-primitives.workspace = true
+
 # tempo
 tempo-chainspec.workspace = true
 tempo-primitives.workspace = true

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -13,8 +13,21 @@ use reth_chainspec::{
 };
 use reth_network_peers::NodeRecord;
 use std::{fmt::Display, sync::Arc};
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TempoHardforks};
+use tempo_chainspec::{
+    TempoChainSpec,
+    hardfork::TempoHardfork,
+    spec::{PRESTO, TempoHardforks},
+};
 use tempo_primitives::TempoHeader;
+
+/// Derives a Zone's EIP-155 chain ID from its parent Tempo chain specification.
+pub fn zone_chain_id(parent: &TempoChainSpec, zone_id: u32) -> u64 {
+    if parent.chain() == PRESTO.chain() {
+        zone_primitives::constants::zone_chain_id(zone_id)
+    } else {
+        zone_primitives::constants::zone_chain_id_testnet(zone_id)
+    }
+}
 
 /// Chain specification for a Tempo Zone.
 ///
@@ -178,7 +191,29 @@ mod tests {
     use super::*;
     #[cfg(feature = "cli")]
     use reth_cli::chainspec::ChainSpecParser;
-    use tempo_chainspec::spec::DEV;
+    use tempo_chainspec::spec::{DEV, MODERATO};
+
+    #[test]
+    fn parent_networks_use_disjoint_zone_chain_ids() {
+        let zone_id = 1;
+
+        assert_eq!(
+            zone_chain_id(&PRESTO, zone_id),
+            zone_primitives::constants::zone_chain_id(zone_id)
+        );
+        assert_eq!(
+            zone_chain_id(&MODERATO, zone_id),
+            zone_primitives::constants::zone_chain_id_testnet(zone_id)
+        );
+        assert_eq!(
+            zone_chain_id(&DEV, zone_id),
+            zone_primitives::constants::zone_chain_id_testnet(zone_id)
+        );
+        assert_ne!(
+            zone_chain_id(&PRESTO, zone_id),
+            zone_chain_id(&MODERATO, zone_id)
+        );
+    }
 
     #[test]
     fn delegates_tempo_chain_behavior() {

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -15,7 +15,7 @@ use alloy_sol_types::SolEvent;
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::{ITIP20, PATH_USD_ADDRESS};
 use tempo_zone_contracts::{ZONE_FACTORY_ADDRESS, ZoneFactory};
-use zone_primitives::constants::zone_chain_id;
+use zone_primitives::constants::zone_chain_id_for_l1;
 use zone_sequencer::register_encryption_key;
 
 /// Provisioning options for [`provision_zone`].
@@ -84,6 +84,7 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .wallet(wallet.clone())
         .connect(&l1_rpc_url)
         .await?;
+    let l1_chain_id = provider.get_chain_id().await?;
 
     ensure_canonical_tempo_header_hash(&provider).await?;
     fund_dev_account(&provider, dev_address).await?;
@@ -140,7 +141,7 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .ok_or_else(|| eyre::eyre!("ZoneCreated event not found"))?;
     let zone_id = zone_created.zoneId;
     let portal = zone_created.portal;
-    let chain_id = zone_chain_id(zone_id);
+    let chain_id = zone_chain_id_for_l1(l1_chain_id, zone_id);
 
     register_encryption_key(&provider, portal, &dev_key).await?;
 

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -15,7 +15,7 @@ use alloy_sol_types::SolEvent;
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::{ITIP20, PATH_USD_ADDRESS};
 use tempo_zone_contracts::{ZONE_FACTORY_ADDRESS, ZoneFactory};
-use zone_primitives::constants::zone_chain_id_for_l1;
+use zone_primitives::constants::zone_chain_id_for_parent;
 use zone_sequencer::register_encryption_key;
 
 /// Provisioning options for [`provision_zone`].
@@ -141,7 +141,7 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .ok_or_else(|| eyre::eyre!("ZoneCreated event not found"))?;
     let zone_id = zone_created.zoneId;
     let portal = zone_created.portal;
-    let chain_id = zone_chain_id_for_l1(l1_chain_id, zone_id);
+    let chain_id = zone_chain_id_for_parent(l1_chain_id, zone_id);
 
     register_encryption_key(&provider, portal, &dev_key).await?;
 

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -13,9 +13,9 @@ use alloy_provider::{PendingTransactionBuilder, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolEvent;
 use tempo_alloy::TempoNetwork;
+use tempo_chainspec::spec::DEV;
 use tempo_contracts::precompiles::{ITIP20, PATH_USD_ADDRESS};
 use tempo_zone_contracts::{ZONE_FACTORY_ADDRESS, ZoneFactory};
-use zone_primitives::constants::zone_chain_id_for_parent;
 use zone_sequencer::register_encryption_key;
 
 /// Provisioning options for [`provision_zone`].
@@ -84,7 +84,6 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .wallet(wallet.clone())
         .connect(&l1_rpc_url)
         .await?;
-    let l1_chain_id = provider.get_chain_id().await?;
 
     ensure_canonical_tempo_header_hash(&provider).await?;
     fund_dev_account(&provider, dev_address).await?;
@@ -141,7 +140,7 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .ok_or_else(|| eyre::eyre!("ZoneCreated event not found"))?;
     let zone_id = zone_created.zoneId;
     let portal = zone_created.portal;
-    let chain_id = zone_chain_id_for_parent(l1_chain_id, zone_id);
+    let chain_id = zone_chainspec::zone_chain_id(&DEV, zone_id);
 
     register_encryption_key(&provider, portal, &dev_key).await?;
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -112,7 +112,9 @@ fn validate_zone_chain_id(zone_id: u32, parent_chain_id: u64, chain_id: u64) -> 
         return Ok(());
     }
 
-    let expected = zone_primitives::constants::zone_chain_id_for_parent(parent_chain_id, zone_id);
+    let parent = tempo_chain_spec_for_l1(parent_chain_id)
+        .ok_or_else(|| eyre::eyre!("unsupported parent Tempo chain ID {parent_chain_id}"))?;
+    let expected = zone_chainspec::zone_chain_id(&parent, zone_id);
     if chain_id != expected {
         eyre::bail!(
             "chain ID mismatch: zone.id={zone_id} on parent chain {parent_chain_id} requires \

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -107,6 +107,22 @@ fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
     })
 }
 
+fn validate_zone_chain_id(zone_id: u32, l1_chain_id: u64, chain_id: u64) -> eyre::Result<()> {
+    if zone_id == 0 {
+        return Ok(());
+    }
+
+    let expected = zone_primitives::constants::zone_chain_id_for_l1(l1_chain_id, zone_id);
+    if chain_id != expected {
+        eyre::bail!(
+            "chain ID mismatch: zone.id={zone_id} on parent chain {l1_chain_id} requires \
+             chain_id={expected}, but genesis has {chain_id}",
+        );
+    }
+
+    Ok(())
+}
+
 /// Network primitives for Zone Nodes
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
@@ -507,6 +523,7 @@ where
             )
             .await?
             .erased();
+        let l1_chain_id = l1_provider.get_chain_id().await?;
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
@@ -542,7 +559,6 @@ where
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let mut p2p_runtime = None;
         if let Some(config) = self.p2p_config.take() {
-            let l1_chain_id = l1_provider.get_chain_id().await?;
             let network_id = P2pNetworkId::new(l1_chain_id, self.portal_address);
             let attestation_domain = AttestationDomain {
                 l1_chain_id,
@@ -657,6 +673,7 @@ where
             self.l1_config.l1_rpc_url.clone(),
             self.l1_config.retry_connection_interval,
             self.l1_config.portal_address,
+            l1_chain_id,
             chain_id,
         )
         .await?;
@@ -685,6 +702,7 @@ where
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.portal_address,
                     self.l1_config.retry_connection_interval,
+                    l1_chain_id,
                     chain_id,
                     attestation.store.clone(),
                 )?),
@@ -734,6 +752,7 @@ where
                 self.l1_config.portal_address,
                 self.l1_config.retry_connection_interval,
                 sequencer_addr,
+                l1_chain_id,
                 chain_id,
                 None,
             )
@@ -927,20 +946,11 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
+        l1_chain_id: u64,
         chain_id: u64,
         attestation_store: Option<AttestationStore>,
     ) -> eyre::Result<LeaderSequencerDeps> {
-        if config.zone_id != 0 {
-            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
-            if chain_id != expected {
-                eyre::bail!(
-                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-                    config.zone_id,
-                    expected,
-                    chain_id,
-                );
-            }
-        }
+        validate_zone_chain_id(config.zone_id, l1_chain_id, chain_id)?;
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
@@ -1072,19 +1082,10 @@ where
         l1_rpc_url: String,
         retry_connection_interval: Duration,
         portal_address: Address,
+        l1_chain_id: u64,
         chain_id: u64,
     ) -> eyre::Result<()> {
-        if config.zone_id != 0 {
-            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
-            if chain_id != expected {
-                eyre::bail!(
-                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-                    config.zone_id,
-                    expected,
-                    chain_id,
-                );
-            }
-        }
+        validate_zone_chain_id(config.zone_id, l1_chain_id, chain_id)?;
 
         let eth_handlers = handle.eth_handlers().clone();
         let zone_rpc_url = handle
@@ -1121,20 +1122,11 @@ where
         portal_address: Address,
         retry_connection_interval: Duration,
         sequencer_addr: Address,
+        l1_chain_id: u64,
         chain_id: u64,
         attestation_store: Option<AttestationStore>,
     ) -> eyre::Result<()> {
-        if config.zone_id != 0 {
-            let expected = zone_primitives::constants::zone_chain_id(config.zone_id);
-            if chain_id != expected {
-                eyre::bail!(
-                    "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-                    config.zone_id,
-                    expected,
-                    chain_id,
-                );
-            }
-        }
+        validate_zone_chain_id(config.zone_id, l1_chain_id, chain_id)?;
 
         info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
         let sequencer_config = ZoneSequencerConfig {
@@ -1555,6 +1547,18 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
         unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
+    }
+
+    #[test]
+    fn validates_zone_chain_id_against_parent_network() {
+        let zone_id = 1;
+        let mainnet_chain_id = zone_primitives::constants::zone_chain_id(zone_id);
+        let testnet_chain_id = zone_primitives::constants::zone_chain_id_testnet(zone_id);
+
+        assert!(validate_zone_chain_id(zone_id, 4217, mainnet_chain_id).is_ok());
+        assert!(validate_zone_chain_id(zone_id, 42431, testnet_chain_id).is_ok());
+        assert!(validate_zone_chain_id(zone_id, 4217, testnet_chain_id).is_err());
+        assert!(validate_zone_chain_id(zone_id, 42431, mainnet_chain_id).is_err());
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -107,15 +107,15 @@ fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
     })
 }
 
-fn validate_zone_chain_id(zone_id: u32, l1_chain_id: u64, chain_id: u64) -> eyre::Result<()> {
+fn validate_zone_chain_id(zone_id: u32, parent_chain_id: u64, chain_id: u64) -> eyre::Result<()> {
     if zone_id == 0 {
         return Ok(());
     }
 
-    let expected = zone_primitives::constants::zone_chain_id_for_l1(l1_chain_id, zone_id);
+    let expected = zone_primitives::constants::zone_chain_id_for_parent(parent_chain_id, zone_id);
     if chain_id != expected {
         eyre::bail!(
-            "chain ID mismatch: zone.id={zone_id} on parent chain {l1_chain_id} requires \
+            "chain ID mismatch: zone.id={zone_id} on parent chain {parent_chain_id} requires \
              chain_id={expected}, but genesis has {chain_id}",
         );
     }

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -167,8 +167,8 @@ pub const fn zone_chain_id_testnet(zone_id: u32) -> u64 {
 ///
 /// Presto zones use the mainnet range. Zones on Moderato and development
 /// parents use the disjoint testnet range.
-pub const fn zone_chain_id_for_l1(l1_chain_id: u64, zone_id: u32) -> u64 {
-    if l1_chain_id == TEMPO_MAINNET_CHAIN_ID {
+pub const fn zone_chain_id_for_parent(parent_chain_id: u64, zone_id: u32) -> u64 {
+    if parent_chain_id == TEMPO_MAINNET_CHAIN_ID {
         zone_chain_id(zone_id)
     } else {
         zone_chain_id_testnet(zone_id)
@@ -184,21 +184,24 @@ mod tests {
         let zone_id = 1;
 
         assert_eq!(
-            zone_chain_id_for_l1(TEMPO_MAINNET_CHAIN_ID, zone_id),
+            zone_chain_id_for_parent(TEMPO_MAINNET_CHAIN_ID, zone_id),
             zone_chain_id(zone_id)
         );
         assert_eq!(
-            zone_chain_id_for_l1(42_431, zone_id),
+            zone_chain_id_for_parent(42_431, zone_id),
             zone_chain_id_testnet(zone_id)
         );
         assert_ne!(
-            zone_chain_id_for_l1(TEMPO_MAINNET_CHAIN_ID, zone_id),
-            zone_chain_id_for_l1(42_431, zone_id)
+            zone_chain_id_for_parent(TEMPO_MAINNET_CHAIN_ID, zone_id),
+            zone_chain_id_for_parent(42_431, zone_id)
         );
     }
 
     #[test]
     fn development_parents_use_the_testnet_range() {
-        assert_eq!(zone_chain_id_for_l1(31_337, 1), zone_chain_id_testnet(1));
+        assert_eq!(
+            zone_chain_id_for_parent(31_337, 1),
+            zone_chain_id_testnet(1)
+        );
     }
 }

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -144,6 +144,9 @@ pub const ZONE_CHAIN_ID_BASE_TESTNET: u64 = 1_424_310_000;
 /// strictly below the EIP-2294 safe ceiling.
 pub const ZONE_CHAIN_ID_RANGE_TESTNET: u64 = 723_173_648;
 
+/// Tempo mainnet (Presto) chain ID.
+pub const TEMPO_MAINNET_CHAIN_ID: u64 = 4_217;
+
 /// Derives the EIP-155 chain ID for a **mainnet** zone from its on-chain zone ID.
 ///
 /// Wraps via modulo so the result always falls in
@@ -158,4 +161,44 @@ pub const fn zone_chain_id(zone_id: u32) -> u64 {
 /// `[ZONE_CHAIN_ID_BASE_TESTNET, ZONE_CHAIN_ID_BASE_TESTNET + ZONE_CHAIN_ID_RANGE_TESTNET)`.
 pub const fn zone_chain_id_testnet(zone_id: u32) -> u64 {
     ZONE_CHAIN_ID_BASE_TESTNET + (zone_id as u64 % ZONE_CHAIN_ID_RANGE_TESTNET)
+}
+
+/// Derives the EIP-155 chain ID for a zone from its parent Tempo chain.
+///
+/// Presto zones use the mainnet range. Zones on Moderato and development
+/// parents use the disjoint testnet range.
+pub const fn zone_chain_id_for_l1(l1_chain_id: u64, zone_id: u32) -> u64 {
+    if l1_chain_id == TEMPO_MAINNET_CHAIN_ID {
+        zone_chain_id(zone_id)
+    } else {
+        zone_chain_id_testnet(zone_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parent_networks_use_disjoint_zone_chain_ids() {
+        let zone_id = 1;
+
+        assert_eq!(
+            zone_chain_id_for_l1(TEMPO_MAINNET_CHAIN_ID, zone_id),
+            zone_chain_id(zone_id)
+        );
+        assert_eq!(
+            zone_chain_id_for_l1(42_431, zone_id),
+            zone_chain_id_testnet(zone_id)
+        );
+        assert_ne!(
+            zone_chain_id_for_l1(TEMPO_MAINNET_CHAIN_ID, zone_id),
+            zone_chain_id_for_l1(42_431, zone_id)
+        );
+    }
+
+    #[test]
+    fn development_parents_use_the_testnet_range() {
+        assert_eq!(zone_chain_id_for_l1(31_337, 1), zone_chain_id_testnet(1));
+    }
 }

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -144,9 +144,6 @@ pub const ZONE_CHAIN_ID_BASE_TESTNET: u64 = 1_424_310_000;
 /// strictly below the EIP-2294 safe ceiling.
 pub const ZONE_CHAIN_ID_RANGE_TESTNET: u64 = 723_173_648;
 
-/// Tempo mainnet (Presto) chain ID.
-pub const TEMPO_MAINNET_CHAIN_ID: u64 = 4_217;
-
 /// Derives the EIP-155 chain ID for a **mainnet** zone from its on-chain zone ID.
 ///
 /// Wraps via modulo so the result always falls in
@@ -161,47 +158,4 @@ pub const fn zone_chain_id(zone_id: u32) -> u64 {
 /// `[ZONE_CHAIN_ID_BASE_TESTNET, ZONE_CHAIN_ID_BASE_TESTNET + ZONE_CHAIN_ID_RANGE_TESTNET)`.
 pub const fn zone_chain_id_testnet(zone_id: u32) -> u64 {
     ZONE_CHAIN_ID_BASE_TESTNET + (zone_id as u64 % ZONE_CHAIN_ID_RANGE_TESTNET)
-}
-
-/// Derives the EIP-155 chain ID for a zone from its parent Tempo chain.
-///
-/// Presto zones use the mainnet range. Zones on Moderato and development
-/// parents use the disjoint testnet range.
-pub const fn zone_chain_id_for_parent(parent_chain_id: u64, zone_id: u32) -> u64 {
-    if parent_chain_id == TEMPO_MAINNET_CHAIN_ID {
-        zone_chain_id(zone_id)
-    } else {
-        zone_chain_id_testnet(zone_id)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parent_networks_use_disjoint_zone_chain_ids() {
-        let zone_id = 1;
-
-        assert_eq!(
-            zone_chain_id_for_parent(TEMPO_MAINNET_CHAIN_ID, zone_id),
-            zone_chain_id(zone_id)
-        );
-        assert_eq!(
-            zone_chain_id_for_parent(42_431, zone_id),
-            zone_chain_id_testnet(zone_id)
-        );
-        assert_ne!(
-            zone_chain_id_for_parent(TEMPO_MAINNET_CHAIN_ID, zone_id),
-            zone_chain_id_for_parent(42_431, zone_id)
-        );
-    }
-
-    #[test]
-    fn development_parents_use_the_testnet_range() {
-        assert_eq!(
-            zone_chain_id_for_parent(31_337, 1),
-            zone_chain_id_testnet(1)
-        );
-    }
 }

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -609,7 +609,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` on Presto or `1424310000 + (zone_id % 723173648)` on Moderato and development parents. |
+| `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` on mainnet or `1424310000 + (zone_id % 723173648)` on testnet. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |
 | `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -609,7 +609,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` (mainnet) or `1424310000 + (zone_id % 723173648)` (testnet). |
+| `--zone.id` | 0 | Zone ID from ZoneFactory (for private RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` on Presto or `1424310000 + (zone_id % 723173648)` on Moderato and development parents. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |
 | `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -271,13 +271,17 @@ The factory performs this initialization natively in the portal account; the Sol
 
 ### Chain ID
 
-Each zone has a unique chain ID derived from its zone ID:
+Each zone has a chain ID derived from its parent Tempo network and zone ID:
 
 ```
-chain_id = 421700000 + zone_id
+Presto:       chain_id = 421700000  + (zone_id % 1002610000)
+Moderato/dev: chain_id = 1424310000 + (zone_id % 723173648)
 ```
 
-The prefix `4217` is derived from the Tempo chain ID. This ensures replay protection between zones. A transaction signed for one zone cannot be replayed on another. The chain ID is set in the zone's genesis configuration and validated by the zone node at startup.
+The disjoint ranges prevent transaction replay between mainnet and non-mainnet
+zones that have the same factory-local zone ID. The chain ID is set in the
+zone's genesis configuration and validated against the parent Tempo network by
+the zone node at startup.
 
 ### Tempo Contracts
 
@@ -1336,7 +1340,7 @@ The stateless execution function must reject the witness on any failed check, mi
    Compute `keccak256(rlp(node))` for each node in `tempo_state_proofs.node_pool` and build a hash-to-node index for proof traversal.
 
 4. **For each `zone_blocks[i]`, verify the block witness before executing it.**
-   In the bootstrap proof, require at least two blocks. Require every field of `zone_blocks[0]` to equal the canonical genesis block derived from `public_inputs.zone_id`, including `chain_id = 421700000 + zone_id`; its parent hash is zero and it contains no user or system transactions. Apply the ordinary block rules to every remaining bootstrap block and to every block in an ordinary batch: require `block.parent_hash == prev_block_hash`, `block.number == prev_header.number + 1`, `block.timestamp >= prev_header.timestamp`, `block.beneficiary == public_inputs.sequencer`, and `tempo_header_rlp` to be present. Require `finalize_withdrawal_batch_count` to be absent in the genesis block and all intermediate blocks, and present in the final block of a batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
+   In the bootstrap proof, require at least two blocks. Require every field of `zone_blocks[0]` to equal the canonical genesis block derived from the parent Tempo network and `public_inputs.zone_id`, including the parent-specific `chain_id` defined in [Chain ID](#chain-id); its parent hash is zero and it contains no user or system transactions. Apply the ordinary block rules to every remaining bootstrap block and to every block in an ordinary batch: require `block.parent_hash == prev_block_hash`, `block.number == prev_header.number + 1`, `block.timestamp >= prev_header.timestamp`, `block.beneficiary == public_inputs.sequencer`, and `tempo_header_rlp` to be present. Require `finalize_withdrawal_batch_count` to be absent in the genesis block and all intermediate blocks, and present in the final block of a batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
 
 5. **Execute `advanceTempo` as the first transaction.**
    Skip this step for the canonical genesis block. For every non-genesis block, call `TempoState.finalizeTempo(header)` using the required `tempo_header_rlp` in the modeled execution environment. If the stored `tempoBlockHash` is non-zero, require the imported header's number to be the stored `tempoBlockNumber + 1` and its parent hash to equal the stored `tempoBlockHash`. If the stored hash is zero, instead verify a Tempo state proof for this portal's `sequencer` slot against the imported header's state root and require the value to be non-zero. Then update the bound `tempoBlockNumber` and `tempoBlockHash` and make the imported header's state root available for subsequent `TempoState.readTempoStorageSlot` calls in this block. Require the finalized `tempoBlockHash` to equal `keccak256(tempo_header_rlp)`. Reject any non-genesis block that omits or executes more than one `advanceTempo` call.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -274,11 +274,11 @@ The factory performs this initialization natively in the portal account; the Sol
 Each zone has a chain ID derived from its parent Tempo network and zone ID:
 
 ```
-Presto:       chain_id = 421700000  + (zone_id % 1002610000)
-Moderato/dev: chain_id = 1424310000 + (zone_id % 723173648)
+Mainnet: chain_id = 421700000  + (zone_id % 1002610000)
+Testnet: chain_id = 1424310000 + (zone_id % 723173648)
 ```
 
-The disjoint ranges prevent transaction replay between mainnet and non-mainnet
+The disjoint ranges prevent transaction replay between mainnet and testnet
 zones that have the same factory-local zone ID. The chain ID is set in the
 zone's genesis configuration and validated against the parent Tempo network by
 the zone node at startup.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,7 +18,7 @@ tempo-evm.workspace = true
 tempo-precompiles.workspace = true
 tempo-primitives.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
-zone-primitives.workspace = true
+zone-chainspec.workspace = true
 zone-precompiles = { workspace = true, features = ["std"] }
 zone-sequencer.workspace = true
 tempo-revm.workspace = true

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -13,13 +13,12 @@ use alloy_rlp::Encodable;
 use eyre::{WrapErr as _, eyre};
 use std::path::PathBuf;
 use tempo_alloy::TempoNetwork;
-use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
+use tempo_chainspec::spec::{DEV, TEMPO_T0_BASE_FEE, chainspec_from_chain_id};
 use tempo_contracts::precompiles::ITIP403Registry;
 use tempo_precompiles::TIP403_REGISTRY_ADDRESS;
 use tempo_zone_contracts::{
     ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactory, ZonePortal,
 };
-use zone_primitives::constants::zone_chain_id_for_parent;
 
 use crate::zone_utils::MODERATO_ZONE_FACTORY;
 
@@ -163,6 +162,7 @@ impl CreateZone {
             .connect(&self.l1_rpc_url)
             .await?;
         let l1_chain_id = provider.get_chain_id().await?;
+        let parent_chain_spec = chainspec_from_chain_id(l1_chain_id).unwrap_or_else(|| DEV.clone());
 
         let factory = ZoneFactory::new(self.zone_factory, &provider);
 
@@ -265,7 +265,7 @@ impl CreateZone {
 
         let zone_id = event.zoneId;
         let portal = event.portal;
-        let chain_id = zone_chain_id_for_parent(l1_chain_id, zone_id);
+        let chain_id = zone_chainspec::zone_chain_id(&parent_chain_spec, zone_id);
 
         let portal_contract = ZonePortal::new(portal, &provider);
         if self.sequencers.len() > 1 {

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -19,7 +19,7 @@ use tempo_precompiles::TIP403_REGISTRY_ADDRESS;
 use tempo_zone_contracts::{
     ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactory, ZonePortal,
 };
-use zone_primitives::constants::zone_chain_id_for_l1;
+use zone_primitives::constants::zone_chain_id_for_parent;
 
 use crate::zone_utils::MODERATO_ZONE_FACTORY;
 
@@ -265,7 +265,7 @@ impl CreateZone {
 
         let zone_id = event.zoneId;
         let portal = event.portal;
-        let chain_id = zone_chain_id_for_l1(l1_chain_id, zone_id);
+        let chain_id = zone_chain_id_for_parent(l1_chain_id, zone_id);
 
         let portal_contract = ZonePortal::new(portal, &provider);
         if self.sequencers.len() > 1 {

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -19,7 +19,7 @@ use tempo_precompiles::TIP403_REGISTRY_ADDRESS;
 use tempo_zone_contracts::{
     ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactory, ZonePortal,
 };
-use zone_primitives::constants::zone_chain_id;
+use zone_primitives::constants::zone_chain_id_for_l1;
 
 use crate::zone_utils::MODERATO_ZONE_FACTORY;
 
@@ -162,6 +162,7 @@ impl CreateZone {
             .wallet(wallet)
             .connect(&self.l1_rpc_url)
             .await?;
+        let l1_chain_id = provider.get_chain_id().await?;
 
         let factory = ZoneFactory::new(self.zone_factory, &provider);
 
@@ -264,7 +265,7 @@ impl CreateZone {
 
         let zone_id = event.zoneId;
         let portal = event.portal;
-        let chain_id = zone_chain_id(zone_id);
+        let chain_id = zone_chain_id_for_l1(l1_chain_id, zone_id);
 
         let portal_contract = ZonePortal::new(portal, &provider);
         if self.sequencers.len() > 1 {


### PR DESCRIPTION
This PR derives Zone chain IDs from the parent Tempo network to prevent cross-chain replay, and resolves ZONE-131.