### PR TITLE
test: remove dead code and debug noise from e2e suite

### DIFF
--- a/crates/node/tests/advance_tempo.rs
+++ b/crates/node/tests/advance_tempo.rs
@@ -1,10 +1,10 @@
-//! Reproduce the `advanceTempo` system tx reverting at 232 gas.
+//! Pins the zone genesis predeploys and portal storage-slot constants to the
+//! Solidity reference implementation.
 //!
-//! Run with: `cargo test -p zone-node --test advance_tempo -- --nocapture`
+//! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
 
 use alloy_evm::{Evm, EvmEnv, EvmFactory};
 use alloy_primitives::{Address, B256, Bytes, U256, address, keccak256};
-use alloy_sol_types::{SolCall, sol};
 use revm::{
     context::result::{ExecutionResult, Output},
     database::{CacheDB, EmptyDB},
@@ -15,41 +15,11 @@ use tempo_evm::evm::{TempoEvm, TempoEvmFactory};
 use tempo_revm::TempoBlockEnv;
 use zone_primitives::constants::{
     PORTAL_ADMIN_SLOT, PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT, PORTAL_ENCRYPTION_KEYS_SLOT,
-    PORTAL_IS_SEQUENCER_SLOT, PORTAL_MAX_TEMPO_GAS_RATE_SLOT, zone_chain_id,
+    PORTAL_IS_SEQUENCER_SLOT, PORTAL_MAX_TEMPO_GAS_RATE_SLOT, TEMPO_STATE_ADDRESS,
+    ZONE_CONFIG_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
 };
 
-const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
-const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
-const ZONE_OUTBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000002");
-const ZONE_CONFIG_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000003");
-
 const DEPLOYER: Address = address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
-
-sol! {
-    function advanceTempo(bytes calldata header, QueuedDeposit[] calldata deposits, DecryptionData[] calldata decryptions, EnabledToken[] calldata enabledTokens);
-    function config() external view returns (address);
-    function tempoBlockHash() external view returns (bytes32);
-
-    struct QueuedDeposit {
-        uint8 depositType;
-        bytes depositData;
-    }
-    struct ChaumPedersenProof {
-        bytes32 s;
-        bytes32 c;
-    }
-    struct DecryptionData {
-        bytes32 sharedSecret;
-        uint8 sharedSecretYParity;
-        ChaumPedersenProof cpProof;
-    }
-    struct EnabledToken {
-        address token;
-        string name;
-        string symbol;
-        string currency;
-    }
-}
 
 /// Load a Foundry artifact's creation bytecode from the specs output directory.
 fn load_artifact(name: &str) -> Vec<u8> {
@@ -131,11 +101,6 @@ fn deploy_contract(
     }
 
     println!("Deployed {name} at {predeploy_addr} (created at {created_addr})");
-}
-
-/// Build an EVM with the zone contracts deployed in-memory (same as xtask generate_zone_genesis).
-fn setup_zone_evm_with_contracts() -> TempoEvm<CacheDB<EmptyDB>> {
-    setup_zone_evm_with_contracts_for_portal(zone_chain_id(1), Address::repeat_byte(0xbb))
 }
 
 fn setup_zone_evm_with_contracts_for_portal(
@@ -382,188 +347,6 @@ fn build_dummy_header_rlp() -> Vec<u8> {
     let mut buf = Vec::new();
     header.encode(&mut buf);
     buf
-}
-
-#[test]
-fn advance_tempo_repro() {
-    let mut evm = setup_zone_evm_with_contracts();
-
-    // System txs use Address::ZERO which bypasses OnlySequencer in ZoneInbox/ZoneOutbox
-    let sequencer = Address::ZERO;
-
-    // ---------------------------------------------------------------
-    // Step 1: Call config() on ZoneInbox — simple view call to verify contracts work
-    // ---------------------------------------------------------------
-    println!("\n=== Calling ZoneInbox.config() ===");
-    let config_calldata = configCall {}.abi_encode();
-    let config_result =
-        evm.transact_system_call(sequencer, ZONE_INBOX_ADDRESS, Bytes::from(config_calldata));
-    match &config_result {
-        Ok(result) => {
-            println!("config() result: {:?}", result.result);
-            let gas_used = result.result.tx_gas_used();
-            match &result.result {
-                ExecutionResult::Success { output, .. } => {
-                    if let Output::Call(data) = output {
-                        println!("config() returned: {data}");
-                    }
-                    println!("config() gas_used: {gas_used}");
-                }
-                ExecutionResult::Revert { output, .. } => {
-                    println!("config() REVERTED: {output}, gas_used: {gas_used}");
-                }
-                ExecutionResult::Halt { reason, .. } => {
-                    println!("config() HALTED: {reason:?}, gas_used: {gas_used}");
-                }
-            }
-        }
-        Err(e) => println!("config() ERROR: {e:?}"),
-    }
-
-    // ---------------------------------------------------------------
-    // Step 2: Call tempoBlockHash() on TempoState to verify it works
-    // ---------------------------------------------------------------
-    println!("\n=== Calling TempoState.tempoBlockHash() ===");
-    let hash_calldata = tempoBlockHashCall {}.abi_encode();
-    let hash_result =
-        evm.transact_system_call(sequencer, TEMPO_STATE_ADDRESS, Bytes::from(hash_calldata));
-    match &hash_result {
-        Ok(result) => {
-            let gas_used = result.result.tx_gas_used();
-            match &result.result {
-                ExecutionResult::Success { output, .. } => {
-                    if let Output::Call(data) = output {
-                        println!("tempoBlockHash() returned: {data}");
-                    }
-                    println!("tempoBlockHash() gas_used: {gas_used}");
-                }
-                ExecutionResult::Revert { output, .. } => {
-                    println!("tempoBlockHash() REVERTED: {output}, gas_used: {gas_used}");
-                }
-                other => println!("tempoBlockHash() other: {other:?}"),
-            }
-        }
-        Err(e) => println!("tempoBlockHash() ERROR: {e:?}"),
-    }
-
-    // ---------------------------------------------------------------
-    // Step 3: Call advanceTempo with a minimal next header
-    // ---------------------------------------------------------------
-    // Verify contracts have code
-    {
-        let inbox_code = evm
-            .db_mut()
-            .cache
-            .accounts
-            .get(&ZONE_INBOX_ADDRESS)
-            .and_then(|a| a.info.code.as_ref())
-            .map(|c| c.len())
-            .unwrap_or(0);
-        let tempostate_code = evm
-            .db_mut()
-            .cache
-            .accounts
-            .get(&TEMPO_STATE_ADDRESS)
-            .and_then(|a| a.info.code.as_ref())
-            .map(|c| c.len())
-            .unwrap_or(0);
-        println!("ZoneInbox code size: {inbox_code}");
-        println!("TempoState code size: {tempostate_code}");
-    }
-
-    // ---------------------------------------------------------------
-    // Step 2.5: Call finalizeTempo directly on TempoState to isolate
-    // ---------------------------------------------------------------
-    println!("\n=== Building child header ===");
-
-    // Build a "next" header that's a child of the genesis.
-    // finalizeTempo requires: tempoParentHash == prev tempoBlockHash, tempoBlockNumber == prev + 1
-    let genesis_hash = {
-        use alloy_rlp::Encodable;
-        let genesis = tempo_primitives::TempoHeader::default();
-        let mut buf = Vec::new();
-        genesis.encode(&mut buf);
-        alloy_primitives::keccak256(&buf)
-    };
-    println!("Genesis hash (computed): {genesis_hash}");
-
-    let next_header = tempo_primitives::TempoHeader {
-        inner: alloy_consensus::Header {
-            number: 1,
-            parent_hash: genesis_hash,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    let next_header_rlp = {
-        use alloy_rlp::Encodable;
-        let mut buf = Vec::new();
-        next_header.encode(&mut buf);
-        buf
-    };
-    println!("Next header RLP length: {}", next_header_rlp.len());
-    println!("Next header block number: {}", next_header.inner.number);
-    println!("Next header parent hash: {}", next_header.inner.parent_hash);
-
-    // NOTE: finalizeTempo() tested separately and works (86729 gas).
-    // Skip calling it directly here to avoid corrupting state for the advanceTempo call.
-
-    println!("\n=== Calling ZoneInbox.advanceTempo() ===");
-
-    let advance_calldata = advanceTempoCall {
-        header: Bytes::from(next_header_rlp),
-        deposits: vec![],
-        decryptions: vec![],
-        enabledTokens: vec![],
-    }
-    .abi_encode();
-
-    println!(
-        "advanceTempo calldata length: {} bytes",
-        advance_calldata.len()
-    );
-    println!(
-        "advanceTempo selector: 0x{}",
-        const_hex::encode(&advance_calldata[..4])
-    );
-
-    let advance_result =
-        evm.transact_system_call(sequencer, ZONE_INBOX_ADDRESS, Bytes::from(advance_calldata));
-    match &advance_result {
-        Ok(result) => {
-            let gas_used = result.result.tx_gas_used();
-            match &result.result {
-                ExecutionResult::Success { output, .. } => {
-                    if let Output::Call(data) = output {
-                        println!("advanceTempo() SUCCESS, output: {data}");
-                    }
-                    println!("advanceTempo() gas_used: {gas_used}");
-                }
-                ExecutionResult::Revert { output, .. } => {
-                    println!("advanceTempo() REVERTED: {output}");
-                    println!("advanceTempo() gas_used: {gas_used}");
-                    if output.len() >= 4 {
-                        let sel = &output[..4];
-                        println!("  error selector: 0x{}", const_hex::encode(sel));
-                        if sel == [0x08, 0xc3, 0x79, 0xa0]
-                            && output.len() > 4
-                            && let Ok(msg) = <alloy_sol_types::sol_data::String as alloy_sol_types::SolType>::abi_decode(&output[4..])
-                        {
-                            println!("  Error message: {msg}");
-                        }
-                    }
-                }
-                ExecutionResult::Halt { reason, .. } => {
-                    println!("advanceTempo() HALTED: {reason:?}");
-                    println!("advanceTempo() gas_used: {gas_used}");
-                }
-            }
-        }
-        Err(e) => println!("advanceTempo() ERROR: {e:?}"),
-    }
-
-    // The test should not panic; we want to see the output
-    println!("\n=== Test complete ===");
 }
 
 /// Pins the Rust portal storage-slot constants to the ZonePortal storage layout.

--- a/crates/node/tests/it/demo_asset_swap.rs
+++ b/crates/node/tests/it/demo_asset_swap.rs
@@ -1,4 +1,6 @@
 //! Multi-asset zone deposit and withdrawal.
+//!
+//! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
 
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
 use alloy::{
@@ -9,15 +11,8 @@ use alloy::{
 /// Longer timeout for real L1 tests.
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Multi-asset deposit + withdrawal:
-///
-/// 1. Start L1 dev node.
-/// 2. Create AlphaUSD and BetaUSD on L1.
-/// 3. Deploy zone, enable both tokens.
-/// 4. Start zone node (tokens auto-initialized via `TokenEnabled` events from L1).
-/// 5. Alice deposits AlphaUSD and BetaUSD.
-/// 6. Spawn sequencer, withdraw both tokens.
-/// 7. Verify L1 withdrawals and L2 balance decreases.
+/// Multi-asset deposit + withdrawal with two freshly created TIP-20 tokens,
+/// auto-initialized on L2 via `TokenEnabled` events:
 ///
 /// ```text
 ///  L1 (AlphaUSD + BetaUSD)            Zone L2
@@ -27,15 +22,12 @@ const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 ///   |<-- withdraw BetaUSD ------------|  ✓ BetaUSD burned
 /// ```
 ///
-/// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime artifacts.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 ---
     let l1 = L1TestNode::start().await?;
 
-    // --- Step 2: Create two TIP-20 tokens on L1 ---
     let alpha_salt = B256::with_last_byte(100);
     let beta_salt = B256::with_last_byte(101);
 
@@ -48,11 +40,9 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
     l1.mint_tip20(l1_beta, l1.dev_address(), mint_amount)
         .await?;
 
-    // --- Step 3: Deploy zone and start zone node ---
     let portal_address = l1.deploy_zone().await?;
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
 
-    // --- Step 4: Enable both tokens on the portal ---
     // Must happen AFTER zone startup so the zone's L1 subscriber picks up the
     // TokenEnabled events from live blocks.
     l1.enable_token_on_portal(portal_address, l1_alpha).await?;
@@ -67,7 +57,6 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
     let l2_alpha = l1_alpha;
     let l2_beta = l1_beta;
 
-    // --- Step 5: Alice deposits both tokens ---
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let alpha_deposit: u128 = 1_000_000; // 1 AlphaUSD
     let beta_deposit: u128 = 2_000_000; // 2 BetaUSD
@@ -102,7 +91,6 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
         "BetaUSD minted should equal deposit"
     );
 
-    // --- Step 6: Spawn zone sequencer (batch submitter + withdrawal processor) ---
     let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
     let withdrawal_timeout = std::time::Duration::from_secs(60);
 
@@ -132,7 +120,6 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
     )
     .await?;
 
-    // --- Step 7: Verify L2 balances decreased ---
     let final_alpha = zone.balance_of(l2_alpha, account.address()).await?;
     assert!(
         final_alpha <= U256::from(alpha_deposit - alpha_withdrawal),

--- a/crates/node/tests/it/demo_cross_zone.rs
+++ b/crates/node/tests/it/demo_cross_zone.rs
@@ -1,4 +1,6 @@
 //! Demo Flow 3: Cross-Zone Transfer
+//!
+//! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
 
 use crate::utils::{
     L1TestNode, WithdrawalArgs, ZoneAccount, ZoneCreationConfig, ZoneTestNode, spawn_sequencer,
@@ -10,16 +12,7 @@ use tempo_zone_contracts::ZONE_TOKEN_ADDRESS;
 /// Longer timeout for real L1 tests.
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Cross-zone transfer via SwapAndDepositRouter:
-///
-/// 1. Start L1 dev node.
-/// 2. Create open zone_a and zone_b through the native factory, then deploy SwapAndDepositRouter.
-/// 3. Start both zone nodes connected to L1.
-/// 4. Alice deposits pathUSD into zone_a.
-/// 5. Spawn sequencers for both zones.
-/// 6. Alice withdraws from zone_a with router callback that deposits into zone_b for Bob.
-/// 7. Verify Bob received the deposit on zone_b.
-/// 8. Verify Alice's zone_a balance decreased.
+/// Cross-zone transfer via SwapAndDepositRouter between two open zones:
 ///
 /// ```text
 ///  Zone A (Alice)       L1 (Router)         Zone B (Bob)
@@ -29,12 +22,10 @@ const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 ///   |  ✓ Alice -= 500                  ✓ Bob += 500
 /// ```
 ///
-/// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime and router artifacts.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cross_zone_send() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 ---
     let l1 = L1TestNode::start().await?;
 
     // Separate sequencer keys for each zone to avoid L1 nonce conflicts
@@ -46,7 +37,6 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
     let bob_address = bob_signer.address();
     let refund_burner = l1.signer_at(5).address();
 
-    // --- Step 2: Deploy L1 infrastructure ---
     let factory = l1.native_zone_factory().await?;
     let portal_a = l1
         .create_zone_with_admin_sequencer_and_config(
@@ -66,7 +56,6 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
         .await?;
     let router = l1.deploy_router(factory).await?;
 
-    // --- Step 3: Start both zone nodes ---
     let zone_a = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_a).await?;
     let zone_b = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_b).await?;
 
@@ -77,13 +66,11 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
     zone_a.assert_gateway_open(true).await?;
     zone_b.assert_gateway_open(true).await?;
 
-    // --- Step 4: Alice deposits into zone_a ---
     let mut alice = ZoneAccount::from_l1_and_zone(&l1, &zone_a, portal_a);
     let deposit_amount: u128 = 1_000_000; // 1 pathUSD
     l1.fund_user(alice.address(), deposit_amount * 2).await?;
     alice.deposit(deposit_amount, L1_TIMEOUT, &zone_a).await?;
 
-    // --- Step 5: Spawn sequencers for both zones ---
     let _seq_a = spawn_sequencer(&l1, &zone_a, portal_a, seq_a_signer.clone()).await;
     let _seq_b = spawn_sequencer(&l1, &zone_b, portal_b, seq_b_signer.clone()).await;
 
@@ -95,7 +82,6 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
         "Bob should start with zero on zone_b"
     );
 
-    // --- Step 6: Alice withdraws from zone_a → router → zone_b (for Bob) ---
     let cross_amount: u128 = 500_000; // 0.5 pathUSD
 
     // Use the cross_zone_via_router helper but with Bob as the recipient
@@ -119,7 +105,6 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
         .await?;
     eyre::ensure!(callback_succeeded, "cross-zone router callback failed");
 
-    // --- Step 7: Verify Bob received deposit on zone_b ---
     let cross_timeout = std::time::Duration::from_secs(60);
     zone_b
         .wait_for_balance(
@@ -137,7 +122,6 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
         "Bob should have received the cross-zone deposit on zone_b"
     );
 
-    // --- Step 8: Verify Alice's zone_a balance decreased ---
     let alice_final = zone_a
         .balance_of(ZONE_TOKEN_ADDRESS, alice.address())
         .await?;

--- a/crates/node/tests/it/demo_shield_and_send.rs
+++ b/crates/node/tests/it/demo_shield_and_send.rs
@@ -1,3 +1,7 @@
+//! Shield-and-send demo: deposit into the zone, then transfer on L2.
+//!
+//! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
+
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode};
 use alloy::{primitives::U256, providers::ProviderBuilder};
 use tempo_zone_contracts::ZONE_TOKEN_ADDRESS;
@@ -6,13 +10,6 @@ use tempo_zone_contracts::ZONE_TOKEN_ADDRESS;
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Shield + in-zone send:
-///
-/// 1. Start L1 dev node.
-/// 2. Create a zone through the native ZoneFactory.
-/// 3. Start zone node connected to L1.
-/// 4. Alice deposits 1 pathUSD into the zone (shield).
-/// 5. Alice transfers 0.5 pathUSD to Bob within the zone (L2 transfer).
-/// 6. Verify Alice has 0.5 and Bob has 0.5 on L2.
 ///
 /// ```text
 ///  L1                         Zone L2
@@ -23,22 +20,17 @@ const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 ///   |                            |  ✓ Bob has 0.5
 /// ```
 ///
-/// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime artifacts.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_shield_and_send() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 ---
     let l1 = L1TestNode::start().await?;
 
-    // --- Step 2: Deploy L1 infrastructure and create a zone ---
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Step 3: Start zone node connected to L1 ---
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
 
-    // --- Step 4: Alice deposits 1 pathUSD (shield) ---
     let mut alice = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let deposit_amount: u128 = 1_000_000; // 1 pathUSD (6 decimals)
     l1.fund_user(alice.address(), deposit_amount * 2).await?;
@@ -50,7 +42,6 @@ async fn test_shield_and_send() -> eyre::Result<()> {
         "Alice should have 1 pathUSD on L2 after deposit"
     );
 
-    // --- Step 5: Alice transfers 0.5 pathUSD to Bob on L2 ---
     // Bob is derived from mnemonic index 2 (Alice is index 1 via user_signer)
     let bob_address = l1.signer_at(2).address();
 
@@ -82,7 +73,6 @@ async fn test_shield_and_send() -> eyre::Result<()> {
         eyre::ensure!(receipt.status(), "L2 transfer from Alice to Bob failed");
     }
 
-    // --- Step 6: Verify balances ---
     let alice_final = zone.balance_of(ZONE_TOKEN_ADDRESS, alice.address()).await?;
     let bob_final = zone.balance_of(ZONE_TOKEN_ADDRESS, bob_address).await?;
 

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -29,6 +29,8 @@ use crate::utils::{
 };
 
 const CONTRACT_CREATION_TX_GAS: u64 = 1_000_000;
+/// Local test nodes finalize empty batches every eight zone blocks.
+const BATCH_INTERVAL_BLOCKS: u64 = 8;
 const LEADER_INCLUSION_TIMEOUT: Duration = Duration::from_secs(30);
 const P2P_RECOVERY_TIMEOUT: Duration = Duration::from_secs(45);
 
@@ -274,7 +276,7 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
     let alice = alice_signer.address();
     let bob = address!("0x0000000000000000000000000000000000000B0B");
 
-    // --- Block 1: fund Alice while pathUSD is still allow-all (anchor L1#1). ---
+    // Block 1: fund Alice while pathUSD is still allow-all (anchor L1#1).
     let deposit_amount: u128 = 1_000_000;
     let deposit = fixture.make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
     let observed = L1PortalEvents::from_deposits(vec![L1Deposit::Regular(deposit.clone())]);
@@ -301,7 +303,7 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
         .await?;
     follower.wait_for_block_number(1, DEFAULT_TIMEOUT).await?;
 
-    // --- Policy change effective at L1 block 2: blacklist Bob on pathUSD. ---
+    // Policy change effective at L1 block 2: blacklist Bob on pathUSD.
     // Seed identically on both nodes, mirroring each node's L1 observer having
     // made block-2 TIP-403 and TIP-20 storage available before publishing the
     // anchor. The L1-backed execution database must select these values from
@@ -334,8 +336,8 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
         );
     }
 
-    // --- Block 2: Alice's transfer is submitted, then the anchoring L1 block is
-    // injected to trigger the build that includes it. ---
+    // Block 2: Alice's transfer is submitted, then the anchoring L1 block is
+    // injected to trigger the build that includes it.
     let alice_provider = ProviderBuilder::new()
         .wallet(alice_signer)
         .connect_http(leader.http_url().clone());
@@ -360,7 +362,7 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
         "leader should revert the blacklisted transfer in the block anchored at L1#2"
     );
 
-    // --- The follower must independently reproduce that revert at height 2. ---
+    // The follower must independently reproduce that revert at height 2.
     // If it read policy at height 1 (allow-all) it would replay the transfer as
     // a success, diverge from the leader's state root, reject the block, and
     // never reach block 2 — so this import succeeding proves exact-anchor policy reads.
@@ -481,14 +483,11 @@ async fn test_multiple_deposits_across_blocks() -> eyre::Result<()> {
     let bob = address!("0x0000000000000000000000000000000000000B0B");
     let sender = address!("0x0000000000000000000000000000000000001111");
 
-    // Block 1: deposit to Alice
     let d1 = fixture.make_deposit(PATH_USD_ADDRESS, sender, alice, 500_000);
     fixture.inject_deposits(zone.deposit_queue(), vec![d1]);
 
-    // Block 2: empty block (no deposits)
     fixture.inject_empty_block(zone.deposit_queue());
 
-    // Block 3: two deposits — one to Alice, one to Bob
     let d2 = fixture.make_deposit(PATH_USD_ADDRESS, sender, alice, 300_000);
     let d3 = fixture.make_deposit(PATH_USD_ADDRESS, sender, bob, 700_000);
     fixture.inject_deposits(zone.deposit_queue(), vec![d2, d3]);
@@ -527,7 +526,6 @@ async fn test_empty_l1_blocks_advance_zone() -> eyre::Result<()> {
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
 
-    // Inject several empty L1 blocks
     fixture.inject_empty_blocks(zone.deposit_queue(), 5);
 
     // Each L1 block advances tempoBlockNumber — wait for all 5
@@ -599,7 +597,6 @@ async fn test_zone_engine_stops_cleanly_between_blocks() -> eyre::Result<()> {
 async fn test_two_zones_independent_deposits() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // Start two zones with different chain IDs
     let zone1 = ZoneTestNode::start_local_with_chain_id(71001).await?;
     let zone2 = ZoneTestNode::start_local_with_chain_id(71002).await?;
 
@@ -691,7 +688,6 @@ async fn test_tempo_state_advances_with_l1_blocks() -> eyre::Result<()> {
         "initial tempoBlockHash should be non-zero (genesis hash)"
     );
 
-    // Inject 3 empty L1 blocks
     for _ in 0..3 {
         fixture.inject_empty_block(zone.deposit_queue());
     }
@@ -840,8 +836,6 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     let zone_outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, zone.provider());
 
     let initial_batch_index = zone_outbox.lastBatch().call().await?.withdrawalBatchIndex;
-    // Local test nodes finalize empty batches every eight zone blocks.
-    const BATCH_INTERVAL_BLOCKS: u64 = 8;
 
     fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS - 1);
 
@@ -1233,9 +1227,6 @@ async fn test_current_only_block_finalizes_at_batch_boundary() -> eyre::Result<(
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
     let (provider, dev_address) = local_dev_zone_account(&zone)?;
     let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
-
-    // Local test nodes finalize empty batches every eight zone blocks.
-    const BATCH_INTERVAL_BLOCKS: u64 = 8;
 
     let batch_index = outbox.lastBatch().call().await?.withdrawalBatchIndex;
     fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS);

--- a/crates/node/tests/it/enable_token.rs
+++ b/crates/node/tests/it/enable_token.rs
@@ -1,5 +1,7 @@
 //! E2e tests for native TIP-20 token initialization via `TokenEnabled` events.
 //!
+//! Requires `forge build --root specs/ref-impls` for the Foundry artifacts (real-L1 test).
+//!
 //! These tests verify that new tokens can be enabled on L2 by injecting
 //! `TokenEnabled` events from L1, and that deposits of the newly-enabled
 //! tokens are correctly minted.
@@ -205,58 +207,32 @@ async fn test_pool_validation_uses_enabled_token_anchored_policy() -> eyre::Resu
 /// 500ms and the L1Subscriber needs to connect, backfill, and subscribe.
 const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Full TokenEnabled pipeline with a real in-process L1 node:
+/// Full TokenEnabled pipeline with a real in-process L1 node: a freshly
+/// created TIP-20 is enabled on the portal, deposited, and withdrawn again.
 ///
-///  1. Start L1 dev node.
-///  2. Create a second TIP-20 token ("AlphaUSD" / "aUSD") on L1.
-///  3. Mint AlphaUSD to the dev account.
-///  4. Create a zone through the native ZoneFactory.
-///  5. Start zone node connected to L1.
-///  6. Enable AlphaUSD on the portal (emits `TokenEnabled` event) — must
-///     happen AFTER zone startup so the live L1 subscriber picks it up
-///     (events in blocks ≤ genesis are not backfilled).
-///  7. Wait for the zone to finalize past the `enableToken` L1 block.
-///  8. Fund user with pathUSD (for L2 gas) and AlphaUSD on L1.
-///  9. Deposit pathUSD first (for L2 gas), then deposit AlphaUSD.
-/// 10. Verify AlphaUSD balance on L2.
-/// 11. Spawn sequencer, withdraw AlphaUSD back to L1.
-/// 12. Wait for the withdrawal to be processed on L1.
-///
-/// ```text
-///  L1 (TokenEnabled + deposit)          Zone L2
-///    |--- enableToken("AlphaUSD") ---->|  ✓ token initialized via builder
-///    |--- deposit pathUSD ------------>|  ✓ pathUSD minted (gas)
-///    |--- deposit AlphaUSD ----------->|  ✓ AlphaUSD minted
-///    |<-- withdraw AlphaUSD -----------|  ✓ AlphaUSD burned
-/// ```
-///
-/// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime artifacts.
+/// The token must be enabled AFTER zone startup so the live L1 subscriber
+/// picks up the `TokenEnabled` event (events in blocks ≤ genesis are not
+/// backfilled).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 ---
     let l1 = L1TestNode::start().await?;
 
-    // --- Step 2: Create AlphaUSD on L1 ---
     let alpha_salt = B256::new([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 99,
     ]);
     let l1_alpha_usd = l1.create_tip20("AlphaUSD", "aUSD", alpha_salt).await?;
 
-    // --- Step 3: Mint AlphaUSD to the dev account ---
     let mint_amount: u128 = 100_000_000; // 100 AlphaUSD (6 decimals)
     l1.mint_tip20(l1_alpha_usd, l1.dev_address(), mint_amount)
         .await?;
 
-    // --- Step 4: Deploy L1 infrastructure and create a zone ---
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Step 5: Start zone node connected to L1 ---
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
 
-    // --- Step 6: Enable AlphaUSD on the portal ---
     // Must happen AFTER zone startup so the zone's L1 subscriber picks up the
     // TokenEnabled event from a live block (events in blocks <= genesis are not
     // backfilled).
@@ -264,11 +240,9 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
         .await?;
     let enable_block = l1.provider().get_block_number().await?;
 
-    // --- Step 7: Wait for the zone to finalize past the enableToken block ---
     zone.wait_for_l2_tempo_finalized(enable_block, L1_TIMEOUT)
         .await?;
 
-    // --- Step 8: Fund user account on L1 ---
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let pathusd_gas_amount: u128 = 5_000_000; // 5 pathUSD for L2 gas
     let alpha_deposit_amount: u128 = 2_000_000; // 2 AlphaUSD
@@ -278,7 +252,6 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
     l1.fund_user_token(l1_alpha_usd, account.address(), alpha_deposit_amount * 2)
         .await?;
 
-    // --- Step 9: Deposit pathUSD (gas) then AlphaUSD ---
     account
         .deposit(pathusd_gas_amount, L1_TIMEOUT, &zone)
         .await?;
@@ -297,14 +270,12 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
         )
         .await?;
 
-    // --- Step 10: Verify AlphaUSD balance on L2 ---
     assert_eq!(
         alpha_minted,
         U256::from(alpha_deposit_amount),
         "AlphaUSD minted balance should equal deposit amount"
     );
 
-    // --- Step 11: Spawn sequencer and withdraw AlphaUSD ---
     let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
     let withdrawal_timeout = std::time::Duration::from_secs(60);
 
@@ -313,7 +284,6 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
         .withdraw_token(l2_alpha_usd, alpha_withdrawal)
         .await?;
 
-    // --- Step 12: Wait for the withdrawal to be processed on L1 ---
     l1.wait_for_withdrawal_on_l1_token(
         portal_address,
         l1_alpha_usd,

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -1,5 +1,7 @@
 //! Full L1+L2 end-to-end tests with a real in-process Tempo L1 node.
 //!
+//! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
+//!
 //! Unlike the injection-based tests in `e2e.rs`, these tests start a real
 //! Tempo L1 dev node and a Zone L2 node connected via WebSocket. The L1
 //! subscriber naturally receives blocks and deposits — no synthetic injection.
@@ -120,7 +122,6 @@ async fn setup_same_zone_swap_fixture() -> eyre::Result<SameZoneSwapFixture> {
 async fn test_zone_advances_with_real_l1() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // Start real Tempo L1 in dev mode (500ms block time)
     let l1 = L1TestNode::start().await?;
 
     // Verify L1 is producing blocks
@@ -228,23 +229,12 @@ async fn test_dev_provisioner_replays_initial_token_event() -> eyre::Result<()> 
     Ok(())
 }
 
-/// Full deposit + withdrawal flow with a real L1:
-/// 1. Start L1 dev node.
-/// 2. Create a zone through the native ZoneFactory (installs ZonePortal).
-/// 3. Start zone node connected to L1 with the portal address.
-/// 4. Deposit pathUSD on the ZonePortal to the dev account.
-/// 5. Verify the zone mints the corresponding pathUSD balance on L2.
-/// 6. Spawn zone sequencer background tasks (batch submitter + withdrawal processor).
-/// 7. Request a withdrawal on L2 (approve + requestWithdrawal on ZoneOutbox).
-/// 8. Wait for the batch to be submitted and the withdrawal to be processed on L1.
-///
-/// NOTE: This test requires the Foundry-compiled shared runtime artifacts.
-/// Run `forge build` in `specs/ref-impls/` first.
+/// Full deposit + withdrawal flow with a real L1: a portal deposit mints
+/// pathUSD on L2, then a withdrawal is batched and processed back on L1.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_deposit_via_real_l1() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // Start real Tempo L1 in dev mode (500ms block time)
     let l1 = L1TestNode::start().await?;
 
     // Deploy L1 infrastructure and create a zone
@@ -255,8 +245,6 @@ async fn test_deposit_via_real_l1() -> eyre::Result<()> {
 
     // Wait for the zone to advance past genesis
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
-
-    // --- Deposit + withdrawal via ZoneAccount ---
 
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let deposit_amount: u128 = 1_000_000; // 1 pathUSD (6 decimals)
@@ -274,7 +262,6 @@ async fn test_deposit_via_real_l1() -> eyre::Result<()> {
         "recipient should start with zero on L2"
     );
 
-    // Deposit on L1, wait for mint on L2
     let minted_balance = account.deposit(deposit_amount, L1_TIMEOUT, &zone).await?;
     assert_eq!(
         minted_balance,
@@ -986,44 +973,23 @@ async fn test_queued_callback_bounces_after_gateway_revocation() -> eyre::Result
     Ok(())
 }
 
-/// Cross-zone withdrawal via the SwapAndDepositRouter:
-///
-///  1. Start L1 dev node.
-///  2. Create zone_a and zone_b through the native factory, then deploy SwapAndDepositRouter.
-///  3. Start both zone nodes connected to L1.
-///  4. Deposit pathUSD into zone_a.
-///  5. Withdraw from zone_a with a callback that deposits into zone_b via the router.
-///  6. Verify the deposit arrives on zone_b.
-///  7. Withdraw from zone_b with a callback that deposits into zone_a via the router.
-///  8. Verify the deposit arrives on zone_a.
-///
-/// ```text
-///  Zone A          L1 (Router)          Zone B
-///    |--- withdraw 0.4 -->|                |
-///    |                    |-- deposit 0.4 ->|
-///    |                    |                 |
-///    |                    |<- withdraw 0.2 -|
-///    |<-- deposit 0.2 ----|                 |
-/// ```
-///
-/// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime and router artifacts.
+/// Cross-zone withdrawal via the SwapAndDepositRouter: zone_a withdraws with
+/// a router callback that deposits into zone_b, then zone_b sends back the
+/// other way.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 ---
     let l1 = L1TestNode::start().await?;
 
     // Separate sequencer keys for each zone to avoid L1 nonce conflicts
     let seq_a_signer = l1.signer_at(2);
     let seq_b_signer = l1.signer_at(3);
 
-    // --- Step 2: Deploy L1 infrastructure (factory, two portals, router) ---
     let (portal_a, portal_b, router) = l1
         .deploy_two_open_zones_with_sequencers(seq_a_signer.clone(), seq_b_signer.clone())
         .await?;
 
-    // --- Step 3: Start both zone nodes ---
     let zone_a = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_a).await?;
     let zone_b = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_b).await?;
 
@@ -1034,7 +1000,6 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     zone_a.assert_gateway_open(true).await?;
     zone_b.assert_gateway_open(true).await?;
 
-    // --- Step 4: Deposit into zone_a ---
     let mut account_a = ZoneAccount::from_l1_and_zone(&l1, &zone_a, portal_a);
     let deposit_amount: u128 = 1_000_000; // 1 pathUSD
     l1.fund_user(account_a.address(), deposit_amount * 2)
@@ -1047,7 +1012,6 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     let _seq_a = spawn_sequencer(&l1, &zone_a, portal_a, seq_a_signer.clone()).await;
     let _seq_b = spawn_sequencer(&l1, &zone_b, portal_b, seq_b_signer.clone()).await;
 
-    // --- Step 5: Cross-zone withdrawal: zone_a → router → zone_b ---
     let cross_amount: u128 = 400_000; // 0.4 pathUSD
     let args_a_to_b = WithdrawalArgs::cross_zone_via_router(
         cross_amount,
@@ -1059,7 +1023,6 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     );
     account_a.withdraw_with(args_a_to_b).await?;
 
-    // --- Step 6: Verify deposit arrives on zone_b ---
     let cross_timeout = std::time::Duration::from_secs(60);
     zone_b
         .wait_for_balance(
@@ -1088,7 +1051,6 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
         "zone_a balance should decrease by at least the cross-zone amount (got {zone_a_balance})"
     );
 
-    // --- Step 7: Cross-zone withdrawal: zone_b → router → zone_a ---
     let mut account_b = ZoneAccount::from_l1_and_zone(&l1, &zone_b, portal_b);
     let reverse_amount: u128 = 200_000; // 0.2 pathUSD
     let args_b_to_a = WithdrawalArgs::cross_zone_via_router(
@@ -1101,7 +1063,6 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     );
     account_b.withdraw_with(args_b_to_a).await?;
 
-    // --- Step 8: Verify deposit arrives on zone_a ---
     zone_a
         .wait_for_balance(
             ZONE_TOKEN_ADDRESS,
@@ -1242,13 +1203,9 @@ async fn test_cross_zone_encrypted_router_tempo_refund_recipient() -> eyre::Resu
     Ok(())
 }
 
-/// Same-zone routed withdrawal that takes the real swap branch:
-///
-///  1. Deposit AlphaUSD into the zone.
-///  2. Withdraw AlphaUSD to the router.
-///  3. Swap AlphaUSD -> BetaUSD via the real StablecoinDEX.
-///  4. Deposit BetaUSD back into the same zone.
-///  5. Verify AlphaUSD was consumed and BetaUSD was minted.
+/// Same-zone routed withdrawal that takes the real swap branch: AlphaUSD is
+/// withdrawn to the router, swapped to BetaUSD on the StablecoinDEX, and
+/// redeposited into the same zone.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -1563,34 +1520,15 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_
     Ok(())
 }
 
-/// Multi-asset deposit + withdrawal test:
-///
-///  1. Start L1 dev node.
-///  2. Create a second TIP-20 token ("ZoneUSD") on L1.
-///  3. Create a zone with pathUSD through the native ZoneFactory.
-///  4. Enable ZoneUSD on the portal.
-///  5. Start zone node connected to L1 (ZoneUSD is auto-initialized via TokenEnabled event).
-///  6. Deposit pathUSD and ZoneUSD into the zone.
-///  7. Spawn sequencer, withdraw both tokens back to L1.
-///  8. Verify withdrawals processed and L2 balances decreased.
-///
-/// ```text
-///  L1 (pathUSD + ZoneUSD)          Zone L2
-///    |--- deposit pathUSD -------->|  ✓ pathUSD minted
-///    |--- deposit ZoneUSD -------->|  ✓ ZoneUSD minted
-///    |<-- withdraw pathUSD --------|  ✓ pathUSD burned
-///    |<-- withdraw ZoneUSD --------|  ✓ ZoneUSD burned
-/// ```
-///
-/// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime artifacts.
+/// Multi-asset deposit + withdrawal: pathUSD plus a second TIP-20 enabled on
+/// the portal (auto-initialized on L2 via the `TokenEnabled` event) both
+/// round-trip through deposit and withdrawal.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 ---
     let l1 = L1TestNode::start().await?;
 
-    // --- Step 2: Create a second TIP-20 token on L1 ---
     let zone_usd_salt = B256::new([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 42,
@@ -1602,13 +1540,10 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     l1.mint_tip20(l1_zone_usd, l1.dev_address(), mint_amount)
         .await?;
 
-    // --- Step 3: Deploy L1 infrastructure and create a zone ---
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Step 4: Start zone node connected to L1 ---
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
 
-    // --- Step 5: Enable ZoneUSD on the portal ---
     // Must happen AFTER zone startup so the zone's L1 subscriber picks up the
     // TokenEnabled event from a live block.
     l1.enable_token_on_portal(portal_address, l1_zone_usd)
@@ -1622,7 +1557,6 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     // L2 token address is the same as L1 by design (auto-initialized via TokenEnabled event)
     let l2_zone_usd = l1_zone_usd;
 
-    // --- Step 6: Deposit both tokens (user account) ---
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let pathusd_amount: u128 = 1_000_000; // 1 pathUSD
     let zoneusd_amount: u128 = 2_000_000; // 2 ZoneUSD
@@ -1632,7 +1566,6 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     l1.fund_user_token(l1_zone_usd, account.address(), zoneusd_amount * 2)
         .await?;
 
-    // Deposit pathUSD
     let pathusd_minted = account.deposit(pathusd_amount, L1_TIMEOUT, &zone).await?;
     assert_eq!(
         pathusd_minted,
@@ -1650,11 +1583,9 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
         "ZoneUSD minted balance should equal deposit amount"
     );
 
-    // --- Step 7: Spawn sequencer and withdraw both tokens ---
     let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
     let withdrawal_timeout = std::time::Duration::from_secs(60);
 
-    // Withdraw pathUSD
     let pathusd_withdrawal: u128 = 500_000; // 0.5 pathUSD
     account.withdraw(pathusd_withdrawal).await?;
 
@@ -1666,7 +1597,6 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     )
     .await?;
 
-    // Withdraw ZoneUSD
     let zoneusd_withdrawal: u128 = 1_000_000; // 1 ZoneUSD
     account
         .withdraw_token(l2_zone_usd, zoneusd_withdrawal)
@@ -1681,7 +1611,6 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     )
     .await?;
 
-    // --- Step 8: Verify L2 balances decreased ---
     let final_pathusd = zone
         .balance_of(ZONE_TOKEN_ADDRESS, account.address())
         .await?;
@@ -1699,54 +1628,18 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Full encrypted deposit + withdrawal flow:
-///
-///  1. Start L1 dev node and create a zone through the native ZoneFactory.
-///  2. Generate sequencer encryption key, start zone with sequencer key.
-///  3. Register encryption key on the portal via `setSequencerEncryptionKey`.
-///  4. Fund depositor, call `depositEncrypted` on the portal — encrypting
-///     (recipient, memo) to the sequencer's public key. The recipient is a
-///     known key (mnemonic index 2) so we can withdraw later.
-///     The zone processes this automatically: ECIES decrypt → CP proof →
-///     AES-GCM verify → mint to recipient. `deposit_encrypted` waits for
-///     the L2 balance to confirm the full pipeline succeeded.
-///  5. Spawn sequencer tasks, recipient requests withdrawal on L2.
-///  6. Wait for batch submission + withdrawal processing on L1.
-///
-/// ```text
-///  L1                                       Zone L2
-///   │                                         │
-///   │  setSequencerEncryptionKey              │
-///   │                                         │
-///   │  depositEncrypted ─────────►    │
-///   │                                         │
-///   │               ECIES decrypt             │
-///   │               + CP proof                │
-///   │                   │                    │
-///   │                   ▼                    │
-///   │            advanceTempo                 │
-///   │                   │                    │
-///   │                   ▼                    │
-///   │            CP ✓ + AES decrypt           │
-///   │            → mint to recipient         │
-///   │                                         │
-///   │   ◄──── requestWithdrawal ───── │
-///   │   ◄──── submitBatch ────────  │
-///   │   processWithdrawals                     │
-///   │            → tokens to L1              │
-/// ```
-///
-/// NOTE: Requires `forge build` in `specs/ref-impls/` for shared runtime artifacts.
+/// Full encrypted deposit + withdrawal flow: `depositEncrypted` encrypts
+/// (recipient, memo) to the sequencer's registered public key, the zone runs
+/// the ECIES decrypt → CP proof → AES-GCM verify → mint pipeline, and the
+/// recipient (a known mnemonic key) then withdraws back to L1.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_encrypted_deposit_and_withdrawal() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 + deploy zone ---
     let l1 = L1TestNode::start().await?;
     let encryption_key = k256::SecretKey::from(l1.dev_signer().credential());
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Step 2: Start zone with sequencer key ---
     // Must start the zone BEFORE registering the encryption key, so the zone's
     // genesis anchor captures the current L1 block. The encryption key registration
     // and deposit happen in subsequent L1 blocks that the zone processes naturally.
@@ -1754,12 +1647,10 @@ async fn test_encrypted_deposit_and_withdrawal() -> eyre::Result<()> {
 
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
 
-    // --- Step 3: Register encryption key on portal ---
     // This produces an L1 block that the zone will process via L1Subscriber.
     l1.set_sequencer_encryption_key(portal_address, &encryption_key)
         .await?;
 
-    // --- Step 4: Encrypted deposit to a recipient we control ---
     // Use mnemonic index 2 as the recipient so we have keys for withdrawal.
     let recipient_signer = l1.signer_at(2);
     let recipient = recipient_signer.address();
@@ -1775,7 +1666,6 @@ async fn test_encrypted_deposit_and_withdrawal() -> eyre::Result<()> {
         .deposit_encrypted(deposit_amount, recipient, B256::ZERO, L1_TIMEOUT, &zone)
         .await?;
 
-    // --- Step 5: Spawn sequencer + withdraw from the recipient's account on L2 ---
     // Spawn sequencer after deposit to avoid L1 nonce races — the dev signer
     // is used by both fund_user and the sequencer's batch submitter.
     let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
@@ -1786,7 +1676,6 @@ async fn test_encrypted_deposit_and_withdrawal() -> eyre::Result<()> {
     let withdrawal_amount: u128 = 500_000; // 0.5 pathUSD
     recipient_account.withdraw(withdrawal_amount).await?;
 
-    // --- Step 6: Wait for the withdrawal to be fully processed on L1 ---
     let withdrawal_timeout = std::time::Duration::from_secs(60);
     l1.wait_for_withdrawal_on_l1(
         portal_address,
@@ -1801,14 +1690,6 @@ async fn test_encrypted_deposit_and_withdrawal() -> eyre::Result<()> {
 
 /// Test that TIP-403 policy operations on L1 work correctly and the zone
 /// continues to advance normally after policy changes.
-///
-///  1. Start L1 dev node, deploy zone.
-///  2. Create a blacklist policy on L1.
-///  3. Assign it to pathUSD.
-///  4. Blacklist a user address.
-///  5. Start zone node, verify it advances past the policy blocks.
-///  6. Verify the policy state on L1 via the helpers.
-///
 /// NOTE: Full on-chain TIP-403 enforcement on the zone (blocking transfers)
 /// requires the TIP403Registry shim precompile, which is not yet wired.
 /// This test validates the L1 infrastructure and that policy changes don't
@@ -1820,7 +1701,6 @@ async fn test_l1_policy_operations_and_zone_advancement() -> eyre::Result<()> {
     let l1 = L1TestNode::start().await?;
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Create policy infrastructure on L1 ---
     let policy_id = l1.create_blacklist_policy().await?;
 
     // Assign the blacklist to pathUSD
@@ -1846,7 +1726,6 @@ async fn test_l1_policy_operations_and_zone_advancement() -> eyre::Result<()> {
         "non-blacklisted user should be authorized on L1"
     );
 
-    // --- Start zone and verify it advances past the policy blocks ---
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
 
@@ -1991,23 +1870,16 @@ async fn test_plaintext_deposit_policy_failure_bounces_to_tempo_refund_recipient
 /// Test that an encrypted deposit whose decrypted recipient is blacklisted
 /// gets bounced back to the sender on L1 instead of minting to the recipient.
 ///
-///  1. Start L1 dev node, deploy zone, register encryption key.
-///  2. Create a blacklist policy, assign to pathUSD, blacklist the recipient.
-///  3. Make an encrypted deposit targeting the blacklisted recipient.
-///  4. Verify upstream TIP-20 mint enforcement fails and refunds the sender on L1.
-///
 /// `L1OverlayDB` exposes finalized L1 policy state directly to upstream Tempo execution.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 + deploy zone ---
     let l1 = L1TestNode::start().await?;
     let sequencer_signer = l1.dev_signer();
     let encryption_key = k256::SecretKey::from(sequencer_signer.credential());
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Step 2: Create blacklist policy and blacklist the intended recipient ---
     let policy_id = l1.create_blacklist_policy().await?;
     l1.change_transfer_policy_id(PATH_USD_ADDRESS, policy_id)
         .await?;
@@ -2022,15 +1894,12 @@ async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
         "recipient should be blacklisted"
     );
 
-    // --- Step 3: Start zone with sequencer key ---
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
 
-    // --- Step 4: Register encryption key ---
     l1.set_sequencer_encryption_key(portal_address, &encryption_key)
         .await?;
 
-    // --- Step 5: Make an encrypted deposit targeting the blacklisted recipient ---
     let depositor = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let deposit_amount: u128 = 1_000_000;
     l1.fund_user(depositor.address(), deposit_amount).await?;
@@ -2114,16 +1983,9 @@ async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Blacklisted sender cannot transfer on the zone.
-///
-///  1. Start L1 dev node, deploy zone.
-///  2. Create a blacklist policy for senders, wrap it in a compound policy
-///     (sender=blacklist, recipient=allow-all, mintRecipient=allow-all).
-///  3. Assign the compound policy to pathUSD's `transferPolicyId`.
-///  4. Blacklist Alice in the sender sub-policy.
-///  5. Start zone connected to L1, wait for it to process the policy blocks.
-///  6. Deposit pathUSD to Alice (succeeds — mint recipient is allow-all).
-///  7. Alice attempts a transfer → rejected at pool level (blacklisted sender).
+/// Blacklisted sender cannot transfer on the zone: a compound policy
+/// (sender=blacklist, recipient/mintRecipient=allow-all) on pathUSD lets the
+/// deposit to Alice mint but rejects her transfer at pool level.
 ///
 /// NOTE: The T2 hardfork must be active on L1 for compound policies and
 /// directional authorization roles to work.
@@ -2131,11 +1993,9 @@ async fn test_encrypted_deposit_blacklisted_recipient() -> eyre::Result<()> {
 async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // --- Step 1: Start L1 ---
     let l1 = L1TestNode::start().await?;
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Step 2: Create compound policy and blacklist Alice as sender ---
     let alice_signer = l1.user_signer();
     let alice = alice_signer.address();
 
@@ -2160,11 +2020,9 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
         );
     }
 
-    // --- Step 3: Start zone connected to L1 ---
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
     zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
 
-    // --- Step 4: Deposit to Alice via the dev account ---
     // Alice is blacklisted as a sender, so she can't transfer pathUSD on L1
     // herself. The dev account deposits on her behalf (recipient = allow-all).
     let deposit_amount: u128 = 1_000_000; // 1 pathUSD
@@ -2199,7 +2057,6 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
     )
     .await?;
 
-    // --- Step 5: Alice simulates a transfer → should be rejected ---
     // Use an exact stateful call instead of waiting on pool inclusion: policy-invalid
     // transactions are allowed to remain pending, so absence of a receipt is not proof.
     let bob = Address::with_last_byte(0xBB);
@@ -2226,13 +2083,8 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Test that a regular deposit to a blacklisted recipient reverts on L1.
-///
-///  1. Start L1 dev node, deploy zone.
-///  2. Create a blacklist policy, assign to pathUSD, blacklist a user.
-///  3. Fund the blacklisted user on L1.
-///  4. Attempt a deposit targeting the blacklisted user — should revert with
-///     `PolicyForbids` on the L1 portal contract.
+/// Test that a regular deposit to a blacklisted recipient reverts with
+/// `PolicyForbids` on the L1 portal contract.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_deposit_to_blacklisted_recipient_reverts_on_l1() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -2240,7 +2092,6 @@ async fn test_deposit_to_blacklisted_recipient_reverts_on_l1() -> eyre::Result<(
     let l1 = L1TestNode::start().await?;
     let portal_address = l1.deploy_zone().await?;
 
-    // --- Create blacklist policy and blacklist the intended deposit recipient ---
     let policy_id = l1.create_blacklist_policy().await?;
     l1.change_transfer_policy_id(PATH_USD_ADDRESS, policy_id)
         .await?;

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -8,8 +8,8 @@
 //! - Method tier enforcement (restricted/disabled/unknown methods)
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, now_secs, start_zone_with_private_rpc,
-    start_zone_with_private_rpc_l1, start_zone_with_private_rpc_l1_with_encryption,
+    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, build_auth_token, now_secs,
+    start_zone_with_private_rpc, start_zone_with_private_rpc_l1,
 };
 use alloy::{
     primitives::{Address, B256, TxKind, U256, address, hex},
@@ -269,7 +269,7 @@ async fn test_auth_rejection() -> eyre::Result<()> {
     );
 
     // Valid signature but wrong chain ID → 403
-    let bad_token = ctx.build_bad_token(&ctx.sequencer_signer, 1, ctx.config.chain_id + 1);
+    let bad_token = build_auth_token(&ctx.sequencer_signer, 1, ctx.config.chain_id + 1);
     let (status, _) = ctx
         .call_raw("eth_blockNumber", serde_json::json!([]), &bad_token)
         .await?;
@@ -1370,7 +1370,7 @@ fn encryption_public_key(secret_key: &k256::SecretKey) -> (String, u8) {
 async fn test_zone_get_encryption_key_reads_latest_l1_key() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let ctx = start_zone_with_private_rpc_l1_with_encryption().await?;
+    let ctx = start_zone_with_private_rpc_l1().await?;
     let portal_address = ctx.portal_address();
     let caller = ctx.l1().user_signer();
 

--- a/crates/node/tests/it/stepping_e2e.rs
+++ b/crates/node/tests/it/stepping_e2e.rs
@@ -5,21 +5,15 @@
 //! boundary successfully once it comes back. This exercises the long-downtime
 //! ancestry path instead of the simpler direct-mode case.
 
-use crate::utils::{
-    L1TestNode, ZoneTestNode, poll_until, spawn_sequencer, spawn_sequencer_with_config,
-};
+use crate::utils::{L1TestNode, ZoneTestNode, poll_until, spawn_sequencer_with_config};
 use alloy::providers::Provider;
 use alloy_sol_types::SolCall;
 use std::time::Duration;
 use tempo_zone_contracts::ZonePortal;
 use zone_sequencer::BatchAnchorConfig;
 
-/// EIP-2935 stores the last 8192 block hashes, so the usable window is 8191 blocks.
-const EIP2935_HISTORY_WINDOW: u64 = 8192 - 1;
-const EIP2935_SAFETY_MARGIN: u64 = 360;
-const EIP2935_EFFECTIVE_WINDOW: u64 = EIP2935_HISTORY_WINDOW - EIP2935_SAFETY_MARGIN;
-const EXTENDED_GAP_BLOCKS: u64 = EIP2935_HISTORY_WINDOW + EIP2935_EFFECTIVE_WINDOW + 64;
-
+/// Scaled-down EIP-2935 window (mainnet keeps 8191 ancestor hashes) so the
+/// out-of-window ancestry path runs in regular integration-test time.
 const SHORT_EIP2935_HISTORY_WINDOW: u64 = 10;
 const SHORT_EIP2935_SAFETY_MARGIN: u64 = 4;
 const SHORT_EIP2935_EFFECTIVE_WINDOW: u64 =
@@ -31,10 +25,6 @@ const SHORT_MULTI_BOUNDARY_GAP_BLOCKS: u64 = SHORT_EIP2935_HISTORY_WINDOW
     + SHORT_EIP2935_EFFECTIVE_WINDOW * SHORT_MULTI_BOUNDARY_BATCH_COUNT
     + 1;
 
-/// Extended timeout for ancestry tests — the L1 needs to mine >16k blocks and
-/// the zone must replay enough history to cross the first out-of-window boundary.
-const STEPPING_TIMEOUT: Duration = Duration::from_secs(300);
-const BATCH_TIMEOUT: Duration = Duration::from_secs(90);
 const SHORT_STEPPING_TIMEOUT: Duration = Duration::from_secs(60);
 
 async fn fetch_submit_batch_call(
@@ -96,129 +86,9 @@ async fn fetch_submit_batch_call(
     Ok((call, block_number))
 }
 
-/// Test that batch submission works after the zone's `tempoBlockNumber` has
-/// fallen far enough behind L1 that the first finalized batch boundary lands
-/// outside the EIP-2935 history window.
-///
-/// 1. Start L1 with 10ms block time to mine blocks quickly.
-/// 2. Deploy zone portal on L1.
-/// 3. Wait for L1 to advance past `history + effective window`, so the first
-///    submitted boundary is still outside the history window.
-/// 4. Start zone node connected to L1, anchored at the portal genesis.
-/// 5. Wait for the zone to replay up to the first out-of-window boundary.
-/// 6. Spawn sequencer while the zone is still far behind L1.
-/// 7. Assert a `BatchSubmitted` event appears.
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "slow: mines >16k L1 blocks and replays zone history, run with --ignored or in nightly CI"]
-async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    // --- Step 1: Start L1 with fast block time ---
-    let l1 = L1TestNode::start_with(|cfg| {
-        cfg.dev.block_time = Some(Duration::from_millis(10));
-    })
-    .await?;
-
-    // --- Step 2: Deploy zone portal ---
-    let portal_address = l1.deploy_zone().await?;
-
-    let genesis_block = l1.provider().get_block_number().await?;
-    let portal = ZonePortal::new(portal_address, l1.provider());
-    let target_block = genesis_block + EXTENDED_GAP_BLOCKS;
-
-    tracing::info!(
-        genesis_block,
-        target_block,
-        "Waiting for L1 to advance past the extended ancestry threshold"
-    );
-
-    // Poll until L1 reaches the target — at 10ms/block this takes ~160 seconds.
-    let poll_start = std::time::Instant::now();
-    loop {
-        let current = l1.provider().get_block_number().await?;
-        if current >= target_block {
-            tracing::info!(
-                current,
-                target_block,
-                elapsed_secs = poll_start.elapsed().as_secs(),
-                "L1 advanced past EIP-2935 window"
-            );
-            break;
-        }
-        if poll_start.elapsed() > STEPPING_TIMEOUT {
-            return Err(eyre::eyre!(
-                "Timed out waiting for L1 to reach block {target_block} (current: {current})"
-            ));
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-
-    // --- Step 4: Start zone node connected to L1, anchored at the portal genesis ---
-    let zone = ZoneTestNode::start_from_l1_genesis_block(
-        l1.http_url(),
-        l1.ws_url(),
-        portal_address,
-        genesis_block,
-    )
-    .await?;
-
-    // --- Step 5: Wait for the zone to replay to the first out-of-window boundary ---
-    let first_step_tempo = genesis_block + EIP2935_EFFECTIVE_WINDOW;
-    zone.wait_for_tempo_block_number(first_step_tempo, STEPPING_TIMEOUT)
-        .await?;
-
-    let l1_tip = l1.provider().get_block_number().await?;
-    eyre::ensure!(
-        l1_tip.saturating_sub(first_step_tempo) > EIP2935_HISTORY_WINDOW,
-        "test precondition not met: first boundary tempo {first_step_tempo} is only {} blocks behind L1 tip {l1_tip}",
-        l1_tip.saturating_sub(first_step_tempo),
-    );
-
-    // --- Step 6: Spawn sequencer while the zone still has a large backlog ---
-    let seq = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-
-    // --- Step 7: Assert batch submission succeeds after the long gap ---
-    let batch_count = poll_until(
-        BATCH_TIMEOUT,
-        Duration::from_millis(500),
-        "BatchSubmitted event after extended L1 gap",
-        || {
-            let portal = &portal;
-            let seq = &seq;
-            async move {
-                if seq.monitor_handle.is_finished() {
-                    eyre::bail!("monitor task exited before submitting a batch");
-                }
-
-                if seq.withdrawal_handle.is_finished() {
-                    eyre::bail!("withdrawal processor exited before batch submission completed");
-                }
-
-                let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
-                let batch_count = events.len();
-                if batch_count >= 1 {
-                    Ok(Some(batch_count))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
-
-    tracing::info!(
-        batch_count,
-        l1_tip,
-        first_step_tempo,
-        first_step_gap = l1_tip.saturating_sub(first_step_tempo),
-        "Batch submission succeeded after extended L1 gap"
-    );
-
-    Ok(())
-}
-
-/// Same ancestry scenario as the ignored long-gap test, but with a 10-block
-/// configured EIP-2935 window so it runs in regular integration test time.
+/// Batch submission still works after the zone falls far enough behind L1 that
+/// the first finalized batch boundary lands outside the configured EIP-2935
+/// window (scaled down to 10 blocks so the gap fits integration-test time).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -67,8 +67,8 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio_util::sync::CancellationToken;
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::{
-    Deposit, DepositQueue, EnabledToken, EncryptedDeposit, L1BlockTracker, L1Deposit,
-    L1PortalEvents, L1StateCache, state::EnabledTokenRegistry,
+    Deposit, DepositQueue, EnabledToken, L1BlockTracker, L1Deposit, L1PortalEvents, L1StateCache,
+    state::EnabledTokenRegistry,
 };
 use zone_node::{ZoneNode, ZoneSequencerAddOnsConfig};
 use zone_p2p::{LeadershipSchedule, LeadershipState, P2pConfig, P2pPeerId, Role};
@@ -3438,14 +3438,14 @@ impl P2pCluster {
     }
 }
 
+/// Returns a free localhost address to bind a P2P listener on.
+fn available_address() -> eyre::Result<SocketAddr> {
+    Ok(TcpListener::bind("127.0.0.1:0")?.local_addr()?)
+}
+
 /// Start a three-node multi-sequencer cluster with identical genesis state and authenticated
 /// P2P identities. Node 0 bootstraps as the leader.
 pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2pCluster> {
-    fn available_address() -> eyre::Result<SocketAddr> {
-        let listener = TcpListener::bind("127.0.0.1:0")?;
-        Ok(listener.local_addr()?)
-    }
-
     let addresses = [
         available_address()?,
         available_address()?,
@@ -3554,10 +3554,6 @@ pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2
 }
 
 pub(crate) fn leader_p2p_config(listen: SocketAddr) -> eyre::Result<P2pConfig> {
-    fn available_address() -> eyre::Result<SocketAddr> {
-        Ok(TcpListener::bind("127.0.0.1:0")?.local_addr()?)
-    }
-
     let identities = [
         Ed25519PrivateKey::from_seed(201),
         Ed25519PrivateKey::from_seed(202),
@@ -3636,7 +3632,7 @@ pub(crate) fn seed_fixture_for_zone(fixture: &L1Fixture, zone: &ZoneTestNode, se
 ///
 /// Signs the token with the given signer and returns the hex string (no `0x` prefix)
 /// suitable for the `X-Authorization-Token` header.
-fn build_auth_token(
+pub(crate) fn build_auth_token(
     signer: &alloy_signer_local::PrivateKeySigner,
     zone_id: u32,
     chain_id: u64,
@@ -3954,16 +3950,6 @@ impl PrivateRpcTestCtx {
         private_rpc_call_no_auth(&self.private_rpc_url, method, params).await
     }
 
-    /// Build an auth token with custom zone_id and chain_id (for negative testing).
-    pub(crate) fn build_bad_token(
-        &self,
-        signer: &alloy_signer_local::PrivateKeySigner,
-        zone_id: u32,
-        chain_id: u64,
-    ) -> String {
-        build_auth_token(signer, zone_id, chain_id)
-    }
-
     /// Inject an empty L1 block and wait for it to be processed.
     pub(crate) async fn inject_empty_block(&mut self) -> eyre::Result<()> {
         let dq = self.zone.deposit_queue().clone();
@@ -4168,15 +4154,9 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
     ))
 }
 
-/// Start a zone with a private RPC server backed by a real L1 + ZonePortal.
-pub(crate) async fn start_zone_with_private_rpc_l1() -> eyre::Result<PrivateRpcL1TestCtx> {
-    start_zone_with_private_rpc_l1_inner().await
-}
-
 /// Start a zone with a private RPC server backed by a real L1 and a portal
-/// with a registered encryption key.
-pub(crate) async fn start_zone_with_private_rpc_l1_with_encryption()
--> eyre::Result<PrivateRpcL1TestCtx> {
+/// with a registered sequencer encryption key.
+pub(crate) async fn start_zone_with_private_rpc_l1() -> eyre::Result<PrivateRpcL1TestCtx> {
     start_zone_with_private_rpc_l1_inner().await
 }
 
@@ -4565,37 +4545,6 @@ impl L1Fixture {
         anchor
     }
 
-    /// Inject an L1 block with mixed regular and encrypted deposits.
-    #[allow(dead_code)]
-    pub(crate) fn inject_l1_deposits(&mut self, queue: &DepositQueue, deposits: Vec<L1Deposit>) {
-        let header = self.next_header();
-        let events = L1PortalEvents::from_deposits(deposits);
-        queue.enqueue(header, events);
-    }
-
-    /// Create an [`EncryptedDeposit`] for testing with dummy ECIES parameters.
-    #[allow(dead_code)]
-    pub(crate) fn make_encrypted_deposit(
-        &self,
-        token: Address,
-        sender: Address,
-        amount: u128,
-    ) -> EncryptedDeposit {
-        EncryptedDeposit {
-            token,
-            sender,
-            amount,
-            fee: 0,
-            tempo_refund_recipient: sender,
-            key_index: alloy_primitives::U256::ZERO,
-            ephemeral_pubkey_x: B256::ZERO,
-            ephemeral_pubkey_y_parity: 0x02,
-            ciphertext: vec![0u8; 64], // ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE = 64
-            nonce: [0u8; 12],
-            tag: [0u8; 16],
-        }
-    }
-
     /// Create a [`Deposit`] for testing.
     pub(crate) fn make_deposit(
         &self,
@@ -4612,68 +4561,6 @@ impl L1Fixture {
             fee: 0,
             tempo_refund_recipient: sender,
             memo: B256::ZERO,
-        }
-    }
-
-    /// Create an [`EncryptedDeposit`] with proper ECIES encryption against the
-    /// sequencer's real public key.
-    ///
-    /// Uses a deterministic ephemeral key for reproducibility.
-    #[allow(clippy::too_many_arguments)]
-    #[allow(dead_code)]
-    pub(crate) fn make_real_encrypted_deposit(
-        &self,
-        sequencer_pub: &k256::AffinePoint,
-        portal_address: Address,
-        key_index: alloy_primitives::U256,
-        token: Address,
-        sender: Address,
-        recipient: Address,
-        amount: u128,
-        memo: B256,
-    ) -> EncryptedDeposit {
-        use k256::{ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
-        use sha2::{Digest, Sha256};
-        use zone_precompiles::ecies::{
-            build_plaintext, compressed_x_and_parity, encrypt_plaintext, hkdf_sha256,
-        };
-
-        // Deterministic ephemeral key for reproducibility
-        let eph_bytes: [u8; 32] = Sha256::digest(b"test-ephemeral-key-for-e2e").into();
-        let eph_key = k256::SecretKey::from_slice(&eph_bytes).expect("valid ephemeral key");
-        let eph_scalar: Scalar = *eph_key.to_nonzero_scalar();
-        let eph_pub = k256::AffinePoint::from(ProjectivePoint::GENERATOR * eph_scalar);
-        let (eph_pub_x, eph_pub_y_parity) = compressed_x_and_parity(&eph_pub);
-
-        // ECDH: shared = eph_scalar * sequencer_pub
-        let shared_proj = ProjectivePoint::from(*sequencer_pub) * eph_scalar;
-        let shared_affine = k256::AffinePoint::from(shared_proj);
-        let ss_enc = shared_affine.to_encoded_point(true);
-        let shared_secret_x: [u8; 32] = ss_enc.x().unwrap().as_slice().try_into().unwrap();
-
-        // HKDF-SHA256 key derivation (matching ecies.rs)
-        let mut info = Vec::with_capacity(84);
-        info.extend_from_slice(portal_address.as_slice());
-        info.extend_from_slice(&key_index.to_be_bytes::<32>());
-        info.extend_from_slice(&eph_pub_x.0);
-        let aes_key = hkdf_sha256(&shared_secret_x, b"ecies-aes-key", &info);
-
-        // Build and encrypt plaintext (deterministic zero nonce)
-        let plaintext = build_plaintext(&recipient, &memo);
-        let (ciphertext, nonce, tag) = encrypt_plaintext(&aes_key, &plaintext);
-
-        EncryptedDeposit {
-            token,
-            sender,
-            amount,
-            fee: 0,
-            tempo_refund_recipient: sender,
-            key_index,
-            ephemeral_pubkey_x: eph_pub_x,
-            ephemeral_pubkey_y_parity: eph_pub_y_parity,
-            ciphertext,
-            nonce,
-            tag,
         }
     }
 }


### PR DESCRIPTION
Pure deletions, no surviving code changes behavior (−760 lines).

Removes `advance_tempo_repro`: a 180-line debug scratchpad that printed every execution outcome — success, revert, halt, transport error — and swallowed all of them, so it could not fail. Also removes stepping's `#[ignore]`d extended-gap test, whose ignore reason pointed at a nightly CI that does not exist (nothing in the repo passes `--run-ignored`, so it never ran anywhere), and ~130 lines of dead harness code: 55 lines of hand-rolled ECIES no test exercises, `start_zone_with_private_rpc_l1_with_encryption` (byte-identical to its non-`_with_encryption` sibling — the inner fn always registers a key), `build_bad_token`, and a duplicated nested `available_address`.

The rest is the narration layer: 40 `// --- Step N ---` banners, 56 numbered doc-comment lines restating test bodies, three ASCII sequence diagrams in `l1_e2e.rs` (one visually broken), and four per-test "requires forge build" notes now stated once per module doc. Comments explaining ordering constraints and invariants stay; the demo files keep their flow diagrams.

---

First PR of the chain (targets `main`). Next: #938.

**Test de-slop stack** (merge in order; bases retarget as predecessors merge):
1. #936 — nextest heavy-test filter
2. #937 — remove dead code and debug noise ← this PR
3. #938 — consolidate redundant e2e tests
4. #939 — split it/utils.rs into modules
5. #940 — dedupe e2e harness helpers
6. #941 — adopt shared harness helpers
7. #942 — dedupe private-RPC, WS, and earn suites
8. #943 — clean up hot suites and refresh test docs
