### PR TITLE
test: dedupe e2e harness helpers

### DIFF
--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -138,7 +138,7 @@ async fn test_zone_advances_with_real_l1() -> eyre::Result<()> {
     // the constructor's initial TokenEnabled event.
     let anchor_block_number = l1.provider().get_block_number().await?;
     let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1_at_block(
+    let zone = ZoneTestNode::start_from_l1_genesis_block(
         l1.http_url(),
         l1.ws_url(),
         portal_address,
@@ -210,7 +210,7 @@ async fn test_dev_provisioner_replays_initial_token_event() -> eyre::Result<()> 
     let latest_l1_block = l1.provider().get_block_number().await?;
     assert!(latest_l1_block > provisioned.anchor_block_number);
 
-    let zone = ZoneTestNode::start_from_l1_at_block(
+    let zone = ZoneTestNode::start_from_l1_genesis_block(
         l1.http_url(),
         l1.ws_url(),
         provisioned.portal,

--- a/crates/node/tests/it/utils/accounts.rs
+++ b/crates/node/tests/it/utils/accounts.rs
@@ -320,6 +320,39 @@ impl ZoneAccount {
         Ok(())
     }
 
+    /// Approve the portal for `token` and submit a raw `deposit` transaction,
+    /// returning the L1 inclusion block WITHOUT waiting for anything on the
+    /// zone.
+    ///
+    /// Negative-path tests use this when the deposit is expected to bounce
+    /// (or revert — the revert surfaces as this method's error).
+    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
+    pub(crate) async fn deposit_raw(
+        &mut self,
+        token: Address,
+        recipient: Address,
+        amount: u128,
+        tempo_refund_recipient: Address,
+    ) -> eyre::Result<u64> {
+        ITIP20::new(token, &self.l1_provider)
+            .approve(self.portal_address, U256::MAX)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        let receipt = ZonePortal::new(self.portal_address, &self.l1_provider)
+            .deposit(token, recipient, amount, B256::ZERO, tempo_refund_recipient)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(receipt.status(), "raw deposit transaction failed on L1");
+        receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("deposit receipt missing block number"))
+    }
+
     /// Approve the ZonePortal to spend pathUSD on L1, then deposit to a specific recipient.
     ///
     /// Waits for the expected post-deposit balance on L2 and returns it.

--- a/crates/node/tests/it/utils/l1.rs
+++ b/crates/node/tests/it/utils/l1.rs
@@ -1477,6 +1477,18 @@ impl L1TestNode {
     }
 }
 
+/// Start a real L1 dev node, deploy a zone portal on it, and start a zone node
+/// anchored to that portal, waiting for the first Tempo finalization.
+///
+/// This is the standard preamble for every real-L1 e2e test.
+pub(crate) async fn start_l1_and_zone() -> eyre::Result<(L1TestNode, ZoneTestNode, Address)> {
+    let l1 = L1TestNode::start().await?;
+    let portal_address = l1.deploy_zone().await?;
+    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
+    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    Ok((l1, zone, portal_address))
+}
+
 /// Build a zone test genesis anchored to a real L1 block — the latest one, or
 /// `at_block` when given.
 ///

--- a/crates/node/tests/it/utils/l1.rs
+++ b/crates/node/tests/it/utils/l1.rs
@@ -400,12 +400,7 @@ impl L1TestNode {
     /// This account is NOT pre-funded — use [`fund_user`](Self::fund_user) to
     /// transfer pathUSD from the dev account before depositing.
     pub(crate) fn user_signer(&self) -> alloy_signer_local::PrivateKeySigner {
-        MnemonicBuilder::<English>::default()
-            .phrase(TEST_MNEMONIC)
-            .index(1)
-            .expect("valid derivation index")
-            .build()
-            .expect("valid test mnemonic")
+        self.signer_at(1)
     }
 
     /// Returns a signer derived from [`TEST_MNEMONIC`] at the given BIP-44 index.
@@ -1006,6 +1001,8 @@ impl L1TestNode {
             .get_receipt()
             .await?;
         eyre::ensure!(receipt.status(), "setGatewayMode failed");
+        // Inverted on purpose: enabling gateway-mode enforcement closes the
+        // gateway, so `isGatewayOpen` reads as the negation of `mode`.
         eyre::ensure!(
             portal.isGatewayOpen().call().await? != mode,
             "L1 ZonePortal gateway mode did not update"
@@ -1021,23 +1018,37 @@ impl L1TestNode {
         enabled: bool,
         admin_signer: alloy_signer_local::PrivateKeySigner,
     ) -> eyre::Result<u64> {
+        self.set_role_on_portal(
+            portal_address,
+            gateway,
+            enabled.then_some(PortalRole::CallbackGateway),
+            admin_signer,
+        )
+        .await
+    }
+
+    /// Set (or clear, on `None`) `target`'s role on a portal and verify it took
+    /// effect. Returns the L1 block number after the update.
+    async fn set_role_on_portal(
+        &self,
+        portal_address: Address,
+        target: Address,
+        role: Option<PortalRole>,
+        admin_signer: alloy_signer_local::PrivateKeySigner,
+    ) -> eyre::Result<u64> {
         let provider = self.provider_with_signer(admin_signer);
         let portal = ZonePortal::new(portal_address, &provider);
-        let role = if enabled {
-            PortalRole::CallbackGateway
-        } else {
-            PortalRole::None
-        };
+        let role = role.unwrap_or(PortalRole::None);
         let receipt = portal
-            .setRole(gateway, role)
+            .setRole(target, role)
             .send()
             .await?
             .get_receipt()
             .await?;
-        eyre::ensure!(receipt.status(), "setRole for gateway failed");
+        eyre::ensure!(receipt.status(), "setRole for {target} failed");
         eyre::ensure!(
-            portal.role(gateway).call().await? as u8 == role as u8,
-            "L1 ZonePortal gateway role for {gateway} did not equal {role:?}"
+            portal.role(target).call().await? as u8 == role as u8,
+            "L1 ZonePortal role for {target} did not equal {role:?}"
         );
         Ok(provider.get_block_number().await?)
     }
@@ -1066,25 +1077,13 @@ impl L1TestNode {
         enabled: bool,
         admin_signer: alloy_signer_local::PrivateKeySigner,
     ) -> eyre::Result<u64> {
-        let provider = self.provider_with_signer(admin_signer);
-        let portal = ZonePortal::new(portal_address, &provider);
-        let role = if enabled {
-            PortalRole::Account
-        } else {
-            PortalRole::None
-        };
-        let receipt = portal
-            .setRole(account, role)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "setRole for account failed");
-        eyre::ensure!(
-            portal.role(account).call().await? as u8 == role as u8,
-            "L1 ZonePortal account role for {account} did not equal {role:?}"
-        );
-        Ok(provider.get_block_number().await?)
+        self.set_role_on_portal(
+            portal_address,
+            account,
+            enabled.then_some(PortalRole::Account),
+            admin_signer,
+        )
+        .await
     }
 
     /// Pause deposits for a token on the ZonePortal.
@@ -1260,17 +1259,17 @@ impl L1TestNode {
         Ok(())
     }
 
-    /// Create a new BLACKLIST policy on L1. Returns the policy ID.
-    pub(crate) async fn create_blacklist_policy(&self) -> eyre::Result<u64> {
+    /// Create a new TIP-403 policy on L1 owned by the dev account. Returns the policy ID.
+    async fn create_policy(&self, policy_type: ITIP403Registry::PolicyType) -> eyre::Result<u64> {
         let provider = self.dev_provider();
         let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider);
         let receipt = registry
-            .createPolicy(self.dev_address(), ITIP403Registry::PolicyType::BLACKLIST)
+            .createPolicy(self.dev_address(), policy_type)
             .send()
             .await?
             .get_receipt()
             .await?;
-        eyre::ensure!(receipt.status(), "createPolicy (BLACKLIST) failed");
+        eyre::ensure!(receipt.status(), "createPolicy failed");
 
         let event = receipt
             .inner
@@ -1282,27 +1281,16 @@ impl L1TestNode {
         Ok(event.policyId)
     }
 
+    /// Create a new BLACKLIST policy on L1. Returns the policy ID.
+    pub(crate) async fn create_blacklist_policy(&self) -> eyre::Result<u64> {
+        self.create_policy(ITIP403Registry::PolicyType::BLACKLIST)
+            .await
+    }
+
     /// Create a new WHITELIST policy on L1. Returns the policy ID.
-    #[allow(dead_code)]
     pub(crate) async fn create_whitelist_policy(&self) -> eyre::Result<u64> {
-        let provider = self.dev_provider();
-        let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider);
-        let receipt = registry
-            .createPolicy(self.dev_address(), ITIP403Registry::PolicyType::WHITELIST)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "createPolicy (WHITELIST) failed");
-
-        let event = receipt
-            .inner
-            .logs()
-            .iter()
-            .find_map(|log| ITIP403Registry::PolicyCreated::decode_log(&log.inner).ok())
-            .ok_or_else(|| eyre::eyre!("PolicyCreated event not found"))?;
-
-        Ok(event.policyId)
+        self.create_policy(ITIP403Registry::PolicyType::WHITELIST)
+            .await
     }
 
     /// Add an address to a blacklist policy.
@@ -1324,7 +1312,6 @@ impl L1TestNode {
     }
 
     /// Add an address to a whitelist policy.
-    #[allow(dead_code)]
     pub(crate) async fn whitelist_address(
         &self,
         policy_id: u64,
@@ -1340,6 +1327,26 @@ impl L1TestNode {
             .await?;
         eyre::ensure!(receipt.status(), "modifyPolicyWhitelist failed");
         Ok(())
+    }
+
+    /// Create a blacklist policy, assign it as `token`'s transfer policy, and
+    /// blacklist `account` on it. Returns the policy ID.
+    ///
+    /// This is the standard preamble for policy-bounce tests.
+    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
+    pub(crate) async fn blacklist_on_token(
+        &self,
+        token: Address,
+        account: Address,
+    ) -> eyre::Result<u64> {
+        let policy_id = self.create_blacklist_policy().await?;
+        self.change_transfer_policy_id(token, policy_id).await?;
+        self.blacklist_address(policy_id, account).await?;
+        eyre::ensure!(
+            !self.is_authorized(policy_id, account).await?,
+            "blacklisted account {account} should not be authorized by policy {policy_id}"
+        );
+        Ok(policy_id)
     }
 
     /// Change a token's transfer policy on L1.

--- a/crates/node/tests/it/utils/l1.rs
+++ b/crates/node/tests/it/utils/l1.rs
@@ -1477,45 +1477,23 @@ impl L1TestNode {
     }
 }
 
-/// Build a zone test genesis anchored to a real L1 block.
+/// Build a zone test genesis anchored to a real L1 block — the latest one, or
+/// `at_block` when given.
 ///
-/// Delegates to [`zone_node::genesis::l1_anchored_genesis`] with the latest L1 header.
+/// Delegates to [`zone_node::genesis::l1_anchored_genesis`] with that block's header.
 ///
 /// Returns `(genesis, genesis_block_number)`.
 pub(crate) async fn build_l1_anchored_genesis(
     l1_http_url: &url::Url,
     portal_address: Address,
+    at_block: Option<u64>,
 ) -> eyre::Result<(Genesis, u64)> {
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(l1_http_url.clone());
 
+    let block_number = at_block.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number);
     let block = l1_provider
-        .get_block_by_number(BlockNumberOrTag::Latest)
-        .await?
-        .ok_or_else(|| eyre::eyre!("L1 latest block not found"))?;
-    let l1_header: &TempoHeader = block.header.as_ref();
-    let default_fee_token = if portal_address.is_zero() {
-        PATH_USD_ADDRESS
-    } else {
-        ZonePortal::new(portal_address, &l1_provider)
-            .enabledTokenAt(U256::ZERO)
-            .call()
-            .await?
-    };
-    zone_node::genesis::l1_anchored_genesis(l1_header, portal_address, default_fee_token)
-}
-
-/// Build a zone test genesis anchored to a specific L1 block number.
-pub(crate) async fn build_l1_anchored_genesis_at_block(
-    l1_http_url: &url::Url,
-    portal_address: Address,
-    block_number: u64,
-) -> eyre::Result<(Genesis, u64)> {
-    let l1_provider =
-        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(l1_http_url.clone());
-
-    let block = l1_provider
-        .get_block_by_number(block_number.into())
+        .get_block_by_number(block_number)
         .await?
         .ok_or_else(|| eyre::eyre!("L1 block {block_number} not found"))?;
     let l1_header: &TempoHeader = block.header.as_ref();

--- a/crates/node/tests/it/utils/mod.rs
+++ b/crates/node/tests/it/utils/mod.rs
@@ -60,6 +60,14 @@ pub(crate) const WITHDRAWAL_TX_GAS: u64 = 10_000_000;
 /// Local test nodes finalize a withdrawal batch every this many zone blocks.
 pub(crate) const WITHDRAWAL_BATCH_INTERVAL_BLOCKS: u64 = 8;
 
+/// Timeout for operations against a real in-process L1 — its dev node produces
+/// blocks every 500ms and the L1Subscriber needs to connect, backfill, and
+/// subscribe.
+pub(crate) const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Timeout for a withdrawal to be batched, submitted, and processed on L1.
+pub(crate) const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 pub(crate) const TEST_MNEMONIC: &str =
     "test test test test test test test test test test test junk";
 

--- a/crates/node/tests/it/utils/mod.rs
+++ b/crates/node/tests/it/utils/mod.rs
@@ -66,6 +66,7 @@ pub(crate) const WITHDRAWAL_BATCH_INTERVAL_BLOCKS: u64 = 8;
 pub(crate) const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Timeout for a withdrawal to be batched, submitted, and processed on L1.
+#[allow(dead_code)] // adopted by the e2e suites in a follow-up
 pub(crate) const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 pub(crate) const TEST_MNEMONIC: &str =

--- a/crates/node/tests/it/utils/mod.rs
+++ b/crates/node/tests/it/utils/mod.rs
@@ -57,6 +57,9 @@ pub(crate) const TIP20_TX_GAS: u64 = 500_000;
 /// withdrawals.
 pub(crate) const WITHDRAWAL_TX_GAS: u64 = 10_000_000;
 
+/// Local test nodes finalize a withdrawal batch every this many zone blocks.
+pub(crate) const WITHDRAWAL_BATCH_INTERVAL_BLOCKS: u64 = 8;
+
 pub(crate) const TEST_MNEMONIC: &str =
     "test test test test test test test test test test test junk";
 

--- a/crates/node/tests/it/utils/node.rs
+++ b/crates/node/tests/it/utils/node.rs
@@ -20,7 +20,8 @@ use tempo_contracts::precompiles::ITIP20;
 use tempo_precompiles::{self, PATH_USD_ADDRESS, tip403_registry::ALLOW_ALL_POLICY_ID};
 use tempo_primitives::TempoHeader;
 use tempo_zone_contracts::{
-    TEMPO_STATE_ADDRESS, TempoState, ZONE_CONFIG_ADDRESS, ZoneConfig,
+    IZoneOutbox, TEMPO_STATE_ADDRESS, TempoState, ZONE_CONFIG_ADDRESS, ZONE_OUTBOX_ADDRESS,
+    ZoneConfig,
     ZonePortal::{self},
 };
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -322,6 +323,50 @@ impl ZoneTestNode {
             previous = current;
         }
         eyre::bail!("ZoneEngine kept producing blocks after cancellation")
+    }
+
+    /// Wait until the ZoneOutbox's `withdrawalBatchIndex` equals `expected`.
+    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
+    pub(crate) async fn wait_for_withdrawal_batch_index(
+        &self,
+        expected: u64,
+        timeout: Duration,
+    ) -> eyre::Result<()> {
+        let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, self.provider());
+        let description = format!("ZoneOutbox withdrawalBatchIndex == {expected}");
+        poll_until(timeout, DEFAULT_POLL, &description, || {
+            let outbox = &outbox;
+            async move {
+                let index = outbox.lastBatch().call().await?.withdrawalBatchIndex;
+                if index == expected {
+                    Ok(Some(()))
+                } else {
+                    Ok(None)
+                }
+            }
+        })
+        .await?;
+        Ok(())
+    }
+
+    /// Fetch the transaction that emitted `log` and decode its calldata as a
+    /// `finalizeWithdrawalBatch` call.
+    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
+    pub(crate) async fn decode_finalize_batch_call(
+        &self,
+        log: &alloy_rpc_types_eth::Log,
+    ) -> eyre::Result<IZoneOutbox::finalizeWithdrawalBatchCall> {
+        let tx_hash = log
+            .transaction_hash
+            .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?;
+        let finalize_tx = self
+            .provider()
+            .get_transaction_by_hash(tx_hash)
+            .await?
+            .ok_or_else(|| eyre::eyre!("finalizeWithdrawalBatch tx {tx_hash} not found"))?;
+        Ok(IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(
+            alloy_consensus::Transaction::input(&finalize_tx).as_ref(),
+        )?)
     }
 
     /// Returns an HTTP provider connected to this zone node.
@@ -767,7 +812,9 @@ impl ZoneTestNode {
                     zone_id: 0,
                     zone_poll_interval: Duration::from_secs(1),
                     batch_anchor_config: Default::default(),
-                    withdrawal_poll_interval: Duration::from_secs(5),
+                    // Matches spawn_sequencer_with_config so both harness paths
+                    // process withdrawals at the same cadence.
+                    withdrawal_poll_interval: Duration::from_millis(500),
                     withdrawal_batch_limits: Default::default(),
                 });
         }

--- a/crates/node/tests/it/utils/node.rs
+++ b/crates/node/tests/it/utils/node.rs
@@ -244,6 +244,39 @@ pub(crate) struct ZoneTestNode {
     _tasks: Runtime,
 }
 
+/// Parameters for [`ZoneTestNode::launch`].
+///
+/// `..Default::default()` gives a self-contained node on the dummy L1 with a
+/// fresh unique chain ID, a throwaway sequencer key, and the standard
+/// withdrawal batch interval.
+pub(crate) struct ZoneNodeParams {
+    pub(crate) l1_ws_url: String,
+    pub(crate) portal_address: Address,
+    pub(crate) chain_id: u64,
+    pub(crate) genesis: Option<Genesis>,
+    /// `None` uses a throwaway key — fine unless the test exercises encrypted
+    /// deposits or asserts on the block beneficiary.
+    pub(crate) sequencer_signer: Option<alloy_signer_local::PrivateKeySigner>,
+    pub(crate) withdrawal_batch_interval_blocks: u64,
+    pub(crate) p2p_config: Option<P2pConfig>,
+    pub(crate) spawn_engine: bool,
+}
+
+impl Default for ZoneNodeParams {
+    fn default() -> Self {
+        Self {
+            l1_ws_url: DUMMY_L1_URL.to_string(),
+            portal_address: Address::ZERO,
+            chain_id: next_unique_chain_id(),
+            genesis: None,
+            sequencer_signer: None,
+            withdrawal_batch_interval_blocks: WITHDRAWAL_BATCH_INTERVAL_BLOCKS,
+            p2p_config: None,
+            spawn_engine: true,
+        }
+    }
+}
+
 impl ZoneTestNode {
     /// Returns the HTTP RPC URL for connecting providers to this node.
     pub(crate) fn http_url(&self) -> &url::Url {
@@ -559,7 +592,12 @@ impl ZoneTestNode {
 
     /// Start a zone node pointing at a real L1 WebSocket URL.
     pub(crate) async fn start(l1_ws_url: String, portal_address: Address) -> eyre::Result<Self> {
-        Self::launch(l1_ws_url, portal_address, next_unique_chain_id()).await
+        Self::launch(ZoneNodeParams {
+            l1_ws_url,
+            portal_address,
+            ..Default::default()
+        })
+        .await
     }
 
     /// Start a zone node connected to a real L1, generating genesis from the L1's
@@ -571,40 +609,14 @@ impl ZoneTestNode {
         l1_ws_url: &url::Url,
         portal_address: Address,
     ) -> eyre::Result<Self> {
-        let (genesis, _) = build_l1_anchored_genesis(l1_http_url, portal_address).await?;
-
-        let signer = l1_dev_signer();
-        Self::launch_with_genesis(
-            l1_ws_url.to_string(),
+        let (genesis, _) = build_l1_anchored_genesis(l1_http_url, portal_address, None).await?;
+        Self::launch(ZoneNodeParams {
+            l1_ws_url: l1_ws_url.to_string(),
             portal_address,
-            next_unique_chain_id(),
-            Some(genesis),
-            signer,
-        )
-        .await
-    }
-
-    /// Start a zone node connected to a real L1, anchoring genesis to a specific L1 block.
-    pub(crate) async fn start_from_l1_at_block(
-        l1_http_url: &url::Url,
-        l1_ws_url: &url::Url,
-        portal_address: Address,
-        block_number: u64,
-    ) -> eyre::Result<Self> {
-        let (genesis, _) =
-            build_l1_anchored_genesis_at_block(l1_http_url, portal_address, block_number).await?;
-
-        let signer = l1_dev_signer();
-        Self::launch_with_genesis_and_withdrawal_batch_interval(
-            l1_ws_url.to_string(),
-            portal_address,
-            next_unique_chain_id(),
-            Some(genesis),
-            signer,
-            8,
-            None,
-            true,
-        )
+            genesis: Some(genesis),
+            sequencer_signer: Some(l1_dev_signer()),
+            ..Default::default()
+        })
         .await
     }
 
@@ -614,19 +626,15 @@ impl ZoneTestNode {
         portal_address: Address,
         withdrawal_batch_interval_blocks: u64,
     ) -> eyre::Result<Self> {
-        let (genesis, _) = build_l1_anchored_genesis(l1_http_url, portal_address).await?;
-
-        let signer = l1_dev_signer();
-        Self::launch_with_genesis_and_withdrawal_batch_interval(
-            l1_ws_url.to_string(),
+        let (genesis, _) = build_l1_anchored_genesis(l1_http_url, portal_address, None).await?;
+        Self::launch(ZoneNodeParams {
+            l1_ws_url: l1_ws_url.to_string(),
             portal_address,
-            next_unique_chain_id(),
-            Some(genesis),
-            signer,
+            genesis: Some(genesis),
+            sequencer_signer: Some(l1_dev_signer()),
             withdrawal_batch_interval_blocks,
-            None,
-            true,
-        )
+            ..Default::default()
+        })
         .await
     }
 
@@ -642,17 +650,15 @@ impl ZoneTestNode {
         genesis_block_number: u64,
     ) -> eyre::Result<Self> {
         let (genesis, _) =
-            build_l1_anchored_genesis_at_block(l1_http_url, portal_address, genesis_block_number)
+            build_l1_anchored_genesis(l1_http_url, portal_address, Some(genesis_block_number))
                 .await?;
-
-        let signer = l1_dev_signer();
-        Self::launch_with_genesis(
-            l1_ws_url.to_string(),
+        Self::launch(ZoneNodeParams {
+            l1_ws_url: l1_ws_url.to_string(),
             portal_address,
-            next_unique_chain_id(),
-            Some(genesis),
-            signer,
-        )
+            genesis: Some(genesis),
+            sequencer_signer: Some(l1_dev_signer()),
+            ..Default::default()
+        })
         .await
     }
 
@@ -663,12 +669,7 @@ impl ZoneTestNode {
     /// directly into the `deposit_queue`; the L1 state cache must be seeded
     /// via [`L1Fixture::seed_l1_cache`] for TempoState storage reads.
     pub(crate) async fn start_local() -> eyre::Result<Self> {
-        Self::launch(
-            DUMMY_L1_URL.to_string(),
-            Address::ZERO,
-            next_unique_chain_id(),
-        )
-        .await
+        Self::launch(ZoneNodeParams::default()).await
     }
 
     /// Start a self-contained zone node with a custom chain ID.
@@ -676,80 +677,42 @@ impl ZoneTestNode {
     /// Useful for running multiple zone nodes in a single test — each needs
     /// a unique chain ID to avoid datadir collisions.
     pub(crate) async fn start_local_with_chain_id(chain_id: u64) -> eyre::Result<Self> {
-        Self::launch(DUMMY_L1_URL.to_string(), Address::ZERO, chain_id).await
+        Self::launch(ZoneNodeParams {
+            chain_id,
+            ..Default::default()
+        })
+        .await
     }
 
     pub(crate) async fn start_local_with_p2p(
         l1_rpc_url: String,
         p2p_config: P2pConfig,
     ) -> eyre::Result<Self> {
-        let throwaway_key = k256::SecretKey::from_slice(&[0x01; 32])?;
-        let signer = alloy_signer_local::PrivateKeySigner::from_signing_key(throwaway_key.into());
-        Self::launch_with_genesis_and_withdrawal_batch_interval(
-            l1_rpc_url,
-            Address::ZERO,
-            next_unique_chain_id(),
-            None,
-            signer,
-            8,
-            Some(p2p_config),
-            true,
-        )
+        Self::launch(ZoneNodeParams {
+            l1_ws_url: l1_rpc_url,
+            p2p_config: Some(p2p_config),
+            ..Default::default()
+        })
         .await
     }
 
-    pub(crate) async fn launch(
-        l1_ws_url: String,
-        portal_address: Address,
-        chain_id: u64,
-    ) -> eyre::Result<Self> {
-        // Generate a throwaway signer for tests that don't use encrypted deposits.
-        let throwaway_key = k256::SecretKey::from_slice(&[0x01; 32]).expect("valid throwaway key");
-        let signer = alloy_signer_local::PrivateKeySigner::from_signing_key(throwaway_key.into());
-        Self::launch_with_genesis_and_withdrawal_batch_interval(
+    pub(crate) async fn launch(params: ZoneNodeParams) -> eyre::Result<Self> {
+        let ZoneNodeParams {
             l1_ws_url,
             portal_address,
             chain_id,
-            None,
-            signer,
-            8,
-            None,
-            true,
-        )
-        .await
-    }
-
-    async fn launch_with_genesis(
-        l1_ws_url: String,
-        portal_address: Address,
-        chain_id: u64,
-        custom_genesis: Option<Genesis>,
-        sequencer_signer: alloy_signer_local::PrivateKeySigner,
-    ) -> eyre::Result<Self> {
-        Self::launch_with_genesis_and_withdrawal_batch_interval(
-            l1_ws_url,
-            portal_address,
-            chain_id,
-            custom_genesis,
+            genesis: custom_genesis,
             sequencer_signer,
-            8,
-            None,
-            true,
-        )
-        .await
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn launch_with_genesis_and_withdrawal_batch_interval(
-        l1_ws_url: String,
-        portal_address: Address,
-        chain_id: u64,
-        custom_genesis: Option<Genesis>,
-        sequencer_signer: alloy_signer_local::PrivateKeySigner,
-        withdrawal_batch_interval_blocks: u64,
-        p2p_config: Option<P2pConfig>,
-        spawn_engine: bool,
-    ) -> eyre::Result<Self> {
+            withdrawal_batch_interval_blocks,
+            p2p_config,
+            spawn_engine,
+        } = params;
+        let sequencer_signer = sequencer_signer.unwrap_or_else(|| {
+            // Throwaway signer for tests that don't use encrypted deposits.
+            let throwaway_key =
+                k256::SecretKey::from_slice(&[0x01; 32]).expect("valid throwaway key");
+            alloy_signer_local::PrivateKeySigner::from_signing_key(throwaway_key.into())
+        });
         let tasks = Runtime::test();
         let is_local_dummy_l1 = l1_ws_url == DUMMY_L1_URL;
         let l1_ws_url = if is_local_dummy_l1 {

--- a/crates/node/tests/it/utils/p2p.rs
+++ b/crates/node/tests/it/utils/p2p.rs
@@ -292,6 +292,12 @@ pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2
             seed_blocks,
         );
     }
+    // Commonware deliberately drops messages for offline peers: give the
+    // cluster one dial interval (loopback dials every 500ms) for peer
+    // handshakes, and the bootstrap leader time to gather tip evidence from
+    // both followers, before tests start producing blocks.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     Ok(P2pCluster {
         nodes,
         p2p_public_keys: public_keys.to_vec(),

--- a/crates/node/tests/it/utils/p2p.rs
+++ b/crates/node/tests/it/utils/p2p.rs
@@ -269,16 +269,15 @@ pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2
     let mut nodes = Vec::with_capacity(3);
     for (index, config) in configs.into_iter().enumerate() {
         nodes.push(
-            ZoneTestNode::launch_with_genesis_and_withdrawal_batch_interval(
-                l1_rpc_url.clone(),
-                Address::ZERO,
+            ZoneTestNode::launch(ZoneNodeParams {
+                l1_ws_url: l1_rpc_url.clone(),
                 chain_id,
-                Some(genesis.clone()),
-                sequencer_signers[index].clone(),
-                8,
-                Some(config),
-                false,
-            )
+                genesis: Some(genesis.clone()),
+                sequencer_signer: Some(sequencer_signers[index].clone()),
+                p2p_config: Some(config),
+                spawn_engine: false,
+                ..Default::default()
+            })
             .await?,
         );
     }

--- a/crates/node/tests/it/utils/private_rpc.rs
+++ b/crates/node/tests/it/utils/private_rpc.rs
@@ -14,7 +14,15 @@ use tempo_contracts::precompiles::{
     },
 };
 use tempo_primitives::transaction::tt_signature::TempoSignature;
-use zone_node::rpc::auth::build_token_fields;
+
+/// Validity window for test auth tokens.
+const AUTH_TOKEN_TTL_SECS: u64 = 600;
+
+/// Token fields and signing digest valid from now for [`AUTH_TOKEN_TTL_SECS`].
+fn fresh_token_fields(zone_id: u32, chain_id: u64) -> ([u8; 29], B256) {
+    let now = now_secs();
+    zone_node::rpc::auth::build_token_fields(zone_id, chain_id, now, now + AUTH_TOKEN_TTL_SECS)
+}
 
 /// Build a hex-encoded authorization token for the private zone RPC.
 ///
@@ -25,19 +33,9 @@ pub(crate) fn build_auth_token(
     zone_id: u32,
     chain_id: u64,
 ) -> String {
-    let now = now_secs();
-    let expires_at = now + 600;
-
-    let (fields, digest) = build_token_fields(zone_id, chain_id, now, expires_at);
+    let (fields, digest) = fresh_token_fields(zone_id, chain_id);
     let sig = signer.sign_hash_sync(&digest).expect("signing failed");
-
-    let mut blob = Vec::with_capacity(65 + fields.len());
-    blob.extend_from_slice(&sig.r().to_be_bytes::<32>());
-    blob.extend_from_slice(&sig.s().to_be_bytes::<32>());
-    blob.push(sig.v() as u8);
-    blob.extend_from_slice(&fields);
-
-    alloy_primitives::hex::encode(&blob)
+    auth_tokens::build_secp256k1_token(&sig, &fields)
 }
 
 fn build_auth_token_with_signature(
@@ -45,17 +43,12 @@ fn build_auth_token_with_signature(
     zone_id: u32,
     chain_id: u64,
 ) -> String {
-    let now = now_secs();
-    let expires_at = now + 600;
-
-    let (fields, _) = build_token_fields(zone_id, chain_id, now, expires_at);
+    let (fields, _) = fresh_token_fields(zone_id, chain_id);
     auth_tokens::build_token_with_signature(signature, &fields)
 }
 
 fn build_p256_auth_token(signing_key: &P256SigningKey, zone_id: u32, chain_id: u64) -> String {
-    let now = now_secs();
-    let expires_at = now + 600;
-    let (_, digest) = zone_node::rpc::auth::build_token_fields(zone_id, chain_id, now, expires_at);
+    let (_, digest) = fresh_token_fields(zone_id, chain_id);
     build_auth_token_with_signature(
         sign_p256_signature(digest, signing_key).expect("p256 signing failed"),
         zone_id,
@@ -69,9 +62,7 @@ fn build_webauthn_auth_token(
     chain_id: u64,
     challenge_digest: Option<B256>,
 ) -> String {
-    let now = now_secs();
-    let expires_at = now + 600;
-    let (_, digest) = zone_node::rpc::auth::build_token_fields(zone_id, chain_id, now, expires_at);
+    let (_, digest) = fresh_token_fields(zone_id, chain_id);
     build_auth_token_with_signature(
         sign_webauthn_signature(signing_key, challenge_digest.unwrap_or(digest))
             .expect("webauthn signing failed"),
@@ -87,9 +78,7 @@ fn build_keychain_auth_token(
     zone_id: u32,
     chain_id: u64,
 ) -> (String, Address) {
-    let now = now_secs();
-    let expires_at = now + 600;
-    let (_, digest) = zone_node::rpc::auth::build_token_fields(zone_id, chain_id, now, expires_at);
+    let (_, digest) = fresh_token_fields(zone_id, chain_id);
     let (signature, key_id) = sign_keychain_signature(digest, signing_key, root_account, version)
         .expect("keychain signing failed");
 
@@ -99,89 +88,51 @@ fn build_keychain_auth_token(
     )
 }
 
-/// Send a JSON-RPC request to the private zone RPC and return the parsed response.
+static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
+    std::sync::LazyLock::new(reqwest::Client::new);
+
+/// POST a JSON-RPC request to the private zone RPC, optionally authenticated,
+/// returning the HTTP status + raw body.
 ///
-/// Returns the full JSON response body (including `jsonrpc`, `id`, `result`/`error`).
+/// The raw form is what auth-failure tests need (401/403 responses have no
+/// JSON body).
+async fn rpc_call_raw(
+    url: &url::Url,
+    method: &str,
+    params: serde_json::Value,
+    auth_token: Option<&str>,
+) -> eyre::Result<(reqwest::StatusCode, String)> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": 1
+    });
+
+    let mut request = HTTP_CLIENT.post(url.as_str()).json(&body);
+    if let Some(token) = auth_token {
+        request = request.header("x-authorization-token", token);
+    }
+    let resp = request.send().await?;
+
+    let status = resp.status();
+    let text = resp.text().await?;
+    Ok((status, text))
+}
+
+/// Send an authenticated JSON-RPC request and return the parsed response body
+/// (including `jsonrpc`, `id`, `result`/`error`).
 async fn private_rpc_call(
     url: &url::Url,
     method: &str,
     params: serde_json::Value,
     auth_token: &str,
 ) -> eyre::Result<serde_json::Value> {
-    let body = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-
-    let resp = reqwest::Client::new()
-        .post(url.as_str())
-        .header("x-authorization-token", auth_token)
-        .json(&body)
-        .send()
-        .await?;
-
-    let status = resp.status();
-    let text = resp.text().await?;
-
+    let (status, text) = rpc_call_raw(url, method, params, Some(auth_token)).await?;
     if !status.is_success() && text.is_empty() {
         eyre::bail!("HTTP {status}");
     }
-
     Ok(serde_json::from_str(&text)?)
-}
-
-/// Send a JSON-RPC request to the private zone RPC and return the HTTP status + body.
-///
-/// Useful for testing authentication failures (401/403).
-async fn private_rpc_call_raw(
-    url: &url::Url,
-    method: &str,
-    params: serde_json::Value,
-    auth_token: &str,
-) -> eyre::Result<(reqwest::StatusCode, String)> {
-    let body = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-
-    let resp = reqwest::Client::new()
-        .post(url.as_str())
-        .header("x-authorization-token", auth_token)
-        .json(&body)
-        .send()
-        .await?;
-
-    let status = resp.status();
-    let text = resp.text().await?;
-    Ok((status, text))
-}
-
-/// Send a JSON-RPC request WITHOUT any auth header.
-async fn private_rpc_call_no_auth(
-    url: &url::Url,
-    method: &str,
-    params: serde_json::Value,
-) -> eyre::Result<(reqwest::StatusCode, String)> {
-    let body = serde_json::json!({
-        "jsonrpc": "2.0",
-        "method": method,
-        "params": params,
-        "id": 1
-    });
-
-    let resp = reqwest::Client::new()
-        .post(url.as_str())
-        .json(&body)
-        .send()
-        .await?;
-
-    let status = resp.status();
-    let text = resp.text().await?;
-    Ok((status, text))
 }
 
 /// Context for private RPC e2e tests.
@@ -230,7 +181,7 @@ impl PrivateRpcL1TestCtx {
 
 impl PrivateRpcTestCtx {
     /// Build an auth token for the sequencer.
-    pub(crate) fn sequencer_token(&self) -> String {
+    fn sequencer_token(&self) -> String {
         build_auth_token(
             &self.sequencer_signer,
             self.config.zone_id,
@@ -321,7 +272,7 @@ impl PrivateRpcTestCtx {
         params: serde_json::Value,
         auth_token: &str,
     ) -> eyre::Result<(reqwest::StatusCode, String)> {
-        private_rpc_call_raw(&self.private_rpc_url, method, params, auth_token).await
+        rpc_call_raw(&self.private_rpc_url, method, params, Some(auth_token)).await
     }
 
     /// Send a JSON-RPC call with no auth header, returning HTTP status + body.
@@ -330,7 +281,7 @@ impl PrivateRpcTestCtx {
         method: &str,
         params: serde_json::Value,
     ) -> eyre::Result<(reqwest::StatusCode, String)> {
-        private_rpc_call_no_auth(&self.private_rpc_url, method, params).await
+        rpc_call_raw(&self.private_rpc_url, method, params, None).await
     }
 
     /// Inject an empty L1 block and wait for it to be processed.
@@ -469,22 +420,6 @@ async fn start_private_rpc_url(
     Ok(format!("http://{local_addr}").parse()?)
 }
 
-fn build_private_rpc_ctx(
-    zone: ZoneTestNode,
-    private_rpc_url: url::Url,
-    sequencer_signer: alloy_signer_local::PrivateKeySigner,
-    config: zone_node::rpc::PrivateRpcConfig,
-    fixture: L1Fixture,
-) -> PrivateRpcTestCtx {
-    PrivateRpcTestCtx {
-        zone,
-        private_rpc_url,
-        sequencer_signer,
-        config,
-        fixture,
-    }
-}
-
 /// Start a zone node with a private RPC server for testing.
 ///
 /// Returns a context with:
@@ -521,28 +456,19 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
 
     let private_rpc_url = start_private_rpc_url(&zone, config.clone()).await?;
 
-    Ok(build_private_rpc_ctx(
+    Ok(PrivateRpcTestCtx {
         zone,
         private_rpc_url,
         sequencer_signer,
         config,
         fixture,
-    ))
+    })
 }
 
 /// Start a zone with a private RPC server backed by a real L1 and a portal
 /// with a registered sequencer encryption key.
 pub(crate) async fn start_zone_with_private_rpc_l1() -> eyre::Result<PrivateRpcL1TestCtx> {
-    start_zone_with_private_rpc_l1_inner().await
-}
-
-async fn start_zone_with_private_rpc_l1_inner() -> eyre::Result<PrivateRpcL1TestCtx> {
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-
-    zone.wait_for_l2_tempo_finalized(0, DEFAULT_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
 
     let key = k256::SecretKey::from(l1.dev_signer().credential());
     l1.set_sequencer_encryption_key(portal_address, &key)
@@ -565,13 +491,13 @@ async fn start_zone_with_private_rpc_l1_inner() -> eyre::Result<PrivateRpcL1Test
     let sequencer_signer = l1.dev_signer();
 
     Ok(PrivateRpcL1TestCtx {
-        ctx: build_private_rpc_ctx(
+        ctx: PrivateRpcTestCtx {
             zone,
             private_rpc_url,
             sequencer_signer,
             config,
-            L1Fixture::new(),
-        ),
+            fixture: L1Fixture::new(),
+        },
         l1,
         portal_address,
     })

--- a/crates/node/tests/it/utils/private_rpc.rs
+++ b/crates/node/tests/it/utils/private_rpc.rs
@@ -88,6 +88,29 @@ fn build_keychain_auth_token(
     )
 }
 
+/// Extract `result` from a JSON-RPC response, panicking with the full response
+/// body when it is an error — so failures show what the server actually said.
+#[allow(dead_code)] // adopted by private_rpc_e2e in a follow-up
+#[track_caller]
+pub(crate) fn expect_result<'a>(
+    resp: &'a serde_json::Value,
+    context: &str,
+) -> &'a serde_json::Value {
+    resp.get("result")
+        .filter(|value| !value.is_null())
+        .unwrap_or_else(|| panic!("{context}: expected result, got: {resp}"))
+}
+
+/// Extract `error.code` from a JSON-RPC response, panicking with the full
+/// response body when the response is not an error.
+#[allow(dead_code)] // adopted by private_rpc_e2e in a follow-up
+#[track_caller]
+pub(crate) fn expect_error_code(resp: &serde_json::Value, context: &str) -> i64 {
+    resp.pointer("/error/code")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or_else(|| panic!("{context}: expected error, got: {resp}"))
+}
+
 static HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
     std::sync::LazyLock::new(reqwest::Client::new);
 

--- a/crates/node/tests/it/utils/private_rpc.rs
+++ b/crates/node/tests/it/utils/private_rpc.rs
@@ -495,12 +495,7 @@ pub(crate) async fn start_zone_with_private_rpc() -> eyre::Result<PrivateRpcTest
     let sequencer_signer = alloy_signer_local::PrivateKeySigner::random();
     let sequencer_address = sequencer_signer.address();
 
-    let zone = ZoneTestNode::launch(
-        DUMMY_L1_URL.to_string(),
-        Address::ZERO,
-        next_unique_chain_id(),
-    )
-    .await?;
+    let zone = ZoneTestNode::start_local().await?;
     let fixture = L1Fixture::new();
 
     fixture.seed_l1_cache(

--- a/crates/rpc/test-utils/auth_tokens.rs
+++ b/crates/rpc/test-utils/auth_tokens.rs
@@ -27,6 +27,19 @@ pub(crate) fn build_token_with_signature(signature: TempoSignature, fields: &[u8
     alloy_primitives::hex::encode(build_signed_token_blob(signature, fields))
 }
 
+/// Encode a secp256k1-signed token blob: `r ‖ s ‖ y_parity ‖ fields`, hex-encoded.
+pub(crate) fn build_secp256k1_token(
+    signature: &alloy_primitives::Signature,
+    fields: &[u8],
+) -> String {
+    let mut blob = Vec::with_capacity(65 + fields.len());
+    blob.extend_from_slice(&signature.r().to_be_bytes::<32>());
+    blob.extend_from_slice(&signature.s().to_be_bytes::<32>());
+    blob.push(signature.v() as u8);
+    blob.extend_from_slice(fields);
+    alloy_primitives::hex::encode(blob)
+}
+
 pub(crate) fn sign_p256_signature(
     digest: B256,
     signing_key: &P256SigningKey,

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -21,6 +21,8 @@ use zone_rpc::{
     types::{BoxEyreFut, BoxFut, JsonRpcError},
 };
 
+// Shared across three consumers; each uses a subset of its helpers.
+#[allow(dead_code)]
 #[path = "../../test-utils/auth_tokens.rs"]
 mod auth_tokens;
 


### PR DESCRIPTION
Collapses the harness's duplicated internals and adds the helpers the suites adopt in the next PRs.

The eight `ZoneTestNode` constructors funnelled through three launch layers, six of them pass-throughs differing only in hardcoded defaults, ending in an eight-positional-argument function behind `#[allow(clippy::too_many_arguments)]`. There is now one `launch(ZoneNodeParams)` with a `Default`-able params struct; the named `start_*` constructors stay as thin wrappers with unchanged signatures (29 `start_from_l1` call sites untouched). `start_from_l1_at_block` merges into `start_from_l1_genesis_block` — their bodies were identical. The copy-paste genesis-builder pair becomes one fn with `at_block: Option<u64>`, the three private-RPC POST helpers become one `rpc_call_raw(.., auth: Option<&str>)` behind a shared lazy reqwest client, the five token builders share `fresh_token_fields` with a named `AUTH_TOKEN_TTL_SECS`, the portal role setters share `set_role_on_portal`, and the blacklist/whitelist policy constructors share `create_policy`. The gateway-mode assert's inverted `isGatewayOpen` check gets an explanatory comment rather than a merge — the inversion is contract semantics, not a copy-paste bug.

New adoption-ready helpers land under temporary `allow(dead_code)` markers that the follow-up PRs remove: `start_l1_and_zone` (the real-L1 preamble), `blacklist_on_token`, `ZoneAccount::deposit_raw`, `ZoneTestNode::wait_for_withdrawal_batch_index` and `decode_finalize_batch_call`, `expect_result`/`expect_error_code`, shared `L1_TIMEOUT`/`WITHDRAWAL_TIMEOUT` constants, and `build_secp256k1_token` in the shared `auth_tokens.rs` (the r ‖ s ‖ parity ‖ fields blob is currently hand-assembled in three places). Two deliberate behavior changes to review: the single-sequencer harness path now polls withdrawals at the same 500ms as `spawn_sequencer_with_config` instead of a silently different 5s, and `start_local_p2p_cluster` waits out the Commonware peer-handshake window itself instead of every caller sleeping around it.

---

Stacked on #939. Next: #941.

**Test de-slop stack** (merge in order; bases retarget as predecessors merge):
1. #936 — nextest heavy-test filter
2. #937 — remove dead code and debug noise
3. #938 — consolidate redundant e2e tests
4. #939 — split it/utils.rs into modules
5. #940 — dedupe e2e harness helpers ← this PR
6. #941 — adopt shared harness helpers
7. #942 — dedupe private-RPC, WS, and earn suites
8. #943 — clean up hot suites and refresh test docs
