### PR TITLE
fix(rpc): re-enable sequencer simulation methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10170,9 +10170,9 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "arbitrary",

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -41,7 +41,7 @@ use reth_node_builder::{
 };
 use reth_primitives_traits::SealedHeader;
 use reth_provider::ChainSpecProvider;
-use reth_rpc_builder::{Identity, TransportRpcModules};
+use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
 use reth_storage_api::{
     BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProvider, StateProviderFactory,
@@ -88,19 +88,6 @@ use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, WithdrawalBatchLimits, ZoneSequencerConfig,
     attestation::AttestationDomain, spawn_zone_sequencer,
 };
-
-const PUBLIC_SIMULATION_METHODS: [&str; 2] = ["eth_call", "eth_estimateGas"];
-
-/// Remove simulation methods from a sequencer's unauthenticated RPC transports.
-///
-/// Simulations can execute TIP-20 policy checks backed by finalized L1 state. Keeping them on the
-/// authenticated private RPC prevents arbitrary public callers from forcing sequencer L1 reads,
-/// while non-sequencer RPC nodes can continue serving simulations.
-fn disable_simulation_methods(modules: &mut TransportRpcModules) {
-    modules.remove_http_methods(PUBLIC_SIMULATION_METHODS);
-    modules.remove_ws_methods(PUBLIC_SIMULATION_METHODS);
-    modules.remove_ipc_methods(PUBLIC_SIMULATION_METHODS);
-}
 
 /// Returns a known Tempo chain spec for an L1 chain ID.
 ///
@@ -230,9 +217,6 @@ pub struct ZoneNode {
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
     external_deposit_consumer: bool,
-    /// Test-only override allowing simulations on a sequencer's public RPC.
-    #[cfg(any(test, feature = "test-utils"))]
-    allow_public_simulation_methods: bool,
 }
 
 impl ZoneNode {
@@ -281,8 +265,6 @@ impl ZoneNode {
             sequencer_config: None,
             p2p_config: None,
             external_deposit_consumer: false,
-            #[cfg(any(test, feature = "test-utils"))]
-            allow_public_simulation_methods: false,
         }
     }
 
@@ -301,13 +283,6 @@ impl ZoneNode {
             config.zone_id,
         )));
         self.sequencer_config = Some(config);
-        self
-    }
-
-    /// Keep simulation methods available on a sequencer's public RPC in test builds.
-    #[cfg(any(test, feature = "test-utils"))]
-    pub fn allow_public_simulation_methods(mut self) -> Self {
-        self.allow_public_simulation_methods = true;
         self
     }
 
@@ -460,9 +435,6 @@ where
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
     external_deposit_consumer: bool,
-    /// Test-only override allowing simulations on a sequencer's public RPC.
-    #[cfg(any(test, feature = "test-utils"))]
-    allow_public_simulation_methods: bool,
 }
 
 impl<N> std::fmt::Debug for ZoneAddOns<N>
@@ -472,27 +444,6 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ZoneAddOns").finish_non_exhaustive()
-    }
-}
-
-impl<N> ZoneAddOns<N>
-where
-    N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>,
-    N::Pool: reth_transaction_pool::TransactionPool<Transaction = TempoPooledTransaction>,
-{
-    fn allows_public_simulation_methods(&self) -> bool {
-        let allow_public_sims = {
-            #[cfg(any(test, feature = "test-utils"))]
-            {
-                self.allow_public_simulation_methods
-            }
-            #[cfg(not(any(test, feature = "test-utils")))]
-            {
-                false
-            }
-        };
-
-        self.sequencer_config.is_none() || allow_public_sims
     }
 }
 
@@ -509,7 +460,6 @@ where
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
         p2p_config: Option<P2pConfig>,
         external_deposit_consumer: bool,
-        #[cfg(any(test, feature = "test-utils"))] allow_public_simulation_methods: bool,
     ) -> Self {
         Self {
             inner: RpcAddOns::new(
@@ -527,8 +477,6 @@ where
             sequencer_config,
             p2p_config,
             external_deposit_consumer,
-            #[cfg(any(test, feature = "test-utils"))]
-            allow_public_simulation_methods,
         }
     }
 }
@@ -704,13 +652,9 @@ where
             provider.clone(),
         );
         let portal_address = self.portal_address;
-        let disable_public_simulations = !self.allows_public_simulation_methods();
         let handle = self
             .inner
             .launch_add_ons_with(ctx, move |container| {
-                if disable_public_simulations {
-                    disable_simulation_methods(container.modules);
-                }
                 container
                     .modules
                     .merge_configured(public_zone_api.into_rpc())?;
@@ -1294,8 +1238,6 @@ where
             self.sequencer_config.clone(),
             self.p2p_config.clone(),
             self.external_deposit_consumer,
-            #[cfg(any(test, feature = "test-utils"))]
-            self.allow_public_simulation_methods,
         )
     }
 }
@@ -1561,37 +1503,6 @@ mod tests {
     use tempo_primitives::transaction::{
         AASigned, Call, PrimitiveSignature, TempoSignature, TempoTransaction,
     };
-
-    #[test]
-    fn public_rpc_disables_simulation_methods_on_all_transports() {
-        fn module() -> jsonrpsee::RpcModule<()> {
-            let mut module = jsonrpsee::RpcModule::new(());
-            for method in ["eth_call", "eth_estimateGas", "eth_chainId"] {
-                module
-                    .register_method(method, |_, _, _| "ok")
-                    .expect("test method should register");
-            }
-            module
-        }
-
-        let mut modules = TransportRpcModules::default()
-            .with_http(module())
-            .with_ws(module())
-            .with_ipc(module());
-        disable_simulation_methods(&mut modules);
-
-        for methods in [
-            modules.http_methods(|_| true),
-            modules.ws_methods(|_| true),
-            modules.ipc_methods(|_| true),
-        ] {
-            let names = methods
-                .expect("transport should be configured")
-                .method_names()
-                .collect::<Vec<_>>();
-            assert_eq!(names, ["eth_chainId"]);
-        }
-    }
 
     fn pooled_transaction(envelope: TempoTxEnvelope, sender: Address) -> TempoPooledTransaction {
         TempoPooledTransaction::new(Recovered::new_unchecked(envelope, sender))

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -25,8 +25,7 @@ use zone_l1::{ChainTempoStateExt, L1Deposit, L1PortalEvents};
 use crate::utils::{
     DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, WITHDRAWAL_TX_GAS, ZoneTestNode,
     approve_outbox, leader_p2p_config, local_dev_zone_account, poll_until, seed_fixture_for_zone,
-    start_chain_id_rpc, start_local_p2p_cluster, start_local_p2p_cluster_with_public_simulations,
-    start_local_zone_with_fixture,
+    start_chain_id_rpc, start_local_p2p_cluster, start_local_zone_with_fixture,
 };
 
 const CONTRACT_CREATION_TX_GAS: u64 = 1_000_000;
@@ -34,10 +33,10 @@ const LEADER_INCLUSION_TIMEOUT: Duration = Duration::from_secs(30);
 const P2P_RECOVERY_TIMEOUT: Duration = Duration::from_secs(45);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_sequencer_blocks_simulation_endpoints() -> eyre::Result<()> {
+async fn test_sequencer_exposes_simulation_endpoints() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let cluster = start_local_p2p_cluster_with_public_simulations(10, false).await?;
+    let cluster = start_local_p2p_cluster(10).await?;
 
     for method in ["eth_call", "eth_estimateGas"] {
         let response = reqwest::Client::new()
@@ -52,7 +51,7 @@ async fn test_sequencer_blocks_simulation_endpoints() -> eyre::Result<()> {
             .await?
             .json::<serde_json::Value>()
             .await?;
-        assert_eq!(response["error"]["code"], -32601, "{method}: {response}");
+        assert_ne!(response["error"]["code"], -32601, "{method}: {response}");
     }
 
     Ok(())

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1006,7 +1006,6 @@ impl ZoneTestNode {
             8,
             None,
             true,
-            false,
         )
         .await
     }
@@ -1029,7 +1028,6 @@ impl ZoneTestNode {
             withdrawal_batch_interval_blocks,
             None,
             true,
-            false,
         )
         .await
     }
@@ -1098,7 +1096,6 @@ impl ZoneTestNode {
             8,
             Some(p2p_config),
             true,
-            false,
         )
         .await
     }
@@ -1120,7 +1117,6 @@ impl ZoneTestNode {
             8,
             None,
             true,
-            false,
         )
         .await
     }
@@ -1141,7 +1137,6 @@ impl ZoneTestNode {
             8,
             None,
             true,
-            false,
         )
         .await
     }
@@ -1156,7 +1151,6 @@ impl ZoneTestNode {
         withdrawal_batch_interval_blocks: u64,
         p2p_config: Option<P2pConfig>,
         spawn_engine: bool,
-        allow_public_simulations: bool,
     ) -> eyre::Result<Self> {
         let tasks = Runtime::test();
         let is_local_dummy_l1 = l1_ws_url == DUMMY_L1_URL;
@@ -1184,9 +1178,6 @@ impl ZoneTestNode {
             zone_node = zone_node
                 .with_l1_chain_id(1337)
                 .with_l1_state_provider_retry_limits(0, NonZeroU32::MIN);
-        }
-        if allow_public_simulations {
-            zone_node = zone_node.allow_public_simulation_methods();
         }
         let p2p_enabled = p2p_config.is_some();
         if p2p_enabled && !is_local_dummy_l1 {
@@ -3450,16 +3441,6 @@ impl P2pCluster {
 /// Start a three-node multi-sequencer cluster with identical genesis state and authenticated
 /// P2P identities. Node 0 bootstraps as the leader.
 pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2pCluster> {
-    start_local_p2p_cluster_with_public_simulations(seed_blocks, true).await
-}
-
-/// Start a P2P cluster, optionally retaining public simulation RPC methods.
-///
-/// Passing `false` exercises the production sequencer RPC policy.
-pub(crate) async fn start_local_p2p_cluster_with_public_simulations(
-    seed_blocks: u64,
-    allow_public_simulations: bool,
-) -> eyre::Result<P2pCluster> {
     fn available_address() -> eyre::Result<SocketAddr> {
         let listener = TcpListener::bind("127.0.0.1:0")?;
         Ok(listener.local_addr()?)
@@ -3549,7 +3530,6 @@ pub(crate) async fn start_local_p2p_cluster_with_public_simulations(
                 8,
                 Some(config),
                 false,
-                allow_public_simulations,
             )
             .await?,
         );


### PR DESCRIPTION
## Summary

- re-enable `eth_call` and `eth_estimateGas` on sequencer HTTP, WebSocket, and IPC RPC transports
- remove the test-only simulation-method override now that sequencers expose these methods by default
- retain the TIP-403 external-call protections introduced in #883

## Context

This reverts the sequencer RPC filtering introduced by `2b7e45c599d65f1f9bdbc40a10afab5e2810e9c8` while preserving the TIP-403 authorization fix from #883.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo check -p zone-node --tests` *(blocked: dependency fetch for `alloy-evm` returned HTTP 401)*

Prompted by: @0xrusowsky