### PR TITLE
fix(precompiles): restrict TIP-20 nonce reads

### DIFF
--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -86,6 +86,9 @@ impl<P: L1StorageReader> CallRules for TIP20Rules<P> {
                     self.check_auth_with_sequencer(caller, &[call.account])
                 })
             }
+            ITIP20::noncesCall::SELECTOR => decode_and_check::<ITIP20::noncesCall>(args, |call| {
+                self.check_auth_with_sequencer(caller, &[call.owner])
+            }),
             ITIP20::allowanceCall::SELECTOR => {
                 decode_and_check::<ITIP20::allowanceCall>(args, |call| {
                     self.check_auth_with_sequencer(caller, &[call.owner, call.spender])
@@ -292,6 +295,11 @@ mod tests {
             assert_allowed(&rules, balance.clone(), owner);
             assert_allowed(&rules, balance.clone(), sequencer);
             assert_unauthorized(&rules, balance, outsider);
+
+            let nonce = ITIP20::noncesCall { owner };
+            assert_allowed(&rules, nonce.clone(), owner);
+            assert_allowed(&rules, nonce.clone(), sequencer);
+            assert_unauthorized(&rules, nonce, outsider);
 
             let allowance = ITIP20::allowanceCall { owner, spender };
             for caller in [owner, spender, sequencer] {


### PR DESCRIPTION
## Summary

- apply TIP-20 caller/sequencer authorization to `nonces(owner)`
- extend the existing read-privacy unit test with owner, sequencer, and outsider nonce coverage

Fixes [ZONE-138](https://linear.app/tempoxyz/issue/ZONE-138).

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Unit tests could not compile locally because the sandbox Git credential rejected the pinned public `alloy-evm` dependency fetch.

Prompted by: @0xrusowsky