### PR TITLE
refactor(node): require attestation store

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -570,7 +570,7 @@ where
                 attestation_domain,
                 config.block_attestation_signer(),
                 config.block_attestation_addresses(),
-                Some(AttestationStore::default()),
+                AttestationStore::default(),
                 l1_provider.clone(),
                 anchor_config,
             );
@@ -944,7 +944,7 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
-        attestation_store: Option<AttestationStore>,
+        attestation_store: AttestationStore,
     ) -> eyre::Result<LeaderSequencerDeps> {
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
@@ -956,7 +956,7 @@ where
             outbox_address: ZONE_OUTBOX_ADDRESS,
             inbox_address: ZONE_INBOX_ADDRESS,
             batch_anchor_config: config.batch_anchor_config,
-            attestation_store,
+            attestation_store: Some(attestation_store),
         };
         Ok(LeaderSequencerDeps {
             config,

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -47,7 +47,7 @@ pub(crate) struct AttestationContext {
     /// `None` on an rpc-only member: it holds no individual key and never signs.
     pub(crate) signer: Option<PrivateKeySigner>,
     pub(crate) addresses: HashMap<zone_p2p::P2pPeerId, alloy_primitives::Address>,
-    pub(crate) store: Option<AttestationStore>,
+    pub(crate) store: AttestationStore,
     pub(crate) l1_provider: DynProvider<TempoNetwork>,
     pub(crate) anchor_config: BatchAnchorConfig,
 }
@@ -57,7 +57,7 @@ impl AttestationContext {
         domain: AttestationDomain,
         signer: Option<PrivateKeySigner>,
         addresses: HashMap<zone_p2p::P2pPeerId, alloy_primitives::Address>,
-        store: Option<AttestationStore>,
+        store: AttestationStore,
         l1_provider: DynProvider<TempoNetwork>,
         anchor_config: BatchAnchorConfig,
     ) -> Self {
@@ -546,8 +546,7 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
                                 Some((signed.attestation.anchorBlockNumber, signed.attestation.anchorBlockHash)),
                             ).await?.ok_or_eyre("signed block is not a batch boundary")?;
                             eyre::ensure!(signed.attestation == expected, "settlement signature does not match leader state");
-                            let (_, signatures) = attestation.store.as_ref()
-                                .expect("leader must have an attestation store")
+                            let (_, signatures) = attestation.store
                                 .insert_settlement(attestation.domain, signer, signed);
                             Ok::<_, eyre::Report>((height, signer, signatures))
                         }.await;

--- a/crates/node/src/settlement_attestation.rs
+++ b/crates/node/src/settlement_attestation.rs
@@ -354,10 +354,7 @@ pub(crate) async fn collect_leader_settlements<P>(
     // persisted-block stream is latest-value based, so notifications are wake-ups rather than a
     // lossless sequence of every persisted block.
     let mut persisted = provider.persisted_block_stream();
-    let store = context
-        .store
-        .as_ref()
-        .expect("leader must have an attestation store");
+    let store = &context.store;
     let mut submitted_heights = store.subscribe_submitted_height();
     let head = match provider.last_block_number() {
         Ok(head) => head,
@@ -534,8 +531,6 @@ where
     let signer = signed.recover_signer(context.domain)?;
     let (_, signatures) = context
         .store
-        .as_ref()
-        .expect("leader must have an attestation store")
         .insert_settlement(context.domain, signer, signed);
     commands
         .send(P2pCommand::BroadcastSettlementProposal(


### PR DESCRIPTION
Makes the attestation store required in `AttestationContext`, this is now never constructed as `None`