### PR TITLE
test: dedupe private-RPC, WS, and earn suites

### DIFF
--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -78,6 +78,9 @@ alloy_sol_types::sol! {
         ExcessReturnFee excess;
     }
 
+    // Mirrors `tempo_zone_contracts::EncryptedDepositPayload`; sol! cannot
+    // reference externally generated types in struct fields, so the layout is
+    // redeclared here and converted by `map_encrypted_payload`.
     struct EarnEncryptedDepositPayload {
         bytes32 ephemeralPubkeyX;
         uint8 ephemeralPubkeyYParity;
@@ -721,7 +724,6 @@ impl EarnZoneFixture {
     async fn callback_data(
         &self,
         flow: EarnFlow,
-        _output_token: Address,
         recipient: Address,
         refund_recipient: Address,
         limits: EarnLimits,
@@ -896,13 +898,7 @@ impl EarnZoneFixture {
         let portal_before = self.l1.balance_of(self.earn_share, self.portal).await?;
         let limits = self.deposit_limits(input_token, AMOUNT).await?;
         let data = self
-            .callback_data(
-                EarnFlow::Deposit,
-                self.earn_share,
-                recipient,
-                self.user.address(),
-                limits,
-            )
+            .callback_data(EarnFlow::Deposit, recipient, self.user.address(), limits)
             .await?;
         self.user
             .withdraw_token_with(
@@ -966,13 +962,7 @@ impl EarnZoneFixture {
         limits: EarnLimits,
     ) -> eyre::Result<()> {
         let data = self
-            .callback_data(
-                EarnFlow::Deposit,
-                self.earn_share,
-                recipient,
-                self.user.address(),
-                limits,
-            )
+            .callback_data(EarnFlow::Deposit, recipient, self.user.address(), limits)
             .await?;
         self.zone_deposit_with_data_expect_callback_bounce(input_token, recipient, data)
             .await
@@ -1092,7 +1082,6 @@ impl EarnZoneFixture {
         let data = self
             .callback_data(
                 EarnFlow::Deposit,
-                self.earn_share,
                 recipient,
                 self.user.address(),
                 EarnLimits::default(),
@@ -1193,13 +1182,7 @@ impl EarnZoneFixture {
         let portal_before = self.l1.balance_of(output_token, self.portal).await?;
         let limits = self.redeem_limits(shares, output_token).await?;
         let data = self
-            .callback_data(
-                EarnFlow::Redeem,
-                output_token,
-                recipient,
-                account.address(),
-                limits,
-            )
+            .callback_data(EarnFlow::Redeem, recipient, account.address(), limits)
             .await?;
         account
             .withdraw_token_with(
@@ -1403,14 +1386,30 @@ impl EarnZoneFixture {
             .call()
             .await?;
 
-        assert_eq!(venue_after - user_venue_after, venue_shares);
-        assert_eq!(engine_venue_after - engine_venue_before, venue_shares);
+        assert_eq!(
+            venue_after - user_venue_after,
+            venue_shares,
+            "migrated venue shares should leave the user's venue balance"
+        );
+        assert_eq!(
+            engine_venue_after - engine_venue_before,
+            venue_shares,
+            "engine venue balance should grow by the migrated shares"
+        );
         assert_eq!(
             public_after, public_before,
             "migrated EarnShare remained public"
         );
-        assert_eq!(supply_after - supply_before, earn_shares);
-        assert_eq!(private_after - private_before, earn_shares);
+        assert_eq!(
+            supply_after - supply_before,
+            earn_shares,
+            "EarnShare supply should grow by the minted shares"
+        );
+        assert_eq!(
+            private_after - private_before,
+            earn_shares,
+            "the user's private EarnShare balance should grow by the minted shares"
+        );
 
         Ok(earn_shares_u128)
     }
@@ -1858,11 +1857,15 @@ async fn matrix_redeem_public_public_succeeds() -> eyre::Result<()> {
     Ok(())
 }
 
+/// The retired public-to-private router surfaces (`depositToZone` and
+/// `redeemToZone`) are no longer callable.
 #[tokio::test(flavor = "multi_thread")]
-async fn matrix_deposit_public_private_rejects_retired_router_surface() -> eyre::Result<()> {
+async fn matrix_public_private_retired_router_surfaces_reject() -> eyre::Result<()> {
     let fixture = EarnZoneFixture::start().await?;
     let user = fixture.user.address();
-    let result = LegacyUniversalEarnRouter::new(fixture.router, fixture.user.l1_provider())
+    let router = LegacyUniversalEarnRouter::new(fixture.router, fixture.user.l1_provider());
+
+    let result = router
         .depositToZone(
             fixture.earn_vault,
             U256::from(AMOUNT),
@@ -1875,14 +1878,8 @@ async fn matrix_deposit_public_private_rejects_retired_router_surface() -> eyre:
         result.is_err(),
         "retired public-to-private deposit surface remained callable"
     );
-    Ok(())
-}
 
-#[tokio::test(flavor = "multi_thread")]
-async fn matrix_redeem_public_private_rejects_retired_router_surface() -> eyre::Result<()> {
-    let fixture = EarnZoneFixture::start().await?;
-    let user = fixture.user.address();
-    let result = LegacyUniversalEarnRouter::new(fixture.router, fixture.user.l1_provider())
+    let result = router
         .redeemToZone(
             fixture.earn_vault,
             U256::from(AMOUNT),

--- a/crates/node/tests/it/private_rpc.rs
+++ b/crates/node/tests/it/private_rpc.rs
@@ -198,14 +198,11 @@ fn tempo_signature_roundtrip_p256_from_token_bytes() {
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
     let (fields, digest) = build_token_fields(1, 2, now, now + 600);
-    let expected = sign_p256_signature(digest, &signing_key)
-        .expect("p256 signing should succeed")
+    let signature = sign_p256_signature(digest, &signing_key).expect("p256 signing should succeed");
+    let expected = signature
         .recover_signer(&digest)
         .expect("p256 recovery should succeed");
-    let blob = build_signed_token_blob(
-        sign_p256_signature(digest, &signing_key).expect("p256 signing should succeed"),
-        &fields,
-    );
+    let blob = build_signed_token_blob(signature, &fields);
     let token = AuthorizationToken::parse(&blob).unwrap();
     let parsed = TempoSignature::from_bytes(&token.signature).unwrap();
 

--- a/crates/node/tests/it/private_rpc_e2e.rs
+++ b/crates/node/tests/it/private_rpc_e2e.rs
@@ -8,7 +8,7 @@
 //! - Method tier enforcement (restricted/disabled/unknown methods)
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, build_auth_token, now_secs,
+    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, build_auth_token, expect_error_code, now_secs,
     start_zone_with_private_rpc, start_zone_with_private_rpc_l1,
 };
 use alloy::{
@@ -103,18 +103,15 @@ fn signed_sponsored_raw_transaction(
 }
 
 fn assert_filter_not_found_error(response: &serde_json::Value) {
-    let error = response
-        .get("error")
-        .unwrap_or_else(|| panic!("expected filter-not-found error, got {response}"));
     assert_eq!(
-        error["code"].as_i64().unwrap(),
+        expect_error_code(response, "filter-not-found"),
         -32602,
-        "filter-not-found should surface as invalid params",
+        "filter-not-found should surface as invalid params: {response}",
     );
     assert_eq!(
-        error["message"].as_str().unwrap(),
-        "filter not found",
-        "filter-not-found message should be stable",
+        response["error"]["message"].as_str(),
+        Some("filter not found"),
+        "filter-not-found message should be stable: {response}",
     );
 }
 
@@ -246,34 +243,52 @@ async fn ws_collect_messages_until_quiet(
     }
 }
 
-/// Auth enforcement: missing header → 401, garbage token → 401/403, wrong chain ID → 403.
+/// Auth-token acceptance and rejection over HTTP: valid P256 and WebAuthn
+/// tokens authenticate, while missing, garbage, wrong-chain-ID, corrupted
+/// P256, and wrong-challenge WebAuthn tokens are refused.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_auth_rejection() -> eyre::Result<()> {
+async fn test_auth_token_acceptance_and_rejection() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let ctx = start_zone_with_private_rpc().await?;
+    let p256_signer = P256SigningKey::random(&mut thread_rng());
+    let webauthn_signer = P256SigningKey::random(&mut thread_rng());
 
-    // No auth header → 401
+    for (label, token) in [
+        ("p256", ctx.p256_token(&p256_signer)),
+        ("webauthn", ctx.webauthn_token(&webauthn_signer)),
+    ] {
+        let resp = ctx
+            .call("eth_blockNumber", serde_json::json!([]), &token)
+            .await?;
+        assert!(
+            resp.get("error").is_none() && resp["result"].as_str().is_some(),
+            "{label} token should authenticate: {resp}"
+        );
+    }
+
     let (status, _) = ctx
         .call_no_auth("eth_blockNumber", serde_json::json!([]))
         .await?;
     assert_eq!(status.as_u16(), 401, "missing auth should return 401");
 
-    // Garbage token → 401 or 403
-    let (status, _) = ctx
-        .call_raw("eth_blockNumber", serde_json::json!([]), "deadbeef")
-        .await?;
-    assert!(
-        status.as_u16() == 401 || status.as_u16() == 403,
-        "invalid auth should return 401 or 403, got {status}"
-    );
-
-    // Valid signature but wrong chain ID → 403
-    let bad_token = build_auth_token(&ctx.sequencer_signer, 1, ctx.config.chain_id + 1);
-    let (status, _) = ctx
-        .call_raw("eth_blockNumber", serde_json::json!([]), &bad_token)
-        .await?;
-    assert_eq!(status.as_u16(), 403, "wrong chain ID should return 403");
+    let wrong_chain_id = build_auth_token(&ctx.sequencer_signer, 1, ctx.config.chain_id + 1);
+    let bad_p256 = corrupt_token_hex(&ctx.p256_token(&p256_signer));
+    let bad_webauthn = ctx.webauthn_token_with_challenge(&webauthn_signer, B256::repeat_byte(0x77));
+    for (label, token, expected) in [
+        ("garbage token", "deadbeef".to_string(), &[401u16, 403][..]),
+        ("wrong chain ID", wrong_chain_id, &[403]),
+        ("corrupted p256", bad_p256, &[403]),
+        ("webauthn wrong challenge", bad_webauthn, &[403]),
+    ] {
+        let (status, _) = ctx
+            .call_raw("eth_blockNumber", serde_json::json!([]), &token)
+            .await?;
+        assert!(
+            expected.contains(&status.as_u16()),
+            "{label}: expected one of {expected:?}, got {status}"
+        );
+    }
 
     Ok(())
 }
@@ -323,63 +338,6 @@ async fn test_send_raw_transaction_requires_enabled_token_balance() -> eyre::Res
     assert!(
         response["result"].as_str().is_some(),
         "funded sender transaction should be accepted: {response}",
-    );
-
-    Ok(())
-}
-
-/// Real P256 and WebAuthn auth tokens are accepted by the private RPC.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_non_secp_auth_tokens() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let ctx = start_zone_with_private_rpc().await?;
-    let p256_signer = P256SigningKey::random(&mut thread_rng());
-    let webauthn_signer = P256SigningKey::random(&mut thread_rng());
-
-    for token in [
-        ctx.p256_token(&p256_signer),
-        ctx.webauthn_token(&webauthn_signer),
-    ] {
-        let resp = ctx
-            .call("eth_blockNumber", serde_json::json!([]), &token)
-            .await?;
-        assert!(
-            resp.get("error").is_none(),
-            "auth token should succeed: {resp}"
-        );
-        assert!(
-            resp["result"].as_str().is_some(),
-            "expected block number result"
-        );
-    }
-
-    Ok(())
-}
-
-/// Invalid P256 signatures and WebAuthn challenge mismatches are rejected.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_invalid_non_secp_auth_tokens_are_rejected() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let ctx = start_zone_with_private_rpc().await?;
-    let p256_signer = P256SigningKey::random(&mut thread_rng());
-    let webauthn_signer = P256SigningKey::random(&mut thread_rng());
-
-    let bad_p256 = corrupt_token_hex(&ctx.p256_token(&p256_signer));
-    let (status, _) = ctx
-        .call_raw("eth_blockNumber", serde_json::json!([]), &bad_p256)
-        .await?;
-    assert_eq!(status.as_u16(), 403, "invalid P256 token should return 403");
-
-    let bad_webauthn = ctx.webauthn_token_with_challenge(&webauthn_signer, B256::repeat_byte(0x77));
-    let (status, _) = ctx
-        .call_raw("eth_blockNumber", serde_json::json!([]), &bad_webauthn)
-        .await?;
-    assert_eq!(
-        status.as_u16(),
-        403,
-        "WebAuthn token with wrong challenge should return 403",
     );
 
     Ok(())
@@ -499,6 +457,8 @@ async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
         now_secs() + 1,
     )
     .await?;
+    // The key's expiry is on-chain state compared against wall-clock time by
+    // the precompile, so the test genuinely has to outwait it.
     sleep(std::time::Duration::from_secs(2)).await;
     let (status, _) = ctx
         .call_raw("eth_blockNumber", serde_json::json!([]), &expired_token)
@@ -531,45 +491,6 @@ async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
         403,
         "signature-type mismatch should return 403",
     );
-
-    Ok(())
-}
-
-/// Public methods work for both sequencer and users without leaking private fee activity.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_public_methods() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let ctx = start_zone_with_private_rpc().await?;
-    let user_signer = PrivateKeySigner::random();
-
-    for method in ["eth_blockNumber", "eth_chainId"] {
-        let seq_resp = ctx.call_as_sequencer(method, serde_json::json!([])).await?;
-        assert!(
-            seq_resp.get("result").is_some() && seq_resp.get("error").is_none(),
-            "sequencer should succeed for {method}"
-        );
-
-        let user_resp = ctx
-            .call_as_user(method, serde_json::json!([]), &user_signer)
-            .await?;
-        assert!(
-            user_resp.get("result").is_some() && user_resp.get("error").is_none(),
-            "user should succeed for {method}"
-        );
-    }
-
-    for (method, expected) in [
-        ("eth_gasPrice", U256::from(TEMPO_T1_BASE_FEE)),
-        ("eth_maxPriorityFeePerGas", U256::ZERO),
-    ] {
-        for response in [
-            ctx.call_as_sequencer(method, json!([])).await?,
-            ctx.call_as_user(method, json!([]), &user_signer).await?,
-        ] {
-            assert_eq!(response["result"], json!(format!("{expected:#x}")));
-        }
-    }
 
     Ok(())
 }
@@ -1045,13 +966,42 @@ async fn test_block_access_control() -> eyre::Result<()> {
 }
 
 /// Method tier enforcement: restricted → -32005 for all callers,
-/// disabled → -32006 for everyone, unknown → -32601.
+/// disabled → -32006 for everyone, unknown → -32601, and public methods
+/// succeed for both callers without leaking private fee activity.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_method_tiers() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let ctx = start_zone_with_private_rpc().await?;
     let user_signer = PrivateKeySigner::random();
+
+    for method in ["eth_blockNumber", "eth_chainId"] {
+        let seq_resp = ctx.call_as_sequencer(method, serde_json::json!([])).await?;
+        assert!(
+            seq_resp.get("result").is_some() && seq_resp.get("error").is_none(),
+            "sequencer should succeed for {method}"
+        );
+
+        let user_resp = ctx
+            .call_as_user(method, serde_json::json!([]), &user_signer)
+            .await?;
+        assert!(
+            user_resp.get("result").is_some() && user_resp.get("error").is_none(),
+            "user should succeed for {method}"
+        );
+    }
+
+    for (method, expected) in [
+        ("eth_gasPrice", U256::from(TEMPO_T1_BASE_FEE)),
+        ("eth_maxPriorityFeePerGas", U256::ZERO),
+    ] {
+        for response in [
+            ctx.call_as_sequencer(method, json!([])).await?,
+            ctx.call_as_user(method, json!([]), &user_signer).await?,
+        ] {
+            assert_eq!(response["result"], json!(format!("{expected:#x}")));
+        }
+    }
 
     // Restricted methods → -32005 for all callers
     for method in [
@@ -1064,11 +1014,8 @@ async fn test_method_tiers() -> eyre::Result<()> {
         let resp = ctx
             .call_as_user(method, serde_json::json!([]), &user_signer)
             .await?;
-        let error = resp
-            .get("error")
-            .unwrap_or_else(|| panic!("{method} should return error"));
         assert_eq!(
-            error["code"].as_i64().unwrap(),
+            expect_error_code(&resp, method),
             -32005,
             "{method} should return -32005"
         );
@@ -1084,11 +1031,8 @@ async fn test_method_tiers() -> eyre::Result<()> {
         let resp = ctx
             .call_as_user(method, serde_json::json!([]), &user_signer)
             .await?;
-        let error = resp
-            .get("error")
-            .unwrap_or_else(|| panic!("{method} should return error"));
         assert_eq!(
-            error["code"].as_i64().unwrap(),
+            expect_error_code(&resp, method),
             -32006,
             "{method} should return -32006 (Method disabled)"
         );
@@ -1102,11 +1046,8 @@ async fn test_method_tiers() -> eyre::Result<()> {
             &user_signer,
         )
         .await?;
-    let error = resp
-        .get("error")
-        .expect("unknown method should return error");
     assert_eq!(
-        error["code"].as_i64().unwrap(),
+        expect_error_code(&resp, "unknown method"),
         -32601,
         "unknown method should return -32601"
     );
@@ -1298,7 +1239,7 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
             .iter()
             .map(|token| token.as_str().unwrap())
             .collect::<Vec<_>>(),
-        vec!["0x20c0000000000000000000000000000000000000"],
+        vec![format!("{PATH_USD_ADDRESS:#x}")],
     );
     assert_eq!(
         zone_info["result"]["chainId"].as_str().unwrap(),
@@ -1313,26 +1254,15 @@ async fn test_zone_metadata_methods() -> eyre::Result<()> {
         format!("0x{tempo_block_number:x}"),
     );
 
-    Ok(())
-}
-
-/// `zone_getZoneInfo` returns every token currently enabled on the portal.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_zone_get_zone_info_returns_all_enabled_tokens() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let ctx = start_zone_with_private_rpc_l1().await?;
-    let user_signer = PrivateKeySigner::random();
+    // Newly enabled portal tokens show up in zoneTokens.
     let alpha_salt = B256::with_last_byte(0x44);
     let alpha_token = ctx
         .l1()
         .create_tip20("AlphaUSD", "aUSD", alpha_salt)
         .await?;
-
     ctx.l1()
         .enable_token_on_portal(ctx.portal_address(), alpha_token)
         .await?;
-
     let zone_info = ctx
         .call_as_user("zone_getZoneInfo", serde_json::json!([]), &user_signer)
         .await?;
@@ -1342,7 +1272,6 @@ async fn test_zone_get_zone_info_returns_all_enabled_tokens() -> eyre::Result<()
         .iter()
         .map(|token| token.as_str().unwrap().to_owned())
         .collect::<Vec<_>>();
-
     assert_eq!(
         zone_tokens,
         vec![

--- a/crates/node/tests/it/utils/private_rpc.rs
+++ b/crates/node/tests/it/utils/private_rpc.rs
@@ -103,7 +103,6 @@ pub(crate) fn expect_result<'a>(
 
 /// Extract `error.code` from a JSON-RPC response, panicking with the full
 /// response body when the response is not an error.
-#[allow(dead_code)] // adopted by private_rpc_e2e in a follow-up
 #[track_caller]
 pub(crate) fn expect_error_code(resp: &serde_json::Value, context: &str) -> i64 {
     resp.pointer("/error/code")

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -57,24 +57,21 @@ impl MockZoneRpcApi {
         );
         Self {
             key_infos: Mutex::new(key_infos),
-            key_lookup_error: None,
-            ws_subscriptions_enabled: false,
+            ..Default::default()
         }
     }
 
     fn with_key_lookup_error(message: &'static str) -> Self {
         Self {
-            key_infos: Mutex::new(HashMap::new()),
             key_lookup_error: Some(message),
-            ws_subscriptions_enabled: false,
+            ..Default::default()
         }
     }
 
     fn with_ws_subscriptions() -> Self {
         Self {
-            key_infos: Mutex::new(HashMap::new()),
-            key_lookup_error: None,
             ws_subscriptions_enabled: true,
+            ..Default::default()
         }
     }
 
@@ -276,20 +273,19 @@ impl TestContext {
     fn build_token_expiring_at(&self, issued_at: u64, expires_at: u64) -> String {
         let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, issued_at, expires_at);
         let sig = self.signer.sign_hash_sync(&digest).expect("signing failed");
-
-        let mut blob = Vec::with_capacity(65 + fields.len());
-        blob.extend_from_slice(&sig.r().to_be_bytes::<32>());
-        blob.extend_from_slice(&sig.s().to_be_bytes::<32>());
-        blob.push(sig.v() as u8);
-        blob.extend_from_slice(&fields);
-
-        alloy_primitives::hex::encode(&blob)
+        auth_tokens::build_secp256k1_token(&sig, &fields)
     }
 
     fn ws_url(&self) -> String {
         format!("ws://{}", self.addr)
     }
 }
+
+/// JSON-RPC error codes asserted by these tests.
+const PARSE_ERROR: i64 = -32700;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+const SUBSCRIPTIONS_DISABLED: i64 = -32006;
 
 /// Build a JSON-RPC request string.
 fn jsonrpc(method: &str, id: u64) -> String {
@@ -300,10 +296,54 @@ fn jsonrpc_with_params(method: &str, params: Value, id: u64) -> String {
     serde_json::json!({"jsonrpc":"2.0","method":method,"params":params,"id":id}).to_string()
 }
 
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// Send a JSON-RPC request and return the parsed response.
+async fn request(ws: &mut WsStream, method: &str, params: Value, id: u64) -> Value {
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params(method, params, id).into(),
+    ))
+    .await
+    .expect("ws send failed");
+    parse_response(ws.next().await.expect("ws stream ended").expect("ws error"))
+}
+
+/// Like [`request`], but skips interleaved subscription notifications until
+/// the response with the matching id arrives.
+async fn request_skipping_notifications(
+    ws: &mut WsStream,
+    method: &str,
+    params: Value,
+    id: u64,
+) -> Value {
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params(method, params, id).into(),
+    ))
+    .await
+    .expect("ws send failed");
+    loop {
+        let message = parse_response(ws.next().await.expect("ws stream ended").expect("ws error"));
+        if message["id"] == id {
+            break message;
+        }
+    }
+}
+
+/// Assert the server terminated the socket: a Close frame, a clean stream end,
+/// or an abrupt reset — anything but a successfully delivered frame.
+fn assert_socket_terminated(event: Option<Result<tungstenite::Message, tungstenite::Error>>) {
+    assert!(
+        matches!(
+            event,
+            None | Some(Ok(tungstenite::Message::Close(_))) | Some(Err(_))
+        ),
+        "expected the server to terminate the socket, got {event:?}"
+    );
+}
+
 /// Connect to the WS endpoint using the X-Authorization-Token header.
-async fn connect_with_header(
-    ctx: &TestContext,
-) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+async fn connect_with_header(ctx: &TestContext) -> WsStream {
     let token = ctx.build_token();
     connect_with_token(&ctx.ws_url(), ctx.addr, &token)
         .await
@@ -314,10 +354,7 @@ async fn connect_with_token(
     ws_url: &str,
     addr: std::net::SocketAddr,
     token: &str,
-) -> Result<
-    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
-    tungstenite::Error,
-> {
+) -> Result<WsStream, tungstenite::Error> {
     let req = tungstenite::http::Request::builder()
         .uri(ws_url)
         .header("x-authorization-token", token)
@@ -352,12 +389,7 @@ async fn ws_roundtrip_with_header_auth() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_blockNumber", 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_blockNumber", json!([]), 1).await;
 
     assert_eq!(resp["id"], 1);
     assert_eq!(resp["result"], "0x42");
@@ -371,12 +403,7 @@ async fn ws_roundtrip_with_query_auth() {
 
     let (mut ws, _) = connect_async(&url).await.expect("ws connect failed");
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_blockNumber", 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_blockNumber", json!([]), 1).await;
 
     assert_eq!(resp["id"], 1);
     assert_eq!(resp["result"], "0x42");
@@ -398,21 +425,7 @@ async fn ws_reject_no_auth() {
 #[tokio::test]
 async fn ws_reject_invalid_token() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
-    let req = tungstenite::http::Request::builder()
-        .uri(ctx.ws_url())
-        .header("x-authorization-token", "deadbeef")
-        .header(
-            "sec-websocket-key",
-            tungstenite::handshake::client::generate_key(),
-        )
-        .header("host", ctx.addr.to_string())
-        .header("upgrade", "websocket")
-        .header("connection", "upgrade")
-        .header("sec-websocket-version", "13")
-        .body(())
-        .unwrap();
-
-    let err = connect_async(req)
+    let err = connect_with_token(&ctx.ws_url(), ctx.addr, "deadbeef")
         .await
         .expect_err("should fail with bad token");
     let tungstenite::Error::Http(response) = err else {
@@ -470,7 +483,7 @@ async fn ws_invalid_json() {
         .unwrap();
     let resp = parse_response(ws.next().await.unwrap().unwrap());
 
-    assert_eq!(resp["error"]["code"], -32700);
+    assert_eq!(resp["error"]["code"], PARSE_ERROR);
 }
 
 #[tokio::test]
@@ -478,13 +491,10 @@ async fn ws_unknown_method() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(jsonrpc("eth_foobar", 1).into()))
-        .await
-        .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_foobar", json!([]), 1).await;
 
     assert_eq!(resp["id"], 1);
-    assert_eq!(resp["error"]["code"], -32601);
+    assert_eq!(resp["error"]["code"], METHOD_NOT_FOUND);
 }
 
 #[tokio::test]
@@ -492,15 +502,10 @@ async fn ws_disabled_subscription_method() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_subscribe", json!(["newHeads"]), 1).await;
 
     assert_eq!(resp["id"], 1);
-    assert_eq!(resp["error"]["code"], -32006);
+    assert_eq!(resp["error"]["code"], SUBSCRIPTIONS_DISABLED);
 }
 
 #[tokio::test]
@@ -508,12 +513,7 @@ async fn ws_subscribe_new_heads_emits_redacted_headers() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_subscribe", json!(["newHeads"]), 1).await;
 
     assert_eq!(resp["id"], 1);
     let subscription_id = resp["result"].as_str().expect("subscription id");
@@ -550,12 +550,7 @@ async fn ws_subscribe_logs_emits_notifications() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["logs", {}]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_subscribe", json!(["logs", {}]), 1).await;
 
     assert_eq!(resp["id"], 1);
     let subscription_id = resp["result"].as_str().expect("subscription id");
@@ -582,15 +577,10 @@ async fn ws_subscribe_pending_transactions_is_disabled() {
         (2, json!(["newPendingTransactions", true])),
         (3, json!(["newPendingTransactions", {}])),
     ] {
-        ws.send(tungstenite::Message::Text(
-            jsonrpc_with_params("eth_subscribe", params, id).into(),
-        ))
-        .await
-        .unwrap();
-        let resp = parse_response(ws.next().await.unwrap().unwrap());
+        let resp = request(&mut ws, "eth_subscribe", params, id).await;
 
         assert_eq!(resp["id"], id);
-        assert_eq!(resp["error"]["code"], -32006);
+        assert_eq!(resp["error"]["code"], SUBSCRIPTIONS_DISABLED);
     }
 }
 
@@ -599,25 +589,12 @@ async fn ws_unsubscribe_removes_subscription() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["logs", {}]), 1).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_subscribe", json!(["logs", {}]), 1).await;
     let subscription_id = resp["result"].clone();
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_unsubscribe", json!([subscription_id]), 2).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = loop {
-        let message = parse_response(ws.next().await.unwrap().unwrap());
-        if message["id"] == 2 {
-            break message;
-        }
-    };
+    let resp =
+        request_skipping_notifications(&mut ws, "eth_unsubscribe", json!([subscription_id]), 2)
+            .await;
 
     assert_eq!(resp["id"], 2);
     assert_eq!(resp["result"], true);
@@ -629,14 +606,9 @@ async fn ws_subscribe_rejects_invalid_param_shapes() {
     let mut ws = connect_with_header(&ctx).await;
 
     for (id, params) in [(1, json!(["newHeads", false])), (2, json!(["logs", false]))] {
-        ws.send(tungstenite::Message::Text(
-            jsonrpc_with_params("eth_subscribe", params, id).into(),
-        ))
-        .await
-        .unwrap();
-        let resp = parse_response(ws.next().await.unwrap().unwrap());
+        let resp = request(&mut ws, "eth_subscribe", params, id).await;
         assert_eq!(resp["id"], id);
-        assert_eq!(resp["error"]["code"], -32602);
+        assert_eq!(resp["error"]["code"], INVALID_PARAMS);
     }
 }
 
@@ -646,36 +618,16 @@ async fn ws_subscribe_rejects_too_many_active_subscriptions() {
     let mut ws = connect_with_header(&ctx).await;
 
     for id in 1..=32 {
-        ws.send(tungstenite::Message::Text(
-            jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), id).into(),
-        ))
-        .await
-        .unwrap();
-
-        let resp = loop {
-            let message = parse_response(ws.next().await.unwrap().unwrap());
-            if message["id"] == id {
-                break message;
-            }
-        };
+        let resp =
+            request_skipping_notifications(&mut ws, "eth_subscribe", json!(["newHeads"]), id).await;
 
         assert!(resp["result"].as_str().is_some());
     }
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 33).into(),
-    ))
-    .await
-    .unwrap();
+    let resp =
+        request_skipping_notifications(&mut ws, "eth_subscribe", json!(["newHeads"]), 33).await;
 
-    let resp = loop {
-        let message = parse_response(ws.next().await.unwrap().unwrap());
-        if message["id"] == 33 {
-            break message;
-        }
-    };
-
-    assert_eq!(resp["error"]["code"], -32602);
+    assert_eq!(resp["error"]["code"], INVALID_PARAMS);
     assert!(
         resp["error"]["message"]
             .as_str()
@@ -694,7 +646,7 @@ async fn ws_empty_batch() {
         .unwrap();
     let resp = parse_response(ws.next().await.unwrap().unwrap());
 
-    assert_eq!(resp["error"]["code"], -32700);
+    assert_eq!(resp["error"]["code"], PARSE_ERROR);
 }
 
 #[tokio::test]
@@ -711,12 +663,7 @@ async fn ws_roundtrip_with_p256_auth() {
         .await
         .expect("p256 ws connect failed");
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_blockNumber", 9).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_blockNumber", json!([]), 9).await;
 
     assert_eq!(resp["id"], 9);
     assert_eq!(resp["result"], "0x42");
@@ -736,12 +683,7 @@ async fn ws_roundtrip_with_webauthn_auth() {
         .await
         .expect("webauthn ws connect failed");
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_chainId", 10).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_chainId", json!([]), 10).await;
 
     assert_eq!(resp["id"], 10);
     assert_eq!(resp["result"], "0x1");
@@ -766,12 +708,7 @@ async fn ws_roundtrip_with_keychain_auth() {
         .await
         .expect("authorized keychain ws connect failed");
 
-    ws.send(tungstenite::Message::Text(
-        jsonrpc("eth_blockNumber", 11).into(),
-    ))
-    .await
-    .unwrap();
-    let resp = parse_response(ws.next().await.unwrap().unwrap());
+    let resp = request(&mut ws, "eth_blockNumber", json!([]), 11).await;
 
     assert_eq!(resp["id"], 11);
     assert_eq!(resp["result"], "0x42");
@@ -786,9 +723,10 @@ async fn ws_closes_when_auth_token_expires() {
         .await
         .expect("ws connect failed");
 
-    let _closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
+    let closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
         .await
         .expect("timed out waiting for token-expiry close");
+    assert_socket_terminated(closed);
 }
 
 #[tokio::test]
@@ -812,9 +750,10 @@ async fn ws_closes_when_keychain_key_is_revoked() {
 
     api.revoke_key(root_account, key_id);
 
-    let _closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
+    let closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
         .await
         .expect("timed out waiting for keychain-revocation close");
+    assert_socket_terminated(closed);
 }
 
 #[tokio::test]


### PR DESCRIPTION
`ws.rs` gains `request()`/`request_skipping_notifications()`, replacing ~14 copies of the send-then-parse chain and the three drain-until-id loops; the JSON-RPC error codes get named constants; the invalid-token test reuses `connect_with_token` instead of inlining the 13-line upgrade request; and the secp token blob comes from the shared `auth_tokens` helper. The two close-on-revocation tests now assert the socket actually terminates — the token-expiry test had been passing on any frame whatsoever, and strengthening it revealed the server ends the connection with an abrupt TCP reset rather than a Close frame, so `assert_socket_terminated` accepts Close, clean end, or reset, but no longer a delivered message.

`private_rpc_e2e.rs` merges the three auth-token tables into one test, folds the public-methods table into `test_method_tiers`, and folds the all-enabled-tokens assertion into `test_zone_metadata_methods` — four fewer full node spawns with identical assertions. Tier-table error extraction goes through `expect_error_code` so failures print the server's actual response, the hardcoded zoneTokens literal becomes `format!("{PATH_USD_ADDRESS:#x}")` (the sibling assertion proves that is the right constant), and the keychain-expiry sleep gets a comment explaining why it cannot be polled away (the key's expiry is on-chain wall-clock state).

`earn_zone_e2e.rs` merges the two stateless retired-router-surface tests into one fixture spawn (~30 L1 transactions saved), drops the unused `_output_token` parameter from `callback_data`, and messages the four bare U256-arithmetic assertions. The `EarnEncryptedDepositPayload` redeclaration stays — `sol!` cannot reference externally generated types in struct fields — but now carries a comment saying exactly that.

---

Stacked on #941. Next: #943.

**Test de-slop stack** (merge in order; bases retarget as predecessors merge):
1. #936 — nextest heavy-test filter
2. #937 — remove dead code and debug noise
3. #938 — consolidate redundant e2e tests
4. #939 — split it/utils.rs into modules
5. #940 — dedupe e2e harness helpers
6. #941 — adopt shared harness helpers
7. #942 — dedupe private-RPC, WS, and earn suites ← this PR
8. #943 — clean up hot suites and refresh test docs
