### PR TITLE
fix(evm): reject unexpected zone system transactions

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -20,8 +20,10 @@ use tempo_primitives::{TempoReceipt, TempoTxEnvelope, TempoTxType};
 use tempo_revm::evm::TempoContext;
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
-use zone_precompiles::{ADVANCE_TEMPO_SELECTOR, L1StorageReader, tx_context};
-use zone_primitives::constants::ZONE_INBOX_ADDRESS;
+use zone_precompiles::{
+    ADVANCE_TEMPO_SELECTOR, L1StorageReader, is_finalize_withdrawal_batch_calldata, tx_context,
+};
+use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
 use crate::{L1OverlayDB, ZoneEvm};
 
@@ -107,8 +109,10 @@ where
             tempo_tx_env.expiring_nonce_idx = None;
         }
 
-        // ensure `advance_tempo` system transaction is the first in the block.
-        let is_advance_tempo = validate_advance_tempo(self.has_advanced_tempo, recovered.tx())?;
+        // Ensure `advanceTempo` is the first transaction and reject any other system
+        // transaction except withdrawal finalization.
+        let is_advance_tempo =
+            validate_system_transaction(self.has_advanced_tempo, recovered.tx())?;
 
         let _tx_context_guard = tx_context::set_current_transaction(
             *recovered.tx().tx_hash(),
@@ -155,7 +159,7 @@ where
     }
 }
 
-fn validate_advance_tempo(
+fn validate_system_transaction(
     has_advanced_tempo: bool,
     tx: &TempoTxEnvelope,
 ) -> Result<bool, BlockExecutionError> {
@@ -164,25 +168,48 @@ fn validate_advance_tempo(
             kind.to() == Some(&ZONE_INBOX_ADDRESS) && input.starts_with(&ADVANCE_TEMPO_SELECTOR)
         });
 
-    match (has_advanced_tempo, is_advance_tempo) {
-        (false, false) => Err(BlockValidationError::msg(
-            "advanceTempo must be the first transaction in a zone block",
-        )
-        .into()),
-        (true, true) => Err(BlockValidationError::msg(
+    if !has_advanced_tempo {
+        return if is_advance_tempo {
+            Ok(true)
+        } else {
+            Err(BlockValidationError::msg(
+                "advanceTempo must be the first transaction in a zone block",
+            )
+            .into())
+        };
+    }
+
+    if is_advance_tempo {
+        return Err(BlockValidationError::msg(
             "advanceTempo must only execute once per zone block",
         )
-        .into()),
-        (false, true) | (true, false) => Ok(is_advance_tempo),
+        .into());
     }
+
+    if tx.is_system_tx()
+        && !tx.calls().any(|(kind, input)| {
+            kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_calldata(input)
+        })
+    {
+        return Err(BlockValidationError::msg(
+            "system transactions after advanceTempo must call ZoneOutbox.finalizeWithdrawalBatch",
+        )
+        .into());
+    }
+
+    Ok(false)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{ADVANCE_TEMPO_SELECTOR, ZONE_INBOX_ADDRESS, validate_advance_tempo};
+    use super::{
+        ADVANCE_TEMPO_SELECTOR, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
+        validate_system_transaction,
+    };
 
     use alloy_consensus::{Signed, TxLegacy};
-    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_primitives::{Address, Bytes, Signature, U256};
+    use alloy_sol_types::SolCall;
     use tempo_precompiles::{
         DEFAULT_FEE_TOKEN, TIP_FEE_MANAGER_ADDRESS,
         storage::{ContractStorage, Handler, StorageCtx, hashmap::HashMapStorageProvider},
@@ -191,6 +218,7 @@ mod tests {
     };
     use tempo_primitives::{TempoTxEnvelope, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE};
     use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
+    use tempo_zone_contracts::IZoneOutbox;
 
     fn system_tx(to: Address, input: Bytes) -> TempoTxEnvelope {
         TempoTxEnvelope::Legacy(Signed::new_unhashed(
@@ -212,11 +240,12 @@ mod tests {
         let mut has_advanced_tempo = false;
 
         // Execution returns the marker but must not mutate committed state.
-        assert!(validate_advance_tempo(has_advanced_tempo, &advance_tempo).unwrap());
+        assert!(validate_system_transaction(has_advanced_tempo, &advance_tempo).unwrap());
         assert!(!has_advanced_tempo);
 
         // Only committing the result records the opening transaction.
-        has_advanced_tempo |= validate_advance_tempo(has_advanced_tempo, &advance_tempo).unwrap();
+        has_advanced_tempo |=
+            validate_system_transaction(has_advanced_tempo, &advance_tempo).unwrap();
         assert!(has_advanced_tempo);
     }
 
@@ -228,17 +257,67 @@ mod tests {
         );
         let ordinary = system_tx(Address::ZERO, Bytes::new());
 
-        let missing_first = validate_advance_tempo(false, &ordinary).unwrap_err();
+        let missing_first = validate_system_transaction(false, &ordinary).unwrap_err();
         assert_eq!(
             missing_first.to_string(),
             "advanceTempo must be the first transaction in a zone block"
         );
 
-        let duplicate = validate_advance_tempo(true, &advance_tempo).unwrap_err();
+        let duplicate = validate_system_transaction(true, &advance_tempo).unwrap_err();
         assert_eq!(
             duplicate.to_string(),
             "advanceTempo must only execute once per zone block"
         );
+    }
+
+    #[test]
+    fn only_withdrawal_finalization_system_transactions_are_allowed_after_advance_tempo() {
+        let finalize = system_tx(
+            ZONE_OUTBOX_ADDRESS,
+            IZoneOutbox::finalizeWithdrawalBatchCall {
+                count: U256::ZERO,
+                blockNumber: 1,
+                encryptedSenders: vec![],
+            }
+            .abi_encode()
+            .into(),
+        );
+        assert!(!validate_system_transaction(true, &finalize).unwrap());
+
+        let setter = system_tx(
+            ZONE_OUTBOX_ADDRESS,
+            IZoneOutbox::setMaxWithdrawalsPerBlockCall {
+                _maxWithdrawalsPerBlock: 1,
+            }
+            .abi_encode()
+            .into(),
+        );
+        let error = validate_system_transaction(true, &setter).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "system transactions after advanceTempo must call \
+             ZoneOutbox.finalizeWithdrawalBatch"
+        );
+
+        let malformed_finalize = system_tx(
+            ZONE_OUTBOX_ADDRESS,
+            Bytes::copy_from_slice(&IZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR),
+        );
+        let error = validate_system_transaction(true, &malformed_finalize).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "system transactions after advanceTempo must call \
+             ZoneOutbox.finalizeWithdrawalBatch"
+        );
+    }
+
+    #[test]
+    fn ordinary_transactions_are_allowed_after_advance_tempo() {
+        let ordinary = TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy::default(),
+            Signature::test_signature(),
+        ));
+        assert!(!validate_system_transaction(true, &ordinary).unwrap());
     }
 
     #[test]

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -57,7 +57,7 @@ pub mod ztip20;
 pub use aes_gcm::{AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt};
 pub use chaum_pedersen::{CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify};
 pub use inbox::{ADVANCE_TEMPO_SELECTOR, ZoneInbox};
-pub use outbox::ZoneOutbox;
+pub use outbox::{ZoneOutbox, is_finalize_withdrawal_batch_calldata};
 pub use storage::{L1State, L1StateError, L1StorageReader};
 pub use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 pub use tempo_state::TempoState;

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -7,6 +7,7 @@ mod tests;
 use alloc::vec::Vec;
 
 use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_sol_types::SolCall;
 use tempo_precompiles::{
     Result as TempoResult,
     error::TempoPrecompileError,
@@ -30,6 +31,14 @@ use crate::{
 
 const MAX_CALLBACK_DATA_SIZE: usize = 1024;
 const WITHDRAWAL_BASE_GAS: u64 = 50_000;
+
+/// Returns whether `calldata` is a canonical `finalizeWithdrawalBatch` call.
+pub fn is_finalize_withdrawal_batch_calldata(calldata: &[u8]) -> bool {
+    let Ok(call) = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(calldata) else {
+        return false;
+    };
+    call.abi_encode() == calldata
+}
 
 #[contract(addr = ZONE_OUTBOX_ADDRESS)]
 pub struct ZoneOutbox {


### PR DESCRIPTION
## Summary

Rejecting unexpected Tempo system transactions during zone block execution.

After the required opening advanceTempo, the executor now permits only:
- Ordinary non-system transactions
- Canonically encoded `ZoneOutbox.finalizeWithdrawalBatch` system transactions

All other system transactions, including privileged outbox setters, cause block validation to fail.