### PR TITLE
fix: derive zone chain IDs by parent L1

### DIFF
--- a/.codex/skills/private-zone-rpc/SKILL.md
+++ b/.codex/skills/private-zone-rpc/SKILL.md
@@ -91,11 +91,17 @@ Prefer exact metadata:
    `zone_primitives::constants::zone_chain_id`:
 
 ```text
-chain_id = 421700000 + (zone_id % 1002610000)
+if parent_chain_id == 4217:
+    chain_id = 421700000 + zone_id
+else if parent_chain_id == 42431:
+    chain_id = 1424310000 + zone_id
+else:
+    chain_id = (parent_chain_id << 32) | zone_id
 ```
 
-`xtask create-zone` writes this value, and the node validates it at startup
-when `--zone.id` is nonzero.
+Production ranges reject exhaustion, and generic parents must be in `1..=1048574`.
+`xtask create-zone` writes this value, and the node validates it at startup against
+the connected parent chain and `ZonePortal.zoneId()`.
 
 Query the factory counter:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13886,6 +13886,7 @@ name = "zone-primitives"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "tempo-hardfork",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13886,6 +13886,7 @@ name = "zone-primitives"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa
   "serde",
 ] }
 tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
 tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72" }
 tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
 tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }

--- a/bin/tempo-zone-spf/src/main.rs
+++ b/bin/tempo-zone-spf/src/main.rs
@@ -323,6 +323,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
 
     let witness = BatchWitness {
         public_inputs: PublicInputs {
+            parent_chain_id: discovery.tempo_chain_id,
             zone_id: discovery.zone_id,
             portal: discovery.portal,
             tempo_block_number: final_tempo_header.number(),
@@ -433,7 +434,7 @@ async fn discover(
         },
         read_portal_snapshot(tempo, portal_address),
     )?;
-    let expected_chain_id = zone_chain_id(zone_id);
+    let expected_chain_id = zone_chain_id(tempo_chain_id, zone_id)?;
     if actual_zone_chain_id != expected_chain_id {
         bail!(
             "Zone portal reports Zone ID {zone_id}, which requires chain ID {expected_chain_id}, but the unrestricted Zone RPC reports {actual_zone_chain_id}"

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -473,11 +473,7 @@ pub struct ZoneArgs {
     pub l1_retry_connection_interval_ms: u64,
 
     /// Zone ID used for chain identity and redacted RPC authentication.
-    #[arg(
-        long = "zone.id",
-        env = "ZONE_ID",
-        value_parser = clap::builder::RangedU64ValueParser::<u32>::new().range(1..)
-    )]
+    #[arg(long = "zone.id", env = "ZONE_ID")]
     pub zone_id: u32,
 
     /// Port for the redacted zone RPC server (0 for OS-assigned).
@@ -599,7 +595,7 @@ mod tests {
     }
 
     #[test]
-    fn zone_id_is_required_and_nonzero() {
+    fn zone_id_is_required() {
         let common = [
             "tempo-zone",
             "--l1.rpc-url",
@@ -613,10 +609,6 @@ mod tests {
             missing.kind(),
             clap::error::ErrorKind::MissingRequiredArgument
         );
-
-        let zero = ZoneArgsParser::try_parse_from(common.into_iter().chain(["--zone.id", "0"]))
-            .unwrap_err();
-        assert_eq!(zero.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -5,7 +5,6 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::{Args, CommandFactory, FromArgMatches};
-use reth_chainspec::EthChainSpec;
 use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
@@ -107,7 +106,6 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
 
         validate_l1_rpc_url(&args.l1_rpc_url)?;
         validate_portal_address(args.portal_address)?;
-        args.validate_zone_id(builder.config().chain.genesis().config.chain_id)?;
 
         let p2p_config = args
             .sequencer_manifest
@@ -475,7 +473,11 @@ pub struct ZoneArgs {
     pub l1_retry_connection_interval_ms: u64,
 
     /// Zone ID used for chain identity and redacted RPC authentication.
-    #[arg(long = "zone.id", env = "ZONE_ID", default_value_t = 0)]
+    #[arg(
+        long = "zone.id",
+        env = "ZONE_ID",
+        value_parser = clap::builder::RangedU64ValueParser::<u32>::new().range(1..)
+    )]
     pub zone_id: u32,
 
     /// Port for the redacted zone RPC server (0 for OS-assigned).
@@ -507,26 +509,6 @@ pub struct ZoneArgs {
     /// Validate finalized batch candidates with the SPF without changing settlement.
     #[arg(long = "sequencer.enable-prover", env = "SEQUENCER_ENABLE_PROVER")]
     pub enable_prover: bool,
-}
-
-impl ZoneArgs {
-    /// Assert the genesis chain ID is the one `zone.id` requires.
-    ///
-    /// `zone_id == 0` means "unset", which imposes no constraint.
-    fn validate_zone_id(&self, chain_id: u64) -> eyre::Result<()> {
-        if self.zone_id == 0 {
-            return Ok(());
-        }
-        let expected = zone_primitives::constants::zone_chain_id(self.zone_id);
-        eyre::ensure!(
-            chain_id == expected,
-            "chain ID mismatch: zone.id={} requires chain_id={}, but genesis has {}",
-            self.zone_id,
-            expected,
-            chain_id,
-        );
-        Ok(())
-    }
 }
 
 fn prepend_log_filter(filter: &mut String, directives: &str) {
@@ -617,22 +599,24 @@ mod tests {
     }
 
     #[test]
-    fn zone_id_must_match_genesis_chain_id() {
-        let args = ZoneArgsParser::try_parse_from([
+    fn zone_id_is_required_and_nonzero() {
+        let common = [
             "tempo-zone",
             "--l1.rpc-url",
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "7",
-        ])
-        .unwrap()
-        .zone;
-        let expected = zone_primitives::constants::zone_chain_id(args.zone_id);
+        ];
 
-        assert!(args.validate_zone_id(expected).is_ok());
-        assert!(args.validate_zone_id(expected + 1).is_err());
+        let missing = ZoneArgsParser::try_parse_from(common).unwrap_err();
+        assert_eq!(
+            missing.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let zero = ZoneArgsParser::try_parse_from(common.into_iter().chain(["--zone.id", "0"]))
+            .unwrap_err();
+        assert_eq!(zero.kind(), clap::error::ErrorKind::ValueValidation);
     }
 
     #[test]
@@ -663,6 +647,8 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "1",
         ];
 
         let parsed = ZoneArgsParser::try_parse_from(
@@ -789,6 +775,8 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "1",
             "--sequencer-key",
             "0x01",
         ];
@@ -837,6 +825,8 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "1",
             "--sequencer-key",
             "0x01",
             "--sequencer",
@@ -854,6 +844,8 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "1",
             "--sequencer-key",
             "0x01",
         ];
@@ -876,6 +868,8 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "1",
         ];
 
         let redacted = ZoneArgsParser::try_parse_from(
@@ -917,6 +911,8 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "1",
             "--sequencer-key",
             "0x01",
         ];
@@ -962,6 +958,8 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "1",
             "--sequencer.manifest",
             "zone.toml",
             "--p2p.key",

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -473,7 +473,7 @@ pub struct ZoneArgs {
     pub l1_retry_connection_interval_ms: u64,
 
     /// Zone ID used for chain identity and redacted RPC authentication.
-    #[arg(long = "zone.id", env = "ZONE_ID")]
+    #[arg(long = "zone.id", env = "ZONE_ID", default_value_t = 0)]
     pub zone_id: u32,
 
     /// Port for the redacted zone RPC server (0 for OS-assigned).
@@ -595,23 +595,6 @@ mod tests {
     }
 
     #[test]
-    fn zone_id_is_required() {
-        let common = [
-            "tempo-zone",
-            "--l1.rpc-url",
-            "ws://localhost:8546",
-            "--l1.portal-address",
-            "0x0000000000000000000000000000000000000001",
-        ];
-
-        let missing = ZoneArgsParser::try_parse_from(common).unwrap_err();
-        assert_eq!(
-            missing.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
-        );
-    }
-
-    #[test]
     fn manifest_mode_rejects_a_txpool_limit_above_the_p2p_wire_limit() {
         assert!(
             validate_p2p_transaction_size_limit(true, zone_p2p::MAX_TRANSACTION_MESSAGE_SIZE,)
@@ -639,8 +622,6 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "1",
         ];
 
         let parsed = ZoneArgsParser::try_parse_from(
@@ -767,8 +748,6 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "1",
             "--sequencer-key",
             "0x01",
         ];
@@ -817,8 +796,6 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "1",
             "--sequencer-key",
             "0x01",
             "--sequencer",
@@ -836,8 +813,6 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "1",
             "--sequencer-key",
             "0x01",
         ];
@@ -860,8 +835,6 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "1",
         ];
 
         let redacted = ZoneArgsParser::try_parse_from(
@@ -903,8 +876,6 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "1",
             "--sequencer-key",
             "0x01",
         ];
@@ -950,8 +921,6 @@ mod tests {
             "ws://localhost:8546",
             "--l1.portal-address",
             "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "1",
             "--sequencer.manifest",
             "zone.toml",
             "--p2p.key",

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -46,8 +46,6 @@ pub struct ProvisionConfig {
 pub struct ProvisionedZone {
     /// Zone ID assigned by the factory.
     pub zone_id: u32,
-    /// Parent Tempo chain ID.
-    pub parent_chain_id: u64,
     /// Zone chain ID derived from the parent and zone IDs.
     pub chain_id: u64,
     /// `ZoneFactory` address on L1.
@@ -115,9 +113,6 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .ok_or_else(|| eyre::eyre!("anchor header {anchor_block_number} not found"))?
         .inner
         .inner;
-    let parent_chain_id = provider.get_chain_id().await?;
-    let expected_zone_id = factory.nextZoneId().call().await?;
-    let chain_id = zone_chain_id(parent_chain_id, expected_zone_id)?;
 
     let receipt = factory
         .createZone(ZoneFactory::CreateZoneParams {
@@ -145,10 +140,8 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .ok_or_else(|| eyre::eyre!("ZoneCreated event not found"))?;
     let zone_id = zone_created.zoneId;
     let portal = zone_created.portal;
-    eyre::ensure!(
-        zone_id == expected_zone_id,
-        "ZoneFactory nextZoneId changed during creation: expected {expected_zone_id}, created {zone_id}"
-    );
+    let parent_chain_id = provider.get_chain_id().await?;
+    let chain_id = zone_chain_id(parent_chain_id, zone_id)?;
 
     register_encryption_key(&provider, portal, &dev_key).await?;
 
@@ -158,7 +151,6 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
 
     Ok(ProvisionedZone {
         zone_id,
-        parent_chain_id,
         chain_id,
         factory: factory_address,
         portal,
@@ -380,7 +372,6 @@ mod command {
             // `sequencerKey` is a well-known dev key; `just zone-up` reads it.
             let zone_json = serde_json::json!({
                 "zoneId": provisioned.zone_id,
-                "parentChainId": provisioned.parent_chain_id,
                 "chainId": provisioned.chain_id,
                 "portal": format!("{}", provisioned.portal),
                 "initialToken": format!("{}", self.initial_token),
@@ -402,7 +393,6 @@ mod command {
 
             println!("Zone provisioned!");
             println!("  Zone ID:      {}", provisioned.zone_id);
-            println!("  Parent chain ID: {}", provisioned.parent_chain_id);
             println!("  Chain ID:     {}", provisioned.chain_id);
             println!("  ZoneFactory:  {}", provisioned.factory);
             println!("  Portal:       {}", provisioned.portal);

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -46,7 +46,9 @@ pub struct ProvisionConfig {
 pub struct ProvisionedZone {
     /// Zone ID assigned by the factory.
     pub zone_id: u32,
-    /// Zone chain ID derived from the zone ID.
+    /// Parent Tempo chain ID.
+    pub parent_chain_id: u64,
+    /// Zone chain ID derived from the parent and zone IDs.
     pub chain_id: u64,
     /// `ZoneFactory` address on L1.
     pub factory: Address,
@@ -113,6 +115,9 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .ok_or_else(|| eyre::eyre!("anchor header {anchor_block_number} not found"))?
         .inner
         .inner;
+    let parent_chain_id = provider.get_chain_id().await?;
+    let expected_zone_id = factory.nextZoneId().call().await?;
+    let chain_id = zone_chain_id(parent_chain_id, expected_zone_id)?;
 
     let receipt = factory
         .createZone(ZoneFactory::CreateZoneParams {
@@ -140,7 +145,10 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
         .ok_or_else(|| eyre::eyre!("ZoneCreated event not found"))?;
     let zone_id = zone_created.zoneId;
     let portal = zone_created.portal;
-    let chain_id = zone_chain_id(zone_id);
+    eyre::ensure!(
+        zone_id == expected_zone_id,
+        "ZoneFactory nextZoneId changed during creation: expected {expected_zone_id}, created {zone_id}"
+    );
 
     register_encryption_key(&provider, portal, &dev_key).await?;
 
@@ -150,6 +158,7 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
 
     Ok(ProvisionedZone {
         zone_id,
+        parent_chain_id,
         chain_id,
         factory: factory_address,
         portal,
@@ -371,6 +380,7 @@ mod command {
             // `sequencerKey` is a well-known dev key; `just zone-up` reads it.
             let zone_json = serde_json::json!({
                 "zoneId": provisioned.zone_id,
+                "parentChainId": provisioned.parent_chain_id,
                 "chainId": provisioned.chain_id,
                 "portal": format!("{}", provisioned.portal),
                 "initialToken": format!("{}", self.initial_token),
@@ -392,6 +402,7 @@ mod command {
 
             println!("Zone provisioned!");
             println!("  Zone ID:      {}", provisioned.zone_id);
+            println!("  Parent chain ID: {}", provisioned.parent_chain_id);
             println!("  Chain ID:     {}", provisioned.chain_id);
             println!("  ZoneFactory:  {}", provisioned.factory);
             println!("  Portal:       {}", provisioned.portal);

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -86,8 +86,8 @@ use zone_payload::{
     DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, WithdrawalRevealEncryptor, ZonePayloadAttributes,
     ZonePayloadFactory, ZonePayloadTypes,
 };
-use zone_rpc::ZoneDebugApiRpcServer;
 use zone_primitives::constants::zone_chain_id;
+use zone_rpc::ZoneDebugApiRpcServer;
 use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
     ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -87,6 +87,7 @@ use zone_payload::{
     ZonePayloadFactory, ZonePayloadTypes,
 };
 use zone_rpc::ZoneDebugApiRpcServer;
+use zone_primitives::constants::zone_chain_id;
 use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
     ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer,
@@ -108,6 +109,18 @@ fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
             .any(|id| id.trim().parse() == Ok(chain_id))
             .then(|| DEV.clone()),
     })
+}
+
+fn validate_zone_chain_id(parent_chain_id: u64, zone_id: u32, chain_id: u64) -> eyre::Result<()> {
+    if zone_id == 0 {
+        return Ok(());
+    }
+    let expected = zone_chain_id(parent_chain_id, zone_id)?;
+    eyre::ensure!(
+        chain_id == expected,
+        "chain ID mismatch: zone.id={zone_id} on parent chain {parent_chain_id} requires chain_id={expected}, but genesis has {chain_id}"
+    );
+    Ok(())
 }
 
 /// Network primitives for Zone Nodes
@@ -545,6 +558,23 @@ where
             )
             .await?
             .erased();
+        let l1_chain_id = l1_provider.get_chain_id().await?;
+        let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
+        if self.redacted_rpc_config.zone_id != 0 {
+            let portal_zone_id = ZonePortal::new(self.portal_address, &l1_provider)
+                .zoneId()
+                .call()
+                .await?;
+            eyre::ensure!(
+                portal_zone_id == self.redacted_rpc_config.zone_id,
+                "zone ID mismatch: portal {} reports zone.id={}, but the node is configured with zone.id={}",
+                self.portal_address,
+                portal_zone_id,
+                self.redacted_rpc_config.zone_id,
+            );
+        }
+        validate_zone_chain_id(l1_chain_id, self.redacted_rpc_config.zone_id, chain_id)?;
+
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
         if let Some(keys) = self.l1_config.encryption_keys.clone() {
@@ -595,7 +625,6 @@ where
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let mut p2p_runtime = None;
         if let Some(config) = self.p2p_config.take() {
-            let l1_chain_id = l1_provider.get_chain_id().await?;
             let network_id = P2pNetworkId::new(l1_chain_id, self.portal_address);
             let attestation_domain = AttestationDomain {
                 l1_chain_id,
@@ -698,6 +727,11 @@ where
         }
 
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
+        let prover_settings = self
+            .sequencer_config
+            .as_ref()
+            .filter(|config| config.enable_prover)
+            .map(|config| (config.zone_id, ctx.node.evm_config().clone()));
         let provider = ctx.node.provider().clone();
         let zone_provider = provider.clone();
         let pool = ctx.node.pool().clone();
@@ -1738,6 +1772,15 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
         unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
+    }
+
+    #[test]
+    fn validates_genesis_chain_id_against_parent_and_zone() {
+        let expected = zone_chain_id(42_431, 7).unwrap();
+        assert!(validate_zone_chain_id(42_431, 7, expected).is_ok());
+        assert!(validate_zone_chain_id(4_217, 7, expected).is_err());
+        assert!(validate_zone_chain_id(42_431, 7, expected + 1).is_err());
+        assert!(validate_zone_chain_id(42_431, 0, 123).is_ok());
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -571,12 +571,11 @@ where
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
         // The CLI rejects a zero portal address. Programmatic test/dev nodes use it as an
         // explicit sentinel because they have no on-chain portal to bind against.
-        let zone_id = if self.portal_address.is_zero() {
+        if self.portal_address.is_zero() {
             warn!(
                 target: "reth::cli",
                 "Skipping portal-bound zone identity validation for a zero-address test/dev portal"
             );
-            self.redacted_rpc_config.zone_id
         } else {
             let portal_zone_id = ZonePortal::new(self.portal_address, &l1_provider)
                 .zoneId()
@@ -605,9 +604,7 @@ where
                 validate_configured_zone_id("P2P manifest", config.zone_id(), portal_zone_id)?;
             }
             validate_zone_chain_id(l1_chain_id, portal_zone_id, chain_id)?;
-            portal_zone_id
-        };
-        self.redacted_rpc_config.zone_id = zone_id;
+        }
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
@@ -663,7 +660,7 @@ where
             let attestation_domain = AttestationDomain {
                 l1_chain_id,
                 portal_address: self.portal_address,
-                zone_id,
+                zone_id: config.zone_id(),
                 sequencer_set_version: config.sequencer_set_version(),
             };
             let anchor_config = self
@@ -774,7 +771,7 @@ where
         let operator_rpc_slot = sequencer_rpc_slot.clone();
         let operator_rpc_provider = provider.clone();
         let operator_zone_api = OperatorZoneApi::new(
-            zone_id,
+            self.redacted_rpc_config.zone_id,
             chain_id,
             self.portal_address,
             l1_provider.clone(),

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -560,19 +560,6 @@ where
             .erased();
         let l1_chain_id = l1_provider.get_chain_id().await?;
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
-        if self.redacted_rpc_config.zone_id != 0 {
-            let portal_zone_id = ZonePortal::new(self.portal_address, &l1_provider)
-                .zoneId()
-                .call()
-                .await?;
-            eyre::ensure!(
-                portal_zone_id == self.redacted_rpc_config.zone_id,
-                "zone ID mismatch: portal {} reports zone.id={}, but the node is configured with zone.id={}",
-                self.portal_address,
-                portal_zone_id,
-                self.redacted_rpc_config.zone_id,
-            );
-        }
         validate_zone_chain_id(l1_chain_id, self.redacted_rpc_config.zone_id, chain_id)?;
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -758,11 +758,6 @@ where
         }
 
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
-        let prover_settings = self
-            .sequencer_config
-            .as_ref()
-            .filter(|config| config.enable_prover)
-            .map(|config| (config.zone_id, ctx.node.evm_config().clone()));
         let provider = ctx.node.provider().clone();
         let zone_provider = provider.clone();
         let pool = ctx.node.pool().clone();
@@ -800,6 +795,7 @@ where
             .as_ref()
             .filter(|config| config.enable_prover)
             .map(|config| ShadowProverConfig {
+                parent_chain_id: l1_chain_id,
                 zone_id: config.zone_id,
                 chain_spec: provider.chain_spec(),
                 debug_api: Arc::new(NodeZoneDebugApi::new(handle.eth_handlers().api.clone())),

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -112,13 +112,22 @@ fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
 }
 
 fn validate_zone_chain_id(parent_chain_id: u64, zone_id: u32, chain_id: u64) -> eyre::Result<()> {
-    if zone_id == 0 {
-        return Ok(());
-    }
     let expected = zone_chain_id(parent_chain_id, zone_id)?;
     eyre::ensure!(
         chain_id == expected,
-        "chain ID mismatch: zone.id={zone_id} on parent chain {parent_chain_id} requires chain_id={expected}, but genesis has {chain_id}"
+        "chain ID mismatch: portal zone ID {zone_id} on parent chain {parent_chain_id} requires chain_id={expected}, but genesis has {chain_id}"
+    );
+    Ok(())
+}
+
+fn validate_configured_zone_id(
+    source: &str,
+    configured_zone_id: u32,
+    portal_zone_id: u32,
+) -> eyre::Result<()> {
+    eyre::ensure!(
+        configured_zone_id == portal_zone_id,
+        "zone ID mismatch: {source} has {configured_zone_id}, but portal has {portal_zone_id}"
     );
     Ok(())
 }
@@ -560,7 +569,45 @@ where
             .erased();
         let l1_chain_id = l1_provider.get_chain_id().await?;
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
-        validate_zone_chain_id(l1_chain_id, self.redacted_rpc_config.zone_id, chain_id)?;
+        // The CLI rejects a zero portal address. Programmatic test/dev nodes use it as an
+        // explicit sentinel because they have no on-chain portal to bind against.
+        let zone_id = if self.portal_address.is_zero() {
+            warn!(
+                target: "reth::cli",
+                "Skipping portal-bound zone identity validation for a zero-address test/dev portal"
+            );
+            self.redacted_rpc_config.zone_id
+        } else {
+            let portal_zone_id = ZonePortal::new(self.portal_address, &l1_provider)
+                .zoneId()
+                .call()
+                .await
+                .map_err(|err| {
+                    eyre::eyre!(
+                        "failed to read zone ID from portal {}: {err}",
+                        self.portal_address
+                    )
+                })?;
+
+            validate_configured_zone_id(
+                "--zone.id/redacted RPC configuration",
+                self.redacted_rpc_config.zone_id,
+                portal_zone_id,
+            )?;
+            if let Some(config) = self.sequencer_config.as_ref() {
+                validate_configured_zone_id(
+                    "sequencer configuration",
+                    config.zone_id,
+                    portal_zone_id,
+                )?;
+            }
+            if let Some(config) = self.p2p_config.as_ref() {
+                validate_configured_zone_id("P2P manifest", config.zone_id(), portal_zone_id)?;
+            }
+            validate_zone_chain_id(l1_chain_id, portal_zone_id, chain_id)?;
+            portal_zone_id
+        };
+        self.redacted_rpc_config.zone_id = zone_id;
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
@@ -616,7 +663,7 @@ where
             let attestation_domain = AttestationDomain {
                 l1_chain_id,
                 portal_address: self.portal_address,
-                zone_id: config.zone_id(),
+                zone_id,
                 sequencer_set_version: config.sequencer_set_version(),
             };
             let anchor_config = self
@@ -727,7 +774,7 @@ where
         let operator_rpc_slot = sequencer_rpc_slot.clone();
         let operator_rpc_provider = provider.clone();
         let operator_zone_api = OperatorZoneApi::new(
-            self.redacted_rpc_config.zone_id,
+            zone_id,
             chain_id,
             self.portal_address,
             l1_provider.clone(),
@@ -1767,7 +1814,14 @@ mod tests {
         assert!(validate_zone_chain_id(42_431, 7, expected).is_ok());
         assert!(validate_zone_chain_id(4_217, 7, expected).is_err());
         assert!(validate_zone_chain_id(42_431, 7, expected + 1).is_err());
-        assert!(validate_zone_chain_id(42_431, 0, 123).is_ok());
+        assert!(validate_zone_chain_id(42_431, 0, 123).is_err());
+    }
+
+    #[test]
+    fn requires_every_configured_zone_id_to_match_the_portal() {
+        assert!(validate_configured_zone_id("test", 7, 7).is_ok());
+        assert!(validate_configured_zone_id("test", 0, 7).is_err());
+        assert!(validate_configured_zone_id("test", 8, 7).is_err());
     }
 
     #[test]

--- a/crates/node/tests/advance_tempo.rs
+++ b/crates/node/tests/advance_tempo.rs
@@ -133,7 +133,10 @@ fn deploy_contract(
 
 /// Build an EVM with the zone contracts deployed in-memory (same as xtask generate_zone_genesis).
 fn setup_zone_evm_with_contracts() -> TempoEvm<CacheDB<EmptyDB>> {
-    setup_zone_evm_with_contracts_for_portal(zone_chain_id(1), Address::repeat_byte(0xbb))
+    setup_zone_evm_with_contracts_for_portal(
+        zone_chain_id(4217, 1).unwrap(),
+        Address::repeat_byte(0xbb),
+    )
 }
 
 fn setup_zone_evm_with_contracts_for_portal(

--- a/crates/node/tests/it/spf.rs
+++ b/crates/node/tests/it/spf.rs
@@ -104,6 +104,7 @@ async fn spf_batch_execute() -> eyre::Result<()> {
 
     let witness = BatchWitness {
         public_inputs: PublicInputs {
+            parent_chain_id: 1_337,
             zone_id: ZONE_ID,
             portal: Address::ZERO,
             tempo_block_number: second_tempo_block.header.number(),
@@ -224,6 +225,7 @@ async fn spf_builder_equivalence() -> eyre::Result<()> {
     let sequencer = built_block.header.beneficiary;
     let witness = BatchWitness {
         public_inputs: PublicInputs {
+            parent_chain_id: 1_337,
             zone_id: ZONE_ID,
             portal: Address::ZERO,
             tempo_block_number: l1_block.header.number(),

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -70,11 +70,12 @@ use zone_l1::{
     Deposit, DepositQueue, EnabledToken, EncryptionKeyRotation, L1BlockTracker, L1Deposit,
     L1PortalEvents, L1StateCache, state::EnabledTokenRegistry,
 };
-use zone_node::{ZoneNode, ZoneSequencerAddOnsConfig};
+use zone_node::{ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig};
 use zone_p2p::{LeadershipSchedule, LeadershipState, P2pConfig, P2pPeerId, Role};
 use zone_precompiles::ZONE_FEE_MANAGER_ADDRESS;
 use zone_primitives::constants::{
     PORTAL_ACCESS_MODE_SLOT, PORTAL_ENCRYPTION_KEYS_SLOT, PORTAL_TOKEN_CONFIGS_SLOT,
+    zone_chain_id as derive_zone_chain_id,
 };
 
 #[path = "../../../rpc/test-utils/auth_tokens.rs"]
@@ -1283,6 +1284,20 @@ impl ZoneTestNode {
             .connect_http(l1_http_url)
             .erased();
 
+        let (chain_id, zone_id) = if portal_address.is_zero() {
+            (chain_id, 0)
+        } else {
+            let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+                .connect(&l1_ws_url)
+                .await?;
+            let parent_chain_id = l1_provider.get_chain_id().await?;
+            let zone_id = ZonePortal::new(portal_address, &l1_provider)
+                .zoneId()
+                .call()
+                .await?;
+            (derive_zone_chain_id(parent_chain_id, zone_id)?, zone_id)
+        };
+
         let mut genesis = custom_genesis.unwrap_or_else(|| {
             serde_json::from_str(zone_node::genesis::GENESIS_TEMPLATE_JSON)
                 .expect("valid zone genesis template")
@@ -1297,6 +1312,10 @@ impl ZoneTestNode {
             std::time::Duration::from_millis(100),
         )
         .with_withdrawal_batch_interval_blocks(withdrawal_batch_interval_blocks)
+        .with_redacted_rpc(ZoneRedactedRpcConfig {
+            zone_id,
+            ..Default::default()
+        })
         .with_deposit_decryption_keys(
             std::iter::once(SecretKey::from(sequencer_signer.credential()))
                 .chain(additional_decryption_keys),

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1287,9 +1287,6 @@ impl ZoneTestNode {
         let (chain_id, zone_id) = if portal_address.is_zero() {
             (chain_id, 0)
         } else {
-            let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-                .connect(&l1_ws_url)
-                .await?;
             let parent_chain_id = l1_provider.get_chain_id().await?;
             let zone_id = ZonePortal::new(portal_address, &l1_provider)
                 .zoneId()

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3505,7 +3505,7 @@ pub(crate) async fn start_local_zone_with_fixture_and_withdrawal_batch_interval(
     let zone = ZoneTestNode::launch_with_genesis_and_withdrawal_batch_interval(
         DUMMY_L1_URL.to_string(),
         Address::ZERO,
-        zone_primitives::constants::zone_chain_id(zone_id),
+        zone_primitives::constants::zone_chain_id(1_337, zone_id)?,
         Some(genesis),
         signer,
         withdrawal_batch_interval_blocks,

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true }
+thiserror.workspace = true
 
 [features]
 default = ["std", "serde"]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -12,9 +12,10 @@ workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true }
-thiserror.workspace = true
+tempo-hardfork = { workspace = true }
+thiserror = { version = "2", default-features = false }
 
 [features]
 default = ["std", "serde"]
-std = ["alloy-primitives/std"]
+std = ["alloy-primitives/std", "thiserror/std"]
 serde = ["alloy-primitives/serde"]

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -158,34 +158,15 @@ pub const ZONE_CHAIN_ID_BASE_TESTNET: u64 = 1_424_310_000;
 pub const ZONE_CHAIN_ID_RANGE_TESTNET: u64 = 723_173_648;
 
 /// Failure to derive a unique zone chain ID.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ZoneChainIdError {
     /// Production zone IDs must fit in the reserved range.
+    #[error("zone ID {zone_id} exhausts the reserved range for parent chain {parent_chain_id}")]
     ZoneIdOutOfRange { parent_chain_id: u64, zone_id: u32 },
     /// Generic parent chain IDs must be nonzero and fit in 32 bits.
+    #[error("generic parent chain ID must be in 1..=u32::MAX, got {0}")]
     InvalidParentChainId(u64),
 }
-
-impl core::fmt::Display for ZoneChainIdError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::ZoneIdOutOfRange {
-                parent_chain_id,
-                zone_id,
-            } => write!(
-                f,
-                "zone ID {zone_id} exhausts the reserved range for parent chain {parent_chain_id}"
-            ),
-            Self::InvalidParentChainId(id) => write!(
-                f,
-                "generic parent chain ID must be in 1..=u32::MAX, got {id}"
-            ),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for ZoneChainIdError {}
 
 /// Derives a zone EIP-155 chain ID from its parent Tempo chain and ZoneFactory ID.
 ///

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -172,11 +172,8 @@ pub enum ZoneChainIdError {
 ///
 /// The production branches remain below 2^31 for ecosystem compatibility. Other
 /// parents use the high 32 bits, making the mapping injective for accepted inputs.
-pub const fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChainIdError> {
-    match validate_chain_id(parent_chain_id, zone_id) {
-        Ok(()) => {}
-        Err(err) => return Err(err),
-    }
+pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChainIdError> {
+    validate_chain_id(parent_chain_id, zone_id)?;
 
     Ok(match parent_chain_id {
         TEMPO_MAINNET_CHAIN_ID => ZONE_CHAIN_ID_BASE + zone_id as u64,
@@ -185,7 +182,7 @@ pub const fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, Zo
     })
 }
 
-const fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {
+fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {
     if parent_chain_id == 0 || parent_chain_id > u32::MAX as u64 {
         return Err(ZoneChainIdError::InvalidParentChainId(parent_chain_id));
     }

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -1,6 +1,7 @@
 //! Zone protocol constants shared between host and guest.
 
 use alloy_primitives::{Address, B256, U256, address};
+use tempo_hardfork::constants::{mainnet::MAINNET_CHAIN_ID, moderato::MODERATO_CHAIN_ID};
 
 /// Sentinel value for empty withdrawal queue slots.
 pub const EMPTY_SENTINEL: B256 = B256::new([0xff; 32]);
@@ -114,13 +115,6 @@ pub const ZONE_OUTBOX_LAST_BATCH_INDEX_SLOT: U256 = {
     le[0] = 2;
     U256::from_le_bytes(le)
 };
-
-/// Tempo mainnet parent chain ID.
-pub const TEMPO_MAINNET_CHAIN_ID: u64 = 4_217;
-
-/// Tempo Moderato parent chain ID.
-pub const TEMPO_MODERATO_CHAIN_ID: u64 = 42_431;
-
 /// Base offset for deriving **mainnet** zone chain IDs.
 ///
 /// # Range safety
@@ -135,8 +129,8 @@ pub const TEMPO_MODERATO_CHAIN_ID: u64 = 42_431;
 ///
 /// | Network  | Base            | Range size        | Chain ID span                         |
 /// |----------|-----------------|-------------------|---------------------------------------|
-/// | Mainnet  | `421_700_000`   | `1_002_610_000`   | `421_700_000 ..  1_424_310_000`       |
-/// | Testnet  | `1_424_310_000` | `723_173_648`     | `1_424_310_000 .. 2_147_483_648`      |
+/// | Mainnet  | `421_700_000`   | `1_002_610_000`   | `421_700_000 ..= 1_424_309_999`       |
+/// | Testnet  | `1_424_310_000` | `723_173_648`     | `1_424_310_000 ..= 2_147_483_647`     |
 ///
 pub const ZONE_CHAIN_ID_BASE: u64 = 421_700_000;
 
@@ -157,14 +151,20 @@ pub const ZONE_CHAIN_ID_BASE_TESTNET: u64 = 1_424_310_000;
 /// strictly below the EIP-2294 safe ceiling.
 pub const ZONE_CHAIN_ID_RANGE_TESTNET: u64 = 723_173_648;
 
+/// Largest generic parent chain ID accepted by [`zone_chain_id`].
+///
+/// This leaves enough headroom that every `u32` zone ID produces an EIP-155
+/// legacy signature `v` value below JavaScript's `Number.MAX_SAFE_INTEGER`.
+pub const MAX_GENERIC_PARENT_CHAIN_ID: u64 = (1 << 20) - 2;
+
 /// Failure to derive a unique zone chain ID.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ZoneChainIdError {
     /// Production zone IDs must fit in the reserved range.
     #[error("zone ID {zone_id} exhausts the reserved range for parent chain {parent_chain_id}")]
     ZoneIdOutOfRange { parent_chain_id: u64, zone_id: u32 },
-    /// Generic parent chain IDs must be nonzero and fit in 32 bits.
-    #[error("generic parent chain ID must be in 1..=u32::MAX, got {0}")]
+    /// Generic parent chain IDs must fit the supported tooling-safe range.
+    #[error("generic parent chain ID must be in 1..={MAX_GENERIC_PARENT_CHAIN_ID}, got {0}")]
     InvalidParentChainId(u64),
 }
 
@@ -176,8 +176,8 @@ pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChai
     validate_chain_id(parent_chain_id, zone_id)?;
 
     let chain_id = match parent_chain_id {
-        TEMPO_MAINNET_CHAIN_ID => ZONE_CHAIN_ID_BASE + zone_id as u64,
-        TEMPO_MODERATO_CHAIN_ID => ZONE_CHAIN_ID_BASE_TESTNET + zone_id as u64,
+        MAINNET_CHAIN_ID => ZONE_CHAIN_ID_BASE + zone_id as u64,
+        MODERATO_CHAIN_ID => ZONE_CHAIN_ID_BASE_TESTNET + zone_id as u64,
         _ => (parent_chain_id << 32) | zone_id as u64,
     };
 
@@ -185,13 +185,12 @@ pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChai
 }
 
 fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {
-    if parent_chain_id == 0 || parent_chain_id > u32::MAX as u64 {
+    if parent_chain_id == 0 || parent_chain_id > MAX_GENERIC_PARENT_CHAIN_ID {
         return Err(ZoneChainIdError::InvalidParentChainId(parent_chain_id));
     }
 
-    if (parent_chain_id == TEMPO_MAINNET_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE)
-        || (parent_chain_id == TEMPO_MODERATO_CHAIN_ID
-            && zone_id as u64 >= ZONE_CHAIN_ID_RANGE_TESTNET)
+    if (parent_chain_id == MAINNET_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE)
+        || (parent_chain_id == MODERATO_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE_TESTNET)
     {
         return Err(ZoneChainIdError::ZoneIdOutOfRange {
             parent_chain_id,
@@ -208,13 +207,13 @@ mod tests {
 
     #[test]
     fn derives_domain_separated_chain_ids() {
-        assert_eq!(zone_chain_id(TEMPO_MAINNET_CHAIN_ID, 7), Ok(421_700_007));
-        assert_eq!(zone_chain_id(TEMPO_MODERATO_CHAIN_ID, 7), Ok(1_424_310_007));
+        assert_eq!(zone_chain_id(MAINNET_CHAIN_ID, 7), Ok(421_700_007));
+        assert_eq!(zone_chain_id(MODERATO_CHAIN_ID, 7), Ok(1_424_310_007));
         assert_ne!(zone_chain_id(1_337, 7), zone_chain_id(1_338, 7));
 
         let production = [
-            zone_chain_id(TEMPO_MAINNET_CHAIN_ID, 42).unwrap(),
-            zone_chain_id(TEMPO_MODERATO_CHAIN_ID, 42).unwrap(),
+            zone_chain_id(MAINNET_CHAIN_ID, 42).unwrap(),
+            zone_chain_id(MODERATO_CHAIN_ID, 42).unwrap(),
         ];
         let generic = zone_chain_id(1, 42).unwrap();
         assert!(production.into_iter().all(|id| id < 1 << 31));
@@ -225,11 +224,11 @@ mod tests {
     #[test]
     fn rejects_exhausted_ranges_and_invalid_generic_parents() {
         assert!(matches!(
-            zone_chain_id(TEMPO_MAINNET_CHAIN_ID, ZONE_CHAIN_ID_RANGE as u32),
+            zone_chain_id(MAINNET_CHAIN_ID, ZONE_CHAIN_ID_RANGE as u32),
             Err(ZoneChainIdError::ZoneIdOutOfRange { .. })
         ));
         assert!(matches!(
-            zone_chain_id(TEMPO_MODERATO_CHAIN_ID, ZONE_CHAIN_ID_RANGE_TESTNET as u32),
+            zone_chain_id(MODERATO_CHAIN_ID, ZONE_CHAIN_ID_RANGE_TESTNET as u32),
             Err(ZoneChainIdError::ZoneIdOutOfRange { .. })
         ));
         assert_eq!(
@@ -237,8 +236,12 @@ mod tests {
             Err(ZoneChainIdError::InvalidParentChainId(0))
         );
         assert!(matches!(
-            zone_chain_id(u32::MAX as u64 + 1, 1),
+            zone_chain_id(MAX_GENERIC_PARENT_CHAIN_ID + 1, 1),
             Err(ZoneChainIdError::InvalidParentChainId(_))
         ));
+
+        let max_generic_chain_id = zone_chain_id(MAX_GENERIC_PARENT_CHAIN_ID, u32::MAX).unwrap();
+        let max_legacy_v = max_generic_chain_id * 2 + 36;
+        assert!(max_legacy_v <= (1 << 53) - 1);
     }
 }

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -175,11 +175,13 @@ pub enum ZoneChainIdError {
 pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChainIdError> {
     validate_chain_id(parent_chain_id, zone_id)?;
 
-    Ok(match parent_chain_id {
+    let chain_id = match parent_chain_id {
         TEMPO_MAINNET_CHAIN_ID => ZONE_CHAIN_ID_BASE + zone_id as u64,
         TEMPO_MODERATO_CHAIN_ID => ZONE_CHAIN_ID_BASE_TESTNET + zone_id as u64,
         _ => (parent_chain_id << 32) | zone_id as u64,
-    })
+    };
+
+    Ok(chain_id)
 }
 
 fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -242,6 +242,6 @@ mod tests {
 
         let max_generic_chain_id = zone_chain_id(MAX_GENERIC_PARENT_CHAIN_ID, u32::MAX).unwrap();
         let max_legacy_v = max_generic_chain_id * 2 + 36;
-        assert!(max_legacy_v <= (1 << 53) - 1);
+        assert!(max_legacy_v < (1 << 53));
     }
 }

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -115,14 +115,13 @@ pub const ZONE_OUTBOX_LAST_BATCH_INDEX_SLOT: U256 = {
     U256::from_le_bytes(le)
 };
 
+/// Tempo mainnet parent chain ID.
+pub const TEMPO_MAINNET_CHAIN_ID: u64 = 4_217;
+
+/// Tempo Moderato parent chain ID.
+pub const TEMPO_MODERATO_CHAIN_ID: u64 = 42_431;
+
 /// Base offset for deriving **mainnet** zone chain IDs.
-///
-/// Each zone gets a unique EIP-155 chain ID derived from its on-chain zone ID
-/// assigned by the `ZoneFactory` contract:
-///
-/// ```text
-/// chain_id = ZONE_CHAIN_ID_BASE + (zone_id % ZONE_CHAIN_ID_RANGE)
-/// ```
 ///
 /// # Range safety
 ///
@@ -139,15 +138,9 @@ pub const ZONE_OUTBOX_LAST_BATCH_INDEX_SLOT: U256 = {
 /// | Mainnet  | `421_700_000`   | `1_002_610_000`   | `421_700_000 ..  1_424_310_000`       |
 /// | Testnet  | `1_424_310_000` | `723_173_648`     | `1_424_310_000 .. 2_147_483_648`      |
 ///
-/// Zone IDs wrap around via modular arithmetic so that chain IDs never leave
-/// their designated range, even with arbitrarily large zone IDs. Because
-/// wrapping can reuse a chain ID that was previously assigned to a different
-/// zone, it is the responsibility of the sequencer to ensure — after deploying
-/// a zone — that the derived chain ID does not correspond to any active chain,
-/// including any zone that has previously used that chain ID.
 pub const ZONE_CHAIN_ID_BASE: u64 = 421_700_000;
 
-/// Number of distinct mainnet zone chain IDs before wrapping.
+/// Number of distinct mainnet zone chain IDs.
 ///
 /// Equal to `ZONE_CHAIN_ID_BASE_TESTNET - ZONE_CHAIN_ID_BASE`, keeping the
 /// mainnet range strictly below the testnet range.
@@ -158,24 +151,112 @@ pub const ZONE_CHAIN_ID_RANGE: u64 = 1_002_610_000;
 /// See [`ZONE_CHAIN_ID_BASE`] for range-safety rationale.
 pub const ZONE_CHAIN_ID_BASE_TESTNET: u64 = 1_424_310_000;
 
-/// Number of distinct testnet zone chain IDs before wrapping.
+/// Number of distinct Moderato zone chain IDs.
 ///
 /// Equal to `2^31 - ZONE_CHAIN_ID_BASE_TESTNET`, keeping the testnet range
 /// strictly below the EIP-2294 safe ceiling.
 pub const ZONE_CHAIN_ID_RANGE_TESTNET: u64 = 723_173_648;
 
-/// Derives the EIP-155 chain ID for a **mainnet** zone from its on-chain zone ID.
-///
-/// Wraps via modulo so the result always falls in
-/// `[ZONE_CHAIN_ID_BASE, ZONE_CHAIN_ID_BASE + ZONE_CHAIN_ID_RANGE)`.
-pub const fn zone_chain_id(zone_id: u32) -> u64 {
-    ZONE_CHAIN_ID_BASE + (zone_id as u64 % ZONE_CHAIN_ID_RANGE)
+/// Failure to derive a unique zone chain ID.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ZoneChainIdError {
+    /// Production zone IDs must fit in the reserved range.
+    ZoneIdOutOfRange { parent_chain_id: u64, zone_id: u32 },
+    /// Generic parent chain IDs must be nonzero and fit in 32 bits.
+    InvalidParentChainId(u64),
 }
 
-/// Derives the EIP-155 chain ID for a **testnet** zone from its on-chain zone ID.
+impl core::fmt::Display for ZoneChainIdError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::ZoneIdOutOfRange {
+                parent_chain_id,
+                zone_id,
+            } => write!(
+                f,
+                "zone ID {zone_id} exhausts the reserved range for parent chain {parent_chain_id}"
+            ),
+            Self::InvalidParentChainId(id) => write!(
+                f,
+                "generic parent chain ID must be in 1..=u32::MAX, got {id}"
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ZoneChainIdError {}
+
+/// Derives a zone EIP-155 chain ID from its parent Tempo chain and ZoneFactory ID.
 ///
-/// Wraps via modulo so the result always falls in
-/// `[ZONE_CHAIN_ID_BASE_TESTNET, ZONE_CHAIN_ID_BASE_TESTNET + ZONE_CHAIN_ID_RANGE_TESTNET)`.
-pub const fn zone_chain_id_testnet(zone_id: u32) -> u64 {
-    ZONE_CHAIN_ID_BASE_TESTNET + (zone_id as u64 % ZONE_CHAIN_ID_RANGE_TESTNET)
+/// The production branches remain below 2^31 for ecosystem compatibility. Other
+/// parents use the high 32 bits, making the mapping injective for accepted inputs.
+pub const fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChainIdError> {
+    if parent_chain_id == 0 || parent_chain_id > u32::MAX as u64 {
+        return Err(ZoneChainIdError::InvalidParentChainId(parent_chain_id));
+    }
+    match parent_chain_id {
+        TEMPO_MAINNET_CHAIN_ID => {
+            if (zone_id as u64) < ZONE_CHAIN_ID_RANGE {
+                Ok(ZONE_CHAIN_ID_BASE + zone_id as u64)
+            } else {
+                Err(ZoneChainIdError::ZoneIdOutOfRange {
+                    parent_chain_id,
+                    zone_id,
+                })
+            }
+        }
+        TEMPO_MODERATO_CHAIN_ID => {
+            if (zone_id as u64) < ZONE_CHAIN_ID_RANGE_TESTNET {
+                Ok(ZONE_CHAIN_ID_BASE_TESTNET + zone_id as u64)
+            } else {
+                Err(ZoneChainIdError::ZoneIdOutOfRange {
+                    parent_chain_id,
+                    zone_id,
+                })
+            }
+        }
+        _ => Ok((parent_chain_id << 32) | zone_id as u64),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_domain_separated_chain_ids() {
+        assert_eq!(zone_chain_id(TEMPO_MAINNET_CHAIN_ID, 7), Ok(421_700_007));
+        assert_eq!(zone_chain_id(TEMPO_MODERATO_CHAIN_ID, 7), Ok(1_424_310_007));
+        assert_ne!(zone_chain_id(1_337, 7), zone_chain_id(1_338, 7));
+
+        let production = [
+            zone_chain_id(TEMPO_MAINNET_CHAIN_ID, 42).unwrap(),
+            zone_chain_id(TEMPO_MODERATO_CHAIN_ID, 42).unwrap(),
+        ];
+        let generic = zone_chain_id(1, 42).unwrap();
+        assert!(production.into_iter().all(|id| id < 1 << 31));
+        assert!(generic >= 1 << 32);
+        assert!(!production.contains(&generic));
+    }
+
+    #[test]
+    fn rejects_exhausted_ranges_and_invalid_generic_parents() {
+        assert!(matches!(
+            zone_chain_id(TEMPO_MAINNET_CHAIN_ID, ZONE_CHAIN_ID_RANGE as u32),
+            Err(ZoneChainIdError::ZoneIdOutOfRange { .. })
+        ));
+        assert!(matches!(
+            zone_chain_id(TEMPO_MODERATO_CHAIN_ID, ZONE_CHAIN_ID_RANGE_TESTNET as u32),
+            Err(ZoneChainIdError::ZoneIdOutOfRange { .. })
+        ));
+        assert_eq!(
+            zone_chain_id(0, 1),
+            Err(ZoneChainIdError::InvalidParentChainId(0))
+        );
+        assert!(matches!(
+            zone_chain_id(u32::MAX as u64 + 1, 1),
+            Err(ZoneChainIdError::InvalidParentChainId(_))
+        ));
+    }
 }

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -173,32 +173,34 @@ pub enum ZoneChainIdError {
 /// The production branches remain below 2^31 for ecosystem compatibility. Other
 /// parents use the high 32 bits, making the mapping injective for accepted inputs.
 pub const fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChainIdError> {
+    match validate_chain_id(parent_chain_id, zone_id) {
+        Ok(()) => {}
+        Err(err) => return Err(err),
+    }
+
+    Ok(match parent_chain_id {
+        TEMPO_MAINNET_CHAIN_ID => ZONE_CHAIN_ID_BASE + zone_id as u64,
+        TEMPO_MODERATO_CHAIN_ID => ZONE_CHAIN_ID_BASE_TESTNET + zone_id as u64,
+        _ => (parent_chain_id << 32) | zone_id as u64,
+    })
+}
+
+const fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {
     if parent_chain_id == 0 || parent_chain_id > u32::MAX as u64 {
         return Err(ZoneChainIdError::InvalidParentChainId(parent_chain_id));
     }
-    match parent_chain_id {
-        TEMPO_MAINNET_CHAIN_ID => {
-            if (zone_id as u64) < ZONE_CHAIN_ID_RANGE {
-                Ok(ZONE_CHAIN_ID_BASE + zone_id as u64)
-            } else {
-                Err(ZoneChainIdError::ZoneIdOutOfRange {
-                    parent_chain_id,
-                    zone_id,
-                })
-            }
-        }
-        TEMPO_MODERATO_CHAIN_ID => {
-            if (zone_id as u64) < ZONE_CHAIN_ID_RANGE_TESTNET {
-                Ok(ZONE_CHAIN_ID_BASE_TESTNET + zone_id as u64)
-            } else {
-                Err(ZoneChainIdError::ZoneIdOutOfRange {
-                    parent_chain_id,
-                    zone_id,
-                })
-            }
-        }
-        _ => Ok((parent_chain_id << 32) | zone_id as u64),
+
+    if (parent_chain_id == TEMPO_MAINNET_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE)
+        || (parent_chain_id == TEMPO_MODERATO_CHAIN_ID
+            && zone_id as u64 >= ZONE_CHAIN_ID_RANGE_TESTNET)
+    {
+        return Err(ZoneChainIdError::ZoneIdOutOfRange {
+            parent_chain_id,
+            zone_id,
+        });
     }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -271,9 +271,15 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     let reads = collect_l1_reads(tempo_reads, &zone_inputs.checkpoint_by_zone_block)?;
     let tempo_state_witness =
         tempo_state_witness(&context.l1_provider, &initial_tempo_header, reads).await?;
+    let parent_chain_id = context
+        .l1_provider
+        .get_chain_id()
+        .await
+        .context("fetch parent Tempo chain ID")?;
 
     let witness = BatchWitness {
         public_inputs: PublicInputs {
+            parent_chain_id,
             zone_id: context.config.zone_id,
             portal: context.portal,
             tempo_block_number: final_tempo_header.number(),

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -43,6 +43,8 @@ type L1Reads = BTreeMap<u64, BTreeMap<Address, BTreeSet<B256>>>;
 /// Node-owned inputs required to validate canonical Zone blocks with the SPF.
 #[derive(Clone)]
 pub struct ShadowProverConfig {
+    /// Parent Tempo chain ID bound into SPF public inputs.
+    pub parent_chain_id: u64,
     /// Zone identifier bound into SPF public inputs.
     pub zone_id: u32,
     /// Chain spec used to configure the SPF.
@@ -55,6 +57,7 @@ impl fmt::Debug for ShadowProverConfig {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ShadowProverConfig")
+            .field("parent_chain_id", &self.parent_chain_id)
             .field("zone_id", &self.zone_id)
             .field("chain_spec", &self.chain_spec)
             .field("debug_api", &"<in-process>")
@@ -271,15 +274,9 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     let reads = collect_l1_reads(tempo_reads, &zone_inputs.checkpoint_by_zone_block)?;
     let tempo_state_witness =
         tempo_state_witness(&context.l1_provider, &initial_tempo_header, reads).await?;
-    let parent_chain_id = context
-        .l1_provider
-        .get_chain_id()
-        .await
-        .context("fetch parent Tempo chain ID")?;
-
     let witness = BatchWitness {
         public_inputs: PublicInputs {
-            parent_chain_id,
+            parent_chain_id: context.config.parent_chain_id,
             zone_id: context.config.zone_id,
             portal: context.portal,
             tempo_block_number: final_tempo_header.number(),

--- a/crates/spf/src/execution/evm.rs
+++ b/crates/spf/src/execution/evm.rs
@@ -53,6 +53,7 @@ pub(crate) struct ExecutedZoneBlock {
 pub(crate) struct BlockReplayContext<'a> {
     pub(crate) parent: &'a TempoHeader,
     pub(crate) block_index: usize,
+    pub(crate) parent_chain_id: u64,
     pub(crate) zone_id: u32,
 }
 
@@ -70,6 +71,7 @@ pub(crate) fn execute_zone_block(
     let BlockReplayContext {
         parent,
         block_index: zone_block_index,
+        parent_chain_id,
         zone_id,
     } = replay;
     let user_transactions = decode_user_transactions(zone_block_index, &block.transactions)?;
@@ -100,8 +102,8 @@ pub(crate) fn execute_zone_block(
     let mut env = evm_config
         .next_evm_env(parent, &attributes)
         .map_err(|_| Error::EvmEnvironment)?;
-    // The Zone ID is verifier-bound independently of the parent Tempo chain specification.
-    env.cfg_env.chain_id = zone_chain_id(zone_id);
+    // The parent and Zone IDs are verifier-bound independently of the local chain specification.
+    env.cfg_env.chain_id = zone_chain_id(parent_chain_id, zone_id)?;
     let assembly_env = env.clone();
     let block_gas_limit = env.block_env.inner.gas_limit;
     let evm = BlockExecutorFactory::evm_factory(&evm_config).create_evm(&mut *zone_state, env);

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -150,6 +150,7 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
             execution::evm::BlockReplayContext {
                 parent: &previous_header,
                 block_index,
+                parent_chain_id: witness.public_inputs.parent_chain_id,
                 zone_id: witness.public_inputs.zone_id,
             },
             block,
@@ -406,6 +407,9 @@ fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<(), Error> 
 /// Errors emitted by the stateless state transition function.
 #[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
+    /// The verifier-bound parent and Zone IDs cannot produce a valid chain ID.
+    #[error(transparent)]
+    ZoneChainId(#[from] zone_primitives::constants::ZoneChainIdError),
     /// The Zone MPT witness did not prove one of its supplied reads.
     #[error(transparent)]
     MptValidation(#[from] StatelessSparseTrieError),
@@ -609,6 +613,7 @@ mod tests {
 
         BatchWitness {
             public_inputs: PublicInputs {
+                parent_chain_id: 1_337,
                 zone_id: 1,
                 portal: Address::repeat_byte(0x11),
                 tempo_block_number: 2,
@@ -805,6 +810,7 @@ mod tests {
         tempo_database: TempoWitnessDatabase,
         parent: &TempoHeader,
         block: &ZoneBlock,
+        parent_chain_id: u64,
         zone_id: u32,
     ) -> Result<alloy_evm::EvmEnv<TempoHardfork, TempoBlockEnv>, Error> {
         let attributes = next_block_env_attributes(config.chain_spec().as_ref(), parent, block)?;
@@ -818,7 +824,7 @@ mod tests {
 
         // ZoneEvmConfig applies these overrides after delegating environment
         // construction to TempoEvmConfig. Keep replay identical to production.
-        env.cfg_env.chain_id = zone_chain_id(zone_id);
+        env.cfg_env.chain_id = zone_chain_id(parent_chain_id, zone_id)?;
         Ok(env)
     }
 
@@ -1025,12 +1031,17 @@ mod tests {
             tempo_database,
             &witness.parent_header,
             &block,
+            witness.public_inputs.parent_chain_id,
             witness.public_inputs.zone_id,
         )
         .unwrap();
         assert_eq!(
             env.cfg_env.chain_id,
-            zone_primitives::constants::zone_chain_id(witness.public_inputs.zone_id)
+            zone_primitives::constants::zone_chain_id(
+                witness.public_inputs.parent_chain_id,
+                witness.public_inputs.zone_id,
+            )
+            .unwrap()
         );
         assert_eq!(env.block_env.inner.basefee, 0);
     }

--- a/crates/spf/src/types.rs
+++ b/crates/spf/src/types.rs
@@ -53,6 +53,8 @@ impl SpfConfig {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct PublicInputs {
+    /// Parent Tempo chain ID used to domain-separate the Zone EVM chain ID.
+    pub parent_chain_id: u64,
     /// Zone identifier from which the SPF derives the EVM chain ID.
     pub zone_id: u32,
     /// Tempo ZonePortal whose state governs L1-backed Zone execution.

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -629,7 +629,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | (required) | Nonzero zone ID from ZoneFactory (for redacted RPC auth and startup chain-ID validation). |
+| `--zone.id` | (required) | Zone ID from ZoneFactory (for redacted RPC auth and startup chain-ID validation). |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |
 | `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -94,6 +94,16 @@ just zone-up my-zone false release
 
 All zone commands need an L1 RPC URL.
 
+The zone chain ID is domain-separated by that L1's chain ID. For parent chain ID
+`4217` (Tempo mainnet), it is `421700000 + zone_id`; for `42431` (Moderato), it is
+`1424310000 + zone_id`. Zone IDs outside each reserved production range are rejected
+rather than wrapped. Mainnet IDs are therefore unchanged, while existing Moderato
+and devnet zones must migrate their genesis chain IDs. For any other nonzero parent
+that fits in `u32`, the chain ID is `(parent_chain_id << 32) | zone_id`. These generic
+IDs are intentionally high and cannot collide with the production ranges. Every
+devnet must use a unique parent chain ID to prevent transaction replay between it and
+other devnets.
+
 **Moderato testnet:**
 ```bash
 export L1_RPC_URL="wss://rpc.moderato.tempo.xyz"
@@ -619,7 +629,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | 0 | Zone ID from ZoneFactory (for redacted RPC auth). The zone's chain ID is derived as `421700000 + (zone_id % 1002610000)` (mainnet) or `1424310000 + (zone_id % 723173648)` (testnet). |
+| `--zone.id` | (required) | Nonzero zone ID from ZoneFactory (for redacted RPC auth and startup chain-ID validation). |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |
 | `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -97,12 +97,10 @@ All zone commands need an L1 RPC URL.
 The zone chain ID is domain-separated by that L1's chain ID. For parent chain ID
 `4217` (Tempo mainnet), it is `421700000 + zone_id`; for `42431` (Moderato), it is
 `1424310000 + zone_id`. Zone IDs outside each reserved production range are rejected
-rather than wrapped. Mainnet IDs are therefore unchanged, while existing Moderato
-and devnet zones must migrate their genesis chain IDs. For any other nonzero parent
-that fits in `u32`, the chain ID is `(parent_chain_id << 32) | zone_id`. These generic
-IDs are intentionally high and cannot collide with the production ranges. Every
-devnet must use a unique parent chain ID to prevent transaction replay between it and
-other devnets.
+rather than wrapped. For any other nonzero parent that fits in `u32`, the chain ID is
+`(parent_chain_id << 32) | zone_id`. These generic IDs are intentionally high and
+cannot collide with the production ranges. Every devnet must use a unique parent
+chain ID to prevent transaction replay between it and other devnets.
 
 **Moderato testnet:**
 ```bash

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -97,10 +97,11 @@ All zone commands need an L1 RPC URL.
 The zone chain ID is domain-separated by that L1's chain ID. For parent chain ID
 `4217` (Tempo mainnet), it is `421700000 + zone_id`; for `42431` (Moderato), it is
 `1424310000 + zone_id`. Zone IDs outside each reserved production range are rejected
-rather than wrapped. For any other nonzero parent that fits in `u32`, the chain ID is
-`(parent_chain_id << 32) | zone_id`. These generic IDs are intentionally high and
-cannot collide with the production ranges. Every devnet must use a unique parent
-chain ID to prevent transaction replay between it and other devnets.
+rather than wrapped. For any other parent in `1..=1048574`, the chain ID is
+`(parent_chain_id << 32) | zone_id`. These generic IDs are intentionally high, cannot
+collide with the production ranges, and remain safe for JavaScript tooling and legacy
+EIP-155 `v` values. Every devnet must use a unique parent chain ID to prevent transaction
+replay between it and other devnets.
 
 **Moderato testnet:**
 ```bash
@@ -627,7 +628,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | 0 | Zone ID from ZoneFactory (for redacted RPC auth and startup chain-ID validation). Set to `0` to skip validation. |
+| `--zone.id` | 0 | Zone ID from ZoneFactory. At startup it must match `ZonePortal.zoneId()`; `0` does not bypass validation. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |
 | `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -629,7 +629,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | (required) | Zone ID from ZoneFactory (for redacted RPC auth and startup chain-ID validation). |
+| `--zone.id` | 0 | Zone ID from ZoneFactory (for redacted RPC auth and startup chain-ID validation). Set to `0` to skip validation. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key` | (optional) | Sequencer private key used when `--sequencer` is enabled; conflicts with `--sequencer-key-file` |
 | `--sequencer-key-file` | (optional) | File or FIFO containing the sequencer private key; avoids exposing it in process arguments |

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -281,7 +281,7 @@ else:
     # 0 < parent_chain_id <= 2^32 - 1
 ```
 
-The production ranges reject exhaustion rather than wrapping. This preserves all existing mainnet zone chain IDs. Moderato and devnet zones migrate to parent-aware IDs; generic IDs are at least `2^32` and cannot collide with the sub-`2^31` production ranges. Distinct devnets MUST use distinct parent chain IDs. This prevents replay between zones and between mainnet, Moderato, and devnets. The chain ID is set in genesis and validated against the connected parent by the zone node at startup.
+The production ranges reject exhaustion rather than wrapping. Generic IDs are at least `2^32` and cannot collide with the sub-`2^31` production ranges. Distinct devnets MUST use distinct parent chain IDs. This prevents replay between zones and between mainnet, Moderato, and devnets. The chain ID is set in genesis and validated against the connected parent by the zone node at startup.
 
 ### Tempo Contracts
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -278,10 +278,10 @@ else if parent_chain_id == 42431:
     chain_id = 1424310000 + zone_id      # zone_id < 723173648
 else:
     chain_id = (parent_chain_id << 32) | zone_id
-    # 0 < parent_chain_id <= 2^32 - 1
+    # 0 < parent_chain_id <= 1048574
 ```
 
-The production ranges reject exhaustion rather than wrapping. Generic IDs are at least `2^32` and cannot collide with the sub-`2^31` production ranges. Distinct devnets MUST use distinct parent chain IDs. This prevents replay between zones and between mainnet, Moderato, and devnets. The chain ID is set in genesis and validated against the connected parent by the zone node at startup.
+The production ranges reject exhaustion rather than wrapping. Generic IDs are at least `2^32` and cannot collide with the sub-`2^31` production ranges. The generic-parent ceiling ensures that even the largest `zone_id` keeps the EIP-155 legacy signature `v` value below JavaScript's `Number.MAX_SAFE_INTEGER`. Distinct devnets MUST use distinct parent chain IDs. This prevents replay between zones and between mainnet, Moderato, and devnets. The chain ID is set in genesis and validated at startup against both the connected parent and the zone ID returned by the configured `ZonePortal.zoneId()`.
 
 ### Tempo Contracts
 
@@ -1026,7 +1026,7 @@ It takes a complete witness of zone blocks and their dependencies, executes EVM 
 
 The witness contains everything needed to re-execute the batch:
 
-- **PublicInputs**: `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. These are the values the portal passes to the verifier and the proof must be consistent with. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `zone_id`. The bootstrap batch has to continue through at least one non-genesis block.
+- **PublicInputs**: `parent_chain_id`, `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. These are the values the portal and verifier bind to the proof: the verifier binds `parent_chain_id` to the L1 execution environment's chain ID, and the portal supplies the remaining values. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `(parent_chain_id, zone_id)`. The bootstrap batch has to continue through at least one non-genesis block.
 - **BatchWitness**: the public inputs, the previous batch's canonical Tempo header (absent for the bootstrap proof), the zone blocks to execute, the initial zone state, Tempo state proofs, and Tempo ancestry headers (for ancestry validation).
 - **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `beneficiary`, `protocol_version`, `tempo_header_rlps` (a non-empty ordered array for every non-genesis block), `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
 - **ZoneStateWitness**: the initial zone state root, a deduplicated pool of zone-state trie nodes, and decoded account / storage reads needed to bootstrap execution. Only accounts and storage slots accessed during execution are included, including EIP-2935 history-contract slots used by `BLOCKHASH` and the `TempoState.tempoBlockNumber` slot used by the TIP-403 overlay's host-side anchor lookup. Missing witness data must produce an error, not default to zero, to prevent the prover from omitting non-zero state.
@@ -1040,7 +1040,7 @@ flowchart TB
     subgraph BW["BatchWitness"]
         direction TB
 
-        PI["PublicInputs<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>sequencer"]
+        PI["PublicInputs<br/>parent_chain_id<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>sequencer"]
 
         PH["parent_header: ZoneHeader<br/>parent_hash<br/>beneficiary<br/>state_root<br/>transactions_root<br/>receipts_root<br/>number<br/>timestamp<br/>protocol_version"]
 
@@ -1104,8 +1104,12 @@ The prover-side inputs are defined concretely below. Types that mirror the oncha
 
 ```rust
 pub struct PublicInputs {
+    /// Parent Tempo chain ID. The verifier must bind this to the L1 execution
+    /// environment's chain ID; the program uses it to derive the zone chain ID.
+    pub parent_chain_id: u64,
+
     /// Zone ID. The verifier must bind this public input to the zone portal;
-    /// the program derives the EVM chain ID from it.
+    /// the program derives the EVM chain ID from it and `parent_chain_id`.
     pub zone_id: u32,
 
     /// Tempo block number for the batch (must equal portal's tempoBlockNumber)
@@ -1302,7 +1306,7 @@ The stateless execution function must reject the witness on any failed check, mi
    Compute `keccak256(rlp(node))` for each node in `tempo_state_witness.node_pool` and build a hash-to-node index for proof traversal. Decode `tempo_state_witness.initial_tempo_header_rlp`; require its hash and block number to equal `TempoState.tempoBlockHash` and `TempoState.tempoBlockNumber` in the initial zone state. Set the active Tempo trie root to the decoded header's `state_root`.
 
 4. **For each `zone_blocks[i]`, verify the block witness before executing it.**
-   In the bootstrap proof, require at least two blocks. Require every field of `zone_blocks[0]` to equal the canonical genesis block derived from `(public_inputs.parent_chain_id, public_inputs.zone_id)`, including the parent-aware chain ID specified in [Chain ID](#chain-id); its parent hash is zero and it contains no user or system transactions. Apply the ordinary block rules to every remaining bootstrap block and to every block in an ordinary batch: require `block.parent_hash == prev_block_hash`, `block.number == prev_header.number + 1`, `block.timestamp >= prev_header.timestamp`, `block.beneficiary == public_inputs.sequencer`, and `tempo_header_rlps` to be non-empty. Require `finalize_withdrawal_batch_count` to be absent in the genesis block and all intermediate blocks, and present in the final block of a batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
+   In the bootstrap proof, require at least two blocks. Require every field of `zone_blocks[0]` to equal the canonical genesis block derived from `(public_inputs.parent_chain_id, public_inputs.zone_id)`, including `chain_id = zone_chain_id(parent_chain_id, zone_id)` under the rules in [Chain ID](#chain-id); its parent hash is zero and it contains no user or system transactions. Apply the ordinary block rules to every remaining bootstrap block and to every block in an ordinary batch: require `block.parent_hash == prev_block_hash`, `block.number == prev_header.number + 1`, `block.timestamp >= prev_header.timestamp`, `block.beneficiary == public_inputs.sequencer`, and `tempo_header_rlps` to be non-empty. Require `finalize_withdrawal_batch_count` to be absent in the genesis block and all intermediate blocks, and present in the final block of a batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
 
 5. **Execute `advanceTempo` as the first transaction.**
    Skip this step for the canonical genesis block. For every non-genesis block, decode all `tempo_header_rlps` and call `TempoState.finalizeTempo(headers)` in the modeled execution environment. If the stored `tempoBlockHash` is non-zero, require the first imported header's number to be the stored `tempoBlockNumber + 1` and its parent hash to equal the stored `tempoBlockHash`. If the stored hash is zero, instead verify a Tempo state proof for this portal's `sequencer` slot against the final imported header's state root and require the value to be non-zero. For every subsequent imported header, require its number to be the preceding header's number plus one and its parent hash to equal the preceding header's hash. Then update the bound `tempoBlockNumber` and `tempoBlockHash` to the final header and make only the final header's state root available for subsequent Tempo L1 storage reads in this block. Require the finalized `tempoBlockHash` to equal the hash of the final header. Reject any non-genesis block that omits or executes more than one `advanceTempo` call.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -269,13 +269,19 @@ The factory performs this initialization natively in the portal account; the Sol
 
 ### Chain ID
 
-Each zone has a unique chain ID derived from its zone ID:
+Each zone has a unique chain ID derived from its parent Tempo chain ID and zone ID:
 
 ```
-chain_id = 421700000 + zone_id
+if parent_chain_id == 4217:
+    chain_id = 421700000 + zone_id       # zone_id < 1002610000
+else if parent_chain_id == 42431:
+    chain_id = 1424310000 + zone_id      # zone_id < 723173648
+else:
+    chain_id = (parent_chain_id << 32) | zone_id
+    # 0 < parent_chain_id <= 2^32 - 1
 ```
 
-The prefix `4217` is derived from the Tempo chain ID. This ensures replay protection between zones. A transaction signed for one zone cannot be replayed on another. The chain ID is set in the zone's genesis configuration and validated by the zone node at startup.
+The production ranges reject exhaustion rather than wrapping. This preserves all existing mainnet zone chain IDs. Moderato and devnet zones migrate to parent-aware IDs; generic IDs are at least `2^32` and cannot collide with the sub-`2^31` production ranges. Distinct devnets MUST use distinct parent chain IDs. This prevents replay between zones and between mainnet, Moderato, and devnets. The chain ID is set in genesis and validated against the connected parent by the zone node at startup.
 
 ### Tempo Contracts
 
@@ -1020,7 +1026,7 @@ It takes a complete witness of zone blocks and their dependencies, executes EVM 
 
 The witness contains everything needed to re-execute the batch:
 
-- **PublicInputs**: `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. These are the values the portal passes to the verifier and the proof must be consistent with. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `zone_id`. The bootstrap batch has to continue through at least one non-genesis block.
+- **PublicInputs**: `parent_chain_id`, `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. The verifier binds `parent_chain_id` to the Tempo L1 `block.chainid`; the portal supplies the remaining values, and the proof must be consistent with all of them. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `parent_chain_id` and `zone_id`. The bootstrap batch has to continue through at least one non-genesis block.
 - **BatchWitness**: the public inputs, the previous batch's canonical Tempo header (absent for the bootstrap proof), the zone blocks to execute, the initial zone state, Tempo state proofs, and Tempo ancestry headers (for ancestry validation).
 - **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `beneficiary`, `protocol_version`, `tempo_header_rlps` (a non-empty ordered array for every non-genesis block), `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
 - **ZoneStateWitness**: the initial zone state root, a deduplicated pool of zone-state trie nodes, and decoded account / storage reads needed to bootstrap execution. Only accounts and storage slots accessed during execution are included, including EIP-2935 history-contract slots used by `BLOCKHASH` and the `TempoState.tempoBlockNumber` slot used by the TIP-403 overlay's host-side anchor lookup. Missing witness data must produce an error, not default to zero, to prevent the prover from omitting non-zero state.
@@ -1034,7 +1040,7 @@ flowchart TB
     subgraph BW["BatchWitness"]
         direction TB
 
-        PI["PublicInputs<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>sequencer"]
+        PI["PublicInputs<br/>parent_chain_id<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>sequencer"]
 
         PH["parent_header: ZoneHeader<br/>parent_hash<br/>beneficiary<br/>state_root<br/>transactions_root<br/>receipts_root<br/>number<br/>timestamp<br/>protocol_version"]
 
@@ -1098,8 +1104,11 @@ The prover-side inputs are defined concretely below. Types that mirror the oncha
 
 ```rust
 pub struct PublicInputs {
+    /// Parent Tempo chain ID. The verifier binds this to block.chainid.
+    pub parent_chain_id: u64,
+
     /// Zone ID. The verifier must bind this public input to the zone portal;
-    /// the program derives the EVM chain ID from it.
+    /// the program derives the EVM chain ID from it and parent_chain_id.
     pub zone_id: u32,
 
     /// Tempo block number for the batch (must equal portal's tempoBlockNumber)
@@ -1296,7 +1305,7 @@ The stateless execution function must reject the witness on any failed check, mi
    Compute `keccak256(rlp(node))` for each node in `tempo_state_witness.node_pool` and build a hash-to-node index for proof traversal. Decode `tempo_state_witness.initial_tempo_header_rlp`; require its hash and block number to equal `TempoState.tempoBlockHash` and `TempoState.tempoBlockNumber` in the initial zone state. Set the active Tempo trie root to the decoded header's `state_root`.
 
 4. **For each `zone_blocks[i]`, verify the block witness before executing it.**
-   In the bootstrap proof, require at least two blocks. Require every field of `zone_blocks[0]` to equal the canonical genesis block derived from `public_inputs.zone_id`, including `chain_id = 421700000 + zone_id`; its parent hash is zero and it contains no user or system transactions. Apply the ordinary block rules to every remaining bootstrap block and to every block in an ordinary batch: require `block.parent_hash == prev_block_hash`, `block.number == prev_header.number + 1`, `block.timestamp >= prev_header.timestamp`, `block.beneficiary == public_inputs.sequencer`, and `tempo_header_rlps` to be non-empty. Require `finalize_withdrawal_batch_count` to be absent in the genesis block and all intermediate blocks, and present in the final block of a batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
+   In the bootstrap proof, require at least two blocks. Require every field of `zone_blocks[0]` to equal the canonical genesis block derived from `(public_inputs.parent_chain_id, public_inputs.zone_id)`, including the parent-aware chain ID specified in [Chain ID](#chain-id); its parent hash is zero and it contains no user or system transactions. Apply the ordinary block rules to every remaining bootstrap block and to every block in an ordinary batch: require `block.parent_hash == prev_block_hash`, `block.number == prev_header.number + 1`, `block.timestamp >= prev_header.timestamp`, `block.beneficiary == public_inputs.sequencer`, and `tempo_header_rlps` to be non-empty. Require `finalize_withdrawal_batch_count` to be absent in the genesis block and all intermediate blocks, and present in the final block of a batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
 
 5. **Execute `advanceTempo` as the first transaction.**
    Skip this step for the canonical genesis block. For every non-genesis block, decode all `tempo_header_rlps` and call `TempoState.finalizeTempo(headers)` in the modeled execution environment. If the stored `tempoBlockHash` is non-zero, require the first imported header's number to be the stored `tempoBlockNumber + 1` and its parent hash to equal the stored `tempoBlockHash`. If the stored hash is zero, instead verify a Tempo state proof for this portal's `sequencer` slot against the final imported header's state root and require the value to be non-zero. For every subsequent imported header, require its number to be the preceding header's number plus one and its parent hash to equal the preceding header's hash. Then update the bound `tempoBlockNumber` and `tempoBlockHash` to the final header and make only the final header's state root available for subsequent Tempo L1 storage reads in this block. Require the finalized `tempoBlockHash` to equal the hash of the final header. Reject any non-genesis block that omits or executes more than one `advanceTempo` call.
@@ -1398,7 +1407,7 @@ interface IVerifier {
 }
 ```
 
-The portal passes its `zoneId`, computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)), and passes them alongside the portal's current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex`. The `verifierConfig` and `proof` are opaque to the portal. Sequencer authorization is enforced separately by the portal's versioned threshold certificate.
+The portal passes its `zoneId`, computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)), and passes them alongside the portal's current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex`. Although `parent_chain_id` is not a caller-supplied ABI argument, the verifier MUST include the executing Tempo L1's `block.chainid` as that public input and reject proofs bound to any other parent. The `verifierConfig` and `proof` are opaque to the portal. Sequencer authorization is enforced separately by the portal's versioned threshold certificate.
 
 ### Anchor Block Validation
 
@@ -1421,8 +1430,9 @@ The proof must validate:
 5. `ZoneOutbox.lastBatch().withdrawalQueueHash` matches the submitted `withdrawalQueueHash`.
 6. Every non-genesis zone block `beneficiary` is an active member of the versioned sequencer set committed by the settlement certificate; the genesis block must match the canonical header in full.
 7. Deposit processing is correct: deposits are processed oldest-first and contiguously from `prevProcessedHash`, `nextProcessedHash` equals the post-state `ZoneInbox.processedDepositQueueHash`, `nextDepositNumber` equals the post-state processed deposit number, and the proof shows `nextProcessedHash` equals the portal's `currentDepositQueueHash` read from Tempo state.
+8. `parent_chain_id` equals the executing Tempo L1's `block.chainid` and is used with `zone_id` to derive the canonical genesis chain ID.
 
-For the first proof, requirement 1 specifically means a transition from `prevBlockHash == 0` through the canonical zone genesis block derived from `zoneId` to the final non-genesis block of a batch containing at least two blocks. That batch's first Tempo import makes requirement 3 applicable immediately and includes the non-zero portal sequencer storage proof against the final imported Tempo block described above.
+For the first proof, requirement 1 specifically means a transition from `prevBlockHash == 0` through the canonical zone genesis block derived from `parent_chain_id` and `zoneId` to the final non-genesis block of a batch containing at least two blocks. That batch's first Tempo import makes requirement 3 applicable immediately and includes the non-zero portal sequencer storage proof against the final imported Tempo block described above.
 
 ## Zone Precompiles
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1026,7 +1026,7 @@ It takes a complete witness of zone blocks and their dependencies, executes EVM 
 
 The witness contains everything needed to re-execute the batch:
 
-- **PublicInputs**: `parent_chain_id`, `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. The verifier binds `parent_chain_id` to the Tempo L1 `block.chainid`; the portal supplies the remaining values, and the proof must be consistent with all of them. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `parent_chain_id` and `zone_id`. The bootstrap batch has to continue through at least one non-genesis block.
+- **PublicInputs**: `zone_id`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. These are the values the portal passes to the verifier and the proof must be consistent with. For an ordinary batch, `prevBlockHash` is derived from `prev_block_header` and bound through the public `block_transition` output. For the bootstrap proof it is zero and the transition function derives the canonical genesis block from `zone_id`. The bootstrap batch has to continue through at least one non-genesis block.
 - **BatchWitness**: the public inputs, the previous batch's canonical Tempo header (absent for the bootstrap proof), the zone blocks to execute, the initial zone state, Tempo state proofs, and Tempo ancestry headers (for ancestry validation).
 - **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `beneficiary`, `protocol_version`, `tempo_header_rlps` (a non-empty ordered array for every non-genesis block), `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
 - **ZoneStateWitness**: the initial zone state root, a deduplicated pool of zone-state trie nodes, and decoded account / storage reads needed to bootstrap execution. Only accounts and storage slots accessed during execution are included, including EIP-2935 history-contract slots used by `BLOCKHASH` and the `TempoState.tempoBlockNumber` slot used by the TIP-403 overlay's host-side anchor lookup. Missing witness data must produce an error, not default to zero, to prevent the prover from omitting non-zero state.
@@ -1040,7 +1040,7 @@ flowchart TB
     subgraph BW["BatchWitness"]
         direction TB
 
-        PI["PublicInputs<br/>parent_chain_id<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>sequencer"]
+        PI["PublicInputs<br/>zone_id<br/>tempo_block_number<br/>anchor_block_number<br/>anchor_block_hash<br/>expected_withdrawal_batch_index<br/>sequencer"]
 
         PH["parent_header: ZoneHeader<br/>parent_hash<br/>beneficiary<br/>state_root<br/>transactions_root<br/>receipts_root<br/>number<br/>timestamp<br/>protocol_version"]
 
@@ -1104,11 +1104,8 @@ The prover-side inputs are defined concretely below. Types that mirror the oncha
 
 ```rust
 pub struct PublicInputs {
-    /// Parent Tempo chain ID. The verifier binds this to block.chainid.
-    pub parent_chain_id: u64,
-
     /// Zone ID. The verifier must bind this public input to the zone portal;
-    /// the program derives the EVM chain ID from it and parent_chain_id.
+    /// the program derives the EVM chain ID from it.
     pub zone_id: u32,
 
     /// Tempo block number for the batch (must equal portal's tempoBlockNumber)
@@ -1407,7 +1404,7 @@ interface IVerifier {
 }
 ```
 
-The portal passes its `zoneId`, computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)), and passes them alongside the portal's current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex`. Although `parent_chain_id` is not a caller-supplied ABI argument, the verifier MUST include the executing Tempo L1's `block.chainid` as that public input and reject proofs bound to any other parent. The `verifierConfig` and `proof` are opaque to the portal. Sequencer authorization is enforced separately by the portal's versioned threshold certificate.
+The portal passes its `zoneId`, computes `anchorBlockNumber` and `anchorBlockHash` from the submission parameters (see [Anchor Block Validation](#anchor-block-validation)), and passes them alongside the portal's current `withdrawalBatchIndex + 1` as `expectedWithdrawalBatchIndex`. The `verifierConfig` and `proof` are opaque to the portal. Sequencer authorization is enforced separately by the portal's versioned threshold certificate.
 
 ### Anchor Block Validation
 
@@ -1430,7 +1427,6 @@ The proof must validate:
 5. `ZoneOutbox.lastBatch().withdrawalQueueHash` matches the submitted `withdrawalQueueHash`.
 6. Every non-genesis zone block `beneficiary` is an active member of the versioned sequencer set committed by the settlement certificate; the genesis block must match the canonical header in full.
 7. Deposit processing is correct: deposits are processed oldest-first and contiguously from `prevProcessedHash`, `nextProcessedHash` equals the post-state `ZoneInbox.processedDepositQueueHash`, `nextDepositNumber` equals the post-state processed deposit number, and the proof shows `nextProcessedHash` equals the portal's `currentDepositQueueHash` read from Tempo state.
-8. `parent_chain_id` equals the executing Tempo L1's `block.chainid` and is used with `zone_id` to derive the canonical genesis chain ID.
 
 For the first proof, requirement 1 specifically means a transition from `prevBlockHash == 0` through the canonical zone genesis block derived from `parent_chain_id` and `zoneId` to the final non-genesis block of a batch containing at least two blocks. That batch's first Tempo import makes requirement 3 applicable immediately and includes the non-zero portal sequencer storage proof against the final imported Tempo block described above.
 

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -223,6 +223,10 @@ impl CreateZone {
         println!("Sequencers: {:?}", self.sequencers);
         println!("Threshold: {}", self.threshold);
 
+        let parent_chain_id = provider.get_chain_id().await?;
+        let expected_zone_id = factory.nextZoneId().call().await?;
+        let chain_id = zone_chain_id(parent_chain_id, expected_zone_id)?;
+
         println!(
             "Creating zone on L1 via ZoneFactory at {}...",
             self.zone_factory
@@ -260,7 +264,10 @@ impl CreateZone {
 
         let zone_id = event.zoneId;
         let portal = event.portal;
-        let chain_id = zone_chain_id(zone_id);
+        eyre::ensure!(
+            zone_id == expected_zone_id,
+            "ZoneFactory nextZoneId changed during creation: expected {expected_zone_id}, created {zone_id}"
+        );
 
         let portal_contract = ZonePortal::new(portal, &provider);
         let creation_block_id = BlockId::number(creation_block);
@@ -324,6 +331,7 @@ impl CreateZone {
         // Write zone.json with deployment metadata for downstream tooling (e.g. `just zone-up`).
         let zone_json = serde_json::json!({
             "zoneId": zone_id,
+            "parentChainId": parent_chain_id,
             "chainId": chain_id,
             "portal": format!("{portal}"),
             "messenger": format!("{ZONE_MESSENGER_ADDRESS}"),
@@ -350,6 +358,7 @@ impl CreateZone {
 
         println!("Zone created successfully!");
         println!("  Zone ID: {zone_id}");
+        println!("  Parent chain ID: {parent_chain_id}");
         println!("  Chain ID: {chain_id}");
         println!("  Portal: {portal}");
         println!("  Messenger: {ZONE_MESSENGER_ADDRESS}");

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -223,10 +223,6 @@ impl CreateZone {
         println!("Sequencers: {:?}", self.sequencers);
         println!("Threshold: {}", self.threshold);
 
-        let parent_chain_id = provider.get_chain_id().await?;
-        let expected_zone_id = factory.nextZoneId().call().await?;
-        let chain_id = zone_chain_id(parent_chain_id, expected_zone_id)?;
-
         println!(
             "Creating zone on L1 via ZoneFactory at {}...",
             self.zone_factory
@@ -264,10 +260,8 @@ impl CreateZone {
 
         let zone_id = event.zoneId;
         let portal = event.portal;
-        eyre::ensure!(
-            zone_id == expected_zone_id,
-            "ZoneFactory nextZoneId changed during creation: expected {expected_zone_id}, created {zone_id}"
-        );
+        let parent_chain_id = provider.get_chain_id().await?;
+        let chain_id = zone_chain_id(parent_chain_id, zone_id)?;
 
         let portal_contract = ZonePortal::new(portal, &provider);
         let creation_block_id = BlockId::number(creation_block);
@@ -331,7 +325,6 @@ impl CreateZone {
         // Write zone.json with deployment metadata for downstream tooling (e.g. `just zone-up`).
         let zone_json = serde_json::json!({
             "zoneId": zone_id,
-            "parentChainId": parent_chain_id,
             "chainId": chain_id,
             "portal": format!("{portal}"),
             "messenger": format!("{ZONE_MESSENGER_ADDRESS}"),
@@ -358,7 +351,6 @@ impl CreateZone {
 
         println!("Zone created successfully!");
         println!("  Zone ID: {zone_id}");
-        println!("  Parent chain ID: {parent_chain_id}");
         println!("  Chain ID: {chain_id}");
         println!("  Portal: {portal}");
         println!("  Messenger: {ZONE_MESSENGER_ADDRESS}");


### PR DESCRIPTION
Zone chain IDs now include the parent Tempo L1 chain ID, preventing identical zone Ids on different parent chains from colliding.

Provisioning derives the chain ID from the emitted zone ID and connected parent, while node startup validates the configured genesis against that same derivation.