### PR TITLE
fix(portal): bound token enablement payloads

### DIFF
--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -111,11 +111,20 @@ impl Harness {
         deposits: Vec<QueuedDeposit>,
         decryptions: Vec<DecryptionData>,
     ) -> IZoneInbox::advanceTempoCall {
+        self.advance_call_with_tokens(deposits, decryptions, Vec::new())
+    }
+
+    fn advance_call_with_tokens(
+        &self,
+        deposits: Vec<QueuedDeposit>,
+        decryptions: Vec<DecryptionData>,
+        enabled_tokens: Vec<EnabledToken>,
+    ) -> IZoneInbox::advanceTempoCall {
         IZoneInbox::advanceTempoCall {
             header: encode_header(&self.child_header()),
             deposits,
             decryptions,
-            enabledTokens: Vec::new(),
+            enabledTokens: enabled_tokens,
         }
     }
 
@@ -209,17 +218,40 @@ impl Harness {
     }
 }
 
-fn failed_deposit_gas(deposits: usize) -> eyre::Result<u64> {
+fn maximum_metadata_token(index: u16) -> EnabledToken {
+    let mut token = [0u8; 20];
+    token[0] = 0x20;
+    token[1] = 0xc0;
+    token[18..].copy_from_slice(&index.to_be_bytes());
+    EnabledToken {
+        token: Address::from(token),
+        name: "n".repeat(64),
+        symbol: "s".repeat(31),
+        currency: "c".repeat(31),
+    }
+}
+
+fn failed_deposit_gas(deposits: usize, token_enablements: usize) -> eyre::Result<u64> {
     let mut harness = Harness::new()?;
+    let enabled_tokens = (1..=token_enablements)
+        .map(|index| maximum_metadata_token(index as u16))
+        .collect::<Vec<_>>();
     {
         let mut storage = test_storage_provider(&mut harness.ctx, u64::MAX, false);
-        StorageCtx::enter(&mut storage, || {
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
             TIP20Token::from_address(PATH_USD_ADDRESS)?.change_transfer_policy_id(
                 ALICE,
                 ITIP20::changeTransferPolicyIdCall {
                     newPolicyId: REJECT_ALL_POLICY_ID,
                 },
-            )
+            )?;
+            let anchored_policy = U256::from(7) | (U256::ONE << 64);
+            for enabled in &enabled_tokens {
+                let binding_slot =
+                    TIP403Registry::new().token_transfer_policies[enabled.token].base_slot();
+                StorageCtx.sstore(TIP403_REGISTRY_ADDRESS, binding_slot, anchored_policy)?;
+            }
+            Ok(())
         })?;
     }
 
@@ -279,7 +311,7 @@ fn failed_deposit_gas(deposits: usize) -> eyre::Result<u64> {
 
     harness.set_queue_hash(head);
     let calldata = harness
-        .advance_call(queued_deposits, decryptions)
+        .advance_call_with_tokens(queued_deposits, decryptions, enabled_tokens)
         .abi_encode();
     let output = harness.call_with_gas(Address::ZERO, calldata, u64::MAX)?;
     assert!(output.is_success(), "deposit block failed: {output:?}");
@@ -293,7 +325,7 @@ fn max_portal_deposit_block_fits_system_gas_budget() -> eyre::Result<()> {
 
     for deposits in [640, MAX_DEPOSITS_PER_TEMPO_BLOCK] {
         let should_fit = deposits <= MAX_DEPOSITS_PER_TEMPO_BLOCK;
-        let gas_used = failed_deposit_gas(deposits)?;
+        let gas_used = failed_deposit_gas(deposits, 0)?;
         eprintln!("{deposits} portal deposit block: {gas_used} gas");
         assert_eq!(
             gas_used <= BUFFERED_GAS_LIMIT,
@@ -301,6 +333,24 @@ fn max_portal_deposit_block_fits_system_gas_budget() -> eyre::Result<()> {
             "{deposits} deposit block used {gas_used} gas"
         );
     }
+    Ok(())
+}
+
+#[test]
+fn max_portal_deposit_and_token_block_fits_system_gas_budget() -> eyre::Result<()> {
+    const COMBINED_BUFFERED_GAS_LIMIT: u64 = 225_000_000;
+    const MAX_DEPOSITS_PER_TEMPO_BLOCK: usize = 230;
+    const MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK: usize = 8;
+
+    let gas_used = failed_deposit_gas(
+        MAX_DEPOSITS_PER_TEMPO_BLOCK,
+        MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK,
+    )?;
+    eprintln!("max portal deposit and token block: {gas_used} gas");
+    assert!(
+        gas_used <= COMBINED_BUFFERED_GAS_LIMIT,
+        "max portal deposit and token block used {gas_used} gas"
+    );
     Ok(())
 }
 

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -355,7 +355,8 @@ interface IZoneTxContext {
 //   slot 22: maxTempoGasRate (uint128)
 //   slot 23: leader (address) + leaderEpoch (uint64) [packed]
 //   slot 24: leaderActivationTempoBlock (uint64) + _depositCountBlock (uint64)
-//            + _depositsInCurrentBlock (uint64) [packed]
+//            + _depositsInCurrentBlock (uint64) + _tokenEnableCountBlock (uint64) [packed]
+//   slot 25: _tokensEnabledInCurrentBlock (uint64)
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneInbox and ZoneOutbox use them to read portal state via
@@ -624,6 +625,10 @@ interface IZonePortal {
     error InvalidProofOfPossession();
     error DepositTooSmall();
     error DepositBlockCapacityExceeded(uint64 maximum);
+    error TokenEnablementBlockCapacityExceeded(uint64 maximum);
+    error TokenNameTooLong(uint256 actual, uint256 maximum);
+    error TokenSymbolTooLong(uint256 actual, uint256 maximum);
+    error TokenCurrencyTooLong(uint256 actual, uint256 maximum);
     error GasFeeRateTooHigh();
     error TokenNotEnabled();
     error DepositsNotActive();
@@ -667,6 +672,18 @@ interface IZonePortal {
 
     /// @notice Maximum deposits accepted by this portal in one Tempo block.
     function MAX_DEPOSITS_PER_TEMPO_BLOCK() external view returns (uint64);
+
+    /// @notice Maximum tokens enabled by this portal in one Tempo block.
+    function MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK() external view returns (uint64);
+
+    /// @notice Maximum byte length accepted for a bridged token name.
+    function MAX_TOKEN_NAME_BYTES() external view returns (uint256);
+
+    /// @notice Maximum byte length accepted for a bridged token symbol.
+    function MAX_TOKEN_SYMBOL_BYTES() external view returns (uint256);
+
+    /// @notice Maximum byte length accepted for a bridged token currency.
+    function MAX_TOKEN_CURRENCY_BYTES() external view returns (uint256);
 
     /// @notice Maximum callback gas accepted for withdrawals
     function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -61,6 +61,18 @@ contract ZonePortal is IZonePortal {
     ///      below the buffered 200,000,000 gas ceiling.
     uint64 public constant MAX_DEPOSITS_PER_TEMPO_BLOCK = 230;
 
+    /// @notice Maximum tokens that may be enabled for this portal in one Tempo block.
+    /// @dev Under T9, processing 230 worst-case deposits plus 8 token enablements with maximum
+    ///      metadata uses 218,815,278 gas, below the buffered 225,000,000 gas ceiling.
+    uint64 public constant MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK = 8;
+
+    /// @notice Maximum token metadata sizes copied into the zone, measured in bytes.
+    /// @dev Symbol and currency stay within Solidity's one-slot short-string representation.
+    ///      A maximum-size name has a bounded three-slot representation.
+    uint256 public constant MAX_TOKEN_NAME_BYTES = 64;
+    uint256 public constant MAX_TOKEN_SYMBOL_BYTES = 31;
+    uint256 public constant MAX_TOKEN_CURRENCY_BYTES = 31;
+
     /// @dev Reserves enough capacity for one maximum-size sequencer withdrawal batch to bounce.
     ///      The 20M batch gas ceiling fits at most 19 simple withdrawals (plus one slot of margin).
     uint64 internal constant WITHDRAWAL_BOUNCEBACK_RESERVE = 20;
@@ -193,6 +205,10 @@ contract ZonePortal is IZonePortal {
     /// @dev Per-Tempo-block deposit admission counter. Appended for upgrade-safe storage layout.
     uint64 internal _depositCountBlock;
     uint64 internal _depositsInCurrentBlock;
+
+    /// @dev Per-Tempo-block token-enablement admission counter. Appended for upgrade safety.
+    uint64 internal _tokenEnableCountBlock;
+    uint64 internal _tokensEnabledInCurrentBlock;
 
     /*//////////////////////////////////////////////////////////////
                              INITIALIZATION
@@ -549,6 +565,26 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Internal function to enable a token (used by initializer and enableToken)
     function _enableTokenInternal(address _token) internal {
+        _recordTokenEnablement();
+
+        // Bound the metadata copied into the zone before mutating portal or policy state. The zone
+        // must initialize every token emitted in this block inside advanceTempo's fixed gas budget.
+        string memory name = ITIP20(_token).name();
+        string memory symbol = ITIP20(_token).symbol();
+        string memory currency = ITIP20(_token).currency();
+        uint256 nameLength = bytes(name).length;
+        uint256 symbolLength = bytes(symbol).length;
+        uint256 currencyLength = bytes(currency).length;
+        if (nameLength > MAX_TOKEN_NAME_BYTES) {
+            revert TokenNameTooLong(nameLength, MAX_TOKEN_NAME_BYTES);
+        }
+        if (symbolLength > MAX_TOKEN_SYMBOL_BYTES) {
+            revert TokenSymbolTooLong(symbolLength, MAX_TOKEN_SYMBOL_BYTES);
+        }
+        if (currencyLength > MAX_TOKEN_CURRENCY_BYTES) {
+            revert TokenCurrencyTooLong(currencyLength, MAX_TOKEN_CURRENCY_BYTES);
+        }
+
         address[] memory tokens = new address[](1);
         tokens[0] = _token;
 
@@ -564,12 +600,21 @@ contract ZonePortal is IZonePortal {
         _tokenConfigs[_token] = TokenConfig({ enabled: true, depositsActive: true });
         _enabledTokens.push(_token);
 
-        // Read token metadata for the event so zone-side can create matching TIP-20
-        string memory name = ITIP20(_token).name();
-        string memory symbol = ITIP20(_token).symbol();
-        string memory currency = ITIP20(_token).currency();
-
         emit TokenEnabled(_token, name, symbol, currency);
+    }
+
+    function _recordTokenEnablement() internal {
+        uint64 currentBlock = uint64(block.number);
+        if (_tokenEnableCountBlock != currentBlock) {
+            _tokenEnableCountBlock = currentBlock;
+            _tokensEnabledInCurrentBlock = 0;
+        }
+        if (_tokensEnabledInCurrentBlock >= MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK) {
+            revert TokenEnablementBlockCapacityExceeded(MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK);
+        }
+        unchecked {
+            ++_tokensEnabledInCurrentBlock;
+        }
     }
 
     /// @notice Update the zone's operator RPC endpoint.

--- a/specs/ref-impls/storage-layouts/ZonePortal.json
+++ b/specs/ref-impls/storage-layouts/ZonePortal.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 5175,
+      "astId": 5235,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "admin",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5178,
+      "astId": 5238,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneGasRate",
       "offset": 0,
@@ -17,7 +17,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5180,
+      "astId": 5240,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "withdrawalBatchIndex",
       "offset": 16,
@@ -25,7 +25,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5182,
+      "astId": 5242,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "blockHash",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5185,
+      "astId": 5245,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "currentDepositQueueHash",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 5188,
+      "astId": 5248,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "depositCount",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5191,
+      "astId": 5251,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastProcessedDepositNumber",
       "offset": 8,
@@ -57,7 +57,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5194,
+      "astId": 5254,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "lastSyncedTempoBlockNumber",
       "offset": 16,
@@ -65,7 +65,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5197,
+      "astId": 5257,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "bouncebackGas",
       "offset": 24,
@@ -73,7 +73,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5202,
+      "astId": 5262,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_encryptionKeys",
       "offset": 0,
@@ -81,7 +81,7 @@
       "type": "t_array(t_struct(EncryptionKeyEntry)2648_storage)dyn_storage"
     },
     {
-      "astId": 5208,
+      "astId": 5268,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_tokenConfigs",
       "offset": 0,
@@ -89,7 +89,7 @@
       "type": "t_mapping(t_address,t_struct(TokenConfig)3074_storage)"
     },
     {
-      "astId": 5212,
+      "astId": 5272,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enabledTokens",
       "offset": 0,
@@ -97,7 +97,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5219,
+      "astId": 5279,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "refunds",
       "offset": 0,
@@ -105,15 +105,15 @@
       "type": "t_mapping(t_address,t_mapping(t_address,t_uint128))"
     },
     {
-      "astId": 5223,
+      "astId": 5283,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalQueue",
       "offset": 0,
       "slot": "9",
-      "type": "t_struct(WithdrawalQueue)4841_storage"
+      "type": "t_struct(WithdrawalQueue)4887_storage"
     },
     {
-      "astId": 5226,
+      "astId": 5286,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "rpcUrl",
       "offset": 0,
@@ -121,7 +121,7 @@
       "type": "t_string_storage"
     },
     {
-      "astId": 5229,
+      "astId": 5289,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "pendingAdmin",
       "offset": 0,
@@ -129,7 +129,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5232,
+      "astId": 5292,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_withdrawalReentrancyStatus",
       "offset": 0,
@@ -137,7 +137,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5235,
+      "astId": 5295,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneId",
       "offset": 0,
@@ -145,7 +145,7 @@
       "type": "t_uint32"
     },
     {
-      "astId": 5238,
+      "astId": 5298,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "messenger",
       "offset": 4,
@@ -153,7 +153,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5240,
+      "astId": 5300,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "verifier",
       "offset": 0,
@@ -161,7 +161,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5242,
+      "astId": 5302,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_initialized",
       "offset": 20,
@@ -169,7 +169,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5245,
+      "astId": 5305,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerSetVersion",
       "offset": 21,
@@ -177,7 +177,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5247,
+      "astId": 5307,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "sequencerThreshold",
       "offset": 29,
@@ -185,7 +185,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 5249,
+      "astId": 5309,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "zoneHeight",
       "offset": 0,
@@ -193,7 +193,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 5252,
+      "astId": 5312,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_sequencers",
       "offset": 0,
@@ -201,7 +201,7 @@
       "type": "t_array(t_address)dyn_storage"
     },
     {
-      "astId": 5256,
+      "astId": 5316,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "isSequencer",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_mapping(t_address,t_bool)"
     },
     {
-      "astId": 5261,
+      "astId": 5321,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "role",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_mapping(t_address,t_enum(Role)2497)"
     },
     {
-      "astId": 5264,
+      "astId": 5324,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isAccessEnforced",
       "offset": 0,
@@ -225,7 +225,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5266,
+      "astId": 5326,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_isGatewayEnforced",
       "offset": 1,
@@ -233,7 +233,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 5269,
+      "astId": 5329,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_enforcementModesPadding",
       "offset": 2,
@@ -241,7 +241,7 @@
       "type": "t_uint240"
     },
     {
-      "astId": 5272,
+      "astId": 5332,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "maxTempoGasRate",
       "offset": 0,
@@ -249,7 +249,7 @@
       "type": "t_uint128"
     },
     {
-      "astId": 5275,
+      "astId": 5335,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leader",
       "offset": 0,
@@ -257,7 +257,7 @@
       "type": "t_address"
     },
     {
-      "astId": 5278,
+      "astId": 5338,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderEpoch",
       "offset": 20,
@@ -265,7 +265,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5281,
+      "astId": 5341,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "leaderActivationTempoBlock",
       "offset": 0,
@@ -273,7 +273,7 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5284,
+      "astId": 5344,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_depositCountBlock",
       "offset": 8,
@@ -281,11 +281,27 @@
       "type": "t_uint64"
     },
     {
-      "astId": 5286,
+      "astId": 5346,
       "contract": "src/tempo/ZonePortal.sol:ZonePortal",
       "label": "_depositsInCurrentBlock",
       "offset": 16,
       "slot": "24",
+      "type": "t_uint64"
+    },
+    {
+      "astId": 5349,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "_tokenEnableCountBlock",
+      "offset": 24,
+      "slot": "24",
+      "type": "t_uint64"
+    },
+    {
+      "astId": 5351,
+      "contract": "src/tempo/ZonePortal.sol:ZonePortal",
+      "label": "_tokensEnabledInCurrentBlock",
+      "offset": 0,
+      "slot": "25",
       "type": "t_uint64"
     }
   ],
@@ -423,13 +439,13 @@
         }
       ]
     },
-    "t_struct(WithdrawalQueue)4841_storage": {
+    "t_struct(WithdrawalQueue)4887_storage": {
       "encoding": "inplace",
       "label": "struct WithdrawalQueue",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 4834,
+          "astId": 4880,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "head",
           "offset": 0,
@@ -437,7 +453,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4836,
+          "astId": 4882,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "tail",
           "offset": 0,
@@ -445,7 +461,7 @@
           "type": "t_uint256"
         },
         {
-          "astId": 4840,
+          "astId": 4886,
           "contract": "src/tempo/ZonePortal.sol:ZonePortal",
           "label": "slots",
           "offset": 0,

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -555,6 +555,29 @@ contract ZonePortalTest is BaseTest {
         return keccak256(abi.encodePacked(sender));
     }
 
+    function _stringOfLength(uint256 length) internal pure returns (string memory value) {
+        bytes memory data = new bytes(length);
+        for (uint256 i; i < length; ++i) {
+            data[i] = "x";
+        }
+        return string(data);
+    }
+
+    function _createEnablementToken(
+        string memory name,
+        string memory symbol,
+        string memory currency,
+        bytes32 salt
+    )
+        internal
+        returns (address token)
+    {
+        token = address(
+            factory.createToken(name, symbol, currency, ITIP20(_PATH_USD), sequencer, salt)
+        );
+        _mockTokenPolicyMigration(token, true);
+    }
+
     function _sequencerSet() internal returns (address[] memory signers) {
         signers = new address[](3);
         signers[0] = vm.addr(SIGNER_A_KEY);
@@ -1119,6 +1142,94 @@ contract ZonePortalTest is BaseTest {
         vm.prank(admin);
         vm.expectRevert(IZonePortal.TokenTransferPolicyNotSet.selector);
         portal.enableToken(token);
+    }
+
+    function test_enableToken_acceptsMaximumMetadataLengths() public {
+        address token = _createEnablementToken(
+            _stringOfLength(portal.MAX_TOKEN_NAME_BYTES()),
+            _stringOfLength(portal.MAX_TOKEN_SYMBOL_BYTES()),
+            _stringOfLength(portal.MAX_TOKEN_CURRENCY_BYTES()),
+            bytes32("max metadata")
+        );
+
+        vm.prank(admin);
+        portal.enableToken(token);
+
+        assertTrue(portal.isTokenEnabled(token));
+    }
+
+    function test_enableToken_rejectsOversizedName() public {
+        uint256 maximum = portal.MAX_TOKEN_NAME_BYTES();
+        address token = _createEnablementToken(
+            _stringOfLength(maximum + 1), "T", "USD", bytes32("long name")
+        );
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.TokenNameTooLong.selector, maximum + 1, maximum)
+        );
+        portal.enableToken(token);
+
+        assertFalse(portal.isTokenEnabled(token));
+    }
+
+    function test_enableToken_rejectsOversizedSymbol() public {
+        uint256 maximum = portal.MAX_TOKEN_SYMBOL_BYTES();
+        address token = _createEnablementToken(
+            "Token", _stringOfLength(maximum + 1), "USD", bytes32("long symbol")
+        );
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.TokenSymbolTooLong.selector, maximum + 1, maximum)
+        );
+        portal.enableToken(token);
+
+        assertFalse(portal.isTokenEnabled(token));
+    }
+
+    function test_enableToken_rejectsOversizedCurrency() public {
+        uint256 maximum = portal.MAX_TOKEN_CURRENCY_BYTES();
+        address token = _createEnablementToken(
+            "Token", "T", _stringOfLength(maximum + 1), bytes32("long currency")
+        );
+
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(IZonePortal.TokenCurrencyTooLong.selector, maximum + 1, maximum)
+        );
+        portal.enableToken(token);
+
+        assertFalse(portal.isTokenEnabled(token));
+    }
+
+    function test_enableToken_enforcesPerTempoBlockCapAndResets() public {
+        uint64 maximum = portal.MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK();
+        assertEq(maximum, 8);
+        assertEq(portal.enabledTokenCount(), 1, "initializer must consume one enablement");
+
+        for (uint256 i = 1; i < maximum; ++i) {
+            address token = _createEnablementToken("Token", "T", "USD", bytes32(uint256(1000 + i)));
+            vm.prank(admin);
+            portal.enableToken(token);
+        }
+        assertEq(portal.enabledTokenCount(), maximum);
+
+        address overflowToken =
+            _createEnablementToken("Overflow", "OVER", "USD", bytes32("overflow"));
+        vm.prank(admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IZonePortal.TokenEnablementBlockCapacityExceeded.selector, maximum
+            )
+        );
+        portal.enableToken(overflowToken);
+        assertFalse(portal.isTokenEnabled(overflowToken));
+
+        vm.roll(block.number + 1);
+        vm.prank(admin);
+        portal.enableToken(overflowToken);
+        assertTrue(portal.isTokenEnabled(overflowToken));
     }
 
     function test_sequencerGovernance_revertsIfAdmin() public {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -384,6 +384,15 @@ contract ZonePortalProxyStorageTest is Test {
         address[] memory tokens = new address[](1);
         tokens[0] = initialToken;
         vm.mockCall(
+            initialToken, abi.encodeWithSelector(ITIP20.name.selector), abi.encode("Initial Token")
+        );
+        vm.mockCall(
+            initialToken, abi.encodeWithSelector(ITIP20.symbol.selector), abi.encode("INITIAL")
+        );
+        vm.mockCall(
+            initialToken, abi.encodeWithSelector(ITIP20.currency.selector), abi.encode("USD")
+        );
+        vm.mockCall(
             StdPrecompiles.TIP403_REGISTRY_ADDRESS,
             abi.encodeCall(ITIP403Registry.migrateTransferPolicyIds, (tokens)),
             abi.encode(0)

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -323,7 +323,7 @@ The admin manages which TIP-20 tokens are available on the zone (see [Access Con
 - `pauseDeposits(token)`: Pause new deposits for a token. Does not affect withdrawals.
 - `resumeDeposits(token)`: Resume deposits for a previously paused token.
 
-The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin can halt deposits but cannot disable withdrawals for an enabled token. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
+The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin can halt deposits but cannot disable withdrawals for an enabled token. To keep the mandatory zone-side `advanceTempo()` call within its fixed system gas budget, each portal accepts at most `MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK` (8) token enablements in one Tempo block, including the initial token enabled during portal creation. Metadata copied into the zone is bounded by encoded byte length: 64 bytes for `name` and 31 bytes each for `symbol` and `currency`. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
 
 ### Gas Rate Configuration
 
@@ -1675,6 +1675,11 @@ interface IZonePortal {
     error InvalidCiphertextLength(uint256 actual, uint256 expected);
     error InvalidProofOfPossession();
     error DepositTooSmall();
+    error DepositBlockCapacityExceeded(uint64 maximum);
+    error TokenEnablementBlockCapacityExceeded(uint64 maximum);
+    error TokenNameTooLong(uint256 actual, uint256 maximum);
+    error TokenSymbolTooLong(uint256 actual, uint256 maximum);
+    error TokenCurrencyTooLong(uint256 actual, uint256 maximum);
     error GasFeeRateTooHigh();
     error TokenNotEnabled();
     error DepositsNotActive();
@@ -1686,6 +1691,11 @@ interface IZonePortal {
     error InvalidQuorumCertificate();
 
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
+    function MAX_DEPOSITS_PER_TEMPO_BLOCK() external view returns (uint64);
+    function MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK() external view returns (uint64);
+    function MAX_TOKEN_NAME_BYTES() external view returns (uint256);
+    function MAX_TOKEN_SYMBOL_BYTES() external view returns (uint256);
+    function MAX_TOKEN_CURRENCY_BYTES() external view returns (uint256);
     function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);
     function MAX_GAS_FEE_RATE() external view returns (uint128);
 
@@ -1898,7 +1908,7 @@ interface IZoneInbox {
 }
 ```
 
-`EnabledToken` carries token metadata (`token`, `name`, `symbol`, `currency`) for direct activation of zone-side TIP-20 precompiles by `ZoneInbox`.
+`EnabledToken` carries token metadata (`token`, `name`, `symbol`, `currency`) for direct activation of zone-side TIP-20 precompiles by `ZoneInbox`. `ZonePortal` admits at most 8 such activations per Tempo block and rejects metadata whose encoded byte length exceeds 64 bytes for `name` or 31 bytes for `symbol` or `currency`.
 
 ### IZoneOutbox
 


### PR DESCRIPTION
Cap number of tokens enabled per L1 block and their metadata sizes to prevent unbounded `advanceTempo` gas usage


fixes ZONE-349