### PR TITLE
fix(payload): redact transaction details from L1 error logs

### DIFF
--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -508,7 +508,12 @@ where
             Err(reth_evm::block::BlockExecutionError::Internal(
                 reth_evm::block::InternalBlockExecutionError::EVM { ref error, .. },
             )) if is_l1_storage_unavailable(error.as_ref()) => {
-                warn!(target: "zone::payload", %error, ?pool_tx, "skipping pool tx due to transient RPC error");
+                warn!(
+                    target: "zone::payload",
+                    %error,
+                    tx_hash = %pool_tx.hash(),
+                    "skipping pool tx due to transient RPC error"
+                );
             }
             Err(err) => return Err(PayloadBuilderError::evm(err)),
         }


### PR DESCRIPTION
Replaces debug logging of the full pooled transaction on the transient L1 storage error path with its transaction hash. This prevents signed envelopes and calldata from entering warning logs.

The path becomes reachable when finite L1 read retries are enabled. Addresses [ZONE-239](https://linear.app/tempoxyz/issue/ZONE-239/stop-logging-full-signed-transactions-on-l1-error-path).