### PR TITLE
fix(portal): reduce deposit block cap

### DIFF
--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -12,7 +12,7 @@ use tempo_precompiles::{
     storage::{ContractStorage, Handler, StorageCtx},
     test_util::TIP20Setup,
     tip20::{ITIP20, TIP20Token},
-    tip403_registry::{ALLOW_ALL_POLICY_ID, ITIP403Registry, REJECT_ALL_POLICY_ID, TIP403Registry},
+    tip403_registry::{REJECT_ALL_POLICY_ID, TIP403Registry},
     zone_factory::{ZonePortalStorage, zone_portal_slots},
 };
 use tempo_primitives::TempoHeader;
@@ -209,20 +209,15 @@ impl Harness {
     }
 }
 
-fn worst_case_encrypted_deposit_block_gas() -> eyre::Result<u64> {
-    const SYSTEM_GAS: u64 = 250_000_000;
-    const MAX_DEPOSITS_PER_TEMPO_BLOCK: usize = 640;
-
+fn failed_encrypted_deposit_gas(deposits: usize) -> eyre::Result<u64> {
     let mut harness = Harness::new()?;
     {
         let mut storage = test_storage_provider(&mut harness.ctx, u64::MAX, false);
         StorageCtx::enter(&mut storage, || {
-            TIP403Registry::new().set_receive_policy(
-                BOB,
-                ITIP403Registry::setReceivePolicyCall {
-                    senderPolicyId: REJECT_ALL_POLICY_ID,
-                    tokenFilterId: ALLOW_ALL_POLICY_ID,
-                    recoveryAuthority: Address::ZERO,
+            TIP20Token::from_address(PATH_USD_ADDRESS)?.change_transfer_policy_id(
+                ALICE,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: REJECT_ALL_POLICY_ID,
                 },
             )
         })?;
@@ -270,12 +265,12 @@ fn worst_case_encrypted_deposit_block_gas() -> eyre::Result<u64> {
         },
     };
 
-    let mut deposits = Vec::with_capacity(MAX_DEPOSITS_PER_TEMPO_BLOCK);
-    let mut decryptions = Vec::with_capacity(MAX_DEPOSITS_PER_TEMPO_BLOCK);
+    let mut queued_deposits = Vec::with_capacity(deposits);
+    let mut decryptions = Vec::with_capacity(deposits);
     let mut head = B256::ZERO;
-    for _ in 0..MAX_DEPOSITS_PER_TEMPO_BLOCK {
+    for _ in 0..deposits {
         head = keccak256((DepositType::Encrypted, deposit.clone(), head).abi_encode_params());
-        deposits.push(QueuedDeposit {
+        queued_deposits.push(QueuedDeposit {
             depositType: DepositType::Encrypted,
             depositData: deposit.abi_encode().into(),
         });
@@ -283,22 +278,29 @@ fn worst_case_encrypted_deposit_block_gas() -> eyre::Result<u64> {
     }
 
     harness.set_queue_hash(head);
-    let calldata = harness.advance_call(deposits, decryptions).abi_encode();
-    let output = harness.call_with_gas(Address::ZERO, calldata, SYSTEM_GAS)?;
-    assert!(output.is_success());
+    let calldata = harness
+        .advance_call(queued_deposits, decryptions)
+        .abi_encode();
+    let output = harness.call_with_gas(Address::ZERO, calldata, u64::MAX)?;
+    assert!(output.is_success(), "deposit block failed: {output:?}");
     Ok(output.gas_used)
 }
 
 #[test]
 fn max_portal_deposit_block_fits_system_gas_budget() -> eyre::Result<()> {
     const BUFFERED_GAS_LIMIT: u64 = 200_000_000;
+    const MAX_DEPOSITS_PER_TEMPO_BLOCK: usize = 230;
 
-    let gas_used = worst_case_encrypted_deposit_block_gas()?;
-    eprintln!("max portal deposit block: {gas_used} gas");
-    assert!(
-        gas_used <= BUFFERED_GAS_LIMIT,
-        "max deposit block used {gas_used} gas"
-    );
+    for deposits in [640, MAX_DEPOSITS_PER_TEMPO_BLOCK] {
+        let should_fit = deposits <= MAX_DEPOSITS_PER_TEMPO_BLOCK;
+        let gas_used = failed_encrypted_deposit_gas(deposits)?;
+        eprintln!("{deposits} portal deposit block: {gas_used} gas");
+        assert_eq!(
+            gas_used <= BUFFERED_GAS_LIMIT,
+            should_fit,
+            "{deposits} deposit block used {gas_used} gas"
+        );
+    }
     Ok(())
 }
 

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -56,10 +56,10 @@ contract ZonePortal is IZonePortal {
     uint64 public constant FIXED_DEPOSIT_GAS = 100_000;
 
     /// @notice Maximum deposits that may be appended to this portal in one Tempo block.
-    /// @dev Under T9, processing 640 encrypted deposits uses 185,349,414 of the
-    ///      250,000,000 gas available to `advanceTempo`. This leaves 64,650,586 gas
-    ///      (25.86%) for fixed overhead and gas-cost variance.
-    uint64 public constant MAX_DEPOSITS_PER_TEMPO_BLOCK = 640;
+    /// @dev Under T9, processing 230 encrypted deposits rejected by the issuer's
+    ///      TIP-403 transfer policy uses 193,044,874 gas, leaving 6,955,126 gas
+    ///      below the buffered 200,000,000 gas ceiling.
+    uint64 public constant MAX_DEPOSITS_PER_TEMPO_BLOCK = 230;
 
     /// @dev Reserves enough capacity for one maximum-size sequencer withdrawal batch to bounce.
     ///      The 20M batch gas ceiling fits at most 19 simple withdrawals (plus one slot of margin).

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -1502,7 +1502,7 @@ contract ZonePortalTest is BaseTest {
     function test_deposit_enforcesPerTempoBlockCapAcrossDepositTypes() public {
         uint64 maximum = portal.MAX_DEPOSITS_PER_TEMPO_BLOCK();
         uint64 maximumPublicDeposits = maximum - 20;
-        assertEq(maximum, 640);
+        assertEq(maximum, 230);
         _setEncKeyWithPoP(ENC_KEY_1);
 
         uint128 amount = 1;


### PR DESCRIPTION
## Summary
- model the worst-case encrypted deposit block with the issuer's TIP-403 transfer policy rejecting every mint
- reduce `MAX_DEPOSITS_PER_TEMPO_BLOCK` from 640 to 230
- keep 20 slots reserved for withdrawal bounce-backs, leaving 210 public deposit slots
- regress both the unsafe old cap and the safe current cap in one gas test

## Gas tuning
A binary search against the 200M buffered ceiling found:
- 238 deposits: 199,712,794 gas
- 239 deposits: 200,546,284 gas
- selected cap of 230 deposits: 193,044,874 gas

The regression loop also confirms the old 640 cap costs 534,775,774 gas and does not fit.

## Validation
- `cargo +nightly-2026-02-21 fmt --all -- --check`
- `cargo +nightly-2026-02-21 test -p zone-precompiles max_portal_deposit_block_fits_system_gas_budget -- --nocapture`
- `forge test --match-path test/tempo/ZonePortal.t.sol` blocked locally because the sandbox injected invalid credentials while fetching public submodules; Forge CI will validate it

Prompted by: @0xrusowsky