### PR TITLE
fix Earn e2e deployment ABI

### DIFF
--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -57,7 +57,13 @@ alloy_sol_types::sol! {
     struct EarnVaultControls {
         address emergencyGuardian;
         address asyncJanitor;
+        uint256 maxManagedAssets;
         EngineMigrationMode migrationMode;
+    }
+
+    struct DistributorConfig {
+        address distributor;
+        uint40 updateDelay;
     }
 
     struct FixedFeeRecipient {
@@ -130,6 +136,7 @@ alloy_sol_types::sol! {
         address engine;
         address owner;
         EarnVaultControls controls;
+        DistributorConfig distributorConfig;
         FeeConfig fees;
         uint64 transferPolicyId;
     }
@@ -378,7 +385,12 @@ impl EarnZoneFixture {
             controls: EarnVaultControls {
                 emergencyGuardian: Address::ZERO,
                 asyncJanitor: Address::ZERO,
+                maxManagedAssets: U256::ZERO,
                 migrationMode: EngineMigrationMode::OperatorEnabled,
+            },
+            distributorConfig: DistributorConfig {
+                distributor: Address::ZERO,
+                updateDelay: Default::default(),
             },
             fees,
             transferPolicyId: 0,


### PR DESCRIPTION
## What

Update the Earn E2E Solidity binding and fixture for the latest EarnFactory deployment ABI:

- include maxManagedAssets in EarnVaultControls
- include DistributorConfig in EarnDeployParams
- preserve the previous test behavior with an unlimited asset cap and no distributor

## Why

The Test workflow checks out tempoxyz/earn main. [tempoxyz/earn#166](https://github.com/tempoxyz/earn/pull/166) and [tempoxyz/earn#165](https://github.com/tempoxyz/earn/pull/165) landed between the last green Zones run and the first red run, adding these tuple fields. The stale Rust tuple encoded every EarnFactory.deploy call with the wrong layout, so all 19 Earn E2E tests reverted during shared fixture setup.

## Validation

- focused matrix_deposit_private_private_succeeds E2E against Earn e67f397 artifacts
- rustup run nightly cargo fmt --all -- --check
- git diff --check