### PR TITLE
fix: interrupt unauthorized websocket sessions

### DIFF
--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -520,10 +520,7 @@ async fn handle_ws_session(
 ) {
     let (mut ws_sender, mut ws_receiver) = socket.split();
     let (notifications, mut outbound) = mpsc::channel::<String>(MAX_WS_OUTBOUND_QUEUE);
-    let (close_session, mut close_session_rx) = watch::channel(false);
-    let token_expiry = tokio::time::sleep(duration_until_unix_timestamp(auth.expires_at));
-    tokio::pin!(token_expiry);
-    let mut keychain_recheck = tokio::time::interval(Duration::from_secs(1));
+    let (close_session, close_session_rx) = watch::channel(false);
     let writer = tokio::spawn(async move {
         while let Some(message) = outbound.recv().await {
             if ws_sender.send(Message::Text(message.into())).await.is_err() {
@@ -533,75 +530,86 @@ async fn handle_ws_session(
     });
 
     let mut session = WsSession::default();
+    let terminate_connection = async {
+        let token_expiry = tokio::time::sleep(duration_until_unix_timestamp(auth.expires_at));
+        tokio::pin!(token_expiry);
+        let mut keychain_recheck = tokio::time::interval(Duration::from_secs(1));
+        let mut close_session_rx = close_session_rx;
 
-    loop {
-        let msg = tokio::select! {
-            biased;
-            _ = &mut token_expiry => break,
-            _ = close_session_rx.changed() => break,
-            _ = keychain_recheck.tick(), if auth.keychain_key_id.is_some() => {
-                // Revalidation may be slow; allow token expiry / forced close to
-                // interrupt it so those deadlines are not delayed by a hung RPC.
-                let still_valid = tokio::select! {
-                    biased;
-                    _ = &mut token_expiry => false,
-                    _ = close_session_rx.changed() => false,
-                    valid = keychain_auth_still_valid(&auth, &state) => valid,
-                };
-                if !still_valid {
-                    break;
-                }
-                continue;
-            }
-            msg = ws_receiver.next() => match msg {
-                Some(msg) => msg,
-                None => break,
-            },
-        };
-
-        let text = match msg {
-            Ok(Message::Text(t)) => t,
-            Ok(Message::Binary(b)) => match std::str::from_utf8(&b) {
-                Ok(s) => s.into(),
-                Err(_) => {
-                    if !try_queue_notification(
-                        &notifications,
-                        &close_session,
-                        serde_json::to_string(&JsonRpcResponse::error(
-                            Value::Null,
-                            JsonRpcError::parse_error("invalid UTF-8"),
-                        ))
-                        .expect("JsonRpcResponse serialization is infallible"),
-                    ) {
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut token_expiry => break,
+                _ = close_session_rx.changed() => break,
+                _ = keychain_recheck.tick(), if auth.keychain_key_id.is_some() => {
+                    // Revalidation may be slow; allow token expiry / forced close to
+                    // interrupt it so those deadlines are not delayed by a hung RPC.
+                    let still_valid = tokio::select! {
+                        biased;
+                        _ = &mut token_expiry => false,
+                        _ = close_session_rx.changed() => false,
+                        valid = keychain_auth_still_valid(&auth, &state) => valid,
+                    };
+                    if !still_valid {
                         break;
                     }
-                    continue;
                 }
-            },
-            Ok(Message::Close(_)) => break,
-            Ok(_) => continue, // Ping/Pong handled by axum
-            Err(e) => {
-                warn!(target: "zone::rpc", err = %e, "ws recv error");
+            }
+        }
+    };
+    let handle_messages = async {
+        loop {
+            let text = match ws_receiver.next().await {
+                Some(Ok(Message::Text(text))) => text,
+                Some(Ok(Message::Binary(bytes))) => match std::str::from_utf8(&bytes) {
+                    Ok(text) => text.into(),
+                    Err(_) => {
+                        if !try_queue_notification(
+                            &notifications,
+                            &close_session,
+                            serde_json::to_string(&JsonRpcResponse::error(
+                                Value::Null,
+                                JsonRpcError::parse_error("invalid UTF-8"),
+                            ))
+                            .expect("JsonRpcResponse serialization is infallible"),
+                        ) {
+                            break;
+                        }
+                        continue;
+                    }
+                },
+                Some(Ok(Message::Close(_))) | None => break,
+                Some(Ok(_)) => continue, // Ping/Pong handled by axum
+                Some(Err(err)) => {
+                    warn!(target: "zone::rpc", %err, "ws recv error");
+                    break;
+                }
+            };
+
+            let (response_json, pending_subscriptions) =
+                process_ws_text(&text, &auth, &state, &mut session).await;
+
+            if !try_queue_notification(&notifications, &close_session, response_json) {
                 break;
             }
-        };
 
-        let (response_json, pending_subscriptions) =
-            process_ws_text(&text, &auth, &state, &mut session).await;
-
-        if !try_queue_notification(&notifications, &close_session, response_json) {
-            break;
+            activate_pending_subscriptions(
+                pending_subscriptions,
+                &notifications,
+                &close_session,
+                &mut session,
+            );
         }
+    };
 
-        activate_pending_subscriptions(
-            pending_subscriptions,
-            &notifications,
-            &close_session,
-            &mut session,
-        );
+    tokio::select! {
+        biased;
+        _ = terminate_connection => {}
+        _ = handle_messages => {}
     }
 
     session.cleanup();
+    writer.abort();
     drop(notifications);
     let _ = writer.await;
 }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -11,6 +11,7 @@ use serde_json::{Value, json};
 use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
     KeyInfo, SignatureType as KeyInfoSignatureType,
 };
+use tokio::sync::Notify;
 use tokio_tungstenite::{connect_async, tungstenite};
 use zone_rpc::{
     RedactedRpcConfig,
@@ -38,6 +39,7 @@ struct MockZoneRpcApi {
     key_infos: Mutex<HashMap<(Address, Address), KeyInfo>>,
     key_lookup_error: Option<&'static str>,
     ws_subscriptions_enabled: bool,
+    blocking_rpc_started: Option<Arc<Notify>>,
 }
 
 impl MockZoneRpcApi {
@@ -57,7 +59,19 @@ impl MockZoneRpcApi {
             key_infos: Mutex::new(key_infos),
             key_lookup_error: None,
             ws_subscriptions_enabled: false,
+            blocking_rpc_started: None,
         }
+    }
+
+    fn with_key_and_blocking_request(
+        account: Address,
+        key_id: Address,
+        signature_type: KeyInfoSignatureType,
+    ) -> (Self, Arc<Notify>) {
+        let mut api = Self::with_key(account, key_id, signature_type);
+        let started = Arc::new(Notify::new());
+        api.blocking_rpc_started = Some(started.clone());
+        (api, started)
     }
 
     fn with_key_lookup_error(message: &'static str) -> Self {
@@ -65,6 +79,7 @@ impl MockZoneRpcApi {
             key_infos: Mutex::new(HashMap::new()),
             key_lookup_error: Some(message),
             ws_subscriptions_enabled: false,
+            blocking_rpc_started: None,
         }
     }
 
@@ -73,6 +88,7 @@ impl MockZoneRpcApi {
             key_infos: Mutex::new(HashMap::new()),
             key_lookup_error: None,
             ws_subscriptions_enabled: true,
+            blocking_rpc_started: None,
         }
     }
 
@@ -134,7 +150,20 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
     stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
     stub!(send_raw_transaction, _a: alloy_primitives::Bytes, _c: zone_rpc::auth::AuthContext);
-    stub!(send_raw_transaction_sync, _a: alloy_primitives::Bytes, _c: zone_rpc::auth::AuthContext);
+    fn send_raw_transaction_sync(
+        &self,
+        _data: alloy_primitives::Bytes,
+        _auth: zone_rpc::auth::AuthContext,
+    ) -> BoxFut<'_> {
+        let started = self.blocking_rpc_started.clone();
+        Box::pin(async move {
+            if let Some(started) = started {
+                started.notify_one();
+                std::future::pending::<()>().await;
+            }
+            Err(JsonRpcError::internal("not implemented"))
+        })
+    }
     stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: zone_rpc::auth::AuthContext);
     stub!(get_logs, _a: alloy_rpc_types_eth::Filter, _c: zone_rpc::auth::AuthContext);
     stub!(new_filter, _a: alloy_rpc_types_eth::Filter, _c: zone_rpc::auth::AuthContext);
@@ -807,6 +836,42 @@ async fn ws_closes_when_keychain_key_is_revoked() {
     let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
         .await
         .expect("authorized keychain ws connect failed");
+
+    api.revoke_key(root_account, key_id);
+
+    let _closed = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for keychain-revocation close");
+}
+
+#[tokio::test]
+async fn ws_closes_when_keychain_key_is_revoked_during_request() {
+    let root_account = Address::repeat_byte(0x78);
+    let access_signer = P256SigningKey::random(&mut thread_rng());
+    let now = now_secs();
+    let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
+    let (signature, key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)
+        .expect("keychain signing should succeed");
+    let (api, blocking_rpc_started) = MockZoneRpcApi::with_key_and_blocking_request(
+        root_account,
+        key_id,
+        KeyInfoSignatureType::P256,
+    );
+    let api = Arc::new(api);
+    let ctx = TestContext::start_shared(api.clone()).await;
+    let token = build_token_with_signature(signature, &fields);
+    let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
+        .await
+        .expect("authorized keychain ws connect failed");
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_sendRawTransactionSync", json!(["0x00"]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(1), blocking_rpc_started.notified())
+        .await
+        .expect("blocking RPC was not dispatched");
 
     api.revoke_key(root_account, key_id);
 


### PR DESCRIPTION
Cancel in-flight WebSocket dispatch and queued output when token expiry or keychain revocation terminates the session.

Fixes [CYCLOPS-529](https://linear.app/tempoxyz/issue/CYCLOPS-529/cyclops-revokedexpired-private-rpc-websocket-sessions-keep-streaming)