### PR TITLE
fix(bench): remove stale L1 genesis flag

### DIFF
--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -1104,7 +1104,6 @@ provision_up() {
         --chain "$zone_genesis" --datadir "$zone_db" \
         --l1.rpc-url ws://127.0.0.1:8545 \
         --l1.portal-address "$portal" \
-        --l1.genesis-block-number "$anchor_block" \
         --zone.id "$zone_id" \
         --http --http.addr 127.0.0.1 --http.port 8546 \
         --http.api eth,net,web3,txpool \


### PR DESCRIPTION
## Summary

- Remove the obsolete `--l1.genesis-block-number` argument from the neobank benchmark Zone launch.
- Restore compatibility with the node CLI after #886 removed the unsafe override.

## Validation

- `bash -n contrib/bench/provision-topology.sh`
- `git diff --check`

Prompted by: @0xrusowsky