### PR TITLE
fix(evm): reject contract creation before pool validation

### DIFF
--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -86,7 +86,7 @@ mod tests {
         inspector::NoOpInspector,
         state::AccountInfo,
     };
-    use tempo_evm::{TempoBlockEnv, TempoHaltReason};
+    use tempo_evm::{TempoBlockEnv, TempoHaltReason, TempoPoolValidationEvm};
     use tempo_primitives::transaction::Call;
     use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
     use zone_precompiles::test_utils::MockL1Reader as TestL1;
@@ -180,6 +180,26 @@ mod tests {
         assert!(matches!(
             err,
             EVMError::Transaction(TempoInvalidTransaction::CallsValidation(..))
+        ));
+    }
+
+    #[test]
+    fn pool_validation_rejects_top_level_create_before_tempo_checks() {
+        let mut evm = evm_with_contract(Address::ZERO, &[]);
+        let (result, _) = evm.validate_pool_transaction(TempoTxEnv {
+            inner: TxEnv {
+                caller: Address::repeat_byte(0x01),
+                kind: TxKind::Create,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            result,
+            Err(EVMError::Transaction(
+                TempoInvalidTransaction::CallsValidation("contract creation is not supported")
+            ))
         ));
     }
 

--- a/crates/evm/src/zone_evm/mod.rs
+++ b/crates/evm/src/zone_evm/mod.rs
@@ -105,6 +105,11 @@ where
         &mut self,
         tx: TempoTxEnv,
     ) -> (TempoPoolValidationResult<DB::Error>, TempoTxEnv) {
+        if let Err(err) = contract_creation::validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)
+        {
+            self.clear_l1_overlay_state();
+            return (Err(EVMError::Transaction(err)), tx);
+        }
         let (result, tx) = self.inner.validate_pool_transaction(tx);
         let result = result.map_err(map_adapter_error);
         self.clear_l1_overlay_state();

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1585,14 +1585,6 @@ where
                 .no_eip4844()
                 .build::<TempoPooledTransaction, _>(blob_store.clone());
 
-        validator.set_additional_stateless_validation(|_origin, tx| {
-            zone_evm::validate_transaction(
-                tx.tx_env(),
-                zone_primitives::constants::CONTRACT_DEPLOYER_ALLOWLIST,
-            )
-            .map_err(|err| InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(err)))
-        });
-
         let provider = ctx.provider().clone();
         let enabled_tokens = self.enabled_tokens;
         validator.set_additional_stateful_validation(move |_origin, tx, _account_state| {


### PR DESCRIPTION
Rejects unauthorized top-level and AA contract creation before full Tempo pool validation

fixes CYCLOPS-834