### PR TITLE
fix(precompiles): restrict receipt balance lookups

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -22,8 +22,9 @@ use crate::{
     precompiles::{
         AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt, CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify,
         L1State, L1StorageReader, TIP403_REGISTRY_ADDRESS, TempoState, ZONE_FEE_MANAGER_ADDRESS,
-        ZoneInbox, ZonePrecompileEnv, create_tip20_precompile, create_tip403_precompile,
-        create_zone_fee_manager_precompile, tx_context::ZoneTxContext,
+        ZoneInbox, ZonePrecompileEnv, create_receive_policy_guard_precompile,
+        create_tip20_precompile, create_tip403_precompile, create_zone_fee_manager_precompile,
+        tx_context::ZoneTxContext,
     },
 };
 use alloy_evm::{
@@ -55,8 +56,7 @@ use tempo_precompiles::{
     RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, STORAGE_CREDITS_ADDRESS,
     TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS,
     account_keychain::AccountKeychain, error::Result as TempoResult, nonce::NonceManager,
-    receive_policy_guard::ReceivePolicyGuard, storage::actions::StorageActions,
-    storage_credits::StorageCredits, tip20::is_tip20_prefix,
+    storage::actions::StorageActions, storage_credits::StorageCredits, tip20::is_tip20_prefix,
 };
 use tempo_primitives::{
     Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType,
@@ -145,7 +145,7 @@ where
             } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
                 Some(AccountKeychain::create_precompile(&tempo_env))
             } else if *address == RECEIVE_POLICY_GUARD_ADDRESS {
-                Some(ReceivePolicyGuard::create_precompile(&tempo_env))
+                Some(create_receive_policy_guard_precompile(&env))
             } else if *address == STORAGE_CREDITS_ADDRESS {
                 Some(StorageCredits::create_precompile(&tempo_env))
             } else {

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -46,6 +46,7 @@ pub mod dispatch {
 mod execution;
 pub use execution::ZonePrecompileEnv;
 pub mod inbox;
+pub mod receive_policy_guard;
 pub mod storage;
 pub mod tempo_state;
 pub mod tip403_proxy;
@@ -68,6 +69,7 @@ use alloy_primitives::Address;
 use alloy_sol_types::SolError;
 use tempo_precompiles::{
     Precompile as _,
+    receive_policy_guard::ReceivePolicyGuard as TempoReceivePolicyGuard,
     tip20::{ITIP20::InsufficientBalance as TIP20InsufficientBalance, TIP20Token},
     tip403_registry::TIP403Registry,
 };
@@ -107,6 +109,16 @@ pub fn create_tip403_precompile(env: &ZonePrecompileEnv) -> DynPrecompile {
         env,
         tip403_proxy::Tip403Rules,
         |data, caller| TIP403Registry::new().call(data, caller),
+    )
+}
+
+/// Creates upstream receive-policy guard execution with Zone receipt-read privacy rules.
+pub fn create_receive_policy_guard_precompile(env: &ZonePrecompileEnv) -> DynPrecompile {
+    execution::create_precompile(
+        "ReceivePolicyGuard",
+        env,
+        receive_policy_guard::ReceivePolicyGuardRules,
+        |data, caller| TempoReceivePolicyGuard::new().call(data, caller),
     )
 }
 

--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -1,0 +1,298 @@
+//! Zone privacy rules for the upstream Tempo `ReceivePolicyGuard` precompile.
+//!
+//! A receipt witness is enumerable when most of its fields are known. Restricting
+//! `balanceOf(bytes)` before the upstream balance lookup prevents unrelated callers from using
+//! the return value as a receipt-existence and amount oracle.
+
+use crate::execution::{CallCheck, CallRules};
+use alloy_primitives::Address;
+use alloy_sol_types::{SolCall, SolError};
+use tempo_contracts::precompiles::IReceivePolicyGuard;
+use tempo_precompiles::{address_registry::AddressRegistry, dispatch::selector_from_calldata};
+use tempo_zone_contracts::Unauthorized;
+
+/// Stakeholder-only admission for receipt balance lookups.
+pub(crate) struct ReceivePolicyGuardRules;
+
+impl CallRules for ReceivePolicyGuardRules {
+    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
+        if selector_from_calldata(data) != Some(IReceivePolicyGuard::balanceOfCall::SELECTOR) {
+            return CallCheck::Continue;
+        }
+
+        let Ok(call) = IReceivePolicyGuard::balanceOfCall::abi_decode_raw(&data[4..]) else {
+            // Preserve the upstream ABI error for malformed calldata.
+            return CallCheck::Continue;
+        };
+        let Ok(receipt) = IReceivePolicyGuard::ClaimReceiptV1::try_from(call.receipt) else {
+            // Preserve the upstream InvalidReceipt error for malformed receipt bytes.
+            return CallCheck::Continue;
+        };
+
+        if caller == receipt.originator
+            || (receipt.recoveryAuthority != Address::ZERO && caller == receipt.recoveryAuthority)
+        {
+            return CallCheck::Continue;
+        }
+
+        if matches!(
+            AddressRegistry::new().resolve_recipient(receipt.recipient),
+            Ok(receiver) if caller == receiver
+        ) {
+            return CallCheck::Continue;
+        }
+
+        CallCheck::Revert(Unauthorized {}.abi_encode().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use alloy_evm::precompiles::DynPrecompile;
+    use alloy_primitives::{B256, Bytes, U256, address};
+    use alloy_sol_types::SolValue;
+    use revm::precompile::{PrecompileOutput, PrecompileResult};
+    use tempo_contracts::precompiles::{IReceivePolicyGuard::InboundKind, ITIP20, ITIP403Registry};
+    use tempo_precompiles::{
+        PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
+        address_registry::AddressRegistry,
+        receive_policy_guard::BLOCKED_RECEIPT_VERSION,
+        storage::StorageCtx,
+        test_util::{TIP20Setup, VIRTUAL_MASTER, register_virtual_master},
+        tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID, TIP403Registry},
+    };
+
+    use crate::{
+        create_receive_policy_guard_precompile,
+        test_utils::{TestContext, call_precompile, test_context, test_env, test_storage_provider},
+    };
+
+    const ADMIN: Address = address!("0x00000000000000000000000000000000000000a1");
+    const ORIGINATOR: Address = address!("0x00000000000000000000000000000000000000a2");
+    const RECEIVER: Address = address!("0x00000000000000000000000000000000000000a3");
+    const RECOVERY: Address = address!("0x00000000000000000000000000000000000000a4");
+    const OUTSIDER: Address = address!("0x00000000000000000000000000000000000000a5");
+    const BLOCKED_AT: u64 = 123;
+    const AMOUNT: U256 = U256::from_limbs([777, 0, 0, 0]);
+
+    fn receipt(
+        recipient: Address,
+        recovery_authority: Address,
+    ) -> IReceivePolicyGuard::ClaimReceiptV1 {
+        IReceivePolicyGuard::ClaimReceiptV1::new(
+            PATH_USD_ADDRESS,
+            recovery_authority,
+            ORIGINATOR,
+            recipient,
+            BLOCKED_AT,
+            1,
+            ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8,
+            InboundKind::TRANSFER,
+            B256::ZERO,
+        )
+    }
+
+    fn balance_call(receipt: &IReceivePolicyGuard::ClaimReceiptV1) -> Bytes {
+        IReceivePolicyGuard::balanceOfCall {
+            receipt: receipt.abi_encode().into(),
+        }
+        .abi_encode()
+        .into()
+    }
+
+    fn assert_allowed(
+        rules: &ReceivePolicyGuardRules,
+        receipt: &IReceivePolicyGuard::ClaimReceiptV1,
+        caller: Address,
+    ) {
+        assert!(matches!(
+            rules.admit(&balance_call(receipt), caller),
+            CallCheck::Continue
+        ));
+    }
+
+    fn assert_unauthorized(
+        rules: &ReceivePolicyGuardRules,
+        receipt: &IReceivePolicyGuard::ClaimReceiptV1,
+        caller: Address,
+    ) {
+        assert!(matches!(
+            rules.admit(&balance_call(receipt), caller),
+            CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
+        ));
+    }
+
+    #[test]
+    fn balance_admission_allows_only_direct_receipt_stakeholders() {
+        let rules = ReceivePolicyGuardRules;
+        let receipt = receipt(RECEIVER, RECOVERY);
+        let mut ctx = test_context();
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+
+        StorageCtx::enter(&mut storage, || {
+            for caller in [ORIGINATOR, RECEIVER, RECOVERY] {
+                assert_allowed(&rules, &receipt, caller);
+            }
+            assert_unauthorized(&rules, &receipt, OUTSIDER);
+        });
+    }
+
+    #[test]
+    fn balance_admission_resolves_virtual_recipient_to_master() -> eyre::Result<()> {
+        let rules = ReceivePolicyGuardRules;
+        let mut ctx = test_context();
+        ctx.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T8;
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
+
+        StorageCtx::enter(&mut storage, || {
+            let (_, virtual_recipient) = register_virtual_master(&mut AddressRegistry::new())?;
+            let receipt = receipt(virtual_recipient, Address::ZERO);
+
+            assert_allowed(&rules, &receipt, VIRTUAL_MASTER);
+            assert_unauthorized(&rules, &receipt, OUTSIDER);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn non_balance_calls_and_malformed_receipts_retain_upstream_dispatch() {
+        let rules = ReceivePolicyGuardRules;
+        let claim = IReceivePolicyGuard::claimCall {
+            to: RECEIVER,
+            receipt: Bytes::new(),
+        }
+        .abi_encode();
+        let malformed = IReceivePolicyGuard::balanceOfCall {
+            receipt: Bytes::from_static(&[0x01]),
+        }
+        .abi_encode();
+
+        assert!(matches!(rules.admit(&claim, OUTSIDER), CallCheck::Continue));
+        assert!(matches!(
+            rules.admit(&malformed, OUTSIDER),
+            CallCheck::Continue
+        ));
+    }
+
+    struct GuardHarness {
+        ctx: TestContext,
+        precompile: DynPrecompile,
+        receipt: IReceivePolicyGuard::ClaimReceiptV1,
+    }
+
+    impl GuardHarness {
+        fn new() -> eyre::Result<Self> {
+            let mut ctx = test_context();
+            ctx.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T8;
+            ctx.block.timestamp = U256::from(BLOCKED_AT);
+
+            {
+                let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
+                StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+                    let mut token = TIP20Setup::path_usd(ADMIN)
+                        .with_issuer(ADMIN)
+                        .with_mint(ORIGINATOR, AMOUNT)
+                        .apply()?;
+                    TIP403Registry::new().set_receive_policy(
+                        RECEIVER,
+                        ITIP403Registry::setReceivePolicyCall {
+                            senderPolicyId: REJECT_ALL_POLICY_ID,
+                            tokenFilterId: ALLOW_ALL_POLICY_ID,
+                            recoveryAuthority: RECEIVER,
+                        },
+                    )?;
+                    token.transfer(
+                        ORIGINATOR,
+                        ITIP20::transferCall {
+                            to: RECEIVER,
+                            amount: AMOUNT,
+                        },
+                    )?;
+                    Ok(())
+                })?;
+            }
+
+            let receipt = receipt(RECEIVER, RECEIVER);
+            assert_eq!(receipt.version, BLOCKED_RECEIPT_VERSION);
+            let env = test_env(&ctx);
+            let precompile = create_receive_policy_guard_precompile(&env);
+            Ok(Self {
+                ctx,
+                precompile,
+                receipt,
+            })
+        }
+
+        fn call(&mut self, caller: Address, data: Bytes, is_static: bool) -> PrecompileResult {
+            call_precompile(
+                &mut self.ctx,
+                &self.precompile,
+                caller,
+                &data,
+                u64::MAX,
+                is_static,
+                RECEIVE_POLICY_GUARD_ADDRESS,
+                RECEIVE_POLICY_GUARD_ADDRESS,
+            )
+        }
+
+        fn balance_of(&mut self, caller: Address) -> PrecompileResult {
+            self.balance_of_receipt(caller, self.receipt.clone())
+        }
+
+        fn balance_of_receipt(
+            &mut self,
+            caller: Address,
+            receipt: IReceivePolicyGuard::ClaimReceiptV1,
+        ) -> PrecompileResult {
+            self.call(caller, balance_call(&receipt), true)
+        }
+    }
+
+    fn decode_balance(output: &PrecompileOutput) -> eyre::Result<U256> {
+        Ok(IReceivePolicyGuard::balanceOfCall::abi_decode_returns(
+            &output.bytes,
+        )?)
+    }
+
+    #[test]
+    fn wrapper_hides_live_balance_from_outsider_and_preserves_claim() -> eyre::Result<()> {
+        let mut harness = GuardHarness::new()?;
+
+        let originator = harness.balance_of(ORIGINATOR)?;
+        assert!(originator.is_success());
+        assert_eq!(decode_balance(&originator)?, AMOUNT);
+
+        let receiver = harness.balance_of(RECEIVER)?;
+        assert!(receiver.is_success());
+        assert_eq!(decode_balance(&receiver)?, AMOUNT);
+
+        let outsider = harness.balance_of(OUTSIDER)?;
+        assert!(outsider.is_revert());
+        assert_eq!(outsider.bytes, Unauthorized {}.abi_encode());
+
+        let mut absent = harness.receipt.clone();
+        absent.blockedNonce += 1;
+        let outsider_absent = harness.balance_of_receipt(OUTSIDER, absent.clone())?;
+        assert!(outsider_absent.is_revert());
+        assert_eq!(outsider_absent.bytes, outsider.bytes);
+        let originator_absent = harness.balance_of_receipt(ORIGINATOR, absent)?;
+        assert!(originator_absent.is_success());
+        assert_eq!(decode_balance(&originator_absent)?, U256::ZERO);
+
+        let claim = IReceivePolicyGuard::claimCall {
+            to: RECEIVER,
+            receipt: harness.receipt.abi_encode().into(),
+        }
+        .abi_encode()
+        .into();
+        let claimed = harness.call(RECEIVER, claim, false)?;
+        assert!(claimed.is_success());
+
+        let balance = harness.balance_of(RECEIVER)?;
+        assert_eq!(decode_balance(&balance)?, U256::ZERO);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Implement the `ReceivePolicyGuard.balanceOf` privacy guard. Add stakeholder-only admission (originator, recovery authority or recipient) to balance lookups.