### PR TITLE
test: cover all node-spawning suites in nextest heavy-test filter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,5 +6,5 @@ test-threads = "num-cpus"
 # Integration tests spin up full reth nodes — limit concurrency to avoid
 # resource contention and flaky timeouts on CI runners.
 [[profile.ci.overrides]]
-filter = "test(/^(e2e|earn_zone_e2e|l1_e2e|restart_e2e|handoff_e2e)::/) | test(advance_tempo)"
+filter = "test(/^(e2e|earn_zone_e2e|l1_e2e|restart_e2e|handoff_e2e|stepping_e2e|demo_asset_swap|demo_cross_zone|demo_shield_and_send)::/) | test(/^enable_token::test_enable_token_via_real_l1$/)"
 threads-required = 8


### PR DESCRIPTION
`stepping_e2e` and the three `demo_*` suites each boot a full in-process Tempo L1 dev node (`demo_cross_zone` boots two zone nodes on top of it), and `enable_token::test_enable_token_via_real_l1` does the same, but none of them were covered by the `threads-required = 8` override — they ran at full parallelism next to 8-thread-reserved neighbours, which is a likely source of the flaky timeouts the override exists to prevent.

This also drops the `test(advance_tempo)` entry entirely: all three tests in that binary are sync `#[test]` fns running revm against `CacheDB<EmptyDB>` in-process, so reserving 8 threads for them only serialized CI for no benefit.

More serialization can shift the two shard wall-times; the consolidation PRs later in this stack delete the most expensive redundant tests as the offset.

---

Independent of the chain below (targets `main` directly); listed with the stack for navigation. Next: #937.

**Test de-slop stack** (merge in order; bases retarget as predecessors merge):
1. #936 — nextest heavy-test filter ← this PR
2. #937 — remove dead code and debug noise
3. #938 — consolidate redundant e2e tests
4. #939 — split it/utils.rs into modules
5. #940 — dedupe e2e harness helpers
6. #941 — adopt shared harness helpers
7. #942 — dedupe private-RPC, WS, and earn suites
8. #943 — clean up hot suites and refresh test docs
