### PR TITLE
test(node): improve integration test synchronization

### DIFF
--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -23,8 +23,8 @@ use crate::utils::{
 /// Ceiling for one leadership switch: covers the Commonware handshake, the promotion
 /// barrier's tip-evidence round trip, and the generation swap.
 const HANDOFF_TIMEOUT: Duration = Duration::from_secs(60);
-/// How long a fenced or demoted node is watched to confirm it produces nothing.
-const QUIESCENCE: Duration = Duration::from_secs(3);
+/// Negative-observation window used only to prove a fenced or demoted node produces nothing.
+const NEGATIVE_OBSERVATION_WINDOW: Duration = Duration::from_secs(3);
 /// Live-propagation ceiling during the observation→activation window: well below the
 /// follower's 30-second inactivity backfill probe, so a routing regression that degrades
 /// the window to backfill-paced replication fails fast instead of passing slowly.
@@ -39,7 +39,6 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     for _ in 0..3 {
         cluster.inject_block(vec![])?;
@@ -64,7 +63,8 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     for _ in 0..3 {
         cluster.inject_block(vec![])?;
     }
-    tokio::time::sleep(QUIESCENCE).await;
+    // Negative assertion: observe the fenced survivors for the full bounded window.
+    tokio::time::sleep(NEGATIVE_OBSERVATION_WINDOW).await;
     for node in &cluster.nodes {
         assert_eq!(
             node.provider().get_block_number().await?,
@@ -155,9 +155,6 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    // Commonware drops messages for offline peers; the bootstrap leader also needs tip
-    // evidence from both followers before its first promotion.
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // --- Blocks 1..=3 are produced by A (the manifest bootstrap leader). ---
     for _ in 0..3 {
@@ -318,7 +315,6 @@ async fn test_lagged_follower_promotes_only_after_catching_up() -> eyre::Result<
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Blocks 1..=2 are observed by everyone.
     for _ in 0..2 {
@@ -349,7 +345,8 @@ async fn test_lagged_follower_promotes_only_after_catching_up() -> eyre::Result<
     // boundary; B cannot produce it either because its consumption is still before the
     // boundary (next anchor 3 is governed by A).
     let boundary = cluster.inject_block_observed_by(vec![], &[0, 2])?;
-    tokio::time::sleep(QUIESCENCE).await;
+    // Negative assertion: observe every node through a bounded no-production window.
+    tokio::time::sleep(NEGATIVE_OBSERVATION_WINDOW).await;
     assert_eq!(
         cluster.nodes[0].provider().get_block_number().await?,
         5,
@@ -409,7 +406,6 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Blocks 1..=3 are produced by A (the manifest bootstrap leader).
     for _ in 0..3 {

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -8,8 +8,9 @@
 //! - Method tier enforcement (restricted/disabled/unknown methods)
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, now_secs, start_zone_with_private_rpc,
-    start_zone_with_private_rpc_l1, start_zone_with_private_rpc_l1_with_encryption,
+    DEFAULT_TIMEOUT, JsonRpcResponseExt, TEST_MNEMONIC, TIP20_TX_GAS, now_secs,
+    start_zone_with_private_rpc, start_zone_with_private_rpc_l1,
+    start_zone_with_private_rpc_l1_with_encryption,
 };
 use alloy::{
     primitives::{Address, B256, TxKind, U256, address, hex},
@@ -20,6 +21,7 @@ use alloy_provider::ProviderBuilder;
 use alloy_signer::SignerSync;
 use alloy_signer_local::{MnemonicBuilder, coins_bip39::English};
 use alloy_sol_types::{SolCall, SolError};
+use eyre::WrapErr;
 use futures::{SinkExt, StreamExt};
 use p256::ecdsa::SigningKey as P256SigningKey;
 use rand::thread_rng;
@@ -44,6 +46,7 @@ use tokio_tungstenite::{
     connect_async,
     tungstenite::{Message, client::IntoClientRequest},
 };
+use zone_rpc::types::{AuthorizationTokenInfoResponse, ZoneInfoResponse};
 
 alloy::sol! {
     interface IMulticall3 {
@@ -102,72 +105,123 @@ fn signed_sponsored_raw_transaction(
     Ok(format!("0x{}", hex::encode(envelope.encoded_2718())))
 }
 
-fn assert_filter_not_found_error(response: &serde_json::Value) {
-    let error = response
-        .get("error")
-        .unwrap_or_else(|| panic!("expected filter-not-found error, got {response}"));
-    assert_eq!(
-        error["code"].as_i64().unwrap(),
-        -32602,
-        "filter-not-found should surface as invalid params",
-    );
-    assert_eq!(
-        error["message"].as_str().unwrap(),
-        "filter not found",
-        "filter-not-found message should be stable",
-    );
+fn assert_filter_not_found_error(response: &serde_json::Value) -> eyre::Result<()> {
+    response.expect_error(-32602, "filter not found")?;
+    Ok(())
 }
 
-fn assert_redacted_block(block: &Value) {
-    assert!(!block.is_null(), "block should not be null");
-    assert!(
+fn expect_redacted_block(response: &Value) -> eyre::Result<Value> {
+    let block: Value = response.expect_result()?;
+    eyre::ensure!(
+        !block.is_null(),
+        "block should not be null; complete response: {response}"
+    );
+    eyre::ensure!(
         block["transactions"]
             .as_array()
             .is_some_and(|transactions| transactions.is_empty()),
-        "block transactions should be empty (redacted)"
+        "block transactions should be empty (redacted); complete response: {response}"
     );
 
     let zero_root = format!("{:#x}", B256::ZERO);
-    assert_eq!(block["transactionsRoot"], zero_root);
-    assert_eq!(block["receiptsRoot"], zero_root);
-    assert_eq!(block["stateRoot"], zero_root);
-    assert_eq!(block["extraData"], "0x");
+    eyre::ensure!(
+        block["transactionsRoot"] == zero_root,
+        "block transactionsRoot should be zero; complete response: {response}"
+    );
+    eyre::ensure!(
+        block["receiptsRoot"] == zero_root,
+        "block receiptsRoot should be zero; complete response: {response}"
+    );
+    eyre::ensure!(
+        block["stateRoot"] == zero_root,
+        "block stateRoot should be zero; complete response: {response}"
+    );
+    eyre::ensure!(
+        block["extraData"] == "0x",
+        "block extraData should be empty; complete response: {response}"
+    );
 
     if let Some(withdrawals_root) = block.get("withdrawalsRoot") {
-        assert!(
+        eyre::ensure!(
             withdrawals_root.is_null() || withdrawals_root == zero_root.as_str(),
-            "block withdrawalsRoot should be null or zero"
+            "block withdrawalsRoot should be null or zero; complete response: {response}"
         );
     }
     if let Some(bloom) = block.get("logsBloom").and_then(Value::as_str) {
         let bloom_trimmed = bloom.strip_prefix("0x").unwrap_or(bloom);
-        assert!(
+        eyre::ensure!(
             bloom_trimmed.chars().all(|c| c == '0'),
-            "block logsBloom should be all zeros"
+            "block logsBloom should be all zeros; complete response: {response}"
         );
     }
-    assert_eq!(block["gasUsed"], "0x0");
+    eyre::ensure!(
+        block["gasUsed"] == "0x0",
+        "block gasUsed should be zero; complete response: {response}"
+    );
     if let Some(size) = block.get("size") {
-        assert_eq!(size.as_str(), Some("0x0"));
+        eyre::ensure!(
+            size.as_str() == Some("0x0"),
+            "block size should be zero; complete response: {response}"
+        );
     }
     if let Some(blob_gas_used) = block.get("blobGasUsed") {
-        assert_eq!(blob_gas_used.as_str(), Some("0x0"));
+        eyre::ensure!(
+            blob_gas_used.as_str() == Some("0x0"),
+            "block blobGasUsed should be zero; complete response: {response}"
+        );
     }
     if let Some(excess_blob_gas) = block.get("excessBlobGas") {
-        assert_eq!(excess_blob_gas.as_str(), Some("0x0"));
+        eyre::ensure!(
+            excess_blob_gas.as_str() == Some("0x0"),
+            "block excessBlobGas should be zero; complete response: {response}"
+        );
     }
     if let Some(withdrawals) = block.get("withdrawals") {
-        assert!(
+        eyre::ensure!(
             withdrawals
                 .as_array()
                 .is_some_and(|withdrawals| withdrawals.is_empty()),
-            "block withdrawals should be empty when present"
+            "block withdrawals should be empty when present; complete response: {response}"
         );
     }
+    Ok(block)
 }
 
 type PrivateRpcWs =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+#[derive(serde::Deserialize)]
+struct LogSubscriptionNotification {
+    params: LogSubscriptionParams,
+}
+
+#[derive(serde::Deserialize)]
+struct LogSubscriptionParams {
+    subscription: String,
+    result: LogSubscriptionResult,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LogSubscriptionResult {
+    transaction_hash: String,
+}
+
+fn expect_log_subscription_notification(
+    notification: &Value,
+    expected_subscription: &str,
+) -> eyre::Result<String> {
+    let parsed: LogSubscriptionNotification = serde_json::from_value(notification.clone())
+        .wrap_err_with(|| {
+            format!("malformed private log subscription notification: {notification}")
+        })?;
+    eyre::ensure!(
+        parsed.params.subscription == expected_subscription,
+        "expected subscription {expected_subscription}, got {}; complete notification: {notification}",
+        parsed.params.subscription,
+    );
+    Ok(parsed.params.result.transaction_hash)
+}
 
 fn private_rpc_ws_url(http_url: &url::Url) -> eyre::Result<url::Url> {
     let mut ws_url = http_url.clone();
@@ -221,10 +275,7 @@ async fn ws_subscribe(ws: &mut PrivateRpcWs, params: Value) -> eyre::Result<Stri
     ))
     .await?;
     let response = ws_next_json(ws).await?;
-    Ok(response["result"]
-        .as_str()
-        .expect("subscription response should include an id")
-        .to_owned())
+    response.expect_result()
 }
 
 async fn ws_collect_messages_until_quiet(
@@ -297,16 +348,10 @@ async fn test_send_raw_transaction_requires_enabled_token_balance() -> eyre::Res
 
     for method in ["eth_sendRawTransaction", "eth_sendRawTransactionSync"] {
         let response = ctx.call_as_user(method, json!([raw]), &user_signer).await?;
-        assert_eq!(
-            response["error"]["code"].as_i64(),
-            Some(-32603),
-            "{method} should reject a sender without enabled-token balance: {response}",
-        );
-        assert_eq!(
-            response["error"]["message"].as_str(),
-            Some("sender must hold a nonzero balance of an enabled zone token"),
-            "{method} should explain why the transaction was rejected: {response}",
-        );
+        response.expect_error(
+            -32603,
+            "sender must hold a nonzero balance of an enabled zone token",
+        )?;
     }
 
     ctx.inject_deposit(
@@ -320,10 +365,7 @@ async fn test_send_raw_transaction_requires_enabled_token_balance() -> eyre::Res
     let response = ctx
         .call_as_user("eth_sendRawTransaction", json!([raw]), &user_signer)
         .await?;
-    assert!(
-        response["result"].as_str().is_some(),
-        "funded sender transaction should be accepted: {response}",
-    );
+    let _: String = response.expect_result()?;
 
     Ok(())
 }
@@ -344,14 +386,7 @@ async fn test_non_secp_auth_tokens() -> eyre::Result<()> {
         let resp = ctx
             .call("eth_blockNumber", serde_json::json!([]), &token)
             .await?;
-        assert!(
-            resp.get("error").is_none(),
-            "auth token should succeed: {resp}"
-        );
-        assert!(
-            resp["result"].as_str().is_some(),
-            "expected block number result"
-        );
+        let _: String = resp.expect_result()?;
     }
 
     Ok(())
@@ -427,9 +462,9 @@ async fn test_keychain_auth_tokens_v1_and_v2() -> eyre::Result<()> {
                 &token,
             )
             .await?;
+        let result: String = resp.expect_result()?;
         assert_eq!(
-            resp["result"].as_str().unwrap(),
-            "0x",
+            result, "0x",
             "keychain auth should allow calls from the root account",
         );
     }
@@ -499,6 +534,7 @@ async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
         now_secs() + 1,
     )
     .await?;
+    // Intentionally clock-based: exercise real authorization-token expiry, not node readiness.
     sleep(std::time::Duration::from_secs(2)).await;
     let (status, _) = ctx
         .call_raw("eth_blockNumber", serde_json::json!([]), &expired_token)
@@ -545,18 +581,12 @@ async fn test_public_methods() -> eyre::Result<()> {
 
     for method in ["eth_blockNumber", "eth_chainId"] {
         let seq_resp = ctx.call_as_sequencer(method, serde_json::json!([])).await?;
-        assert!(
-            seq_resp.get("result").is_some() && seq_resp.get("error").is_none(),
-            "sequencer should succeed for {method}"
-        );
+        let _: String = seq_resp.expect_result()?;
 
         let user_resp = ctx
             .call_as_user(method, serde_json::json!([]), &user_signer)
             .await?;
-        assert!(
-            user_resp.get("result").is_some() && user_resp.get("error").is_none(),
-            "user should succeed for {method}"
-        );
+        let _: String = user_resp.expect_result()?;
     }
 
     for (method, expected) in [
@@ -567,7 +597,8 @@ async fn test_public_methods() -> eyre::Result<()> {
             ctx.call_as_sequencer(method, json!([])).await?,
             ctx.call_as_user(method, json!([]), &user_signer).await?,
         ] {
-            assert_eq!(response["result"], json!(format!("{expected:#x}")));
+            let result: String = response.expect_result()?;
+            assert_eq!(result, format!("{expected:#x}"));
         }
     }
 
@@ -586,11 +617,7 @@ async fn test_filter_ownership_and_uninstall_cleanup() -> eyre::Result<()> {
     let create_resp = ctx
         .call_as_user("eth_newBlockFilter", serde_json::json!([]), &owner_signer)
         .await?;
-    assert!(
-        create_resp.get("error").is_none(),
-        "owner should be able to create a block filter: {create_resp}"
-    );
-    let filter_id = create_resp["result"].clone();
+    let filter_id: String = create_resp.expect_result()?;
 
     ctx.inject_empty_block().await?;
 
@@ -601,14 +628,9 @@ async fn test_filter_ownership_and_uninstall_cleanup() -> eyre::Result<()> {
             &owner_signer,
         )
         .await?;
+    let owner_changes: Vec<String> = owner_changes.expect_result()?;
     assert!(
-        owner_changes.get("error").is_none(),
-        "owner should be able to read filter changes: {owner_changes}"
-    );
-    assert!(
-        owner_changes["result"]
-            .as_array()
-            .is_some_and(|changes| !changes.is_empty()),
+        !owner_changes.is_empty(),
         "owner should observe at least one new block hash"
     );
 
@@ -619,7 +641,7 @@ async fn test_filter_ownership_and_uninstall_cleanup() -> eyre::Result<()> {
             &other_signer,
         )
         .await?;
-    assert_filter_not_found_error(&other_changes);
+    assert_filter_not_found_error(&other_changes)?;
 
     let uninstall_resp = ctx
         .call_as_user(
@@ -629,7 +651,7 @@ async fn test_filter_ownership_and_uninstall_cleanup() -> eyre::Result<()> {
         )
         .await?;
     assert!(
-        uninstall_resp["result"].as_bool().unwrap(),
+        uninstall_resp.expect_result::<bool>()?,
         "owner uninstall should succeed",
     );
 
@@ -640,7 +662,7 @@ async fn test_filter_ownership_and_uninstall_cleanup() -> eyre::Result<()> {
             &owner_signer,
         )
         .await?;
-    assert_filter_not_found_error(&after_uninstall);
+    assert_filter_not_found_error(&after_uninstall)?;
 
     Ok(())
 }
@@ -664,17 +686,17 @@ async fn test_balance_privacy() -> eyre::Result<()> {
 
     // User querying another address's balance → 0x0
     let resp = ctx.get_balance_as_user(recipient, &user_signer).await?;
+    let balance: String = resp.expect_result()?;
     assert_eq!(
-        resp["result"].as_str().unwrap(),
-        "0x0",
+        balance, "0x0",
         "non-owner should see 0x0 balance for other addresses"
     );
 
     // User querying another address's tx count → 0x0
     let resp = ctx.get_tx_count_as_user(recipient, &user_signer).await?;
+    let tx_count: String = resp.expect_result()?;
     assert_eq!(
-        resp["result"].as_str().unwrap(),
-        "0x0",
+        tx_count, "0x0",
         "non-owner should see 0x0 for other address's tx count"
     );
 
@@ -682,17 +704,11 @@ async fn test_balance_privacy() -> eyre::Result<()> {
     let resp = ctx
         .get_balance_as_user(user_signer.address(), &user_signer)
         .await?;
-    assert!(
-        resp.get("result").is_some() && resp.get("error").is_none(),
-        "user should be able to query own balance"
-    );
+    let _: String = resp.expect_result()?;
 
     // Sequencer querying any address → full access
     let resp = ctx.get_balance_as_sequencer(recipient).await?;
-    assert!(
-        resp.get("result").is_some() && resp.get("error").is_none(),
-        "sequencer should be able to query any address's balance"
-    );
+    let _: String = resp.expect_result()?;
 
     Ok(())
 }
@@ -751,10 +767,7 @@ async fn test_tip20_eth_call_privacy() -> eyre::Result<()> {
             &outsider_signer,
         )
         .await?;
-    assert!(
-        outsider_balance.get("error").is_some(),
-        "non-owner balanceOf(other) should revert"
-    );
+    outsider_balance.expect_error_response()?;
 
     let outsider_allowance = ctx
         .call_as_user(
@@ -769,10 +782,7 @@ async fn test_tip20_eth_call_privacy() -> eyre::Result<()> {
             &outsider_signer,
         )
         .await?;
-    assert!(
-        outsider_allowance.get("error").is_some(),
-        "unrelated caller allowance(owner, spender) should revert"
-    );
+    outsider_allowance.expect_error_response()?;
 
     let sequencer_balance = ctx
         .call_as_sequencer(
@@ -787,12 +797,8 @@ async fn test_tip20_eth_call_privacy() -> eyre::Result<()> {
             ]),
         )
         .await?;
-    let sequencer_balance_bytes = hex::decode(
-        sequencer_balance["result"]
-            .as_str()
-            .expect("sequencer balanceOf should return hex")
-            .trim_start_matches("0x"),
-    )?;
+    let sequencer_balance: String = sequencer_balance.expect_result()?;
+    let sequencer_balance_bytes = hex::decode(sequencer_balance.trim_start_matches("0x"))?;
     assert_eq!(
         PrecompileTip20::balanceOfCall::abi_decode_returns(&sequencer_balance_bytes)?,
         expected_owner_balance
@@ -811,12 +817,8 @@ async fn test_tip20_eth_call_privacy() -> eyre::Result<()> {
             ]),
         )
         .await?;
-    let sequencer_allowance_bytes = hex::decode(
-        sequencer_allowance["result"]
-            .as_str()
-            .expect("sequencer allowance should return hex")
-            .trim_start_matches("0x"),
-    )?;
+    let sequencer_allowance: String = sequencer_allowance.expect_result()?;
+    let sequencer_allowance_bytes = hex::decode(sequencer_allowance.trim_start_matches("0x"))?;
     assert_eq!(
         PrecompileTip20::allowanceCall::abi_decode_returns(&sequencer_allowance_bytes)?,
         U256::from(allowance_amount)
@@ -856,12 +858,11 @@ async fn test_zone_inbox_refunds_eth_call_privacy() -> eyre::Result<()> {
             &outsider_signer,
         )
         .await?;
-    let outsider_error = outsider_refunds["error"]["message"]
-        .as_str()
-        .expect("non-owner refund read should return an RPC error message");
+    let outsider_error = outsider_refunds.expect_error_response()?;
     let unauthorized_selector = format!("0x{}", hex::encode(Unauthorized::SELECTOR));
     assert!(
-        outsider_error.contains("Unauthorized") && outsider_error.contains(&unauthorized_selector),
+        outsider_error.message.contains("Unauthorized")
+            && outsider_error.message.contains(&unauthorized_selector),
         "the ZoneInbox getter must reject a direct non-owner refund read with Unauthorized(): {outsider_refunds}"
     );
 
@@ -878,12 +879,8 @@ async fn test_zone_inbox_refunds_eth_call_privacy() -> eyre::Result<()> {
             &owner_signer,
         )
         .await?;
-    let owner_refunds_bytes = hex::decode(
-        owner_refunds["result"]
-            .as_str()
-            .expect("own refunds call should return hex")
-            .trim_start_matches("0x"),
-    )?;
+    let owner_refunds: String = owner_refunds.expect_result()?;
+    let owner_refunds_bytes = hex::decode(owner_refunds.trim_start_matches("0x"))?;
     assert_eq!(
         IZoneInbox::refundsCall::abi_decode_returns(&owner_refunds_bytes)?,
         0,
@@ -909,10 +906,7 @@ async fn test_zone_inbox_refunds_eth_call_privacy() -> eyre::Result<()> {
             &outsider_signer,
         )
         .await?;
-    assert!(
-        forwarded_refunds.get("result").is_none() && forwarded_refunds.get("error").is_some(),
-        "Multicall3 must not expose another owner's refund balance: {forwarded_refunds}"
-    );
+    forwarded_refunds.expect_error_response()?;
 
     Ok(())
 }
@@ -939,15 +933,7 @@ async fn test_simulation_validation_rejects_create_and_overrides() -> eyre::Resu
                 &user_signer,
             )
             .await?;
-        assert_eq!(
-            create_resp["error"]["code"].as_i64().unwrap(),
-            -32602,
-            "{method} should reject create-style requests",
-        );
-        assert_eq!(
-            create_resp["error"]["message"].as_str().unwrap(),
-            "contract creation not supported on zones",
-        );
+        create_resp.expect_error(-32602, "contract creation not supported on zones")?;
 
         let user_override_resp = ctx
             .call_as_user(
@@ -963,15 +949,7 @@ async fn test_simulation_validation_rejects_create_and_overrides() -> eyre::Resu
                 &user_signer,
             )
             .await?;
-        assert_eq!(
-            user_override_resp["error"]["code"].as_i64().unwrap(),
-            -32602,
-            "{method} should reject user state overrides",
-        );
-        assert_eq!(
-            user_override_resp["error"]["message"].as_str().unwrap(),
-            "state overrides not allowed",
-        );
+        user_override_resp.expect_error(-32602, "state overrides not allowed")?;
     }
 
     let fill_resp = ctx
@@ -985,11 +963,7 @@ async fn test_simulation_validation_rejects_create_and_overrides() -> eyre::Resu
             &user_signer,
         )
         .await?;
-    assert_eq!(fill_resp["error"]["code"].as_i64().unwrap(), -32602);
-    assert_eq!(
-        fill_resp["error"]["message"].as_str().unwrap(),
-        "contract creation not supported on zones",
-    );
+    fill_resp.expect_error(-32602, "contract creation not supported on zones")?;
 
     Ok(())
 }
@@ -1013,12 +987,7 @@ async fn test_block_access_control() -> eyre::Result<()> {
             &user_signer,
         )
         .await?;
-    let error = resp.get("error").expect("full=true should be rejected");
-    assert_eq!(
-        error["code"].as_i64().unwrap(),
-        -32005,
-        "full=true should return -32005"
-    );
+    resp.expect_error_code(-32005)?;
 
     // full=false → redacted block (empty txs, zeroed logsBloom)
     let resp = ctx
@@ -1028,10 +997,12 @@ async fn test_block_access_control() -> eyre::Result<()> {
             &user_signer,
         )
         .await?;
-    let block = resp.get("result").expect("should have result");
-    assert_redacted_block(block);
+    let block = expect_redacted_block(&resp)?;
 
-    let block_hash = block["hash"].as_str().expect("block should have hash");
+    let block_hash = block["hash"]
+        .as_str()
+        .ok_or_else(|| eyre::eyre!("redacted block had no hash; complete response: {resp}"))?
+        .to_owned();
     let resp = ctx
         .call_as_user(
             "eth_getBlockByHash",
@@ -1039,7 +1010,7 @@ async fn test_block_access_control() -> eyre::Result<()> {
             &user_signer,
         )
         .await?;
-    assert_redacted_block(resp.get("result").expect("should have result"));
+    expect_redacted_block(&resp)?;
 
     Ok(())
 }
@@ -1064,14 +1035,7 @@ async fn test_method_tiers() -> eyre::Result<()> {
         let resp = ctx
             .call_as_user(method, serde_json::json!([]), &user_signer)
             .await?;
-        let error = resp
-            .get("error")
-            .unwrap_or_else(|| panic!("{method} should return error"));
-        assert_eq!(
-            error["code"].as_i64().unwrap(),
-            -32005,
-            "{method} should return -32005"
-        );
+        resp.expect_error_code(-32005)?;
     }
 
     // Disabled methods → -32006 for everyone
@@ -1084,14 +1048,7 @@ async fn test_method_tiers() -> eyre::Result<()> {
         let resp = ctx
             .call_as_user(method, serde_json::json!([]), &user_signer)
             .await?;
-        let error = resp
-            .get("error")
-            .unwrap_or_else(|| panic!("{method} should return error"));
-        assert_eq!(
-            error["code"].as_i64().unwrap(),
-            -32006,
-            "{method} should return -32006 (Method disabled)"
-        );
+        resp.expect_error_code(-32006)?;
     }
 
     // Unknown method → -32601
@@ -1102,14 +1059,7 @@ async fn test_method_tiers() -> eyre::Result<()> {
             &user_signer,
         )
         .await?;
-    let error = resp
-        .get("error")
-        .expect("unknown method should return error");
-    assert_eq!(
-        error["code"].as_i64().unwrap(),
-        -32601,
-        "unknown method should return -32601"
-    );
+    resp.expect_error_code(-32601)?;
 
     Ok(())
 }
@@ -1156,12 +1106,11 @@ async fn test_ws_logs_subscription_is_sender_scoped() -> eyre::Result<()> {
         ))
         .await?;
     let broad_subscription = ws_next_json(&mut owner_ws).await?;
-    assert_eq!(broad_subscription["id"], 1);
-    assert_eq!(
-        broad_subscription["error"]["code"].as_i64().unwrap(),
-        -32602,
-        "broad private log subscriptions should be rejected"
+    eyre::ensure!(
+        broad_subscription["id"] == 1,
+        "broad subscription response had the wrong id; complete response: {broad_subscription}"
     );
+    broad_subscription.expect_error_code(-32602)?;
 
     let owner_subscription = ws_subscribe(
         &mut owner_ws,
@@ -1210,16 +1159,9 @@ async fn test_ws_logs_subscription_is_sender_scoped() -> eyre::Result<()> {
     let owner_hashes = owner_notifications
         .into_iter()
         .map(|notification| {
-            assert_eq!(
-                notification["params"]["subscription"].as_str().unwrap(),
-                owner_subscription
-            );
-            notification["params"]["result"]["transactionHash"]
-                .as_str()
-                .unwrap()
-                .to_owned()
+            expect_log_subscription_notification(&notification, &owner_subscription)
         })
-        .collect::<HashSet<_>>();
+        .collect::<eyre::Result<HashSet<_>>>()?;
     assert_eq!(owner_hashes, HashSet::from([format!("{owner_hash:#x}")]));
 
     Ok(())
@@ -1246,12 +1188,11 @@ async fn test_ws_pending_transaction_subscriptions_are_disabled() -> eyre::Resul
             ))
             .await?;
         let response = ws_next_json(&mut user_ws).await?;
-        assert_eq!(response["id"], id);
-        assert_eq!(
-            response["error"]["code"].as_i64().unwrap(),
-            -32006,
-            "newPendingTransactions should be disabled"
+        eyre::ensure!(
+            response["id"] == id,
+            "pending-subscription response had the wrong id; complete response: {response}"
         );
+        response.expect_error_code(-32006)?;
     }
 
     Ok(())
@@ -1273,45 +1214,27 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
             &user_signer,
         )
         .await?;
-    assert_eq!(
-        auth_info["result"]["account"].as_str().unwrap(),
-        format!("{:#x}", user_signer.address()),
-    );
+    let auth_info: AuthorizationTokenInfoResponse = auth_info.expect_result()?;
+    assert_eq!(auth_info.account, user_signer.address());
     assert!(
-        auth_info["result"]["expiresAt"].as_str().is_some(),
-        "expiresAt should be a quantity string",
+        !auth_info.expires_at.is_zero(),
+        "expiresAt should be non-zero"
     );
 
     let zone_info = ctx
         .call_as_user("zone_getZoneInfo", serde_json::json!([]), &user_signer)
         .await?;
-    assert_eq!(
-        zone_info["result"]["zoneId"].as_str().unwrap(),
-        format!("0x{:x}", ctx.config.zone_id),
-    );
-    assert_eq!(zone_info["result"]["isAccessEnforced"], true);
-    assert_eq!(zone_info["result"]["isGatewayOpen"], false);
-    assert_eq!(
-        zone_info["result"]["zoneTokens"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|token| token.as_str().unwrap())
-            .collect::<Vec<_>>(),
-        vec!["0x20c0000000000000000000000000000000000000"],
-    );
-    assert_eq!(
-        zone_info["result"]["chainId"].as_str().unwrap(),
-        format!("0x{:x}", ctx.config.chain_id),
-    );
+    let zone_info: ZoneInfoResponse = zone_info.expect_result()?;
+    assert_eq!(zone_info.zone_id.to::<u64>(), u64::from(ctx.config.zone_id));
+    assert!(zone_info.is_access_enforced);
+    assert!(!zone_info.is_gateway_open);
+    assert_eq!(zone_info.zone_tokens, vec![PATH_USD_ADDRESS],);
+    assert_eq!(zone_info.chain_id.to::<u64>(), ctx.config.chain_id);
     let tempo_block_number = TempoState::new(TEMPO_STATE_ADDRESS, ctx.zone.provider())
         .tempoBlockNumber()
         .call()
         .await?;
-    assert_eq!(
-        zone_info["result"]["tempoBlockNumber"],
-        format!("0x{tempo_block_number:x}"),
-    );
+    assert_eq!(zone_info.tempo_block_number.to::<u64>(), tempo_block_number,);
 
     Ok(())
 }
@@ -1336,20 +1259,9 @@ async fn test_zone_get_zone_info_returns_all_enabled_tokens() -> eyre::Result<()
     let zone_info = ctx
         .call_as_user("zone_getZoneInfo", serde_json::json!([]), &user_signer)
         .await?;
-    let zone_tokens = zone_info["result"]["zoneTokens"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|token| token.as_str().unwrap().to_owned())
-        .collect::<Vec<_>>();
+    let zone_tokens = zone_info.expect_result::<ZoneInfoResponse>()?.zone_tokens;
 
-    assert_eq!(
-        zone_tokens,
-        vec![
-            format!("{PATH_USD_ADDRESS:#x}"),
-            format!("{alpha_token:#x}")
-        ],
-    );
+    assert_eq!(zone_tokens, vec![PATH_USD_ADDRESS, alpha_token],);
 
     Ok(())
 }
@@ -1383,12 +1295,9 @@ async fn test_zone_get_encryption_key_reads_latest_l1_key() -> eyre::Result<()> 
     let second = ctx
         .call_as_user("zone_getEncryptionKey", serde_json::json!([]), &caller)
         .await?;
-    assert!(
-        second.get("error").is_none(),
-        "unexpected response: {second}"
-    );
+    let second: Value = second.expect_result()?;
     assert_eq!(
-        second["result"],
+        second,
         serde_json::json!({
             "x": second_x,
             "yParity": second_prefix,

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -8,14 +8,18 @@
 //! - Multiple restart cycles don't corrupt state
 
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, B256, U256};
 use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
+use zone_sequencer::ZoneSequencerHandle;
 
 /// Longer timeout for real L1 tests.
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Timeout for waiting on withdrawals (includes batch submission + processing).
 const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Bound for confirming aborted sequencer tasks have actually terminated.
+const TASK_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Read the portal's `blockHash()` — the last submitted zone block hash.
 async fn portal_block_hash(
@@ -72,9 +76,88 @@ async fn wait_for_withdrawal_requested(
     .await
 }
 
-async fn abort_task(handle: tokio::task::JoinHandle<()>) {
+async fn await_aborted_task(name: &str, handle: tokio::task::JoinHandle<()>) -> eyre::Result<()> {
+    let result = tokio::time::timeout(TASK_SHUTDOWN_TIMEOUT, handle)
+        .await
+        .map_err(|_| {
+            eyre::eyre!("timed out after {TASK_SHUTDOWN_TIMEOUT:?} waiting for {name} to terminate")
+        })?;
+    match result {
+        Err(error) if error.is_cancelled() => Ok(()),
+        Err(error) => eyre::bail!("{name} failed while stopping: {error}"),
+        Ok(()) => eyre::bail!("{name} exited unexpectedly before abort completed"),
+    }
+}
+
+async fn abort_task(name: &str, handle: tokio::task::JoinHandle<()>) -> eyre::Result<()> {
     handle.abort();
-    let _ = handle.await;
+    await_aborted_task(name, handle).await
+}
+
+async fn abort_sequencer(handle: ZoneSequencerHandle) -> eyre::Result<()> {
+    let ZoneSequencerHandle {
+        withdrawal_handle,
+        monitor_handle,
+    } = handle;
+    withdrawal_handle.abort();
+    monitor_handle.abort();
+    let (withdrawal_result, monitor_result) = tokio::join!(
+        await_aborted_task("withdrawal processor", withdrawal_handle),
+        await_aborted_task("zone monitor", monitor_handle),
+    );
+    withdrawal_result?;
+    monitor_result?;
+    Ok(())
+}
+
+async fn wait_for_batch_progress(
+    l1: &L1TestNode,
+    portal_address: Address,
+    before_count: usize,
+    before_hash: B256,
+    sequencer: &ZoneSequencerHandle,
+) -> eyre::Result<(usize, B256)> {
+    let started = std::time::Instant::now();
+    let mut last_observed = (before_count, before_hash);
+    loop {
+        if sequencer.monitor_handle.is_finished() {
+            eyre::bail!("restarted zone monitor exited before submitting a new batch");
+        }
+        if sequencer.withdrawal_handle.is_finished() {
+            eyre::bail!("restarted withdrawal processor exited before batch progress");
+        }
+
+        let remaining = WITHDRAWAL_TIMEOUT.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            eyre::bail!(
+                "timed out after {WITHDRAWAL_TIMEOUT:?} waiting for batch progress after restart; \
+                 before count={before_count}, hash={before_hash}; last observed count={}, hash={}",
+                last_observed.0,
+                last_observed.1,
+            );
+        }
+        let (count, hash) = tokio::time::timeout(remaining, async {
+            tokio::try_join!(
+                batch_submitted_count(l1, portal_address),
+                portal_block_hash(l1, portal_address),
+            )
+        })
+        .await
+        .map_err(|_| {
+            eyre::eyre!(
+                "timed out after {WITHDRAWAL_TIMEOUT:?} waiting for batch state RPCs after \
+                 restart; before count={before_count}, hash={before_hash}; last observed \
+                 count={}, hash={}",
+                last_observed.0,
+                last_observed.1,
+            )
+        })??;
+        last_observed = (count, hash);
+        if count > before_count && hash != before_hash {
+            return Ok((count, hash));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
 }
 
 /// Sequencer restart after a successful batch + withdrawal cycle.
@@ -126,9 +209,7 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
     );
 
     // --- Phase 2: Restart sequencer ---
-    seq_handle.monitor_handle.abort();
-    seq_handle.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    abort_sequencer(seq_handle).await?;
 
     // Respawn — should resume from portal's blockHash, not block 0
     let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
@@ -190,7 +271,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
 
     // Keep batch submission running, but stop L1 processing so the portal queue
     // is guaranteed to remain pending until after the restart.
-    abort_task(withdrawal_handle).await;
+    abort_task("withdrawal processor", withdrawal_handle).await?;
 
     // Request withdrawal — wait for the batch to be submitted to L1
     let withdrawal_amount: u128 = 500_000;
@@ -219,7 +300,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     );
 
     // --- Abort sequencer BEFORE the withdrawal is processed ---
-    abort_task(monitor_handle).await;
+    abort_task("zone monitor", monitor_handle).await?;
 
     // --- Respawn sequencer (fetch_pending_withdrawals runs during init) ---
     let seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
@@ -308,9 +389,7 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     )
     .await?;
 
-    seq1.monitor_handle.abort();
-    seq1.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    abort_sequencer(seq1).await?;
 
     // --- Cycle 2 ---
     let seq2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
@@ -324,9 +403,7 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     )
     .await?;
 
-    seq2.monitor_handle.abort();
-    seq2.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    abort_sequencer(seq2).await?;
 
     // --- Cycle 3 (final) ---
     let _seq3 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
@@ -399,29 +476,12 @@ async fn test_batch_only_restart_no_withdrawals() -> eyre::Result<()> {
     let batches_before = batch_submitted_count(&l1, portal_address).await?;
 
     // Restart
-    seq1.monitor_handle.abort();
-    seq1.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    abort_sequencer(seq1).await?;
 
-    let _seq2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    let seq2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
-    // Wait for more zone blocks to be produced and batched
-    // The zone produces blocks as L1 blocks arrive (every 500ms in dev mode),
-    // so just waiting a bit should produce new blocks to batch.
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
-    let batches_after = batch_submitted_count(&l1, portal_address).await?;
-    assert!(
-        batches_after > batches_before,
-        "new batches should be submitted after restart (before={batches_before}, after={batches_after})"
-    );
-
-    // Portal block hash should have advanced
-    let hash_after = portal_block_hash(&l1, portal_address).await?;
-    assert_ne!(
-        hash_before, hash_after,
-        "portal blockHash should advance after restart"
-    );
+    // Observe the exact post-restart transition instead of assuming a fixed delay is enough.
+    wait_for_batch_progress(&l1, portal_address, batches_before, hash_before, &seq2).await?;
 
     Ok(())
 }
@@ -475,9 +535,7 @@ async fn test_deferred_withdrawal_survives_sequencer_restart() -> eyre::Result<(
     // The continuously running L1/zone stack may already have produced the next L2
     // block by this point, so checking current pendingWithdrawalsCount() would race
     // with the intended +1-block finalization.
-    seq_handle.monitor_handle.abort();
-    seq_handle.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    abort_sequencer(seq_handle).await?;
     let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
     l1.wait_for_withdrawal_on_l1(

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -20,6 +20,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_provider::{BlockNumReader, ChainSpecProvider, HeaderProvider};
 use reth_rpc_builder::RpcModuleSelection;
 use reth_tasks::Runtime;
+use serde::de::DeserializeOwned;
 use std::{
     collections::{BTreeMap, BTreeSet},
     future::Future,
@@ -74,6 +75,7 @@ use zone_node::{ZoneNode, ZoneSequencerAddOnsConfig};
 use zone_p2p::{LeadershipSchedule, LeadershipState, P2pConfig, P2pPeerId, Role};
 use zone_precompiles::ZONE_FEE_MANAGER_ADDRESS;
 use zone_primitives::constants::{PORTAL_ACCESS_MODE_SLOT, PORTAL_TOKEN_CONFIGS_SLOT};
+use zone_rpc::types::SequencerInfoResponse;
 
 #[path = "../../../rpc/test-utils/auth_tokens.rs"]
 mod auth_tokens;
@@ -102,6 +104,188 @@ pub(crate) const DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::fro
 
 /// Default poll interval for e2e tests.
 pub(crate) const DEFAULT_POLL: std::time::Duration = std::time::Duration::from_millis(200);
+
+/// P2P startup can span several transport retry rounds on loaded CI hosts.
+const P2P_STARTUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Typed assertions for complete JSON-RPC response objects.
+pub(crate) trait JsonRpcResponseExt {
+    /// Extract and deserialize a successful `result`.
+    fn expect_result<T: DeserializeOwned>(&self) -> eyre::Result<T>;
+
+    /// Extract an error payload without constraining its code or message.
+    fn expect_error_response(&self) -> eyre::Result<JsonRpcErrorPayload>;
+
+    /// Assert an error code while returning the complete typed error payload.
+    fn expect_error_code(&self, expected_code: i64) -> eyre::Result<JsonRpcErrorPayload>;
+
+    /// Assert an exact error code and message.
+    fn expect_error(
+        &self,
+        expected_code: i64,
+        expected_message: &str,
+    ) -> eyre::Result<JsonRpcErrorPayload>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+pub(crate) struct JsonRpcErrorPayload {
+    pub code: i64,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcResponseExt for serde_json::Value {
+    fn expect_result<T: DeserializeOwned>(&self) -> eyre::Result<T> {
+        if self.get("error").is_some() {
+            eyre::bail!(
+                "expected JSON-RPC success with result type {}, but response contained an error; \
+                 complete response: {self}",
+                std::any::type_name::<T>(),
+            );
+        }
+        let result = self.get("result").ok_or_else(|| {
+            eyre::eyre!(
+                "expected JSON-RPC success with result type {}, but response had no result; \
+                 complete response: {self}",
+                std::any::type_name::<T>(),
+            )
+        })?;
+        serde_json::from_value(result.clone()).wrap_err_with(|| {
+            format!(
+                "failed to deserialize JSON-RPC result as {}; complete response: {self}",
+                std::any::type_name::<T>(),
+            )
+        })
+    }
+
+    fn expect_error_response(&self) -> eyre::Result<JsonRpcErrorPayload> {
+        if self.get("result").is_some() {
+            eyre::bail!(
+                "expected JSON-RPC error, but response contained a result; complete response: {self}"
+            );
+        }
+        let error = self.get("error").ok_or_else(|| {
+            eyre::eyre!(
+                "expected JSON-RPC error, but response had no error; complete response: {self}"
+            )
+        })?;
+        serde_json::from_value(error.clone()).wrap_err_with(|| {
+            format!("failed to deserialize JSON-RPC error payload; complete response: {self}")
+        })
+    }
+
+    fn expect_error_code(&self, expected_code: i64) -> eyre::Result<JsonRpcErrorPayload> {
+        let actual = self.expect_error_response()?;
+        eyre::ensure!(
+            actual.code == expected_code,
+            "expected JSON-RPC error code {expected_code}, got code {} with message {:?}; \
+             complete response: {self}",
+            actual.code,
+            actual.message,
+        );
+        Ok(actual)
+    }
+
+    fn expect_error(
+        &self,
+        expected_code: i64,
+        expected_message: &str,
+    ) -> eyre::Result<JsonRpcErrorPayload> {
+        let actual = self.expect_error_response()?;
+        eyre::ensure!(
+            actual.code == expected_code && actual.message == expected_message,
+            "expected JSON-RPC error code {expected_code} with message {expected_message:?}, got \
+             code {} with message {:?}; complete response: {self}",
+            actual.code,
+            actual.message,
+        );
+        Ok(actual)
+    }
+}
+
+#[cfg(test)]
+mod json_rpc_response_tests {
+    use super::JsonRpcResponseExt;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_typed_result() {
+        let response = json!({"jsonrpc": "2.0", "id": 1, "result": ["0x1", "0x2"]});
+        let result = response
+            .expect_result::<Vec<String>>()
+            .expect("valid typed result");
+        assert_eq!(result, vec!["0x1", "0x2"]);
+    }
+
+    #[test]
+    fn missing_result_reports_complete_response() {
+        let response = json!({"jsonrpc": "2.0", "id": 7});
+        let error = response.expect_result::<String>().unwrap_err().to_string();
+        assert!(error.contains("had no result"));
+        assert!(error.contains(r#""jsonrpc":"2.0""#));
+        assert!(error.contains(r#""id":7"#));
+    }
+
+    #[test]
+    fn malformed_result_reports_complete_response() {
+        let response = json!({"jsonrpc": "2.0", "id": 8, "result": {"not": "a string"}});
+        let error = response.expect_result::<String>().unwrap_err().to_string();
+        assert!(error.contains("failed to deserialize JSON-RPC result"));
+        assert!(error.contains(r#""result":{"not":"a string"}"#));
+        assert!(error.contains(r#""id":8"#));
+    }
+
+    #[test]
+    fn exact_error_assertion_accepts_typed_payload() {
+        let response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32602, "message": "invalid params", "data": {"field": "from"}}
+        });
+        let error = response
+            .expect_error(-32602, "invalid params")
+            .expect("matching error");
+        assert_eq!(error.code, -32602);
+        assert_eq!(error.message, "invalid params");
+        assert_eq!(error.data, Some(json!({"field": "from"})));
+    }
+
+    #[test]
+    fn missing_or_malformed_error_reports_complete_response() {
+        let missing = json!({"jsonrpc": "2.0", "id": 9});
+        let missing_error = missing
+            .expect_error(-32602, "invalid")
+            .unwrap_err()
+            .to_string();
+        assert!(missing_error.contains("had no error"));
+        assert!(missing_error.contains(r#""id":9"#));
+
+        let malformed =
+            json!({"jsonrpc": "2.0", "id": 10, "error": {"code": "bad", "message": 42}});
+        let malformed_error = malformed
+            .expect_error(-32602, "invalid")
+            .unwrap_err()
+            .to_string();
+        assert!(malformed_error.contains("failed to deserialize JSON-RPC error payload"));
+        assert!(malformed_error.contains(r#""code":"bad""#));
+        assert!(malformed_error.contains(r#""id":10"#));
+    }
+
+    #[test]
+    fn mismatched_error_reports_expected_actual_and_complete_response() {
+        let response =
+            json!({"jsonrpc": "2.0", "id": 11, "error": {"code": -32000, "message": "actual"}});
+        let error = response
+            .expect_error(-32602, "expected")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("expected JSON-RPC error code -32602"));
+        assert!(error.contains("got code -32000"));
+        assert!(error.contains(r#""message":"actual""#));
+        assert!(error.contains(r#""id":11"#));
+    }
+}
 
 /// Gas limit for ordinary TIP-20 calls under the current Tempo fork schedule.
 pub(crate) const TIP20_TX_GAS: u64 = 500_000;
@@ -3412,6 +3596,93 @@ impl P2pCluster {
         Ok(())
     }
 
+    /// Wait until the role controller has promoted the bootstrap leader and started every
+    /// follower generation. Requiring each follower to finish its startup backfill probe against
+    /// the leader proves the P2P sessions needed for live block routing are established.
+    async fn wait_until_ready(&self, timeout: Duration) -> eyre::Result<()> {
+        let expected_roles = ["leader", "follower", "follower"];
+        eyre::ensure!(
+            self.nodes.len() == expected_roles.len(),
+            "P2P readiness expects {} nodes, got {}",
+            expected_roles.len(),
+            self.nodes.len(),
+        );
+
+        let started = std::time::Instant::now();
+        let mut last_observed = Vec::new();
+        loop {
+            if started.elapsed() >= timeout {
+                eyre::bail!(
+                    "timed out after {timeout:?} waiting for P2P cluster readiness; last observed: {}",
+                    last_observed.join("; "),
+                );
+            }
+            last_observed.clear();
+            let mut ready = true;
+            for (index, (node, expected_role)) in self.nodes.iter().zip(expected_roles).enumerate()
+            {
+                let remaining = timeout.saturating_sub(started.elapsed());
+                if remaining.is_zero() {
+                    ready = false;
+                    last_observed.push(format!("node {index}: readiness deadline elapsed"));
+                    break;
+                }
+                let provider = node.provider();
+                let request = provider.raw_request("zone_getSequencerInfo".into(), ());
+                let info: SequencerInfoResponse =
+                    match tokio::time::timeout(remaining, request).await {
+                        Ok(Ok(info)) => info,
+                        Ok(Err(error)) => {
+                            ready = false;
+                            last_observed.push(format!("node {index}: RPC error: {error}"));
+                            continue;
+                        }
+                        Err(_) => {
+                            ready = false;
+                            last_observed.push(format!(
+                                "node {index}: status request exceeded the readiness deadline"
+                            ));
+                            break;
+                        }
+                    };
+                let role = info
+                    .local
+                    .as_ref()
+                    .map(|local| local.role.as_str())
+                    .unwrap_or("<uninitialized>");
+                let promotion_ready = info
+                    .readiness
+                    .as_ref()
+                    .is_some_and(|readiness| readiness.ready_for_promotion);
+                let reasons = info
+                    .readiness
+                    .map(|readiness| readiness.reasons)
+                    .unwrap_or_default();
+                let leader_tip_observed = info
+                    .peers
+                    .iter()
+                    .any(|peer| peer.name == "node-0" && peer.tip.is_some());
+                last_observed.push(format!(
+                    "node {index}: role={role}, promotion_ready={promotion_ready}, \
+                     leader_tip_observed={leader_tip_observed}, reasons={reasons:?}"
+                ));
+                ready &= role == expected_role
+                    && (expected_role != "leader" || promotion_ready)
+                    && (expected_role != "follower" || leader_tip_observed);
+            }
+            if ready {
+                return Ok(());
+            }
+            if started.elapsed() >= timeout {
+                eyre::bail!(
+                    "timed out after {timeout:?} waiting for P2P cluster readiness; last observed: {}",
+                    last_observed.join("; "),
+                );
+            }
+            tokio::time::sleep(DEFAULT_POLL).await;
+        }
+    }
+
     /// Assert every node holds the same block at `height` and return its header.
     pub(crate) async fn assert_same_block(
         &self,
@@ -3545,12 +3816,14 @@ pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2
             seed_blocks,
         );
     }
-    Ok(P2pCluster {
+    let cluster = P2pCluster {
         nodes,
         p2p_public_keys: public_keys.to_vec(),
         sequencer_signers,
         fixture,
-    })
+    };
+    cluster.wait_until_ready(P2P_STARTUP_TIMEOUT).await?;
+    Ok(cluster)
 }
 
 pub(crate) fn leader_p2p_config(listen: SocketAddr) -> eyre::Result<P2pConfig> {
@@ -3746,11 +4019,13 @@ async fn private_rpc_call(
     let status = resp.status();
     let text = resp.text().await?;
 
-    if !status.is_success() && text.is_empty() {
-        eyre::bail!("HTTP {status}");
+    if !status.is_success() {
+        eyre::bail!("private RPC returned HTTP {status}; complete response body: {text}");
     }
 
-    Ok(serde_json::from_str(&text)?)
+    serde_json::from_str(&text).wrap_err_with(|| {
+        format!("private RPC returned malformed JSON; complete response body: {text}")
+    })
 }
 
 /// Send a JSON-RPC request to the private zone RPC and return the HTTP status + body.


### PR DESCRIPTION
## Summary

- Add reusable typed JSON-RPC response assertions that deserialize successful results and error payloads while including the complete response in every diagnostic, then migrate the private-RPC integration coverage away from brittle raw indexing and unwraps.
- Gate local P2P cluster startup on observable sequencer role, promotion, and follower backfill state; await aborted sequencer tasks; and poll for the exact post-restart batch transition instead of assuming fixed delays.
- Preserve the explicit handoff no-production observation windows and the authorization-token expiry delay because those durations are the behavior under test, not readiness synchronization.

## Why

Fixed startup and restart delays could race slower CI hosts or waste time without proving the intended state transition. Raw JSON indexing also hid malformed protocol responses behind generic unwrap failures. These changes make failures actionable and keep waits bounded without changing production or settlement behavior.