### PR TITLE
test: consolidate redundant e2e tests

### DIFF
--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -395,44 +395,6 @@ async fn test_p2p_listener_failure_stops_node() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Self-contained test: inject a deposit via the queue and verify the zone
-/// mints the corresponding pathUSD balance on L2.
-///
-/// Flow:
-/// 1. Start a zone node with no real L1 (dummy URL).
-/// 2. Inject an L1 block with a deposit into the deposit queue.
-/// 3. Wait for the ZoneEngine to produce L2 blocks.
-/// 4. Verify the recipient's pathUSD balance increased on L2.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_deposit_via_queue_injection() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-
-    let depositor = address!("0x0000000000000000000000000000000000001234");
-    let recipient = address!("0x0000000000000000000000000000000000005678");
-    let deposit_amount: u128 = 1_000_000; // 1 pathUSD (6 decimals)
-
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, depositor, recipient, deposit_amount);
-    fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
-
-    let balance = zone
-        .wait_for_balance(
-            PATH_USD_ADDRESS,
-            recipient,
-            U256::from(deposit_amount),
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
-    assert_eq!(
-        balance,
-        U256::from(deposit_amount),
-        "minted amount should equal deposit amount"
-    );
-
-    Ok(())
-}
-
 /// Verify a contract-creation transaction is rejected by a running zone node.
 ///
 /// This exercises the complete public transaction path: wallet signing, HTTP RPC,
@@ -471,8 +433,8 @@ async fn test_contract_creation_transaction_is_rejected() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Self-contained test: inject multiple deposits across multiple L1 blocks
-/// and verify all are minted on L2.
+/// Self-contained test: inject deposits across multiple L1 blocks — including
+/// a ten-deposit batch in a single block — and verify all are minted on L2.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_multiple_deposits_across_blocks() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -491,6 +453,22 @@ async fn test_multiple_deposits_across_blocks() -> eyre::Result<()> {
     let d2 = fixture.make_deposit(PATH_USD_ADDRESS, sender, alice, 300_000);
     let d3 = fixture.make_deposit(PATH_USD_ADDRESS, sender, bob, 700_000);
     fixture.inject_deposits(zone.deposit_queue(), vec![d2, d3]);
+
+    // Third block: a large batch of deposits to distinct recipients, processed
+    // by a single advanceTempo.
+    let amount_each: u128 = 100_000;
+    let batch_recipients: Vec<Address> = (1..=10u8)
+        .map(|i| {
+            let mut addr_bytes = [0u8; 20];
+            addr_bytes[19] = i;
+            Address::from(addr_bytes)
+        })
+        .collect();
+    let batch: Vec<_> = batch_recipients
+        .iter()
+        .map(|to| fixture.make_deposit(PATH_USD_ADDRESS, sender, *to, amount_each))
+        .collect();
+    fixture.inject_deposits(zone.deposit_queue(), batch);
 
     // Alice should have 500k + 300k = 800k
     let alice_balance = zone
@@ -514,22 +492,23 @@ async fn test_multiple_deposits_across_blocks() -> eyre::Result<()> {
         .await?;
     assert_eq!(bob_balance, U256::from(700_000u128));
 
-    Ok(())
-}
-
-/// Self-contained test: verify the zone produces blocks even for empty L1
-/// blocks (no deposits). The zone must advance its TempoState for every L1
-/// block to maintain chain continuity.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_empty_l1_blocks_advance_zone() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-
-    fixture.inject_empty_blocks(zone.deposit_queue(), 5);
-
-    // Each L1 block advances tempoBlockNumber — wait for all 5
-    zone.wait_for_tempo_block_number(5, DEFAULT_TIMEOUT).await?;
+    // All ten batch recipients received their deposit from the single block.
+    let last_recipient = *batch_recipients.last().expect("ten recipients");
+    zone.wait_for_balance(
+        PATH_USD_ADDRESS,
+        last_recipient,
+        U256::from(amount_each),
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    for recipient in &batch_recipients {
+        let balance = zone.balance_of(PATH_USD_ADDRESS, *recipient).await?;
+        assert_eq!(
+            balance,
+            U256::from(amount_each),
+            "recipient {recipient} should have {amount_each}"
+        );
+    }
 
     Ok(())
 }
@@ -773,55 +752,6 @@ async fn test_zone_inbox_events_on_deposit() -> eyre::Result<()> {
         dp_event.amount, deposit_amount,
         "DepositProcessed amount mismatch"
     );
-
-    Ok(())
-}
-
-/// Verify a large batch of deposits in a single L1 block is processed correctly.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_large_deposit_batch() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-
-    let sender = address!("0x0000000000000000000000000000000000001111");
-    let num_deposits = 10u128;
-    let amount_each: u128 = 100_000;
-
-    // Build 10 deposits to different recipients in one L1 block
-    let recipients: Vec<Address> = (0..num_deposits)
-        .map(|i| {
-            let mut addr_bytes = [0u8; 20];
-            addr_bytes[19] = (i + 1) as u8;
-            Address::from(addr_bytes)
-        })
-        .collect();
-    let deposits: Vec<_> = recipients
-        .iter()
-        .map(|to| fixture.make_deposit(PATH_USD_ADDRESS, sender, *to, amount_each))
-        .collect();
-
-    fixture.inject_deposits(zone.deposit_queue(), deposits);
-
-    // Wait for the last recipient to receive their deposit
-    let last_recipient = *recipients.last().unwrap();
-    zone.wait_for_balance(
-        PATH_USD_ADDRESS,
-        last_recipient,
-        U256::from(amount_each),
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-
-    // Verify all recipients received the correct amount
-    for recipient in &recipients {
-        let balance = zone.balance_of(PATH_USD_ADDRESS, *recipient).await?;
-        assert_eq!(
-            balance,
-            U256::from(amount_each),
-            "recipient {recipient} should have {amount_each}"
-        );
-    }
 
     Ok(())
 }

--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -1496,15 +1496,6 @@ fn ensure_gas_headroom(gas_used: u64, gas_limit: u64, operation: &str) -> eyre::
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn matrix_deposit_private_private_succeeds() -> eyre::Result<()> {
-    let mut fixture = EarnZoneFixture::start().await?;
-    let user = fixture.user.address();
-    let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
-    assert_eq!(shares, AMOUNT, "direct Zone deposit was not 1:1");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn zone_deposit_third_party_recipient() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let recipient = fixture.l1.signer_at(3).address();
@@ -1520,6 +1511,7 @@ async fn matrix_redeem_private_private_succeeds() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
     let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
+    assert_eq!(shares, AMOUNT, "direct Zone deposit was not 1:1");
     let output = fixture
         .zone_redeem(shares, fixture.alternate_asset, user)
         .await?;
@@ -1540,21 +1532,10 @@ async fn zone_redeem_third_party_recipient() -> eyre::Result<()> {
     Ok(())
 }
 
+/// The `min_vault_assets` bound is enforced: an unsatisfiable minimum makes
+/// the deposit callback bounce instead of minting shares.
 #[tokio::test(flavor = "multi_thread")]
-async fn zone_lifecycle_swapped() -> eyre::Result<()> {
-    let mut fixture = EarnZoneFixture::start().await?;
-    let user = fixture.user.address();
-    let shares = fixture.zone_deposit(fixture.alternate_asset, user).await?;
-    assert_eq!(shares, AMOUNT, "swapped Zone deposit was not 1:1");
-    let output = fixture
-        .zone_redeem(shares, fixture.alternate_asset, user)
-        .await?;
-    assert_eq!(output, AMOUNT, "swapped Zone lifecycle was not 1:1");
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn zone_swap_slippage_bounces() -> eyre::Result<()> {
+async fn zone_deposit_min_vault_assets_bounces() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
 

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -229,75 +229,6 @@ async fn test_dev_provisioner_replays_initial_token_event() -> eyre::Result<()> 
     Ok(())
 }
 
-/// Full deposit + withdrawal flow with a real L1: a portal deposit mints
-/// pathUSD on L2, then a withdrawal is batched and processed back on L1.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_deposit_via_real_l1() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let l1 = L1TestNode::start().await?;
-
-    // Deploy L1 infrastructure and create a zone
-    let portal_address = l1.deploy_zone().await?;
-
-    // Start zone node connected to L1 with the real portal
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-
-    // Wait for the zone to advance past genesis
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
-
-    let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
-    let deposit_amount: u128 = 1_000_000; // 1 pathUSD (6 decimals)
-
-    // Fund the user account on L1 (separate from the sequencer/dev account)
-    l1.fund_user(account.address(), deposit_amount * 2).await?;
-
-    // Verify recipient starts with zero on L2
-    let balance_before = zone
-        .balance_of(ZONE_TOKEN_ADDRESS, account.address())
-        .await?;
-    assert_eq!(
-        balance_before,
-        U256::ZERO,
-        "recipient should start with zero on L2"
-    );
-
-    let minted_balance = account.deposit(deposit_amount, L1_TIMEOUT, &zone).await?;
-    assert_eq!(
-        minted_balance,
-        U256::from(deposit_amount),
-        "minted balance should equal deposit amount (fee=0)"
-    );
-
-    // Spawn zone sequencer (batch submitter + withdrawal processor)
-    let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-
-    // Request withdrawal on L2
-    let withdrawal_amount: u128 = 500_000; // 0.5 pathUSD
-    account.withdraw(withdrawal_amount).await?;
-
-    // Wait for the withdrawal to be fully processed on L1
-    let withdrawal_timeout = std::time::Duration::from_secs(60);
-    l1.wait_for_withdrawal_on_l1(
-        portal_address,
-        account.address(),
-        withdrawal_amount,
-        withdrawal_timeout,
-    )
-    .await?;
-
-    // Verify the L2 balance decreased by at least the withdrawal amount
-    let l2_balance_after = zone
-        .balance_of(ZONE_TOKEN_ADDRESS, account.address())
-        .await?;
-    assert!(
-        l2_balance_after <= U256::from(deposit_amount - withdrawal_amount),
-        "L2 balance should decrease by at least the withdrawal amount (got {l2_balance_after})"
-    );
-
-    Ok(())
-}
-
 /// Deposit to enough independent accounts to force several gas-bounded withdrawal transactions,
 /// then submit the accounts concurrently, including repeated withdrawals from half of them.
 ///
@@ -1304,25 +1235,72 @@ async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Same-zone routed withdrawal where the downstream plaintext deposit fails.
-///
-/// Deposits for BetaUSD are paused on the target portal so the router callback
-/// reverts and the original AlphaUSD withdrawal bounces back to the sender.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_failure()
--> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
+/// Which router-callback flavor a bounce test exercises.
+enum RouterCallbackKind {
+    Plaintext,
+    Encrypted,
+}
 
+/// Same-zone routed withdrawal where the downstream deposit fails: deposits
+/// for BetaUSD are paused on the target portal so the router callback reverts
+/// and the original AlphaUSD withdrawal bounces back to the sender.
+async fn run_swap_and_deposit_bounce_test(kind: RouterCallbackKind) -> eyre::Result<()> {
     let mut fixture = setup_same_zone_swap_fixture().await?;
     let expected_beta = fixture
         .l1
         .quote_dex_swap_exact_amount_in(fixture.alpha, fixture.beta, fixture.swap_amount)
         .await?;
 
+    if matches!(kind, RouterCallbackKind::Encrypted) {
+        use sha2::{Digest, Sha256};
+        let enc_key_bytes: [u8; 32] =
+            Sha256::digest(b"swap-and-deposit-router-encrypted-tempo-refund").into();
+        let encryption_key = k256::SecretKey::from_slice(&enc_key_bytes).expect("valid key");
+        fixture
+            .l1
+            .set_sequencer_encryption_key(fixture.portal_address, &encryption_key)
+            .await?;
+    }
+
     fixture
         .l1
         .pause_deposits_on_portal(fixture.portal_address, fixture.beta)
         .await?;
+
+    let args = match kind {
+        RouterCallbackKind::Plaintext => {
+            WithdrawalArgs::swap_and_deposit_via_router(PlaintextRouterCallbackArgs {
+                amount: fixture.swap_amount,
+                router: fixture.router,
+                token_out: fixture.beta,
+                target_portal: fixture.portal_address,
+                recipient: fixture.account.address(),
+                tempo_refund_recipient: fixture.account.address(),
+                memo: B256::ZERO,
+                min_amount_out: expected_beta,
+            })
+        }
+        RouterCallbackKind::Encrypted => {
+            let (key_index, encrypted) = fixture
+                .l1
+                .encrypt_deposit_for_portal(
+                    fixture.portal_address,
+                    fixture.account.address(),
+                    B256::ZERO,
+                )
+                .await?;
+            WithdrawalArgs::swap_and_deposit_encrypted_via_router(EncryptedRouterCallbackArgs {
+                amount: fixture.swap_amount,
+                router: fixture.router,
+                token_out: fixture.beta,
+                target_portal: fixture.portal_address,
+                key_index,
+                encrypted,
+                tempo_refund_recipient: fixture.account.address(),
+                min_amount_out: expected_beta,
+            })
+        }
+    };
 
     let _sequencer = spawn_sequencer(
         &fixture.l1,
@@ -1332,16 +1310,6 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
     )
     .await;
 
-    let args = WithdrawalArgs::swap_and_deposit_via_router(PlaintextRouterCallbackArgs {
-        amount: fixture.swap_amount,
-        router: fixture.router,
-        token_out: fixture.beta,
-        target_portal: fixture.portal_address,
-        recipient: fixture.account.address(),
-        tempo_refund_recipient: fixture.account.address(),
-        memo: B256::ZERO,
-        min_amount_out: expected_beta,
-    });
     fixture
         .account
         .withdraw_token_with(fixture.alpha, args)
@@ -1375,7 +1343,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
     assert_eq!(
         alpha_after,
         U256::from(fixture.swap_amount),
-        "AlphaUSD should bounce back after the router's plaintext deposit reverts"
+        "AlphaUSD should bounce back after the routed deposit reverts"
     );
 
     let beta_after = fixture
@@ -1385,7 +1353,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
     assert_eq!(
         beta_after,
         U256::ZERO,
-        "BetaUSD should not be minted when the routed plaintext deposit fails"
+        "BetaUSD should not be minted when the routed deposit fails"
     );
 
     fixture
@@ -1402,6 +1370,15 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
     Ok(())
 }
 
+/// Same-zone routed withdrawal where the downstream plaintext deposit fails
+/// and the original AlphaUSD withdrawal bounces back to the sender.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_failure()
+-> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+    run_swap_and_deposit_bounce_test(RouterCallbackKind::Plaintext).await
+}
+
 /// Same-zone routed withdrawal where the downstream encrypted deposit fails.
 ///
 /// This pins the callback behavior for `depositEncrypted`: even with a valid
@@ -1411,113 +1388,7 @@ async fn test_swap_and_deposit_into_same_zone_bounces_back_on_plaintext_deposit_
 async fn test_swap_and_deposit_into_same_zone_bounces_back_on_encrypted_deposit_failure()
 -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
-
-    use sha2::{Digest, Sha256};
-
-    let mut fixture = setup_same_zone_swap_fixture().await?;
-    let expected_beta = fixture
-        .l1
-        .quote_dex_swap_exact_amount_in(fixture.alpha, fixture.beta, fixture.swap_amount)
-        .await?;
-
-    let enc_key_bytes: [u8; 32] =
-        Sha256::digest(b"swap-and-deposit-router-encrypted-tempo-refund").into();
-    let encryption_key = k256::SecretKey::from_slice(&enc_key_bytes).expect("valid key");
-
-    fixture
-        .l1
-        .set_sequencer_encryption_key(fixture.portal_address, &encryption_key)
-        .await?;
-    fixture
-        .l1
-        .pause_deposits_on_portal(fixture.portal_address, fixture.beta)
-        .await?;
-
-    let (key_index, encrypted) = fixture
-        .l1
-        .encrypt_deposit_for_portal(
-            fixture.portal_address,
-            fixture.account.address(),
-            B256::ZERO,
-        )
-        .await?;
-
-    let _sequencer = spawn_sequencer(
-        &fixture.l1,
-        &fixture.zone,
-        fixture.portal_address,
-        fixture.l1.dev_signer(),
-    )
-    .await;
-
-    let args = WithdrawalArgs::swap_and_deposit_encrypted_via_router(EncryptedRouterCallbackArgs {
-        amount: fixture.swap_amount,
-        router: fixture.router,
-        token_out: fixture.beta,
-        target_portal: fixture.portal_address,
-        key_index,
-        encrypted,
-        tempo_refund_recipient: fixture.account.address(),
-        min_amount_out: expected_beta,
-    });
-    fixture
-        .account
-        .withdraw_token_with(fixture.alpha, args)
-        .await?;
-
-    let alpha_after_request = fixture
-        .zone
-        .balance_of(fixture.alpha, fixture.account.address())
-        .await?;
-    assert_eq!(
-        alpha_after_request,
-        U256::ZERO,
-        "AlphaUSD should leave the zone before the encrypted callback bounces back"
-    );
-
-    let timeout = Duration::from_secs(60);
-    fixture
-        .zone
-        .wait_for_balance(
-            fixture.alpha,
-            fixture.account.address(),
-            U256::from(fixture.swap_amount),
-            timeout,
-        )
-        .await?;
-
-    let alpha_after = fixture
-        .zone
-        .balance_of(fixture.alpha, fixture.account.address())
-        .await?;
-    assert_eq!(
-        alpha_after,
-        U256::from(fixture.swap_amount),
-        "AlphaUSD should bounce back when the routed encrypted deposit fails"
-    );
-
-    let beta_after = fixture
-        .zone
-        .balance_of(fixture.beta, fixture.account.address())
-        .await?;
-    assert_eq!(
-        beta_after,
-        U256::ZERO,
-        "BetaUSD should not be minted when the routed encrypted deposit fails"
-    );
-
-    fixture
-        .l1
-        .assert_withdrawal_processed_with_status(
-            fixture.portal_address,
-            fixture.router,
-            fixture.alpha,
-            fixture.swap_amount,
-            false,
-        )
-        .await?;
-
-    Ok(())
+    run_swap_and_deposit_bounce_test(RouterCallbackKind::Encrypted).await
 }
 
 /// Multi-asset deposit + withdrawal: pathUSD plus a second TIP-20 enabled on

--- a/crates/node/tests/it/stepping_e2e.rs
+++ b/crates/node/tests/it/stepping_e2e.rs
@@ -86,16 +86,30 @@ async fn fetch_submit_batch_call(
     Ok((call, block_number))
 }
 
-/// Batch submission still works after the zone falls far enough behind L1 that
-/// the first finalized batch boundary lands outside the configured EIP-2935
-/// window (scaled down to 10 blocks so the gap fits integration-test time).
-#[tokio::test(flavor = "multi_thread")]
-async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
+/// Shared harness for the configured-short-window ancestry tests: starts a
+/// fast-block L1, lets it advance `gap_blocks` past the portal genesis, starts
+/// a zone anchored at that genesis, waits for it to replay `replay_windows`
+/// effective windows, verifies the first boundary is genuinely outside the
+/// configured window, and spawns the sequencer with the shortened anchor
+/// config only after the backlog has accumulated.
+struct ShortGapHarness {
+    l1: L1TestNode,
+    /// Kept alive for the duration of the test; the tests themselves only
+    /// observe the L1 portal.
+    _zone: ZoneTestNode,
+    portal_address: alloy_primitives::Address,
+    genesis_block: u64,
+    seq: zone_sequencer::ZoneSequencerHandle,
+}
 
+async fn start_short_gap_harness(
+    gap_blocks: u64,
+    replay_windows: u64,
+) -> eyre::Result<ShortGapHarness> {
     let anchor_config =
         BatchAnchorConfig::new(SHORT_EIP2935_HISTORY_WINDOW, SHORT_EIP2935_SAFETY_MARGIN)?;
 
+    // Fast blocks so the configured test window ages out quickly.
     let l1 = L1TestNode::start_with(|cfg| {
         cfg.dev.block_time = Some(Duration::from_millis(20));
     })
@@ -103,8 +117,7 @@ async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<(
 
     let portal_address = l1.deploy_zone().await?;
     let genesis_block = l1.provider().get_block_number().await?;
-    let portal = ZonePortal::new(portal_address, l1.provider());
-    let target_block = genesis_block + SHORT_EXTENDED_GAP_BLOCKS;
+    let target_block = genesis_block + gap_blocks;
 
     poll_until(
         SHORT_STEPPING_TIMEOUT,
@@ -132,10 +145,11 @@ async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<(
     )
     .await?;
 
-    let first_step_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW;
-    zone.wait_for_tempo_block_number(first_step_tempo, SHORT_STEPPING_TIMEOUT)
+    let replay_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW * replay_windows;
+    zone.wait_for_tempo_block_number(replay_tempo, SHORT_STEPPING_TIMEOUT)
         .await?;
 
+    let first_step_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW;
     let l1_tip = l1.provider().get_block_number().await?;
     eyre::ensure!(
         l1_tip.saturating_sub(first_step_tempo) > SHORT_EIP2935_HISTORY_WINDOW,
@@ -153,34 +167,13 @@ async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<(
     )
     .await;
 
-    poll_until(
-        SHORT_STEPPING_TIMEOUT,
-        Duration::from_millis(250),
-        "BatchSubmitted event after configured short L1 gap",
-        || {
-            let portal = &portal;
-            let seq = &seq;
-            async move {
-                if seq.monitor_handle.is_finished() {
-                    eyre::bail!("monitor task exited before submitting a batch");
-                }
-
-                if seq.withdrawal_handle.is_finished() {
-                    eyre::bail!("withdrawal processor exited before batch submission completed");
-                }
-
-                let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
-                if events.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some(events.len()))
-                }
-            }
-        },
-    )
-    .await?;
-
-    Ok(())
+    Ok(ShortGapHarness {
+        l1,
+        _zone: zone,
+        portal_address,
+        genesis_block,
+        seq,
+    })
 }
 
 /// Verifies that a larger configured-window gap submits multiple finalized
@@ -189,76 +182,23 @@ async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<(
 async fn test_configured_short_l1_gap_submits_multiple_batch_boundaries() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let anchor_config =
-        BatchAnchorConfig::new(SHORT_EIP2935_HISTORY_WINDOW, SHORT_EIP2935_SAFETY_MARGIN)?;
-
-    // Start L1 with fast blocks so the configured test window ages out quickly.
-    let l1 = L1TestNode::start_with(|cfg| {
-        cfg.dev.block_time = Some(Duration::from_millis(20));
-    })
-    .await?;
-
-    let portal_address = l1.deploy_zone().await?;
-    let genesis_block = l1.provider().get_block_number().await?;
-    let portal = ZonePortal::new(portal_address, l1.provider());
-    let target_block = genesis_block + SHORT_MULTI_BOUNDARY_GAP_BLOCKS;
-
-    // Mine enough L1 blocks that catching up requires several ancestry batches.
-    poll_until(
-        SHORT_STEPPING_TIMEOUT,
-        Duration::from_millis(50),
-        "L1 advanced far enough to require multiple configured ancestry batches",
-        || {
-            let provider = l1.provider();
-            async move {
-                let current = provider.get_block_number().await?;
-                if current >= target_block {
-                    Ok(Some(current))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
+    let harness = start_short_gap_harness(
+        SHORT_MULTI_BOUNDARY_GAP_BLOCKS,
+        SHORT_MULTI_BOUNDARY_BATCH_COUNT,
     )
     .await?;
+    let l1 = &harness.l1;
+    let seq = &harness.seq;
+    let portal = ZonePortal::new(harness.portal_address, l1.provider());
 
-    let zone = ZoneTestNode::start_from_l1_genesis_block(
-        l1.http_url(),
-        l1.ws_url(),
-        portal_address,
-        genesis_block,
-    )
-    .await?;
-
-    // Let the zone replay far enough to have multiple valid split boundaries.
+    // The multi-boundary target must still be below the safe L1 anchor tip.
     let multi_step_tempo =
-        genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW * SHORT_MULTI_BOUNDARY_BATCH_COUNT;
-    zone.wait_for_tempo_block_number(multi_step_tempo, SHORT_STEPPING_TIMEOUT)
-        .await?;
-
-    // Assert the first submitted boundary is genuinely outside the configured history window.
-    let first_step_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW;
+        harness.genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW * SHORT_MULTI_BOUNDARY_BATCH_COUNT;
     let l1_tip = l1.provider().get_block_number().await?;
-    eyre::ensure!(
-        l1_tip.saturating_sub(first_step_tempo) > SHORT_EIP2935_HISTORY_WINDOW,
-        "test precondition not met: first configured boundary tempo {first_step_tempo} is only {} blocks behind L1 tip {l1_tip}",
-        l1_tip.saturating_sub(first_step_tempo),
-    );
     eyre::ensure!(
         multi_step_tempo < l1_tip.saturating_sub(SHORT_EIP2935_SAFETY_MARGIN),
         "test precondition not met: multi-boundary tempo {multi_step_tempo} is not below the safe L1 anchor tip {l1_tip}",
     );
-
-    // Start the sequencer only after the backlog has accumulated.
-    let seq = spawn_sequencer_with_config(
-        &l1,
-        &zone,
-        portal_address,
-        l1.dev_signer(),
-        anchor_config,
-        zone_sequencer::WithdrawalBatchLimits::default(),
-    )
-    .await;
 
     // Wait for the boundary walk to submit the first configured catch-up batches.
     let calls = poll_until(
@@ -267,8 +207,6 @@ async fn test_configured_short_l1_gap_submits_multiple_batch_boundaries() -> eyr
         "multiple boundary BatchSubmitted events",
         || {
             let portal = &portal;
-            let seq = &seq;
-            let l1 = &l1;
             async move {
                 if seq.monitor_handle.is_finished() {
                     eyre::bail!("monitor task exited before submitting boundary batches");
@@ -335,65 +273,10 @@ async fn test_configured_short_l1_gap_submits_multiple_batch_boundaries() -> eyr
 async fn test_boundary_ancestry_submission_uses_recent_anchor() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let anchor_config =
-        BatchAnchorConfig::new(SHORT_EIP2935_HISTORY_WINDOW, SHORT_EIP2935_SAFETY_MARGIN)?;
-
-    let l1 = L1TestNode::start_with(|cfg| {
-        cfg.dev.block_time = Some(Duration::from_millis(20));
-    })
-    .await?;
-
-    let portal_address = l1.deploy_zone().await?;
-    let genesis_block = l1.provider().get_block_number().await?;
-    let portal = ZonePortal::new(portal_address, l1.provider());
-    let target_block = genesis_block + SHORT_EXTENDED_GAP_BLOCKS;
-
-    poll_until(
-        SHORT_STEPPING_TIMEOUT,
-        Duration::from_millis(50),
-        "L1 advanced past configured short EIP-2935 window",
-        || {
-            let provider = l1.provider();
-            async move {
-                let current = provider.get_block_number().await?;
-                if current >= target_block {
-                    Ok(Some(current))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
-
-    let zone = ZoneTestNode::start_from_l1_genesis_block(
-        l1.http_url(),
-        l1.ws_url(),
-        portal_address,
-        genesis_block,
-    )
-    .await?;
-
-    let first_step_tempo = genesis_block + SHORT_EIP2935_EFFECTIVE_WINDOW;
-    zone.wait_for_tempo_block_number(first_step_tempo, SHORT_STEPPING_TIMEOUT)
-        .await?;
-
-    let l1_tip = l1.provider().get_block_number().await?;
-    eyre::ensure!(
-        l1_tip.saturating_sub(first_step_tempo) > SHORT_EIP2935_HISTORY_WINDOW,
-        "test precondition not met: first configured boundary tempo {first_step_tempo} is only {} blocks behind L1 tip {l1_tip}",
-        l1_tip.saturating_sub(first_step_tempo),
-    );
-
-    let seq = spawn_sequencer_with_config(
-        &l1,
-        &zone,
-        portal_address,
-        l1.dev_signer(),
-        anchor_config,
-        zone_sequencer::WithdrawalBatchLimits::default(),
-    )
-    .await;
+    let harness = start_short_gap_harness(SHORT_EXTENDED_GAP_BLOCKS, 1).await?;
+    let l1 = &harness.l1;
+    let seq = &harness.seq;
+    let portal = ZonePortal::new(harness.portal_address, l1.provider());
 
     let (call, inclusion_block) = poll_until(
         SHORT_STEPPING_TIMEOUT,
@@ -401,8 +284,6 @@ async fn test_boundary_ancestry_submission_uses_recent_anchor() -> eyre::Result<
         "ancestry submitBatch calldata using recent anchor",
         || {
             let portal = &portal;
-            let seq = &seq;
-            let l1 = &l1;
             async move {
                 if seq.monitor_handle.is_finished() {
                     eyre::bail!("monitor task exited before submitting a batch");


### PR DESCRIPTION
Removes tests whose assertions are strict subsets of surviving tests and merges one near-identical pair. Coverage mapping — every deleted test with the survivor covering its assertions:

- `stepping_e2e::test_batch_submission_after_configured_short_l1_gap` → `test_boundary_ancestry_submission_uses_recent_anchor` (its 59-line setup was byte-identical and is now the shared `start_short_gap_harness`; "a batch was submitted" is implied by the survivor's calldata assertions)
- `e2e::test_deposit_via_queue_injection` → `test_multiple_deposits_across_blocks` (mint amounts) + `test_zone_inbox_events_on_deposit` (event emission)
- `e2e::test_empty_l1_blocks_advance_zone` → `test_tempo_state_advances_with_l1_blocks` (also asserts the hash)
- `e2e::test_large_deposit_batch` → folded into `test_multiple_deposits_across_blocks` as a third injected block carrying the ten-deposit fan-out and per-recipient assertions
- `l1_e2e::test_deposit_via_real_l1` → `test_multiasset_deposit_withdrawal` (the pathUSD round trip is its first leg)
- `earn_zone_e2e::matrix_deposit_private_private_succeeds` and `zone_lifecycle_swapped` → `matrix_redeem_private_private_succeeds` (shares assertion carried over, making it the full lifecycle test)

The two 85%-identical router-bounce tests in `l1_e2e.rs` now share one body parameterized over `RouterCallbackKind`; both test names remain. `zone_swap_slippage_bounces` is renamed to `zone_deposit_min_vault_assets_bounces` — the swap it referenced no longer exists. Each merged scenario is one fewer full L1+zone spawn in CI.

---

Stacked on #937. Next: #939.

**Test de-slop stack** (merge in order; bases retarget as predecessors merge):
1. #936 — nextest heavy-test filter
2. #937 — remove dead code and debug noise
3. #938 — consolidate redundant e2e tests ← this PR
4. #939 — split it/utils.rs into modules
5. #940 — dedupe e2e harness helpers
6. #941 — adopt shared harness helpers
7. #942 — dedupe private-RPC, WS, and earn suites
8. #943 — clean up hot suites and refresh test docs
