### PR TITLE
fix(cli): alias private RPC port flag

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -425,6 +425,7 @@ pub struct ZoneArgs {
     /// Port for the redacted zone RPC server (0 for OS-assigned).
     #[arg(
         long = "redacted-rpc.port",
+        alias = "private-rpc.port",
         env = "REDACTED_RPC_PORT",
         default_value_t = 8544
     )]
@@ -744,6 +745,29 @@ mod tests {
         )
         .unwrap();
         assert_eq!(overridden.zone.zone_poll_interval_secs, 3);
+    }
+
+    #[test]
+    fn private_rpc_port_alias_is_accepted() {
+        let common = [
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+        ];
+
+        let redacted = ZoneArgsParser::try_parse_from(
+            common.into_iter().chain(["--redacted-rpc.port", "9544"]),
+        )
+        .unwrap();
+        let private = ZoneArgsParser::try_parse_from(
+            common.into_iter().chain(["--private-rpc.port", "9544"]),
+        )
+        .unwrap();
+
+        assert_eq!(redacted.zone.redacted_rpc_port, 9544);
+        assert_eq!(private.zone.redacted_rpc_port, 9544);
     }
 
     #[test]

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -307,7 +307,11 @@ mod command {
         http_port: u16,
 
         /// Zone redacted RPC port.
-        #[arg(long = "redacted-rpc.port", default_value_t = 8544)]
+        #[arg(
+            long = "redacted-rpc.port",
+            alias = "private-rpc.port",
+            default_value_t = 8544
+        )]
         redacted_rpc_port: u16,
 
         /// Extra arguments forwarded to `tempo-zone node`.
@@ -489,7 +493,20 @@ mod command {
 
     #[cfg(test)]
     mod tests {
-        use super::ensure_ws_url;
+        use clap::Parser as _;
+
+        use super::{DevCommand, ensure_ws_url};
+
+        #[test]
+        fn private_rpc_port_alias_is_accepted() {
+            let redacted =
+                DevCommand::try_parse_from(["dev", "--redacted-rpc.port", "9544"]).unwrap();
+            let private =
+                DevCommand::try_parse_from(["dev", "--private-rpc.port", "9544"]).unwrap();
+
+            assert_eq!(redacted.redacted_rpc_port, 9544);
+            assert_eq!(private.redacted_rpc_port, 9544);
+        }
 
         #[test]
         fn ensure_ws_url_accepts_websocket_schemes() {


### PR DESCRIPTION
## Summary

- accept `--private-rpc.port` as a backward-compatible alias for `--redacted-rpc.port`
- support the alias for both `tempo-zone node` and `tempo-zone dev`
- add parser tests proving both spellings populate the same redacted RPC port

## Context

Zones [#934](https://github.com/tempoxyz/zones/pull/934) renamed the flag, while existing deployment templates continued passing the old spelling. Keeping the old spelling as an alias allows independently updated images and deployment templates to remain compatible during rollout.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- focused tests and clippy could not run because Cargo dependency fetches from `alloy-rs/evm` receive HTTP 401 in this sandbox

Prompted by: aditya
