### PR TITLE
test: adopt shared harness helpers in core e2e suites

### DIFF
--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -8,11 +8,9 @@
 use std::{net::TcpListener, time::Duration};
 
 use alloy::primitives::{Address, B256, Bytes, TxKind, U256, address};
-use alloy_consensus::Transaction;
 use alloy_eips::NumHash;
 use alloy_provider::{DynProvider, Provider};
 use alloy_rpc_types_eth::TransactionRequest;
-use alloy_sol_types::SolCall;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::ITIP20;
 use tempo_precompiles::PATH_USD_ADDRESS;
@@ -23,14 +21,13 @@ use tempo_zone_contracts::{
 use zone_l1::{ChainTempoStateExt, L1Deposit, L1PortalEvents};
 
 use crate::utils::{
-    DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, WITHDRAWAL_TX_GAS, ZoneTestNode,
-    approve_outbox, leader_p2p_config, local_dev_zone_account, poll_until, seed_fixture_for_zone,
-    start_chain_id_rpc, start_local_p2p_cluster, start_local_zone_with_fixture,
+    DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, WITHDRAWAL_BATCH_INTERVAL_BLOCKS,
+    WITHDRAWAL_TX_GAS, ZoneTestNode, approve_outbox, leader_p2p_config, local_dev_zone_account,
+    poll_until, seed_fixture_for_zone, start_chain_id_rpc, start_local_p2p_cluster,
+    start_local_zone_with_fixture, submit_withdrawal, submit_withdrawals,
 };
 
 const CONTRACT_CREATION_TX_GAS: u64 = 1_000_000;
-/// Local test nodes finalize empty batches every eight zone blocks.
-const BATCH_INTERVAL_BLOCKS: u64 = 8;
 const LEADER_INCLUSION_TIMEOUT: Duration = Duration::from_secs(30);
 const P2P_RECOVERY_TIMEOUT: Duration = Duration::from_secs(45);
 
@@ -65,12 +62,6 @@ async fn test_p2p_follower_tracks_leader_balance() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(10).await?;
-
-    // Commonware deliberately drops messages for offline peers. Wait for
-    // peer dial/handshake (loopback dials every 500ms) before producing the
-    // first block. The bootstrap leader also needs tip evidence from both
-    // followers before its first promotion.
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     let mut fixture = std::mem::replace(&mut cluster.fixture, L1Fixture::new());
     let [leader, follower, _third] = cluster
@@ -255,10 +246,6 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(10).await?;
-
-    // Commonware drops messages for offline peers; wait for the dial/handshake
-    // before producing the first block (mirrors the sibling P2P test).
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // The block producer (fee recipient) must be covered by the seeded policy below.
     let producer = cluster.sequencer_signers[0].address();
@@ -767,7 +754,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
 
     let initial_batch_index = zone_outbox.lastBatch().call().await?.withdrawalBatchIndex;
 
-    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS - 1);
+    fixture.inject_empty_blocks(zone.deposit_queue(), WITHDRAWAL_BATCH_INTERVAL_BLOCKS - 1);
 
     let before_first_boundary = poll_until(
         DEFAULT_TIMEOUT,
@@ -777,7 +764,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
             let provider = zone.provider();
             async move {
                 let number = provider.get_block_number().await?;
-                if number >= BATCH_INTERVAL_BLOCKS - 1 {
+                if number >= WITHDRAWAL_BATCH_INTERVAL_BLOCKS - 1 {
                     Ok(Some(number))
                 } else {
                     Ok(None)
@@ -786,7 +773,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
         },
     )
     .await?;
-    assert_eq!(before_first_boundary, BATCH_INTERVAL_BLOCKS - 1);
+    assert_eq!(before_first_boundary, WITHDRAWAL_BATCH_INTERVAL_BLOCKS - 1);
     assert_eq!(
         zone_outbox.lastBatch().call().await?.withdrawalBatchIndex,
         initial_batch_index,
@@ -794,25 +781,10 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     );
 
     fixture.inject_empty_block(zone.deposit_queue());
-    poll_until(
-        DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
-        "first empty withdrawal batch finalized",
-        || {
-            let zone_outbox = &zone_outbox;
-            async move {
-                let idx = zone_outbox.lastBatch().call().await?.withdrawalBatchIndex;
-                if idx == initial_batch_index + 1 {
-                    Ok(Some(idx))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
+    zone.wait_for_withdrawal_batch_index(initial_batch_index + 1, DEFAULT_TIMEOUT)
+        .await?;
 
-    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS - 1);
+    fixture.inject_empty_blocks(zone.deposit_queue(), WITHDRAWAL_BATCH_INTERVAL_BLOCKS - 1);
     poll_until(
         DEFAULT_TIMEOUT,
         DEFAULT_POLL,
@@ -821,7 +793,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
             let provider = zone.provider();
             async move {
                 let number = provider.get_block_number().await?;
-                if number >= (2 * BATCH_INTERVAL_BLOCKS) - 1 {
+                if number >= (2 * WITHDRAWAL_BATCH_INTERVAL_BLOCKS) - 1 {
                     Ok(Some(number))
                 } else {
                     Ok(None)
@@ -840,29 +812,8 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
 
     fixture.inject_empty_blocks(zone.deposit_queue(), 1);
 
-    let final_batch_index = poll_until(
-        DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
-        "withdrawalBatchIndex advanced",
-        || {
-            let zone_outbox = &zone_outbox;
-            async move {
-                let idx = zone_outbox.lastBatch().call().await?.withdrawalBatchIndex;
-                if idx == initial_batch_index + 2 {
-                    Ok(Some(idx))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
-
-    assert_eq!(
-        final_batch_index,
-        initial_batch_index + 2,
-        "withdrawalBatchIndex should advance at the next block-number boundary"
-    );
+    zone.wait_for_withdrawal_batch_index(initial_batch_index + 2, DEFAULT_TIMEOUT)
+        .await?;
 
     // lastBatch should have zero withdrawalQueueHash (no withdrawals requested)
     let last_batch = zone_outbox.lastBatch().call().await?;
@@ -875,78 +826,26 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     Ok(())
 }
 
-async fn submit_withdrawal(
+/// Fund `dev_address` with pathUSD via an injected deposit and approve the
+/// ZoneOutbox to burn it for withdrawals.
+async fn fund_and_approve_outbox(
     fixture: &mut L1Fixture,
     zone: &ZoneTestNode,
     provider: &DynProvider,
     dev_address: Address,
     amount: u128,
-) -> eyre::Result<u64> {
-    submit_withdrawals(fixture, zone, provider, dev_address, &[amount]).await
-}
-
-async fn submit_withdrawals(
-    fixture: &mut L1Fixture,
-    zone: &ZoneTestNode,
-    provider: &DynProvider,
-    dev_address: Address,
-    amounts: &[u128],
-) -> eyre::Result<u64> {
-    eyre::ensure!(
-        !amounts.is_empty(),
-        "at least one withdrawal amount is required"
-    );
-
-    let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
-    let nonce = provider
-        .get_transaction_count(dev_address)
-        .pending()
-        .await?;
-    let mut pending = Vec::with_capacity(amounts.len());
-    for (offset, amount) in amounts.iter().copied().enumerate() {
-        pending.push(
-            outbox
-                .requestWithdrawal(
-                    PATH_USD_ADDRESS,
-                    dev_address,
-                    amount,
-                    B256::ZERO,
-                    0,
-                    dev_address,
-                    Bytes::new(),
-                    Bytes::new(),
-                )
-                .nonce(nonce + offset as u64)
-                .gas_price(TEMPO_T0_BASE_FEE as u128)
-                .gas(WITHDRAWAL_TX_GAS)
-                .send()
-                .await?,
-        );
-    }
-
-    fixture.inject_empty_block(zone.deposit_queue());
-    let mut withdrawal_block = None;
-    for pending_tx in pending {
-        let receipt = pending_tx.get_receipt().await?;
-        assert!(
-            receipt.status(),
-            "withdrawal should succeed (gas used: {})",
-            receipt.gas_used
-        );
-        let block_number = receipt
-            .block_number
-            .ok_or_else(|| eyre::eyre!("withdrawal receipt missing block number"))?;
-        if let Some(expected) = withdrawal_block {
-            eyre::ensure!(
-                block_number == expected,
-                "withdrawals were included in different blocks: {expected} and {block_number}"
-            );
-        } else {
-            withdrawal_block = Some(block_number);
-        }
-    }
-
-    withdrawal_block.ok_or_else(|| eyre::eyre!("withdrawal block missing"))
+) -> eyre::Result<()> {
+    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, amount);
+    fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
+    zone.wait_for_balance(
+        PATH_USD_ADDRESS,
+        dev_address,
+        U256::from(amount),
+        DEFAULT_TIMEOUT,
+    )
+    .await?;
+    approve_outbox(fixture, zone, provider).await?;
+    Ok(())
 }
 
 /// Verify a withdrawal and its batch boundary are emitted in the same block.
@@ -959,16 +858,7 @@ async fn test_withdrawal_request_finalizes_same_block() -> eyre::Result<()> {
     let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
 
     let deposit_amount: u128 = 2_000_000;
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
-    fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
-    zone.wait_for_balance(
-        PATH_USD_ADDRESS,
-        dev_address,
-        U256::from(deposit_amount),
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-    approve_outbox(&mut fixture, &zone, &provider).await?;
+    fund_and_approve_outbox(&mut fixture, &zone, &provider, dev_address, deposit_amount).await?;
 
     let batch_index_before = outbox.lastBatch().call().await?.withdrawalBatchIndex;
     let withdrawal_block =
@@ -1017,15 +907,7 @@ async fn test_withdrawal_request_finalizes_same_block() -> eyre::Result<()> {
         "withdrawal block should advance the batch index"
     );
 
-    let tx_hash = log
-        .transaction_hash
-        .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?;
-    let finalize_tx = provider
-        .get_transaction_by_hash(tx_hash)
-        .await?
-        .ok_or_else(|| eyre::eyre!("finalizeWithdrawalBatch tx {tx_hash} not found"))?;
-    let finalize_call =
-        IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(finalize_tx.input().as_ref())?;
+    let finalize_call = zone.decode_finalize_batch_call(log).await?;
     assert_eq!(
         finalize_call.count,
         U256::from(1),
@@ -1063,16 +945,7 @@ async fn test_multiple_withdrawals_finalize_in_one_batch() -> eyre::Result<()> {
     let (provider, dev_address) = local_dev_zone_account(&zone)?;
     let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
 
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, 2_000_000);
-    fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
-    zone.wait_for_balance(
-        PATH_USD_ADDRESS,
-        dev_address,
-        U256::from(2_000_000u128),
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-    approve_outbox(&mut fixture, &zone, &provider).await?;
+    fund_and_approve_outbox(&mut fixture, &zone, &provider, dev_address, 2_000_000).await?;
 
     let batch_index_before = outbox.lastBatch().call().await?.withdrawalBatchIndex;
     let withdrawal_block = submit_withdrawals(
@@ -1120,15 +993,7 @@ async fn test_multiple_withdrawals_finalize_in_one_batch() -> eyre::Result<()> {
     assert_eq!(finalized.withdrawalQueueHash, expected_hash);
     assert_eq!(finalized.withdrawalBatchIndex, batch_index_before + 1);
 
-    let tx_hash = log
-        .transaction_hash
-        .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?;
-    let finalize_tx = provider
-        .get_transaction_by_hash(tx_hash)
-        .await?
-        .ok_or_else(|| eyre::eyre!("finalizeWithdrawalBatch tx {tx_hash} not found"))?;
-    let finalize_call =
-        IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(finalize_tx.input().as_ref())?;
+    let finalize_call = zone.decode_finalize_batch_call(log).await?;
     assert_eq!(
         finalize_call.count,
         U256::from(2),
@@ -1159,35 +1024,11 @@ async fn test_current_only_block_finalizes_at_batch_boundary() -> eyre::Result<(
     let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
 
     let batch_index = outbox.lastBatch().call().await?.withdrawalBatchIndex;
-    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS);
-    poll_until(
-        DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
-        "first empty batch boundary closed",
-        || {
-            let outbox = &outbox;
-            async move {
-                let idx = outbox.lastBatch().call().await?.withdrawalBatchIndex;
-                if idx == batch_index + 1 {
-                    Ok(Some(idx))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
+    fixture.inject_empty_blocks(zone.deposit_queue(), WITHDRAWAL_BATCH_INTERVAL_BLOCKS);
+    zone.wait_for_withdrawal_batch_index(batch_index + 1, DEFAULT_TIMEOUT)
+        .await?;
 
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, 1_000_000);
-    fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
-    zone.wait_for_balance(
-        PATH_USD_ADDRESS,
-        dev_address,
-        U256::from(1_000_000u128),
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-    approve_outbox(&mut fixture, &zone, &provider).await?;
+    fund_and_approve_outbox(&mut fixture, &zone, &provider, dev_address, 1_000_000).await?;
 
     // Advance to exactly one block before the next batch boundary, then wait
     // for those quiet blocks to be built. `inject_empty_blocks` only enqueues
@@ -1195,7 +1036,7 @@ async fn test_current_only_block_finalizes_at_batch_boundary() -> eyre::Result<(
     // still-building quiet zone blocks.
     let current_block = zone.provider().get_block_number().await?;
     let quiet_blocks_until_pre_boundary =
-        (BATCH_INTERVAL_BLOCKS - 1) - (current_block % BATCH_INTERVAL_BLOCKS);
+        (WITHDRAWAL_BATCH_INTERVAL_BLOCKS - 1) - (current_block % WITHDRAWAL_BATCH_INTERVAL_BLOCKS);
     let pre_boundary_block = current_block + quiet_blocks_until_pre_boundary;
     fixture.inject_empty_blocks(zone.deposit_queue(), quiet_blocks_until_pre_boundary);
     let observed_pre_boundary = poll_until(
@@ -1219,14 +1060,17 @@ async fn test_current_only_block_finalizes_at_batch_boundary() -> eyre::Result<(
         observed_pre_boundary, pre_boundary_block,
         "zone should be exactly one block before the withdrawal boundary"
     );
-    assert_eq!((observed_pre_boundary + 1) % BATCH_INTERVAL_BLOCKS, 0);
+    assert_eq!(
+        (observed_pre_boundary + 1) % WITHDRAWAL_BATCH_INTERVAL_BLOCKS,
+        0
+    );
 
     let batch_index_before = outbox.lastBatch().call().await?.withdrawalBatchIndex;
     // The next block is a deterministic batch boundary, so it finalizes its
     // own withdrawal rather than deferring it to the following block.
     let withdrawal_block =
         submit_withdrawal(&mut fixture, &zone, &provider, dev_address, 250_000).await?;
-    assert_eq!(withdrawal_block % BATCH_INTERVAL_BLOCKS, 0);
+    assert_eq!(withdrawal_block % WITHDRAWAL_BATCH_INTERVAL_BLOCKS, 0);
 
     poll_until(
         DEFAULT_TIMEOUT,
@@ -1274,16 +1118,9 @@ async fn test_current_only_block_finalizes_at_batch_boundary() -> eyre::Result<(
         Withdrawal::queue_hash(&[withdrawal])
     );
 
-    let tx_hash = finalized_logs[0]
-        .1
-        .transaction_hash
-        .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?;
-    let finalize_tx = provider
-        .get_transaction_by_hash(tx_hash)
-        .await?
-        .ok_or_else(|| eyre::eyre!("finalizeWithdrawalBatch tx {tx_hash} not found"))?;
-    let finalize_call =
-        IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(finalize_tx.input().as_ref())?;
+    let finalize_call = zone
+        .decode_finalize_batch_call(&finalized_logs[0].1)
+        .await?;
     assert_eq!(finalize_call.count, U256::from(1));
 
     Ok(())
@@ -1304,18 +1141,7 @@ async fn test_withdrawal_request_rejects_over_max_callback_gas() -> eyre::Result
     let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &provider);
 
     let deposit_amount: u128 = 1_000_000;
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
-    fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
-
-    zone.wait_for_balance(
-        PATH_USD_ADDRESS,
-        dev_address,
-        U256::from(deposit_amount),
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-
-    approve_outbox(&mut fixture, &zone, &provider).await?;
+    fund_and_approve_outbox(&mut fixture, &zone, &provider, dev_address, deposit_amount).await?;
 
     let pending_before = outbox
         .pendingWithdrawalsCount()

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -7,17 +7,15 @@
 //! subscriber naturally receives blocks and deposits — no synthetic injection.
 
 use crate::utils::{
-    EncryptedRouterCallbackArgs, L1TestNode, PlaintextRouterCallbackArgs, PolicySeed,
-    STABLECOIN_DEX_ADDRESS, WithdrawalArgs, ZoneAccount, ZoneCreationConfig, ZoneTestNode,
-    poll_until, seed_raw_tip403_policy, seed_raw_tip403_token_policy, spawn_sequencer,
-    spawn_sequencer_with_config,
+    DEFAULT_POLL, EncryptedRouterCallbackArgs, L1_TIMEOUT, L1TestNode, PlaintextRouterCallbackArgs,
+    PolicySeed, STABLECOIN_DEX_ADDRESS, WITHDRAWAL_TIMEOUT, WithdrawalArgs, ZoneAccount,
+    ZoneCreationConfig, ZoneTestNode, poll_until, seed_raw_tip403_policy,
+    seed_raw_tip403_token_policy, spawn_sequencer, spawn_sequencer_with_config, start_l1_and_zone,
 };
 use alloy::{
     primitives::{Address, B256, U256},
     providers::Provider,
-    sol_types::SolCall,
 };
-use alloy_consensus::Transaction;
 use eyre::WrapErr as _;
 use futures::future::try_join_all;
 use std::{collections::HashMap, time::Duration};
@@ -28,9 +26,6 @@ use tempo_zone_contracts::{
 };
 use zone_node::dev::{ProvisionConfig, provision_zone};
 
-/// Longer timeout for real L1 tests — the L1 dev node produces blocks every
-/// 500ms and the L1Subscriber needs to connect, backfill, and subscribe.
-const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const ROUTER_SWAP_TICK: i16 = 0;
 const ROUTER_SWAP_AMOUNT: u128 = 100_000_000;
 const ROUTER_DEX_LIQUIDITY: u128 = 300_000_000;
@@ -126,12 +121,19 @@ async fn test_zone_advances_with_real_l1() -> eyre::Result<()> {
 
     // Verify L1 is producing blocks
     let l1_block_0 = l1.provider().get_block_number().await?;
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    let l1_block_1 = l1.provider().get_block_number().await?;
-    assert!(
-        l1_block_1 > l1_block_0,
-        "L1 should be producing blocks in dev mode"
-    );
+    poll_until(
+        L1_TIMEOUT,
+        DEFAULT_POLL,
+        "L1 producing blocks in dev mode",
+        || {
+            let provider = l1.provider();
+            async move {
+                let current = provider.get_block_number().await?;
+                Ok((current > l1_block_0).then_some(current))
+            }
+        },
+    )
+    .await?;
 
     // Match the normal provision flow by anchoring immediately before the portal deployment.
     // Startup must leave the registry empty at this anchor and let subscriber backfill process
@@ -251,10 +253,7 @@ async fn test_many_concurrent_withdrawals_are_batched() -> eyre::Result<()> {
     const WITHDRAWAL_AMOUNT: u128 = 250_000;
     const WITHDRAWAL_TIMEOUT: Duration = Duration::from_secs(120);
 
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
 
     let signers = (FIRST_ACCOUNT_INDEX..FIRST_ACCOUNT_INDEX + ACCOUNT_COUNT)
         .map(|index| l1.signer_at(index))
@@ -385,14 +384,7 @@ async fn test_many_concurrent_withdrawals_are_batched() -> eyre::Result<()> {
     let finalized_batches = outbox.BatchFinalized_filter().from_block(0).query().await?;
     let mut slot_sizes = Vec::new();
     for (_, log) in finalized_batches {
-        let tx_hash = log
-            .transaction_hash
-            .ok_or_else(|| eyre::eyre!("BatchFinalized log missing transaction hash"))?;
-        let tx = zone_provider
-            .get_transaction_by_hash(tx_hash)
-            .await?
-            .ok_or_else(|| eyre::eyre!("finalizeWithdrawalBatch tx {tx_hash} not found"))?;
-        let call = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(tx.input().as_ref())?;
+        let call = zone.decode_finalize_batch_call(&log).await?;
         slot_sizes.push(call.count.to::<usize>());
     }
     assert_eq!(
@@ -400,7 +392,11 @@ async fn test_many_concurrent_withdrawals_are_batched() -> eyre::Result<()> {
         WITHDRAWAL_COUNT,
         "finalized slots should contain every requested withdrawal"
     );
-    let largest_slot = slot_sizes.iter().copied().max().unwrap_or_default();
+    eyre::ensure!(
+        !slot_sizes.is_empty(),
+        "no finalized withdrawal batches were observed"
+    );
+    let largest_slot = slot_sizes.iter().copied().max().expect("checked non-empty");
     assert!(
         largest_slot.div_ceil(MAX_WITHDRAWALS_PER_BATCH) > TEST_MAX_IN_FLIGHT_BATCHES,
         "at least one queue slot must require refilling the in-flight window"
@@ -492,7 +488,7 @@ async fn test_open_mode_unlisted_account_roundtrip() -> eyre::Result<()> {
         portal_address,
         arbitrary_l1_recipient,
         withdrawal_amount,
-        Duration::from_secs(60),
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
 
@@ -544,7 +540,7 @@ async fn test_open_mode_unlisted_account_roundtrip() -> eyre::Result<()> {
             router,
             PATH_USD_ADDRESS,
             callback_amount,
-            Duration::from_secs(60),
+            WITHDRAWAL_TIMEOUT,
         )
         .await?;
     eyre::ensure!(
@@ -555,7 +551,7 @@ async fn test_open_mode_unlisted_account_roundtrip() -> eyre::Result<()> {
         ZONE_TOKEN_ADDRESS,
         account.address(),
         balance_after_callback_request + U256::from(callback_amount),
-        Duration::from_secs(60),
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
     l1.assert_withdrawal_processed_with_status(
@@ -576,10 +572,7 @@ async fn test_open_mode_unlisted_account_roundtrip() -> eyre::Result<()> {
 async fn test_closed_mode_rejects_unlisted_deposit_and_withdrawal_recipient() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
     zone.assert_access_enforced(true).await?;
 
     let outsider_signer = l1.signer_at(3);
@@ -761,10 +754,7 @@ async fn test_access_and_gateway_modes_are_mutable_and_independent() -> eyre::Re
 async fn test_queued_plain_withdrawal_bounces_after_recipient_revocation() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
 
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let revoked_recipient = account.address();
@@ -797,14 +787,14 @@ async fn test_queued_plain_withdrawal_bounces_after_recipient_revocation() -> ey
         ZONE_TOKEN_ADDRESS,
         account.address(),
         balance_after_queue + U256::from(bounced_amount),
-        Duration::from_secs(60),
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
     l1.wait_for_balance(
         PATH_USD_ADDRESS,
         trailing_recipient,
         trailing_l1_before + U256::from(trailing_amount),
-        Duration::from_secs(60),
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
     l1.assert_withdrawals_processed_in_order(
@@ -878,7 +868,7 @@ async fn test_queued_callback_bounces_after_gateway_revocation() -> eyre::Result
             ZONE_TOKEN_ADDRESS,
             fixture.account.address(),
             balance_after_queue + U256::from(callback_amount),
-            Duration::from_secs(60),
+            WITHDRAWAL_TIMEOUT,
         )
         .await?;
     fixture
@@ -887,7 +877,7 @@ async fn test_queued_callback_bounces_after_gateway_revocation() -> eyre::Result
             PATH_USD_ADDRESS,
             trailing_recipient,
             trailing_l1_before + U256::from(trailing_amount),
-            Duration::from_secs(60),
+            WITHDRAWAL_TIMEOUT,
         )
         .await?;
     fixture
@@ -954,7 +944,7 @@ async fn test_cross_zone_withdrawal() -> eyre::Result<()> {
     );
     account_a.withdraw_with(args_a_to_b).await?;
 
-    let cross_timeout = std::time::Duration::from_secs(60);
+    let cross_timeout = WITHDRAWAL_TIMEOUT;
     zone_b
         .wait_for_balance(
             ZONE_TOKEN_ADDRESS,
@@ -1190,7 +1180,7 @@ async fn test_swap_and_deposit_into_same_zone() -> eyre::Result<()> {
         "AlphaUSD should be burned on withdrawal before the routed deposit lands"
     );
 
-    let timeout = Duration::from_secs(60);
+    let timeout = WITHDRAWAL_TIMEOUT;
     fixture
         .zone
         .wait_for_balance(
@@ -1325,7 +1315,7 @@ async fn run_swap_and_deposit_bounce_test(kind: RouterCallbackKind) -> eyre::Res
         "AlphaUSD should leave the zone before the bounce-back is processed"
     );
 
-    let timeout = Duration::from_secs(60);
+    let timeout = WITHDRAWAL_TIMEOUT;
     fixture
         .zone
         .wait_for_balance(
@@ -1455,7 +1445,7 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
     );
 
     let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-    let withdrawal_timeout = std::time::Duration::from_secs(60);
+    let withdrawal_timeout = WITHDRAWAL_TIMEOUT;
 
     let pathusd_withdrawal: u128 = 500_000; // 0.5 pathUSD
     account.withdraw(pathusd_withdrawal).await?;
@@ -1547,7 +1537,7 @@ async fn test_encrypted_deposit_and_withdrawal() -> eyre::Result<()> {
     let withdrawal_amount: u128 = 500_000; // 0.5 pathUSD
     recipient_account.withdraw(withdrawal_amount).await?;
 
-    let withdrawal_timeout = std::time::Duration::from_secs(60);
+    let withdrawal_timeout = WITHDRAWAL_TIMEOUT;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         recipient,
@@ -1639,7 +1629,7 @@ async fn test_plaintext_deposit_policy_failure_bounces_to_tempo_refund_recipient
 -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    use tempo_contracts::precompiles::{ITIP20, ITIP403Registry::PolicyType};
+    use tempo_contracts::precompiles::ITIP403Registry::PolicyType;
 
     let l1 = L1TestNode::start().await?;
     let portal_address = l1.deploy_zone().await?;
@@ -1672,45 +1662,30 @@ async fn test_plaintext_deposit_policy_failure_bounces_to_tempo_refund_recipient
         )],
     )?;
 
-    let depositor = l1.user_signer();
+    let mut depositor = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let tempo_refund_recipient = depositor.address();
     let deposit_amount = 1_000_000u128;
     l1.fund_user(tempo_refund_recipient, deposit_amount).await?;
-    let provider = l1.provider_with_signer(depositor);
-    ITIP20::new(PATH_USD_ADDRESS, &provider)
-        .approve(portal_address, U256::MAX)
-        .send()
-        .await?
-        .get_receipt()
-        .await?;
     let refund_balance_before = l1
         .balance_of(PATH_USD_ADDRESS, tempo_refund_recipient)
         .await?;
 
     let _sequencer = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-    let portal = ZonePortal::new(portal_address, &provider);
-    let receipt = portal
-        .deposit(
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    depositor
+        .deposit_raw(
             PATH_USD_ADDRESS,
             rejected_recipient,
             deposit_amount,
-            B256::ZERO,
             tempo_refund_recipient,
         )
-        .send()
-        .await?
-        .get_receipt()
         .await?;
-    eyre::ensure!(
-        receipt.status(),
-        "plaintext L1 deposit failed before queueing"
-    );
 
     l1.wait_for_balance(
         PATH_USD_ADDRESS,
         tempo_refund_recipient,
         refund_balance_before,
-        Duration::from_secs(60),
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
     assert_eq!(
@@ -1897,27 +1872,9 @@ async fn test_blacklisted_sender_transfer_rejected() -> eyre::Result<()> {
     // Alice is blacklisted as a sender, so she can't transfer pathUSD on L1
     // herself. The dev account deposits on her behalf (recipient = allow-all).
     let deposit_amount: u128 = 1_000_000; // 1 pathUSD
-    {
-        use tempo_contracts::precompiles::ITIP20;
-        use tempo_zone_contracts::ZonePortal;
-
-        let dev_provider = l1.dev_provider();
-        ITIP20::new(PATH_USD_ADDRESS, &dev_provider)
-            .approve(portal_address, U256::MAX)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-
-        let portal = ZonePortal::new(portal_address, &dev_provider);
-        let receipt = portal
-            .deposit(PATH_USD_ADDRESS, alice, deposit_amount, B256::ZERO, alice)
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-        eyre::ensure!(receipt.status(), "L1 deposit tx failed");
-    }
+    ZoneAccount::with_signer(l1.dev_signer(), &l1, &zone, portal_address)
+        .deposit_raw(PATH_USD_ADDRESS, alice, deposit_amount, alice)
+        .await?;
 
     // Wait for the deposit to be minted on L2
     zone.wait_for_balance(
@@ -1963,18 +1920,9 @@ async fn test_deposit_to_blacklisted_recipient_reverts_on_l1() -> eyre::Result<(
     let l1 = L1TestNode::start().await?;
     let portal_address = l1.deploy_zone().await?;
 
-    let policy_id = l1.create_blacklist_policy().await?;
-    l1.change_transfer_policy_id(PATH_USD_ADDRESS, policy_id)
-        .await?;
-
     let blacklisted_recipient = l1.signer_at(2).address();
-    l1.blacklist_address(policy_id, blacklisted_recipient)
+    l1.blacklist_on_token(PATH_USD_ADDRESS, blacklisted_recipient)
         .await?;
-
-    assert!(
-        !l1.is_authorized(policy_id, blacklisted_recipient).await?,
-        "recipient should be blacklisted"
-    );
 
     // Fund a depositor (signer_at(3) — not the blacklisted recipient)
     let depositor_signer = l1.signer_at(3);

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -7,12 +7,11 @@
 //! - Withdrawals continue to be processed after a sequencer restart
 //! - Multiple restart cycles don't corrupt state
 
-use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
+use crate::utils::{
+    L1_TIMEOUT, L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer, start_l1_and_zone,
+};
 use alloy::primitives::{Address, U256};
 use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
-
-/// Longer timeout for real L1 tests.
-const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Timeout for waiting on withdrawals (includes batch submission + processing).
 const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
@@ -77,6 +76,19 @@ async fn abort_task(handle: tokio::task::JoinHandle<()>) {
     let _ = handle.await;
 }
 
+/// Abort the sequencer tasks and wait for them to wind down, then respawn —
+/// mirroring a process restart without racing the old tasks.
+async fn restart_sequencer(
+    seq: zone_sequencer::ZoneSequencerHandle,
+    l1: &L1TestNode,
+    zone: &ZoneTestNode,
+    portal_address: Address,
+) -> zone_sequencer::ZoneSequencerHandle {
+    abort_task(seq.monitor_handle).await;
+    abort_task(seq.withdrawal_handle).await;
+    spawn_sequencer(l1, zone, portal_address, l1.dev_signer()).await
+}
+
 /// Sequencer restart after a successful batch + withdrawal cycle.
 ///
 /// 1. Start L1 + zone, deposit, spawn sequencer, withdraw, wait for L1 processing.
@@ -90,10 +102,7 @@ async fn abort_task(handle: tokio::task::JoinHandle<()>) {
 async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
 
     // --- Phase 1: Deposit + first withdrawal ---
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
@@ -126,12 +135,9 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
     );
 
     // --- Phase 2: Restart sequencer ---
-    seq_handle.monitor_handle.abort();
-    seq_handle.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Respawn — should resume from portal's blockHash, not block 0
-    let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    let _seq_handle2 = restart_sequencer(seq_handle, &l1, &zone, portal_address).await;
 
     // --- Phase 3: Second withdrawal after restart ---
     let second_withdrawal: u128 = 300_000;
@@ -173,10 +179,7 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
 async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
 
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let deposit_amount: u128 = 3_000_000;
@@ -286,10 +289,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
 async fn test_double_sequencer_restart() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
 
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
     let deposit_amount: u128 = 5_000_000;
@@ -308,12 +308,8 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     )
     .await?;
 
-    seq1.monitor_handle.abort();
-    seq1.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
     // --- Cycle 2 ---
-    let seq2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    let seq2 = restart_sequencer(seq1, &l1, &zone, portal_address).await;
 
     account.withdraw(300_000).await?;
     l1.wait_for_withdrawal_on_l1(
@@ -324,12 +320,8 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     )
     .await?;
 
-    seq2.monitor_handle.abort();
-    seq2.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
     // --- Cycle 3 (final) ---
-    let _seq3 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    let _seq3 = restart_sequencer(seq2, &l1, &zone, portal_address).await;
 
     account.withdraw(400_000).await?;
     l1.wait_for_withdrawal_on_l1(
@@ -368,10 +360,7 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
 async fn test_batch_only_restart_no_withdrawals() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let l1 = L1TestNode::start().await?;
-    let portal_address = l1.deploy_zone().await?;
-    let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
-    zone.wait_for_l2_tempo_finalized(0, L1_TIMEOUT).await?;
+    let (l1, zone, portal_address) = start_l1_and_zone().await?;
 
     // Deposit to generate L2 activity but don't withdraw
     let mut account = ZoneAccount::from_l1_and_zone(&l1, &zone, portal_address);
@@ -405,16 +394,18 @@ async fn test_batch_only_restart_no_withdrawals() -> eyre::Result<()> {
 
     let _seq2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
-    // Wait for more zone blocks to be produced and batched
     // The zone produces blocks as L1 blocks arrive (every 500ms in dev mode),
-    // so just waiting a bit should produce new blocks to batch.
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-
-    let batches_after = batch_submitted_count(&l1, portal_address).await?;
-    assert!(
-        batches_after > batches_before,
-        "new batches should be submitted after restart (before={batches_before}, after={batches_after})"
-    );
+    // so new batches show up shortly after the restart.
+    crate::utils::poll_until(
+        WITHDRAWAL_TIMEOUT,
+        std::time::Duration::from_millis(200),
+        "new batches submitted after restart",
+        || async {
+            let batches_after = batch_submitted_count(&l1, portal_address).await?;
+            Ok((batches_after > batches_before).then_some(batches_after))
+        },
+    )
+    .await?;
 
     // Portal block hash should have advanced
     let hash_after = portal_block_hash(&l1, portal_address).await?;
@@ -473,10 +464,7 @@ async fn test_finalized_withdrawal_survives_sequencer_restart() -> eyre::Result<
     );
 
     // Restart the batch submitter after proving the request block finalized its withdrawal.
-    seq_handle.monitor_handle.abort();
-    seq_handle.withdrawal_handle.abort();
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    let _seq_handle2 = restart_sequencer(seq_handle, &l1, &zone, portal_address).await;
 
     l1.wait_for_withdrawal_on_l1(
         portal_address,

--- a/crates/node/tests/it/tip403_transfers.rs
+++ b/crates/node/tests/it/tip403_transfers.rs
@@ -20,7 +20,7 @@ use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS};
 
 use crate::utils::{
     DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, WITHDRAWAL_TX_GAS, approve_outbox,
-    local_dev_zone_account, start_local_zone_with_fixture,
+    local_dev_zone_account, start_local_zone_with_fixture, submit_withdrawal,
 };
 
 /// Deposit pathUSD to the dev account, then transfer a portion to Bob.
@@ -154,27 +154,14 @@ async fn test_deposit_then_request_withdrawal() -> eyre::Result<()> {
         "outbox should start with zero token balance"
     );
 
-    let withdrawal_pending = outbox
-        .requestWithdrawal(
-            PATH_USD_ADDRESS,
-            dev_address,
-            withdrawal_amount,
-            B256::ZERO,
-            0,
-            dev_address,
-            alloy_primitives::Bytes::new(),
-            alloy_primitives::Bytes::new(),
-        )
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(WITHDRAWAL_TX_GAS)
-        .send()
-        .await?;
-    fixture.inject_empty_block(zone.deposit_queue());
-    let withdrawal_receipt = withdrawal_pending.get_receipt().await?;
-    assert!(
-        withdrawal_receipt.status(),
-        "withdrawal request should succeed"
-    );
+    submit_withdrawal(
+        &mut fixture,
+        &zone,
+        &provider,
+        dev_address,
+        withdrawal_amount,
+    )
+    .await?;
 
     let balance_after = zone.balance_of(PATH_USD_ADDRESS, dev_address).await?;
     assert!(

--- a/crates/node/tests/it/utils/accounts.rs
+++ b/crates/node/tests/it/utils/accounts.rs
@@ -326,7 +326,6 @@ impl ZoneAccount {
     ///
     /// Negative-path tests use this when the deposit is expected to bounce
     /// (or revert — the revert surfaces as this method's error).
-    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
     pub(crate) async fn deposit_raw(
         &mut self,
         token: Address,

--- a/crates/node/tests/it/utils/fixture.rs
+++ b/crates/node/tests/it/utils/fixture.rs
@@ -1,10 +1,13 @@
 //! Synthetic L1 fixture for deposit-queue injection tests.
 
 use super::*;
+use alloy_provider::{DynProvider, Provider};
+use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
+use tempo_zone_contracts::IZoneOutbox;
 
 use alloy_consensus::Header;
 use alloy_eips::NumHash;
-use alloy_primitives::{Address, B256, U256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_rlp::Encodable;
 use alloy_sol_types::SolValue;
 use reth_primitives_traits::SealedHeader;
@@ -418,4 +421,81 @@ impl L1Fixture {
             memo: B256::ZERO,
         }
     }
+}
+
+/// Submit `requestWithdrawal` transactions from `dev_address` for each amount,
+/// inject one empty L1 block to include them, and return the zone block that
+/// contains them (asserting they all landed in the same block).
+pub(crate) async fn submit_withdrawal(
+    fixture: &mut L1Fixture,
+    zone: &ZoneTestNode,
+    provider: &DynProvider,
+    dev_address: Address,
+    amount: u128,
+) -> eyre::Result<u64> {
+    submit_withdrawals(fixture, zone, provider, dev_address, &[amount]).await
+}
+
+pub(crate) async fn submit_withdrawals(
+    fixture: &mut L1Fixture,
+    zone: &ZoneTestNode,
+    provider: &DynProvider,
+    dev_address: Address,
+    amounts: &[u128],
+) -> eyre::Result<u64> {
+    eyre::ensure!(
+        !amounts.is_empty(),
+        "at least one withdrawal amount is required"
+    );
+
+    let outbox = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, provider.clone());
+    let nonce = provider
+        .get_transaction_count(dev_address)
+        .pending()
+        .await?;
+    let mut pending = Vec::with_capacity(amounts.len());
+    for (offset, amount) in amounts.iter().copied().enumerate() {
+        pending.push(
+            outbox
+                .requestWithdrawal(
+                    PATH_USD_ADDRESS,
+                    dev_address,
+                    amount,
+                    B256::ZERO,
+                    0,
+                    dev_address,
+                    Bytes::new(),
+                    Bytes::new(),
+                )
+                .nonce(nonce + offset as u64)
+                .gas_price(TEMPO_T0_BASE_FEE as u128)
+                .gas(WITHDRAWAL_TX_GAS)
+                .send()
+                .await?,
+        );
+    }
+
+    fixture.inject_empty_block(zone.deposit_queue());
+    let mut withdrawal_block = None;
+    for pending_tx in pending {
+        let receipt = pending_tx.get_receipt().await?;
+        assert!(
+            receipt.status(),
+            "withdrawal should succeed (gas used: {})",
+            receipt.gas_used
+        );
+        let block_number = receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("withdrawal receipt missing block number"))?;
+        if let Some(expected) = withdrawal_block {
+            eyre::ensure!(
+                block_number == expected,
+                "withdrawals were included in different blocks: {expected} and {block_number}"
+            );
+        } else {
+            withdrawal_block = Some(block_number);
+        }
+    }
+
+    withdrawal_block.ok_or_else(|| eyre::eyre!("withdrawal block missing"))
 }

--- a/crates/node/tests/it/utils/l1.rs
+++ b/crates/node/tests/it/utils/l1.rs
@@ -1333,7 +1333,6 @@ impl L1TestNode {
     /// blacklist `account` on it. Returns the policy ID.
     ///
     /// This is the standard preamble for policy-bounce tests.
-    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
     pub(crate) async fn blacklist_on_token(
         &self,
         token: Address,

--- a/crates/node/tests/it/utils/mod.rs
+++ b/crates/node/tests/it/utils/mod.rs
@@ -66,7 +66,6 @@ pub(crate) const WITHDRAWAL_BATCH_INTERVAL_BLOCKS: u64 = 8;
 pub(crate) const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Timeout for a withdrawal to be batched, submitted, and processed on L1.
-#[allow(dead_code)] // adopted by the e2e suites in a follow-up
 pub(crate) const WITHDRAWAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 pub(crate) const TEST_MNEMONIC: &str =

--- a/crates/node/tests/it/utils/node.rs
+++ b/crates/node/tests/it/utils/node.rs
@@ -326,7 +326,6 @@ impl ZoneTestNode {
     }
 
     /// Wait until the ZoneOutbox's `withdrawalBatchIndex` equals `expected`.
-    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
     pub(crate) async fn wait_for_withdrawal_batch_index(
         &self,
         expected: u64,
@@ -351,7 +350,6 @@ impl ZoneTestNode {
 
     /// Fetch the transaction that emitted `log` and decode its calldata as a
     /// `finalizeWithdrawalBatch` call.
-    #[allow(dead_code)] // adopted by the e2e suites in a follow-up
     pub(crate) async fn decode_finalize_batch_call(
         &self,
         log: &alloy_rpc_types_eth::Log,


### PR DESCRIPTION
The adoption pass over the core suites (−395/+219): `l1_e2e.rs` uses `start_l1_and_zone`, `blacklist_on_token`, and `deposit_raw` for its repeated preambles and raw portal deposits, replaces fifteen inline 60-second literals with `WITHDRAWAL_TIMEOUT`, polls instead of sleeping to check L1 block production, and turns an `unwrap_or_default()` that would have masked "no batches finalized" into an explicit `ensure!`. `e2e.rs` replaces three copy-pasted `withdrawalBatchIndex` poll closures with `wait_for_withdrawal_batch_index` (one tautological follow-up assert died with them), the three `BatchFinalized` decode blocks with `decode_finalize_batch_call`, and its four fund+approve preambles with a local helper; both post-cluster sleeps are gone. `restart_e2e.rs` replaces the four abort-sleep(1s)-respawn sequences with a `restart_sequencer` helper that awaits task teardown via the existing `abort_task` instead of sleeping over the race, and the suite's worst flake bet — sleep(5s) then assert new batches appeared — is now a poll.

`submit_withdrawal`/`submit_withdrawals` move to `utils::fixture` and replace `tip403_transfers`' hand-rolled copy. The original plan's `withdraw_token_with` retarget was wrong for these files: injection-based tests have no `L1TestNode`, so `ZoneAccount` cannot be constructed there. Two more deliberate keeps: `stepping_e2e`'s raw-JSON `fetch_submit_batch_call` stays for now (its calls-array fallback for AA transactions needs runtime verification), and `restart_e2e` keeps its 120-second withdrawal timeout since restart cycles span two sequencer lifecycles.

---

Stacked on #940. Next: #942.

**Test de-slop stack** (merge in order; bases retarget as predecessors merge):
1. #936 — nextest heavy-test filter
2. #937 — remove dead code and debug noise
3. #938 — consolidate redundant e2e tests
4. #939 — split it/utils.rs into modules
5. #940 — dedupe e2e harness helpers
6. #941 — adopt shared harness helpers ← this PR
7. #942 — dedupe private-RPC, WS, and earn suites
8. #943 — clean up hot suites and refresh test docs
