### PR TITLE
fix(evm): reject subblock transactions in zones

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -40,6 +40,13 @@ enum ZoneBlockPhase {
 
 impl ZoneBlockPhase {
     fn validate_transaction(self, tx: &TempoTxEnvelope) -> Result<Self, BlockExecutionError> {
+        if tx.subblock_proposer().is_some() {
+            return Err(BlockValidationError::msg(
+                "subblock transactions are not supported in zone blocks",
+            )
+            .into());
+        }
+
         let tx_kind = ZoneTransactionKind::classify(tx);
 
         match (self, tx_kind) {
@@ -251,7 +258,13 @@ mod tests {
         test_util::TIP20Setup,
         tip_fee_manager::{TipFeeManager, amm::PoolKey},
     };
-    use tempo_primitives::{TempoTxEnvelope, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE};
+    use tempo_primitives::{
+        TempoTxEnvelope,
+        subblock::TEMPO_SUBBLOCK_NONCE_KEY_PREFIX,
+        transaction::{
+            Call, TempoSignature, TempoTransaction, envelope::TEMPO_SYSTEM_TX_SIGNATURE,
+        },
+    };
     use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
     use tempo_zone_contracts::IZoneOutbox;
 
@@ -295,6 +308,24 @@ mod tests {
             },
             Signature::test_signature(),
         ))
+    }
+
+    fn subblock_tx() -> TempoTxEnvelope {
+        let mut nonce_key = [0u8; 32];
+        nonce_key[0] = TEMPO_SUBBLOCK_NONCE_KEY_PREFIX;
+
+        TempoTxEnvelope::AA(
+            TempoTransaction {
+                calls: vec![Call {
+                    to: Address::ZERO.into(),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                }],
+                nonce_key: U256::from_be_bytes(nonce_key),
+                ..Default::default()
+            }
+            .into_signed(TempoSignature::from(Signature::test_signature())),
+        )
     }
 
     #[test]
@@ -383,6 +414,24 @@ mod tests {
                 .unwrap(),
             ZoneBlockPhase::Executing
         );
+    }
+
+    #[test]
+    fn subblock_transactions_are_rejected_in_every_block_phase() {
+        let subblock = subblock_tx();
+        assert!(subblock.subblock_proposer().is_some());
+
+        for phase in [
+            ZoneBlockPhase::AwaitingAdvanceTempo,
+            ZoneBlockPhase::Executing,
+            ZoneBlockPhase::WithdrawalsFinalized,
+        ] {
+            let error = phase.validate_transaction(&subblock).unwrap_err();
+            assert_eq!(
+                error.to_string(),
+                "subblock transactions are not supported in zone blocks"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject Tempo subblock-marked transactions at the Zone consensus execution boundary
- prevent imported blocks from reaching Tempo-only subblock fee-failure semantics
- cover rejection during every Zone block execution phase

Fixes CYCLOPS-837