### PR TITLE
fix: make withdrawal finalization system-only

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -32,6 +32,7 @@ use crate::{L1OverlayDB, ZoneEvm};
 pub struct ZoneTxResult<H, T> {
     inner: EthTxResult<H, T>,
     is_advance_tempo: bool,
+    is_finalize_withdrawal_batch: bool,
 }
 
 impl<H, T> TxResult for ZoneTxResult<H, T>
@@ -58,6 +59,7 @@ where
 pub struct ZoneBlockExecutor<'a, DB: Database, I, L1: L1StorageReader = L1StateProvider> {
     inner: EthBlockExecutor<'a, ZoneEvm<DB, I, L1>, &'a ZoneChainSpec, TempoReceiptBuilder>,
     has_advanced_tempo: bool,
+    has_finalized_withdrawal_batch: bool,
 }
 
 impl<'a, DB, I, L1> ZoneBlockExecutor<'a, DB, I, L1>
@@ -80,6 +82,7 @@ where
                 TempoReceiptBuilder::default(),
             ),
             has_advanced_tempo: false,
+            has_finalized_withdrawal_batch: false,
         }
     }
 }
@@ -111,8 +114,11 @@ where
 
         // Ensure `advanceTempo` is the first transaction and reject any other system
         // transaction except withdrawal finalization.
-        let is_advance_tempo =
-            validate_system_transaction(self.has_advanced_tempo, recovered.tx())?;
+        let (is_advance_tempo, is_finalize_withdrawal_batch) = validate_system_transaction(
+            self.has_advanced_tempo,
+            self.has_finalized_withdrawal_batch,
+            recovered.tx(),
+        )?;
 
         let _tx_context_guard = tx_context::set_current_transaction(
             *recovered.tx().tx_hash(),
@@ -126,11 +132,13 @@ where
         Ok(ZoneTxResult {
             inner: result?,
             is_advance_tempo,
+            is_finalize_withdrawal_batch,
         })
     }
 
     fn commit_transaction(&mut self, output: Self::Result) -> GasOutput {
         self.has_advanced_tempo |= output.is_advance_tempo;
+        self.has_finalized_withdrawal_batch |= output.is_finalize_withdrawal_batch;
         self.inner.commit_transaction(output.inner)
     }
 
@@ -161,8 +169,16 @@ where
 
 fn validate_system_transaction(
     has_advanced_tempo: bool,
+    has_finalized_withdrawal_batch: bool,
     tx: &TempoTxEnvelope,
-) -> Result<bool, BlockExecutionError> {
+) -> Result<(bool, bool), BlockExecutionError> {
+    if has_finalized_withdrawal_batch {
+        return Err(BlockValidationError::msg(
+            "finalizeWithdrawalBatch must be the last transaction in a zone block",
+        )
+        .into());
+    }
+
     let is_advance_tempo = tx.is_system_tx()
         && tx.calls().any(|(kind, input)| {
             kind.to() == Some(&ZONE_INBOX_ADDRESS) && input.starts_with(&ADVANCE_TEMPO_SELECTOR)
@@ -170,7 +186,7 @@ fn validate_system_transaction(
 
     if !has_advanced_tempo {
         return if is_advance_tempo {
-            Ok(true)
+            Ok((true, false))
         } else {
             Err(BlockValidationError::msg(
                 "advanceTempo must be the first transaction in a zone block",
@@ -186,18 +202,18 @@ fn validate_system_transaction(
         .into());
     }
 
-    if tx.is_system_tx()
-        && !tx.calls().any(|(kind, input)| {
+    let is_finalize_withdrawal_batch = tx.is_system_tx()
+        && tx.calls().any(|(kind, input)| {
             kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_calldata(input)
-        })
-    {
+        });
+    if tx.is_system_tx() && !is_finalize_withdrawal_batch {
         return Err(BlockValidationError::msg(
             "system transactions after advanceTempo must call ZoneOutbox.finalizeWithdrawalBatch",
         )
         .into());
     }
 
-    Ok(false)
+    Ok((false, is_finalize_withdrawal_batch))
 }
 
 #[cfg(test)]
@@ -240,12 +256,17 @@ mod tests {
         let mut has_advanced_tempo = false;
 
         // Execution returns the marker but must not mutate committed state.
-        assert!(validate_system_transaction(has_advanced_tempo, &advance_tempo).unwrap());
+        assert_eq!(
+            validate_system_transaction(has_advanced_tempo, false, &advance_tempo).unwrap(),
+            (true, false)
+        );
         assert!(!has_advanced_tempo);
 
         // Only committing the result records the opening transaction.
         has_advanced_tempo |=
-            validate_system_transaction(has_advanced_tempo, &advance_tempo).unwrap();
+            validate_system_transaction(has_advanced_tempo, false, &advance_tempo)
+                .unwrap()
+                .0;
         assert!(has_advanced_tempo);
     }
 
@@ -257,13 +278,13 @@ mod tests {
         );
         let ordinary = system_tx(Address::ZERO, Bytes::new());
 
-        let missing_first = validate_system_transaction(false, &ordinary).unwrap_err();
+        let missing_first = validate_system_transaction(false, false, &ordinary).unwrap_err();
         assert_eq!(
             missing_first.to_string(),
             "advanceTempo must be the first transaction in a zone block"
         );
 
-        let duplicate = validate_system_transaction(true, &advance_tempo).unwrap_err();
+        let duplicate = validate_system_transaction(true, false, &advance_tempo).unwrap_err();
         assert_eq!(
             duplicate.to_string(),
             "advanceTempo must only execute once per zone block"
@@ -282,7 +303,10 @@ mod tests {
             .abi_encode()
             .into(),
         );
-        assert!(!validate_system_transaction(true, &finalize).unwrap());
+        assert_eq!(
+            validate_system_transaction(true, false, &finalize).unwrap(),
+            (false, true)
+        );
 
         let setter = system_tx(
             ZONE_OUTBOX_ADDRESS,
@@ -292,7 +316,7 @@ mod tests {
             .abi_encode()
             .into(),
         );
-        let error = validate_system_transaction(true, &setter).unwrap_err();
+        let error = validate_system_transaction(true, false, &setter).unwrap_err();
         assert_eq!(
             error.to_string(),
             "system transactions after advanceTempo must call \
@@ -303,7 +327,7 @@ mod tests {
             ZONE_OUTBOX_ADDRESS,
             Bytes::copy_from_slice(&IZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR),
         );
-        let error = validate_system_transaction(true, &malformed_finalize).unwrap_err();
+        let error = validate_system_transaction(true, false, &malformed_finalize).unwrap_err();
         assert_eq!(
             error.to_string(),
             "system transactions after advanceTempo must call \
@@ -317,7 +341,43 @@ mod tests {
             TxLegacy::default(),
             Signature::test_signature(),
         ));
-        assert!(!validate_system_transaction(true, &ordinary).unwrap());
+        assert_eq!(
+            validate_system_transaction(true, false, &ordinary).unwrap(),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn withdrawal_finalization_is_the_last_transaction() {
+        let finalize = system_tx(
+            ZONE_OUTBOX_ADDRESS,
+            IZoneOutbox::finalizeWithdrawalBatchCall {
+                count: U256::ZERO,
+                blockNumber: 1,
+                encryptedSenders: vec![],
+            }
+            .abi_encode()
+            .into(),
+        );
+        let ordinary = TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy::default(),
+            Signature::test_signature(),
+        ));
+        let mut has_finalized_withdrawal_batch = false;
+
+        let result =
+            validate_system_transaction(true, has_finalized_withdrawal_batch, &finalize).unwrap();
+        assert!(!has_finalized_withdrawal_batch);
+
+        has_finalized_withdrawal_batch |= result.1;
+        for tx in [&ordinary, &finalize] {
+            let error =
+                validate_system_transaction(true, has_finalized_withdrawal_batch, tx).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "finalizeWithdrawalBatch must be the last transaction in a zone block"
+            );
+        }
     }
 
     #[test]

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -283,11 +283,13 @@ impl ZoneOutbox {
 
     fn finalize_withdrawal_batch<P: L1StorageReader>(
         &mut self,
-        l1: &L1State<P>,
+        _l1: &L1State<P>,
         caller: Address,
         call: IZoneOutbox::finalizeWithdrawalBatchCall,
     ) -> ZoneResult<B256> {
-        self.ensure_sequencer(l1, caller)?;
+        if caller != Address::ZERO {
+            return Err(ZoneOutboxError::only_sequencer().into());
+        }
         if call.blockNumber != self.storage.block_number() {
             return Err(ZoneOutboxError::invalid_block_number().into());
         }

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -235,7 +235,7 @@ impl Harness {
 
     fn finalize(&mut self, count: usize) -> PrecompileResult {
         self.call(
-            SEQUENCER,
+            Address::ZERO,
             ZoneOutboxAbi::finalizeWithdrawalBatchCall {
                 count: U256::from(count),
                 blockNumber: 0,
@@ -517,7 +517,7 @@ fn finalize_single_and_multiple_withdrawals_match_canonical_queue_hash() -> eyre
 }
 
 #[test]
-fn finalize_rejects_wrong_count_and_non_sequencer() -> eyre::Result<()> {
+fn finalize_rejects_wrong_count_and_non_system_caller() -> eyre::Result<()> {
     let mut harness = Harness::new()?;
     harness.request(100, ALICE, B256::ZERO)?;
     assert_revert(
@@ -526,7 +526,7 @@ fn finalize_rejects_wrong_count_and_non_sequencer() -> eyre::Result<()> {
     );
 
     let result = harness.call(
-        ALICE,
+        SEQUENCER,
         ZoneOutboxAbi::finalizeWithdrawalBatchCall {
             count: U256::ONE,
             blockNumber: 0,
@@ -709,7 +709,7 @@ fn encrypted_sender_count_and_length_are_validated() -> eyre::Result<()> {
     harness.request(1, BOB, B256::ZERO)?;
     assert_revert(
         harness.call(
-            SEQUENCER,
+            Address::ZERO,
             ZoneOutboxAbi::finalizeWithdrawalBatchCall {
                 count: U256::ONE,
                 blockNumber: 0,
@@ -721,7 +721,7 @@ fn encrypted_sender_count_and_length_are_validated() -> eyre::Result<()> {
     );
     assert_revert(
         harness.call(
-            SEQUENCER,
+            Address::ZERO,
             ZoneOutboxAbi::finalizeWithdrawalBatchCall {
                 count: U256::ONE,
                 blockNumber: 0,

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -218,7 +218,7 @@ The following table lists every privileged action and the role authorized to inv
 | `processWithdrawals(...)` | [`ZonePortal`](#izoneportal) | **any active sequencer** |
 | `setTempoGasRate(rate)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | **sequencer** or zone system caller (`address(0)`) |
 | `setMaxWithdrawalsPerBlock(limit)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | **sequencer** or zone system caller (`address(0)`) |
-| `finalizeWithdrawalBatch(...)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | **sequencer** or zone system caller (`address(0)`) |
+| `finalizeWithdrawalBatch(...)` | [`ZoneOutbox`](#izoneoutbox) (zone-side) | **zone system caller (`address(0)`) only** |
 | Block production / `beneficiary` | zone | **sequencer** |
 
 Rationale notes:
@@ -226,7 +226,7 @@ Rationale notes:
 - **Token enablement and deposit pause/resume are admin-only** because they govern what the zone is and which deposit flows are open. A compromised sequencer hot key MUST NOT be able to enable arbitrary tokens or unilaterally re-open paused deposits.
 - **Withdrawal gas rates are sequencer-controlled within an admin ceiling** so the sequencer can react quickly to Tempo gas-price fluctuations while the admin retains control over the maximum user fee. The admin directly controls the Tempo-side deposit and bounce-back fee parameters.
 - **Encryption key management is sequencer-only** because the proof of possession requires the encryption private key.
-- **Zone-side system calls** to `ZoneOutbox` may use `msg.sender == address(0)` so the block builder can inject protocol system transactions. Ordinary user transactions must come from the registered sequencer address for these calls.
+- **Zone-side system calls** to `ZoneOutbox` use `msg.sender == address(0)`. Withdrawal finalization is system-only; sequencers may call the gas-rate and withdrawal-limit setters directly.
 - **Withdrawal processing is sequencer-only** today; whether to make it permissionless once the proof has settled is tracked separately.
 
 <br>
@@ -658,7 +658,7 @@ fee = (WITHDRAWAL_BASE_GAS + gasLimit) * tempoGasRate
 
 ### Withdrawal Batching
 
-A withdrawal batch ends with exactly one call to `finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` on the `ZoneOutbox` in the final block of that batch. The block builder may include this as a zone system transaction (`msg.sender == address(0)`), and the `blockNumber` argument must match the current zone block number. The encrypted-senders array carries one sequencer-supplied ciphertext per finalized withdrawal for [authenticated withdrawals](#authenticated-withdrawals) (empty bytes for withdrawals without `revealTo`); `senderTag` is recomputed by the outbox from the queued withdrawal sender and transaction hash. This constructs a hash chain from pending withdrawals in LIFO order (newest to oldest), so the oldest withdrawal ends up outermost, enabling FIFO processing on Tempo:
+A withdrawal batch ends with exactly one call to `finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` on the `ZoneOutbox` in the final block of that batch. The block builder includes this as the last transaction using the zone system caller (`msg.sender == address(0)`), and the `blockNumber` argument must match the current zone block number. The encrypted-senders array carries one sequencer-supplied ciphertext per finalized withdrawal for [authenticated withdrawals](#authenticated-withdrawals) (empty bytes for withdrawals without `revealTo`); `senderTag` is recomputed by the outbox from the queued withdrawal sender and transaction hash. This constructs a hash chain from pending withdrawals in LIFO order (newest to oldest), so the oldest withdrawal ends up outermost, enabling FIFO processing on Tempo:
 
 ```
 withdrawalQueueHash = EMPTY_SENTINEL
@@ -781,7 +781,7 @@ Each zone block contains system transactions and user transactions in a fixed or
 
 1. `ZoneInbox.advanceTempo(header, deposits, decryptions, enabledTokens)` (required as the first transaction in every non-genesis block). Imports exactly one finalized Tempo block, enables newly-bridged tokens, processes any pending deposits, and verifies encrypted deposit decryptions.
 2. User transactions, executed in order.
-3. `ZoneOutbox.finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` (required in the final block of a batch, absent in intermediate blocks). Constructs the withdrawal hash chain from pending withdrawals, populates `encryptedSender` for authenticated withdrawals, and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to state. Must be called at each batch boundary even if there are zero withdrawals so the batch index advances. The builder may execute it as a zone system transaction with `msg.sender == address(0)`.
+3. `ZoneOutbox.finalizeWithdrawalBatch(count, blockNumber, encryptedSenders)` (required in the final block of a batch, absent in intermediate blocks). Constructs the withdrawal hash chain from pending withdrawals, populates `encryptedSender` for authenticated withdrawals, and writes the `withdrawalQueueHash` and `withdrawalBatchIndex` to state. Must be called at each batch boundary even if there are zero withdrawals so the batch index advances. It is the unique final transaction and uses the zone system caller (`msg.sender == address(0)`).
 
 A batch covers one or more zone blocks and ends with exactly one `finalizeWithdrawalBatch` call. The bootstrap batch MUST contain at least two blocks. Its first block is the canonical genesis block, which contains no transactions, and every subsequent block follows the non-genesis rules above. This guarantees that the first submitted batch imports at least one finalized Tempo block, performs the corresponding Tempo state reads, and finalizes the withdrawal batch in a non-genesis block.
 


### PR DESCRIPTION
This PR makes withdrawal batch finalization system-only and rejects transactions after the finalization transaction. This ensures the finalization event is unique and always at the tail of the block.

Closes CYCLOPS-527