### PR TITLE
feat: forced recovery

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -56,10 +56,10 @@ use zone_l1::{DepositQueue, L1BlockDeposits, L1BlockTracker, PreparedL1Block};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 
-/// Per-anchor production permit backed by the leadership schedule.
+/// Per-anchor production permit backed by the effective leadership schedule.
 ///
-/// The permit is a single schedule lookup: produce anchor `N` only if
-/// `schedule.leader_for(N)` is this node.
+/// The permit is a single schedule lookup: produce anchor `N` only if the portal schedule or an
+/// active bounded forced-recovery override assigns `N` to this node.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
     schedule: LeadershipSchedule,
@@ -571,6 +571,7 @@ mod tests {
 
     #[test]
     fn production_permit_is_a_single_schedule_lookup() {
+        use alloy_primitives::B256;
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use zone_p2p::LeadershipState;
 
@@ -578,14 +579,30 @@ mod tests {
         let other = PrivateKey::from_seed(2).public_key();
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(1, me.clone(), 0));
         schedule
-            .publish(LeadershipState::new(2, other, 100))
+            .publish(LeadershipState::new(2, other.clone(), 100))
             .unwrap();
-        let permit = ProductionPermit::new(schedule, me);
+        let permit = ProductionPermit::new(schedule, me.clone());
 
         assert_eq!(permit.check(0), PermitDecision::Produce);
         assert_eq!(permit.check(99), PermitDecision::Produce);
         assert_eq!(permit.check(100), PermitDecision::Demoted { epoch: 2 });
         assert_eq!(permit.check(u64::MAX), PermitDecision::Demoted { epoch: 2 });
+
+        let recovery_schedule = LeadershipSchedule::seeded(LeadershipState::new(7, me, 0));
+        recovery_schedule
+            .prepare_forced_recovery(8, other.clone(), B256::repeat_byte(0x11), 51)
+            .unwrap();
+        recovery_schedule
+            .publish(LeadershipState::new(8, other.clone(), 60))
+            .unwrap();
+        let recovery_permit = ProductionPermit::new(recovery_schedule, other);
+        assert_eq!(
+            recovery_permit.check(50),
+            PermitDecision::Demoted { epoch: 7 }
+        );
+        assert_eq!(recovery_permit.check(51), PermitDecision::Produce);
+        assert_eq!(recovery_permit.check(59), PermitDecision::Produce);
+        assert_eq!(recovery_permit.check(60), PermitDecision::Produce);
 
         let uninitialized = ProductionPermit::new(
             LeadershipSchedule::uninitialized(),

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -331,22 +331,10 @@ pub(crate) struct PendingPeerBlock {
 
 /// Latest tip evidence advertised by each peer, with observation time.
 ///
-/// Fed by backfill completions on the follower sync loop, consumed by the role controller's
-/// promotion gate and the status RPC.
-#[derive(Debug, Clone)]
+/// Fed by backfill completions on the follower sync loop and consumed by the status RPC.
+#[derive(Debug, Clone, Default)]
 pub(crate) struct PeerTipRegistry {
     inner: std::sync::Arc<std::sync::Mutex<HashMap<P2pPeerId, (PeerTip, std::time::Instant)>>>,
-    changed: tokio::sync::watch::Sender<()>,
-}
-
-impl Default for PeerTipRegistry {
-    fn default() -> Self {
-        let (changed, _) = tokio::sync::watch::channel(());
-        Self {
-            inner: Default::default(),
-            changed,
-        }
-    }
 }
 
 impl PeerTipRegistry {
@@ -355,7 +343,6 @@ impl PeerTipRegistry {
             .lock()
             .expect("poisoned")
             .insert(peer, (tip, std::time::Instant::now()));
-        self.changed.send_replace(());
     }
 
     pub(crate) fn snapshot(&self) -> Vec<(P2pPeerId, PeerTip, std::time::Instant)> {
@@ -365,10 +352,6 @@ impl PeerTipRegistry {
             .iter()
             .map(|(peer, (tip, at))| (peer.clone(), *tip, *at))
             .collect()
-    }
-
-    pub(crate) fn subscribe(&self) -> tokio::sync::watch::Receiver<()> {
-        self.changed.subscribe()
     }
 }
 
@@ -1494,6 +1477,26 @@ mod tests {
         assert!(message.contains("schedule assigns that anchor"));
     }
 
+    #[test]
+    fn forced_recovery_reassigns_live_sender_for_missing_anchors() {
+        use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+
+        let outgoing = PrivateKey::from_seed(1).public_key();
+        let incoming = PrivateKey::from_seed(2).public_key();
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, outgoing.clone(), 0));
+        schedule
+            .prepare_forced_recovery(8, incoming.clone(), B256::repeat_byte(0x11), 51)
+            .unwrap();
+        schedule
+            .publish(LeadershipState::new(8, incoming.clone(), 60))
+            .unwrap();
+
+        validate_live_block_sender(&schedule, Some(&incoming), 51, 11).unwrap();
+        let error = validate_live_block_sender(&schedule, Some(&outgoing), 51, 11)
+            .expect_err("the crashed leader must not remain authoritative in the recovery window");
+        assert!(error.to_string().contains(&incoming.to_string()));
+    }
+
     #[tokio::test]
     async fn broadcasts_block_persisted_during_startup_reconciliation_once() {
         let source = StartupRaceSource {
@@ -1568,13 +1571,11 @@ mod tests {
     }
 
     #[test]
-    fn peer_tip_registry_announces_fresh_evidence() {
+    fn peer_tip_registry_records_latest_tip() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use zone_p2p::PeerTip;
 
         let registry = super::PeerTipRegistry::default();
-        let mut changes = registry.subscribe();
-        assert!(!changes.has_changed().unwrap());
 
         let peer = PrivateKey::from_seed(1).public_key();
         let tip = PeerTip {
@@ -1584,12 +1585,9 @@ mod tests {
             tempo_block_hash: B256::repeat_byte(0x11),
         };
         registry.record(peer.clone(), tip);
-        assert!(changes.has_changed().unwrap());
-        changes.borrow_and_update();
 
-        // Re-advertising the same tip refreshes its evidence timestamp and must wake waiters.
+        // Re-advertising the same tip refreshes its observation timestamp.
         registry.record(peer.clone(), tip);
-        assert!(changes.has_changed().unwrap());
         let snapshot = registry.snapshot();
         assert_eq!(snapshot.len(), 1);
         assert_eq!(snapshot[0].0, peer);

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -2,7 +2,7 @@
 //!
 //! The [`RoleController`] switches complete role generations — block production or import,
 //! broadcast, transaction flow, settlement, and sequencer background tasks — as one fenced
-//! unit, driven by the finalized [`LeadershipSchedule`].
+//! unit, driven by the effective [`LeadershipSchedule`].
 //!
 //! The control rule is about the **next anchor**, never the last applied one: for the next
 //! Tempo anchor `N` to be consumed, if `schedule.leader_for(N)` is this node and the zone
@@ -57,8 +57,6 @@ const GENERATION_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const GENERATION_RESTART_BACKOFF: Duration = Duration::from_millis(500);
 /// Buffer size for per-generation event channels.
 const GENERATION_EVENT_BACKLOG: usize = 128;
-/// Tip evidence older than this is stale for promotion decisions.
-const TIP_EVIDENCE_TTL: Duration = Duration::from_secs(30);
 
 /// Everything a role generation needs to start its tasks.
 pub(crate) struct RoleControllerContext<P, Pool> {
@@ -373,106 +371,65 @@ where
     })
 }
 
-/// Promotion-readiness verdict from hash-carrying peer tip evidence.
+/// Promotion-readiness verdict from the evidence required by the active transition mode.
 #[derive(Debug)]
 enum Readiness {
     Ready,
-    NotReady(Vec<String>),
-    /// A peer holds a different block at a height we consider canonical: fence.
     Conflicted(String),
 }
 
 /// Evaluate the promotion barrier
 ///
-/// Quorum depends on the mode: a **planned handoff** (the outgoing leader is alive and authoritative)
-/// requires the outgoing leader's fresh evidence to match our head;
-/// **same-identity recovery** (we already governed the previous anchor, or nothing did) requires fresh
-/// evidence from every other quorum peer, because an unreachable follower may hold replicated blocks
-/// the others lack.
+/// Forced-recovery promotion requires the local canonical head to remain exactly at the
+/// operator-selected block. Normal transitions need no additional evidence: the next-anchor rule
+/// and one-to-one zone/L1 block mapping ensure all earlier leaders' blocks are already local.
 fn promotion_readiness<P>(
     provider: &P,
     schedule: &LeadershipSchedule,
     local: &P2pPeerId,
-    quorum_peers: &[P2pPeerId],
-    registry: &PeerTipRegistry,
     next_anchor: u64,
 ) -> Readiness
 where
     P: BlockNumReader + HeaderProvider<Header = TempoHeader>,
 {
-    let local_head = match provider.best_block_number() {
-        Ok(head) => head,
-        Err(err) => return Readiness::NotReady(vec![format!("cannot read the local head: {err}")]),
-    };
-
-    let now = tokio::time::Instant::now().into_std();
-    let mut fresh = std::collections::HashMap::new();
-    for (peer, tip, at) in registry.snapshot() {
-        if now.duration_since(at) <= TIP_EVIDENCE_TTL {
-            fresh.insert(peer, tip);
-        }
-    }
-
-    let mut reasons = Vec::new();
-    for (peer, tip) in &fresh {
-        if tip.zone_height > local_head {
-            reasons.push(format!(
-                "peer {peer} advertises tip {} above the local head {local_head}",
-                tip.zone_height
-            ));
-            continue;
-        }
-        match provider.sealed_header(tip.zone_height) {
-            Ok(Some(header)) if header.hash() == tip.zone_hash => {}
-            Ok(Some(header)) => {
+    if let Some(recovery) = schedule.forced_recovery().filter(|recovery| {
+        recovery.is_active()
+            && &recovery.leader == local
+            && next_anchor >= recovery.recovery_start_tempo_block
+    }) {
+        let local_height = match provider.best_block_number() {
+            Ok(height) => height,
+            Err(err) => {
                 return Readiness::Conflicted(format!(
-                    "peer {peer} holds a conflicting block at height {}: local {}, peer {}",
-                    tip.zone_height,
-                    header.hash(),
-                    tip.zone_hash,
+                    "cannot read the local head for forced recovery: {err}"
                 ));
             }
-            Ok(None) => reasons.push(format!(
-                "local canonical header {} is missing while validating peer {peer} evidence",
-                tip.zone_height
-            )),
-            Err(err) => reasons.push(format!(
-                "cannot read local header {}: {err}",
-                tip.zone_height
-            )),
-        }
-    }
-
-    // A planned handoff has a distinct outgoing leader governing the previous anchor.
-    let outgoing = schedule
-        .leader_for(next_anchor.saturating_sub(1))
-        .filter(|record| &record.leader != local)
-        .map(|record| record.leader);
-    match outgoing {
-        Some(outgoing) => {
-            if !fresh.contains_key(&outgoing) {
-                reasons.push(format!(
-                    "no fresh tip evidence from the outgoing leader {outgoing}"
+        };
+        let header = match provider.sealed_header(local_height) {
+            Ok(Some(header)) => header,
+            Ok(None) => {
+                return Readiness::Conflicted(format!(
+                    "forced recovery local header {local_height} is missing"
                 ));
             }
-        }
-        None => {
-            for peer in quorum_peers {
-                if peer != local && !fresh.contains_key(peer) {
-                    reasons.push(format!(
-                        "no fresh tip evidence from peer {peer} (required for same-identity \
-                         recovery; an unreachable follower may hold replicated blocks)"
-                    ));
-                }
+            Err(err) => {
+                return Readiness::Conflicted(format!(
+                    "cannot read forced recovery local header {local_height}: {err}"
+                ));
             }
+        };
+        if header.hash() != recovery.recovery_block_hash {
+            return Readiness::Conflicted(format!(
+                "forced recovery canonical head mismatch at height {local_height}: expected {}, \
+                 found {}",
+                recovery.recovery_block_hash,
+                header.hash(),
+            ));
         }
+        return Readiness::Ready;
     }
 
-    if reasons.is_empty() {
-        Readiness::Ready
-    } else {
-        Readiness::NotReady(reasons)
-    }
+    Readiness::Ready
 }
 
 /// Run the role controller until the process shuts down.
@@ -480,8 +437,8 @@ where
 /// `sinks` must be the same [`EventSinks`] handed to [`route_events_to_generations`] — the
 /// router is long-lived while generations come and go.
 ///
-/// Subscribes to schedule and peer-tip notifications plus generation task completion,
-/// re-derives the desired role by the next-anchor rule, and switches role generations.
+/// Subscribes to schedule notifications plus generation task completion, re-derives the desired
+/// role by the next-anchor rule, and switches role generations.
 /// Observation alone never switches roles — the trigger is consumption progress reaching
 /// the boundary, which this loop tracks by re-reading the local Tempo checkpoint.
 pub(crate) async fn run_role_controller<P, Pool>(
@@ -502,15 +459,9 @@ pub(crate) async fn run_role_controller<P, Pool>(
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
 {
     let mut schedule_changes = context.schedule.subscribe();
-    let mut peer_tip_changes = context.peer_tips.subscribe();
 
     let mut generation_id: u64 = 0;
     let mut current: Option<RunningGeneration> = None;
-    // Standbys are excluded: one is never a catch-up source for a quorum node, so it never
-    // returns the backfill completion that carries tip evidence, and requiring evidence from one
-    // would block same-identity recovery forever.
-    let manifest_peers: Vec<P2pPeerId> = context.attestation.addresses.keys().cloned().collect();
-    let quorum_peers = context.schedule.quorum_peers(&manifest_peers);
 
     loop {
         // An rpc-only member is not registered with `ZonePortal`, so it can never be named
@@ -535,9 +486,8 @@ pub(crate) async fn run_role_controller<P, Pool>(
             }
         };
 
-        // Promotion barrier: switching the head writer to this node requires hash-carrying
-        // tip evidence. Until the barrier is satisfied the node keeps importing as a
-        // follower and actively probes peers for evidence.
+        // Only forced recovery has an additional promotion barrier. Normal transitions are
+        // complete when the local next anchor is assigned to this node.
         let mut ready_for_promotion = true;
         let mut promotion_reasons = Vec::new();
         if let DesiredRole::Leader { epoch, next_anchor } = desired
@@ -547,25 +497,10 @@ pub(crate) async fn run_role_controller<P, Pool>(
                 &context.provider,
                 &context.schedule,
                 &context.local_ed25519_public_key,
-                &quorum_peers,
-                &context.peer_tips,
                 next_anchor,
             ) {
                 Readiness::Ready => {
                     info!(target: "zone::role", epoch, next_anchor, "Promotion barrier satisfied");
-                }
-                Readiness::NotReady(reasons) => {
-                    retry_decision = true;
-                    ready_for_promotion = false;
-                    debug!(target: "zone::role", epoch, next_anchor, ?reasons, "Promotion pending readiness");
-                    promotion_reasons = reasons;
-                    // Probe peers so evidence (and any missing blocks) arrive promptly.
-                    if let Ok(best) = context.provider.best_block_number() {
-                        let _ = context.commands.try_send(P2pCommand::RequestBackfill {
-                            start: best.saturating_add(1),
-                        });
-                    }
-                    desired = DesiredRole::Follower { epoch };
                 }
                 Readiness::Conflicted(detail) => {
                     ready_for_promotion = false;
@@ -573,7 +508,7 @@ pub(crate) async fn run_role_controller<P, Pool>(
                         target: "zone::role",
                         epoch,
                         %detail,
-                        "Conflicting peer tip evidence; fencing instead of promoting"
+                        "Conflicting promotion evidence; fencing instead of promoting"
                     );
                     promotion_reasons = vec![detail];
                     desired = DesiredRole::Fenced;
@@ -688,12 +623,6 @@ pub(crate) async fn run_role_controller<P, Pool>(
             changed = schedule_changes.changed() => {
                 if changed.is_err() {
                     error!(target: "zone::role", "Leadership schedule notifier closed");
-                    return;
-                }
-            }
-            changed = peer_tip_changes.changed() => {
-                if changed.is_err() {
-                    error!(target: "zone::role", "Peer tip notifier closed");
                     return;
                 }
             }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -24,7 +24,7 @@ use alloy_sol_types::SolCall;
 use eyre::WrapErr;
 use futures::StreamExt;
 use jsonrpsee::{RpcModule, core::RpcResult, proc_macros::rpc, types::ErrorObjectOwned};
-use reth_provider::CanonStateSubscriptions;
+use reth_provider::{CanonStateSubscriptions, HeaderProvider};
 use reth_rpc::{EthFilter, eth::filter::EthFilterError};
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
@@ -51,14 +51,14 @@ use zone_l1::TempoStateExt as _;
 
 use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
 use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
-use zone_p2p::{LeadershipSchedule, ZoneManifest};
+use zone_p2p::{LeadershipSchedule, PeerTip, ZoneManifest};
 use zone_rpc::{
     auth::AuthContext,
     types::{
         ActiveLeaderInfo, AuthorizationTokenInfoResponse, BoxEyreFut, BoxFut, JsonRpcError,
         LocalSequencerInfo, PeerTipInfo, SequencerInfoResponse, SequencerPeerInfo,
-        SequencerProgress, SequencerReadiness, SetLeaderResponse, ZoneInfoResponse, internal,
-        raw_null, raw_zero, to_raw,
+        SequencerProgress, SequencerReadiness, SetLeaderOptions, SetLeaderParams,
+        SetLeaderResponse, ZoneInfoResponse, internal, raw_null, raw_zero, to_raw,
     },
 };
 
@@ -189,17 +189,25 @@ pub(crate) fn public_zone_rpc_module<P>(
     provider: P,
 ) -> Result<RpcModule<()>, jsonrpsee::core::RegisterMethodError>
 where
-    P: BlockNumReader + StateProviderFactory + Clone + Send + Sync + 'static,
+    P: BlockNumReader + HeaderProvider + StateProviderFactory + Clone + Send + Sync + 'static,
 {
     let mut module = RpcModule::new(());
     let set_leader_sequencer = sequencer.clone();
+    let set_leader_provider = provider.clone();
     module.register_async_method("zone_setLeader", move |params, _, _| {
         let sequencer = set_leader_sequencer.clone();
+        let provider = set_leader_provider.clone();
         async move {
-            let (target,) = params.parse::<(Address,)>()?;
-            set_leader(portal_address, sequencer.as_ref(), target)
-                .await
-                .map_err(public_rpc_error)
+            let (target, options) = params.parse::<SetLeaderParams>()?.into_parts();
+            set_leader(
+                portal_address,
+                sequencer.as_ref(),
+                &provider,
+                target,
+                options,
+            )
+            .await
+            .map_err(public_rpc_error)
         }
     })?;
     module.register_async_method("zone_getSequencerInfo", move |_, _, _| {
@@ -313,7 +321,7 @@ fn get_sequencer_info<P>(
     provider: &P,
 ) -> Result<SequencerInfoResponse, JsonRpcError>
 where
-    P: BlockNumReader + StateProviderFactory,
+    P: BlockNumReader + HeaderProvider + StateProviderFactory,
 {
     let Some(context) = sequencer.get() else {
         // Single-sequencer (or not yet initialized) node: report the minimal view.
@@ -322,6 +330,7 @@ where
             portal: portal_address,
             local: None,
             active_leader: None,
+            local_tip: None,
             peers: Vec::new(),
             progress: None,
             readiness: None,
@@ -365,12 +374,7 @@ where
         })
         .collect();
 
-    let zone_height = provider.best_block_number().map_err(internal)?;
-    let tempo_block_number = provider
-        .latest()
-        .map_err(internal)?
-        .tempo_block_number()
-        .map_err(internal)?;
+    let local_tip = local_recovery_tip(provider)?;
 
     let local_node = context
         .manifest
@@ -387,10 +391,16 @@ where
             role: status.role.to_owned(),
         }),
         active_leader,
+        local_tip: Some(PeerTipInfo {
+            zone_height: U64::from(local_tip.zone_height),
+            zone_hash: local_tip.zone_hash,
+            tempo_block_number: U64::from(local_tip.tempo_block_number),
+            tempo_block_hash: local_tip.tempo_block_hash,
+        }),
         peers,
         progress: Some(SequencerProgress {
-            zone_height: U64::from(zone_height),
-            tempo_block_number: U64::from(tempo_block_number),
+            zone_height: U64::from(local_tip.zone_height),
+            tempo_block_number: U64::from(local_tip.tempo_block_number),
             latest_observed_leadership_epoch: context
                 .schedule
                 .latest_observed_epoch()
@@ -1138,11 +1148,57 @@ where
     }
 }
 
-async fn set_leader(
+fn local_recovery_tip<P>(provider: &P) -> Result<PeerTip, JsonRpcError>
+where
+    P: BlockNumReader + HeaderProvider + StateProviderFactory,
+{
+    let zone_height = provider.best_block_number().map_err(internal)?;
+    let zone_header = provider
+        .sealed_header(zone_height)
+        .map_err(internal)?
+        .ok_or_else(|| JsonRpcError::internal("local canonical zone header is missing"))?;
+    let tempo_tip = provider
+        .state_by_block_hash(zone_header.hash())
+        .map_err(internal)?
+        .tempo_num_hash()
+        .map_err(internal)?;
+    Ok(PeerTip {
+        zone_height,
+        zone_hash: zone_header.hash(),
+        tempo_block_number: tempo_tip.number,
+        tempo_block_hash: tempo_tip.hash,
+    })
+}
+
+fn parse_forced_recovery(options: SetLeaderOptions) -> Result<Option<(u64, B256)>, JsonRpcError> {
+    if !options.force {
+        if options.expected_epoch.is_some() || options.recovery_block_hash.is_some() {
+            return Err(JsonRpcError::invalid_params(
+                "expectedEpoch and recoveryBlockHash require force=true",
+            ));
+        }
+        return Ok(None);
+    }
+    let expected_epoch = options
+        .expected_epoch
+        .ok_or_else(|| JsonRpcError::invalid_params("force=true requires expectedEpoch"))?
+        .to::<u64>();
+    let recovery_block_hash = options
+        .recovery_block_hash
+        .ok_or_else(|| JsonRpcError::invalid_params("force=true requires recoveryBlockHash"))?;
+    Ok(Some((expected_epoch, recovery_block_hash)))
+}
+
+async fn set_leader<P>(
     portal_address: Address,
     sequencer: &std::sync::OnceLock<SequencerRpcContext>,
+    provider: &P,
     target: Address,
-) -> Result<SetLeaderResponse, JsonRpcError> {
+    options: SetLeaderOptions,
+) -> Result<SetLeaderResponse, JsonRpcError>
+where
+    P: BlockNumReader + HeaderProvider + StateProviderFactory,
+{
     let Some(context) = sequencer.get() else {
         return Err(JsonRpcError::invalid_params(
             "zone_setLeader requires multi-sequencer mode",
@@ -1166,13 +1222,13 @@ async fn set_leader(
         ));
     };
     let portal = ZonePortal::new(portal_address, relayer);
+    let forced = parse_forced_recovery(options)?;
 
     // The target must be a manifest member and a registered portal sequencer.
-    if context.manifest.node_by_secp256k1_address(target).is_none() {
-        return Err(JsonRpcError::invalid_params(
-            "target is not a manifest member",
-        ));
-    }
+    let target_node = context
+        .manifest
+        .node_by_secp256k1_address(target)
+        .ok_or_else(|| JsonRpcError::invalid_params("target is not a manifest member"))?;
     let is_sequencer = portal
         .isSequencer(target)
         .block(BlockId::finalized())
@@ -1193,6 +1249,55 @@ async fn set_leader(
     let epoch_call = portal.leaderEpoch().block(BlockId::finalized());
     let (leader, expected_epoch) =
         tokio::try_join!(leader_call.call(), epoch_call.call()).map_err(internal)?;
+
+    if let Some((requested_epoch, recovery_block_hash)) = forced {
+        let recovery_epoch = requested_epoch
+            .checked_add(1)
+            .ok_or_else(|| JsonRpcError::invalid_params("forced recovery epoch overflow"))?;
+        if leader == target {
+            if expected_epoch != recovery_epoch {
+                return Err(JsonRpcError::invalid_params(format!(
+                    "finalized target epoch is {expected_epoch}, expected forced recovery epoch \
+                     {recovery_epoch}"
+                )));
+            }
+        } else if expected_epoch != requested_epoch {
+            return Err(JsonRpcError::invalid_params(format!(
+                "finalized leadership epoch is {expected_epoch}, expected {requested_epoch}"
+            )));
+        }
+
+        let local_tip = local_recovery_tip(provider)?;
+        if local_tip.zone_hash != recovery_block_hash {
+            return Err(JsonRpcError::invalid_params(format!(
+                "forced recovery block hash {recovery_block_hash} does not equal local canonical \
+                 head {} at height {}",
+                local_tip.zone_hash, local_tip.zone_height,
+            )));
+        }
+
+        let prepared = context
+            .schedule
+            .prepare_forced_recovery(
+                recovery_epoch,
+                target_node.ed25519_public_key().clone(),
+                recovery_block_hash,
+                local_tip.tempo_block_number.saturating_add(1),
+            )
+            .map_err(|err| JsonRpcError::invalid_params(err.to_string()))?;
+        tracing::info!(
+            target: "zone::rpc",
+            %target,
+            requested_epoch,
+            recovery_zone_height = local_tip.zone_height,
+            recovery_zone_hash = %recovery_block_hash,
+            recovery_tempo_block = local_tip.tempo_block_number,
+            recovery_tempo_hash = %local_tip.tempo_block_hash,
+            prepared,
+            "Prepared forced leader recovery"
+        );
+    }
+
     if leader == target {
         return Ok(SetLeaderResponse {
             status: "alreadyActive".to_owned(),

--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -30,6 +30,120 @@ const QUIESCENCE: Duration = Duration::from_secs(3);
 /// the window to backfill-paced replication fails fast instead of passing slowly.
 const LIVE_PROPAGATION_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// A crashes after producing a tip shared by every follower. Three L1 anchors pass with no zone
+/// blocks, then an operator selects B and the shared tip for forced recovery. The matching
+/// finalized transition lets B fill the missing anchor range and continue as the portal leader,
+/// without replacing any block preceding the crash.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut cluster = start_local_p2p_cluster(24).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    for _ in 0..3 {
+        cluster.inject_block(vec![])?;
+    }
+    cluster.wait_all_at(3, HANDOFF_TIMEOUT).await?;
+
+    let recovery_tip_height = 3;
+    let mut original_hashes = Vec::new();
+    for height in 1..=recovery_tip_height {
+        original_hashes.push(cluster.assert_same_block(height).await?.hash);
+    }
+    let recovery_block_hash = original_hashes[(recovery_tip_height - 1) as usize];
+    let recovery_start_tempo_block = cluster.next_anchor_number();
+    assert_eq!(recovery_start_tempo_block, 4);
+
+    // Node 0 is A. Removing it leaves B and C running with their original manifest identities.
+    let crashed_leader = cluster.nodes.remove(0);
+    crashed_leader.crash();
+
+    // These are the three missed boundaries used by the operator's failure detector. B and C
+    // observe and queue them, but cannot build while finalized portal authority still names A.
+    for _ in 0..3 {
+        cluster.inject_block(vec![])?;
+    }
+    tokio::time::sleep(QUIESCENCE).await;
+    for node in &cluster.nodes {
+        assert_eq!(
+            node.provider().get_block_number().await?,
+            recovery_tip_height,
+            "a follower produced while the crashed leader still held authority"
+        );
+    }
+
+    // The force RPC installs this request on each surviving node before relaying setLeader.
+    // Publishing the matching transition stands in for their subscribers finalizing that L1
+    // transaction. Its portal activation is anchor 7, while the recovery override starts at 4.
+    let recovery_epoch = 1;
+    let replacement_index = 1;
+    let replacement = cluster.p2p_public_keys[replacement_index].clone();
+    for node in &cluster.nodes {
+        assert!(node.leadership().prepare_forced_recovery(
+            recovery_epoch,
+            replacement.clone(),
+            recovery_block_hash,
+            recovery_start_tempo_block,
+        )?);
+        assert!(
+            node.leadership()
+                .leader_for(recovery_start_tempo_block)
+                .is_none(),
+            "the recovery range must remain fenced before setLeader finalizes"
+        );
+    }
+
+    let portal_activation_tempo_block = cluster.next_anchor_number();
+    assert_eq!(portal_activation_tempo_block, 7);
+    cluster.publish_transition(
+        recovery_epoch,
+        replacement_index,
+        portal_activation_tempo_block,
+    )?;
+    cluster.inject_block(vec![])?;
+    cluster
+        .wait_all_at(portal_activation_tempo_block, HANDOFF_TIMEOUT)
+        .await?;
+
+    // The pre-crash prefix is unchanged on both survivors.
+    for (offset, expected_hash) in original_hashes.into_iter().enumerate() {
+        let height = offset as u64 + 1;
+        assert_eq!(
+            cluster.assert_same_block(height).await?.hash,
+            expected_hash,
+            "forced recovery replaced pre-crash block {height}"
+        );
+    }
+
+    // B produced every missing block and the portal-activation block. Once anchor 7 is applied,
+    // ordinary portal authority takes over and the temporary recovery state is removed.
+    let b_producer = cluster.sequencer_signers[replacement_index].address();
+    for height in recovery_start_tempo_block..=portal_activation_tempo_block {
+        assert_eq!(
+            cluster.assert_same_block(height).await?.beneficiary,
+            b_producer,
+            "replacement leader B did not produce recovery block {height}"
+        );
+    }
+    for node in &cluster.nodes {
+        assert!(
+            node.leadership().forced_recovery().is_none(),
+            "recovery state remained after portal activation was applied"
+        );
+    }
+
+    // Production remains live under ordinary portal authority after the recovery window.
+    cluster.inject_block(vec![])?;
+    let next_height = portal_activation_tempo_block + 1;
+    cluster.wait_all_at(next_height, HANDOFF_TIMEOUT).await?;
+    assert_eq!(
+        cluster.assert_same_block(next_height).await?.beneficiary,
+        b_producer
+    );
+    Ok(())
+}
+
 /// Planned A→B handoff at an exact activation boundary.
 ///
 /// Asserts the plan's v1 success criterion: no missing or duplicate zone height, no

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -639,6 +639,13 @@ impl ZoneTestNode {
         &self.http_url
     }
 
+    /// Stop this node's task runtime while retaining its storage handles for the test lifetime.
+    pub(crate) fn crash(&self) {
+        let _ = self
+            ._tasks
+            .graceful_shutdown_with_timeout(Duration::from_secs(5));
+    }
+
     async fn spawn_sequencer(
         &self,
         config: zone_sequencer::ZoneSequencerConfig,

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -5,11 +5,17 @@ multi-sequencer Tempo Zone. A manifest defines the static peer topology (names, 
 Ed25519 identities, individual secp256k1 addresses). Each node loads its own Commonware
 Ed25519 identity and validates that it appears in the manifest.
 
-Which member *leads* (produces blocks) is not decided by the manifest: it is derived
-exclusively from finalized Tempo L1 state — the `ZonePortal`'s `leader`, `leaderEpoch`, and
+Which member *leads* (produces blocks) is not decided by the manifest: normally it is derived
+from finalized Tempo L1 state — the `ZonePortal`'s `leader`, `leaderEpoch`, and
 `leaderActivationTempoBlock` fields and its `LeaderUpdated` event. Every observed transition
-is retained in an activation-indexed `LeadershipSchedule`; production and import authority
-for a given Tempo anchor is answered by `leader_for(anchor)` over that retained timeline.
+is retained in an activation-indexed `LeadershipSchedule`.
+
+For manual crashed-leader recovery, an operator may install the same force request on
+the surviving nodes. The request fences the next anchor at the exact operator-selected tip until
+the matching `LeaderUpdated` transition is finalized, then assigns the replacement leader from
+that anchor until the portal activation. The portal schedule is authoritative from its activation
+onward. Operational consumers use `leader_for(anchor)`, which incorporates the recovery without
+mutating the retained portal transition timeline.
 
 If a manifest is not specified, `tempo-zone` retains its existing single-sequencer startup
 behavior.

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -7,8 +7,8 @@ mod network;
 mod runtime;
 
 pub use manifest::{
-    LeadershipSchedule, LeadershipState, ManifestAddress, ManifestError, ManifestNode, Role,
-    ZoneManifest,
+    ForcedRecoveryState, LeadershipSchedule, LeadershipState, ManifestAddress, ManifestError,
+    ManifestNode, Role, ZoneManifest,
 };
 pub use network::P2pNetworkId;
 pub use runtime::{

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -81,6 +81,44 @@ impl LeadershipState {
     }
 }
 
+/// Forced-recovery authority attached to the finalized leadership schedule.
+///
+/// Before the matching portal transition is finalized, the record fences the selected recovery
+/// boundary so the old leader cannot move the local tip. The transition activates the replacement
+/// leader from `recovery_start_tempo_block` until ordinary portal authority takes over.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForcedRecoveryState {
+    /// Epoch assigned by the matching portal transition.
+    pub epoch: u64,
+    /// Ed25519 identity selected as the replacement leader.
+    pub leader: PublicKey,
+    /// Exact canonical zone block hash selected by the force RPC.
+    pub recovery_block_hash: B256,
+    /// First Tempo anchor governed by the recovery override.
+    pub recovery_start_tempo_block: u64,
+    /// Activation anchor from the matching finalized portal transition.
+    pub portal_activation_tempo_block: Option<u64>,
+}
+
+impl ForcedRecoveryState {
+    /// Whether finalized L1 has activated this recovery.
+    pub const fn is_active(&self) -> bool {
+        self.portal_activation_tempo_block.is_some()
+    }
+
+    fn leadership_record_for(&self, tempo_anchor: u64) -> Option<LeadershipState> {
+        let portal_activation = self.portal_activation_tempo_block?;
+        if !(self.recovery_start_tempo_block..portal_activation).contains(&tempo_anchor) {
+            return None;
+        }
+        Some(LeadershipState::new(
+            self.epoch,
+            self.leader.clone(),
+            self.recovery_start_tempo_block,
+        ))
+    }
+}
+
 #[derive(Debug, Default)]
 struct LeadershipScheduleState {
     /// Retained transitions indexed by activation Tempo block.
@@ -89,17 +127,62 @@ struct LeadershipScheduleState {
     latest_observed_epoch: Option<u64>,
     /// Highest Tempo anchor embedded in a locally canonical zone block.
     applied_anchor: Option<u64>,
+    /// Optional operator-requested forced recovery.
+    forced_recovery: Option<ForcedRecoveryState>,
 }
 
 impl LeadershipScheduleState {
-    fn next_anchor_record(&self) -> Option<&LeadershipState> {
+    fn leader_for(&self, tempo_anchor: u64) -> Option<LeadershipState> {
+        if self.forced_recovery.as_ref().is_some_and(|recovery| {
+            !recovery.is_active() && tempo_anchor >= recovery.recovery_start_tempo_block
+        }) {
+            // If there's a forced recovery pending for this anchor, return None because `setLeader` call must finalize first.
+            return None;
+        }
+        let scheduled = self
+            .transitions
+            .range(..=tempo_anchor)
+            .next_back()
+            .map(|(_, record)| record.clone());
+        let recovery = self
+            .forced_recovery
+            .as_ref()
+            .and_then(|recovery| recovery.leadership_record_for(tempo_anchor));
+        recovery.or(scheduled)
+    }
+
+    fn next_anchor_record(&self) -> Option<LeadershipState> {
         let next_anchor = self
             .applied_anchor
             .map_or(u64::MAX, |applied| applied.saturating_add(1));
-        self.transitions
-            .range(..=next_anchor)
-            .next_back()
-            .map(|(_, record)| record)
+        self.leader_for(next_anchor)
+    }
+
+    fn maybe_activate_forced_recovery(&mut self) {
+        let Some(recovery) = self.forced_recovery.as_mut() else {
+            return;
+        };
+        if recovery.is_active() {
+            return;
+        }
+        let Some(record) = self
+            .transitions
+            .last_key_value()
+            .map(|(_, record)| record.clone())
+        else {
+            return;
+        };
+        if record.epoch != recovery.epoch || record.leader != recovery.leader {
+            // Once finalized L1 has reached or passed the expected recovery epoch with a
+            // different authority, this request can never become valid.
+            if record.epoch >= recovery.epoch {
+                self.forced_recovery = None;
+            }
+            return;
+        }
+        recovery.portal_activation_tempo_block = Some(record.activation_tempo_block);
+        metrics::counter!("zone_forced_recovery_transitions_total", "state" => "active")
+            .increment(1);
     }
 }
 
@@ -233,22 +316,22 @@ impl LeadershipSchedule {
         state
             .transitions
             .insert(record.activation_tempo_block, record);
+        state.maybe_activate_forced_recovery();
         drop(state);
         self.changed.send_replace(());
         Ok(true)
     }
 
-    /// Returns the record governing `tempo_anchor`: the greatest activation `<= tempo_anchor`
-    /// over every retained transition. `None` while uninitialized or for anchors before the
-    /// first retained activation — both fence production and import for that anchor.
+    /// Returns the operational authority for `tempo_anchor`.
+    ///
+    /// A pending forced recovery fences its recovery boundary. Once finalized, it overrides the
+    /// earlier portal schedule from that boundary until the matching portal activation. Returns
+    /// `None` while fenced, uninitialized, or for an anchor no retained transition governs.
     pub fn leader_for(&self, tempo_anchor: u64) -> Option<LeadershipState> {
         self.inner
             .read()
             .expect("poisoned")
-            .transitions
-            .range(..=tempo_anchor)
-            .next_back()
-            .map(|(_, record)| record.clone())
+            .leader_for(tempo_anchor)
     }
 
     /// Returns the most recently observed record (status only, never a production permit).
@@ -270,11 +353,56 @@ impl LeadershipSchedule {
     /// outgoing leader — not the most recently observed one — still produces. Routing only,
     /// never a production permit.
     pub fn next_anchor_record(&self) -> Option<LeadershipState> {
-        self.inner
-            .read()
-            .expect("poisoned")
-            .next_anchor_record()
-            .cloned()
+        self.inner.read().expect("poisoned").next_anchor_record()
+    }
+
+    /// Install a forced-recovery request.
+    ///
+    /// Repeating the identical request is an idempotent no-op. A different outstanding request
+    /// is rejected. The caller must validate the exact local canonical recovery tip first. Until
+    /// the matching portal transition is finalized, the request fences the next anchor.
+    pub fn prepare_forced_recovery(
+        &self,
+        recovery_epoch: u64,
+        leader: PublicKey,
+        recovery_block_hash: B256,
+        recovery_start_tempo_block: u64,
+    ) -> eyre::Result<bool> {
+        let requested = ForcedRecoveryState {
+            epoch: recovery_epoch,
+            leader,
+            recovery_block_hash,
+            recovery_start_tempo_block,
+            portal_activation_tempo_block: None,
+        };
+
+        let mut state = self.inner.write().expect("poisoned");
+        if let Some(existing) = &state.forced_recovery {
+            eyre::ensure!(
+                existing.epoch == requested.epoch
+                    && existing.leader == requested.leader
+                    && existing.recovery_block_hash == requested.recovery_block_hash
+                    && existing.recovery_start_tempo_block == requested.recovery_start_tempo_block,
+                "conflicting forced recovery request is already installed"
+            );
+            return Ok(false);
+        }
+        state.forced_recovery = Some(requested);
+        state.maybe_activate_forced_recovery();
+        eyre::ensure!(
+            state.forced_recovery.is_some(),
+            "latest finalized leadership transition conflicts with forced recovery request"
+        );
+        drop(state);
+        self.changed.send_replace(());
+        metrics::counter!("zone_forced_recovery_requests_total", "result" => "prepared")
+            .increment(1);
+        Ok(true)
+    }
+
+    /// Return the current forced-recovery request, if any.
+    pub fn forced_recovery(&self) -> Option<ForcedRecoveryState> {
+        self.inner.read().expect("poisoned").forced_recovery.clone()
     }
 
     /// Highest epoch finalized L1 has shown us.
@@ -310,7 +438,7 @@ impl LeadershipSchedule {
     /// recovery by asking who governed the previous anchor.
     pub fn record_applied_anchor(&self, tempo_anchor: u64) {
         let mut state = self.inner.write().expect("poisoned");
-        let previous_next_anchor_record = state.next_anchor_record().cloned();
+        let previous_next_anchor_record = state.next_anchor_record();
         state.applied_anchor = Some(
             state
                 .applied_anchor
@@ -332,11 +460,22 @@ impl LeadershipSchedule {
                 .transitions
                 .retain(|&activation, _| activation >= keep_from);
         }
-        let governing_record_changed =
-            state.next_anchor_record() != previous_next_anchor_record.as_ref();
+        let recovery_completed = state.forced_recovery.as_ref().is_some_and(|recovery| {
+            recovery
+                .portal_activation_tempo_block
+                .is_some_and(|activation| applied >= activation)
+        });
+        if recovery_completed {
+            state.forced_recovery = None;
+        }
+        let governing_record_changed = state.next_anchor_record() != previous_next_anchor_record;
         drop(state);
-        if governing_record_changed {
+        if governing_record_changed || recovery_completed {
             self.changed.send_replace(());
+        }
+        if recovery_completed {
+            metrics::counter!("zone_forced_recovery_transitions_total", "state" => "complete")
+                .increment(1);
         }
     }
 
@@ -954,6 +1093,7 @@ pub enum ManifestError {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::B256;
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
     use super::{
@@ -962,6 +1102,10 @@ mod tests {
 
     fn public_key(seed: u64) -> commonware_cryptography::ed25519::PublicKey {
         PrivateKey::from_seed(seed).public_key()
+    }
+
+    fn recovery_block_hash() -> B256 {
+        B256::repeat_byte(0x11)
     }
 
     #[test]
@@ -1000,6 +1144,123 @@ mod tests {
         assert_eq!(schedule.leader_for(u64::MAX).unwrap().leader, public_key(3));
         assert_eq!(schedule.latest_observed_epoch(), Some(3));
         assert_eq!(schedule.pending_transitions(), 2);
+    }
+
+    #[test]
+    fn forced_recovery_fences_until_matching_transition_then_is_bounded() {
+        let outgoing = public_key(1);
+        let incoming = public_key(2);
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, outgoing.clone(), 0));
+        schedule.record_applied_anchor(50);
+
+        assert!(
+            schedule
+                .prepare_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
+                .unwrap()
+        );
+        assert!(
+            schedule.leader_for(51).is_none(),
+            "pending recovery must fence the selected boundary"
+        );
+
+        schedule
+            .publish(LeadershipState::new(8, incoming.clone(), 60))
+            .unwrap();
+        assert_eq!(schedule.leader_for(50).unwrap().leader, outgoing);
+        assert_eq!(schedule.leader_for(51).unwrap().leader, incoming);
+        assert_eq!(schedule.leader_for(59).unwrap().leader, incoming);
+        assert_eq!(
+            schedule.leader_for(60).unwrap().leader,
+            incoming,
+            "recovery agrees with portal authority at the activation boundary"
+        );
+        schedule
+            .publish(LeadershipState::new(9, public_key(3), 70))
+            .unwrap();
+        assert_eq!(schedule.leader_for(69).unwrap().leader, incoming);
+        assert_eq!(schedule.leader_for(70).unwrap().leader, public_key(3));
+    }
+
+    #[test]
+    fn forced_recovery_atomically_reconciles_a_transition_published_first() {
+        let incoming = public_key(2);
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
+        schedule
+            .publish(LeadershipState::new(8, incoming.clone(), 60))
+            .unwrap();
+
+        schedule
+            .prepare_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
+            .unwrap();
+
+        assert!(schedule.forced_recovery().unwrap().is_active());
+        assert_eq!(schedule.leader_for(51).unwrap().leader, incoming);
+    }
+
+    #[test]
+    fn forced_recovery_rejects_a_conflicting_transition_published_first() {
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
+        schedule
+            .publish(LeadershipState::new(8, public_key(3), 60))
+            .unwrap();
+
+        assert!(
+            schedule
+                .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
+                .is_err()
+        );
+        assert!(schedule.forced_recovery().is_none());
+    }
+
+    #[test]
+    fn forced_recovery_clears_after_portal_activation_is_applied() {
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
+        schedule.record_applied_anchor(50);
+        schedule
+            .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
+            .unwrap();
+        schedule
+            .publish(LeadershipState::new(8, public_key(2), 60))
+            .unwrap();
+
+        schedule.record_applied_anchor(59);
+        assert!(schedule.forced_recovery().is_some());
+        schedule.record_applied_anchor(60);
+        assert!(schedule.forced_recovery().is_none());
+    }
+
+    #[test]
+    fn empty_recovery_window_still_activates_recovery() {
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
+        schedule
+            .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 60)
+            .unwrap();
+        schedule
+            .publish(LeadershipState::new(8, public_key(2), 60))
+            .unwrap();
+
+        assert!(schedule.forced_recovery().unwrap().is_active());
+        assert_eq!(schedule.leader_for(60).unwrap().leader, public_key(2));
+    }
+
+    #[test]
+    fn forced_recovery_request_is_idempotent_and_rejects_conflict() {
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
+        assert!(
+            schedule
+                .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
+                .unwrap()
+        );
+        assert!(
+            !schedule
+                .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
+                .unwrap()
+        );
+        assert!(
+            schedule
+                .prepare_forced_recovery(8, public_key(3), recovery_block_hash(), 51)
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -297,6 +297,9 @@ pub struct SequencerInfoResponse {
     /// Active finalized leader (multi-sequencer mode only, once observed).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_leader: Option<ActiveLeaderInfo>,
+    /// Exact local canonical tip usable as a forced-recovery point.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_tip: Option<PeerTipInfo>,
     /// All configured manifest members with observed tip evidence.
     pub peers: Vec<SequencerPeerInfo>,
     /// Consumption and observation progress (multi-sequencer mode only).
@@ -305,6 +308,41 @@ pub struct SequencerInfoResponse {
     /// Promotion-readiness snapshot (multi-sequencer mode only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub readiness: Option<SequencerReadiness>,
+}
+
+/// Optional behavior for `zone_setLeader`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetLeaderOptions {
+    /// Enable the crashed-leader recovery override.
+    #[serde(default)]
+    pub force: bool,
+    /// Finalized portal epoch that the call is expected to replace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_epoch: Option<U64>,
+    /// Exact canonical zone head from which the selected leader must recover.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_block_hash: Option<B256>,
+}
+
+/// Backward-compatible parameters for `zone_setLeader`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum SetLeaderParams {
+    /// Existing form: `[target]`.
+    Regular((Address,)),
+    /// Extended form: `[target, options]`.
+    WithOptions((Address, SetLeaderOptions)),
+}
+
+impl SetLeaderParams {
+    /// Split the parsed parameters into their target and optional behavior.
+    pub fn into_parts(self) -> (Address, SetLeaderOptions) {
+        match self {
+            Self::Regular((target,)) => (target, SetLeaderOptions::default()),
+            Self::WithOptions((target, options)) => (target, options),
+        }
+    }
 }
 
 /// Response payload for `zone_setLeader`.
@@ -429,4 +467,38 @@ pub fn to_raw<T: serde::Serialize>(value: &T) -> Result<Box<RawValue>, JsonRpcEr
 /// Shorthand for wrapping any `Display` error into a [`JsonRpcError::internal`].
 pub fn internal(e: impl std::fmt::Display) -> JsonRpcError {
     JsonRpcError::internal(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256};
+
+    use super::SetLeaderParams;
+
+    #[test]
+    fn set_leader_params_accept_legacy_and_force_forms() {
+        let target = Address::repeat_byte(0x11);
+        let legacy: SetLeaderParams = serde_json::from_value(serde_json::json!([target])).unwrap();
+        let (parsed_target, options) = legacy.into_parts();
+        assert_eq!(parsed_target, target);
+        assert!(!options.force);
+
+        let forced: SetLeaderParams = serde_json::from_value(serde_json::json!([
+            target,
+            {
+                "force": true,
+                "expectedEpoch": "0x7",
+                "recoveryBlockHash": B256::repeat_byte(0x22),
+            }
+        ]))
+        .unwrap();
+        let (parsed_target, options) = forced.into_parts();
+        assert_eq!(parsed_target, target);
+        assert!(options.force);
+        assert_eq!(options.expected_epoch.unwrap().to::<u64>(), 7);
+        assert_eq!(
+            options.recovery_block_hash.unwrap(),
+            B256::repeat_byte(0x22)
+        );
+    }
 }


### PR DESCRIPTION
Adds support for triggering forced recovery via `zone_setLeader` request. Forced recovery allows overriding the leader used for the remainder of current epoch if the current leader is down