### PR TITLE
test: clean up hot suites and refresh test docs

### DIFF
--- a/crates/node/tests/it/README.md
+++ b/crates/node/tests/it/README.md
@@ -39,6 +39,13 @@ The harness provides two independent testing paths:
               └─────────────────────────┘
 ```
 
+The shared harness lives in `utils/`, one module per concern: `node`
+(`ZoneTestNode` + the mock L1 RPC), `l1` (`L1TestNode`, TIP-403 seeding,
+genesis builders), `fixture` (`L1Fixture` + queue injection), `accounts`
+(`ZoneAccount`, withdrawal args), `p2p` (multi-sequencer cluster), and
+`private_rpc` (auth tokens, RPC test contexts). Everything is re-exported
+through `utils::`.
+
 ### Injection Path (`e2e.rs`)
 
 Uses `L1Fixture` to manually construct `TempoHeader` and `Deposit` objects,
@@ -47,8 +54,8 @@ push them into the `DepositQueue`, and seed the `L1StateCache` for
 
 ```rust
 let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-let deposit = fixture.make_deposit(sender, recipient, amount);
-fixture.inject_deposits(&zone.deposit_queue, vec![deposit]);
+let deposit = make_deposit(PATH_USD_ADDRESS, sender, recipient, amount);
+fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
 // poll for balance change...
 ```
 
@@ -63,15 +70,15 @@ fixture.inject_deposits(&zone.deposit_queue, vec![deposit]);
 
 ```rust
 let b1 = fixture.next_block();
-fixture.enqueue(&b1, &zone1.deposit_queue, vec![deposit_for_zone1]);
-fixture.enqueue(&b1, &zone2.deposit_queue, vec![]);
+fixture.enqueue(&b1, zone1.deposit_queue(), vec![deposit_for_zone1]);
+fixture.enqueue(&b1, zone2.deposit_queue(), vec![]);
 ```
 
 ### Real L1 Path (`l1_e2e.rs`)
 
-Starts an in-process Tempo L1 dev node via `L1TestNode::start()`, then connects
-a zone node via `ZoneTestNode::start_from_l1()`. The `L1Subscriber` receives
-real blocks over WebSocket.
+`start_l1_and_zone()` starts an in-process Tempo L1 dev node, deploys a zone
+portal on it, and connects a zone node whose `L1Subscriber` receives real
+blocks over WebSocket.
 
 **Genesis patching in `start_from_l1()`:**
 
@@ -84,50 +91,43 @@ template (`crates/node/assets/zone-dev-genesis.json`, via `zone_node::genesis`):
    - Layout: `(tempoBlockNumber:u64, tempoGasLimit:u64, tempoGasUsed:u64, tempoTimestamp:u64)`
    - Only `tempoBlockNumber` is currently patched; other fields retain genesis defaults
 
-## Test Inventory
+## Test Modules
 
-### `e2e.rs` — Injection-Based Tests
+| Module | Covers |
+|--------|--------|
+| `e2e.rs` | Injection-based deposits, withdrawal batching, P2P leader/follower, engine lifecycle |
+| `l1_e2e.rs` | Real-L1 deposits/withdrawals, cross-zone routing, encrypted deposits, TIP-403 policy bounces |
+| `earn_zone_e2e.rs` | Earn vault deposit/redeem matrix through the zone (needs the private `earn` artifacts) |
+| `restart_e2e.rs` | Sequencer restart resilience (batch submission and withdrawals resume from portal state) |
+| `handoff_e2e.rs` | Multi-sequencer leadership handoff, forwarded transactions, live propagation |
+| `stepping_e2e.rs` | Out-of-EIP-2935-window batch submission via ancestry anchors |
+| `tip403_policy.rs` | Zone TIP-403 proxy precompile against seeded raw L1 policy state |
+| `tip403_transfers.rs` | TIP-20 transfer/withdrawal flows under receive policies |
+| `enable_token.rs` | `TokenEnabled` pipelines (injected events and the live real-L1 path) |
+| `private_rpc.rs` | Auth-token parsing and method classification (pure unit tests) |
+| `private_rpc_e2e.rs` | Private RPC server: auth, privacy scoping, method tiers, WS subscriptions |
+| `demo_*.rs` | Narrated end-to-end flows: shield-and-send, multi-asset, cross-zone |
+| `deposit.rs` | Real-testnet deposit round trip (`#[ignore]`d; needs `L1_PORTAL_ADDRESS`) |
+| `precompiles.rs` | Precompiles disabled on zones |
 
-| Test | What it exercises |
-|------|-------------------|
-| `test_deposit_via_queue_injection` | Single deposit → pathUSD mint on L2 |
-| `test_multiple_deposits_across_blocks` | Multi-block, multi-recipient deposits |
-| `test_empty_l1_blocks_advance_zone` | Chain continuity without deposits |
-| `test_two_zones_independent_deposits` | Cross-zone isolation (shared L1 timeline, independent queues) |
-| `test_tempo_state_advances_with_l1_blocks` | `tempoBlockNumber` and `tempoBlockHash` tracking |
-| `test_zone_inbox_events_on_deposit` | `TempoAdvanced` + `DepositProcessed` event emission |
-| `test_withdrawal_batch_finalization` | `ZoneOutbox.withdrawalBatchIndex` advancement |
-| `test_large_deposit_batch` | 10 deposits in one L1 block |
-
-### `l1_e2e.rs` — Real L1 Integration Tests
-
-| Test | What it exercises |
-|------|-------------------|
-| `test_zone_advances_with_real_l1` | Full L1Subscriber → DepositQueue → ZoneEngine pipeline |
-| `test_deposit_via_real_l1` | Zone startup from real L1 + initial state verification |
-
-### `deposit.rs` — Testnet Integration Tests (ignored by default)
-
-| Test | What it exercises |
-|------|-------------------|
-| `test_l1_deposit_mints_on_zone` | Real deposit on testnet portal → mint on local zone |
+Real-L1 modules require `forge build --root specs/ref-impls` first.
 
 ## Key Types
 
 - **`ZoneTestNode`** — In-process zone L2 node with RPC endpoint. Fields are
   private; use `http_url()`, `deposit_queue()`, `l1_state_cache()` getters.
-  Constructed via `start_local()`, `start_from_l1()`, or `start()`.
+  Constructed via the `start_*` wrappers or `launch(ZoneNodeParams)`.
 - **`L1TestNode`** — In-process Tempo L1 dev node. Fields are private; use
-  `http_url()` and `ws_url()` getters. Constructed via `start()`.
+  `http_url()` and `ws_url()` getters. Constructed via `start()`; most tests
+  use `start_l1_and_zone()` for the full preamble.
+- **`ZoneAccount`** — A funded account with providers on both layers; wraps
+  deposits (plain, token, encrypted, raw) and withdrawals.
 - **`L1Fixture`** — Synthetic L1 block builder maintaining hash chain continuity.
 - **`FixtureBlock`** — Clonable L1 block for multi-zone broadcast.
 - **`poll_until`** — Generic async condition poller with timeout.
 
 ## Known Issues / Improvements
 
-- **Chain ID collisions:** `start_local()` hardcodes `chain_id = 1337`. Tests
-  running in parallel can collide. Use `start_local_with_chain_id()` with unique
-  IDs, or switch `start_local()` to pick random chain IDs.
 - **Slot 7 partial patch:** `start_from_l1()` only patches `tempoBlockNumber` in
   the packed slot 7. Should also patch `tempoGasLimit`, `tempoGasUsed`, and
   `tempoTimestamp` from the anchor header for full consistency.

--- a/crates/node/tests/it/demo_asset_swap.rs
+++ b/crates/node/tests/it/demo_asset_swap.rs
@@ -2,14 +2,13 @@
 //!
 //! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
 
-use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
+use crate::utils::{
+    L1_TIMEOUT, L1TestNode, WITHDRAWAL_TIMEOUT, ZoneAccount, ZoneTestNode, spawn_sequencer,
+};
 use alloy::{
     primitives::{B256, U256},
     providers::Provider,
 };
-
-/// Longer timeout for real L1 tests.
-const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Multi-asset deposit + withdrawal with two freshly created TIP-20 tokens,
 /// auto-initialized on L2 via `TokenEnabled` events:
@@ -92,7 +91,6 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
     );
 
     let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-    let withdrawal_timeout = std::time::Duration::from_secs(60);
 
     // Withdraw AlphaUSD
     let alpha_withdrawal: u128 = 500_000; // 0.5 AlphaUSD
@@ -103,7 +101,7 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
         l1_alpha,
         account.address(),
         alpha_withdrawal,
-        withdrawal_timeout,
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
 
@@ -116,7 +114,7 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
         l1_beta,
         account.address(),
         beta_withdrawal,
-        withdrawal_timeout,
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
 

--- a/crates/node/tests/it/demo_cross_zone.rs
+++ b/crates/node/tests/it/demo_cross_zone.rs
@@ -3,14 +3,12 @@
 //! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
 
 use crate::utils::{
-    L1TestNode, WithdrawalArgs, ZoneAccount, ZoneCreationConfig, ZoneTestNode, spawn_sequencer,
+    L1_TIMEOUT, L1TestNode, WITHDRAWAL_TIMEOUT, WithdrawalArgs, ZoneAccount, ZoneCreationConfig,
+    ZoneTestNode, spawn_sequencer,
 };
 use alloy::primitives::U256;
 use tempo_precompiles::PATH_USD_ADDRESS;
 use tempo_zone_contracts::ZONE_TOKEN_ADDRESS;
-
-/// Longer timeout for real L1 tests.
-const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Cross-zone transfer via SwapAndDepositRouter between two open zones:
 ///
@@ -100,12 +98,12 @@ async fn test_cross_zone_send() -> eyre::Result<()> {
             router,
             PATH_USD_ADDRESS,
             cross_amount,
-            std::time::Duration::from_secs(60),
+            WITHDRAWAL_TIMEOUT,
         )
         .await?;
     eyre::ensure!(callback_succeeded, "cross-zone router callback failed");
 
-    let cross_timeout = std::time::Duration::from_secs(60);
+    let cross_timeout = WITHDRAWAL_TIMEOUT;
     zone_b
         .wait_for_balance(
             ZONE_TOKEN_ADDRESS,

--- a/crates/node/tests/it/demo_shield_and_send.rs
+++ b/crates/node/tests/it/demo_shield_and_send.rs
@@ -2,12 +2,9 @@
 //!
 //! Requires `forge build --root specs/ref-impls` for the Foundry artifacts.
 
-use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode};
+use crate::utils::{L1_TIMEOUT, L1TestNode, ZoneAccount, ZoneTestNode};
 use alloy::{primitives::U256, providers::ProviderBuilder};
 use tempo_zone_contracts::ZONE_TOKEN_ADDRESS;
-
-/// Longer timeout for real L1 tests.
-const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Shield + in-zone send:
 ///

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -23,7 +23,7 @@ use zone_l1::{ChainTempoStateExt, L1Deposit, L1PortalEvents};
 use crate::utils::{
     DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, WITHDRAWAL_BATCH_INTERVAL_BLOCKS,
     WITHDRAWAL_TX_GAS, ZoneTestNode, approve_outbox, leader_p2p_config, local_dev_zone_account,
-    poll_until, seed_fixture_for_zone, start_chain_id_rpc, start_local_p2p_cluster,
+    make_deposit, poll_until, seed_fixture_for_zone, start_chain_id_rpc, start_local_p2p_cluster,
     start_local_zone_with_fixture, submit_withdrawal, submit_withdrawals,
 };
 
@@ -87,7 +87,7 @@ async fn test_p2p_follower_tracks_leader_balance() -> eyre::Result<()> {
     let depositor = address!("0x0000000000000000000000000000000000001234");
     let recipient = address!("0x0000000000000000000000000000000000005678");
     let amount = 1_000_000_u128;
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, depositor, recipient, amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, depositor, recipient, amount);
     let observed = L1PortalEvents::from_deposits(vec![L1Deposit::Regular(deposit.clone())]);
     let anchor = fixture.inject_deposits(leader.deposit_queue(), vec![deposit]);
     follower
@@ -118,7 +118,7 @@ async fn test_p2p_follower_tracks_leader_balance() -> eyre::Result<()> {
     let (follower_wallet, sender) = local_dev_zone_account(&follower)?;
     let transfer_recipient = address!("0x0000000000000000000000000000000000009abc");
     fixture.seed_no_receive_policy(transfer_recipient)?;
-    let sender_deposit = fixture.make_deposit(PATH_USD_ADDRESS, sender, sender, amount);
+    let sender_deposit = make_deposit(PATH_USD_ADDRESS, sender, sender, amount);
     let observed = L1PortalEvents::from_deposits(vec![L1Deposit::Regular(sender_deposit.clone())]);
     let anchor = fixture.inject_deposits(leader.deposit_queue(), vec![sender_deposit]);
     follower
@@ -265,7 +265,7 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
 
     // Block 1: fund Alice while pathUSD is still allow-all (anchor L1#1).
     let deposit_amount: u128 = 1_000_000;
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
     let observed = L1PortalEvents::from_deposits(vec![L1Deposit::Regular(deposit.clone())]);
     let anchor = fixture.inject_deposits(leader.deposit_queue(), vec![deposit]);
     leader
@@ -392,7 +392,7 @@ async fn test_contract_creation_transaction_is_rejected() -> eyre::Result<()> {
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
     let (provider, dev_address) = local_dev_zone_account(&zone)?;
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, 1_000_000);
+    let deposit = make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, 1_000_000);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
     zone.wait_for_balance(
         PATH_USD_ADDRESS,
@@ -432,13 +432,13 @@ async fn test_multiple_deposits_across_blocks() -> eyre::Result<()> {
     let bob = address!("0x0000000000000000000000000000000000000B0B");
     let sender = address!("0x0000000000000000000000000000000000001111");
 
-    let d1 = fixture.make_deposit(PATH_USD_ADDRESS, sender, alice, 500_000);
+    let d1 = make_deposit(PATH_USD_ADDRESS, sender, alice, 500_000);
     fixture.inject_deposits(zone.deposit_queue(), vec![d1]);
 
     fixture.inject_empty_block(zone.deposit_queue());
 
-    let d2 = fixture.make_deposit(PATH_USD_ADDRESS, sender, alice, 300_000);
-    let d3 = fixture.make_deposit(PATH_USD_ADDRESS, sender, bob, 700_000);
+    let d2 = make_deposit(PATH_USD_ADDRESS, sender, alice, 300_000);
+    let d3 = make_deposit(PATH_USD_ADDRESS, sender, bob, 700_000);
     fixture.inject_deposits(zone.deposit_queue(), vec![d2, d3]);
 
     // Third block: a large batch of deposits to distinct recipients, processed
@@ -453,7 +453,7 @@ async fn test_multiple_deposits_across_blocks() -> eyre::Result<()> {
         .collect();
     let batch: Vec<_> = batch_recipients
         .iter()
-        .map(|to| fixture.make_deposit(PATH_USD_ADDRESS, sender, *to, amount_each))
+        .map(|to| make_deposit(PATH_USD_ADDRESS, sender, *to, amount_each))
         .collect();
     fixture.inject_deposits(zone.deposit_queue(), batch);
 
@@ -577,20 +577,20 @@ async fn test_two_zones_independent_deposits() -> eyre::Result<()> {
 
     // L1 block 1: deposit to Alice on zone1, empty on zone2
     let b1 = fixture.next_block();
-    let d1 = L1Fixture::make_deposit_for_block(PATH_USD_ADDRESS, sender, alice, 500_000);
+    let d1 = make_deposit(PATH_USD_ADDRESS, sender, alice, 500_000);
     fixture.enqueue(&b1, zone1.deposit_queue(), vec![d1]);
     fixture.enqueue(&b1, zone2.deposit_queue(), vec![]);
 
     // L1 block 2: empty on zone1, deposit to Bob on zone2
     let b2 = fixture.next_block();
-    let d2 = L1Fixture::make_deposit_for_block(PATH_USD_ADDRESS, sender, bob, 700_000);
+    let d2 = make_deposit(PATH_USD_ADDRESS, sender, bob, 700_000);
     fixture.enqueue(&b2, zone1.deposit_queue(), vec![]);
     fixture.enqueue(&b2, zone2.deposit_queue(), vec![d2]);
 
     // L1 block 3: deposits on both zones
     let b3 = fixture.next_block();
-    let d3a = L1Fixture::make_deposit_for_block(PATH_USD_ADDRESS, sender, alice, 300_000);
-    let d3b = L1Fixture::make_deposit_for_block(PATH_USD_ADDRESS, sender, bob, 200_000);
+    let d3a = make_deposit(PATH_USD_ADDRESS, sender, alice, 300_000);
+    let d3b = make_deposit(PATH_USD_ADDRESS, sender, bob, 200_000);
     fixture.enqueue(&b3, zone1.deposit_queue(), vec![d3a]);
     fixture.enqueue(&b3, zone2.deposit_queue(), vec![d3b]);
 
@@ -688,7 +688,7 @@ async fn test_zone_inbox_events_on_deposit() -> eyre::Result<()> {
     let recipient = address!("0x0000000000000000000000000000000000002222");
     let deposit_amount: u128 = 5_000_000;
 
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, sender, recipient, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, sender, recipient, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
 
     // Wait for the deposit to be processed
@@ -835,7 +835,7 @@ async fn fund_and_approve_outbox(
     dev_address: Address,
     amount: u128,
 ) -> eyre::Result<()> {
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
     zone.wait_for_balance(
         PATH_USD_ADDRESS,

--- a/crates/node/tests/it/enable_token.rs
+++ b/crates/node/tests/it/enable_token.rs
@@ -6,22 +6,19 @@
 //! `TokenEnabled` events from L1, and that deposits of the newly-enabled
 //! tokens are correctly minted.
 
-use alloy::primitives::{U256, address};
+use alloy::primitives::{B256, U256, address};
 use alloy_network::ReceiptResponse;
-use zone_l1::{EnabledToken, L1Deposit, L1PortalEvents};
-
-use crate::utils::{
-    DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, local_dev_tempo_zone_account,
-    start_local_zone_with_fixture,
-};
-
-// Imports for real-L1 tests
-use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
-use alloy::primitives::B256;
 use alloy_provider::Provider;
 use tempo_alloy::rpc::TempoCallBuilderExt;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::ITIP20;
+use zone_l1::{EnabledToken, L1Deposit, L1PortalEvents};
+
+use crate::utils::{
+    DEFAULT_TIMEOUT, L1_TIMEOUT, L1TestNode, TIP20_TX_GAS, WITHDRAWAL_TIMEOUT, ZoneAccount,
+    ZoneTestNode, local_dev_tempo_zone_account, make_deposit, spawn_sequencer,
+    start_local_zone_with_fixture,
+};
 
 /// Enable a new token (AlphaUSD) via a `TokenEnabled` event, then deposit it
 /// and verify the recipient receives the minted balance.
@@ -47,7 +44,7 @@ async fn test_enable_token_then_deposit() -> eyre::Result<()> {
     let recipient = address!("0x0000000000000000000000000000000000005678");
     let deposit_amount: u128 = 1_000_000;
 
-    let deposit = fixture.make_deposit(alpha_token, sender, recipient, deposit_amount);
+    let deposit = make_deposit(alpha_token, sender, recipient, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
 
     // Verify the recipient received the AlphaUSD
@@ -92,7 +89,7 @@ async fn test_enable_token_and_deposit_same_block() -> eyre::Result<()> {
 
     // Single L1 block with both TokenEnabled + deposit
     let block = fixture.next_block();
-    let deposit = L1Fixture::make_deposit_for_block(beta_token, sender, recipient, deposit_amount);
+    let deposit = make_deposit(beta_token, sender, recipient, deposit_amount);
     let events = L1PortalEvents {
         deposits: vec![L1Deposit::Regular(deposit)],
         enabled_tokens: vec![enabled],
@@ -134,7 +131,7 @@ async fn test_pool_validation_uses_enabled_token_anchored_policy() -> eyre::Resu
     let transfer_amount = 100_000u128;
 
     let block = fixture.next_block();
-    let deposit = L1Fixture::make_deposit_for_block(token_address, sender, sender, deposit_amount);
+    let deposit = make_deposit(token_address, sender, sender, deposit_amount);
     fixture.enqueue_events(
         &block,
         zone.deposit_queue(),
@@ -203,16 +200,14 @@ async fn test_pool_validation_uses_enabled_token_anchored_policy() -> eyre::Resu
     Ok(())
 }
 
-/// Longer timeout for real L1 tests — the L1 dev node produces blocks every
-/// 500ms and the L1Subscriber needs to connect, backfill, and subscribe.
-const L1_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-
 /// Full TokenEnabled pipeline with a real in-process L1 node: a freshly
 /// created TIP-20 is enabled on the portal, deposited, and withdrawn again.
 ///
 /// The token must be enabled AFTER zone startup so the live L1 subscriber
 /// picks up the `TokenEnabled` event (events in blocks ≤ genesis are not
-/// backfilled).
+/// backfilled). This is the live-event counterpart of
+/// `demo_asset_swap::test_multiasset_deposit_and_withdraw`, which enables its
+/// tokens before the zone starts and covers the genesis-carried path.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -277,7 +272,6 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
     );
 
     let _sequencer_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-    let withdrawal_timeout = std::time::Duration::from_secs(60);
 
     let alpha_withdrawal: u128 = 1_000_000; // 1 AlphaUSD
     account
@@ -289,7 +283,7 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
         l1_alpha_usd,
         account.address(),
         alpha_withdrawal,
-        withdrawal_timeout,
+        WITHDRAWAL_TIMEOUT,
     )
     .await?;
 

--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -9,15 +9,15 @@
 
 use std::time::Duration;
 
-use alloy::primitives::{U256, address};
+use alloy::primitives::{B256, U256, address};
 use alloy_provider::Provider;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::ITIP20;
 use tempo_precompiles::PATH_USD_ADDRESS;
 
 use crate::utils::{
-    DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, local_dev_zone_account, poll_until,
-    start_local_p2p_cluster,
+    DEFAULT_POLL, DEFAULT_TIMEOUT, P2pCluster, TIP20_TX_GAS, ZoneTestNode, local_dev_zone_account,
+    make_deposit, poll_until, start_local_p2p_cluster,
 };
 
 /// Ceiling for one leadership switch: covers the Commonware handshake, the promotion
@@ -30,6 +30,65 @@ const QUIESCENCE: Duration = Duration::from_secs(3);
 /// the window to backfill-paced replication fails fast instead of passing slowly.
 const LIVE_PROPAGATION_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Assert every block in `1..=last_height` is identical on all nodes and was
+/// produced by node 0 below `handoff_anchor` and by node 1 from it onwards.
+async fn assert_producer_boundary(
+    cluster: &P2pCluster,
+    last_height: u64,
+    handoff_anchor: u64,
+) -> eyre::Result<()> {
+    let a_producer = cluster.sequencer_signers[0].address();
+    let b_producer = cluster.sequencer_signers[1].address();
+    for height in 1..=last_height {
+        let header = cluster.assert_same_block(height).await?;
+        let expected = if height < handoff_anchor {
+            a_producer
+        } else {
+            b_producer
+        };
+        assert_eq!(
+            header.beneficiary, expected,
+            "block {height} has the wrong producer (boundary at {handoff_anchor})"
+        );
+    }
+    Ok(())
+}
+
+/// Fund a dev-account sender via a block-4 deposit and wait for the mint.
+async fn fund_sender_in_block_4(
+    cluster: &mut P2pCluster,
+) -> eyre::Result<alloy_provider::DynProvider> {
+    let (sender_wallet, sender) = local_dev_zone_account(&cluster.nodes[2])?;
+    let amount = 1_000_000_u128;
+    cluster.inject_block(vec![make_deposit(PATH_USD_ADDRESS, sender, sender, amount)])?;
+    cluster.wait_all_at(4, DEFAULT_TIMEOUT).await?;
+    cluster.nodes[2]
+        .wait_for_balance(
+            PATH_USD_ADDRESS,
+            sender,
+            U256::from(amount),
+            DEFAULT_TIMEOUT,
+        )
+        .await?;
+    Ok(sender_wallet)
+}
+
+/// Poll until `node`'s transaction pool knows the forwarded transaction.
+async fn wait_for_pooled_tx(
+    node: &ZoneTestNode,
+    transaction_hash: B256,
+    timeout: Duration,
+    description: &'static str,
+) -> eyre::Result<()> {
+    let provider = node.provider();
+    poll_until(timeout, DEFAULT_POLL, description, || {
+        let provider = &provider;
+        async move { Ok(provider.get_transaction_by_hash(transaction_hash).await?) }
+    })
+    .await?;
+    Ok(())
+}
+
 /// A crashes after producing a tip shared by every follower. Three L1 anchors pass with no zone
 /// blocks, then an operator selects B and the shared tip for forced recovery. The matching
 /// finalized transition lets B fill the missing anchor range and continue as the portal leader,
@@ -39,7 +98,6 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     for _ in 0..3 {
         cluster.inject_block(vec![])?;
@@ -155,9 +213,6 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    // Commonware drops messages for offline peers; the bootstrap leader also needs tip
-    // evidence from both followers before its first promotion.
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // --- Blocks 1..=3 are produced by A (the manifest bootstrap leader). ---
     for _ in 0..3 {
@@ -166,23 +221,7 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
     cluster.wait_all_at(3, HANDOFF_TIMEOUT).await?;
 
     // --- Block 4 funds a sender so a pending transaction can ride through the handoff. ---
-    let (sender_wallet, sender) = local_dev_zone_account(&cluster.nodes[2])?;
-    let amount = 1_000_000_u128;
-    cluster.inject_block(vec![L1Fixture::make_deposit_for_block(
-        PATH_USD_ADDRESS,
-        sender,
-        sender,
-        amount,
-    )])?;
-    cluster.wait_all_at(4, DEFAULT_TIMEOUT).await?;
-    cluster.nodes[2]
-        .wait_for_balance(
-            PATH_USD_ADDRESS,
-            sender,
-            U256::from(amount),
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
+    let sender_wallet = fund_sender_in_block_4(&mut cluster).await?;
 
     // Submit a transfer to follower C. C admits it locally and forwards it to every quorum peer,
     // including active leader A and incoming leader B. Nobody includes it before the handoff
@@ -197,34 +236,18 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
         .send()
         .await?;
     let transaction_hash = *pending.tx_hash();
-    let leader_provider = cluster.nodes[0].provider();
-    poll_until(
+    wait_for_pooled_tx(
+        &cluster.nodes[0],
+        transaction_hash,
         DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
         "forwarded transaction in the outgoing leader's pool",
-        || {
-            let leader_provider = &leader_provider;
-            async move {
-                Ok(leader_provider
-                    .get_transaction_by_hash(transaction_hash)
-                    .await?)
-            }
-        },
     )
     .await?;
-    let incoming_leader_provider = cluster.nodes[1].provider();
-    poll_until(
+    wait_for_pooled_tx(
+        &cluster.nodes[1],
+        transaction_hash,
         DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
         "forwarded transaction in the incoming leader's pool",
-        || {
-            let incoming_leader_provider = &incoming_leader_provider;
-            async move {
-                Ok(incoming_leader_provider
-                    .get_transaction_by_hash(transaction_hash)
-                    .await?)
-            }
-        },
     )
     .await?;
 
@@ -273,27 +296,14 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
     // at the activation boundary (block height == embedded anchor in this harness). ---
     let final_height = cluster.nodes[1].provider().get_block_number().await?;
     cluster.wait_all_at(final_height, HANDOFF_TIMEOUT).await?;
-    let a_producer = cluster.sequencer_signers[0].address();
-    let b_producer = cluster.sequencer_signers[1].address();
-    for height in 1..=final_height {
-        let header = cluster.assert_same_block(height).await?;
-        let expected = if height < handoff_anchor {
-            a_producer
-        } else {
-            b_producer
-        };
-        assert_eq!(
-            header.beneficiary, expected,
-            "block {height} has the wrong producer (boundary at {handoff_anchor})"
-        );
-    }
+    assert_producer_boundary(&cluster, final_height, handoff_anchor).await?;
 
     // --- A remains a live follower of B: it imports the next B-produced block. ---
     cluster.inject_block(vec![])?;
     let next = final_height + 1;
     cluster.wait_all_at(next, HANDOFF_TIMEOUT).await?;
     let header = cluster.assert_same_block(next).await?;
-    assert_eq!(header.beneficiary, b_producer);
+    assert_eq!(header.beneficiary, cluster.sequencer_signers[1].address());
 
     // Every recipient balance is identical everywhere.
     for node in &cluster.nodes {
@@ -318,7 +328,6 @@ async fn test_lagged_follower_promotes_only_after_catching_up() -> eyre::Result<
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Blocks 1..=2 are observed by everyone.
     for _ in 0..2 {
@@ -374,25 +383,15 @@ async fn test_lagged_follower_promotes_only_after_catching_up() -> eyre::Result<
     cluster.record_anchor(1, boundary, vec![])?;
     cluster.wait_all_at(6, HANDOFF_TIMEOUT).await?;
 
-    let a_producer = cluster.sequencer_signers[0].address();
-    let b_producer = cluster.sequencer_signers[1].address();
-    for height in 1..=6 {
-        let header = cluster.assert_same_block(height).await?;
-        let expected = if height < handoff_anchor {
-            a_producer
-        } else {
-            b_producer
-        };
-        assert_eq!(
-            header.beneficiary, expected,
-            "block {height} has the wrong producer (boundary at {handoff_anchor})"
-        );
-    }
+    assert_producer_boundary(&cluster, 6, handoff_anchor).await?;
 
     // B keeps producing; everyone follows.
     cluster.inject_block(vec![])?;
     cluster.wait_all_at(7, HANDOFF_TIMEOUT).await?;
-    assert_eq!(cluster.assert_same_block(7).await?.beneficiary, b_producer);
+    assert_eq!(
+        cluster.assert_same_block(7).await?.beneficiary,
+        cluster.sequencer_signers[1].address()
+    );
     Ok(())
 }
 
@@ -409,7 +408,6 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
     reth_tracing::init_test_tracing();
 
     let mut cluster = start_local_p2p_cluster(24).await?;
-    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Blocks 1..=3 are produced by A (the manifest bootstrap leader).
     for _ in 0..3 {
@@ -418,23 +416,7 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
     cluster.wait_all_at(3, HANDOFF_TIMEOUT).await?;
 
     // Block 4 funds a sender used during the window.
-    let (sender_wallet, sender) = local_dev_zone_account(&cluster.nodes[2])?;
-    let amount = 1_000_000_u128;
-    cluster.inject_block(vec![L1Fixture::make_deposit_for_block(
-        PATH_USD_ADDRESS,
-        sender,
-        sender,
-        amount,
-    )])?;
-    cluster.wait_all_at(4, DEFAULT_TIMEOUT).await?;
-    cluster.nodes[2]
-        .wait_for_balance(
-            PATH_USD_ADDRESS,
-            sender,
-            U256::from(amount),
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
+    let sender_wallet = fund_sender_in_block_4(&mut cluster).await?;
 
     // Publish A→B three anchors ahead of the boundary: every node observes B's upcoming
     // leadership while A still rightfully produces anchors 5..=7.
@@ -458,15 +440,11 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
         .send()
         .await?;
     let transaction_hash = *pending.tx_hash();
-    let outgoing_leader_provider = cluster.nodes[0].provider();
-    poll_until(
+    wait_for_pooled_tx(
+        &cluster.nodes[0],
+        transaction_hash,
         LIVE_PROPAGATION_TIMEOUT,
-        DEFAULT_POLL,
         "forwarded transaction in the outgoing leader's pool during the window",
-        || {
-            let provider = &outgoing_leader_provider;
-            async move { Ok(provider.get_transaction_by_hash(transaction_hash).await?) }
-        },
     )
     .await?;
 
@@ -502,20 +480,7 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
         .wait_all_at(handoff_anchor + 1, HANDOFF_TIMEOUT)
         .await?;
 
-    let a_producer = cluster.sequencer_signers[0].address();
-    let b_producer = cluster.sequencer_signers[1].address();
-    for height in 1..=handoff_anchor + 1 {
-        let header = cluster.assert_same_block(height).await?;
-        let expected = if height < handoff_anchor {
-            a_producer
-        } else {
-            b_producer
-        };
-        assert_eq!(
-            header.beneficiary, expected,
-            "block {height} has the wrong producer (boundary at {handoff_anchor})"
-        );
-    }
+    assert_producer_boundary(&cluster, handoff_anchor + 1, handoff_anchor).await?;
 
     // Every recipient balance is identical everywhere.
     for node in &cluster.nodes {

--- a/crates/node/tests/it/tip403_policy.rs
+++ b/crates/node/tests/it/tip403_policy.rs
@@ -4,97 +4,22 @@
 //! finalized raw L1 storage via `L1StateCache` and rejects mutating calls. The cache is populated
 //! directly in tests (no L1 subscriber).
 
-use alloy::primitives::{TxKind, U256, address};
-use alloy_provider::{Provider, ProviderBuilder};
+use alloy::primitives::{Address, TxKind, U256, address};
+use alloy_provider::Provider;
 use alloy_rpc_types_eth::TransactionRequest;
-use alloy_signer_local::{MnemonicBuilder, coins_bip39::English};
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
-use tempo_contracts::precompiles::{
-    ITIP20,
-    ITIP403Registry::{self, PolicyType},
-};
+use tempo_contracts::precompiles::ITIP403Registry::{self, PolicyType};
 use tempo_precompiles::{PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS, tip403_registry::AuthRole};
 use zone_precompiles::ZONE_FEE_MANAGER_ADDRESS;
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, PolicySeed, TEST_MNEMONIC, TIP20_TX_GAS, seed_raw_tip403_policy,
-    seed_raw_tip403_token_policy, start_local_zone_with_fixture,
+    DEFAULT_TIMEOUT, PolicySeed, TIP20_TX_GAS, local_dev_zone_account, make_deposit,
+    seed_raw_tip403_policy, seed_raw_tip403_token_policy, start_local_zone_with_fixture,
 };
 
-/// Deposit pathUSD to Alice, then transfer a portion to Bob on the zone.
-///
-/// TIP-20 transfers use the default anchored `transferPolicyId` of 1 (allow all).
-#[tokio::test(flavor = "multi_thread")]
-async fn test_tip20_transfer_on_zone() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-
-    let alice_signer = MnemonicBuilder::<English>::default()
-        .phrase(TEST_MNEMONIC)
-        .build()?;
-    let alice = alice_signer.address();
-
-    let bob = address!("0x0000000000000000000000000000000000000B0B");
-    let deposit_amount: u128 = 1_000_000; // 1 pathUSD (6 decimals)
-
-    // Deposit pathUSD to Alice
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
-    fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
-
-    zone.wait_for_balance(
-        PATH_USD_ADDRESS,
-        alice,
-        U256::from(deposit_amount),
-        DEFAULT_TIMEOUT,
-    )
-    .await?;
-
-    // Alice transfers 400,000 to Bob
-    let transfer_amount: u128 = 400_000;
-    let alice_provider = ProviderBuilder::new()
-        .wallet(alice_signer)
-        .connect_http(zone.http_url().clone());
-
-    // T6+ transfers also consult the recipient's address-level receive policy on L1.
-    // Seed the anchor before pool validation; the next execution block inherits this baseline.
-    fixture.seed_no_receive_policy(bob)?;
-
-    let tip20 = ITIP20::new(PATH_USD_ADDRESS, &alice_provider);
-    let pending = tip20
-        .transfer(bob, U256::from(transfer_amount))
-        .gas_price(TEMPO_T0_BASE_FEE as u128)
-        .gas(TIP20_TX_GAS)
-        .send()
-        .await?;
-
-    // Inject an empty L1 block to trigger block production including the pool tx.
-    fixture.inject_empty_block(zone.deposit_queue());
-
-    let receipt = pending.get_receipt().await?;
-    assert!(receipt.status(), "transfer should succeed");
-
-    // Verify Bob received the transfer
-    let bob_balance = zone
-        .wait_for_balance(
-            PATH_USD_ADDRESS,
-            bob,
-            U256::from(transfer_amount),
-            DEFAULT_TIMEOUT,
-        )
-        .await?;
-    assert_eq!(bob_balance, U256::from(transfer_amount));
-
-    // Alice should have remaining balance minus gas
-    let alice_balance = zone.balance_of(PATH_USD_ADDRESS, alice).await?;
-    let expected_remaining = deposit_amount - transfer_amount;
-    assert!(
-        alice_balance <= U256::from(expected_remaining),
-        "alice should have at most {expected_remaining} (got {alice_balance})"
-    );
-
-    Ok(())
-}
+const ALICE: Address = address!("0x000000000000000000000000000000000000A11C");
+const BOB: Address = address!("0x0000000000000000000000000000000000000B0B");
+const CAROL: Address = address!("0x000000000000000000000000000000000000CA01");
 
 /// Protocol fee collection must use the finalized L1 policy even when the tx does not call TIP-20.
 #[tokio::test(flavor = "multi_thread")]
@@ -102,13 +27,10 @@ async fn test_l1_blacklisted_sender_cannot_pay_for_empty_transaction() -> eyre::
     reth_tracing::init_test_tracing();
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-    let alice_signer = MnemonicBuilder::<English>::default()
-        .phrase(TEST_MNEMONIC)
-        .build()?;
-    let alice = alice_signer.address();
+    let (alice_provider, alice) = local_dev_zone_account(&zone)?;
 
     let deposit_amount = 1_000_000u128;
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
     zone.wait_for_balance(
         PATH_USD_ADDRESS,
@@ -136,9 +58,6 @@ async fn test_l1_blacklisted_sender_cannot_pay_for_empty_transaction() -> eyre::
         )],
     )?;
 
-    let alice_provider = ProviderBuilder::new()
-        .wallet(alice_signer)
-        .connect_http(zone.http_url().clone());
     let request = TransactionRequest {
         to: Some(TxKind::Call(alice)),
         gas: Some(TIP20_TX_GAS),
@@ -169,79 +88,49 @@ async fn test_l1_blacklisted_sender_cannot_pay_for_empty_transaction() -> eyre::
     Ok(())
 }
 
-/// Whitelist policy: set entries are authorized, non-set entries are not (fail-closed).
+/// List policies: whitelists authorize only set entries (fail-closed), while
+/// blacklists authorize everyone except set entries.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_policy_proxy_whitelist_authorization() -> eyre::Result<()> {
+async fn test_policy_proxy_list_authorization() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
+    const LIST_POLICY_ID: u64 = 5;
+    for (policy_type, listed_authorized, unlisted_authorized) in [
+        (PolicyType::WHITELIST, true, false),
+        (PolicyType::BLACKLIST, false, true),
+    ] {
+        let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
 
-    let alice = address!("0x000000000000000000000000000000000000A11C");
-    let bob = address!("0x0000000000000000000000000000000000000B0B");
+        seed_raw_tip403_policy(
+            zone.l1_state_cache(),
+            1,
+            &[
+                PolicySeed::simple(LIST_POLICY_ID, policy_type, &[(ALICE, true)]),
+                PolicySeed::simple(LIST_POLICY_ID, policy_type, &[(BOB, false)]),
+            ],
+        )?;
 
-    // Populate raw L1 state at block 1.
-    seed_raw_tip403_policy(
-        zone.l1_state_cache(),
-        1,
-        &[
-            PolicySeed::simple(5, PolicyType::WHITELIST, &[(alice, true)]),
-            PolicySeed::simple(5, PolicyType::WHITELIST, &[(bob, false)]),
-        ],
-    )?;
+        fixture.inject_empty_blocks(zone.deposit_queue(), 3);
+        zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
 
-    fixture.inject_empty_blocks(zone.deposit_queue(), 3);
-    zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
-
-    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice, bob], 1, 5)?;
-
-    // Alice is whitelisted → authorized
-    let alice_authorized = registry.is_auth_as(alice, alice, AuthRole::Transfer).await;
-    assert!(alice_authorized, "alice should be authorized (whitelisted)");
-    // Bob is NOT in whitelist → not authorized (fail-closed)
-    let bob_authorized = registry.is_auth_as(bob, bob, AuthRole::Transfer).await;
-    assert!(
-        !bob_authorized,
-        "bob should NOT be authorized (not in whitelist)"
-    );
-
-    Ok(())
-}
-
-/// Blacklist policy: set entries are NOT authorized, non-set entries ARE authorized.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_policy_proxy_blacklist_authorization() -> eyre::Result<()> {
-    reth_tracing::init_test_tracing();
-
-    let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
-
-    let alice = address!("0x000000000000000000000000000000000000A11C");
-    let bob = address!("0x0000000000000000000000000000000000000B0B");
-
-    // Populate raw L1 state at block 1.
-    seed_raw_tip403_policy(
-        zone.l1_state_cache(),
-        1,
-        &[
-            PolicySeed::simple(5, PolicyType::BLACKLIST, &[(alice, true)]),
-            PolicySeed::simple(5, PolicyType::BLACKLIST, &[(bob, false)]),
-        ],
-    )?;
-
-    fixture.inject_empty_blocks(zone.deposit_queue(), 3);
-    zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
-
-    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice, bob], 1, 5)?;
-
-    // Alice is in blacklist → NOT authorized
-    let alice_authorized = registry.is_auth_as(alice, alice, AuthRole::Transfer).await;
-    assert!(
-        !alice_authorized,
-        "alice should NOT be authorized (blacklisted)"
-    );
-
-    // Bob is NOT in blacklist → authorized
-    let bob_authorized = registry.is_auth_as(bob, bob, AuthRole::Transfer).await;
-    assert!(bob_authorized, "bob should be authorized (not blacklisted)");
+        let registry = fixture.tip403_registry_check(
+            &zone,
+            PATH_USD_ADDRESS,
+            &[ALICE, BOB],
+            1,
+            LIST_POLICY_ID,
+        )?;
+        assert_eq!(
+            registry.is_auth_as(ALICE, ALICE, AuthRole::Transfer).await,
+            listed_authorized,
+            "{policy_type:?}: listed entry"
+        );
+        assert_eq!(
+            registry.is_auth_as(BOB, BOB, AuthRole::Transfer).await,
+            unlisted_authorized,
+            "{policy_type:?}: unlisted entry"
+        );
+    }
 
     Ok(())
 }
@@ -253,36 +142,48 @@ async fn test_policy_proxy_compound_policy() -> eyre::Result<()> {
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
 
-    let alice = address!("0x000000000000000000000000000000000000A11C");
-    let bob = address!("0x0000000000000000000000000000000000000B0B");
-
-    // Seed the compound policy graph at block 1.
-    // Policy 5 = sender whitelist, policy 6 = recipient blacklist; compound policy 10
-    // references them.
+    const SENDER_WHITELIST_ID: u64 = 5;
+    const RECIPIENT_BLACKLIST_ID: u64 = 6;
+    const COMPOUND_POLICY_ID: u64 = 10;
     seed_raw_tip403_policy(
         zone.l1_state_cache(),
         1,
         &[
-            PolicySeed::simple(5, PolicyType::WHITELIST, &[(alice, true)]),
-            PolicySeed::simple(6, PolicyType::BLACKLIST, &[(alice, false), (bob, true)]),
-            PolicySeed::compound(10, 5, 6, 1),
+            PolicySeed::simple(SENDER_WHITELIST_ID, PolicyType::WHITELIST, &[(ALICE, true)]),
+            PolicySeed::simple(
+                RECIPIENT_BLACKLIST_ID,
+                PolicyType::BLACKLIST,
+                &[(ALICE, false), (BOB, true)],
+            ),
+            PolicySeed::compound(
+                COMPOUND_POLICY_ID,
+                SENDER_WHITELIST_ID,
+                RECIPIENT_BLACKLIST_ID,
+                1,
+            ),
         ],
     )?;
 
     fixture.inject_empty_blocks(zone.deposit_queue(), 3);
     zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
 
-    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice, bob], 1, 10)?;
+    let registry = fixture.tip403_registry_check(
+        &zone,
+        PATH_USD_ADDRESS,
+        &[ALICE, BOB],
+        1,
+        COMPOUND_POLICY_ID,
+    )?;
 
     // Alice is in sender whitelist → authorized as sender
-    let alice_sender = registry.is_auth_as(alice, alice, AuthRole::Sender).await;
-    assert!(alice_sender, "alice should be authorized as sender");
+    let alice_sender = registry.is_auth_as(ALICE, ALICE, AuthRole::Sender).await;
+    assert!(alice_sender, "ALICE should be authorized as sender");
 
     // Bob is in recipient blacklist → NOT authorized as recipient
-    let bob_recipient = registry.is_auth_as(bob, alice, AuthRole::Recipient).await;
+    let bob_recipient = registry.is_auth_as(BOB, ALICE, AuthRole::Recipient).await;
     assert!(
         !bob_recipient,
-        "bob should NOT be authorized as recipient (blacklisted)"
+        "BOB should NOT be authorized as recipient (blacklisted)"
     );
 
     Ok(())
@@ -295,21 +196,20 @@ async fn test_policy_proxy_builtin_policies() -> eyre::Result<()> {
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
 
-    let alice = address!("0x000000000000000000000000000000000000A11C");
-    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice], 1, 0)?;
+    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[ALICE], 1, 0)?;
 
     fixture.inject_empty_block(zone.deposit_queue());
     zone.wait_for_tempo_block_number(1, DEFAULT_TIMEOUT).await?;
     assert!(
-        !registry.is_auth_as(alice, alice, AuthRole::Transfer).await,
+        !registry.is_auth_as(ALICE, ALICE, AuthRole::Transfer).await,
         "policy 0 should reject all"
     );
 
-    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice], 2, 1)?;
+    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[ALICE], 2, 1)?;
     fixture.inject_empty_block(zone.deposit_queue());
     zone.wait_for_tempo_block_number(2, DEFAULT_TIMEOUT).await?;
     assert!(
-        registry.is_auth_as(alice, alice, AuthRole::Transfer).await,
+        registry.is_auth_as(ALICE, ALICE, AuthRole::Transfer).await,
         "policy 1 should allow all"
     );
 
@@ -349,10 +249,6 @@ async fn test_compound_policy_transfer_role_authorization() -> eyre::Result<()> 
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
 
-    let alice = address!("0x000000000000000000000000000000000000A11C");
-    let bob = address!("0x0000000000000000000000000000000000000B0B");
-    let carol = address!("0x000000000000000000000000000000000000CA01");
-
     // Seed the complete policy membership at block 1.
     seed_raw_tip403_policy(
         zone.l1_state_cache(),
@@ -361,12 +257,12 @@ async fn test_compound_policy_transfer_role_authorization() -> eyre::Result<()> 
             PolicySeed::simple(
                 5,
                 PolicyType::WHITELIST,
-                &[(alice, true), (bob, false), (carol, true)],
+                &[(ALICE, true), (BOB, false), (CAROL, true)],
             ),
             PolicySeed::simple(
                 6,
                 PolicyType::BLACKLIST,
-                &[(alice, false), (bob, true), (carol, true)],
+                &[(ALICE, false), (BOB, true), (CAROL, true)],
             ),
             PolicySeed::compound(10, 5, 6, 1),
         ],
@@ -376,27 +272,27 @@ async fn test_compound_policy_transfer_role_authorization() -> eyre::Result<()> 
     zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
 
     let registry =
-        fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice, bob, carol], 1, 10)?;
+        fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[ALICE, BOB, CAROL], 1, 10)?;
 
     // Alice: whitelisted as sender + NOT in recipient blacklist → true
-    let alice_auth = registry.is_auth_as(alice, alice, AuthRole::Transfer).await;
+    let alice_auth = registry.is_auth_as(ALICE, ALICE, AuthRole::Transfer).await;
     assert!(
         alice_auth,
-        "alice should be authorized (passes both sender and recipient checks)"
+        "ALICE should be authorized (passes both sender and recipient checks)"
     );
 
     // Bob: NOT in sender whitelist → false (short-circuits before recipient check)
-    let bob_auth = registry.is_auth_as(bob, bob, AuthRole::Transfer).await;
+    let bob_auth = registry.is_auth_as(BOB, BOB, AuthRole::Transfer).await;
     assert!(
         !bob_auth,
-        "bob should NOT be authorized (not in sender whitelist)"
+        "BOB should NOT be authorized (not in sender whitelist)"
     );
 
     // Carol is whitelisted as sender but blacklisted as recipient, so transfer auth fails.
-    let carol_auth = registry.is_auth_as(carol, carol, AuthRole::Transfer).await;
+    let carol_auth = registry.is_auth_as(CAROL, CAROL, AuthRole::Transfer).await;
     assert!(
         !carol_auth,
-        "carol should NOT be authorized (passes sender but fails recipient blacklist)"
+        "CAROL should NOT be authorized (passes sender but fails recipient blacklist)"
     );
 
     Ok(())
@@ -409,23 +305,22 @@ async fn test_policy_proxy_uses_block_versioned_raw_state() -> eyre::Result<()> 
 
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
 
-    let alice = address!("0x000000000000000000000000000000000000A11C");
     // Step 1: materialize block-1 state before accepting block 1, then query at anchor 1.
-    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice], 1, 5)?;
+    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[ALICE], 1, 5)?;
     seed_raw_tip403_policy(
         zone.l1_state_cache(),
         1,
         &[PolicySeed::simple(
             5,
             PolicyType::WHITELIST,
-            &[(alice, true)],
+            &[(ALICE, true)],
         )],
     )?;
     fixture.inject_empty_block(zone.deposit_queue());
     zone.wait_for_tempo_block_number(1, DEFAULT_TIMEOUT).await?;
 
-    let authorized = registry.is_auth_as(alice, alice, AuthRole::Transfer).await;
-    assert!(authorized, "alice should be authorized at block 1");
+    let authorized = registry.is_auth_as(ALICE, ALICE, AuthRole::Transfer).await;
+    assert!(authorized, "ALICE should be authorized at block 1");
 
     // Step 2: materialize block-2 state before accepting block 2, then query at anchor 2.
     seed_raw_tip403_policy(
@@ -434,17 +329,17 @@ async fn test_policy_proxy_uses_block_versioned_raw_state() -> eyre::Result<()> 
         &[PolicySeed::simple(
             5,
             PolicyType::WHITELIST,
-            &[(alice, false)],
+            &[(ALICE, false)],
         )],
     )?;
     fixture.inject_empty_block(zone.deposit_queue());
     zone.wait_for_tempo_block_number(2, DEFAULT_TIMEOUT).await?;
 
-    let authorized = registry.is_auth_as(alice, alice, AuthRole::Transfer).await;
-    assert!(!authorized, "alice should NOT be authorized at block 2");
+    let authorized = registry.is_auth_as(ALICE, ALICE, AuthRole::Transfer).await;
+    assert!(!authorized, "ALICE should NOT be authorized at block 2");
 
     // Step 3: materialize the compound policy before accepting block 3.
-    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[alice], 3, 10)?;
+    let registry = fixture.tip403_registry_check(&zone, PATH_USD_ADDRESS, &[ALICE], 3, 10)?;
     seed_raw_tip403_policy(
         zone.l1_state_cache(),
         3,
@@ -454,8 +349,8 @@ async fn test_policy_proxy_uses_block_versioned_raw_state() -> eyre::Result<()> 
     zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
 
     // Policy 10 uses the block-2 whitelist where Alice was removed.
-    let authorized = registry.is_auth_as(alice, alice, AuthRole::Transfer).await;
-    assert!(!authorized, "compound policy 10 should reject alice");
+    let authorized = registry.is_auth_as(ALICE, ALICE, AuthRole::Transfer).await;
+    assert!(!authorized, "compound policy 10 should reject ALICE");
 
     Ok(())
 }

--- a/crates/node/tests/it/tip403_transfers.rs
+++ b/crates/node/tests/it/tip403_transfers.rs
@@ -20,7 +20,7 @@ use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS};
 
 use crate::utils::{
     DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, WITHDRAWAL_TX_GAS, approve_outbox,
-    local_dev_zone_account, start_local_zone_with_fixture, submit_withdrawal,
+    local_dev_zone_account, make_deposit, start_local_zone_with_fixture, submit_withdrawal,
 };
 
 /// Deposit pathUSD to the dev account, then transfer a portion to Bob.
@@ -39,7 +39,7 @@ async fn test_deposit_then_transfer() -> eyre::Result<()> {
     let deposit_amount: u128 = 1_000_000;
 
     // Deposit pathUSD to the dev account
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
 
     zone.wait_for_balance(
@@ -133,7 +133,7 @@ async fn test_deposit_then_request_withdrawal() -> eyre::Result<()> {
         .and_then(|value| value.checked_add(gas_buffer))
         .expect("test deposit amount should not overflow");
 
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
 
     zone.wait_for_balance(
@@ -211,7 +211,7 @@ async fn test_sequential_transfers() -> eyre::Result<()> {
     let deposit_amount: u128 = 2_000_000;
 
     // Deposit to Alice
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
     zone.wait_for_balance(
         PATH_USD_ADDRESS,
@@ -328,7 +328,7 @@ async fn test_transfer_emits_events() -> eyre::Result<()> {
     let transfer_amount: u128 = 250_000;
 
     // Deposit to dev
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
     zone.wait_for_balance(
         PATH_USD_ADDRESS,
@@ -395,7 +395,7 @@ async fn test_transfer_with_memo() -> eyre::Result<()> {
     let memo = B256::with_last_byte(0x42);
 
     // Deposit to dev
-    let deposit = fixture.make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
+    let deposit = make_deposit(PATH_USD_ADDRESS, dev_address, dev_address, deposit_amount);
     fixture.inject_deposits(zone.deposit_queue(), vec![deposit]);
     zone.wait_for_balance(
         PATH_USD_ADDRESS,

--- a/crates/node/tests/it/utils/fixture.rs
+++ b/crates/node/tests/it/utils/fixture.rs
@@ -338,24 +338,6 @@ impl L1Fixture {
         queue.enqueue(block.header.clone(), events);
     }
 
-    /// Create a [`Deposit`] for a specific L1 block.
-    pub(crate) fn make_deposit_for_block(
-        token: Address,
-        sender: Address,
-        to: Address,
-        amount: u128,
-    ) -> Deposit {
-        Deposit {
-            token,
-            sender,
-            to,
-            amount,
-            fee: 0,
-            tempo_refund_recipient: sender,
-            memo: B256::ZERO,
-        }
-    }
-
     /// Inject an L1 block with enabled tokens (no deposits) into the queue.
     pub(crate) fn inject_enabled_tokens(
         &mut self,
@@ -402,24 +384,19 @@ impl L1Fixture {
         queue.enqueue(header, events);
         anchor
     }
+}
 
-    /// Create a [`Deposit`] for testing.
-    pub(crate) fn make_deposit(
-        &self,
-        token: Address,
-        sender: Address,
-        to: Address,
-        amount: u128,
-    ) -> Deposit {
-        Deposit {
-            token,
-            sender,
-            to,
-            amount,
-            fee: 0,
-            tempo_refund_recipient: sender,
-            memo: B256::ZERO,
-        }
+/// Create a [`Deposit`] with zero fee, a zero memo, and the sender as its own
+/// Tempo refund recipient.
+pub(crate) fn make_deposit(token: Address, sender: Address, to: Address, amount: u128) -> Deposit {
+    Deposit {
+        token,
+        sender,
+        to,
+        amount,
+        fee: 0,
+        tempo_refund_recipient: sender,
+        memo: B256::ZERO,
     }
 }
 

--- a/crates/node/tests/it/utils/private_rpc.rs
+++ b/crates/node/tests/it/utils/private_rpc.rs
@@ -324,9 +324,7 @@ impl PrivateRpcTestCtx {
         recipient: Address,
         amount: u128,
     ) -> eyre::Result<()> {
-        let deposit = self
-            .fixture
-            .make_deposit(token, depositor, recipient, amount);
+        let deposit = make_deposit(token, depositor, recipient, amount);
         let dq = self.zone.deposit_queue().clone();
         self.fixture.inject_deposits(&dq, vec![deposit]);
         self.zone


### PR DESCRIPTION
The hot-file pass, deliberately last in the stack to minimize rebase pressure on files with recent feature work.

`handoff_e2e.rs` drops the four post-cluster sleeps (the harness waits out the Commonware handshake itself since the readiness change earlier in the stack) and extracts the thrice-copied producer-boundary assertion loop, the twice-copied block-4 funding preamble, and the pool-forwarding polls into local helpers — deletions and extractions only, no reordering. `tip403_policy.rs` loses `test_tip20_transfer_on_zone` (a weaker copy of `tip403_transfers::test_deposit_then_transfer`, minus that test's native-balance and gas checks), merges the structurally identical whitelist/blacklist tests into one table-driven test, names the magic addresses and compound-policy-graph ids, and uses `local_dev_zone_account` instead of hand-rolled mnemonic plumbing.

`enable_token.rs` consolidates its two import blocks, adopts the shared timeout constants, and documents that its real-L1 test is the live-`TokenEnabled`-event counterpart of `demo_asset_swap`'s genesis-carried path — they exercise different enable pipelines, so both stay. The demo files retire the last per-file timeout constants, `L1Fixture::make_deposit`/`make_deposit_for_block` (identical bodies, one taking an unused `&self`) become a single free `make_deposit()`, and the README swaps its rotting 10-of-97 per-test inventory for a per-module table, documents the `utils/` layout, fixes examples that no longer compiled, and drops the "chain ID collisions" known-issue fixed by `next_unique_chain_id` long ago.

---

Stacked on #942. Top of the stack.

**Test de-slop stack** (merge in order; bases retarget as predecessors merge):
1. #936 — nextest heavy-test filter
2. #937 — remove dead code and debug noise
3. #938 — consolidate redundant e2e tests
4. #939 — split it/utils.rs into modules
5. #940 — dedupe e2e harness helpers
6. #941 — adopt shared harness helpers
7. #942 — dedupe private-RPC, WS, and earn suites
8. #943 — clean up hot suites and refresh test docs ← this PR
