### PR TITLE
ZONE-351: Reject authorization lists in Zones

### DIFF
--- a/crates/evm/src/zone_evm/mod.rs
+++ b/crates/evm/src/zone_evm/mod.rs
@@ -111,7 +111,6 @@ where
             .as_ref()
             .is_some_and(|env| !env.tempo_authorization_list.is_empty());
         if has_eip7702_authorizations || has_tempo_authorizations {
-            self.clear_l1_overlay_state();
             return (
                 Err(EVMError::Transaction(
                     TempoInvalidTransaction::CallsValidation(
@@ -123,7 +122,6 @@ where
         }
         if let Err(err) = contract_creation::validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)
         {
-            self.clear_l1_overlay_state();
             return (Err(EVMError::Transaction(err)), tx);
         }
         let (result, tx) = self.inner.validate_pool_transaction(tx);

--- a/crates/evm/src/zone_evm/mod.rs
+++ b/crates/evm/src/zone_evm/mod.rs
@@ -105,6 +105,22 @@ where
         &mut self,
         tx: TempoTxEnv,
     ) -> (TempoPoolValidationResult<DB::Error>, TempoTxEnv) {
+        let has_eip7702_authorizations = !tx.inner.authorization_list.is_empty();
+        let has_tempo_authorizations = tx
+            .tempo_tx_env
+            .as_ref()
+            .is_some_and(|env| !env.tempo_authorization_list.is_empty());
+        if has_eip7702_authorizations || has_tempo_authorizations {
+            self.clear_l1_overlay_state();
+            return (
+                Err(EVMError::Transaction(
+                    TempoInvalidTransaction::CallsValidation(
+                        "authorization lists are not supported",
+                    ),
+                )),
+                tx,
+            );
+        }
         if let Err(err) = contract_creation::validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)
         {
             self.clear_l1_overlay_state();

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1562,7 +1562,6 @@ where
                 .disable_balance_check()
                 .with_minimum_priority_fee(ctx.config().txpool.minimum_priority_fee)
                 .with_custom_tx_type(TempoTxType::AA as u8)
-                .no_eip7702()
                 .no_eip4844()
                 .build::<TempoPooledTransaction, _>(blob_store.clone());
 


### PR DESCRIPTION
Prohibits `tempoAuthorizationList` for zones transactions and unifies logic for authorization lists validation in `TempoEvm::validate_pool_transaction`

fixes ZONE-351