### PR TITLE
fix: Forward txns to all nodes (not just leader)

### DIFF
--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -786,7 +786,8 @@ where
         }
         DesiredRole::Follower { epoch } => {
             let (sync_tx, sync_rx) = mpsc::channel(GENERATION_EVENT_BACKLOG);
-            sinks.install(sync_tx, None);
+            let (transactions_tx, transactions_rx) = mpsc::channel(GENERATION_EVENT_BACKLOG);
+            sinks.install(sync_tx, Some(transactions_tx));
 
             let follower_token = token.clone();
             let provider = context.provider.clone();
@@ -829,6 +830,19 @@ where
                     () = forward_token.cancelled() => TaskEnd::Ended("transaction-forwarding (cancelled)"),
                     () = forward_new_transactions(pool, listener, commands) => {
                         TaskEnd::Ended("transaction-forwarding")
+                    }
+                }
+            });
+
+            // Followers retain transactions received from other nodes in case it
+            // gets promoted to leader in the future.
+            let pool = context.pool.clone();
+            let import_token = token.clone();
+            tasks.spawn(async move {
+                tokio::select! {
+                    () = import_token.cancelled() => TaskEnd::Ended("transaction-import (cancelled)"),
+                    () = insert_forwarded_transactions(pool, transactions_rx) => {
+                        TaskEnd::Ended("transaction-import")
                     }
                 }
             });

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -834,8 +834,9 @@ where
                 }
             });
 
-            // Followers retain transactions received from other nodes in case it
-            // gets promoted to leader in the future.
+            // Quorum followers retain transactions received from originating peers so a future
+            // promotion cannot lose traffic submitted immediately before the handoff. RPC-only
+            // followers receive no transaction events from the P2P transport.
             let pool = context.pool.clone();
             let import_token = token.clone();
             tasks.spawn(async move {

--- a/crates/node/src/tx_forwarding.rs
+++ b/crates/node/src/tx_forwarding.rs
@@ -1,4 +1,4 @@
-//! Follower-to-leader raw transaction forwarding and leader pool admission.
+//! Raw transaction propagation and replica pool admission.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -31,8 +31,8 @@ enum QueueOutcome {
     Closed,
 }
 
-/// Immediately queue new follower transactions, then periodically reconcile the pool
-/// to recover from intermittent connection issues / restarts.
+/// Immediately queue new follower transactions for every peer, then periodically reconcile the
+/// pool to recover from intermittent connection issues / restarts.
 pub(crate) async fn forward_new_transactions<P>(
     pool: P,
     mut transactions: mpsc::Receiver<NewTransactionEvent<TempoPooledTransaction>>,
@@ -90,7 +90,7 @@ fn try_queue_transaction(
     }) {
         Ok(()) => {
             metrics::counter!("zone_node_transactions_queued_for_forwarding_total").increment(1);
-            debug!(target: "zone::p2p", ?hash, transaction_size_bytes = encoded_len, "Queued follower transaction for leader");
+            debug!(target: "zone::p2p", ?hash, transaction_size_bytes = encoded_len, "Queued follower transaction for peers");
             QueueOutcome::Queued
         }
         Err(mpsc::error::TrySendError::Full(_)) => {
@@ -149,8 +149,7 @@ where
     true
 }
 
-/// Recover forwarded bytes and admit valid transactions to the leader's pool as external traffic.
-/// Note that only leader node will run this, followers don't need to keep track of mempool.
+/// Recover forwarded bytes and admit valid transactions to this replica's pool as external traffic.
 pub(crate) async fn insert_forwarded_transactions<P>(pool: P, mut events: mpsc::Receiver<P2pEvent>)
 where
     P: TransactionPool<Transaction = TempoPooledTransaction>,
@@ -179,7 +178,7 @@ where
         match pool.add_external_transaction(transaction).await {
             Ok(outcome) => {
                 metrics::counter!("zone_node_forwarded_transaction_admissions_total").increment(1);
-                debug!(target: "zone::p2p", %peer, ?hash, ?outcome, "Admitted forwarded transaction to leader pool");
+                debug!(target: "zone::p2p", %peer, ?hash, ?outcome, "Admitted forwarded transaction to local pool");
             }
             Err(err) if matches!(err.kind, PoolErrorKind::AlreadyImported) => {
                 metrics::counter!("zone_node_forwarded_transaction_duplicates_total").increment(1);
@@ -187,11 +186,11 @@ where
             }
             Err(err) => {
                 metrics::counter!("zone_node_forwarded_transaction_rejections_total").increment(1);
-                warn!(target: "zone::p2p", %peer, ?hash, %err, "Leader pool rejected forwarded transaction");
+                warn!(target: "zone::p2p", %peer, ?hash, %err, "Local pool rejected forwarded transaction");
             }
         }
     }
-    tracing::error!(target: "zone::p2p", "Leader P2P event channel closed");
+    debug!(target: "zone::p2p", "Transaction P2P event channel closed");
 }
 
 #[cfg(test)]
@@ -396,7 +395,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn leader_consumer_survives_malformed_and_duplicate_transactions() {
+    async fn replica_consumer_survives_malformed_and_duplicate_transactions() {
         let pool = test_pool();
         let (events, event_rx) = tokio::sync::mpsc::channel(8);
         let task = tokio::spawn(insert_forwarded_transactions(pool.clone(), event_rx));

--- a/crates/node/src/tx_forwarding.rs
+++ b/crates/node/src/tx_forwarding.rs
@@ -8,7 +8,7 @@ use std::{
 use alloy_eips::eip2718::Encodable2718 as _;
 use alloy_primitives::B256;
 use reth_transaction_pool::{
-    NewTransactionEvent, PoolTransaction, TransactionPool, error::PoolErrorKind,
+    NewTransactionEvent, PoolTransaction, TransactionOrigin, TransactionPool, error::PoolErrorKind,
 };
 use tempo_transaction_pool::transaction::TempoPooledTransaction;
 use tokio::{
@@ -31,8 +31,8 @@ enum QueueOutcome {
     Closed,
 }
 
-/// Immediately queue new follower transactions for every peer, then periodically reconcile the
-/// pool to recover from intermittent connection issues / restarts.
+/// Immediately queue locally originated follower transactions for the quorum, then periodically
+/// reconcile local-origin pool entries to recover from intermittent connection issues / restarts.
 pub(crate) async fn forward_new_transactions<P>(
     pool: P,
     mut transactions: mpsc::Receiver<NewTransactionEvent<TempoPooledTransaction>>,
@@ -52,6 +52,11 @@ pub(crate) async fn forward_new_transactions<P>(
                     tracing::error!(target: "zone::p2p", "Follower transaction pool listener closed");
                     return;
                 };
+                // Transactions admitted from P2P use `External` origin. Retain them for a future
+                // promotion, but do not relay them and create quorum-wide re-flooding.
+                if !event.transaction.origin.is_local() {
+                    continue;
+                }
                 let transaction = &event.transaction.transaction;
                 let hash = *transaction.hash();
 
@@ -90,7 +95,7 @@ fn try_queue_transaction(
     }) {
         Ok(()) => {
             metrics::counter!("zone_node_transactions_queued_for_forwarding_total").increment(1);
-            debug!(target: "zone::p2p", ?hash, transaction_size_bytes = encoded_len, "Queued follower transaction for peers");
+            debug!(target: "zone::p2p", ?hash, transaction_size_bytes = encoded_len, "Queued local follower transaction for quorum peers");
             QueueOutcome::Queued
         }
         Err(mpsc::error::TrySendError::Full(_)) => {
@@ -104,9 +109,9 @@ fn try_queue_transaction(
     }
 }
 
-/// Scan the current txpool to recover missed listener events and retry transactions whose retry
-/// interval has elapsed. Prune retry state for transactions no longer in the txpool, stop when
-/// the command channel applies backpressure, and return `false` if that channel has closed.
+/// Scan locally originated txpool entries to recover missed listener events and retry transactions
+/// whose retry interval has elapsed. Prune retry state for transactions no longer in that set,
+/// stop when the command channel applies backpressure, and return `false` if that channel closes.
 fn reconcile_txpool<P>(
     pool: &P,
     commands: &mpsc::Sender<P2pCommand>,
@@ -115,7 +120,7 @@ fn reconcile_txpool<P>(
 where
     P: TransactionPool<Transaction = TempoPooledTransaction>,
 {
-    let mut transactions = pool.pooled_transactions();
+    let mut transactions = pool.get_transactions_by_origin(TransactionOrigin::Local);
     let live_hashes: HashSet<_> = transactions.iter().map(|tx| *tx.hash()).collect();
     retry_at.retain(|hash, _| live_hashes.contains(hash));
 
@@ -150,6 +155,9 @@ where
 }
 
 /// Recover forwarded bytes and admit valid transactions to this replica's pool as external traffic.
+///
+/// The P2P layer emits these events only on quorum members, so promotable followers retain pending
+/// transactions while RPC-only standbys never receive their bodies.
 pub(crate) async fn insert_forwarded_transactions<P>(pool: P, mut events: mpsc::Receiver<P2pEvent>)
 where
     P: TransactionPool<Transaction = TempoPooledTransaction>,
@@ -321,7 +329,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn propagate_only_listener_excludes_private_transactions() {
+    async fn externally_admitted_transaction_is_retained_without_reforwarding() {
+        let pool = test_pool();
+        let listener = pool.new_transactions_listener();
+        let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);
+        let task = tokio::spawn(forward_new_transactions(pool.clone(), listener, commands));
+        let (transaction, _) = signed_transaction(0);
+        let transaction_hash = *transaction.hash();
+
+        pool.add_transaction(TransactionOrigin::External, transaction)
+            .await
+            .unwrap();
+
+        assert!(pool.contains(&transaction_hash));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), command_rx.recv())
+                .await
+                .is_err(),
+            "externally admitted transaction was re-forwarded"
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn forwarder_excludes_private_transactions() {
         let pool = test_pool();
         let listener = pool.new_transactions_listener();
         let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);

--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -52,7 +52,7 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
     cluster.wait_all_at(3, HANDOFF_TIMEOUT).await?;
 
     // --- Block 4 funds a sender so a pending transaction can ride through the handoff. ---
-    let (sender_wallet, sender) = local_dev_zone_account(&cluster.nodes[1])?;
+    let (sender_wallet, sender) = local_dev_zone_account(&cluster.nodes[2])?;
     let amount = 1_000_000_u128;
     cluster.inject_block(vec![L1Fixture::make_deposit_for_block(
         PATH_USD_ADDRESS,
@@ -61,7 +61,7 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
         amount,
     )])?;
     cluster.wait_all_at(4, DEFAULT_TIMEOUT).await?;
-    cluster.nodes[1]
+    cluster.nodes[2]
         .wait_for_balance(
             PATH_USD_ADDRESS,
             sender,
@@ -70,9 +70,9 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
         )
         .await?;
 
-    // Submit a transfer to follower B. B admits it locally and forwards it to the active
-    // leader A; nobody includes it before the handoff because no further anchor is injected
-    // under A's authorization.
+    // Submit a transfer to follower C. C admits it locally and forwards it to every peer,
+    // including active leader A and incoming leader B. Nobody includes it before the handoff
+    // because no further anchor is injected under A's authorization.
     let recipient = address!("0x00000000000000000000000000000000000ffff1");
     cluster.fixture.seed_no_receive_policy(recipient)?;
     let transfer_amount = 123_456_u128;
@@ -98,6 +98,21 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
         },
     )
     .await?;
+    let incoming_leader_provider = cluster.nodes[1].provider();
+    poll_until(
+        DEFAULT_TIMEOUT,
+        DEFAULT_POLL,
+        "forwarded transaction in the incoming leader's pool",
+        || {
+            let incoming_leader_provider = &incoming_leader_provider;
+            async move {
+                Ok(incoming_leader_provider
+                    .get_transaction_by_hash(transaction_hash)
+                    .await?)
+            }
+        },
+    )
+    .await?;
 
     // --- The handoff: leadership of every anchor >= H moves to B. ---
     let handoff_anchor = cluster.next_anchor_number();
@@ -107,8 +122,8 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
     );
     cluster.publish_transition(1, 1, handoff_anchor)?;
 
-    // Produce blocks under B until the pending transfer is included. B's own pool already
-    // holds the transaction, and A's post-demotion reconciliation re-forwards its pool to B.
+    // Produce blocks under B until the pending transfer is included. B already retained the
+    // transaction before the handoff, independently of A's post-demotion reconciliation.
     let receipt = tokio::time::timeout(HANDOFF_TIMEOUT, async {
         loop {
             cluster.inject_block(vec![])?;
@@ -317,9 +332,8 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
     let handoff_anchor = next_anchor + 3;
     cluster.publish_transition(1, 1, handoff_anchor)?;
 
-    // A transfer submitted to follower C during the window must be forwarded to the
-    // still-active leader A — not to the not-yet-active B, whose follower generation
-    // holds no transaction sink.
+    // A transfer submitted to follower C during the window is forwarded to every peer,
+    // including both still-active leader A and not-yet-active leader B.
     let recipient = address!("0x00000000000000000000000000000000000ffff2");
     cluster.fixture.seed_no_receive_policy(recipient)?;
     let transfer_amount = 123_456_u128;

--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -70,7 +70,7 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
         )
         .await?;
 
-    // Submit a transfer to follower C. C admits it locally and forwards it to every peer,
+    // Submit a transfer to follower C. C admits it locally and forwards it to every quorum peer,
     // including active leader A and incoming leader B. Nobody includes it before the handoff
     // because no further anchor is injected under A's authorization.
     let recipient = address!("0x00000000000000000000000000000000000ffff1");
@@ -332,7 +332,7 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
     let handoff_anchor = next_anchor + 3;
     cluster.publish_transition(1, 1, handoff_anchor)?;
 
-    // A transfer submitted to follower C during the window is forwarded to every peer,
+    // A transfer submitted to follower C during the window is forwarded to every quorum peer,
     // including both still-active leader A and not-yet-active leader B.
     let recipient = address!("0x00000000000000000000000000000000000ffff2");
     cluster.fixture.seed_no_receive_policy(recipient)?;

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -15,7 +15,7 @@ pub(crate) const BLOCK_CHANNEL: u64 = 0;
 pub(crate) const BACKFILL_REQUEST_CHANNEL: u64 = 1;
 /// Ordered block and completion frames returned for a catch-up request.
 pub(crate) const BACKFILL_RESPONSE_CHANNEL: u64 = 2;
-/// Raw transaction propagation channel between Zone nodes.
+/// Raw transaction propagation channel into the sequencer quorum.
 pub(crate) const TRANSACTION_CHANNEL: u64 = 3;
 /// Leader-to-follower proposed settlement statement channel.
 pub(crate) const SETTLEMENT_PROPOSAL_CHANNEL: u64 = 4;

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -15,7 +15,7 @@ pub(crate) const BLOCK_CHANNEL: u64 = 0;
 pub(crate) const BACKFILL_REQUEST_CHANNEL: u64 = 1;
 /// Ordered block and completion frames returned for a catch-up request.
 pub(crate) const BACKFILL_RESPONSE_CHANNEL: u64 = 2;
-/// Follower-to-leader raw transaction forwarding channel.
+/// Raw transaction propagation channel between Zone nodes.
 pub(crate) const TRANSACTION_CHANNEL: u64 = 3;
 /// Leader-to-follower proposed settlement statement channel.
 pub(crate) const SETTLEMENT_PROPOSAL_CHANNEL: u64 = 4;

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -345,7 +345,7 @@ pub enum P2pCommand {
         request_id: u64,
         tip: PeerTip,
     },
-    /// Forward one canonical EIP-2718 transaction to every other Zone node.
+    /// Forward one canonical EIP-2718 transaction to every other quorum member.
     ForwardTransaction {
         transaction_hash: B256,
         transaction: Vec<u8>,
@@ -385,7 +385,7 @@ pub enum P2pEvent {
     BackfillBlockReceived { peer: PublicKey, block: Vec<u8> },
     /// The responder sent all blocks available in this response page.
     BackfillCompleted { peer: PublicKey, tip: PeerTip },
-    /// A node received a raw transaction from an authenticated follower.
+    /// A quorum member received a raw transaction from an authenticated follower.
     TransactionReceived {
         follower_ed25519_public_key: PublicKey,
         transaction: Vec<u8>,
@@ -840,8 +840,9 @@ async fn run_commands(
                 transaction,
             } => {
                 // Only followers run the transaction-forwarding task. Keep the outbound role
-                // fence, but send to every other manifest member so every possible successor
-                // retains the transaction before a leadership handoff.
+                // fence, but send to every other quorum member so every possible successor
+                // retains the transaction before a leadership handoff. RPC-only standbys can
+                // originate transactions but never need to retain transactions from other nodes.
                 let Some(record) = leadership.next_anchor_record() else {
                     metrics::counter!("zone_p2p_uninitialized_leadership_commands_dropped_total")
                         .increment(1);
@@ -854,28 +855,28 @@ async fn run_commands(
                     warn!(target: "zone::p2p", ?transaction_hash, "Ignoring outbound transaction command on the next-anchor leader");
                     continue;
                 }
-                let recipients = others();
+                let recipients = leadership.quorum_peers(&others());
                 let configured = recipients.len();
                 let transaction_size = transaction.len();
                 let sent = match senders
                     .transactions
-                    .send(Recipients::Some(recipients), transaction, true)
+                    .send(Recipients::Some(recipients), transaction, false)
                     .await
                 {
                     Ok(sent) => sent,
                     Err(err) => {
                         metrics::counter!("zone_p2p_transaction_sends_without_peers_total")
                             .increment(1);
-                        warn!(target: "zone::p2p", ?transaction_hash, transaction_size_bytes = transaction_size, %err, "Failed to forward transaction to peers; dropping this send attempt");
+                        warn!(target: "zone::p2p", ?transaction_hash, transaction_size_bytes = transaction_size, %err, "Failed to forward transaction to quorum peers; dropping this send attempt");
                         continue;
                     }
                 };
                 if sent.is_empty() {
                     metrics::counter!("zone_p2p_transaction_sends_without_peers_total")
                         .increment(1);
-                    warn!(target: "zone::p2p", ?transaction_hash, configured, transaction_size_bytes = transaction_size, "Forwarded transaction reached no peer (peers disconnected, sender throttled, or outbound queue full); dropping this send attempt");
+                    warn!(target: "zone::p2p", ?transaction_hash, configured, transaction_size_bytes = transaction_size, "Forwarded transaction reached no quorum peer (peers disconnected, sender throttled, or outbound queue full); dropping this send attempt");
                 } else {
-                    debug!(target: "zone::p2p", ?transaction_hash, connected = sent.len(), configured, transaction_size_bytes = transaction_size, "Forwarded transaction to peers");
+                    debug!(target: "zone::p2p", ?transaction_hash, connected = sent.len(), configured, transaction_size_bytes = transaction_size, "Forwarded transaction to quorum peers");
                 }
             }
         }
@@ -1016,12 +1017,13 @@ async fn run_receivers(
                 }
             }
 
-            // Got a transaction forwarded by an authenticated manifest peer. Every node admits
-            // these into its pool so a future leader does not start its generation empty.
+            // Got a transaction forwarded by an authenticated manifest peer. Only quorum members
+            // admit these into their pools; RPC-only standbys can never become leader.
             result = transactions.recv() => {
                 let (peer, bytes) = result.map_err(|err| eyre::eyre!("transaction channel receive failed: {err}"))?;
                 if peer == local_ed25519_public_key
                     || !manifest.contains_ed25519_public_key(&peer)
+                    || !leadership.is_quorum_member(&local_ed25519_public_key)
                 {
                     metrics::counter!("zone_p2p_role_invalid_messages_dropped_total").increment(1);
                     warn!(target: "zone::p2p", %peer, "Ignoring transaction from role-invalid peer");
@@ -1900,8 +1902,8 @@ mod tests {
         }
     }
 
-    /// An RPC-only member replicates and forwards like any follower, but stays outside the
-    /// settlement quorum in both directions.
+    /// An RPC-only member replicates blocks and forwards its own transactions into the quorum,
+    /// but receives neither settlement traffic nor transactions submitted to other nodes.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_only_follower_replicates_but_never_settles() {
         const LEADER: usize = 0;
@@ -1944,6 +1946,12 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let leader_commands = handles[LEADER].parts.as_ref().unwrap().commands.clone();
+        let quorum_follower_commands = handles[QUORUM_FOLLOWER]
+            .parts
+            .as_ref()
+            .unwrap()
+            .commands
+            .clone();
         let rpc_commands = handles[RPC_FOLLOWER]
             .parts
             .as_ref()
@@ -2016,7 +2024,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Public RPC submissions reach every other replica, not just the active leader.
+        // Public RPC submissions reach every quorum member, not just the active leader.
         let transaction_hash = B256::with_last_byte(7);
         let transaction = vec![0x76, 0x07];
         let forwarder = repeat(
@@ -2046,6 +2054,24 @@ mod tests {
             });
         }
         forwarder.abort();
+
+        // Transactions submitted to a quorum follower stay within the quorum. The RPC-only
+        // standby continues replicating blocks but does not retain unrelated pending bodies.
+        let quorum_forwarder = repeat(
+            quorum_follower_commands,
+            P2pCommand::ForwardTransaction {
+                transaction_hash: B256::with_last_byte(8),
+                transaction: vec![0x76, 0x08],
+            },
+        );
+        assert_no_event_matching(
+            handles[RPC_FOLLOWER].events_mut(),
+            Duration::from_secs(2),
+            "RPC-only follower received another node's transaction",
+            |event| matches!(event, P2pEvent::TransactionReceived { .. }),
+        )
+        .await;
+        quorum_forwarder.abort();
 
         for handle in handles {
             tokio::time::timeout(Duration::from_secs(10), handle.shutdown())

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -345,7 +345,7 @@ pub enum P2pCommand {
         request_id: u64,
         tip: PeerTip,
     },
-    /// Forward one canonical EIP-2718 transaction from a follower to the leader.
+    /// Forward one canonical EIP-2718 transaction to every other Zone node.
     ForwardTransaction {
         transaction_hash: B256,
         transaction: Vec<u8>,
@@ -385,7 +385,7 @@ pub enum P2pEvent {
     BackfillBlockReceived { peer: PublicKey, block: Vec<u8> },
     /// The responder sent all blocks available in this response page.
     BackfillCompleted { peer: PublicKey, tip: PeerTip },
-    /// The leader received a raw transaction from an authenticated follower.
+    /// A node received a raw transaction from an authenticated follower.
     TransactionReceived {
         follower_ed25519_public_key: PublicKey,
         transaction: Vec<u8>,
@@ -639,8 +639,7 @@ async fn run_commands(
     mut commands: mpsc::Receiver<P2pCommand>,
 ) -> eyre::Result<()> {
     while let Some(command) = commands.recv().await {
-        // Built only in arms that actually address a peer set — forwarding a transaction must
-        // not allocate one.
+        // Built only in arms that actually address a peer set.
         let others = || {
             peers
                 .iter()
@@ -840,9 +839,9 @@ async fn run_commands(
                 transaction_hash,
                 transaction,
             } => {
-                // A forwarded transaction is for the producer of the *next* anchor — the
-                // most recently observed record may only activate in the future, and its
-                // leader runs a follower generation that holds no transaction sink yet.
+                // Only followers run the transaction-forwarding task. Keep the outbound role
+                // fence, but send to every other manifest member so every possible successor
+                // retains the transaction before a leadership handoff.
                 let Some(record) = leadership.next_anchor_record() else {
                     metrics::counter!("zone_p2p_uninitialized_leadership_commands_dropped_total")
                         .increment(1);
@@ -855,29 +854,28 @@ async fn run_commands(
                     warn!(target: "zone::p2p", ?transaction_hash, "Ignoring outbound transaction command on the next-anchor leader");
                     continue;
                 }
+                let recipients = others();
+                let configured = recipients.len();
+                let transaction_size = transaction.len();
                 let sent = match senders
                     .transactions
-                    .send(
-                        Recipients::Some(vec![leader.clone()]),
-                        transaction.clone(),
-                        true,
-                    )
+                    .send(Recipients::Some(recipients), transaction, true)
                     .await
                 {
                     Ok(sent) => sent,
                     Err(err) => {
-                        metrics::counter!("zone_p2p_transaction_sends_without_leader_total")
+                        metrics::counter!("zone_p2p_transaction_sends_without_peers_total")
                             .increment(1);
-                        warn!(target: "zone::p2p", ?transaction_hash, leader = %leader, transaction_size_bytes = transaction.len(), %err, "Failed to send forwarded transaction; dropping this send attempt");
+                        warn!(target: "zone::p2p", ?transaction_hash, transaction_size_bytes = transaction_size, %err, "Failed to forward transaction to peers; dropping this send attempt");
                         continue;
                     }
                 };
                 if sent.is_empty() {
-                    metrics::counter!("zone_p2p_transaction_sends_without_leader_total")
+                    metrics::counter!("zone_p2p_transaction_sends_without_peers_total")
                         .increment(1);
-                    warn!(target: "zone::p2p", ?transaction_hash, leader = %leader, transaction_size_bytes = transaction.len(), "Forwarded transaction was not sent (leader disconnected, sender throttled, or outbound queue full); dropping this send attempt");
+                    warn!(target: "zone::p2p", ?transaction_hash, configured, transaction_size_bytes = transaction_size, "Forwarded transaction reached no peer (peers disconnected, sender throttled, or outbound queue full); dropping this send attempt");
                 } else {
-                    debug!(target: "zone::p2p", ?transaction_hash, leader = %leader, transaction_size_bytes = transaction.len(), "Forwarded transaction to leader");
+                    debug!(target: "zone::p2p", ?transaction_hash, connected = sent.len(), configured, transaction_size_bytes = transaction_size, "Forwarded transaction to peers");
                 }
             }
         }
@@ -1018,12 +1016,12 @@ async fn run_receivers(
                 }
             }
 
-            // Got a transaction forwarded by an authenticated follower.
+            // Got a transaction forwarded by an authenticated manifest peer. Every node admits
+            // these into its pool so a future leader does not start its generation empty.
             result = transactions.recv() => {
                 let (peer, bytes) = result.map_err(|err| eyre::eyre!("transaction channel receive failed: {err}"))?;
                 if peer == local_ed25519_public_key
                     || !manifest.contains_ed25519_public_key(&peer)
-                    || !leadership.is_scheduled_leader(&local_ed25519_public_key)
                 {
                     metrics::counter!("zone_p2p_role_invalid_messages_dropped_total").increment(1);
                     warn!(target: "zone::p2p", %peer, "Ignoring transaction from role-invalid peer");
@@ -1385,41 +1383,31 @@ mod tests {
 
         let transaction_hash = B256::with_last_byte(2);
         let transaction = vec![0x76, 0x01, 0x02, 0x03];
-        follower_commands
-            .send(P2pCommand::ForwardTransaction {
+        let forwarder = repeat(
+            follower_commands.clone(),
+            P2pCommand::ForwardTransaction {
                 transaction_hash,
                 transaction: transaction.clone(),
+            },
+        );
+        for index in [0, 2] {
+            tokio::time::timeout(Duration::from_secs(15), async {
+                loop {
+                    if let Some(P2pEvent::TransactionReceived {
+                        follower_ed25519_public_key,
+                        transaction: received,
+                    }) = handles[index].events_mut().recv().await
+                    {
+                        assert_eq!(follower_ed25519_public_key, first_follower_peer);
+                        assert_eq!(received, transaction);
+                        return;
+                    }
+                }
             })
             .await
-            .unwrap();
-        tokio::time::timeout(Duration::from_secs(15), async {
-            loop {
-                if let Some(P2pEvent::TransactionReceived {
-                    follower_ed25519_public_key,
-                    transaction: received,
-                }) = handles[0].events_mut().recv().await
-                {
-                    assert_eq!(follower_ed25519_public_key, first_follower_peer);
-                    assert_eq!(received, transaction);
-                    return;
-                }
-            }
-        })
-        .await
-        .expect("leader did not receive forwarded transaction");
-
-        // Forwarding is point-to-point: the other follower receives neither the transaction nor
-        // the role-invalid block command above.
-        let other_follower = tokio::time::timeout(Duration::from_millis(300), async {
-            while let Some(event) = handles[2].events_mut().recv().await {
-                assert!(
-                    !matches!(event, P2pEvent::TransactionReceived { .. }),
-                    "forwarded transaction reached another follower"
-                );
-            }
-        })
-        .await;
-        assert!(other_follower.is_err(), "other follower runtime stopped");
+            .unwrap_or_else(|_| panic!("node-{index} did not receive forwarded transaction"));
+        }
+        forwarder.abort();
 
         let proposal = vec![0x10, 0x20];
         leader_commands
@@ -1697,7 +1685,7 @@ mod tests {
     /// traffic early: while the local applied anchor is still governed by the outgoing
     /// leader, its block broadcasts and settlement proposals keep flowing (including to the
     /// incoming leader), signatures return to the proposer, and forwarded transactions
-    /// target the next-anchor leader — never the most recently observed record.
+    /// reach every replica before the transition activates.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn advance_scheduled_transition_keeps_anchor_relevant_routing() {
         let addresses = [
@@ -1839,26 +1827,26 @@ mod tests {
         .await
         .expect("outgoing leader did not receive the settlement signature");
 
-        // Forwarded transactions go to the producer of the next anchor (A), never to the
-        // observed-latest leader (B) whose production only starts at the boundary. B's own
-        // forwards reach A as well.
+        // Forwarded transactions reach every other replica. In particular, B retains C's
+        // transaction before its leadership activates, while B's own forward reaches A and C.
         let transaction = vec![0x76, 0x01, 0x02, 0x03];
-        follower_commands
-            .send(P2pCommand::ForwardTransaction {
+        let follower_forwarder = repeat(
+            follower_commands.clone(),
+            P2pCommand::ForwardTransaction {
                 transaction_hash: B256::with_last_byte(1),
                 transaction: transaction.clone(),
-            })
-            .await
-            .unwrap();
-        incoming_commands
-            .send(P2pCommand::ForwardTransaction {
+            },
+        );
+        let incoming_forwarder = repeat(
+            incoming_commands.clone(),
+            P2pCommand::ForwardTransaction {
                 transaction_hash: B256::with_last_byte(2),
                 transaction: transaction.clone(),
-            })
-            .await
-            .unwrap();
+            },
+        );
         tokio::time::timeout(Duration::from_secs(15), async {
-            let mut senders = Vec::new();
+            let mut received_from_incoming = false;
+            let mut received_from_follower = false;
             loop {
                 if let Some(P2pEvent::TransactionReceived {
                     follower_ed25519_public_key,
@@ -1866,8 +1854,12 @@ mod tests {
                 }) = handles[0].events_mut().recv().await
                 {
                     assert_eq!(received, transaction);
-                    senders.push(follower_ed25519_public_key);
-                    if senders.len() == 2 {
+                    if follower_ed25519_public_key == incoming_leader {
+                        received_from_incoming = true;
+                    } else if follower_ed25519_public_key == follower_peer {
+                        received_from_follower = true;
+                    }
+                    if received_from_incoming && received_from_follower {
                         return;
                     }
                 }
@@ -1875,21 +1867,30 @@ mod tests {
         })
         .await
         .expect("outgoing leader did not receive both forwarded transactions");
-        let incoming_got_transaction = tokio::time::timeout(Duration::from_millis(300), async {
-            loop {
-                if matches!(
-                    handles[1].events_mut().recv().await,
-                    Some(P2pEvent::TransactionReceived { .. }) | None
-                ) {
-                    return;
+
+        for (recipient, expected_sender) in
+            [(1, follower_peer.clone()), (2, incoming_leader.clone())]
+        {
+            tokio::time::timeout(Duration::from_secs(15), async {
+                loop {
+                    if let Some(P2pEvent::TransactionReceived {
+                        follower_ed25519_public_key,
+                        transaction: received,
+                    }) = handles[recipient].events_mut().recv().await
+                    {
+                        assert_eq!(follower_ed25519_public_key, expected_sender);
+                        assert_eq!(received, transaction);
+                        return;
+                    }
                 }
-            }
-        })
-        .await;
-        assert!(
-            incoming_got_transaction.is_err(),
-            "a forwarded transaction was misrouted to the not-yet-active incoming leader"
-        );
+            })
+            .await
+            .unwrap_or_else(|_| {
+                panic!("node-{recipient} did not receive the peer's forwarded transaction")
+            });
+        }
+        follower_forwarder.abort();
+        incoming_forwarder.abort();
 
         for handle in handles {
             tokio::time::timeout(Duration::from_secs(10), handle.shutdown())
@@ -2015,7 +2016,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Transaction forwarding still works: public RPC submissions must reach the leader.
+        // Public RPC submissions reach every other replica, not just the active leader.
         let transaction_hash = B256::with_last_byte(7);
         let transaction = vec![0x76, 0x07];
         let forwarder = repeat(
@@ -2025,27 +2026,25 @@ mod tests {
                 transaction: transaction.clone(),
             },
         );
-        tokio::time::timeout(Duration::from_secs(15), async {
-            loop {
-                match handles[LEADER].events_mut().recv().await {
-                    Some(P2pEvent::SettlementSignatureReceived { follower, .. }) => {
-                        panic!("leader accepted a settlement signature from {follower}")
-                    }
-                    Some(P2pEvent::TransactionReceived {
+        for index in [LEADER, QUORUM_FOLLOWER, QUORUM_FOLLOWER_B] {
+            tokio::time::timeout(Duration::from_secs(15), async {
+                loop {
+                    if let Some(P2pEvent::TransactionReceived {
                         follower_ed25519_public_key,
                         transaction: received,
-                    }) => {
+                    }) = handles[index].events_mut().recv().await
+                    {
                         assert_eq!(follower_ed25519_public_key, rpc_follower_peer);
                         assert_eq!(received, transaction);
                         return;
                     }
-                    Some(_) => {}
-                    None => panic!("leader event channel closed"),
                 }
-            }
-        })
-        .await
-        .expect("leader did not receive the RPC-only follower's forwarded transaction");
+            })
+            .await
+            .unwrap_or_else(|_| {
+                panic!("node-{index} did not receive the RPC-only follower's transaction")
+            });
+        }
         forwarder.abort();
 
         for handle in handles {
@@ -2130,7 +2129,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn unavailable_leader_drops_transaction_without_stopping_follower() {
+    async fn followers_exchange_transactions_while_leader_is_offline() {
         let addresses = [
             available_address(),
             available_address(),
@@ -2154,65 +2153,78 @@ mod tests {
             ));
         }
         let manifest = Arc::new(ZoneManifest::parse(&input).unwrap());
-        let identity = ed25519_identity(12);
-        let secp256k1_identity = secp256k1_identity(12);
-        let role = manifest
-            .validate_node(
-                9,
-                &identity.ed25519_public_key(),
-                Some(secp256k1_identity.address()),
-                None,
-            )
-            .unwrap();
-        assert_eq!(role, crate::Role::Follower);
-        let mut handle = spawn_p2p(
-            P2pConfig {
-                manifest: manifest.clone(),
-                ed25519_identity: identity,
-                secp256k1_identity: Some(secp256k1_identity),
-                listen: addresses[1],
-                bypass_ip_check: false,
-                leadership: crate::LeadershipSchedule::seeded(manifest.bootstrap_leadership()),
-            },
-            P2pNetworkId::new(1, address!("1111111111111111111111111111111111111111")),
-        )
-        .unwrap();
+        let sender_peer = identities[1].ed25519_public_key();
+        let mut handles = identities
+            .into_iter()
+            .zip(addresses)
+            .enumerate()
+            .skip(1)
+            .map(|(index, (identity, listen))| {
+                let secp256k1_identity = secp256k1_identity(index as u64 + 11);
+                let role = manifest
+                    .validate_node(
+                        9,
+                        &identity.ed25519_public_key(),
+                        Some(secp256k1_identity.address()),
+                        None,
+                    )
+                    .unwrap();
+                assert_eq!(role, crate::Role::Follower);
+                spawn_p2p(
+                    P2pConfig {
+                        manifest: manifest.clone(),
+                        ed25519_identity: identity,
+                        secp256k1_identity: Some(secp256k1_identity),
+                        listen,
+                        bypass_ip_check: false,
+                        leadership: crate::LeadershipSchedule::seeded(
+                            manifest.bootstrap_leadership(),
+                        ),
+                    },
+                    P2pNetworkId::new(1, address!("1111111111111111111111111111111111111111")),
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
 
-        tokio::time::timeout(Duration::from_secs(5), async {
-            while !matches!(
-                handle.events_mut().recv().await,
-                Some(P2pEvent::Started { .. })
-            ) {}
+        for handle in &mut handles {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                while !matches!(
+                    handle.events_mut().recv().await,
+                    Some(P2pEvent::Started { .. })
+                ) {}
+            })
+            .await
+            .expect("follower P2P runtime did not start");
+        }
+        let commands = handles[0].parts.as_ref().unwrap().commands.clone();
+        let transaction = vec![0x76, 0x01];
+        let forwarder = repeat(
+            commands,
+            P2pCommand::ForwardTransaction {
+                transaction_hash: B256::with_last_byte(1),
+                transaction: transaction.clone(),
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                if let Some(P2pEvent::TransactionReceived {
+                    follower_ed25519_public_key,
+                    transaction: received,
+                }) = handles[1].events_mut().recv().await
+                {
+                    assert_eq!(follower_ed25519_public_key, sender_peer);
+                    assert_eq!(received, transaction);
+                    return;
+                }
+            }
         })
         .await
-        .expect("follower P2P runtime did not start");
-        let commands = handle.parts.as_ref().unwrap().commands.clone();
-        commands
-            .send(P2pCommand::ForwardTransaction {
-                transaction_hash: B256::with_last_byte(1),
-                transaction: vec![0x76, 0x01],
-            })
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        commands
-            .send(P2pCommand::ForwardTransaction {
-                transaction_hash: B256::with_last_byte(2),
-                transaction: vec![0x76, 0x02],
-            })
-            .await
-            .expect("a dropped send must not stop the command loop");
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        assert!(
-            tokio::time::timeout(
-                Duration::from_millis(100),
-                &mut handle.parts.as_mut().unwrap().stopped,
-            )
-            .await
-            .is_err(),
-            "follower runtime stopped after an unavailable-leader send"
-        );
+        .expect("reachable follower did not receive transaction while leader was offline");
+        forwarder.abort();
 
-        handle.shutdown().await.unwrap();
+        for handle in handles {
+            handle.shutdown().await.unwrap();
+        }
     }
 }


### PR DESCRIPTION
Currently, followers forward recieved txns only to the current leader. however, since a leader can rotate, a newly promoted leader might start with 0 transactions and the former leader's mempool txns will get dropped.

Fixed by having the recieved txns forwarded to all nodes