### PR TITLE
fix(l1): always apply backpressure

### DIFF
--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -92,8 +92,7 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
-    MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS,
+    L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -30,8 +30,7 @@ struct L1BlockObservation {
 /// `advanceTempo`. The tracker also provides backpressure for the L1 subscriber: before fetching
 /// a block, the subscriber waits for capacity relative to the last checkpoint released by the
 /// Zone consumer. Queue-backed subscribers therefore retain observations until block production
-/// or follower import calls [`L1BlockTracker::prune_through`]. Sink-less observers have no Zone
-/// consumer and release each observation after applying its L1-derived state.
+/// or follower import calls [`L1BlockTracker::prune_through`].
 ///
 /// This tracker deliberately assumes observed L1 blocks do not reorg: conflicting or
 /// non-contiguous observations are errors.
@@ -94,7 +93,7 @@ impl L1BlockTracker {
         Ok(())
     }
 
-    /// Return the next L1 height the observer needs to retain.
+    /// Return the next L1 height the subscriber needs to retain.
     pub fn next_observation_number(&self) -> Option<u64> {
         let state = self.state.read();
         state
@@ -294,36 +293,6 @@ pub(crate) trait LocalTempoCheckpointReader: Send + Sync {
     fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash>;
 }
 
-/// Optional sink for finalized deposit-bearing L1 blocks.
-///
-/// Sequencers and P2P replicas retain a queue so blocks can be produced or validated later.
-/// Observer-only nodes still apply finalized events to their caches, but retain no queue.
-#[derive(Debug, Clone)]
-pub(crate) enum DepositSink {
-    Queue(DepositQueue),
-    Observer,
-}
-
-impl DepositSink {
-    fn last_enqueued(&self) -> Option<NumHash> {
-        match self {
-            Self::Queue(queue) => queue.last_enqueued(),
-            Self::Observer => None,
-        }
-    }
-
-    fn enqueue(
-        &self,
-        header: SealedHeader<TempoHeader>,
-        events: L1PortalEvents,
-    ) -> eyre::Result<bool> {
-        match self {
-            Self::Queue(queue) => queue.try_enqueue_sealed(header, events),
-            Self::Observer => Ok(false),
-        }
-    }
-}
-
 struct ProviderLocalTempoCheckpointReader<P> {
     provider: P,
 }
@@ -343,8 +312,8 @@ where
 pub struct L1Subscriber {
     pub(crate) config: L1SubscriberConfig,
     pub(crate) local_state: Arc<dyn LocalTempoCheckpointReader>,
-    /// Optional deposit sink. P2P members retain it so follower queues stay warm.
-    pub(crate) deposit_sink: DepositSink,
+    /// Finalized L1 blocks retained until a Zone consumer processes them.
+    pub(crate) deposit_queue: DepositQueue,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
     pub(crate) subscriber_metrics: crate::metrics::L1SubscriberMetrics,
 }
@@ -409,45 +378,12 @@ impl L1Subscriber {
     ) where
         P: StateProviderFactory + Clone + Send + Sync + 'static,
     {
-        Self::spawn_inner(
-            config,
-            local_state_provider,
-            DepositSink::Queue(deposit_queue),
-            task_executor,
-        );
-    }
-
-    /// Create and spawn an observer that advances finalized L1-derived caches without
-    /// retaining deposit blocks.
-    pub fn spawn_observer<P>(
-        config: L1SubscriberConfig,
-        local_state_provider: P,
-        task_executor: reth_tasks::Runtime,
-    ) where
-        P: StateProviderFactory + Clone + Send + Sync + 'static,
-    {
-        Self::spawn_inner(
-            config,
-            local_state_provider,
-            DepositSink::Observer,
-            task_executor,
-        );
-    }
-
-    fn spawn_inner<P>(
-        config: L1SubscriberConfig,
-        local_state_provider: P,
-        deposit_sink: DepositSink,
-        task_executor: reth_tasks::Runtime,
-    ) where
-        P: StateProviderFactory + Clone + Send + Sync + 'static,
-    {
         let subscriber = Self {
             config,
             local_state: Arc::new(ProviderLocalTempoCheckpointReader {
                 provider: local_state_provider,
             }),
-            deposit_sink,
+            deposit_queue,
             subscriber_metrics: Default::default(),
         };
 
@@ -561,7 +497,7 @@ impl L1Subscriber {
     pub(crate) fn next_block_to_sync(&self) -> eyre::Result<u64> {
         let resolved = self.resolve_start_block()?;
         let queued = self
-            .deposit_sink
+            .deposit_queue
             .last_enqueued()
             .map(|last| last.number.saturating_add(1));
         let observed = self
@@ -777,8 +713,8 @@ impl L1Subscriber {
                 }
             }
             let appended = self
-                .deposit_sink
-                .enqueue(sealed, events.clone())
+                .deposit_queue
+                .try_enqueue_sealed(sealed, events.clone())
                 .wrap_err_with(|| {
                     format!("unexpected discontinuity while enqueueing L1 block {block_number}")
                 })?;
@@ -791,12 +727,6 @@ impl L1Subscriber {
             self.update_l1_state_anchor(block_number, &invalidated);
             if appended {
                 self.subscriber_metrics.blocks_enqueued.increment(1);
-            }
-            // Queue-backed subscribers are backpressured by the tracker until their Zone
-            // consumer confirms the corresponding queue entry and prunes this observation.
-            // A sink-less observer has no such consumer, so release its observation immediately.
-            if matches!(&self.deposit_sink, DepositSink::Observer) {
-                self.config.block_tracker.prune_through(anchor.number);
             }
             processed += 1;
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -6,9 +6,9 @@ use tempo_primitives::is_tip20_prefix;
 
 use std::collections::BTreeMap;
 
-/// Maximum number of authenticated L1 blocks a follower may retain ahead of its imported Tempo
-/// checkpoint (approximately one hour at Tempo's 500ms block time).
-pub const MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS: u64 = 7_200;
+/// Maximum number of authenticated L1 blocks the subscriber may retain ahead of the Zone
+/// consumer's imported Tempo checkpoint (approximately one hour at Tempo's 500ms block time).
+pub const MAX_L1_LOOKAHEAD_BLOCKS: u64 = 7_200;
 
 #[derive(Debug, Default)]
 struct L1BlockTrackerState {
@@ -26,9 +26,15 @@ struct L1BlockObservation {
 /// L1 blocks whose headers and receipts have been independently validated and
 /// whose derived state has been applied to the local caches.
 ///
-/// Followers use this to gate zone-block import on the exact L1 anchor embedded
-/// in `advanceTempo`. This tracker deliberately assumes observed L1 blocks do
-/// not reorg: conflicting or non-contiguous observations are errors.
+/// Followers use this to gate zone-block import on the exact L1 anchor embedded in
+/// `advanceTempo`. The tracker also provides backpressure for the L1 subscriber: before fetching
+/// a block, the subscriber waits for capacity relative to the last checkpoint released by the
+/// Zone consumer. Queue-backed subscribers therefore retain observations until block production
+/// or follower import calls [`L1BlockTracker::prune_through`]. Sink-less observers have no Zone
+/// consumer and release each observation after applying its L1-derived state.
+///
+/// This tracker deliberately assumes observed L1 blocks do not reorg: conflicting or
+/// non-contiguous observations are errors.
 #[derive(Debug, Clone)]
 pub struct L1BlockTracker {
     state: Arc<parking_lot::RwLock<L1BlockTrackerState>>,
@@ -68,14 +74,15 @@ impl L1BlockTracker {
         self.state.read().latest
     }
 
-    /// Return whether `number` fits inside the bounded follower lookahead window.
+    /// Return whether `number` fits inside the bounded subscriber lookahead window.
     pub fn has_capacity_for(&self, number: u64) -> bool {
-        self.state.read().pruned_through.is_none_or(|consumed| {
-            number <= consumed.saturating_add(MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS)
-        })
+        self.state
+            .read()
+            .pruned_through
+            .is_none_or(|consumed| number <= consumed.saturating_add(MAX_L1_LOOKAHEAD_BLOCKS))
     }
 
-    /// Wait until canonical follower import advances enough to retain `number`.
+    /// Wait until the Zone consumer advances enough for the subscriber to retain `number`.
     pub async fn wait_for_capacity(&self, number: u64) -> eyre::Result<()> {
         let mut changed = self.changed.subscribe();
         while !self.has_capacity_for(number) {
@@ -183,10 +190,10 @@ impl L1BlockTracker {
             .pruned_through
             .get_or_insert_with(|| block.number.saturating_sub(1));
         eyre::ensure!(
-            block.number <= consumed.saturating_add(MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS),
-            "L1 observation {} exceeds follower lookahead through {}",
+            block.number <= consumed.saturating_add(MAX_L1_LOOKAHEAD_BLOCKS),
+            "L1 observation {} exceeds subscriber lookahead through {}",
             block.number,
-            consumed.saturating_add(MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS)
+            consumed.saturating_add(MAX_L1_LOOKAHEAD_BLOCKS)
         );
         if let Some(latest) = state.latest {
             eyre::ensure!(
@@ -216,7 +223,10 @@ impl L1BlockTracker {
         Ok(())
     }
 
-    /// Drop observations through `number` after canonical follower import.
+    /// Drop observations through `number` after the corresponding Zone checkpoint is canonical.
+    ///
+    /// Advancing this watermark releases L1 subscriber capacity, so queue consumers must call it
+    /// only after successfully consuming the matching finalized L1 work.
     pub fn prune_through(&self, number: u64) {
         let mut state = self.state.write();
         state.observed.retain(|height, _| *height > number);
@@ -268,8 +278,6 @@ pub struct L1SubscriberConfig {
     pub l1_state_cache: crate::state::cache::L1StateCache,
     /// Validated and applied L1 anchors shared with follower block import.
     pub block_tracker: L1BlockTracker,
-    /// Whether observations must be retained until a consumer releases them.
-    pub retain_observations: bool,
     /// Maximum number of concurrent header and receipt fetches while syncing a
     /// finalized L1 range.
     pub l1_fetch_concurrency: usize,
@@ -784,7 +792,10 @@ impl L1Subscriber {
             if appended {
                 self.subscriber_metrics.blocks_enqueued.increment(1);
             }
-            if !self.config.retain_observations {
+            // Queue-backed subscribers are backpressured by the tracker until their Zone
+            // consumer confirms the corresponding queue entry and prunes this observation.
+            // A sink-less observer has no such consumer, so release its observation immediately.
+            if matches!(&self.deposit_sink, DepositSink::Observer) {
                 self.config.block_tracker.prune_through(anchor.number);
             }
             processed += 1;

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -173,7 +173,6 @@ fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscr
             enabled_tokens: crate::state::EnabledTokenRegistry::default(),
             l1_state_cache: crate::L1StateCache::new(),
             block_tracker: L1BlockTracker::default(),
-            retain_observations: true,
             l1_fetch_concurrency: 1,
             retry_connection_interval: Duration::from_secs(1),
             leadership_sink: None,
@@ -187,7 +186,6 @@ fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscr
 
 fn test_observer(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscriber {
     let mut subscriber = test_subscriber(local_state);
-    subscriber.config.retain_observations = false;
     subscriber.deposit_sink = DepositSink::Observer;
     subscriber
 }
@@ -314,13 +312,13 @@ async fn l1_block_tracker_backpressures_at_one_hour_lookahead() {
     let consumed = 100;
     tracker.initialize_consumed_through(consumed);
 
-    for number in consumed + 1..=consumed + MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS {
+    for number in consumed + 1..=consumed + MAX_L1_LOOKAHEAD_BLOCKS {
         tracker
             .record(NumHash::new(number, B256::with_last_byte(number as u8)))
             .unwrap();
     }
 
-    let blocked_number = consumed + MAX_FOLLOWER_L1_LOOKAHEAD_BLOCKS + 1;
+    let blocked_number = consumed + MAX_L1_LOOKAHEAD_BLOCKS + 1;
     assert!(!tracker.has_capacity_for(blocked_number));
     assert_eq!(tracker.next_observation_number(), Some(blocked_number));
     assert!(
@@ -743,6 +741,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
     let header_10 = make_test_header(10);
     let header_11 = make_chained_header(11, header_hash(&header_10));
     let header_12 = make_chained_header(12, header_hash(&header_11));
+    let anchor_12 = seal(header_12.clone()).num_hash();
 
     // Initial sync through finalized block 10.
     asserter.push_success(&Some(header_response(header_10.clone())));
@@ -773,6 +772,11 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
             .map(|block| block.header.number())
             .collect::<Vec<_>>(),
         vec![10, 11, 12]
+    );
+    assert_eq!(
+        subscriber.config.block_tracker.observed_hash(12),
+        Some(anchor_12.hash),
+        "a queue-backed subscriber must retain observations until its consumer prunes them"
     );
     assert!(asserter.read_q().is_empty());
 }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    abi::DepositType,
-    subscriber::{DepositSink, is_fenced_ingestion_error},
-};
+use crate::{abi::DepositType, subscriber::is_fenced_ingestion_error};
 use alloy_consensus::{Header, ReceiptWithBloom};
 use alloy_primitives::{Bloom, Bytes, address};
 use alloy_rpc_types_eth::{Header as RpcHeader, TransactionReceipt};
@@ -179,15 +176,9 @@ fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscr
             encryption_keys: None,
         },
         local_state,
-        deposit_sink: DepositSink::Queue(DepositQueue::default()),
+        deposit_queue: DepositQueue::default(),
         subscriber_metrics: Default::default(),
     }
-}
-
-fn test_observer(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscriber {
-    let mut subscriber = test_subscriber(local_state);
-    subscriber.deposit_sink = DepositSink::Observer;
-    subscriber
 }
 
 #[tokio::test]
@@ -762,10 +753,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
         .expect_err("finite trigger stream should end the subscriber");
     assert!(err.to_string().contains("head notification stream ended"));
 
-    let DepositSink::Queue(queue) = &subscriber.deposit_sink else {
-        panic!("test subscriber must retain deposits");
-    };
-    let blocks = queue.drain();
+    let blocks = subscriber.deposit_queue.drain();
     assert_eq!(
         blocks
             .iter()
@@ -777,60 +765,6 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
         subscriber.config.block_tracker.observed_hash(12),
         Some(anchor_12.hash),
         "a queue-backed subscriber must retain observations until its consumer prunes them"
-    );
-    assert!(asserter.read_q().is_empty());
-}
-
-#[tokio::test]
-async fn observer_advances_caches_without_retaining_deposit_blocks() {
-    let subscriber = test_observer(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
-    let cached_address = address!("0x0000000000000000000000000000000000000ABC");
-    let cached_slot = B256::with_last_byte(1);
-    let cached_value = B256::with_last_byte(2);
-    {
-        let mut cache = subscriber.config.l1_state_cache.lock();
-        cache.invalidate_and_set_anchor(9, []);
-        cache.set(cached_address, cached_slot, 9, cached_value);
-    }
-
-    let asserter = Asserter::new();
-    let l1_provider =
-        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
-    let header_10 = make_test_header(10);
-    let header_11 = make_chained_header(11, header_hash(&header_10));
-    let header_12 = make_chained_header(12, header_hash(&header_11));
-
-    asserter.push_success(&Some(header_response(header_12.clone())));
-    push_header_and_empty_receipts(&asserter, header_10);
-    push_header_and_empty_receipts(&asserter, header_11);
-    push_header_and_empty_receipts(&asserter, header_12);
-
-    assert_eq!(
-        subscriber
-            .sync_finalized_once(&l1_provider, 10)
-            .await
-            .unwrap(),
-        13
-    );
-
-    assert_eq!(
-        subscriber
-            .config
-            .l1_state_cache
-            .lock()
-            .get(cached_address, cached_slot, 12),
-        Some(cached_value),
-        "receipt coverage must keep advancing on an observer"
-    );
-    assert_eq!(subscriber.config.block_tracker.latest().unwrap().number, 12);
-    assert_eq!(
-        subscriber.config.block_tracker.observed_hash(12),
-        None,
-        "an observer has no downstream consumer requiring retained observations"
-    );
-    assert!(
-        matches!(subscriber.deposit_sink, DepositSink::Observer),
-        "an observer must not accumulate finalized blocks in a deposit queue"
     );
     assert!(asserter.read_q().is_empty());
 }
@@ -870,10 +804,7 @@ async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
         .unwrap();
 
     assert_eq!(next, 11);
-    let DepositSink::Queue(queue) = &subscriber.deposit_sink else {
-        panic!("test subscriber must retain deposits");
-    };
-    assert!(queue.drain().is_empty());
+    assert!(subscriber.deposit_queue.drain().is_empty());
     assert!(asserter.read_q().is_empty());
 }
 
@@ -1717,9 +1648,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
 async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
-    let DepositSink::Queue(queue) = subscriber.deposit_sink.clone() else {
-        panic!("test subscriber must retain deposits");
-    };
+    let queue = subscriber.deposit_queue.clone();
 
     let receipt =
         make_receipt_with_logs(10, B256::ZERO, vec![corrupt_recognized_portal_log(portal)]);
@@ -1773,9 +1702,7 @@ impl LeadershipSink for RecordingLeadershipSink {
 async fn sync_applies_leadership_transition_before_enqueueing_the_activation_block() {
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
-    let DepositSink::Queue(queue) = subscriber.deposit_sink.clone() else {
-        panic!("test subscriber must retain deposits");
-    };
+    let queue = subscriber.deposit_queue.clone();
     let sink = Arc::new(RecordingLeadershipSink {
         queue: queue.clone(),
         seen: parking_lot::Mutex::new(Vec::new()),
@@ -1822,9 +1749,7 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
 async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition() {
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
-    let DepositSink::Queue(queue) = subscriber.deposit_sink.clone() else {
-        panic!("test subscriber must retain deposits");
-    };
+    let queue = subscriber.deposit_queue.clone();
     subscriber.config.leadership_sink = Some(Arc::new(RecordingLeadershipSink {
         queue: queue.clone(),
         seen: parking_lot::Mutex::new(Vec::new()),

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -240,7 +240,6 @@ impl ZoneNode {
             block_tracker: l1_block_tracker.clone(),
             l1_fetch_concurrency,
             retry_connection_interval,
-            retain_observations: false,
             leadership_sink: None,
             encryption_keys: None,
         };
@@ -315,9 +314,6 @@ impl ZoneNode {
 
     /// Enable static Zone P2P networking for this node.
     pub fn with_p2p(mut self, config: P2pConfig) -> Self {
-        // Multi-sequencer members gate follower block import on independently observed L1
-        // anchors, so observations must survive until their zone block is consumed.
-        self.l1_config.retain_observations = true;
         self.p2p_config = Some(config);
         self
     }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -304,9 +304,8 @@ impl ZoneNode {
 
     /// Declare that a consumer outside this builder drains [`Self::deposit_queue`].
     ///
-    /// Without a sequencer or P2P config the node assumes nothing consumes deposits and
-    /// launches a sink-less L1 observer. Callers that drive their own [`crate::ZoneEngine`]
-    /// against the shared queue — such as test harnesses — must opt back into retention.
+    /// Callers that drive their own [`crate::ZoneEngine`] against the shared queue — such as test
+    /// harnesses — must opt in so node startup knows the Zone chain can advance.
     pub fn with_external_deposit_consumer(mut self) -> Self {
         self.external_deposit_consumer = true;
         self
@@ -517,6 +516,13 @@ where
     > as NodeAddOns<N>>::Handle;
 
     async fn launch_add_ons(mut self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
+        eyre::ensure!(
+            self.sequencer_config.is_some()
+                || self.p2p_config.is_some()
+                || self.external_deposit_consumer,
+            "no Zone chain advancement mechanism configured: enable a sequencer, configure P2P, or register an external deposit consumer"
+        );
+
         let tempo_block_number = ctx.node.provider().latest()?.tempo_block_number()?;
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
@@ -563,7 +569,13 @@ where
             }));
         }
 
-        self.spawn_l1_subscriber(&ctx);
+        L1Subscriber::spawn(
+            self.l1_config.clone(),
+            ctx.node.provider().clone(),
+            self.deposit_queue.clone(),
+            ctx.node.task_executor().clone(),
+        );
+        info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
 
         let task_executor = ctx.node.task_executor().clone();
         // Start the Commonware network and the long-lived event router
@@ -1159,33 +1171,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Spawn shared L1 observation.
-    ///
-    /// Sequencers, P2P replicas, and externally driven queue consumers retain finalized blocks
-    /// in the deposit queue. A node with none of those only maintains its L1-derived caches and
-    /// must not accumulate an unconsumed queue.
-    fn spawn_l1_subscriber(&mut self, ctx: &AddOnsContext<'_, N>) {
-        if self.sequencer_config.is_some()
-            || self.p2p_config.is_some()
-            || self.external_deposit_consumer
-        {
-            L1Subscriber::spawn(
-                self.l1_config.clone(),
-                ctx.node.provider().clone(),
-                self.deposit_queue.clone(),
-                ctx.node.task_executor().clone(),
-            );
-            info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
-        } else {
-            L1Subscriber::spawn_observer(
-                self.l1_config.clone(),
-                ctx.node.provider().clone(),
-                ctx.node.task_executor().clone(),
-            );
-            info!(target: "reth::cli", "L1 observer started without a deposit sink");
-        }
     }
 
     /// Spawn the [`ZoneEngine`] for L1-event-driven block production.


### PR DESCRIPTION
Removes observer mode and `retain_observations` flag, making sure that every zones node applies backpressure for `L1Subscriber` via `block_tracker.wait_for_capacity`

Fixes ZONE-161