### PR TITLE
refactor: unify redacted block lookups

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -709,17 +709,10 @@ where
         reward_percentiles: Option<Vec<f64>>,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            // Avoid loading private block bodies to calculate reward percentiles.
-            let mut history = EthFees::fee_history(&self.eth.api, block_count, newest_block, None)
-                .await
-                .map_err(internal)?;
-            if let Some(reward_percentiles) = reward_percentiles.as_deref() {
-                history.reward = Some(vec![
-                    vec![0; reward_percentiles.len()];
-                    history.gas_used_ratio.len()
-                ]);
-            }
-
+            let mut history =
+                EthFees::fee_history(&self.eth.api, block_count, newest_block, reward_percentiles)
+                    .await
+                    .map_err(internal)?;
             // Redact gas fields (like `gas_used_ratio`) that can be used to guess tx counts
             redact_fee_history(&mut history);
             to_raw(&history)
@@ -1264,7 +1257,7 @@ fn redact_header(header: &mut TempoHeaderResponse) {
     inner.withdrawals_root = inner.withdrawals_root.map(|_| B256::ZERO);
 }
 
-/// Clear gas-related fields that leak the size (and therefore tx counts).
+/// Clear gas related fields that leak the size (and therefore tx counts)
 fn redact_fee_history(history: &mut FeeHistory) {
     history.base_fee_per_gas.fill(u128::from(TEMPO_T0_BASE_FEE));
     history.gas_used_ratio.fill(0.0);

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -709,10 +709,17 @@ where
         reward_percentiles: Option<Vec<f64>>,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            let mut history =
-                EthFees::fee_history(&self.eth.api, block_count, newest_block, reward_percentiles)
-                    .await
-                    .map_err(internal)?;
+            // Avoid loading private block bodies to calculate reward percentiles.
+            let mut history = EthFees::fee_history(&self.eth.api, block_count, newest_block, None)
+                .await
+                .map_err(internal)?;
+            if let Some(reward_percentiles) = reward_percentiles.as_deref() {
+                history.reward = Some(vec![
+                    vec![0; reward_percentiles.len()];
+                    history.gas_used_ratio.len()
+                ]);
+            }
+
             // Redact gas fields (like `gas_used_ratio`) that can be used to guess tx counts
             redact_fee_history(&mut history);
             to_raw(&history)
@@ -1257,7 +1264,7 @@ fn redact_header(header: &mut TempoHeaderResponse) {
     inner.withdrawals_root = inner.withdrawals_root.map(|_| B256::ZERO);
 }
 
-/// Clear gas related fields that leak the size (and therefore tx counts)
+/// Clear gas-related fields that leak the size (and therefore tx counts).
 fn redact_fee_history(history: &mut FeeHistory) {
     history.base_fee_per_gas.fill(u128::from(TEMPO_T0_BASE_FEE));
     history.gas_used_ratio.fill(0.0);

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -606,6 +606,27 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
     }
 }
 
+impl<Api> ZoneRpc<Api>
+where
+    Api: FullEthApi + EthApiTypes<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
+{
+    fn block_by_id(&self, id: BlockId) -> BoxFut<'_> {
+        Box::pin(async move {
+            let block = EthBlocks::rpc_block(&self.eth.api, id, false)
+                .await
+                .map_err(internal)?;
+
+            let Some(mut block) = block else {
+                return Ok(raw_null());
+            };
+
+            redact_block(&mut block);
+
+            to_raw(&block)
+        })
+    }
+}
+
 impl<Api> zone_rpc::ZoneRpcApi for ZoneRpc<Api>
 where
     Api: FullEthApi + EthApiTypes<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
@@ -737,38 +758,14 @@ where
     fn block_by_number(
         &self,
         number: BlockNumberOrTag,
-        full: bool,
+        _full: bool,
         _auth: AuthContext,
     ) -> BoxFut<'_> {
-        Box::pin(async move {
-            let block = EthBlocks::rpc_block(&self.eth.api, number.into(), full)
-                .await
-                .map_err(internal)?;
-
-            let Some(mut block) = block else {
-                return Ok(raw_null());
-            };
-
-            redact_block(&mut block);
-
-            to_raw(&block)
-        })
+        self.block_by_id(number.into())
     }
 
-    fn block_by_hash(&self, hash: B256, full: bool, _auth: AuthContext) -> BoxFut<'_> {
-        Box::pin(async move {
-            let block = EthBlocks::rpc_block(&self.eth.api, hash.into(), full)
-                .await
-                .map_err(internal)?;
-
-            let Some(mut block) = block else {
-                return Ok(raw_null());
-            };
-
-            redact_block(&mut block);
-
-            to_raw(&block)
-        })
+    fn block_by_hash(&self, hash: B256, _full: bool, _auth: AuthContext) -> BoxFut<'_> {
+        self.block_by_id(hash.into())
     }
 
     fn transaction_by_hash(&self, hash: B256, auth: AuthContext) -> BoxFut<'_> {


### PR DESCRIPTION
## Summary

Use one `block_by_id` helper for redacted block lookups and forward both number- and hash-based requests through Reth's regular `rpc_block` handler with `full=false`.

This preserves the existing redaction behavior and keeps the redacted RPC's `full=true` rejection in the handler layer while removing the custom header reconstruction path.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo check -p zone-node` *(blocked before compilation: Cargo could not fetch the pinned private `alloy-evm` revision; GitHub returned HTTP 401)*

Prompted by: @mattsse

Fixes ZONE-282