### PR TITLE
fix(payload): finalize withdrawals in the request block

### DIFF
--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -958,37 +958,76 @@ async fn submit_withdrawal(
     dev_address: Address,
     amount: u128,
 ) -> eyre::Result<u64> {
-    let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
-    let pending = outbox
-        .requestWithdrawal(
-            PATH_USD_ADDRESS,
-            dev_address,
-            amount,
-            B256::ZERO,
-            0,
-            dev_address,
-            Bytes::new(),
-            Bytes::new(),
-        )
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(WITHDRAWAL_TX_GAS)
-        .send()
-        .await?;
-    fixture.inject_empty_block(zone.deposit_queue());
-    let receipt = pending.get_receipt().await?;
-    assert!(
-        receipt.status(),
-        "withdrawal should succeed (gas used: {})",
-        receipt.gas_used
-    );
-    receipt
-        .block_number
-        .ok_or_else(|| eyre::eyre!("withdrawal receipt missing block number"))
+    submit_withdrawals(fixture, zone, provider, dev_address, &[amount]).await
 }
 
-/// Verify a lone withdrawal in a current-only block is deferred to the next block.
+async fn submit_withdrawals(
+    fixture: &mut L1Fixture,
+    zone: &ZoneTestNode,
+    provider: &DynProvider,
+    dev_address: Address,
+    amounts: &[u128],
+) -> eyre::Result<u64> {
+    eyre::ensure!(
+        !amounts.is_empty(),
+        "at least one withdrawal amount is required"
+    );
+
+    let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
+    let nonce = provider
+        .get_transaction_count(dev_address)
+        .pending()
+        .await?;
+    let mut pending = Vec::with_capacity(amounts.len());
+    for (offset, amount) in amounts.iter().copied().enumerate() {
+        pending.push(
+            outbox
+                .requestWithdrawal(
+                    PATH_USD_ADDRESS,
+                    dev_address,
+                    amount,
+                    B256::ZERO,
+                    0,
+                    dev_address,
+                    Bytes::new(),
+                    Bytes::new(),
+                )
+                .nonce(nonce + offset as u64)
+                .gas_price(TEMPO_T0_BASE_FEE as u128)
+                .gas(WITHDRAWAL_TX_GAS)
+                .send()
+                .await?,
+        );
+    }
+
+    fixture.inject_empty_block(zone.deposit_queue());
+    let mut withdrawal_block = None;
+    for pending_tx in pending {
+        let receipt = pending_tx.get_receipt().await?;
+        assert!(
+            receipt.status(),
+            "withdrawal should succeed (gas used: {})",
+            receipt.gas_used
+        );
+        let block_number = receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("withdrawal receipt missing block number"))?;
+        if let Some(expected) = withdrawal_block {
+            eyre::ensure!(
+                block_number == expected,
+                "withdrawals were included in different blocks: {expected} and {block_number}"
+            );
+        } else {
+            withdrawal_block = Some(block_number);
+        }
+    }
+
+    withdrawal_block.ok_or_else(|| eyre::eyre!("withdrawal block missing"))
+}
+
+/// Verify a withdrawal and its batch boundary are emitted in the same block.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_withdrawal_requests_finalize_next_block() -> eyre::Result<()> {
+async fn test_withdrawal_request_finalizes_same_block() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
@@ -1011,53 +1050,6 @@ async fn test_withdrawal_requests_finalize_next_block() -> eyre::Result<()> {
     let withdrawal_block =
         submit_withdrawal(&mut fixture, &zone, &provider, dev_address, 250_000).await?;
 
-    // Current-only block defers finalization — no BatchFinalized yet.
-    let deferred_logs = outbox
-        .BatchFinalized_filter()
-        .from_block(withdrawal_block)
-        .to_block(withdrawal_block)
-        .query()
-        .await?;
-    assert!(
-        deferred_logs.is_empty(),
-        "withdrawal block {withdrawal_block} should defer BatchFinalized"
-    );
-    assert_eq!(
-        outbox.lastBatch().call().await?.withdrawalBatchIndex,
-        batch_index_before,
-        "withdrawalBatchIndex should not advance on deferred block"
-    );
-    assert!(
-        outbox
-            .pendingWithdrawalsCount()
-            .from(Address::ZERO)
-            .call()
-            .await?
-            > U256::ZERO,
-        "withdrawal should remain pending after deferred block"
-    );
-
-    // Next quiet block finalizes the deferred withdrawal via the prior path.
-    fixture.inject_empty_block(zone.deposit_queue());
-    let quiet_block = withdrawal_block + 1;
-    let finalized_batch_index = poll_until(
-        DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
-        "withdrawal batch finalized on next block",
-        || {
-            let outbox = &outbox;
-            async move {
-                let index = outbox.lastBatch().call().await?.withdrawalBatchIndex;
-                if index == batch_index_before + 1 {
-                    Ok(Some(index))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
-
     assert_eq!(
         outbox
             .pendingWithdrawalsCount()
@@ -1065,17 +1057,7 @@ async fn test_withdrawal_requests_finalize_next_block() -> eyre::Result<()> {
             .call()
             .await?,
         U256::ZERO,
-        "finalize block should sweep pending withdrawals"
-    );
-    assert!(
-        outbox
-            .WithdrawalRequested_filter()
-            .from_block(quiet_block)
-            .to_block(quiet_block)
-            .query()
-            .await?
-            .is_empty(),
-        "quiet boundary block should carry no WithdrawalRequested logs"
+        "withdrawal block should sweep pending withdrawals"
     );
 
     let requested_logs = outbox
@@ -1094,18 +1076,22 @@ async fn test_withdrawal_requests_finalize_next_block() -> eyre::Result<()> {
 
     let finalized_logs = outbox
         .BatchFinalized_filter()
-        .from_block(quiet_block)
-        .to_block(quiet_block)
+        .from_block(withdrawal_block)
+        .to_block(withdrawal_block)
         .query()
         .await?;
     assert_eq!(
         finalized_logs.len(),
         1,
-        "exactly one BatchFinalized should follow deferred withdrawal"
+        "withdrawal block should emit exactly one BatchFinalized"
     );
     let (finalized, log) = &finalized_logs[0];
     assert_eq!(finalized.withdrawalQueueHash, expected_hash);
-    assert_eq!(finalized.withdrawalBatchIndex, finalized_batch_index);
+    assert_eq!(
+        finalized.withdrawalBatchIndex,
+        batch_index_before + 1,
+        "withdrawal block should advance the batch index"
+    );
 
     let tx_hash = log
         .transaction_hash
@@ -1119,20 +1105,34 @@ async fn test_withdrawal_requests_finalize_next_block() -> eyre::Result<()> {
     assert_eq!(
         finalize_call.count,
         U256::from(1),
-        "builder should finalize exactly the deferred withdrawal"
+        "builder should finalize exactly the current withdrawal"
     );
+    assert_eq!(finalize_call.blockNumber, withdrawal_block);
     assert_eq!(finalize_call.encryptedSenders.len(), 1);
+
+    let transaction_count = provider
+        .get_block_transaction_count_by_number(withdrawal_block.into())
+        .await?
+        .ok_or_else(|| eyre::eyre!("withdrawal block {withdrawal_block} not found"))?;
+    let finalize_index = log
+        .transaction_index
+        .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction index"))?;
+    assert_eq!(
+        finalize_index + 1,
+        transaction_count,
+        "finalizeWithdrawalBatch should be the last transaction"
+    );
 
     let last_batch = outbox.lastBatch().call().await?;
     assert_eq!(last_batch.withdrawalQueueHash, expected_hash);
-    assert_eq!(last_batch.withdrawalBatchIndex, finalized_batch_index);
+    assert_eq!(last_batch.withdrawalBatchIndex, batch_index_before + 1);
 
     Ok(())
 }
 
-/// Two consecutive withdrawal blocks are joined into a single batch at block N+1.
+/// Multiple withdrawals created in one block are finalized as one batch in that block.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_consecutive_withdrawal_blocks_joined_into_one_batch() -> eyre::Result<()> {
+async fn test_multiple_withdrawals_finalize_in_one_batch() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
@@ -1151,68 +1151,37 @@ async fn test_consecutive_withdrawal_blocks_joined_into_one_batch() -> eyre::Res
     approve_outbox(&mut fixture, &zone, &provider).await?;
 
     let batch_index_before = outbox.lastBatch().call().await?.withdrawalBatchIndex;
-    let block_n = submit_withdrawal(&mut fixture, &zone, &provider, dev_address, 250_000).await?;
-    let deferred_logs = outbox
-        .BatchFinalized_filter()
-        .from_block(block_n)
-        .to_block(block_n)
-        .query()
-        .await?;
-    assert!(
-        deferred_logs.is_empty(),
-        "block N should defer finalization"
-    );
-
-    let block_n_plus_1 =
-        submit_withdrawal(&mut fixture, &zone, &provider, dev_address, 350_000).await?;
-
-    poll_until(
-        DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
-        "joined withdrawal batch finalized",
-        || {
-            let outbox = &outbox;
-            async move {
-                let index = outbox.lastBatch().call().await?.withdrawalBatchIndex;
-                if index == batch_index_before + 1 {
-                    Ok(Some(index))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
+    let withdrawal_block = submit_withdrawals(
+        &mut fixture,
+        &zone,
+        &provider,
+        dev_address,
+        &[250_000, 350_000],
     )
     .await?;
 
     let finalized_logs = outbox
         .BatchFinalized_filter()
-        .from_block(block_n_plus_1)
-        .to_block(block_n_plus_1)
+        .from_block(withdrawal_block)
+        .to_block(withdrawal_block)
         .query()
         .await?;
     assert_eq!(
         finalized_logs.len(),
         1,
-        "block N+1 should emit exactly one BatchFinalized covering both withdrawals"
+        "withdrawal block should emit one BatchFinalized"
     );
 
-    let requested_n = outbox
+    let requested_logs = outbox
         .WithdrawalRequested_filter()
-        .from_block(block_n)
-        .to_block(block_n)
+        .from_block(withdrawal_block)
+        .to_block(withdrawal_block)
         .query()
         .await?;
-    let requested_n1 = outbox
-        .WithdrawalRequested_filter()
-        .from_block(block_n_plus_1)
-        .to_block(block_n_plus_1)
-        .query()
-        .await?;
-    assert_eq!(requested_n.len(), 1);
-    assert_eq!(requested_n1.len(), 1);
+    assert_eq!(requested_logs.len(), 2);
 
     let mut withdrawals = Vec::new();
-    for (requested, log) in requested_n.iter().chain(requested_n1.iter()) {
+    for (requested, log) in &requested_logs {
         let tx_hash = log
             .transaction_hash
             .ok_or_else(|| eyre::eyre!("WithdrawalRequested log missing transaction hash"))?;
@@ -1225,6 +1194,7 @@ async fn test_consecutive_withdrawal_blocks_joined_into_one_batch() -> eyre::Res
     let expected_hash = Withdrawal::queue_hash(&withdrawals);
     let (finalized, log) = &finalized_logs[0];
     assert_eq!(finalized.withdrawalQueueHash, expected_hash);
+    assert_eq!(finalized.withdrawalBatchIndex, batch_index_before + 1);
 
     let tx_hash = log
         .transaction_hash
@@ -1238,9 +1208,19 @@ async fn test_consecutive_withdrawal_blocks_joined_into_one_batch() -> eyre::Res
     assert_eq!(
         finalize_call.count,
         U256::from(2),
-        "joined batch should cover both withdrawal blocks"
+        "one batch should cover both current-block withdrawals"
     );
+    assert_eq!(finalize_call.blockNumber, withdrawal_block);
     assert_eq!(finalize_call.encryptedSenders.len(), 2);
+    assert_eq!(
+        outbox
+            .pendingWithdrawalsCount()
+            .from(Address::ZERO)
+            .call()
+            .await?,
+        U256::ZERO,
+        "batch should sweep both pending withdrawals"
+    );
 
     Ok(())
 }

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -426,18 +426,18 @@ async fn test_batch_only_restart_no_withdrawals() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Withdrawal batching with +1 block deferral survives sequencer restart.
+/// Withdrawal processing survives sequencer restart after same-block batch finalization.
 ///
-/// The batch submitter reconstructs prior withdrawals from chain history on resume;
-/// defer/finalize timing is covered by local e2e tests in `e2e.rs`.
+/// The batch submitter reconstructs finalized withdrawals from chain history on resume;
+/// same-block finalization timing is covered by local e2e tests in `e2e.rs`.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_deferred_withdrawal_survives_sequencer_restart() -> eyre::Result<()> {
+async fn test_finalized_withdrawal_survives_sequencer_restart() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let l1 = L1TestNode::start().await?;
     let portal_address = l1.deploy_zone().await?;
-    // Use a long withdrawal batch interval so this live L1 restart test can
-    // deterministically assert that the request block itself does not finalize.
+    // Use a long withdrawal batch interval so this live L1 restart test knows
+    // finalization was triggered by the withdrawal rather than an empty-batch boundary.
     let zone = ZoneTestNode::start_from_l1_with_withdrawal_batch_interval(
         l1.http_url(),
         l1.ws_url(),
@@ -466,15 +466,13 @@ async fn test_deferred_withdrawal_survives_sequencer_restart() -> eyre::Result<(
         .to_block(withdrawal_block)
         .query()
         .await?;
-    assert!(
-        same_block_finalized.is_empty(),
-        "withdrawal block {withdrawal_block} should defer BatchFinalized"
+    assert_eq!(
+        same_block_finalized.len(),
+        1,
+        "withdrawal block {withdrawal_block} should emit BatchFinalized"
     );
 
-    // Restart the batch submitter after proving the request block deferred finalization.
-    // The continuously running L1/zone stack may already have produced the next L2
-    // block by this point, so checking current pendingWithdrawalsCount() would race
-    // with the intended +1-block finalization.
+    // Restart the batch submitter after proving the request block finalized its withdrawal.
     seq_handle.monitor_handle.abort();
     seq_handle.withdrawal_handle.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -252,10 +252,6 @@ where
             PayloadBuilderError::Internal(err.into())
         })?;
 
-        let pending_withdrawals_at_block_start =
-            read_pending_withdrawals_from_outbox(builder.evm_mut(), block_number)?;
-        let has_prior_withdrawals = !pending_withdrawals_at_block_start.is_empty();
-
         // Execute advanceTempo system transaction — exactly one per zone block.
         builder
             .execute_transaction(build_advance_tempo_tx(prepared))
@@ -292,7 +288,6 @@ where
             &mut builder,
             block_number,
             self.withdrawal_batch_interval_blocks,
-            has_prior_withdrawals,
             self.withdrawal_reveal_encryptor.as_deref(),
         )?;
 
@@ -539,23 +534,22 @@ fn is_l1_storage_unavailable(error: &(dyn Error + 'static)) -> bool {
     false
 }
 
-/// Finalize withdrawals when the block started with pending requests or reaches a batch boundary.
+/// Finalize withdrawals when the current pending list is non-empty or at a batch boundary.
 fn finalize_withdrawal_batch_if_needed<B>(
     builder: &mut B,
     block_number: u64,
     interval_blocks: u64,
-    has_prior_withdrawals: bool,
     encryptor: Option<&dyn WithdrawalRevealEncryptor>,
 ) -> Result<(), PayloadBuilderError>
 where
     B: BlockBuilder<Primitives = tempo_primitives::TempoPrimitives>,
 {
-    if !has_prior_withdrawals && !block_number.is_multiple_of(interval_blocks) {
+    let pending_withdrawals =
+        read_pending_withdrawals_from_outbox(builder.evm_mut(), block_number)?;
+    if pending_withdrawals.is_empty() && !block_number.is_multiple_of(interval_blocks) {
         return Ok(());
     }
 
-    let pending_withdrawals =
-        read_pending_withdrawals_from_outbox(builder.evm_mut(), block_number)?;
     let encrypted_senders = pending_withdrawals
         .iter()
         .map(|request| {


### PR DESCRIPTION
## Summary

Finalize withdrawals in the same zone block that executes the withdrawal request.

## Root cause

The payload builder read `getPendingWithdrawals` before `advanceTempo` and pool transactions, then carried a `has_prior_withdrawals` boolean into the finalization decision. A withdrawal created by a pool transaction was therefore absent from that block-start snapshot, adding one deterministic zone tick between `WithdrawalRequested` and `BatchFinalized`.

## Change

Remove the block-start read and stale boolean. After pool transactions execute, read the current pending withdrawal list once and append `finalizeWithdrawalBatch` when it is non-empty. Empty batches still finalize at `withdrawal_batch_interval_blocks`, and the finalization system transaction remains last in the block.

## Impact

A newly requested withdrawal now reaches its `BatchFinalized` boundary in the request block, removing one zone-block of deterministic latency. This only changes the zone-side batching boundary; the later L1 batch settlement and withdrawal processing stages are unchanged.