### PR TITLE
fix(portal): reject registered portal bounceback recipients

### DIFF
--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -11,6 +11,7 @@ import {
     EncryptedDepositPayload,
     EncryptionKeyEntry,
     IVerifier,
+    IZoneFactory,
     IZoneMessenger,
     IZonePortal,
     MAX_WITHDRAWAL_CALLBACK_GAS,
@@ -749,6 +750,15 @@ contract ZonePortal is IZonePortal {
         if (role[account] != Role.Account) revert AccountNotAllowed(account);
     }
 
+    function _validateBouncebackRecipient(address tempoRefundRecipient) internal view {
+        if (
+            tempoRefundRecipient == address(0)
+                || IZoneFactory(ZONE_FACTORY_ADDRESS).isZonePortal(tempoRefundRecipient)
+        ) {
+            revert InvalidBouncebackRecipient();
+        }
+    }
+
     function _isAllowed(address account) internal view returns (bool) {
         return !_isAccessEnforced || role[account] == Role.Account;
     }
@@ -833,7 +843,7 @@ contract ZonePortal is IZonePortal {
         external
         returns (bytes32 newCurrentDepositQueueHash)
     {
-        if (tempoRefundRecipient == address(0)) revert InvalidBouncebackRecipient();
+        _validateBouncebackRecipient(tempoRefundRecipient);
         // An enforced, registered gateway is independently authorized to return callback funds.
         _requireAllowedDepositor(msg.sender);
         _requireAllowed(tempoRefundRecipient);
@@ -891,7 +901,7 @@ contract ZonePortal is IZonePortal {
         external
         returns (bytes32 newCurrentDepositQueueHash)
     {
-        if (tempoRefundRecipient == address(0)) revert InvalidBouncebackRecipient();
+        _validateBouncebackRecipient(tempoRefundRecipient);
         // Enforced gateways may deposit callback returns without also being allowed accounts.
         _requireAllowedDepositor(msg.sender);
         _requireAllowed(tempoRefundRecipient);

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 5225,
+      "astId": 5226,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5228,
+      "astId": 5229,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5230,
+      "astId": 5231,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -25,7 +25,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5232,
+      "astId": 5233,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5235,
+      "astId": 5236,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5238,
+      "astId": 5239,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5241,
+      "astId": 5242,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -57,7 +57,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5244,
+      "astId": 5245,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5247,
+      "astId": 5248,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "bouncebackGas",
       "offset": 24,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5252,
+      "astId": 5253,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_array(t_struct(EncryptionKeyEntry)2654_storage)dyn_storage"
     },
     {
-      "astId": 5258,
+      "astId": 5259,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_mapping(t_address,t_struct(TokenConfig)3080_storage)"
     },
     {
-      "astId": 5262,
+      "astId": 5263,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5269,
+      "astId": 5270,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -105,7 +105,7 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 5273,
+      "astId": 5274,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
@@ -113,7 +113,7 @@
       "type": "t_struct(WithdrawalQueue)4891_storage"
     },
     {
-      "astId": 5276,
+      "astId": 5277,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 5279,
+      "astId": 5280,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5282,
+      "astId": 5283,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5285,
+      "astId": 5286,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5288,
+      "astId": 5289,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -153,7 +153,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5290,
+      "astId": 5291,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5292,
+      "astId": 5293,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 20,
@@ -169,7 +169,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5295,
+      "astId": 5296,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerSetVersion",
       "offset": 21,
@@ -177,7 +177,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5297,
+      "astId": 5298,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerThreshold",
       "offset": 29,
@@ -185,7 +185,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 5299,
+      "astId": 5300,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneHeight",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5302,
+      "astId": 5303,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_sequencers",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5306,
+      "astId": 5307,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "isSequencer",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 5311,
+      "astId": 5312,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "role",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_mapping(t_address,t_enum(Role)2497)"
     },
     {
-      "astId": 5314,
+      "astId": 5315,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isAccessEnforced",
       "offset": 0,
@@ -225,7 +225,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5316,
+      "astId": 5317,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isGatewayEnforced",
       "offset": 1,
@@ -233,7 +233,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5319,
+      "astId": 5320,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enforcementModesPadding",
       "offset": 2,
@@ -241,7 +241,7 @@
       "type": "t_uint240"
     },
     {
-      "astId": 5322,
+      "astId": 5323,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "maxTempoGasRate",
       "offset": 0,
@@ -249,7 +249,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5325,
+      "astId": 5326,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leader",
       "offset": 0,
@@ -257,7 +257,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5328,
+      "astId": 5329,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderEpoch",
       "offset": 20,
@@ -265,7 +265,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5331,
+      "astId": 5332,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderActivationTempoBlock",
       "offset": 0,
@@ -273,7 +273,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5334,
+      "astId": 5335,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_depositCountBlock",
       "offset": 8,
@@ -281,7 +281,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5336,
+      "astId": 5337,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_depositsInCurrentBlock",
       "offset": 16,

--- a/specs/ref-impls/test/BaseTest.t.sol
+++ b/specs/ref-impls/test/BaseTest.t.sol
@@ -238,6 +238,16 @@ contract BaseTest is Test {
                 })
             )
         );
+        vm.mockCall(
+            ZONE_FACTORY_ADDRESS,
+            abi.encodeWithSelector(IZoneFactory.isZonePortal.selector),
+            abi.encode(false)
+        );
+        vm.mockCall(
+            ZONE_FACTORY_ADDRESS,
+            abi.encodeCall(IZoneFactory.isZonePortal, (address(portal))),
+            abi.encode(true)
+        );
     }
 
     function _singleWithdrawal(Withdrawal memory withdrawal)

--- a/specs/ref-impls/test/BaseTest.t.sol
+++ b/specs/ref-impls/test/BaseTest.t.sol
@@ -152,6 +152,12 @@ contract BaseTest is Test {
         );
 
         _mockTokenPolicyMigration(_PATH_USD, true);
+
+        vm.mockCall(
+            ZONE_FACTORY_ADDRESS,
+            abi.encodeWithSelector(IZoneFactory.isZonePortal.selector),
+            abi.encode(false)
+        );
     }
 
     function _mockTokenPolicyMigration(address token, bool isSet) internal {
@@ -237,11 +243,6 @@ contract BaseTest is Test {
                     rpcUrl: rpcUrl
                 })
             )
-        );
-        vm.mockCall(
-            ZONE_FACTORY_ADDRESS,
-            abi.encodeWithSelector(IZoneFactory.isZonePortal.selector),
-            abi.encode(false)
         );
         vm.mockCall(
             ZONE_FACTORY_ADDRESS,

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -1471,6 +1471,12 @@ contract ZonePortalTest is BaseTest {
         portal.deposit(address(pathUSD), alice, 1, bytes32(0), outsider);
     }
 
+    function test_deposit_revertsForPortalBouncebackRecipient() public {
+        vm.prank(alice);
+        vm.expectRevert(IZonePortal.InvalidBouncebackRecipient.selector);
+        portal.deposit(address(pathUSD), alice, 1, bytes32(0), address(portal));
+    }
+
     function test_deposit_updatesHashChain() public {
         uint128 depositAmount = 1000e6;
 
@@ -4239,6 +4245,17 @@ contract ZonePortalTest is BaseTest {
         pathUSD.approve(address(portal), depositAmount);
         vm.expectRevert(ITIP20.PolicyForbids.selector);
         portal.depositEncrypted(address(pathUSD), depositAmount, 0, _makeEncryptedPayload(), bob);
+        vm.stopPrank();
+    }
+
+    function test_depositEncrypted_revertsForPortalBouncebackRecipient() public {
+        _setEncKeyWithPoP(ENC_KEY_1);
+
+        vm.startPrank(alice);
+        vm.expectRevert(IZonePortal.InvalidBouncebackRecipient.selector);
+        portal.depositEncrypted(
+            address(pathUSD), 1000e6, 0, _makeEncryptedPayload(), address(portal)
+        );
         vm.stopPrank();
     }
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -381,7 +381,7 @@ Deposits move TIP-20 tokens from Tempo into a zone. The user deposits on Tempo, 
 An account deposits by calling `deposit(token, to, amount, memo, tempoRefundRecipient)` on the portal. The portal:
 
 1. In closed access mode, requires `msg.sender` and `tempoRefundRecipient` to have the `Account` role. A caller with the `CallbackGateway` role may make callback-return deposits while gateway mode is enforced. Open access mode skips these membership checks. The zone recipient `to` need not be allowed.
-2. Validates the token is enabled and deposits are active, requires `tempoRefundRecipient != address(0)`, validates `to` against the token's TIP-403 recipient and mint-recipient policies, and validates `tempoRefundRecipient` against the token's TIP-403 recipient policy.
+2. Validates the token is enabled and deposits are active, requires `tempoRefundRecipient` to be nonzero and not a registered `ZonePortal`, validates `to` against the token's TIP-403 recipient and mint-recipient policies, and validates `tempoRefundRecipient` against the token's TIP-403 recipient policy.
 3. Computes `depositFee` from `zoneGasRate` and checks `amount >= depositFee + currentBouncebackFee`, where `currentBouncebackFee = ceil(bouncebackGas * block.basefee / 1e12)` (reverts `DepositTooSmall` otherwise). This prevents obvious dust deposits that could not pay for an immediate Tempo refund when bounce-back gas is configured.
 4. Transfers `amount` from the user into the portal.
 5. Pays the `depositFee` to the portal admin immediately.
@@ -520,7 +520,7 @@ sequenceDiagram
 
 Deposits can fail because the zone-side mint reverts (including a TIP-403 policy rejection) or because an encrypted deposit fails onchain decryption verification. To make sure that all cases can be handled without loss of user funds, every deposit carries a `tempoRefundRecipient`: a Tempo address that receives a refund if zone-side processing fails. The sequencer has no discretionary rejection flag: every regular deposit attempts its mint, and every encrypted deposit is verified and then attempts its mint when decryption succeeds.
 
-**Validation at deposit time.** Both `deposit(...)` and `depositEncrypted(...)` require an allowed `tempoRefundRecipient` and require it to be authorized by the token's TIP-403 recipient policy. Zone recipients are not checked against closed-loop membership. If the on-Tempo refund transfer later reverts because policy changed, the funds are parked in a per-recipient refund registry on the portal and may be claimed only by that allowed recipient via `claimRefund(token)`.
+**Validation at deposit time.** Both `deposit(...)` and `depositEncrypted(...)` require an allowed `tempoRefundRecipient` that is neither the zero address nor a registered `ZonePortal`, and require it to be authorized by the token's TIP-403 recipient policy. Zone recipients are not checked against closed-loop membership. If the on-Tempo refund transfer later reverts because policy changed, the funds are parked in a per-recipient refund registry on the portal and may be claimed only by that allowed recipient via `claimRefund(token)`.
 
 **Triggering conditions.** There are two triggering sites:
 


### PR DESCRIPTION
## Summary
- reject zero-address and registered ZonePortal bounce-back recipients through one shared validation helper
- cover regular and encrypted deposits with regression tests
- document the non-portal bounce-back invariant in the protocol spec

## Validation
- `forge fmt --check`
- `git diff --check`
- `forge test --match-path test/tempo/ZonePortal.t.sol` *(blocked: sandbox submodules are empty and Foundry could not clone them because GitHub credentials were rejected)*

Linear: ZONE-233 (reported as CHAIN-1248)

Prompted by: @0xrusowsky