### PR TITLE
fix(evm): reserve withdrawal finalization for system txs

### DIFF
--- a/crates/contracts/src/precompiles/outbox.rs
+++ b/crates/contracts/src/precompiles/outbox.rs
@@ -49,6 +49,7 @@ crate::sol! {
         // -- Errors --
 
         error OnlySequencer();
+        error OnlySystemTransaction();
         error GasLimitTooHigh();
         error OnlyZoneInbox();
         error InvalidWithdrawalCount(uint256 actual, uint256 expected);

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -163,8 +163,13 @@ fn validate_system_transaction(
     has_advanced_tempo: bool,
     tx: &TempoTxEnvelope,
 ) -> Result<bool, BlockExecutionError> {
+    let mut calls = tx.calls();
+    let first_call = calls.next();
+    let has_additional_calls = calls.next().is_some();
+    let is_single_call = first_call.is_some() && !has_additional_calls;
     let is_advance_tempo = tx.is_system_tx()
-        && tx.calls().any(|(kind, input)| {
+        && is_single_call
+        && first_call.is_some_and(|(kind, input)| {
             kind.to() == Some(&ZONE_INBOX_ADDRESS) && input.starts_with(&ADVANCE_TEMPO_SELECTOR)
         });
 
@@ -186,13 +191,25 @@ fn validate_system_transaction(
         .into());
     }
 
-    if tx.is_system_tx()
-        && !tx.calls().any(|(kind, input)| {
+    let is_finalize_withdrawal_batch = is_single_call
+        && first_call.is_some_and(|(kind, input)| {
+            kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_calldata(input)
+        });
+
+    if tx.is_system_tx() && !is_finalize_withdrawal_batch {
+        return Err(BlockValidationError::msg(
+            "system transactions after advanceTempo must call ZoneOutbox.finalizeWithdrawalBatch",
+        )
+        .into());
+    }
+
+    if !tx.is_system_tx()
+        && tx.calls().any(|(kind, input)| {
             kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_calldata(input)
         })
     {
         return Err(BlockValidationError::msg(
-            "system transactions after advanceTempo must call ZoneOutbox.finalizeWithdrawalBatch",
+            "ZoneOutbox.finalizeWithdrawalBatch requires a system transaction",
         )
         .into());
     }
@@ -208,7 +225,7 @@ mod tests {
     };
 
     use alloy_consensus::{Signed, TxLegacy};
-    use alloy_primitives::{Address, Bytes, Signature, U256};
+    use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
     use alloy_sol_types::SolCall;
     use tempo_precompiles::{
         DEFAULT_FEE_TOKEN, TIP_FEE_MANAGER_ADDRESS,
@@ -216,7 +233,13 @@ mod tests {
         test_util::TIP20Setup,
         tip_fee_manager::{TipFeeManager, amm::PoolKey},
     };
-    use tempo_primitives::{TempoTxEnvelope, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE};
+    use tempo_primitives::{
+        TempoTxEnvelope,
+        transaction::{
+            AASigned, Call, PrimitiveSignature, TempoSignature, TempoTransaction,
+            envelope::TEMPO_SYSTEM_TX_SIGNATURE,
+        },
+    };
     use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
     use tempo_zone_contracts::IZoneOutbox;
 
@@ -318,6 +341,67 @@ mod tests {
             Signature::test_signature(),
         ));
         assert!(!validate_system_transaction(true, &ordinary).unwrap());
+    }
+
+    #[test]
+    fn withdrawal_finalization_requires_a_system_transaction() {
+        let finalize_calldata: Bytes = IZoneOutbox::finalizeWithdrawalBatchCall {
+            count: U256::ONE,
+            blockNumber: 1,
+            encryptedSenders: vec![Bytes::new()],
+        }
+        .abi_encode()
+        .into();
+
+        let direct = TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy {
+                to: ZONE_OUTBOX_ADDRESS.into(),
+                input: finalize_calldata.clone(),
+                ..Default::default()
+            },
+            Signature::test_signature(),
+        ));
+        let error = validate_system_transaction(true, &direct).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "ZoneOutbox.finalizeWithdrawalBatch requires a system transaction"
+        );
+
+        let aa = AASigned::new_unhashed(
+            TempoTransaction {
+                calls: vec![
+                    Call {
+                        to: TxKind::Call(ZONE_OUTBOX_ADDRESS),
+                        value: U256::ZERO,
+                        input: IZoneOutbox::requestWithdrawalCall {
+                            token: Address::with_last_byte(1),
+                            to: Address::with_last_byte(2),
+                            amount: 1,
+                            memo: B256::ZERO,
+                            gasLimit: 0,
+                            zoneFallbackRecipient: Address::with_last_byte(3),
+                            data: Bytes::new(),
+                            revealTo: Bytes::new(),
+                        }
+                        .abi_encode()
+                        .into(),
+                    },
+                    Call {
+                        to: TxKind::Call(ZONE_OUTBOX_ADDRESS),
+                        value: U256::ZERO,
+                        input: finalize_calldata,
+                    },
+                ],
+                ..Default::default()
+            },
+            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature())),
+        )
+        .into();
+        let error = validate_system_transaction(true, &aa).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "ZoneOutbox.finalizeWithdrawalBatch requires a system transaction"
+        );
     }
 
     #[test]

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -21,8 +21,7 @@ use tempo_revm::evm::TempoContext;
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{
-    ADVANCE_TEMPO_SELECTOR, L1StorageReader, is_finalize_withdrawal_batch_calldata,
-    is_finalize_withdrawal_batch_selector, tx_context,
+    ADVANCE_TEMPO_SELECTOR, L1StorageReader, is_finalize_withdrawal_batch_calldata, tx_context,
 };
 use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
@@ -204,17 +203,6 @@ fn validate_system_transaction(
         .into());
     }
 
-    if !tx.is_system_tx()
-        && tx.calls().any(|(kind, input)| {
-            kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_selector(input)
-        })
-    {
-        return Err(BlockValidationError::msg(
-            "ZoneOutbox.finalizeWithdrawalBatch requires a system transaction",
-        )
-        .into());
-    }
-
     Ok(false)
 }
 
@@ -222,8 +210,7 @@ fn validate_system_transaction(
 mod tests {
     use super::{
         ADVANCE_TEMPO_SELECTOR, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
-        is_finalize_withdrawal_batch_calldata, is_finalize_withdrawal_batch_selector,
-        validate_system_transaction,
+        is_finalize_withdrawal_batch_calldata, validate_system_transaction,
     };
 
     use alloy_consensus::{Signed, TxLegacy};
@@ -346,7 +333,7 @@ mod tests {
     }
 
     #[test]
-    fn withdrawal_finalization_requires_a_system_transaction() {
+    fn user_withdrawal_finalization_is_not_a_fatal_block_error() {
         let finalize_calldata: Bytes = IZoneOutbox::finalizeWithdrawalBatchCall {
             count: U256::ONE,
             blockNumber: 1,
@@ -363,19 +350,12 @@ mod tests {
             },
             Signature::test_signature(),
         ));
-        let error = validate_system_transaction(true, &direct).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "ZoneOutbox.finalizeWithdrawalBatch requires a system transaction"
-        );
+        assert!(!validate_system_transaction(true, &direct).unwrap());
 
         let mut noncanonical_finalize_calldata = finalize_calldata.to_vec();
         noncanonical_finalize_calldata.extend([0_u8; 32]);
         let noncanonical_finalize_calldata = Bytes::from(noncanonical_finalize_calldata);
         assert!(!is_finalize_withdrawal_batch_calldata(
-            &noncanonical_finalize_calldata
-        ));
-        assert!(is_finalize_withdrawal_batch_selector(
             &noncanonical_finalize_calldata
         ));
         let aa = AASigned::new_unhashed(
@@ -408,11 +388,7 @@ mod tests {
             TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature())),
         )
         .into();
-        let error = validate_system_transaction(true, &aa).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "ZoneOutbox.finalizeWithdrawalBatch requires a system transaction"
-        );
+        assert!(!validate_system_transaction(true, &aa).unwrap());
     }
 
     #[test]

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -21,7 +21,8 @@ use tempo_revm::evm::TempoContext;
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{
-    ADVANCE_TEMPO_SELECTOR, L1StorageReader, is_finalize_withdrawal_batch_calldata, tx_context,
+    ADVANCE_TEMPO_SELECTOR, L1StorageReader, is_finalize_withdrawal_batch_calldata,
+    is_finalize_withdrawal_batch_selector, tx_context,
 };
 use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
@@ -205,7 +206,7 @@ fn validate_system_transaction(
 
     if !tx.is_system_tx()
         && tx.calls().any(|(kind, input)| {
-            kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_calldata(input)
+            kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_selector(input)
         })
     {
         return Err(BlockValidationError::msg(
@@ -221,6 +222,7 @@ fn validate_system_transaction(
 mod tests {
     use super::{
         ADVANCE_TEMPO_SELECTOR, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
+        is_finalize_withdrawal_batch_calldata, is_finalize_withdrawal_batch_selector,
         validate_system_transaction,
     };
 
@@ -367,6 +369,15 @@ mod tests {
             "ZoneOutbox.finalizeWithdrawalBatch requires a system transaction"
         );
 
+        let mut noncanonical_finalize_calldata = finalize_calldata.to_vec();
+        noncanonical_finalize_calldata.extend([0_u8; 32]);
+        let noncanonical_finalize_calldata = Bytes::from(noncanonical_finalize_calldata);
+        assert!(!is_finalize_withdrawal_batch_calldata(
+            &noncanonical_finalize_calldata
+        ));
+        assert!(is_finalize_withdrawal_batch_selector(
+            &noncanonical_finalize_calldata
+        ));
         let aa = AASigned::new_unhashed(
             TempoTransaction {
                 calls: vec![
@@ -389,7 +400,7 @@ mod tests {
                     Call {
                         to: TxKind::Call(ZONE_OUTBOX_ADDRESS),
                         value: U256::ZERO,
-                        input: finalize_calldata,
+                        input: noncanonical_finalize_calldata,
                     },
                 ],
                 ..Default::default()

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -58,9 +58,7 @@ pub mod ztip20;
 pub use aes_gcm::{AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt};
 pub use chaum_pedersen::{CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify};
 pub use inbox::{ADVANCE_TEMPO_SELECTOR, ZoneInbox};
-pub use outbox::{
-    ZoneOutbox, is_finalize_withdrawal_batch_calldata, is_finalize_withdrawal_batch_selector,
-};
+pub use outbox::{ZoneOutbox, is_finalize_withdrawal_batch_calldata};
 pub use storage::{L1State, L1StateError, L1StorageReader};
 pub use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 pub use tempo_state::TempoState;

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -58,7 +58,9 @@ pub mod ztip20;
 pub use aes_gcm::{AES_GCM_DECRYPT_ADDRESS, AesGcmDecrypt};
 pub use chaum_pedersen::{CHAUM_PEDERSEN_VERIFY_ADDRESS, ChaumPedersenVerify};
 pub use inbox::{ADVANCE_TEMPO_SELECTOR, ZoneInbox};
-pub use outbox::{ZoneOutbox, is_finalize_withdrawal_batch_calldata};
+pub use outbox::{
+    ZoneOutbox, is_finalize_withdrawal_batch_calldata, is_finalize_withdrawal_batch_selector,
+};
 pub use storage::{L1State, L1StateError, L1StorageReader};
 pub use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 pub use tempo_state::TempoState;

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -32,6 +32,11 @@ use crate::{
 const MAX_CALLBACK_DATA_SIZE: usize = 1024;
 const WITHDRAWAL_BASE_GAS: u64 = 50_000;
 
+/// Returns whether `calldata` carries the `finalizeWithdrawalBatch` selector.
+pub fn is_finalize_withdrawal_batch_selector(calldata: &[u8]) -> bool {
+    calldata.starts_with(&IZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR)
+}
+
 /// Returns whether `calldata` is a canonical `finalizeWithdrawalBatch` call.
 pub fn is_finalize_withdrawal_batch_calldata(calldata: &[u8]) -> bool {
     let Ok(call) = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(calldata) else {

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -32,11 +32,6 @@ use crate::{
 const MAX_CALLBACK_DATA_SIZE: usize = 1024;
 const WITHDRAWAL_BASE_GAS: u64 = 50_000;
 
-/// Returns whether `calldata` carries the `finalizeWithdrawalBatch` selector.
-pub fn is_finalize_withdrawal_batch_selector(calldata: &[u8]) -> bool {
-    calldata.starts_with(&IZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR)
-}
-
 /// Returns whether `calldata` is a canonical `finalizeWithdrawalBatch` call.
 pub fn is_finalize_withdrawal_batch_calldata(calldata: &[u8]) -> bool {
     let Ok(call) = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(calldata) else {
@@ -288,11 +283,13 @@ impl ZoneOutbox {
 
     fn finalize_withdrawal_batch<P: L1StorageReader>(
         &mut self,
-        l1: &L1State<P>,
+        _l1: &L1State<P>,
         caller: Address,
         call: IZoneOutbox::finalizeWithdrawalBatchCall,
     ) -> ZoneResult<B256> {
-        self.ensure_sequencer(l1, caller)?;
+        if caller != Address::ZERO {
+            return Err(ZoneOutboxError::only_system_transaction().into());
+        }
         if call.blockNumber != self.storage.block_number() {
             return Err(ZoneOutboxError::invalid_block_number().into());
         }

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -235,7 +235,7 @@ impl Harness {
 
     fn finalize(&mut self, count: usize) -> PrecompileResult {
         self.call(
-            SEQUENCER,
+            Address::ZERO,
             ZoneOutboxAbi::finalizeWithdrawalBatchCall {
                 count: U256::from(count),
                 blockNumber: 0,
@@ -517,7 +517,7 @@ fn finalize_single_and_multiple_withdrawals_match_canonical_queue_hash() -> eyre
 }
 
 #[test]
-fn finalize_rejects_wrong_count_and_non_sequencer() -> eyre::Result<()> {
+fn finalize_rejects_wrong_count_and_non_system_callers() -> eyre::Result<()> {
     let mut harness = Harness::new()?;
     harness.request(100, ALICE, B256::ZERO)?;
     assert_revert(
@@ -525,16 +525,15 @@ fn finalize_rejects_wrong_count_and_non_sequencer() -> eyre::Result<()> {
         ZoneOutboxError::invalid_withdrawal_count(U256::ZERO, U256::ONE),
     );
 
-    let result = harness.call(
-        ALICE,
-        ZoneOutboxAbi::finalizeWithdrawalBatchCall {
-            count: U256::ONE,
-            blockNumber: 0,
-            encryptedSenders: vec![Bytes::new()],
-        }
-        .abi_encode(),
-    );
-    assert_revert(result, ZoneOutboxError::only_sequencer());
+    let call = ZoneOutboxAbi::finalizeWithdrawalBatchCall {
+        count: U256::ONE,
+        blockNumber: 0,
+        encryptedSenders: vec![Bytes::new()],
+    };
+    for caller in [ALICE, SEQUENCER] {
+        let result = harness.call(caller, call.abi_encode());
+        assert_revert(result, ZoneOutboxError::only_system_transaction());
+    }
     Ok(())
 }
 
@@ -709,7 +708,7 @@ fn encrypted_sender_count_and_length_are_validated() -> eyre::Result<()> {
     harness.request(1, BOB, B256::ZERO)?;
     assert_revert(
         harness.call(
-            SEQUENCER,
+            Address::ZERO,
             ZoneOutboxAbi::finalizeWithdrawalBatchCall {
                 count: U256::ONE,
                 blockNumber: 0,
@@ -721,7 +720,7 @@ fn encrypted_sender_count_and_length_are_validated() -> eyre::Result<()> {
     );
     assert_revert(
         harness.call(
-            SEQUENCER,
+            Address::ZERO,
             ZoneOutboxAbi::finalizeWithdrawalBatchCall {
                 count: U256::ONE,
                 blockNumber: 0,

--- a/specs/ref-impls/src/zone/ZoneOutbox.sol
+++ b/specs/ref-impls/src/zone/ZoneOutbox.sol
@@ -101,6 +101,7 @@ contract ZoneOutbox is IZoneOutbox {
     error GasFeeRateTooHigh();
     error TransferFailed();
     error OnlySequencer();
+    error OnlySystemTransaction();
     error InvalidBlockNumber();
     error TooManyWithdrawalsThisBlock();
     error InvalidRevealTo();
@@ -373,7 +374,7 @@ contract ZoneOutbox is IZoneOutbox {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Finalize the batch at end of block - build withdrawal hash and emit proof inputs
-    /// @dev Only callable by sequencer at the end of a block.
+    /// @dev Only callable by the canonical system transaction at the end of a block.
     ///      The proof enforces that this is the last call in the block and that a batch
     ///      ends with exactly one finalizeWithdrawalBatch call. `count` must equal the
     ///      current pending withdrawal count (including 0 if no withdrawals).
@@ -401,7 +402,7 @@ contract ZoneOutbox is IZoneOutbox {
         internal
         returns (bytes32 withdrawalQueueHash)
     {
-        if (msg.sender != address(0) && !config.isSequencer(msg.sender)) revert OnlySequencer();
+        if (msg.sender != address(0)) revert OnlySystemTransaction();
         if (blockNumber != uint64(block.number)) revert InvalidBlockNumber();
 
         uint256 pending = _pendingWithdrawals.length;

--- a/specs/ref-impls/test/tempo/ZoneBridge.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneBridge.t.sol
@@ -299,7 +299,7 @@ contract ZoneBridgeTest is BaseTest {
         if (count == type(uint256).max) {
             count = l2Outbox.pendingWithdrawalsCount();
         }
-        vm.startPrank(sequencer);
+        vm.startPrank(address(0));
         bytes32 hash = l2Outbox.finalizeWithdrawalBatch(
             count, uint64(block.number), _emptyEncryptedSenders(count)
         );

--- a/specs/ref-impls/test/tempo/ZoneIntegration.t.sol
+++ b/specs/ref-impls/test/tempo/ZoneIntegration.t.sol
@@ -269,7 +269,7 @@ contract ZoneIntegrationTest is BaseTest {
         if (count == type(uint256).max) {
             count = l2Outbox.pendingWithdrawalsCount();
         }
-        vm.startPrank(sequencer);
+        vm.startPrank(address(0));
         bytes32 hash = l2Outbox.finalizeWithdrawalBatch(
             count, uint64(block.number), _emptyEncryptedSenders(count)
         );

--- a/specs/ref-impls/test/zone/ZoneOutbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneOutbox.t.sol
@@ -184,7 +184,7 @@ contract ZoneOutboxTest is Test {
     }
 
     function _finalizeWithdrawalBatch(uint256 count) internal returns (bytes32) {
-        return _finalizeWithdrawalBatchAs(sequencer, count);
+        return _finalizeWithdrawalBatchAs(address(0), count);
     }
 
     function test_enqueueDepositBounceBack_queuesRevokedTempoRefundRecipient() public {
@@ -401,7 +401,7 @@ contract ZoneOutboxTest is Test {
 
         bytes[] memory encryptedSenders = new bytes[](0);
 
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(abi.encodeWithSelector(ZoneOutbox.InvalidWithdrawalCount.selector, 0, 1));
         outbox.finalizeWithdrawalBatch(0, uint64(block.number), encryptedSenders);
         assertEq(_pendingWithdrawalsCount(), 1);
@@ -478,7 +478,7 @@ contract ZoneOutboxTest is Test {
         assertEq(_pendingWithdrawalsCount(), 3);
 
         bytes[] memory encryptedSenders = new bytes[](2);
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(abi.encodeWithSelector(ZoneOutbox.InvalidWithdrawalCount.selector, 2, 3));
         outbox.finalizeWithdrawalBatch(2, uint64(block.number), encryptedSenders);
         assertEq(_pendingWithdrawalsCount(), 3);
@@ -567,24 +567,23 @@ contract ZoneOutboxTest is Test {
                           ACCESS CONTROL TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function test_finalizeWithdrawalBatch_onlySequencer() public {
+    function test_finalizeWithdrawalBatch_onlySystemTransaction() public {
         vm.startPrank(alice);
         zoneToken.approve(address(outbox), 500e6);
         outbox.requestWithdrawal(address(zoneToken), alice, 500e6, bytes32(0), 0, alice, "");
         vm.stopPrank();
 
-        // Non-sequencer should revert
+        // User and registered-sequencer calls should both revert.
         bytes[] memory encryptedSenders = _emptyEncryptedSenders(1);
-        vm.startPrank(alice);
-        vm.expectRevert(ZoneOutbox.OnlySequencer.selector);
+        vm.prank(alice);
+        vm.expectRevert(ZoneOutbox.OnlySystemTransaction.selector);
         outbox.finalizeWithdrawalBatch(1, uint64(block.number), encryptedSenders);
-        vm.stopPrank();
 
-        // Any additional active member has the same authority.
-        tempoState.setMockStorageValue(
-            mockPortal, keccak256(abi.encode(bob, PORTAL_IS_SEQUENCER_SLOT)), bytes32(uint256(1))
-        );
-        vm.prank(bob);
+        vm.prank(sequencer);
+        vm.expectRevert(ZoneOutbox.OnlySystemTransaction.selector);
+        outbox.finalizeWithdrawalBatch(1, uint64(block.number), encryptedSenders);
+
+        vm.prank(address(0));
         bytes32 hash = outbox.finalizeWithdrawalBatch(1, uint64(block.number), encryptedSenders);
         assertTrue(hash != bytes32(0));
     }
@@ -592,7 +591,7 @@ contract ZoneOutboxTest is Test {
     function test_finalizeWithdrawalBatch_revertsOnInvalidBlockNumber() public {
         bytes[] memory encryptedSenders = new bytes[](0);
 
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(ZoneOutbox.InvalidBlockNumber.selector);
         outbox.finalizeWithdrawalBatch(0, uint64(block.number + 1), encryptedSenders);
     }
@@ -807,7 +806,7 @@ contract ZoneOutboxTest is Test {
         vm.stopPrank();
 
         bytes[] memory senders = _emptyEncryptedSenders(5);
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(abi.encodeWithSelector(ZoneOutbox.InvalidWithdrawalCount.selector, 5, 4));
         outbox.finalizeWithdrawalBatch(5, uint64(block.number), senders);
         assertEq(_pendingWithdrawalsCount(), 4);
@@ -925,7 +924,7 @@ contract ZoneOutboxTest is Test {
         bytes[] memory encryptedSenders = new bytes[](1);
         encryptedSenders[0] = new bytes(outbox.AUTHENTICATED_WITHDRAWAL_CIPHERTEXT_LENGTH());
 
-        vm.prank(sequencer);
+        vm.prank(address(0));
         bytes32 hash = outbox.finalizeWithdrawalBatch(1, uint64(block.number), encryptedSenders);
         assertTrue(hash != bytes32(0));
     }
@@ -992,7 +991,7 @@ contract ZoneOutboxTest is Test {
 
         bytes[] memory encryptedSenders = new bytes[](0);
 
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(
             abi.encodeWithSelector(ZoneOutbox.InvalidEncryptedSenderCount.selector, 0, 1)
         );
@@ -1017,7 +1016,7 @@ contract ZoneOutboxTest is Test {
                 outbox.AUTHENTICATED_WITHDRAWAL_CIPHERTEXT_LENGTH()
             )
         );
-        vm.prank(sequencer);
+        vm.prank(address(0));
         outbox.finalizeWithdrawalBatch(1, uint64(block.number), encryptedSenders);
     }
 
@@ -1070,7 +1069,7 @@ contract ZoneOutboxTest is Test {
         assertEq(_pendingWithdrawalsCount(), 5);
 
         bytes[] memory encryptedSenders = new bytes[](2);
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(abi.encodeWithSelector(ZoneOutbox.InvalidWithdrawalCount.selector, 2, 5));
         outbox.finalizeWithdrawalBatch(2, uint64(block.number), encryptedSenders);
         assertEq(_pendingWithdrawalsCount(), 5);
@@ -1084,7 +1083,7 @@ contract ZoneOutboxTest is Test {
         vm.stopPrank();
 
         bytes[] memory encryptedSenders = new bytes[](1000);
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(abi.encodeWithSelector(ZoneOutbox.InvalidWithdrawalCount.selector, 1000, 2));
         outbox.finalizeWithdrawalBatch(1000, uint64(block.number), encryptedSenders);
 
@@ -1390,7 +1389,7 @@ contract ZoneOutboxTest is Test {
         vm.stopPrank();
 
         bytes[] memory encryptedSenders = new bytes[](0);
-        vm.prank(sequencer);
+        vm.prank(address(0));
         vm.expectRevert(abi.encodeWithSelector(ZoneOutbox.InvalidWithdrawalCount.selector, 0, 1));
         outbox.finalizeWithdrawalBatch(0, uint64(block.number), encryptedSenders);
         assertEq(_pendingWithdrawalsCount(), 1);

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -218,7 +218,7 @@ The following table lists every privileged action and the role authorized to inv
 | `processWithdrawals(...)` | [`ZonePortal`](#izoneportal) | **any active sequencer** |
 | `setTempoGasRate(rate)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | **sequencer** or zone system caller (`address(0)`) |
 | `setMaxWithdrawalsPerBlock(limit)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | **sequencer** or zone system caller (`address(0)`) |
-| `finalizeWithdrawalBatch(...)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | **sequencer** or zone system caller (`address(0)`) |
+| `finalizeWithdrawalBatch(...)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | zone system caller (`address(0)`) only |
 | Block production / `beneficiary` | zone | **sequencer** |
 
 Rationale notes:
@@ -226,7 +226,7 @@ Rationale notes:
 - **Token enablement and deposit pause/resume are admin-only** because they govern what the zone is and which deposit flows are open. A compromised sequencer hot key MUST NOT be able to enable arbitrary tokens or unilaterally re-open paused deposits.
 - **Withdrawal gas rates are sequencer-controlled within an admin ceiling** so the sequencer can react quickly to Tempo gas-price fluctuations while the admin retains control over the maximum user fee. The admin directly controls the Tempo-side deposit and bounce-back fee parameters.
 - **Encryption key management is sequencer-only** because the proof of possession requires the encryption private key.
-- **Zone-side system calls** to `ZoneOutbox` may use `msg.sender == address(0)` so the block builder can inject protocol system transactions. Ordinary user transactions must come from the registered sequencer address for these calls.
+- **Zone-side system calls** use `msg.sender == address(0)` so the block builder can inject protocol system transactions. Withdrawal batch finalization is reserved to this system caller; other sequencer-managed outbox settings also accept registered sequencer addresses.
 - **Withdrawal processing is sequencer-only** today; whether to make it permissionless once the proof has settled is tracked separately.
 
 <br>
@@ -656,7 +656,7 @@ fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
 
 ### Withdrawal Batching
 
-A withdrawal batch ends with exactly one call to `finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` on the `ZoneOutbox` in the final block of that batch. The block builder may include this as a zone system transaction (`msg.sender == address(0)`), and the `blockNumber` argument must match the current zone block number. The encrypted-senders array carries one sequencer-supplied ciphertext per finalized withdrawal for [authenticated withdrawals](#authenticated-withdrawals) (empty bytes for withdrawals without `revealTo`); `senderTag` is recomputed by the outbox from the queued withdrawal sender and transaction hash. This constructs a hash chain from pending withdrawals in LIFO order (newest to oldest), so the oldest withdrawal ends up outermost, enabling FIFO processing on Tempo:
+A withdrawal batch ends with exactly one call to `finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` on the `ZoneOutbox` in the final block of that batch. The block builder includes this as a zone system transaction (`msg.sender == address(0)`), which is the only caller authorized to finalize, and the `blockNumber` argument must match the current zone block number. The encrypted-senders array carries one sequencer-supplied ciphertext per finalized withdrawal for [authenticated withdrawals](#authenticated-withdrawals) (empty bytes for withdrawals without `revealTo`); `senderTag` is recomputed by the outbox from the queued withdrawal sender and transaction hash. This constructs a hash chain from pending withdrawals in LIFO order (newest to oldest), so the oldest withdrawal ends up outermost, enabling FIFO processing on Tempo:
 
 ```
 withdrawalQueueHash = EMPTY_SENTINEL
@@ -779,7 +779,7 @@ Each zone block contains system transactions and user transactions in a fixed or
 
 1. `ZoneInbox.advanceTempo(header, deposits, decryptions, enabledTokens)` (required as the first transaction in every non-genesis block). Imports exactly one finalized Tempo block, enables newly-bridged tokens, processes any pending deposits, and verifies encrypted deposit decryptions.
 2. User transactions, executed in order.
-3. `ZoneOutbox.finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` (required in the final block of a batch, absent in intermediate blocks). Constructs the withdrawal hash chain from pending withdrawals, populates `encryptedSender` for authenticated withdrawals, and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to state. Must be called at each batch boundary even if there are zero withdrawals so the batch index advances. The builder may execute it as a zone system transaction with `msg.sender == address(0)`.
+3. `ZoneOutbox.finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` (required in the final block of a batch, absent in intermediate blocks). Constructs the withdrawal hash chain from pending withdrawals, populates `encryptedSender` for authenticated withdrawals, and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to state. Must be called at each batch boundary even if there are zero withdrawals so the batch index advances. Only the builder-generated zone system transaction with `msg.sender == address(0)` may execute it.
 
 A batch covers one or more zone blocks and ends with exactly one `finalizeWithdrawalBatch` call. The bootstrap batch MUST contain at least two blocks. Its first block is the canonical genesis block, which contains no transactions, and every subsequent block follows the non-genesis rules above. This guarantees that the first submitted batch imports at least one finalized Tempo block, performs the corresponding Tempo state reads, and finalizes the withdrawal batch in a non-genesis block.
 


### PR DESCRIPTION
## Summary

- require `advanceTempo` and `finalizeWithdrawalBatch` system transactions to contain exactly one call
- reject direct and AA user transactions that invoke `ZoneOutbox.finalizeWithdrawalBatch`
- add regression coverage for an AA transaction that calls `requestWithdrawal` followed by `finalizeWithdrawalBatch`

## Root cause

A registered sequencer could include `finalizeWithdrawalBatch` as a later call in an AA transaction. The outbox accepted the inner call, but settlement later identified the outer transaction from `BatchFinalized` and decoded `Transaction::input()`, which exposes only the AA transaction's first call. The resulting decode failure prevented the zone monitor from advancing past that finalized boundary.

The existing executor rule restricted unexpected system transactions but did not reserve finalization itself to the builder-generated system transaction.

## Impact

Finalization can now only occur through the canonical single-call system transaction emitted by the payload builder. This prevents a compromised leader or non-leader sequencer from creating a `BatchFinalized` boundary that the L1 settlement monitor cannot reconstruct.

Addresses [ZONE-227](https://linear.app/tempoxyz/issue/ZONE-227/compromised-sequencer-can-dos-zone-l1-settlement-with-aa-tx). Related to #745 and #914.

## Validation

- `rustup run nightly cargo test -p zone-evm`
- `rustup run nightly cargo clippy -p zone-evm --all-targets -- -D warnings`
- `git diff --check`