### PR TITLE
feat(bench): warm earn state and lower callback gas to 2.5M

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -97,7 +97,7 @@ on:
         description: L1 callback gas requested by composable withdrawals (maximum 10000000).
         type: string
         required: true
-        default: "10000000"
+        default: "2500000"
       swap-liquidity:
         description: Untimed liquidity seeded into the selected swap mechanism.
         type: string
@@ -269,7 +269,7 @@ jobs:
           INPUT_WITHDRAWAL_AMOUNT: ${{ inputs.withdrawal-amount || '1000000' }}
           INPUT_SWAP_MECHANISM: ${{ inputs.swap-mechanism || 'direct-swap' }}
           INPUT_RECIPIENT_MODE: ${{ inputs.recipient-mode || 'existing' }}
-          INPUT_CALLBACK_GAS_LIMIT: ${{ inputs.callback-gas-limit || '10000000' }}
+          INPUT_CALLBACK_GAS_LIMIT: ${{ inputs.callback-gas-limit || '2500000' }}
           INPUT_SWAP_LIQUIDITY: ${{ inputs.swap-liquidity || '10000000000' }}
           INPUT_L1_GAS_LIMIT: ${{ inputs.l1-gas-limit || '30000000' }}
           INPUT_L1_GENERAL_GAS_LIMIT: ${{ inputs.l1-general-gas-limit || '30000000' }}

--- a/contrib/bench/run-neobank-private-flow.sh
+++ b/contrib/bench/run-neobank-private-flow.sh
@@ -88,9 +88,14 @@ ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT="${ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT:-10
 #
 # Do not lower this based on receipt gas: under TIP-1016, each new storage slot needs
 # ~248k gas in-frame on top of execution gas, and that state gas never appears in
-# receipt gas_used (receipts report the regular dimension only). A first-time user's
-# callback creates dozens of slots, so 5M and below deterministically out-of-gases.
+# receipt gas_used (receipts report the regular dimension only). The first-ever
+# callback per flow creates dozens of system-level slots (router, vault, and portal
+# balances, DEX state), so 5M and below deterministically out-of-gases cold. When a
+# lower measured value is configured, one untimed warm-up journey pays those one-time
+# creations with the full allowance first; measured journeys then only need execution
+# gas plus per-transaction state headroom (approve-cycle slots).
 ZONES_BENCH_CALLBACK_GAS_LIMIT="${ZONES_BENCH_CALLBACK_GAS_LIMIT:-10000000}"
+ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT="${ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT:-10000000}"
 ZONES_BENCH_OUTPUT="${ZONES_BENCH_OUTPUT:-target/zones-benchmark/neobank-e2e}"
 ZONES_BENCH_REPORT="${ZONES_BENCH_REPORT:-target/zones-benchmark/report-neobank-e2e.json}"
 ZONES_BENCH_RENDERED_SCENARIO="${ZONES_BENCH_RENDERED_SCENARIO:-$ZONES_BENCH_OUTPUT/scenario.rendered.yml}"
@@ -193,7 +198,8 @@ esac
 for name in ZONES_BENCH_CONTROL_ACCOUNT_INDEX ZONES_BENCH_ACCOUNT_START ZONES_BENCH_ACCOUNTS ZONES_BENCH_SEQUENCER_ACCOUNT_INDEX ZONES_BENCH_COUNT \
     ZONES_BENCH_MAX_CONCURRENT ZONES_BENCH_DEPOSIT_AMOUNT ZONES_BENCH_ACTIVITY_AMOUNT \
     ZONES_BENCH_WITHDRAWAL_AMOUNT ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT \
-    ZONES_BENCH_CALLBACK_GAS_LIMIT ZONES_BENCH_SAMPLE_INSTANCES ZONES_BENCH_SEED \
+    ZONES_BENCH_CALLBACK_GAS_LIMIT ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT \
+    ZONES_BENCH_SAMPLE_INSTANCES ZONES_BENCH_SEED \
     ZONES_BENCH_ACCOUNT_END ZONES_BENCH_CONTROL_ACCOUNT_END \
     ZONES_BENCH_SEQUENCER_ACCOUNT_END ZONES_BENCH_EXPECTED_L1_CHAIN_ID \
     ZONES_BENCH_EXPECTED_ZONE_CHAIN_ID ZONES_BENCH_EXPECTED_ZONE_ID \
@@ -689,6 +695,19 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "slippage-bounce" ]]; then
     [[ "$bounce_earn_supply" =~ ^[0-9]+$ && "$bounce_vault_balance" =~ ^[0-9]+$ ]] ||
         die "could not read slippage-bounce L1 preconditions"
     stage_end slippage_precondition
+fi
+
+# One untimed journey pays the one-time system-level TIP-1016 state creations with the
+# full callback allowance so the measured journeys can run with the configured lower
+# value; see the ZONES_BENCH_CALLBACK_GAS_LIMIT note above. A failed cold callback
+# reverts its creations, so without this the first measured wave can never warm the
+# state itself. Skipped when the measured allowance is not lower.
+if (( 10#$ZONES_BENCH_CALLBACK_GAS_LIMIT < 10#$ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT )); then
+    measured_callback_gas_limit="$ZONES_BENCH_CALLBACK_GAS_LIMIT"
+    export ZONES_BENCH_CALLBACK_GAS_LIMIT="$ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT"
+    run_setup_scenario earn_warmup "$scenario_path" 1 \
+        "$ZONES_BENCH_OUTPUT/earn-warmup-report.json"
+    export ZONES_BENCH_CALLBACK_GAS_LIMIT="$measured_callback_gas_limit"
 fi
 
 measured_token_balance_before=""

--- a/contrib/bench/run-neobank-private-flow.sh
+++ b/contrib/bench/run-neobank-private-flow.sh
@@ -83,18 +83,19 @@ ZONES_BENCH_DEPOSIT_AMOUNT="${ZONES_BENCH_DEPOSIT_AMOUNT:-2000000}"
 ZONES_BENCH_ACTIVITY_AMOUNT="${ZONES_BENCH_ACTIVITY_AMOUNT:-1}"
 ZONES_BENCH_WITHDRAWAL_AMOUNT="${ZONES_BENCH_WITHDRAWAL_AMOUNT:-1000000}"
 ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT="${ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT:-10000000}"
-# The canonical Zone boundary e2e uses the full callback allowance: a gateway
-# callback can include a swap, vault action, and encrypted return deposit.
+# Callback gas requested by measured composable withdrawals. The untimed earn warm-up
+# journey below runs first with ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT and pays the
+# one-time system-level TIP-1016 state creation (router, vault, portal, and DEX first
+# touches), so measured callbacks only need execution gas plus per-transaction state
+# headroom (approve-cycle slots).
 #
-# Do not lower this based on receipt gas: under TIP-1016, each new storage slot needs
-# ~248k gas in-frame on top of execution gas, and that state gas never appears in
-# receipt gas_used (receipts report the regular dimension only). The first-ever
-# callback per flow creates dozens of system-level slots (router, vault, and portal
-# balances, DEX state), so 5M and below deterministically out-of-gases cold. When a
-# lower measured value is configured, one untimed warm-up journey pays those one-time
-# creations with the full allowance first; measured journeys then only need execution
-# gas plus per-transaction state headroom (approve-cycle slots).
-ZONES_BENCH_CALLBACK_GAS_LIMIT="${ZONES_BENCH_CALLBACK_GAS_LIMIT:-10000000}"
+# Do not size these from receipt gas: under TIP-1016, each new storage slot needs
+# ~248k gas in-frame on top of execution gas, and state gas never appears in receipt
+# gas_used (receipts report the regular dimension only). Without the warm-up, the
+# first-ever callback per flow creates dozens of slots, 5M and below deterministically
+# out-of-gases cold, and a failed cold callback reverts its creations, so a too-small
+# allowance can never warm the state itself.
+ZONES_BENCH_CALLBACK_GAS_LIMIT="${ZONES_BENCH_CALLBACK_GAS_LIMIT:-2500000}"
 ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT="${ZONES_BENCH_WARMUP_CALLBACK_GAS_LIMIT:-10000000}"
 ZONES_BENCH_OUTPUT="${ZONES_BENCH_OUTPUT:-target/zones-benchmark/neobank-e2e}"
 ZONES_BENCH_REPORT="${ZONES_BENCH_REPORT:-target/zones-benchmark/report-neobank-e2e.json}"


### PR DESCRIPTION
Stacked on #931 so the pull-request benchmark job exercises these changes together with the atomic settlement fast path.

Under TIP-1016, the first-ever earn callback pays one-time system-level state creation — roughly 248k gas in-frame per new storage slot for the router, vault, portal, and DEX first touches — and that state gas never appears in receipt `gas_used`, which reports the regular dimension only. A failed cold callback reverts its creations, so a too-small allowance can never warm the state itself. This is why simply lowering the callback default failed deterministically (runs 30637943025 at 2.5M, 30640369281 at 3M, 30641666224 at 5M): the first journey wave wedged cold and every retry re-paid the full creation cost.

The fix is one untimed warm-up journey that runs the preset scenario with the full 10M allowance whenever the measured callback gas is configured lower, before the measured phase. Warm measured callbacks then only need execution gas plus per-transaction state headroom, so the measured default drops to 2.5M, where the withdrawal planner packs four callbacks per batch instead of one 12.25M singleton each and callback-bearing slots become eligible for atomic settlement. Defaults are unchanged when the measured allowance is not lower than the warm-up allowance, and the warm-up report is included in the benchmark artifact.

Dispatch run 30645610512 validates the warm-up with a 2.5M measured allowance on this branch.