### PR TITLE
fix(tests): sync Earn deployment ABI

### DIFF
--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -60,6 +60,11 @@ alloy_sol_types::sol! {
         EngineMigrationMode migrationMode;
     }
 
+    struct DistributorConfig {
+        address distributor;
+        uint40 updateDelay;
+    }
+
     struct FixedFeeRecipient {
         address account;
         uint16 rateBps;
@@ -130,6 +135,7 @@ alloy_sol_types::sol! {
         address engine;
         address owner;
         EarnVaultControls controls;
+        DistributorConfig distributorConfig;
         FeeConfig fees;
         uint64 transferPolicyId;
     }
@@ -379,6 +385,10 @@ impl EarnZoneFixture {
                 emergencyGuardian: Address::ZERO,
                 asyncJanitor: Address::ZERO,
                 migrationMode: EngineMigrationMode::OperatorEnabled,
+            },
+            distributorConfig: DistributorConfig {
+                distributor: Address::ZERO,
+                updateDelay: 0,
             },
             fees,
             transferPolicyId: 0,


### PR DESCRIPTION
## Summary

- Sync the Rust `EarnFactory.DeployParams` ABI with Earn's new `DistributorConfig` field.
- Pass a zero-valued distributor configuration to preserve the existing disabled-distributor behavior.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo check -p zone-node --tests` could not complete because Cargo received HTTP 401 while fetching the pinned `alloy-evm` revision.

Prompted by: aditya