### PR TITLE
fix(node): retain encryption keys across rotations

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -10,6 +10,9 @@ use alloy_primitives::{Address, B256, Bytes, keccak256};
 use alloy_sol_types::SolValue;
 use zone_primitives::constants::EMPTY_SENTINEL;
 
+/// Old encryption keys remain valid for new deposits for one day at one-second blocks.
+pub const ENCRYPTION_KEY_GRACE_PERIOD: u64 = 86_400;
+
 crate::sol! {
     #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
     contract ZonePortal {
@@ -49,6 +52,12 @@ crate::sol! {
             address tempoRefundRecipient;
             uint256 keyIndex;
             EncryptedDepositPayload encrypted;
+        }
+
+        struct EncryptionKeyEntry {
+            bytes32 x;
+            uint8 yParity;
+            uint64 activationBlock;
         }
 
         struct BlockTransition {
@@ -295,6 +304,8 @@ crate::sol! {
         function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
 
         function encryptionKeyCount() external view returns (uint256);
+        function encryptionKeyAt(uint256 index)
+            external view returns (EncryptionKeyEntry memory entry);
         function encryptionKeyAtBlock(uint64 tempoBlockNumber)
             external view returns (bytes32 x, uint8 yParity, uint256 keyIndex);
         function claimRefund(address token) external returns (uint128 amount);

--- a/crates/l1/src/block.rs
+++ b/crates/l1/src/block.rs
@@ -1,5 +1,47 @@
 use super::*;
 
+/// Sequencer encryption private keys indexed by their position in Portal key history.
+#[derive(Clone)]
+pub struct SequencerKeyring {
+    keys: Vec<(U256, k256::SecretKey)>,
+}
+
+impl SequencerKeyring {
+    /// Create a keyring from `(Portal key index, private key)` entries.
+    pub fn new(mut keys: Vec<(U256, k256::SecretKey)>) -> eyre::Result<Self> {
+        eyre::ensure!(!keys.is_empty(), "sequencer encryption keyring is empty");
+        keys.sort_unstable_by_key(|(index, _)| *index);
+        eyre::ensure!(
+            keys.windows(2).all(|pair| pair[0].0 != pair[1].0),
+            "sequencer encryption keyring contains duplicate indices"
+        );
+        Ok(Self { keys })
+    }
+
+    /// Return the private key registered at `key_index`.
+    pub fn key_at(&self, key_index: U256) -> eyre::Result<&k256::SecretKey> {
+        self.keys
+            .iter()
+            .find_map(|(index, key)| (*index == key_index).then_some(key))
+            .ok_or_else(|| {
+                eyre::eyre!("missing sequencer encryption key for portal key index {key_index}")
+            })
+    }
+
+    /// Portal indices present in this keyring.
+    pub fn indices(&self) -> impl Iterator<Item = U256> + '_ {
+        self.keys.iter().map(|(index, _)| *index)
+    }
+}
+
+impl core::fmt::Debug for SequencerKeyring {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SequencerKeyring")
+            .field("indices", &self.indices().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
 /// An L1 block's header paired with the deposits found in that block.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct L1BlockDeposits {
@@ -18,7 +60,7 @@ impl L1BlockDeposits {
     /// builder.
     pub async fn prepare(
         self,
-        sequencer_key: &k256::SecretKey,
+        sequencer_keys: &SequencerKeyring,
         portal_address: Address,
     ) -> eyre::Result<PreparedL1Block> {
         use crate::precompiles::ecies;
@@ -34,6 +76,7 @@ impl L1BlockDeposits {
                 L1Deposit::Regular(_) => queued_deposits.push(deposit.to_abi_queued_deposit()),
                 L1Deposit::Encrypted(d) => {
                     let queued = deposit.to_abi_queued_deposit();
+                    let sequencer_key = sequencer_keys.key_at(d.key_index)?;
 
                     // Attempt full ECIES decryption.
                     let dec = ecies::decrypt_deposit(

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -83,7 +83,7 @@ mod subscriber;
 #[cfg(test)]
 mod tests;
 
-pub use block::{L1BlockDeposits, PreparedL1Block};
+pub use block::{L1BlockDeposits, PreparedL1Block, SequencerKeyring};
 pub use deposit::{Deposit, EncryptedDeposit, L1Deposit};
 pub use event::{EnabledToken, L1PortalEvents, LeaderTransition};
 pub use ext::{ChainTempoStateExt, TempoStateExt};

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1145,7 +1145,10 @@ async fn test_prepare_decrypted_deposit_defers_policy_to_upstream_mint() {
     };
 
     let prepared = block
-        .prepare(&sequencer_key, portal)
+        .prepare(
+            &SequencerKeyring::new(vec![(U256::ZERO, sequencer_key)]).unwrap(),
+            portal,
+        )
         .await
         .expect("decrypted deposit should prepare without an engine-side policy read");
 
@@ -1158,6 +1161,107 @@ async fn test_prepare_decrypted_deposit_defers_policy_to_upstream_mint() {
         prepared.decryptions.len(),
         1,
         "successfully decrypted deposits must provide on-chain decryption data"
+    );
+}
+
+#[tokio::test]
+async fn test_prepare_selects_encryption_key_by_portal_index() {
+    use k256::{AffinePoint, ProjectivePoint, Scalar};
+
+    let portal = address!("0x0000000000000000000000000000000000000ABC");
+    let sender = address!("0x0000000000000000000000000000000000001234");
+    let token = address!("0x0000000000000000000000000000000000001000");
+    let previous = k256::SecretKey::from_slice(&[0x11; 32]).expect("valid previous key");
+    let current = k256::SecretKey::from_slice(&[0x22; 32]).expect("valid current key");
+
+    let encrypted_deposit = |key: &k256::SecretKey, key_index: U256, recipient: Address| {
+        let scalar: Scalar = *key.to_nonzero_scalar();
+        let public = AffinePoint::from(ProjectivePoint::GENERATOR * scalar);
+        let (x, y_parity) = crate::precompiles::ecies::compressed_x_and_parity(&public);
+        let encrypted = crate::precompiles::ecies::encrypt_deposit(
+            &x,
+            y_parity,
+            recipient,
+            B256::ZERO,
+            portal,
+            key_index,
+        )
+        .expect("encrypted deposit should be valid");
+        L1Deposit::Encrypted(EncryptedDeposit {
+            token,
+            sender,
+            amount: 1_000_000,
+            fee: 0,
+            tempo_refund_recipient: sender,
+            key_index,
+            ephemeral_pubkey_x: encrypted.eph_pub_x,
+            ephemeral_pubkey_y_parity: encrypted.eph_pub_y_parity,
+            ciphertext: encrypted.ciphertext,
+            nonce: encrypted.nonce,
+            tag: encrypted.tag,
+        })
+    };
+
+    let block = L1BlockDeposits {
+        header: seal(make_test_header(10)),
+        events: L1PortalEvents::from_deposits(vec![
+            encrypted_deposit(
+                &previous,
+                U256::ZERO,
+                address!("0x000000000000000000000000000000000000BEEF"),
+            ),
+            encrypted_deposit(
+                &current,
+                U256::from(1),
+                address!("0x000000000000000000000000000000000000CAFE"),
+            ),
+        ]),
+    };
+    let keys =
+        SequencerKeyring::new(vec![(U256::ZERO, previous), (U256::from(1), current)]).unwrap();
+
+    let prepared = block.prepare(&keys, portal).await.unwrap();
+
+    assert_eq!(prepared.queued_deposits.len(), 2);
+    assert_eq!(prepared.decryptions.len(), 2);
+}
+
+#[tokio::test]
+async fn test_prepare_fails_when_deposit_key_is_not_retained() {
+    let block = L1BlockDeposits {
+        header: seal(make_test_header(10)),
+        events: L1PortalEvents::from_deposits(vec![L1Deposit::Encrypted(EncryptedDeposit {
+            token: Address::ZERO,
+            sender: Address::ZERO,
+            amount: 1,
+            fee: 0,
+            tempo_refund_recipient: Address::ZERO,
+            key_index: U256::ZERO,
+            ephemeral_pubkey_x: B256::ZERO,
+            ephemeral_pubkey_y_parity: 2,
+            ciphertext: vec![].into(),
+            nonce: [0; 12],
+            tag: [0; 16],
+        })]),
+    };
+    let keys = SequencerKeyring::new(vec![
+        (
+            U256::from(1),
+            k256::SecretKey::from_slice(&[0x11; 32]).unwrap(),
+        ),
+        (
+            U256::from(2),
+            k256::SecretKey::from_slice(&[0x22; 32]).unwrap(),
+        ),
+    ])
+    .unwrap();
+
+    let error = block.prepare(&keys, Address::ZERO).await.unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("missing sequencer encryption key for portal key index 0")
     );
 }
 

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1239,7 +1239,7 @@ async fn test_prepare_fails_when_deposit_key_is_not_retained() {
             key_index: U256::ZERO,
             ephemeral_pubkey_x: B256::ZERO,
             ephemeral_pubkey_y_parity: 2,
-            ciphertext: vec![].into(),
+            ciphertext: vec![],
             nonce: [0; 12],
             tag: [0; 16],
         })]),

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -154,9 +154,13 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         // private key for encrypted deposits and must not sit on an internet-facing host.
         let rpc_only = p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
         let should_sequence_blocks = sequencer_enabled(args.enable_sequencer, p2p_config.as_ref());
-        if rpc_only && (args.sequencer_key.is_some() || args.sequencer_key_file.is_some()) {
+        if rpc_only
+            && (args.sequencer_key.is_some()
+                || args.sequencer_key_file.is_some()
+                || !args.sequencer_key_history_files.is_empty())
+        {
             return Err(eyre::eyre!(
-                "this node is `rpc_only` in the manifest, so --sequencer-key/--sequencer-key-file must not be provided: the shared key is never used here and is also the zone ECIES private key for encrypted deposits"
+                "this node is `rpc_only` in the manifest, so sequencer encryption keys must not be provided: the shared keys are never used here"
             ));
         }
         let sequencer_signer = if should_sequence_blocks {
@@ -167,6 +171,21 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         } else {
             None
         };
+        let mut historical_sequencer_signers = Vec::new();
+        if should_sequence_blocks {
+            for path in &args.sequencer_key_history_files {
+                historical_sequencer_signers.push(
+                    load_sequencer_signer(None, Some(path))
+                        .await
+                        .map_err(|err| {
+                            eyre::eyre!(
+                                "failed to load historical sequencer key from {}: {err}",
+                                path.display()
+                            )
+                        })?,
+                );
+            }
+        }
 
         builder.config_mut().network.discovery.disable_discovery = true;
         builder.config_mut().rpc.disable_auth_server = true;
@@ -198,6 +217,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 .and_then(P2pConfig::block_attestation_signer);
             node = node.with_sequencer(ZoneSequencerAddOnsConfig {
                 sequencer_signer,
+                historical_sequencer_signers,
                 l1_transaction_signer,
                 zone_id: args.zone_id,
                 zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
@@ -295,6 +315,16 @@ pub struct ZoneArgs {
         conflicts_with = "sequencer_key"
     )]
     pub sequencer_key_file: Option<PathBuf>,
+
+    /// Historical sequencer encryption key files retained for deposits accepted during rotation.
+    #[arg(
+        long = "sequencer-key-history-file",
+        env = "SEQUENCER_KEY_HISTORY_FILES",
+        value_name = "PATH",
+        value_delimiter = ',',
+        action = clap::ArgAction::Append
+    )]
+    pub sequencer_key_history_files: Vec<PathBuf>,
 
     /// Path to the static multi-sequencer manifest. Its presence activates
     /// multi-sequencer mode and makes the manifest authoritative for role selection.
@@ -592,6 +622,30 @@ mod tests {
         ]))
         .unwrap_err();
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn sequencer_key_history_files_are_repeatable() {
+        let parsed = ZoneArgsParser::try_parse_from([
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--sequencer-key-history-file",
+            "/run/secrets/sequencer-key-0",
+            "--sequencer-key-history-file",
+            "/run/secrets/sequencer-key-1",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            parsed.zone.sequencer_key_history_files,
+            vec![
+                std::path::PathBuf::from("/run/secrets/sequencer-key-0"),
+                std::path::PathBuf::from("/run/secrets/sequencer-key-1"),
+            ]
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -52,7 +52,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use zone_chainspec::ZoneChainSpec;
-use zone_l1::{DepositQueue, L1BlockDeposits, L1BlockTracker, PreparedL1Block};
+use zone_l1::{DepositQueue, L1BlockDeposits, L1BlockTracker, PreparedL1Block, SequencerKeyring};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 
@@ -181,8 +181,8 @@ pub struct ZoneEngine {
     last_header: SealedHeader<TempoHeader>,
     /// Address that receives block fees.
     fee_recipient: Address,
-    /// Sequencer's secp256k1 secret key for ECIES decryption of encrypted deposits.
-    sequencer_key: k256::SecretKey,
+    /// Sequencer ECIES private keys indexed by Portal key history.
+    sequencer_keys: SequencerKeyring,
     /// ZonePortal address on L1 — used as context in HKDF key derivation.
     portal_address: Address,
     /// Optional per-anchor leadership permit. `None` runs the legacy single-sequencer mode.
@@ -198,7 +198,7 @@ impl ZoneEngine {
         l1_block_tracker: L1BlockTracker,
         last_header: SealedHeader<TempoHeader>,
         fee_recipient: Address,
-        sequencer_key: k256::SecretKey,
+        sequencer_keys: SequencerKeyring,
         portal_address: Address,
     ) -> Self {
         Self {
@@ -209,7 +209,7 @@ impl ZoneEngine {
             l1_block_tracker,
             last_header,
             fee_recipient,
-            sequencer_key,
+            sequencer_keys,
             portal_address,
             production_permit: None,
         }
@@ -316,7 +316,7 @@ impl ZoneEngine {
     /// against the finalized L1 anchor.
     async fn prepare_l1_block(&self, l1_block: L1BlockDeposits) -> eyre::Result<PreparedL1Block> {
         l1_block
-            .prepare(&self.sequencer_key, self.portal_address)
+            .prepare(&self.sequencer_keys, self.portal_address)
             .await
     }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -217,6 +217,8 @@ pub struct ZoneNode {
     redacted_rpc_config: ZoneRedactedRpcConfig,
     /// Optional sequencer config. When set, sequencer tasks are spawned.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Pre-resolved encryption keys for synthetic test environments without Portal RPC state.
+    sequencer_encryption_keys: Option<SequencerKeyring>,
     /// Optional static Zone P2P networking config.
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
@@ -267,6 +269,7 @@ impl ZoneNode {
             withdrawal_reveal_encryptor: None,
             redacted_rpc_config: ZoneRedactedRpcConfig::default(),
             sequencer_config: None,
+            sequencer_encryption_keys: None,
             p2p_config: None,
             external_deposit_consumer: false,
         }
@@ -287,6 +290,13 @@ impl ZoneNode {
             config.zone_id,
         )));
         self.sequencer_config = Some(config);
+        self
+    }
+
+    /// Supply pre-resolved encryption keys for test environments without Portal RPC state.
+    #[cfg(feature = "test-utils")]
+    pub fn with_sequencer_encryption_keys(mut self, keys: SequencerKeyring) -> Self {
+        self.sequencer_encryption_keys = Some(keys);
         self
     }
 
@@ -435,6 +445,8 @@ where
     redacted_rpc_config: ZoneRedactedRpcConfig,
     /// Sequencer configuration.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Pre-resolved encryption keys for synthetic test environments without Portal RPC state.
+    sequencer_encryption_keys: Option<SequencerKeyring>,
     /// Static Zone P2P networking configuration.
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
@@ -462,6 +474,7 @@ where
         portal_address: Address,
         redacted_rpc_config: ZoneRedactedRpcConfig,
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+        sequencer_encryption_keys: Option<SequencerKeyring>,
         p2p_config: Option<P2pConfig>,
         external_deposit_consumer: bool,
     ) -> Self {
@@ -479,6 +492,7 @@ where
             portal_address,
             redacted_rpc_config,
             sequencer_config,
+            sequencer_encryption_keys,
             p2p_config,
             external_deposit_consumer,
         }
@@ -515,6 +529,9 @@ where
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
         let sequencer_encryption_keys = match self.sequencer_config.as_ref() {
+            Some(_) if self.sequencer_encryption_keys.is_some() => {
+                self.sequencer_encryption_keys.take()
+            }
             Some(config) => Some(
                 resolve_sequencer_encryption_keys(
                     &l1_provider,
@@ -1432,6 +1449,7 @@ where
             self.portal_address,
             self.redacted_rpc_config.clone(),
             self.sequencer_config.clone(),
+            self.sequencer_encryption_keys.clone(),
             self.p2p_config.clone(),
             self.external_deposit_consumer,
         )

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,7 +18,7 @@ use crate::{
         operator_zone_rpc_module, rpc_connection_config, start_redacted_rpc,
     },
 };
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
 use k256::SecretKey;
@@ -68,13 +68,15 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
-use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
+use tempo_zone_contracts::{
+    ENCRYPTION_KEY_GRACE_PERIOD, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
+};
 use tracing::{debug, info, warn};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{
     DepositQueue, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeaderTransition,
-    LeadershipSink, TempoStateExt,
+    LeadershipSink, SequencerKeyring, TempoStateExt,
     state::{EnabledTokenRegistry, L1StateCache, L1StateProvider, L1StateProviderConfig},
 };
 use zone_p2p::{
@@ -162,6 +164,8 @@ impl WithdrawalRevealEncryptor for SequencerWithdrawalRevealEncryptor {
 pub struct ZoneSequencerAddOnsConfig {
     /// Shared sequencer signer used for block production and encryption.
     pub sequencer_signer: PrivateKeySigner,
+    /// Historical encryption keys retained while old-key deposits remain processable.
+    pub historical_sequencer_signers: Vec<PrivateKeySigner>,
     /// Individual manifest-node signer used for L1 settlement transactions.
     pub l1_transaction_signer: Option<PrivateKeySigner>,
     /// Zone ID used by sequencer encryption.
@@ -510,6 +514,18 @@ where
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
+        let sequencer_encryption_keys = match self.sequencer_config.as_ref() {
+            Some(config) => Some(
+                resolve_sequencer_encryption_keys(
+                    &l1_provider,
+                    self.portal_address,
+                    &config.sequencer_signer,
+                    &config.historical_sequencer_signers,
+                )
+                .await?,
+            ),
+            None => None,
+        };
 
         // Multi-sequencer mode: bootstrap the leadership schedule from the portal
         // snapshot at the local Tempo anchor, and install the transition sink before
@@ -638,8 +654,13 @@ where
         } else if let Some(ref config) = self.sequencer_config {
             // Legacy single-sequencer mode keeps the static engine.
             let sequencer_addr = config.sequencer_signer.address();
-            let sequencer_key = SecretKey::from(config.sequencer_signer.credential());
-            self.spawn_zone_engine(&ctx, sequencer_addr, sequencer_key)?;
+            self.spawn_zone_engine(
+                &ctx,
+                sequencer_addr,
+                sequencer_encryption_keys
+                    .clone()
+                    .expect("sequencer encryption keys are resolved when sequencing is enabled"),
+            )?;
         }
 
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
@@ -704,6 +725,9 @@ where
             let sequencer = match self.sequencer_config.take() {
                 Some(config) => Some(Self::build_leader_sequencer_deps(
                     config,
+                    sequencer_encryption_keys.clone().expect(
+                        "sequencer encryption keys are resolved when sequencing is enabled",
+                    ),
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.portal_address,
                     self.l1_config.retry_connection_interval,
@@ -933,6 +957,112 @@ async fn seed_leadership_schedule(
     Ok(())
 }
 
+async fn resolve_sequencer_encryption_keys(
+    l1_provider: &alloy_provider::DynProvider<TempoNetwork>,
+    portal_address: Address,
+    current_signer: &PrivateKeySigner,
+    historical_signers: &[PrivateKeySigner],
+) -> eyre::Result<SequencerKeyring> {
+    let portal = ZonePortal::new(portal_address, l1_provider);
+    let snapshot_block = l1_provider.get_block_number().await?;
+    let block_id = alloy_rpc_types_eth::BlockId::number(snapshot_block);
+    let count = portal.encryptionKeyCount().block(block_id).call().await?;
+    eyre::ensure!(
+        count > U256::ZERO,
+        "portal {portal_address} has no encryption key at L1 block {snapshot_block}"
+    );
+
+    let count = usize::try_from(count)
+        .map_err(|_| eyre::eyre!("portal encryption key count does not fit usize"))?;
+    let entries = futures::future::try_join_all((0..count).map(|index| {
+        let portal = &portal;
+        async move {
+            portal
+                .encryptionKeyAt(U256::from(index))
+                .block(block_id)
+                .call()
+                .await
+        }
+    }))
+    .await?;
+    let keyring =
+        build_sequencer_keyring(&entries, snapshot_block, current_signer, historical_signers)?;
+
+    info!(
+        target: "reth::cli",
+        current_index = entries.len() - 1,
+        retained_indices = ?keyring.indices().collect::<Vec<_>>(),
+        snapshot_block,
+        "Resolved sequencer encryption keyring from Portal history"
+    );
+    Ok(keyring)
+}
+
+fn build_sequencer_keyring(
+    entries: &[ZonePortal::EncryptionKeyEntry],
+    snapshot_block: u64,
+    current_signer: &PrivateKeySigner,
+    historical_signers: &[PrivateKeySigner],
+) -> eyre::Result<SequencerKeyring> {
+    use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+
+    fn public_key(secret: &SecretKey) -> (B256, u8) {
+        let encoded = secret.public_key().to_encoded_point(true);
+        (
+            B256::from_slice(encoded.x().expect("compressed public key has x")),
+            encoded.as_bytes()[0],
+        )
+    }
+
+    eyre::ensure!(
+        !entries.is_empty(),
+        "Portal encryption key history is empty"
+    );
+    let current_index = entries.len() - 1;
+    let current_secret = SecretKey::from(current_signer.credential());
+    let (current_x, current_y_parity) = public_key(&current_secret);
+    eyre::ensure!(
+        entries[current_index].x == current_x && entries[current_index].yParity == current_y_parity,
+        "configured sequencer key does not match portal encryption key index {current_index}"
+    );
+
+    let mut keys = vec![(U256::from(current_index), current_secret)];
+    for signer in historical_signers {
+        let secret = SecretKey::from(signer.credential());
+        let (x, y_parity) = public_key(&secret);
+        let mut matches = entries.iter().enumerate().filter_map(|(index, entry)| {
+            (entry.x == x && entry.yParity == y_parity).then_some(index)
+        });
+        let index = matches.next().ok_or_else(|| {
+            eyre::eyre!("configured historical sequencer key is not in Portal key history")
+        })?;
+        eyre::ensure!(
+            matches.next().is_none(),
+            "configured historical sequencer key appears more than once in Portal history"
+        );
+        eyre::ensure!(
+            index != current_index,
+            "current sequencer key must not also be configured as a historical key"
+        );
+        keys.push((U256::from(index), secret));
+    }
+
+    for index in 0..current_index {
+        let expires_at = entries[index + 1]
+            .activationBlock
+            .saturating_add(ENCRYPTION_KEY_GRACE_PERIOD);
+        if snapshot_block < expires_at {
+            eyre::ensure!(
+                keys.iter()
+                    .any(|(configured_index, _)| *configured_index == U256::from(index)),
+                "Portal encryption key index {index} remains valid until block {expires_at}; configure its private key with --sequencer-key-history-file"
+            );
+        }
+    }
+
+    SequencerKeyring::new(keys)
+}
+
 impl<N> ZoneAddOns<N>
 where
     N: FullNodeComponents<Types = ZoneNode, Evm = ZoneEvmConfig>,
@@ -1005,6 +1135,7 @@ where
     /// Build the leader-generation sequencer dependencies (activated only while leader).
     fn build_leader_sequencer_deps(
         config: ZoneSequencerAddOnsConfig,
+        encryption_keys: SequencerKeyring,
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
@@ -1025,6 +1156,7 @@ where
         Ok(LeaderSequencerDeps {
             config,
             sequencer_config,
+            encryption_keys,
         })
     }
 
@@ -1110,7 +1242,7 @@ where
         &self,
         ctx: &AddOnsContext<'_, N>,
         fee_recipient: Address,
-        sequencer_key: SecretKey,
+        sequencer_keys: SequencerKeyring,
     ) -> eyre::Result<()> {
         let provider = ctx.node.provider();
         let last_header = provider
@@ -1124,7 +1256,7 @@ where
             self.l1_config.block_tracker.clone(),
             last_header,
             fee_recipient,
-            sequencer_key,
+            sequencer_keys,
             self.portal_address,
         );
         ctx.node
@@ -1568,6 +1700,25 @@ mod tests {
         AASigned, Call, PrimitiveSignature, TempoSignature, TempoTransaction,
     };
 
+    fn signer(byte: u8) -> PrivateKeySigner {
+        PrivateKeySigner::from_slice(&[byte; 32]).unwrap()
+    }
+
+    fn encryption_key_entry(
+        signer: &PrivateKeySigner,
+        activation_block: u64,
+    ) -> ZonePortal::EncryptionKeyEntry {
+        use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+
+        let secret = SecretKey::from(signer.credential());
+        let encoded = secret.public_key().to_encoded_point(true);
+        ZonePortal::EncryptionKeyEntry {
+            x: B256::from_slice(encoded.x().unwrap()),
+            yParity: encoded.as_bytes()[0],
+            activationBlock: activation_block,
+        }
+    }
+
     fn pooled_transaction(envelope: TempoTxEnvelope, sender: Address) -> TempoPooledTransaction {
         TempoPooledTransaction::new(Recovered::new_unchecked(envelope, sender))
     }
@@ -1599,6 +1750,43 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
         unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
+    }
+
+    #[test]
+    fn keyring_requires_every_historical_key_still_in_grace() {
+        let previous = signer(0x11);
+        let current = signer(0x22);
+        let entries = vec![
+            encryption_key_entry(&previous, 10),
+            encryption_key_entry(&current, 100),
+        ];
+
+        let error = build_sequencer_keyring(&entries, 101, &current, &[]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Portal encryption key index 0 remains valid until block 86500")
+        );
+
+        let keyring = build_sequencer_keyring(&entries, 101, &current, &[previous]).unwrap();
+        assert_eq!(
+            keyring.indices().collect::<Vec<_>>(),
+            vec![U256::ZERO, U256::from(1)]
+        );
+    }
+
+    #[test]
+    fn keyring_allows_expired_historical_keys_to_be_omitted() {
+        let previous = signer(0x11);
+        let current = signer(0x22);
+        let entries = vec![
+            encryption_key_entry(&previous, 10),
+            encryption_key_entry(&current, 100),
+        ];
+
+        let keyring = build_sequencer_keyring(&entries, 86_500, &current, &[]).unwrap();
+
+        assert_eq!(keyring.indices().collect::<Vec<_>>(), vec![U256::from(1)]);
     }
 
     #[test]

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -27,7 +27,7 @@ use tokio::{sync::mpsc, task::JoinSet};
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{debug, error, info, warn};
 use zone_chainspec::ZoneChainSpec;
-use zone_l1::{DepositQueue, L1BlockTracker, TempoStateExt as _};
+use zone_l1::{DepositQueue, L1BlockTracker, SequencerKeyring, TempoStateExt as _};
 use zone_p2p::{LeadershipSchedule, P2pCommand, P2pEvent, P2pPeerId};
 use zone_payload::ZonePayloadTypes;
 use zone_sequencer::{
@@ -103,6 +103,7 @@ pub type SharedRoleStatus = Arc<std::sync::Mutex<RoleStatus>>;
 pub(crate) struct LeaderSequencerDeps {
     pub config: ZoneSequencerAddOnsConfig,
     pub sequencer_config: ZoneSequencerConfig,
+    pub encryption_keys: SequencerKeyring,
 }
 
 /// Sinks for the long-lived P2P event demultiplexer.
@@ -902,7 +903,6 @@ fn build_engine<P, Pool>(
 where
     P: Clone,
 {
-    let sequencer_key = k256::SecretKey::from(sequencer.config.sequencer_signer.credential());
     ZoneEngine::new(
         context.chain_spec.clone(),
         context.engine_handle.clone(),
@@ -911,7 +911,7 @@ where
         context.l1_block_tracker.clone(),
         last_header,
         sequencer.config.sequencer_signer.address(),
-        sequencer_key,
+        sequencer.encryption_keys.clone(),
         context.portal_address,
     )
     .with_production_permit(ProductionPermit::new(

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1224,7 +1224,11 @@ impl ZoneTestNode {
                     batch_anchor_config: Default::default(),
                     withdrawal_poll_interval: Duration::from_secs(5),
                     withdrawal_batch_limits: Default::default(),
-                });
+                })
+                .with_sequencer_encryption_keys(zone_l1::SequencerKeyring::new(vec![(
+                    U256::ZERO,
+                    SecretKey::from(sequencer_signer.credential()),
+                )])?);
         }
         // Multi-sequencer nodes run the real role controller, which owns the engine; the
         // harness must not drive a second head writer against the same queue.

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1217,6 +1217,7 @@ impl ZoneTestNode {
                 .with_p2p(p2p_config)
                 .with_sequencer(ZoneSequencerAddOnsConfig {
                     sequencer_signer: sequencer_signer.clone(),
+                    historical_sequencer_signers: Vec::new(),
                     l1_transaction_signer: None,
                     zone_id: 0,
                     zone_poll_interval: Duration::from_secs(1),
@@ -1285,7 +1286,10 @@ impl ZoneTestNode {
                 l1_block_tracker.clone(),
                 last_header,
                 sequencer_signer.address(),
-                SecretKey::from(sequencer_signer.credential()),
+                zone_l1::SequencerKeyring::new(vec![(
+                    U256::ZERO,
+                    SecretKey::from(sequencer_signer.credential()),
+                )])?,
                 portal_address,
             );
             node_handle


### PR DESCRIPTION
## Summary

- build a static sequencer ECIES keyring at startup by matching the current key and configured historical keys against a pinned Portal key-history snapshot
- select the private key using each encrypted deposit's exact `keyIndex`
- require every historical key that is still accepted during the Portal grace period
- fail closed when a queued deposit references a key that was not retained
- add repeatable `--sequencer-key-history-file` / `SEQUENCER_KEY_HISTORY_FILES` configuration

## Why

The Portal accepts deposits encrypted to a superseded key for `86,400` blocks after a rotation. The node currently decrypts every encrypted deposit with only the current private key, so a valid old-key deposit can be turned into a failed decryption/proof and bounced.

This addresses the key-retention issue raised in the [Cyclops review](https://github.com/tempoxyz/zones/pull/965#pullrequestreview-4846325508). It is separate from #965's key/index snapshot consistency fix.

The keyring is deliberately static: rotations require updating the configured key files and restarting the sequencer. Expired historical keys may be omitted; if an older queued deposit still references one, production stops at that deposit until the key is restored.

## Validation

- `rustup run nightly cargo test -p zone-l1 --lib`
- `rustup run nightly cargo test -p zone-node --features cli --lib`
- `rustup run nightly cargo clippy -p zone-l1 -p zone-node --features zone-node/cli --lib -- -D warnings`
- `rustup run nightly cargo fmt --all -- --check`
