### PR TITLE
fix(xtask): initialize sequencer quorum atomically

### DIFF
--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -73,7 +73,7 @@ the configuration shape:
 
 ```toml
 zone_id = 7
-sequencer_set_version = 1
+sequencer_set_version = 0
 leader_ed25519_public_key = "0xleader..."
 
 [[nodes]]
@@ -102,6 +102,11 @@ rpc_only = true
 ```
 
 `rpc_only` defaults to `false`, so existing manifests keep their current meaning.
+
+`sequencer_set_version` must exactly match the value reported by `ZonePortal`. Version `0` is
+valid for the initial sequencer set installed atomically by `ZoneFactory`; later
+`setSequencerSet` calls increment it. The field defaults to `1` for compatibility with existing
+manifests that omitted it.
 
 An `rpc_only` entry declares no `secp256k1_address` and the node is started without
 `--secp256k1.key`. It never signs a settlement attestation, so the key would be dead weight —

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -672,9 +672,6 @@ impl ZoneManifest {
     /// Parses and validates a TOML manifest.
     pub fn parse(input: &str) -> Result<Self, ManifestError> {
         let raw: RawManifest = toml::from_str(input).map_err(ManifestError::Toml)?;
-        if raw.sequencer_set_version == 0 {
-            return Err(ManifestError::InvalidSequencerSetVersion);
-        }
 
         let leader_ed25519_public_key =
             parse_ed25519_public_key("leader_ed25519_public_key", &raw.leader_ed25519_public_key)?;
@@ -1001,9 +998,6 @@ fn parse_ed25519_public_key(field: &str, encoded: &str) -> Result<PublicKey, Man
 /// Manifest parsing and validation errors.
 #[derive(Debug, thiserror::Error)]
 pub enum ManifestError {
-    #[error("sequencer_set_version must be non-zero")]
-    InvalidSequencerSetVersion,
-
     #[error("failed reading sequencer manifest `{path}`")]
     Read {
         path: std::path::PathBuf,
@@ -1493,6 +1487,24 @@ mod tests {
                 .unwrap(),
             Role::Follower
         );
+    }
+
+    #[test]
+    fn accepts_factory_installed_sequencer_set_version_zero() {
+        let input = format!(
+            "sequencer_set_version = 0\n{}",
+            manifest(
+                1,
+                &[
+                    (1, "leader", "127.0.0.1:9200"),
+                    (2, "follower-a", "127.0.0.1:9201"),
+                    (3, "follower-b", "127.0.0.1:9202"),
+                ],
+            )
+        );
+
+        let manifest = ZoneManifest::parse(&input).unwrap();
+        assert_eq!(manifest.sequencer_set_version(), 0);
     }
 
     #[test]

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -562,6 +562,20 @@ contract ZonePortalTest is BaseTest {
         signers[2] = vm.addr(SIGNER_C_KEY);
     }
 
+    function test_initializeInstallsFullQuorumAtVersionZero() public {
+        address[] memory signers = _sequencerSet();
+        ZonePortal quorumPortal =
+            _createZonePortal(2, address(pathUSD), admin, signers, 2, "https://quorum.example");
+
+        assertEq(quorumPortal.sequencerSetVersion(), 0);
+        assertEq(quorumPortal.sequencerThreshold(), 2);
+        assertEq(quorumPortal.sequencerCount(), 3);
+        assertEq(quorumPortal.leader(), signers[0]);
+        for (uint256 i; i < signers.length; ++i) {
+            assertTrue(quorumPortal.isSequencer(signers[i]));
+        }
+    }
+
     function _activateSequencerSet(uint8 quorum) internal returns (address[] memory signers) {
         signers = _sequencerSet();
         // The portal rejects a set that drops the active leader, so rotation is three steps:

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -61,11 +61,8 @@ pub(crate) struct CreateZone {
     /// Sequencer address that will operate the zone. Repeat for a
     /// multi-sequencer set; the first address is the leader.
     ///
-    /// A multi-sequencer set is installed via a post-creation `setSequencerSet`
-    /// call so the on-chain `sequencerSetVersion` becomes non-zero, which the
-    /// P2P manifest requires. That call must be signed by the zone admin, so
-    /// `--private-key` must be the admin key when more than one sequencer is
-    /// given.
+    /// The complete set and threshold are installed atomically by `createZone`;
+    /// the first address is also the initial block-production leader.
     #[arg(long = "sequencer", required = true)]
     sequencers: Vec<Address>,
 
@@ -105,6 +102,20 @@ pub(crate) struct CreateZone {
 const MAX_SEQUENCERS: usize = 8;
 
 impl CreateZone {
+    fn factory_params(&self) -> ZoneFactory::CreateZoneParams {
+        ZoneFactory::CreateZoneParams {
+            initialToken: self.initial_token,
+            accessMode: self.access_mode,
+            gatewayMode: self.gateway_mode,
+            allowedAccounts: self.allowed_accounts.clone(),
+            zoneGateways: self.zone_gateways.clone(),
+            admin: self.admin,
+            sequencers: self.sequencers.clone(),
+            threshold: self.threshold,
+            rpcUrl: self.rpc_url.clone(),
+        }
+    }
+
     pub(crate) async fn run(self) -> eyre::Result<()> {
         let leader = *self
             .sequencers
@@ -148,15 +159,6 @@ impl CreateZone {
             .strip_prefix("0x")
             .unwrap_or(&self.private_key);
         let signer: PrivateKeySigner = key_str.parse()?;
-        let signer_address = signer.address();
-        if self.sequencers.len() > 1 && signer_address != self.admin {
-            return Err(eyre!(
-                "multi-sequencer creation requires --private-key to be the admin key \
-                 ({}) so the sequencer set can be installed via setSequencerSet, \
-                 but the key resolves to {signer_address}",
-                self.admin
-            ));
-        }
         let wallet = EthereumWallet::from(signer);
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
@@ -222,26 +224,14 @@ impl CreateZone {
             "Creating zone on L1 via ZoneFactory at {}...",
             self.zone_factory
         );
-        // The native factory initializes the portal at `sequencerSetVersion` 0,
-        // but the P2P manifest (and follower attestation checks) require a
-        // non-zero version. Create the zone with a 1-of-1 leader set, then
-        // install the full set via `setSequencerSet`, which bumps the version
-        // to 1. Single-sequencer zones keep the legacy 1-of-1 set at version 0.
-        // The portal also bootstraps the first sequencer as the initial
+        // Install the requested set in the factory transaction. A separate
+        // setSequencerSet call would leave the portal live as a temporary
+        // 1-of-1 settlement authority before the intended quorum is active.
+        // The portal bootstraps the first sequencer as the initial
         // block-production leader (leaderEpoch 1); later transfers go through
-        // setLeader.
+        // setLeader. The factory-installed set starts at version 0.
         let receipt = factory
-            .createZone(ZoneFactory::CreateZoneParams {
-                initialToken: self.initial_token,
-                accessMode: self.access_mode,
-                gatewayMode: self.gateway_mode,
-                allowedAccounts: self.allowed_accounts.clone(),
-                zoneGateways: self.zone_gateways.clone(),
-                admin: self.admin,
-                sequencers: vec![leader],
-                threshold: 1,
-                rpcUrl: self.rpc_url.clone(),
-            })
+            .createZone(self.factory_params())
             .send_sync()
             .await?;
         println!("Transaction confirmed in block {:?}", receipt.block_number);
@@ -267,23 +257,6 @@ impl CreateZone {
         let chain_id = zone_chain_id(zone_id);
 
         let portal_contract = ZonePortal::new(portal, &provider);
-        if self.sequencers.len() > 1 {
-            println!(
-                "Installing {}-of-{} sequencer set via setSequencerSet...",
-                self.threshold,
-                self.sequencers.len()
-            );
-            let receipt = portal_contract
-                .setSequencerSet(self.sequencers.clone(), self.threshold)
-                .send_sync()
-                .await?;
-            if !receipt.status() {
-                return Err(eyre!(
-                    "setSequencerSet transaction reverted (tx: {:?})",
-                    receipt.transaction_hash
-                ));
-            }
-        }
         let sequencer_set_version = portal_contract.sequencerSetVersion().call().await?;
         println!("Sequencer set version: {sequencer_set_version}");
 
@@ -362,5 +335,41 @@ impl CreateZone {
         println!("  Zone metadata written to: {}", zone_json_path.display());
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn factory_params_install_the_requested_quorum_atomically() {
+        let sequencers = vec![
+            address!("0x1000000000000000000000000000000000000001"),
+            address!("0x2000000000000000000000000000000000000002"),
+            address!("0x3000000000000000000000000000000000000003"),
+        ];
+        let command = CreateZone {
+            output: PathBuf::new(),
+            l1_rpc_url: String::new(),
+            zone_factory: Address::ZERO,
+            initial_token: address!("0x4000000000000000000000000000000000000004"),
+            access_mode: true,
+            gateway_mode: true,
+            zone_gateways: Vec::new(),
+            allowed_accounts: Vec::new(),
+            sequencers: sequencers.clone(),
+            threshold: 2,
+            admin: address!("0x5000000000000000000000000000000000000005"),
+            rpc_url: String::new(),
+            private_key: String::new(),
+            base_fee_per_gas: 1,
+            gas_limit: 30_000_000,
+            specs_out: PathBuf::new(),
+        };
+
+        let params = command.factory_params();
+        assert_eq!(params.sequencers, sequencers);
+        assert_eq!(params.threshold, 2);
     }
 }


### PR DESCRIPTION
## Summary

- pass the complete sequencer set and threshold to `ZoneFactory.createZone`
- remove the post-creation `setSequencerSet` transaction and its admin-key requirement
- allow P2P manifests to use sequencer-set version `0`, the initial factory-installed version
- add command, manifest, and Portal-initialization regression coverage

## Root cause

Multi-sequencer creation first deployed a live 1-of-1 Portal and only installed the requested quorum in a second transaction. During that gap, the bootstrap leader could submit a settlement alone and persist a terminal Zone height before the intended threshold became active.

The native factory already accepts the complete set and threshold. Installing them in its creation transaction removes the intermediate authority state. Version `0` is a valid signed configuration identifier for that factory-installed set, so the manifest now accepts it and must match the Portal exactly.

Fixes [ZONE-172](https://linear.app/tempoxyz/issue/ZONE-172/t2-007-bootstrap-signer-can-set-a-terminal-portal-settlement-height).

## Validation

- `rustup run nightly cargo test -p tempo-xtask -p zone-p2p` — 34 passed
- `rustup run nightly cargo clippy -p tempo-xtask -p zone-p2p --all-targets -- -D warnings`
- `forge test --root specs/ref-impls --match-path test/tempo/ZonePortal.t.sol --match-test test_initializeInstallsFullQuorumAtVersionZero -vv` — passed
- `rustup run nightly cargo fmt --all -- --check`
- `git diff --check`