### PR TITLE
fix(sequencer): stop stale settlement quorum waits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13781,6 +13781,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tracing",
+ "zone-l1",
 ]
 
 [[package]]

--- a/crates/l1/src/event.rs
+++ b/crates/l1/src/event.rs
@@ -15,6 +15,18 @@ pub struct L1PortalEvents {
     /// The portal allows at most one distinct transition per Tempo block.
     #[serde(default)]
     pub leader_transitions: Vec<LeaderTransition>,
+    /// Confirmed batch submissions in canonical log order.
+    #[serde(default)]
+    pub batch_submissions: Vec<BatchSubmission>,
+}
+
+/// A finalized `BatchSubmitted` Portal event.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BatchSubmission {
+    /// Monotonic batch index assigned by the Portal.
+    pub withdrawal_batch_index: u64,
+    /// Zone block hash accepted as the new Portal tip.
+    pub next_block_hash: B256,
 }
 
 /// A finalized `SequencerEncryptionKeyUpdated` Portal event.
@@ -70,12 +82,13 @@ impl EnabledToken {
 
 impl L1PortalEvents {
     /// Event signature hashes that this container knows how to decode.
-    const SIGNATURE_HASHES: [B256; 5] = [
+    const SIGNATURE_HASHES: [B256; 6] = [
         DepositMade::SIGNATURE_HASH,
         WithdrawalBounceBack::SIGNATURE_HASH,
         TokenEnabled::SIGNATURE_HASH,
         SequencerEncryptionKeyUpdated::SIGNATURE_HASH,
         LeaderUpdated::SIGNATURE_HASH,
+        BatchSubmitted::SIGNATURE_HASH,
     ];
 
     /// Create portal events from deposits only.
@@ -204,6 +217,18 @@ impl L1PortalEvents {
                     new_leader: event.newLeader,
                     epoch: event.epoch,
                     activation_tempo_block: event.activationTempoBlock,
+                });
+            }
+            ZonePortalEvents::BatchSubmitted(event) => {
+                info!(
+                    l1_block = block_number,
+                    withdrawal_batch_index = event.withdrawalBatchIndex,
+                    next_block_hash = %event.nextBlockHash,
+                    "Batch submitted on L1"
+                );
+                self.batch_submissions.push(BatchSubmission {
+                    withdrawal_batch_index: event.withdrawalBatchIndex,
+                    next_block_hash: event.nextBlockHash,
                 });
             }
             _ => {}

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -69,7 +69,7 @@ pub(crate) mod rpc {
 use crate::abi::{
     Deposit as AbiDeposit, DepositPayload as AbiDepositPayload,
     ZonePortal::{
-        DepositMade, LeaderUpdated, SequencerEncryptionKeyUpdated, TokenEnabled,
+        BatchSubmitted, DepositMade, LeaderUpdated, SequencerEncryptionKeyUpdated, TokenEnabled,
         WithdrawalBounceBack, ZonePortalEvents,
     },
 };
@@ -87,7 +87,9 @@ mod tests;
 pub use block::{L1BlockDeposits, PreparedL1Block};
 pub use deposit::{Deposit, L1Deposit, WithdrawalBounceBackDeposit};
 pub use encryption_keys::EncryptionKeyRing;
-pub use event::{EnabledToken, EncryptionKeyRotation, L1PortalEvents, LeaderTransition};
+pub use event::{
+    BatchSubmission, EnabledToken, EncryptionKeyRotation, L1PortalEvents, LeaderTransition,
+};
 pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -38,14 +38,17 @@ struct L1BlockObservation {
 pub struct L1BlockTracker {
     state: Arc<parking_lot::RwLock<L1BlockTrackerState>>,
     changed: tokio::sync::watch::Sender<()>,
+    batch_submission: tokio::sync::watch::Sender<Option<crate::BatchSubmission>>,
 }
 
 impl Default for L1BlockTracker {
     fn default() -> Self {
         let (changed, _) = tokio::sync::watch::channel(());
+        let (batch_submission, _) = tokio::sync::watch::channel(None);
         Self {
             state: Default::default(),
             changed,
+            batch_submission,
         }
     }
 }
@@ -71,6 +74,13 @@ impl L1BlockTracker {
     /// Return the highest independently observed L1 anchor.
     pub fn latest(&self) -> Option<NumHash> {
         self.state.read().latest
+    }
+
+    /// Subscribe to the latest receipt-authenticated `BatchSubmitted` event.
+    pub fn subscribe_batch_submissions(
+        &self,
+    ) -> tokio::sync::watch::Receiver<Option<crate::BatchSubmission>> {
+        self.batch_submission.subscribe()
     }
 
     /// Return whether `number` fits inside the bounded subscriber lookahead window.
@@ -169,6 +179,7 @@ impl L1BlockTracker {
         block: NumHash,
         portal_events: L1PortalEvents,
     ) -> eyre::Result<()> {
+        let batch_submission = portal_events.batch_submissions.last().cloned();
         let mut state = self.state.write();
         if let Some(observation) = state.observed.get(&block.number) {
             eyre::ensure!(
@@ -218,6 +229,9 @@ impl L1BlockTracker {
         );
         state.latest = Some(block);
         drop(state);
+        if let Some(batch_submission) = batch_submission {
+            self.batch_submission.send_replace(Some(batch_submission));
+        }
         self.changed.send_replace(());
         Ok(())
     }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -208,6 +208,27 @@ async fn l1_block_tracker_returns_receipt_authenticated_portal_events() {
     );
 }
 
+#[tokio::test]
+async fn l1_block_tracker_publishes_batch_submissions() {
+    let tracker = L1BlockTracker::default();
+    let mut submissions = tracker.subscribe_batch_submissions();
+    let expected = BatchSubmission {
+        withdrawal_batch_index: 7,
+        next_block_hash: B256::repeat_byte(0x42),
+    };
+    let events = L1PortalEvents {
+        batch_submissions: vec![expected.clone()],
+        ..Default::default()
+    };
+
+    tracker
+        .record_with_portal_events(NumHash::new(10, B256::with_last_byte(0x10)), events)
+        .unwrap();
+
+    submissions.changed().await.unwrap();
+    assert_eq!(submissions.borrow_and_update().as_ref(), Some(&expected));
+}
+
 #[test]
 fn observed_portal_events_require_complete_advance_tempo_inputs() {
     let events = L1PortalEvents {
@@ -223,6 +244,7 @@ fn observed_portal_events_require_complete_advance_tempo_inputs() {
         }],
         encryption_key_rotations: vec![],
         leader_transitions: vec![],
+        batch_submissions: vec![],
     };
     let deposits: Vec<_> = events
         .deposits
@@ -1454,6 +1476,24 @@ fn leader_updated_log(
     }
 }
 
+fn batch_submitted_log(portal: Address, batch_index: u64, next_block_hash: B256) -> Log {
+    let event = crate::abi::ZonePortal::BatchSubmitted {
+        withdrawalBatchIndex: batch_index,
+        withdrawalQueueIndex: U256::MAX,
+        nextProcessedDepositQueueHash: B256::ZERO,
+        nextBlockHash: next_block_hash,
+        withdrawalQueueHash: B256::ZERO,
+        lastProcessedDepositNumber: 0,
+    };
+    Log {
+        inner: alloy_primitives::Log {
+            address: portal,
+            data: event.encode_log_data(),
+        },
+        ..Default::default()
+    }
+}
+
 fn encryption_key_updated_log(
     portal: Address,
     x: B256,
@@ -1523,6 +1563,25 @@ fn decodes_leader_updated_into_portal_events() {
     let transition = events.final_leader_transition().unwrap().unwrap();
     assert_eq!(transition.new_leader, new_leader);
     assert_eq!(transition.epoch, 4);
+}
+
+#[test]
+fn decodes_batch_submitted_into_portal_events() {
+    let portal = address!("0x0000000000000000000000000000000000000ABC");
+    let next_block_hash = B256::repeat_byte(0x42);
+    let mut events = L1PortalEvents::default();
+
+    events
+        .push_log(&batch_submitted_log(portal, 7, next_block_hash), 77)
+        .unwrap();
+
+    assert_eq!(
+        events.batch_submissions,
+        vec![BatchSubmission {
+            withdrawal_batch_index: 7,
+            next_block_hash,
+        }]
+    );
 }
 
 #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -741,6 +741,7 @@ where
                     self.l1_config.portal_address,
                     self.l1_config.retry_connection_interval,
                     attestation.store.clone(),
+                    self.l1_config.block_tracker.clone(),
                 )?),
                 None => None,
             };
@@ -791,6 +792,7 @@ where
                 self.l1_config.retry_connection_interval,
                 sequencer_addr,
                 None,
+                self.l1_config.block_tracker.clone(),
             )
             .await?;
         }
@@ -1044,6 +1046,7 @@ where
         portal_address: Address,
         retry_connection_interval: Duration,
         attestation_store: AttestationStore,
+        l1_block_tracker: L1BlockTracker,
     ) -> eyre::Result<LeaderSequencerDeps> {
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
@@ -1056,6 +1059,7 @@ where
             inbox_address: ZONE_INBOX_ADDRESS,
             batch_anchor_config: config.batch_anchor_config,
             attestation_store: Some(attestation_store),
+            l1_block_tracker,
         };
         Ok(LeaderSequencerDeps {
             config,
@@ -1249,6 +1253,7 @@ where
         retry_connection_interval: Duration,
         sequencer_addr: Address,
         attestation_store: Option<AttestationStore>,
+        l1_block_tracker: L1BlockTracker,
     ) -> eyre::Result<()> {
         info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
         let sequencer_config = ZoneSequencerConfig {
@@ -1262,6 +1267,7 @@ where
             inbox_address: ZONE_INBOX_ADDRESS,
             batch_anchor_config: config.batch_anchor_config,
             attestation_store,
+            l1_block_tracker,
         };
         let l1_transaction_signer = config
             .l1_transaction_signer

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3364,6 +3364,7 @@ pub(crate) async fn spawn_sequencer_with_config(
         inbox_address: ZONE_INBOX_ADDRESS,
         batch_anchor_config,
         attestation_store: None,
+        l1_block_tracker: zone_l1::L1BlockTracker::default(),
     };
 
     zone.spawn_sequencer(config, sequencer_signer).await
@@ -4672,6 +4673,7 @@ impl L1Fixture {
             enabled_tokens: tokens,
             encryption_key_rotations: vec![],
             leader_transitions: vec![],
+            batch_submissions: vec![],
         };
         queue.enqueue(header, events);
     }

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -16,6 +16,7 @@ tempo-alloy.workspace = true
 tempo-chainspec.workspace = true
 tempo-primitives.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
+zone-l1.workspace = true
 
 # reth
 reth-chain-state.workspace = true

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -105,6 +105,8 @@ pub struct ZoneSequencerConfig {
     pub batch_anchor_config: BatchAnchorConfig,
     /// Shared P2P attestation store used for quorum batch submission.
     pub attestation_store: Option<AttestationStore>,
+    /// Receipt-authenticated finalized L1 observations, including external batch submissions.
+    pub l1_block_tracker: zone_l1::L1BlockTracker,
 }
 
 /// Handles returned by [`spawn_zone_sequencer`] for managing background tasks.
@@ -167,6 +169,7 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
         portal_address: config.portal_address,
         batch_anchor_config: config.batch_anchor_config,
         attestation_store: config.attestation_store,
+        batch_submissions: Some(config.l1_block_tracker.subscribe_batch_submissions()),
     };
 
     let withdrawal_handle = withdrawals::spawn_withdrawal_processor(

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -68,6 +68,8 @@ pub struct ZoneMonitorConfig {
     pub batch_anchor_config: BatchAnchorConfig,
     /// Shared P2P attestations, required after a settlement signer set is activated.
     pub attestation_store: Option<AttestationStore>,
+    /// Finalized external batch submissions observed by the L1 subscriber.
+    pub batch_submissions: Option<tokio::sync::watch::Receiver<Option<zone_l1::BatchSubmission>>>,
 }
 
 /// Withdrawal state shared between the zone monitor and withdrawal processor.
@@ -177,6 +179,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             config.batch_anchor_config,
         );
         batch_submitter.set_attestation_store(config.attestation_store.clone());
+        batch_submitter.set_batch_submissions(config.batch_submissions.clone());
 
         let prev_zone_block_hash = batch_submitter
             .read_portal_block_hash()
@@ -957,6 +960,7 @@ mod tests {
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
             attestation_store: None,
+            batch_submissions: None,
         };
         let l1_provider = mock_provider(l1);
 
@@ -987,6 +991,7 @@ mod tests {
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
             attestation_store: None,
+            batch_submissions: None,
         };
 
         l1.push_failure_msg("boom");

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -154,6 +154,8 @@ pub struct BatchSubmitter {
     anchor_config: BatchAnchorConfig,
     /// Signatures from followers attesting to the batch.
     attestation_store: Option<AttestationStore>,
+    /// Finalized external batch submissions published by the L1 subscriber.
+    batch_submissions: Option<tokio::sync::watch::Receiver<Option<zone_l1::BatchSubmission>>>,
     /// Validated, RLP-encoded L1 headers retained across overlapping ancestry
     /// requests. Settlement batches are submitted in order, so later requests
     /// can reuse almost the entire preceding range.
@@ -212,6 +214,7 @@ impl BatchSubmitter {
             l1_fetch_concurrency: 16,
             anchor_config,
             attestation_store: None,
+            batch_submissions: None,
             ancestry_header_cache: RwLock::new(LruMap::new(ByLength::new(
                 DEFAULT_ANCESTRY_HEADER_CACHE_CAPACITY,
             ))),
@@ -221,6 +224,14 @@ impl BatchSubmitter {
     /// Attach the shared store populated by leader and follower settlement signatures.
     pub fn set_attestation_store(&mut self, store: Option<AttestationStore>) {
         self.attestation_store = store;
+    }
+
+    /// Attach the finalized batch-submission stream published by the L1 subscriber.
+    pub fn set_batch_submissions(
+        &mut self,
+        submissions: Option<tokio::sync::watch::Receiver<Option<zone_l1::BatchSubmission>>>,
+    ) {
+        self.batch_submissions = submissions;
     }
 
     /// Submit a batch to the ZonePortal on Tempo L1.
@@ -272,9 +283,9 @@ impl BatchSubmitter {
                     zone_height = batch.zone_height,
                     threshold, "Waiting for settlement quorum"
                 );
-                let certificate = store
-                    .wait_for_settlement(batch.zone_height, threshold)
-                    .await;
+                let certificate = self
+                    .wait_for_settlement_or_portal_progress(store, batch, threshold)
+                    .await?;
                 let anchor_mode = match self
                     .validate_certificate(batch, batch.zone_height, metadata, &certificate)
                     .await
@@ -392,6 +403,45 @@ impl BatchSubmitter {
         );
 
         Ok(event)
+    }
+
+    /// Wait for a local settlement certificate while the batch still extends the portal tip.
+    ///
+    /// Another retained leader may submit the same boundary first. In that case honest followers
+    /// stop signing the now-stale statement, so a waiter that only observes the local attestation
+    /// store would never return. The finalized L1 subscriber wakes the submission attempt when it
+    /// observes `BatchSubmitted`; the monitor's existing retry preflight then resyncs from the
+    /// accepted boundary.
+    async fn wait_for_settlement_or_portal_progress(
+        &self,
+        store: &AttestationStore,
+        batch: &BatchData,
+        threshold: usize,
+    ) -> Result<SettlementCertificate> {
+        let quorum = store.wait_for_settlement(batch.zone_height, threshold);
+        tokio::pin!(quorum);
+        let mut batch_submissions = self
+            .batch_submissions
+            .clone()
+            .ok_or_eyre("settlement quorum requires the L1 batch-submission stream")?;
+
+        loop {
+            if let Some(submission) = batch_submissions.borrow_and_update().clone() {
+                eyre::ensure!(
+                    submission.next_block_hash == batch.prev_block_hash,
+                    "portal advanced from {} to {} while waiting for settlement quorum at zone block {}",
+                    batch.prev_block_hash,
+                    submission.next_block_hash,
+                    batch.zone_height,
+                );
+            }
+            tokio::select! {
+                biased;
+                certificate = &mut quorum => return Ok(certificate),
+                changed = batch_submissions.changed() => changed
+                    .map_err(|_| eyre::eyre!("L1 batch-submission stream closed"))?,
+            }
+        }
     }
 
     fn sign_settlement_attestation(
@@ -2039,6 +2089,59 @@ mod tests {
         assert_eq!(second.verifier, next_verifier);
         assert_eq!(second.stable.zone_id, 42);
         assert_eq!(second.stable.chain_id, 42431);
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn settlement_wait_stops_after_external_portal_progress() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_mocked_client(asserter.clone())
+            .erased();
+        let mut submitter = BatchSubmitter::new(Address::ZERO, provider);
+        let l1_block_tracker = zone_l1::L1BlockTracker::default();
+        submitter.set_batch_submissions(Some(l1_block_tracker.subscribe_batch_submissions()));
+        let store = AttestationStore::default();
+        let batch = BatchData {
+            zone_height: 20,
+            tempo_block_number: 123,
+            prev_block_hash: B256::repeat_byte(0x11),
+            next_block_hash: B256::repeat_byte(0x22),
+            prev_processed_deposit_hash: B256::ZERO,
+            next_processed_deposit_hash: B256::ZERO,
+            prev_deposit_number: 0,
+            next_deposit_number: 0,
+            withdrawal_queue_hash: B256::ZERO,
+            withdrawal_batch_index: 1,
+        };
+        let portal_hash = batch.next_block_hash;
+
+        let waiting = submitter.wait_for_settlement_or_portal_progress(&store, &batch, 2);
+        tokio::pin!(waiting);
+        tokio::select! {
+            biased;
+            _ = &mut waiting => panic!("settlement wait returned before portal progress"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(1)) => {}
+        }
+        l1_block_tracker
+            .record_with_portal_events(
+                alloy_eips::NumHash::new(10, B256::repeat_byte(0x33)),
+                zone_l1::L1PortalEvents {
+                    batch_submissions: vec![zone_l1::BatchSubmission {
+                        withdrawal_batch_index: 1,
+                        next_block_hash: portal_hash,
+                    }],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let error = waiting.await.unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("portal advanced from 0x1111111111111111111111111111111111111111111111111111111111111111 to 0x2222222222222222222222222222222222222222222222222222222222222222 while waiting for settlement quorum at zone block 20")
+        );
         assert!(asserter.read_q().is_empty());
     }
 


### PR DESCRIPTION
Stops a leader’s settlement task from waiting indefinitely after another authorized leader submits the pending batch.

The finalized L1 subscriber now decodes `BatchSubmitted` and publishes the latest accepted block hash through `L1BlockTracker`. Settlement quorum waits race local signatures against this signal; when the portal advances, the attempt exits and the existing preflight/resync path restores submission and withdrawal state.

Fixes [ZONE-342](https://linear.app/tempoxyz/issue/ZONE-342/cyclops-external-valid-submitbatch-progress-can-strand-the-scheduled).

This reuses the subscriber’s reconnect and backfill handling instead of adding a separate poller.