### PR TITLE
docs(primitives): correct chain ID boundary value

### DIFF
--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -107,7 +107,7 @@ pub const ZONE_INBOX_PROCESSED_HASH_SLOT: U256 = U256::ZERO;
 /// # Range safety
 ///
 /// EIP-2294 and ENSIP-11 reserve bit 31 (`0x8000_0000`) for coin-type flags,
-/// making chain IDs ≥ 2^31 (2,147,483,647) unsafe in parts of the ecosystem
+/// making chain IDs ≥ 2^31 (2,147,483,648) unsafe in parts of the ecosystem
 /// (ENS multi-chain address resolution, some JavaScript tooling that uses
 /// 32-bit integers, etc.).
 ///


### PR DESCRIPTION
Corrects the decimal expansion of the exclusive `2^31` boundary in the zone chain-ID documentation from `2,147,483,647` to `2,147,483,648`. This aligns the prose with EIP-2294, ENSIP-11, and the existing half-open range.
