### PR TITLE
fix(precompiles): expose outbox portal address

### DIFF
--- a/crates/contracts/src/precompiles/outbox.rs
+++ b/crates/contracts/src/precompiles/outbox.rs
@@ -66,6 +66,7 @@ crate::sol! {
 
         // -- View functions --
 
+        function tempoPortal() external view returns (address);
         function tempoGasRate() external view returns (uint128);
         function maxWithdrawalsPerBlock() external view returns (uint32);
         function lastBatch() external view returns (LastBatch memory);

--- a/crates/precompiles/src/outbox/dispatch.rs
+++ b/crates/precompiles/src/outbox/dispatch.rs
@@ -31,6 +31,7 @@ impl ZoneOutbox {
 
         dispatch!(calldata, |call| match call {
             IZoneOutbox::IZoneOutboxCalls {
+                tempoPortal(_) => metadata::<IZoneOutbox::tempoPortalCall>(|| Ok(l1.portal())),
                 tempoGasRate(_) => metadata::<IZoneOutbox::tempoGasRateCall>(|| self.tempo_gas_rate.read()),
                 maxWithdrawalsPerBlock(_) => metadata::<IZoneOutbox::maxWithdrawalsPerBlockCall>(|| self.max_withdrawals_per_block.read()),
                 lastBatch(_) => metadata::<IZoneOutbox::lastBatchCall>(|| self.last_batch()),

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -794,6 +794,17 @@ fn per_block_cap_is_unlimited_resettable_and_updateable() -> eyre::Result<()> {
 }
 
 #[test]
+fn tempo_portal_returns_configured_l1_portal() -> eyre::Result<()> {
+    let mut harness = Harness::new()?;
+    let output = harness.call_static(ALICE, ZoneOutboxAbi::tempoPortalCall {}.abi_encode())?;
+    assert_eq!(
+        ZoneOutboxAbi::tempoPortalCall::abi_decode_returns(&output.bytes)?,
+        PORTAL,
+    );
+    Ok(())
+}
+
+#[test]
 fn many_withdrawals_finalize_and_clear_pending_state() -> eyre::Result<()> {
     let mut harness = Harness::new()?;
     for i in 0..20u64 {

--- a/crates/precompiles/src/outbox/tests.rs
+++ b/crates/precompiles/src/outbox/tests.rs
@@ -794,17 +794,6 @@ fn per_block_cap_is_unlimited_resettable_and_updateable() -> eyre::Result<()> {
 }
 
 #[test]
-fn tempo_portal_returns_configured_l1_portal() -> eyre::Result<()> {
-    let mut harness = Harness::new()?;
-    let output = harness.call_static(ALICE, ZoneOutboxAbi::tempoPortalCall {}.abi_encode())?;
-    assert_eq!(
-        ZoneOutboxAbi::tempoPortalCall::abi_decode_returns(&output.bytes)?,
-        PORTAL,
-    );
-    Ok(())
-}
-
-#[test]
 fn many_withdrawals_finalize_and_clear_pending_state() -> eyre::Result<()> {
     let mut harness = Harness::new()?;
     for i in 0..20u64 {


### PR DESCRIPTION
Previously txgen workflows were failing because the Zone resolver calls the removed `config()` selector on ZoneInbox and ZoneOutbox while resolving the L1 Portal address.

This PR exposes `tempoPortal()` on ZoneOutbox so the resolver can read the portal directly from precompiles without restoring ZoneConfig.