### PR TITLE
feat: add withdrawal simulation endpoint

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -181,6 +181,8 @@ crate::sol! {
         error DepositBlockCapacityExceeded(uint64 maximum);
         error InvalidCallbackTarget();
         error AccountNotAllowed(address account);
+        error SimulationPassed(uint256 gasUsed);
+        error WithdrawalSimulationFailed(uint256 index, bytes4 reason);
         error InvalidLeader();
         error ActiveLeaderRemoved();
         error LeaderAlreadyUpdatedThisBlock();
@@ -238,6 +240,10 @@ crate::sol! {
             returns (bytes32 newCurrentDepositQueueHash);
 
         function processWithdrawals(Withdrawal[] calldata withdrawals, bytes32 remainingQueue) external;
+        function simulateProcessWithdrawals(
+            Withdrawal[] calldata withdrawals,
+            bytes32 remainingQueue
+        ) external;
 
         function submitBatch(
             uint64 tempoBlockNumber,
@@ -386,6 +392,8 @@ impl core::fmt::Display for ZonePortal::ZonePortalErrors {
             Self::DepositBlockCapacityExceeded(_) => f.write_str("DepositBlockCapacityExceeded"),
             Self::InvalidCallbackTarget(_) => f.write_str("InvalidCallbackTarget"),
             Self::AccountNotAllowed(_) => f.write_str("AccountNotAllowed"),
+            Self::SimulationPassed(_) => f.write_str("SimulationPassed"),
+            Self::WithdrawalSimulationFailed(_) => f.write_str("WithdrawalSimulationFailed"),
             Self::InvalidLeader(_) => f.write_str("InvalidLeader"),
             Self::ActiveLeaderRemoved(_) => f.write_str("ActiveLeaderRemoved"),
             Self::LeaderAlreadyUpdatedThisBlock(_) => f.write_str("LeaderAlreadyUpdatedThisBlock"),

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -660,6 +660,10 @@ interface IZonePortal {
     error CallbackDidNotReturnToZone();
     error InvalidAllowedAccount();
     error AccountNotAllowed(address account);
+    /// @notice Returned by `simulateProcessWithdrawals` after a successful dry run.
+    error SimulationPassed(uint256 gasUsed);
+    /// @notice Identifies the withdrawal and callback error that made a dry run fail.
+    error WithdrawalSimulationFailed(uint256 index, bytes4 reason);
 
     /// @notice Emitted when an account's portal role is initialized or updated.
     event RoleUpdated(address indexed account, Role prev, Role next);
@@ -931,6 +935,14 @@ interface IZonePortal {
         returns (bytes32 newCurrentDepositQueueHash);
 
     function processWithdrawals(Withdrawal[] calldata withdrawals, bytes32 remainingQueue) external;
+
+    /// @notice Execute withdrawal processing for estimation, reverting after a successful run.
+    /// @dev Callback failures are surfaced instead of being converted into bounce-backs.
+    function simulateProcessWithdrawals(
+        Withdrawal[] calldata withdrawals,
+        bytes32 remainingQueue
+    )
+        external;
 
     function deliverWithdrawal(
         address token,

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -984,6 +984,32 @@ contract ZonePortal is IZonePortal {
         onlySequencer
         nonReentrantWithdrawal
     {
+        _processWithdrawals(withdrawals, remainingQueue, false);
+    }
+
+    /// @notice Simulate withdrawal processing without committing any state changes.
+    /// @dev This intentionally reverts after a successful run so callers must use `eth_call`.
+    ///      Unlike `processWithdrawals`, callback failures are surfaced to help size callbacks.
+    function simulateProcessWithdrawals(
+        Withdrawal[] calldata withdrawals,
+        bytes32 remainingQueue
+    )
+        external
+        onlySequencer
+        nonReentrantWithdrawal
+    {
+        uint256 gasStart = gasleft();
+        _processWithdrawals(withdrawals, remainingQueue, true);
+        revert SimulationPassed(gasStart - gasleft());
+    }
+
+    function _processWithdrawals(
+        Withdrawal[] calldata withdrawals,
+        bytes32 remainingQueue,
+        bool strict
+    )
+        internal
+    {
         bytes32[] memory remainingQueues = new bytes32[](withdrawals.length);
         bytes32 nextQueue = remainingQueue;
 
@@ -994,11 +1020,18 @@ contract ZonePortal is IZonePortal {
         }
 
         for (uint256 i; i < withdrawals.length; ++i) {
-            _processWithdrawal(withdrawals[i], remainingQueues[i]);
+            _processWithdrawal(withdrawals[i], remainingQueues[i], strict, i);
         }
     }
 
-    function _processWithdrawal(Withdrawal calldata withdrawal, bytes32 remainingQueue) internal {
+    function _processWithdrawal(
+        Withdrawal calldata withdrawal,
+        bytes32 remainingQueue,
+        bool strict,
+        uint256 index
+    )
+        internal
+    {
         // Pop from withdrawal queue (library handles swap and hash verification)
         _withdrawalQueue.dequeue(withdrawal, remainingQueue);
 
@@ -1010,6 +1043,7 @@ contract ZonePortal is IZonePortal {
         }
 
         if (withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) {
+            if (strict) revert WithdrawalSimulationFailed(index, bytes4(0));
             _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackNonce);
             emit WithdrawalProcessed(
                 withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, false
@@ -1025,27 +1059,53 @@ contract ZonePortal is IZonePortal {
                 && _isAllowed(withdrawal.to)
                 && _tryTransfer(_token, withdrawal.to, withdrawal.amount);
         } else {
-            // Isolate callback effects so failure can be caught without reverting the dequeue.
-            try this.deliverWithdrawal(
-                _token,
-                withdrawal.to,
-                withdrawal.amount,
-                withdrawal.senderTag,
-                withdrawal.gasLimit,
-                withdrawal.callbackData
-            ) {
+            if (strict) {
+                // Preserve the real self-call and callback gas semantics, but report the item
+                // that failed instead of converting the failure into a bounce-back.
+                try this.deliverWithdrawal(
+                    _token,
+                    withdrawal.to,
+                    withdrawal.amount,
+                    withdrawal.senderTag,
+                    withdrawal.gasLimit,
+                    withdrawal.callbackData
+                ) { }
+                catch (bytes memory reason) {
+                    revert WithdrawalSimulationFailed(index, _revertSelector(reason));
+                }
                 success = true;
-            } catch {
-                success = false;
+            } else {
+                // Isolate callback effects so failure can be caught without reverting the dequeue.
+                try this.deliverWithdrawal(
+                    _token,
+                    withdrawal.to,
+                    withdrawal.amount,
+                    withdrawal.senderTag,
+                    withdrawal.gasLimit,
+                    withdrawal.callbackData
+                ) {
+                    success = true;
+                } catch {
+                    success = false;
+                }
             }
         }
 
+        if (strict && !success) revert WithdrawalSimulationFailed(index, bytes4(0));
         if (!success) {
             _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackNonce);
         }
         emit WithdrawalProcessed(
             withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, success
         );
+    }
+
+    function _revertSelector(bytes memory reason) internal pure returns (bytes4 selector) {
+        if (reason.length >= 4) {
+            assembly ("memory-safe") {
+                selector := mload(add(reason, 0x20))
+            }
+        }
     }
 
     /// @notice Deliver a callback withdrawal in a revertable self-call frame.

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -2324,6 +2324,92 @@ contract ZonePortalTest is BaseTest {
         assertEq(withdrawalReceiver.lastCallbackData(), "callback_data");
     }
 
+    function test_simulateProcessWithdrawals_revertsAfterSuccessfulRun() public {
+        _openPortalModes();
+        uint128 amount = 500e6;
+        _fundCallbackWithdrawal(amount);
+
+        Withdrawal memory w = _withdrawal(
+            address(pathUSD),
+            alice,
+            address(successfulReceiver),
+            amount,
+            bytes32(0),
+            5_000_000,
+            alice,
+            "callback_data"
+        );
+        _enqueueWithdrawal(w);
+
+        uint256 headBefore = portal.withdrawalQueueHead();
+        uint256 tailBefore = portal.withdrawalQueueTail();
+        uint256 portalBalanceBefore = pathUSD.balanceOf(address(portal));
+        uint256 receiverBalanceBefore = pathUSD.balanceOf(address(successfulReceiver));
+        uint256 callCountBefore = successfulReceiver.callCount();
+
+        try portal.simulateProcessWithdrawals(_singleWithdrawal(w), bytes32(0)) {
+            assertTrue(false, "simulation should always revert");
+        } catch (bytes memory reason) {
+            bytes4 selector;
+            uint256 gasUsed;
+            assembly {
+                selector := mload(add(reason, 0x20))
+                gasUsed := mload(add(reason, 0x24))
+            }
+            assertEq(selector, IZonePortal.SimulationPassed.selector);
+            assertGt(gasUsed, 0);
+        }
+
+        assertEq(portal.withdrawalQueueHead(), headBefore);
+        assertEq(portal.withdrawalQueueTail(), tailBefore);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBalanceBefore);
+        assertEq(pathUSD.balanceOf(address(successfulReceiver)), receiverBalanceBefore);
+        assertEq(successfulReceiver.callCount(), callCountBefore);
+    }
+
+    function test_simulateProcessWithdrawals_reportsCallbackFailure() public {
+        _openPortalModes();
+        uint128 amount = 500e6;
+        _fundCallbackWithdrawal(amount);
+        withdrawalReceiver.setShouldRevert(true);
+
+        Withdrawal memory w = _withdrawal(
+            address(pathUSD),
+            alice,
+            address(withdrawalReceiver),
+            amount,
+            bytes32(0),
+            5_000_000,
+            alice,
+            "callback_data"
+        );
+        _enqueueWithdrawal(w);
+
+        uint256 headBefore = portal.withdrawalQueueHead();
+        uint256 tailBefore = portal.withdrawalQueueTail();
+        uint256 portalBalanceBefore = pathUSD.balanceOf(address(portal));
+
+        try portal.simulateProcessWithdrawals(_singleWithdrawal(w), bytes32(0)) {
+            assertTrue(false, "simulation should revert on callback failure");
+        } catch (bytes memory reason) {
+            bytes4 selector;
+            uint256 index;
+            bytes4 callbackReason;
+            assembly {
+                selector := mload(add(reason, 0x20))
+                index := mload(add(reason, 0x24))
+                callbackReason := mload(add(reason, 0x44))
+            }
+            assertEq(selector, IZonePortal.WithdrawalSimulationFailed.selector);
+            assertEq(index, 0);
+            assertEq(callbackReason, IZonePortal.CallbackRejected.selector);
+        }
+
+        assertEq(portal.withdrawalQueueHead(), headBefore);
+        assertEq(portal.withdrawalQueueTail(), tailBefore);
+        assertEq(pathUSD.balanceOf(address(portal)), portalBalanceBefore);
+    }
+
     function _callbackData(
         GatewayFlow flow,
         address tempoRefundRecipient,

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -686,6 +686,8 @@ The portal dequeues before executing the withdrawal, then independently requires
 
 The sequencer first packs withdrawals into transactions using a configurable per-transaction gas budget, then submits them through a queue bounded by transaction count. Transactions use consecutive nonces on the dedicated withdrawal nonce key, preserving FIFO queue transitions even when later transactions are broadcast before earlier receipts arrive. If a submission reverts or cannot be confirmed, the sequencer stops admitting new transactions, drains those already submitted, then reconciles the on-chain queue and retries its unfinished suffix.
 
+For callback gas estimation, the sequencer may call `simulateProcessWithdrawals(withdrawals, remainingQueue)` with `eth_call` from an active sequencer address. The function runs the same queue, transfer, messenger, and callback path as `processWithdrawals`, but does not convert failures into bounce-backs. A successful dry run reverts with `SimulationPassed(gasUsed)` after all work has executed; a failure reverts with `WithdrawalSimulationFailed(index, reason)`, where `index` identifies the batch item and `reason` is the callback revert selector when available. Because the call reverts, queue, token, callback, and event changes are discarded. The sequencer can vary each withdrawal's callback `gasLimit` and repeat the simulation to find a passing value before estimating the outer processing transaction.
+
 For a plain withdrawal (`gasLimit == 0`), the portal rechecks the current modes and roles before transferring directly. A failed transfer or a destination invalidated by a mode or membership change creates a withdrawal bounce-back deposit for the Zone-local `zoneFallbackRecipient`.
 
 ### Withdrawal Callbacks
@@ -1835,6 +1837,7 @@ interface IZonePortal {
 
     // Withdrawal processing
     function processWithdrawals(Withdrawal[] calldata withdrawals, bytes32 remainingQueue) external;
+    function simulateProcessWithdrawals(Withdrawal[] calldata withdrawals, bytes32 remainingQueue) external;
 
     // Refund registry (deposit bounce-back transfers that reverted on Tempo, e.g.
     // because the recipient was rejected by the token's TIP-403 policy at refund time)


### PR DESCRIPTION
Adds a strict simulation entrypoint for ZonePortal withdrawal batches.

`simulateProcessWithdrawals` reuses the production queue, transfer, messenger, and callback path, but surfaces failures as `WithdrawalSimulationFailed(index, reason)`. Successful `eth_call` simulations revert with `SimulationPassed(gasUsed)` so all state and callback effects are discarded. The interface, Rust ABI, reference implementation, spec, and focused tests are updated.

Tests:
- `cargo +nightly fmt --check` (passed)
- `forge fmt --check` (passed)
- `forge test --match-path test/tempo/ZonePortal.t.sol --match-test 'test_simulateProcessWithdrawals'` (blocked: forge-std and tempo-std submodules could not be cloned with the available credentials)
- `cargo check -p tempo-zone-contracts` (blocked: Cargo could not fetch the pinned alloy-evm dependency with the available credentials)

Prompted by: @mattsse