### PR TITLE
feat: configure forced recovery via manifest

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -58,8 +58,9 @@ use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 
 /// Per-anchor production permit backed by the effective leadership schedule.
 ///
-/// The permit is a single schedule lookup: produce anchor `N` only if the portal schedule or an
-/// active bounded forced-recovery override assigns `N` to this node.
+/// The permit is a single schedule lookup: produce anchor `N` only if the portal schedule or a
+/// forced-recovery override assigns `N` to this node. An optimistic override is open-ended until
+/// the next finalized portal transition supplies the ordinary-authority boundary.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
     schedule: LeadershipSchedule,
@@ -587,7 +588,7 @@ mod tests {
 
         let recovery_schedule = LeadershipSchedule::seeded(LeadershipState::new(7, me, 0));
         recovery_schedule
-            .prepare_forced_recovery(8, other.clone(), B256::repeat_byte(0x11), 51)
+            .install_forced_recovery(8, other.clone(), B256::repeat_byte(0x11), 51)
             .unwrap();
         recovery_schedule
             .publish(LeadershipState::new(8, other.clone(), 60))

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -529,6 +529,12 @@ where
             // Seed the applied anchor from the persisted checkpoint so it targets the leader
             // of the next anchor from the very start (and not after the first post-restart block)
             schedule.record_applied_anchor(snapshot_anchor);
+            install_manifest_forced_recovery(
+                ctx.node.provider(),
+                snapshot_anchor,
+                p2p.manifest(),
+                &schedule,
+            )?;
             self.l1_config.leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
                 schedule,
                 manifest: p2p.manifest().clone(),
@@ -793,6 +799,64 @@ impl LeadershipSink for ScheduleLeadershipSink {
         );
         Ok(())
     }
+}
+
+/// Install the manifest's temporary runtime authority before any role-dependent task starts.
+///
+/// The selected block must be the persisted canonical head. The schedule was seeded from the
+/// portal at that block's Tempo anchor immediately before this call, so its latest epoch is the
+/// portal state being overridden.
+fn install_manifest_forced_recovery<P>(
+    provider: &P,
+    snapshot_anchor: u64,
+    manifest: &ZoneManifest,
+    schedule: &LeadershipSchedule,
+) -> eyre::Result<()>
+where
+    P: BlockNumReader + HeaderProvider<Header = TempoHeader>,
+{
+    let Some(recovery) = manifest.forced_recovery() else {
+        return Ok(());
+    };
+    let portal_epoch = schedule.latest().map(|record| record.epoch).ok_or_else(|| {
+        eyre::eyre!(
+            "forced recovery requires a portal leadership snapshot at the local Tempo checkpoint"
+        )
+    })?;
+    let zone_height = provider.best_block_number()?;
+    let zone_header = provider
+        .sealed_header(zone_height)?
+        .ok_or_else(|| eyre::eyre!("local canonical zone header {zone_height} is missing"))?;
+    eyre::ensure!(
+        zone_header.hash() == recovery.recovery_block_hash(),
+        "forced recovery block hash {} does not equal local canonical head {} at height {}",
+        recovery.recovery_block_hash(),
+        zone_header.hash(),
+        zone_height,
+    );
+
+    let recovery_start_tempo_block = snapshot_anchor
+        .checked_add(1)
+        .ok_or_else(|| eyre::eyre!("forced recovery Tempo anchor overflow"))?;
+    let recovery_epoch = portal_epoch
+        .checked_add(1)
+        .ok_or_else(|| eyre::eyre!("forced recovery epoch overflow"))?;
+    schedule.install_forced_recovery(
+        recovery_epoch,
+        recovery.leader().clone(),
+        recovery.recovery_block_hash(),
+        recovery_start_tempo_block,
+    )?;
+    info!(
+        target: "reth::cli",
+        leader = %recovery.leader(),
+        portal_epoch,
+        recovery_zone_height = zone_height,
+        recovery_zone_hash = %recovery.recovery_block_hash(),
+        recovery_start_tempo_block,
+        "Installed manifest forced recovery"
+    );
+    Ok(())
 }
 
 /// Seed the leadership schedule from the portal snapshot at the local Tempo anchor.

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1484,7 +1484,7 @@ mod tests {
         let incoming = PrivateKey::from_seed(2).public_key();
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, outgoing.clone(), 0));
         schedule
-            .prepare_forced_recovery(8, incoming.clone(), B256::repeat_byte(0x11), 51)
+            .install_forced_recovery(8, incoming.clone(), B256::repeat_byte(0x11), 51)
             .unwrap();
         schedule
             .publish(LeadershipState::new(8, incoming.clone(), 60))

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -415,9 +415,11 @@ where
     P: BlockNumReader + HeaderProvider<Header = TempoHeader>,
 {
     if let Some(recovery) = schedule.forced_recovery().filter(|recovery| {
-        recovery.is_active()
-            && &recovery.leader == local
+        &recovery.leader == local
             && next_anchor >= recovery.recovery_start_tempo_block
+            && recovery
+                .portal_activation_tempo_block
+                .is_none_or(|activation| next_anchor < activation)
     }) {
         let local_height = match provider.best_block_number() {
             Ok(height) => height,

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -57,8 +57,8 @@ use zone_rpc::{
     types::{
         ActiveLeaderInfo, AuthorizationTokenInfoResponse, BoxEyreFut, BoxFut, JsonRpcError,
         LocalSequencerInfo, PeerTipInfo, SequencerInfoResponse, SequencerPeerInfo,
-        SequencerProgress, SequencerReadiness, SetLeaderOptions, SetLeaderParams,
-        SetLeaderResponse, ZoneInfoResponse, internal, raw_null, raw_zero, to_raw,
+        SequencerProgress, SequencerReadiness, SetLeaderResponse, ZoneInfoResponse, internal,
+        raw_null, raw_zero, to_raw,
     },
 };
 
@@ -193,21 +193,13 @@ where
 {
     let mut module = RpcModule::new(());
     let set_leader_sequencer = sequencer.clone();
-    let set_leader_provider = provider.clone();
     module.register_async_method("zone_setLeader", move |params, _, _| {
         let sequencer = set_leader_sequencer.clone();
-        let provider = set_leader_provider.clone();
         async move {
-            let (target, options) = params.parse::<SetLeaderParams>()?.into_parts();
-            set_leader(
-                portal_address,
-                sequencer.as_ref(),
-                &provider,
-                target,
-                options,
-            )
-            .await
-            .map_err(operator_rpc_error)
+            let (target,) = params.parse::<(Address,)>()?;
+            set_leader(portal_address, sequencer.as_ref(), target)
+                .await
+                .map_err(operator_rpc_error)
         }
     })?;
     module.register_async_method("zone_getSequencerInfo", move |_, _, _| {
@@ -1163,35 +1155,11 @@ where
     })
 }
 
-fn parse_forced_recovery(options: SetLeaderOptions) -> Result<Option<(u64, B256)>, JsonRpcError> {
-    if !options.force {
-        if options.expected_epoch.is_some() || options.recovery_block_hash.is_some() {
-            return Err(JsonRpcError::invalid_params(
-                "expectedEpoch and recoveryBlockHash require force=true",
-            ));
-        }
-        return Ok(None);
-    }
-    let expected_epoch = options
-        .expected_epoch
-        .ok_or_else(|| JsonRpcError::invalid_params("force=true requires expectedEpoch"))?
-        .to::<u64>();
-    let recovery_block_hash = options
-        .recovery_block_hash
-        .ok_or_else(|| JsonRpcError::invalid_params("force=true requires recoveryBlockHash"))?;
-    Ok(Some((expected_epoch, recovery_block_hash)))
-}
-
-async fn set_leader<P>(
+async fn set_leader(
     portal_address: Address,
     sequencer: &std::sync::OnceLock<SequencerRpcContext>,
-    provider: &P,
     target: Address,
-    options: SetLeaderOptions,
-) -> Result<SetLeaderResponse, JsonRpcError>
-where
-    P: BlockNumReader + HeaderProvider + StateProviderFactory,
-{
+) -> Result<SetLeaderResponse, JsonRpcError> {
     let Some(context) = sequencer.get() else {
         return Err(JsonRpcError::invalid_params(
             "zone_setLeader requires multi-sequencer mode",
@@ -1203,10 +1171,9 @@ where
         ));
     }
 
-    // The public endpoint is intentionally unauthenticated. The transaction itself is still
-    // signed by this node's individual sequencer key, and the portal enforces relayer authority.
-    // An rpc-only node holds no such key, so it cannot relay: operators call this on a quorum
-    // member instead.
+    // The transaction is signed by this node's individual sequencer key, and the portal enforces
+    // relayer authority. An rpc-only node holds no such key, so it cannot relay: operators call
+    // this on a quorum member instead.
     let (Some(relayer), Some(relayer_address)) =
         (context.relayer.as_ref(), context.local_secp256k1_address)
     else {
@@ -1215,13 +1182,13 @@ where
         ));
     };
     let portal = ZonePortal::new(portal_address, relayer);
-    let forced = parse_forced_recovery(options)?;
 
     // The target must be a manifest member and a registered portal sequencer.
-    let target_node = context
-        .manifest
-        .node_by_secp256k1_address(target)
-        .ok_or_else(|| JsonRpcError::invalid_params("target is not a manifest member"))?;
+    if context.manifest.node_by_secp256k1_address(target).is_none() {
+        return Err(JsonRpcError::invalid_params(
+            "target is not a manifest member",
+        ));
+    }
     let is_sequencer = portal
         .isSequencer(target)
         .block(BlockId::finalized())
@@ -1243,54 +1210,6 @@ where
     let (leader, expected_epoch) =
         tokio::try_join!(leader_call.call(), epoch_call.call()).map_err(internal)?;
 
-    if let Some((requested_epoch, recovery_block_hash)) = forced {
-        let recovery_epoch = requested_epoch
-            .checked_add(1)
-            .ok_or_else(|| JsonRpcError::invalid_params("forced recovery epoch overflow"))?;
-        if leader == target {
-            if expected_epoch != recovery_epoch {
-                return Err(JsonRpcError::invalid_params(format!(
-                    "finalized target epoch is {expected_epoch}, expected forced recovery epoch \
-                     {recovery_epoch}"
-                )));
-            }
-        } else if expected_epoch != requested_epoch {
-            return Err(JsonRpcError::invalid_params(format!(
-                "finalized leadership epoch is {expected_epoch}, expected {requested_epoch}"
-            )));
-        }
-
-        let local_tip = local_recovery_tip(provider)?;
-        if local_tip.zone_hash != recovery_block_hash {
-            return Err(JsonRpcError::invalid_params(format!(
-                "forced recovery block hash {recovery_block_hash} does not equal local canonical \
-                 head {} at height {}",
-                local_tip.zone_hash, local_tip.zone_height,
-            )));
-        }
-
-        let prepared = context
-            .schedule
-            .prepare_forced_recovery(
-                recovery_epoch,
-                target_node.ed25519_public_key().clone(),
-                recovery_block_hash,
-                local_tip.tempo_block_number.saturating_add(1),
-            )
-            .map_err(|err| JsonRpcError::invalid_params(err.to_string()))?;
-        tracing::info!(
-            target: "zone::rpc",
-            %target,
-            requested_epoch,
-            recovery_zone_height = local_tip.zone_height,
-            recovery_zone_hash = %recovery_block_hash,
-            recovery_tempo_block = local_tip.tempo_block_number,
-            recovery_tempo_hash = %local_tip.tempo_block_hash,
-            prepared,
-            "Prepared forced leader recovery"
-        );
-    }
-
     if leader == target {
         return Ok(SetLeaderResponse {
             status: "alreadyActive".to_owned(),
@@ -1300,9 +1219,9 @@ where
         });
     }
 
-    // Relay with the individual key on the reserved admin-operations nonce lane and
-    // return immediately: the node's role changes only when its finalized L1
-    // subscriber observes the resulting transition (I6).
+    // Relay with the individual key on the reserved admin-operations nonce lane and return
+    // immediately. Runtime recovery is configured separately in the manifest; this method only
+    // changes the ordinary on-chain leadership schedule when the operator invokes it.
     let pending = portal
         .setLeader(target, expected_epoch)
         .nonce_key(zone_sequencer::nonce_keys::ADMIN_OPS_NONCE_KEY)
@@ -1436,6 +1355,22 @@ mod tests {
                 .to_string()
                 .contains("zone_setLeader requires multi-sequencer mode")
         );
+
+        let error = module
+            .call::<_, SetLeaderResponse>(
+                "zone_setLeader",
+                (
+                    Address::repeat_byte(0x22),
+                    serde_json::json!({
+                        "force": true,
+                        "expectedEpoch": "0x7",
+                        "recoveryBlockHash": B256::repeat_byte(0x33),
+                    }),
+                ),
+            )
+            .await
+            .expect_err("zone_setLeader no longer accepts runtime recovery options");
+        assert!(error.to_string().contains("Invalid params"));
     }
 
     #[test]

--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -31,9 +31,9 @@ const QUIESCENCE: Duration = Duration::from_secs(3);
 const LIVE_PROPAGATION_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// A crashes after producing a tip shared by every follower. Three L1 anchors pass with no zone
-/// blocks, then an operator selects B and the shared tip for forced recovery. The matching
-/// finalized transition lets B fill the missing anchor range and continue as the portal leader,
-/// without replacing any block preceding the crash.
+/// blocks, then an operator selects B and the shared tip for forced recovery. B optimistically
+/// fills the missing anchor range before the next transition finalizes. That transition selects C,
+/// which takes over at its exact anchor without replacing any block preceding the crash.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -73,32 +73,48 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
         );
     }
 
-    // The force RPC installs this request on each surviving node before relaying setLeader.
-    // Publishing the matching transition stands in for their subscribers finalizing that L1
-    // transaction. Its portal activation is anchor 7, while the recovery override starts at 4.
+    // A coordinated restart installs the same manifest directive on each surviving node. The
+    // runtime override immediately lets B consume the queued anchors.
     let recovery_epoch = 1;
     let replacement_index = 1;
     let replacement = cluster.p2p_public_keys[replacement_index].clone();
     for node in &cluster.nodes {
-        assert!(node.leadership().prepare_forced_recovery(
+        assert!(node.leadership().install_forced_recovery(
             recovery_epoch,
             replacement.clone(),
             recovery_block_hash,
             recovery_start_tempo_block,
         )?);
-        assert!(
+        assert_eq!(
             node.leadership()
                 .leader_for(recovery_start_tempo_block)
-                .is_none(),
-            "the recovery range must remain fenced before setLeader finalizes"
+                .expect("optimistic recovery must govern immediately")
+                .leader,
+            replacement,
+        );
+        assert!(!node.leadership().forced_recovery().unwrap().is_bounded());
+    }
+
+    let optimistic_tip = recovery_start_tempo_block + 2;
+    cluster.wait_all_at(optimistic_tip, HANDOFF_TIMEOUT).await?;
+    let b_producer = cluster.sequencer_signers[replacement_index].address();
+    for height in recovery_start_tempo_block..=optimistic_tip {
+        assert_eq!(
+            cluster.assert_same_block(height).await?.beneficiary,
+            b_producer,
+            "replacement leader B did not optimistically produce recovery block {height}"
         );
     }
 
+    // A finalized transition to C at anchor 7 closes the optimistic override even though it does
+    // not select B. Subscriber ordering publishes this transition before anchor 7 can be built.
     let portal_activation_tempo_block = cluster.next_anchor_number();
     assert_eq!(portal_activation_tempo_block, 7);
+    let portal_leader_index = 2;
+    let c_producer = cluster.sequencer_signers[portal_leader_index].address();
     cluster.publish_transition(
         recovery_epoch,
-        replacement_index,
+        portal_leader_index,
         portal_activation_tempo_block,
     )?;
     cluster.inject_block(vec![])?;
@@ -116,16 +132,16 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
         );
     }
 
-    // B produced every missing block and the portal-activation block. Once anchor 7 is applied,
-    // ordinary portal authority takes over and the temporary recovery state is removed.
-    let b_producer = cluster.sequencer_signers[replacement_index].address();
-    for height in recovery_start_tempo_block..=portal_activation_tempo_block {
-        assert_eq!(
-            cluster.assert_same_block(height).await?.beneficiary,
-            b_producer,
-            "replacement leader B did not produce recovery block {height}"
-        );
-    }
+    // C, rather than B, produces the portal-activation block. Once it is applied, the temporary
+    // recovery state is removed.
+    assert_eq!(
+        cluster
+            .assert_same_block(portal_activation_tempo_block)
+            .await?
+            .beneficiary,
+        c_producer,
+        "portal-selected leader C did not produce the transition block"
+    );
     for node in &cluster.nodes {
         assert!(
             node.leadership().forced_recovery().is_none(),
@@ -139,7 +155,7 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     cluster.wait_all_at(next_height, HANDOFF_TIMEOUT).await?;
     assert_eq!(
         cluster.assert_same_block(next_height).await?.beneficiary,
-        b_producer
+        c_producer
     );
     Ok(())
 }

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -10,12 +10,17 @@ from finalized Tempo L1 state — the `ZonePortal`'s `leader`, `leaderEpoch`, an
 `leaderActivationTempoBlock` fields and its `LeaderUpdated` event. Every observed transition
 is retained in an activation-indexed `LeadershipSchedule`.
 
-For manual crashed-leader recovery, an operator may install the same force request on
-the surviving nodes. The request fences the next anchor at the exact operator-selected tip until
-the matching `LeaderUpdated` transition is finalized, then assigns the replacement leader from
-that anchor until the portal activation. The portal schedule is authoritative from its activation
-onward. Operational consumers use `leader_for(anchor)`, which incorporates the recovery without
-mutating the retained portal transition timeline.
+For manual crashed-leader recovery, the operator stops the nodes, selects a canonical tip shared by
+the survivors, adds the same `[forced_recovery]` directive to every manifest, and restarts them.
+Each node verifies that its local canonical head has the configured hash before any role task
+starts. The selected replacement governs from the next Tempo anchor until the first subsequent
+finalized portal transition reaches its activation anchor. Nodes never submit that transition
+automatically: the operator may call the ordinary `zone_setLeader` RPC whenever the zone is ready
+to return to the on-chain schedule.
+
+The configured hash must be the local canonical head at startup. After a normal portal transition
+ends recovery, the operator must remove the directive before restarting the nodes. Restarting with
+the directive after the replacement has produced past `recovery_block_hash` is unsupported.
 
 If a manifest is not specified, `tempo-zone` retains its existing single-sequencer startup
 behavior.
@@ -107,6 +112,18 @@ rpc_only = true
 valid for the initial sequencer set installed atomically by `ZoneFactory`; later
 `setSequencerSet` calls increment it. The field defaults to `1` for compatibility with existing
 manifests that omitted it.
+
+To recover a crashed leader, add this top-level table before restarting the fleet:
+
+```toml
+[forced_recovery]
+leader = "follower-a"
+recovery_block_hash = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+```
+
+`leader` is a manifest node name and must identify a quorum member. Because the configured hash
+must be the current head, the first recovery anchor and portal epoch are taken from the node's
+persisted checkpoint; no independently configured height or epoch can disagree with the hash.
 
 An `rpc_only` entry declares no `secp256k1_address` and the node is started without
 `--secp256k1.key`. It never signs a settlement attestation, so the key would be dead weight —

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -7,8 +7,8 @@ mod network;
 mod runtime;
 
 pub use manifest::{
-    ForcedRecoveryState, LeadershipSchedule, LeadershipState, ManifestAddress, ManifestError,
-    ManifestNode, Role, ZoneManifest,
+    ForcedRecoveryConfig, ForcedRecoveryState, LeadershipSchedule, LeadershipState,
+    ManifestAddress, ManifestError, ManifestNode, Role, ZoneManifest,
 };
 pub use network::P2pNetworkId;
 pub use runtime::{

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -81,34 +81,63 @@ impl LeadershipState {
     }
 }
 
+/// Operator-declared crashed-leader recovery configuration.
+///
+/// Every node loads this directive before starting its role controller. The selected block hash
+/// pins the shared canonical tip and its embedded Tempo anchor identifies the portal leadership
+/// state that recovery temporarily overrides.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForcedRecoveryConfig {
+    /// Ed25519 identity selected as the temporary runtime leader.
+    leader: PublicKey,
+    /// Exact canonical zone block hash selected by the operator.
+    recovery_block_hash: B256,
+}
+
+impl ForcedRecoveryConfig {
+    /// Ed25519 identity selected as the temporary runtime leader.
+    pub const fn leader(&self) -> &PublicKey {
+        &self.leader
+    }
+
+    /// Exact canonical zone block hash selected by the operator.
+    pub const fn recovery_block_hash(&self) -> B256 {
+        self.recovery_block_hash
+    }
+}
+
 /// Forced-recovery authority attached to the finalized leadership schedule.
 ///
-/// Before the matching portal transition is finalized, the record fences the selected recovery
-/// boundary so the old leader cannot move the local tip. The transition activates the replacement
-/// leader from `recovery_start_tempo_block` until ordinary portal authority takes over.
+/// The manifest directive immediately assigns the replacement leader from
+/// `recovery_start_tempo_block`, allowing it to consume the L1 backlog. The range is open-ended
+/// until the next finalized portal transition, whose activation boundary restores ordinary portal
+/// authority regardless of which leader it selects.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForcedRecoveryState {
-    /// Epoch assigned by the matching portal transition.
+    /// Epoch expected for the next portal transition.
     pub epoch: u64,
     /// Ed25519 identity selected as the replacement leader.
     pub leader: PublicKey,
-    /// Exact canonical zone block hash selected by the force RPC.
+    /// Exact canonical zone block hash selected in the manifest.
     pub recovery_block_hash: B256,
     /// First Tempo anchor governed by the recovery override.
     pub recovery_start_tempo_block: u64,
-    /// Activation anchor from the matching finalized portal transition.
+    /// Activation anchor from the next finalized portal transition.
     pub portal_activation_tempo_block: Option<u64>,
 }
 
 impl ForcedRecoveryState {
-    /// Whether finalized L1 has activated this recovery.
-    pub const fn is_active(&self) -> bool {
+    /// Whether finalized L1 has bounded this runtime override.
+    pub const fn is_bounded(&self) -> bool {
         self.portal_activation_tempo_block.is_some()
     }
 
     fn leadership_record_for(&self, tempo_anchor: u64) -> Option<LeadershipState> {
-        let portal_activation = self.portal_activation_tempo_block?;
-        if !(self.recovery_start_tempo_block..portal_activation).contains(&tempo_anchor) {
+        if tempo_anchor < self.recovery_start_tempo_block
+            || self
+                .portal_activation_tempo_block
+                .is_some_and(|activation| tempo_anchor >= activation)
+        {
             return None;
         }
         Some(LeadershipState::new(
@@ -125,18 +154,12 @@ struct LeadershipScheduleState {
     transitions: std::collections::BTreeMap<u64, LeadershipState>,
     /// Highest Tempo anchor embedded in a locally canonical zone block.
     applied_anchor: Option<u64>,
-    /// Optional operator-requested forced recovery.
+    /// Optional manifest-declared forced recovery.
     forced_recovery: Option<ForcedRecoveryState>,
 }
 
 impl LeadershipScheduleState {
     fn leader_for(&self, tempo_anchor: u64) -> Option<LeadershipState> {
-        if self.forced_recovery.as_ref().is_some_and(|recovery| {
-            !recovery.is_active() && tempo_anchor >= recovery.recovery_start_tempo_block
-        }) {
-            // If there's a forced recovery pending for this anchor, return None because `setLeader` call must finalize first.
-            return None;
-        }
         let scheduled = self
             .transitions
             .range(..=tempo_anchor)
@@ -156,31 +179,28 @@ impl LeadershipScheduleState {
         self.leader_for(next_anchor)
     }
 
-    fn maybe_activate_forced_recovery(&mut self) {
-        let Some(recovery) = self.forced_recovery.as_mut() else {
-            return;
+    fn maybe_bound_forced_recovery(&mut self) -> bool {
+        let Some(recovery) = self.forced_recovery.as_ref() else {
+            return false;
         };
-        if recovery.is_active() {
-            return;
+        if recovery.is_bounded() {
+            return false;
         }
         let Some(record) = self
             .transitions
-            .last_key_value()
-            .map(|(_, record)| record.clone())
+            .values()
+            .find(|record| record.epoch >= recovery.epoch)
         else {
-            return;
+            return false;
         };
-        if record.epoch != recovery.epoch || record.leader != recovery.leader {
-            // Once finalized L1 has reached or passed the expected recovery epoch with a
-            // different authority, this request can never become valid.
-            if record.epoch >= recovery.epoch {
-                self.forced_recovery = None;
-            }
-            return;
-        }
-        recovery.portal_activation_tempo_block = Some(record.activation_tempo_block);
-        metrics::counter!("zone_forced_recovery_transitions_total", "state" => "active")
+        let activation = record.activation_tempo_block;
+        self.forced_recovery
+            .as_mut()
+            .expect("recovery was read above")
+            .portal_activation_tempo_block = Some(activation);
+        metrics::counter!("zone_forced_recovery_transitions_total", "state" => "bounded")
             .increment(1);
+        true
     }
 }
 
@@ -309,7 +329,7 @@ impl LeadershipSchedule {
         state
             .transitions
             .insert(record.activation_tempo_block, record);
-        state.maybe_activate_forced_recovery();
+        state.maybe_bound_forced_recovery();
         drop(state);
         self.changed.send_replace(());
         Ok(true)
@@ -317,9 +337,10 @@ impl LeadershipSchedule {
 
     /// Returns the operational authority for `tempo_anchor`.
     ///
-    /// A pending forced recovery fences its recovery boundary. Once finalized, it overrides the
-    /// earlier portal schedule from that boundary until the matching portal activation. Returns
-    /// `None` while fenced, uninitialized, or for an anchor no retained transition governs.
+    /// An optimistic forced recovery overrides the earlier portal schedule from its recovery
+    /// boundary until the next finalized portal transition, regardless of which leader that
+    /// transition selects. Returns `None` while uninitialized or for an anchor no retained
+    /// transition governs.
     pub fn leader_for(&self, tempo_anchor: u64) -> Option<LeadershipState> {
         self.inner
             .read()
@@ -349,12 +370,13 @@ impl LeadershipSchedule {
         self.inner.read().expect("poisoned").next_anchor_record()
     }
 
-    /// Install a forced-recovery request.
+    /// Install a manifest-declared forced recovery.
     ///
-    /// Repeating the identical request is an idempotent no-op. A different outstanding request
-    /// is rejected. The caller must validate the exact local canonical recovery tip first. Until
-    /// the matching portal transition is finalized, the request fences the next anchor.
-    pub fn prepare_forced_recovery(
+    /// Reinstalling the identical directive is an idempotent no-op. A different outstanding
+    /// directive is rejected. The caller must validate the exact local canonical recovery tip
+    /// first. The directive immediately governs the next anchor and remains in force until the
+    /// next finalized portal transition.
+    pub fn install_forced_recovery(
         &self,
         recovery_epoch: u64,
         leader: PublicKey,
@@ -376,24 +398,22 @@ impl LeadershipSchedule {
                     && existing.leader == requested.leader
                     && existing.recovery_block_hash == requested.recovery_block_hash
                     && existing.recovery_start_tempo_block == requested.recovery_start_tempo_block,
-                "conflicting forced recovery request is already installed"
+                "conflicting forced recovery directive is already installed"
             );
             return Ok(false);
         }
         state.forced_recovery = Some(requested);
-        state.maybe_activate_forced_recovery();
-        eyre::ensure!(
-            state.forced_recovery.is_some(),
-            "latest finalized leadership transition conflicts with forced recovery request"
-        );
+        state.maybe_bound_forced_recovery();
         drop(state);
         self.changed.send_replace(());
-        metrics::counter!("zone_forced_recovery_requests_total", "result" => "prepared")
+        metrics::counter!("zone_forced_recovery_directives_total", "result" => "installed")
+            .increment(1);
+        metrics::counter!("zone_forced_recovery_transitions_total", "state" => "active")
             .increment(1);
         Ok(true)
     }
 
-    /// Return the current forced-recovery request, if any.
+    /// Return the current forced-recovery directive, if any.
     pub fn forced_recovery(&self) -> Option<ForcedRecoveryState> {
         self.inner.read().expect("poisoned").forced_recovery.clone()
     }
@@ -665,6 +685,7 @@ pub struct ZoneManifest {
     zone_id: u32,
     sequencer_set_version: u64,
     leader_ed25519_public_key: PublicKey,
+    forced_recovery: Option<ForcedRecoveryConfig>,
     nodes: Vec<ManifestNode>,
 }
 
@@ -758,10 +779,37 @@ impl ZoneManifest {
             return Err(ManifestError::TooFewQuorumNodes(quorum_node_count));
         }
 
+        let forced_recovery = if let Some(recovery) = raw.forced_recovery {
+            let node = nodes
+                .iter()
+                .find(|node| node.name == recovery.leader)
+                .ok_or_else(|| {
+                    ManifestError::ForcedRecoveryLeaderNotFound(recovery.leader.clone())
+                })?;
+            if node.rpc_only {
+                return Err(ManifestError::RpcOnlyForcedRecoveryLeader(recovery.leader));
+            }
+            let recovery_block_hash =
+                recovery
+                    .recovery_block_hash
+                    .parse::<B256>()
+                    .map_err(|source| ManifestError::InvalidRecoveryBlockHash {
+                        hash: recovery.recovery_block_hash,
+                        reason: source.to_string(),
+                    })?;
+            Some(ForcedRecoveryConfig {
+                leader: node.ed25519_public_key.clone(),
+                recovery_block_hash,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             zone_id: raw.zone_id,
             sequencer_set_version: raw.sequencer_set_version,
             leader_ed25519_public_key,
+            forced_recovery,
             nodes,
         })
     }
@@ -846,6 +894,11 @@ impl ZoneManifest {
     /// Manifest-derived initial leadership record (epoch 0, active from genesis).
     pub fn bootstrap_leadership(&self) -> LeadershipState {
         LeadershipState::new(0, self.leader_ed25519_public_key.clone(), 0)
+    }
+
+    /// Optional operator-declared crashed-leader recovery directive.
+    pub const fn forced_recovery(&self) -> Option<&ForcedRecoveryConfig> {
+        self.forced_recovery.as_ref()
     }
 
     /// Role of `ed25519_public_key` under the manifest's bootstrap leader.
@@ -962,11 +1015,22 @@ struct RawManifest {
     #[serde(default = "default_sequencer_set_version")]
     sequencer_set_version: u64,
     leader_ed25519_public_key: String,
+    #[serde(default)]
+    forced_recovery: Option<RawForcedRecovery>,
     nodes: Vec<RawManifestNode>,
 }
 
 const fn default_sequencer_set_version() -> u64 {
     1
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawForcedRecovery {
+    /// Manifest node name selected as the temporary runtime leader.
+    leader: String,
+    /// Exact canonical zone block hash shared by every restarting node.
+    recovery_block_hash: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1016,6 +1080,15 @@ pub enum ManifestError {
 
     #[error("sequencer manifest leader `{0}` cannot be `rpc_only`")]
     RpcOnlyLeader(String),
+
+    #[error("forced recovery leader `{0}` does not match any manifest node name")]
+    ForcedRecoveryLeaderNotFound(String),
+
+    #[error("forced recovery leader `{0}` cannot be `rpc_only`")]
+    RpcOnlyForcedRecoveryLeader(String),
+
+    #[error("invalid forced recovery block hash `{hash}`: {reason}")]
+    InvalidRecoveryBlockHash { hash: String, reason: String },
 
     #[error("sequencer manifest node `{0}` must declare a secp256k1_address")]
     MissingSecp256k1Address(String),
@@ -1140,38 +1213,40 @@ mod tests {
     }
 
     #[test]
-    fn forced_recovery_fences_until_matching_transition_then_is_bounded() {
+    fn forced_recovery_is_optimistic_until_next_transition_bounds_it() {
         let outgoing = public_key(1);
         let incoming = public_key(2);
+        let portal_leader = public_key(3);
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, outgoing.clone(), 0));
         schedule.record_applied_anchor(50);
 
         assert!(
             schedule
-                .prepare_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
+                .install_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
                 .unwrap()
         );
-        assert!(
-            schedule.leader_for(51).is_none(),
-            "pending recovery must fence the selected boundary"
-        );
+        assert_eq!(schedule.leader_for(50).unwrap().leader, outgoing);
+        assert_eq!(schedule.leader_for(51).unwrap().leader, incoming);
+        assert_eq!(schedule.leader_for(u64::MAX).unwrap().leader, incoming);
+        assert!(!schedule.forced_recovery().unwrap().is_bounded());
 
         schedule
-            .publish(LeadershipState::new(8, incoming.clone(), 60))
+            .publish(LeadershipState::new(8, portal_leader.clone(), 60))
             .unwrap();
+        assert!(schedule.forced_recovery().unwrap().is_bounded());
         assert_eq!(schedule.leader_for(50).unwrap().leader, outgoing);
         assert_eq!(schedule.leader_for(51).unwrap().leader, incoming);
         assert_eq!(schedule.leader_for(59).unwrap().leader, incoming);
         assert_eq!(
             schedule.leader_for(60).unwrap().leader,
-            incoming,
-            "recovery agrees with portal authority at the activation boundary"
+            portal_leader,
+            "ordinary portal authority must take over at the activation boundary"
         );
         schedule
-            .publish(LeadershipState::new(9, public_key(3), 70))
+            .publish(LeadershipState::new(9, public_key(4), 70))
             .unwrap();
-        assert_eq!(schedule.leader_for(69).unwrap().leader, incoming);
-        assert_eq!(schedule.leader_for(70).unwrap().leader, public_key(3));
+        assert_eq!(schedule.leader_for(69).unwrap().leader, public_key(3));
+        assert_eq!(schedule.leader_for(70).unwrap().leader, public_key(4));
     }
 
     #[test]
@@ -1183,26 +1258,49 @@ mod tests {
             .unwrap();
 
         schedule
-            .prepare_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
+            .install_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
             .unwrap();
 
-        assert!(schedule.forced_recovery().unwrap().is_active());
+        assert!(schedule.forced_recovery().unwrap().is_bounded());
         assert_eq!(schedule.leader_for(51).unwrap().leader, incoming);
     }
 
     #[test]
-    fn forced_recovery_rejects_a_conflicting_transition_published_first() {
+    fn forced_recovery_respects_a_different_transition_published_first() {
+        let incoming = public_key(2);
+        let portal_leader = public_key(3);
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
         schedule
-            .publish(LeadershipState::new(8, public_key(3), 60))
+            .publish(LeadershipState::new(8, portal_leader.clone(), 60))
             .unwrap();
 
-        assert!(
-            schedule
-                .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
-                .is_err()
-        );
-        assert!(schedule.forced_recovery().is_none());
+        schedule
+            .install_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
+            .unwrap();
+
+        assert!(schedule.forced_recovery().unwrap().is_bounded());
+        assert_eq!(schedule.leader_for(51).unwrap().leader, incoming);
+        assert_eq!(schedule.leader_for(59).unwrap().leader, public_key(2));
+        assert_eq!(schedule.leader_for(60).unwrap().leader, portal_leader);
+    }
+
+    #[test]
+    fn forced_recovery_respects_a_different_transition_published_later() {
+        let incoming = public_key(2);
+        let portal_leader = public_key(3);
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
+        schedule
+            .install_forced_recovery(8, incoming.clone(), recovery_block_hash(), 51)
+            .unwrap();
+
+        schedule
+            .publish(LeadershipState::new(8, portal_leader.clone(), 60))
+            .unwrap();
+        let recovery = schedule.forced_recovery().unwrap();
+        assert!(recovery.is_bounded());
+        assert_eq!(schedule.leader_for(51).unwrap().leader, incoming);
+        assert_eq!(schedule.leader_for(59).unwrap().leader, public_key(2));
+        assert_eq!(schedule.leader_for(60).unwrap().leader, portal_leader);
     }
 
     #[test]
@@ -1210,7 +1308,7 @@ mod tests {
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
         schedule.record_applied_anchor(50);
         schedule
-            .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
+            .install_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
             .unwrap();
         schedule
             .publish(LeadershipState::new(8, public_key(2), 60))
@@ -1223,35 +1321,35 @@ mod tests {
     }
 
     #[test]
-    fn empty_recovery_window_still_activates_recovery() {
+    fn empty_recovery_window_is_bounded_by_portal_transition() {
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
         schedule
-            .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 60)
+            .install_forced_recovery(8, public_key(2), recovery_block_hash(), 60)
             .unwrap();
         schedule
-            .publish(LeadershipState::new(8, public_key(2), 60))
+            .publish(LeadershipState::new(8, public_key(3), 60))
             .unwrap();
 
-        assert!(schedule.forced_recovery().unwrap().is_active());
-        assert_eq!(schedule.leader_for(60).unwrap().leader, public_key(2));
+        assert!(schedule.forced_recovery().unwrap().is_bounded());
+        assert_eq!(schedule.leader_for(60).unwrap().leader, public_key(3));
     }
 
     #[test]
-    fn forced_recovery_request_is_idempotent_and_rejects_conflict() {
+    fn forced_recovery_directive_is_idempotent_and_rejects_conflict() {
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
         assert!(
             schedule
-                .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
+                .install_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
                 .unwrap()
         );
         assert!(
             !schedule
-                .prepare_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
+                .install_forced_recovery(8, public_key(2), recovery_block_hash(), 51)
                 .unwrap()
         );
         assert!(
             schedule
-                .prepare_forced_recovery(8, public_key(3), recovery_block_hash(), 51)
+                .install_forced_recovery(8, public_key(3), recovery_block_hash(), 51)
                 .is_err()
         );
     }
@@ -1410,6 +1508,17 @@ mod tests {
         manifest_with_rpc_only(leader, &quorum)
     }
 
+    fn with_forced_recovery(manifest: &str, leader: &str, recovery_block_hash: &str) -> String {
+        manifest.replacen(
+            "\n[[nodes]]",
+            &format!(
+                "\n[forced_recovery]\nleader = \"{leader}\"\nrecovery_block_hash = \
+                 \"{recovery_block_hash}\"\n\n[[nodes]]"
+            ),
+            1,
+        )
+    }
+
     /// Builds a manifest where the fourth tuple element marks a node `rpc_only`. An `rpc_only`
     /// node declares no `secp256k1_address`, exactly as the loader requires.
     fn manifest_with_rpc_only(leader: u64, nodes: &[(u64, &str, &str, bool)]) -> String {
@@ -1504,6 +1613,52 @@ mod tests {
 
         let manifest = ZoneManifest::parse(&input).unwrap();
         assert_eq!(manifest.sequencer_set_version(), 0);
+    }
+
+    #[test]
+    fn parses_forced_recovery_directive() {
+        let input = with_forced_recovery(
+            &manifest(
+                1,
+                &[
+                    (1, "leader", "127.0.0.1:9200"),
+                    (2, "follower-a", "127.0.0.1:9201"),
+                    (3, "follower-b", "127.0.0.1:9202"),
+                ],
+            ),
+            "follower-a",
+            &recovery_block_hash().to_string(),
+        );
+        let manifest = ZoneManifest::parse(&input).unwrap();
+        let recovery = manifest.forced_recovery().unwrap();
+
+        assert_eq!(recovery.leader(), &public_key(2));
+        assert_eq!(recovery.recovery_block_hash(), recovery_block_hash());
+    }
+
+    #[test]
+    fn forced_recovery_leader_must_be_a_quorum_manifest_node() {
+        let base = manifest_with_rpc_only(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200", false),
+                (2, "follower-a", "127.0.0.1:9201", false),
+                (3, "follower-b", "127.0.0.1:9202", false),
+                (4, "public-rpc", "127.0.0.1:9203", true),
+            ],
+        );
+        let unknown = with_forced_recovery(&base, "missing", &recovery_block_hash().to_string());
+        assert!(matches!(
+            ZoneManifest::parse(&unknown),
+            Err(ManifestError::ForcedRecoveryLeaderNotFound(name)) if name == "missing"
+        ));
+
+        let rpc_only =
+            with_forced_recovery(&base, "public-rpc", &recovery_block_hash().to_string());
+        assert!(matches!(
+            ZoneManifest::parse(&rpc_only),
+            Err(ManifestError::RpcOnlyForcedRecoveryLeader(name)) if name == "public-rpc"
+        ));
     }
 
     #[test]

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -537,18 +537,22 @@ impl LeadershipSchedule {
             .cloned()
             .collect()
     }
-    /// Returns whether `ed25519_public_key` leads any retained transition.
+    /// Returns whether `ed25519_public_key` leads any retained portal transition or forced
+    /// recovery range.
     ///
     /// A transport-level acceptance check for live blocks: a lagging follower must keep
     /// accepting the rightful producer of in-between anchors after a later transition is
     /// observed. The exact per-anchor fence lives in the import path.
     pub fn is_scheduled_leader(&self, ed25519_public_key: &PublicKey) -> bool {
-        self.inner
-            .read()
-            .expect("poisoned")
+        let state = self.inner.read().expect("poisoned");
+        state
             .transitions
             .values()
             .any(|record| &record.leader == ed25519_public_key)
+            || state
+                .forced_recovery
+                .as_ref()
+                .is_some_and(|recovery| &recovery.leader == ed25519_public_key)
     }
 }
 
@@ -1318,6 +1322,27 @@ mod tests {
         assert!(schedule.forced_recovery().is_some());
         schedule.record_applied_anchor(60);
         assert!(schedule.forced_recovery().is_none());
+    }
+
+    #[test]
+    fn forced_recovery_leader_is_scheduled_until_recovery_completes() {
+        let recovery_leader = public_key(2);
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(7, public_key(1), 0));
+        schedule.record_applied_anchor(50);
+
+        assert!(!schedule.is_scheduled_leader(&recovery_leader));
+        schedule
+            .install_forced_recovery(8, recovery_leader.clone(), recovery_block_hash(), 51)
+            .unwrap();
+        assert!(schedule.is_scheduled_leader(&recovery_leader));
+
+        schedule
+            .publish(LeadershipState::new(8, public_key(3), 60))
+            .unwrap();
+        assert!(schedule.is_scheduled_leader(&recovery_leader));
+
+        schedule.record_applied_anchor(60);
+        assert!(!schedule.is_scheduled_leader(&recovery_leader));
     }
 
     #[test]

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -310,41 +310,6 @@ pub struct SequencerInfoResponse {
     pub readiness: Option<SequencerReadiness>,
 }
 
-/// Optional behavior for `zone_setLeader`.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SetLeaderOptions {
-    /// Enable the crashed-leader recovery override.
-    #[serde(default)]
-    pub force: bool,
-    /// Finalized portal epoch that the call is expected to replace.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expected_epoch: Option<U64>,
-    /// Exact canonical zone head from which the selected leader must recover.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub recovery_block_hash: Option<B256>,
-}
-
-/// Backward-compatible parameters for `zone_setLeader`.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(untagged)]
-pub enum SetLeaderParams {
-    /// Existing form: `[target]`.
-    Regular((Address,)),
-    /// Extended form: `[target, options]`.
-    WithOptions((Address, SetLeaderOptions)),
-}
-
-impl SetLeaderParams {
-    /// Split the parsed parameters into their target and optional behavior.
-    pub fn into_parts(self) -> (Address, SetLeaderOptions) {
-        match self {
-            Self::Regular((target,)) => (target, SetLeaderOptions::default()),
-            Self::WithOptions((target, options)) => (target, options),
-        }
-    }
-}
-
 /// Response payload for `zone_setLeader`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -467,38 +432,4 @@ pub fn to_raw<T: serde::Serialize>(value: &T) -> Result<Box<RawValue>, JsonRpcEr
 /// Shorthand for wrapping any `Display` error into a [`JsonRpcError::internal`].
 pub fn internal(e: impl std::fmt::Display) -> JsonRpcError {
     JsonRpcError::internal(e.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use alloy_primitives::{Address, B256};
-
-    use super::SetLeaderParams;
-
-    #[test]
-    fn set_leader_params_accept_legacy_and_force_forms() {
-        let target = Address::repeat_byte(0x11);
-        let legacy: SetLeaderParams = serde_json::from_value(serde_json::json!([target])).unwrap();
-        let (parsed_target, options) = legacy.into_parts();
-        assert_eq!(parsed_target, target);
-        assert!(!options.force);
-
-        let forced: SetLeaderParams = serde_json::from_value(serde_json::json!([
-            target,
-            {
-                "force": true,
-                "expectedEpoch": "0x7",
-                "recoveryBlockHash": B256::repeat_byte(0x22),
-            }
-        ]))
-        .unwrap();
-        let (parsed_target, options) = forced.into_parts();
-        assert_eq!(parsed_target, target);
-        assert!(options.force);
-        assert_eq!(options.expected_epoch.unwrap().to::<u64>(), 7);
-        assert_eq!(
-            options.recovery_block_hash.unwrap(),
-            B256::repeat_byte(0x22)
-        );
-    }
 }


### PR DESCRIPTION
## Summary

- replace the force variant of `zone_setLeader` with an operator-declared `[forced_recovery]` manifest directive
- require the configured recovery hash to equal the local canonical head at startup, then install the runtime leadership override before role-dependent tasks start
- let the replacement leader produce from the next Tempo anchor until the first subsequent finalized portal transition reaches its activation boundary
- keep on-chain recovery explicit: nodes never submit `setLeader` automatically, and the operator can use the ordinary RPC when ready
- document the restart/removal requirements and update recovery, replication, RPC, and manifest tests

## Why

Waiting for a recovery `setLeader` transaction to finalize before activating the replacement can deadlock after enough downtime because L1 ingestion is bounded relative to zone progress. A manifest directive lets the operator restart every survivor with the same pinned canonical tip and apply the temporary runtime authority immediately, while the next finalized portal transition still restores the ordinary on-chain schedule.
