### PR TITLE
fix(bench): align Tempo revision with ZoneFactory

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -233,7 +233,7 @@ jobs:
           INPUT_SETUP_SETTLEMENT_TIMEOUT_SECS: ${{ inputs.setup-settlement-timeout-secs || '120' }}
           INPUT_DRAIN_TIMEOUT: ${{ inputs.drain-timeout || '300' }}
           INPUT_SEED: ${{ inputs.seed || '' }}
-          INPUT_TEMPO_REF: a55a6395567f529f03fa88bc457584fa8ed89af8
+          INPUT_TEMPO_REF: a80c1438241e9edd67d8a96c6c07d3697fcf77d8
           INPUT_TXGEN_REF: 072877b673f60b5f559f17da098296f1841b6732
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}


### PR DESCRIPTION
Updates the Zones benchmark Tempo L1 pin to match the workspace dependency revision. This revision includes ZoneFactory leader initialization, preventing provisioning from rejecting a successful createZone transaction with a zeroed leader snapshot. The Tempo revision participates in the snapshot cache key, so the next benchmark run rebuilds the L1 baseline.