### PR TITLE
Update Earn factory ABI in Zone E2E

### DIFF
--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -57,7 +57,13 @@ alloy_sol_types::sol! {
     struct EarnVaultControls {
         address emergencyGuardian;
         address asyncJanitor;
+        uint256 maxManagedAssets;
         EngineMigrationMode migrationMode;
+    }
+
+    struct DistributorConfig {
+        address distributor;
+        uint40 updateDelay;
     }
 
     struct FixedFeeRecipient {
@@ -130,6 +136,7 @@ alloy_sol_types::sol! {
         address engine;
         address owner;
         EarnVaultControls controls;
+        DistributorConfig distributorConfig;
         FeeConfig fees;
         uint64 transferPolicyId;
     }
@@ -378,7 +385,12 @@ impl EarnZoneFixture {
             controls: EarnVaultControls {
                 emergencyGuardian: Address::ZERO,
                 asyncJanitor: Address::ZERO,
+                maxManagedAssets: U256::ZERO,
                 migrationMode: EngineMigrationMode::OperatorEnabled,
+            },
+            distributorConfig: DistributorConfig {
+                distributor: Address::ZERO,
+                updateDelay: Default::default(),
             },
             fees,
             transferPolicyId: 0,


### PR DESCRIPTION
## Summary

- add `maxManagedAssets` to the Zone E2E binding for `EarnVaultControls`
- add the new `DistributorConfig` field to `EarnFactory.DeployParams`
- preserve the fixture's prior behavior with unlimited capacity and no distributor

This fixes the `Earn main × Zones main` compatibility lane, where all 19 scenarios reverted during the shared `EarnFactory.deploy` preview after tempoxyz/earn#166 and tempoxyz/earn#165 changed the deployment tuple.

## Validation

- `cargo fmt --all -- --check`
- `forge build --root specs/ref-impls` (local Forge does not expose CI's `--no-lint` flag)
- `forge build --root /Users/kartik/tempo/earn --skip test --skip script --out <zones>/specs/ref-impls/out`
- `cargo nextest run --profile ci -p zone-node --test it -E 'test(/^earn_zone_e2e::/)'` — 19 passed, 123 skipped