### PR TITLE
fix(sequencer): reduce initial retry delay

### DIFF
--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -48,7 +48,7 @@ use crate::{
 const MAX_RETRIES: u32 = 3;
 
 /// Initial delay between retries (doubles on each attempt).
-const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(2);
+const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(200);
 
 /// Backoff before rebuilding the monitor after a start or run failure.
 const RESTART_BACKOFF: Duration = Duration::from_secs(5);


### PR DESCRIPTION
## Summary

- reduce the sequencer monitor's initial retry delay from 2 seconds to 200 milliseconds
- retry at least once per L1 block under typical block timing

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test -p zone-sequencer` *(blocked before compilation: Cargo received HTTP 401 fetching pinned `alloy-evm` Git dependency)*

Prompted by: @mattsse
