### PR TITLE
fix(rpc): expose TransferBlocked receipts to stakeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13729,6 +13729,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
+ "alloy-sol-types",
  "axum",
  "base64 0.22.1",
  "eyre",

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -915,7 +915,8 @@ where
         Box::pin(async move {
             let zone_tokens = self.zone_tokens().await?;
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
-            zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
+            let scope = zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
+            zone_rpc::filter::validate_receipt_query(&filter, scope)?;
             let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
                 .await
                 .map_err(internal)?;
@@ -928,7 +929,8 @@ where
         Box::pin(async move {
             let zone_tokens = self.zone_tokens().await?;
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
-            zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
+            let scope = zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
+            zone_rpc::filter::validate_live_filter(scope)?;
             let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
                 .await
                 .map_err(internal)?;
@@ -1061,7 +1063,8 @@ where
 
             let zone_tokens = self.zone_tokens().await?;
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
-            zone_rpc::filter::scope_filter_for_caller(&mut filter, &caller)?;
+            let scope = zone_rpc::filter::scope_filter_for_caller(&mut filter, &caller)?;
+            zone_rpc::filter::validate_live_filter(scope)?;
 
             let stream = provider
                 .canonical_state_stream()

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -915,8 +915,7 @@ where
         Box::pin(async move {
             let zone_tokens = self.zone_tokens().await?;
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
-            let scope = zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
-            zone_rpc::filter::validate_receipt_query(&filter, scope)?;
+            zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
             let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
                 .await
                 .map_err(internal)?;
@@ -929,8 +928,7 @@ where
         Box::pin(async move {
             let zone_tokens = self.zone_tokens().await?;
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
-            let scope = zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
-            zone_rpc::filter::validate_live_filter(scope)?;
+            zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
             let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
                 .await
                 .map_err(internal)?;
@@ -1063,8 +1061,7 @@ where
 
             let zone_tokens = self.zone_tokens().await?;
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
-            let scope = zone_rpc::filter::scope_filter_for_caller(&mut filter, &caller)?;
-            zone_rpc::filter::validate_live_filter(scope)?;
+            zone_rpc::filter::scope_filter_for_caller(&mut filter, &caller)?;
 
             let stream = provider
                 .canonical_state_stream()

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -28,6 +28,7 @@ alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rpc-types-eth.workspace = true
 alloy-signer.workspace = true
 alloy-signer-local.workspace = true
+alloy-sol-types.workspace = true
 
 # rpc server
 axum = { workspace = true, features = ["ws"] }

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -106,14 +106,6 @@ fn is_transfer_blocked_caller_eligible(log: &Log, caller: &Address) -> bool {
         return false;
     };
 
-    // Refuse malformed or inconsistent witnesses even if one field happens to name the caller.
-    if event.token != receipt.token
-        || event.blockedNonce != receipt.blockedNonce
-        || event.receiptVersion != receipt.version
-    {
-        return false;
-    }
-
     *caller == event.receiver
         || *caller == receipt.originator
         || (receipt.recoveryAuthority != Address::ZERO && *caller == receipt.recoveryAuthority)

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -7,7 +7,7 @@
 use alloy_consensus::TxReceipt;
 use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, B256, b256};
-use alloy_rpc_types_eth::{Filter, FilterSet, Log};
+use alloy_rpc_types_eth::{Filter, FilterBlockOption, FilterSet, Log};
 use alloy_sol_types::SolEvent;
 use tempo_alloy::rpc::TempoTransactionReceipt;
 use tempo_contracts::precompiles::{IReceivePolicyGuard, RECEIVE_POLICY_GUARD_ADDRESS};
@@ -47,6 +47,13 @@ pub const WHITELISTED_TOPICS: [B256; 6] = [
     TRANSFER_BLOCKED_TOPIC,
 ];
 
+const TOPIC1_CALLER_TOPICS: [B256; 5] = [
+    TRANSFER_TOPIC,
+    APPROVAL_TOPIC,
+    TRANSFER_WITH_MEMO_TOPIC,
+    MINT_TOPIC,
+    BURN_TOPIC,
+];
 const TOPIC2_CALLER_TOPICS: [B256; 4] = [
     TRANSFER_TOPIC,
     APPROVAL_TOPIC,
@@ -55,6 +62,19 @@ const TOPIC2_CALLER_TOPICS: [B256; 4] = [
 ];
 const CALLER_SCOPED_FILTER_ERROR: &str =
     "private log filter must include authenticated caller in topic1 or topic2";
+const RECEIPT_QUERY_RANGE_ERROR: &str = "private TransferBlocked discovery requires blockHash, matching numeric block bounds, or no block bounds";
+const RECEIPT_LIVE_FILTER_ERROR: &str =
+    "private TransferBlocked discovery without indexed receiver is only supported by eth_getLogs";
+
+/// Describes whether the backend filter is already tied to an indexed caller topic or still needs
+/// receipt decoding to authorize each result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallerFilterScope {
+    /// The backend query is correlated to an indexed caller topic.
+    Indexed,
+    /// The originator/recovery authority can only be identified after decoding each receipt.
+    ReceiptPostFilter,
+}
 
 /// Returns `true` if `caller` appears in an eligible indexed-topic position
 /// for the log's event type.
@@ -236,16 +256,27 @@ pub fn scope_filter(filter: &mut Filter) {
 /// The authenticated caller must normally appear in an eligible indexed topic before backend log
 /// retrieval. An explicit `TransferBlocked` filter is also allowed because the originator and
 /// recovery authority can only be authorized by decoding the returned receipt.
-pub fn scope_filter_for_caller(filter: &mut Filter, caller: &Address) -> Result<(), JsonRpcError> {
+pub fn scope_filter_for_caller(
+    filter: &mut Filter,
+    caller: &Address,
+) -> Result<CallerFilterScope, JsonRpcError> {
     scope_filter(filter);
     if filter.topics[0].len() == 1 && filter.topics[0].contains(&B256::ZERO) {
-        return Ok(());
+        return Ok(CallerFilterScope::Indexed);
     }
 
     let caller_word = B256::left_padding_from(caller.as_slice());
     if filter.topics[1].contains(&caller_word) {
-        filter.topics[1] = FilterSet::from(caller_word);
-        return Ok(());
+        let topic0 = filter.topics[0]
+            .iter()
+            .copied()
+            .filter(|topic| TOPIC1_CALLER_TOPICS.contains(topic))
+            .collect::<Vec<_>>();
+        if !topic0.is_empty() {
+            filter.topics[0] = FilterSet::from(topic0);
+            filter.topics[1] = FilterSet::from(caller_word);
+            return Ok(CallerFilterScope::Indexed);
+        }
     }
 
     if filter.topics[2].contains(&caller_word) {
@@ -257,7 +288,7 @@ pub fn scope_filter_for_caller(filter: &mut Filter, caller: &Address) -> Result<
         if !topic0.is_empty() {
             filter.topics[0] = FilterSet::from(topic0);
             filter.topics[2] = FilterSet::from(caller_word);
-            return Ok(());
+            return Ok(CallerFilterScope::Indexed);
         }
     }
 
@@ -265,10 +296,63 @@ pub fn scope_filter_for_caller(filter: &mut Filter, caller: &Address) -> Result<
     // Permit an explicitly TransferBlocked-only query and enforce stakeholder access after the
     // backend returns the logs by decoding each receipt in `is_log_visible`.
     if filter.topics[0].len() == 1 && filter.topics[0].contains(&TRANSFER_BLOCKED_TOPIC) {
-        return Ok(());
+        if filter.address.contains(&RECEIVE_POLICY_GUARD_ADDRESS) {
+            filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
+            return Ok(CallerFilterScope::ReceiptPostFilter);
+        }
+
+        // An explicitly different allowed address cannot emit the canonical guard event.
+        filter.topics[0] = FilterSet::from(B256::ZERO);
+        return Ok(CallerFilterScope::Indexed);
     }
 
     Err(JsonRpcError::invalid_params(CALLER_SCOPED_FILTER_ERROR))
+}
+
+/// Bounds one-shot queries that require receipt post-filtering to a single block.
+///
+/// Reth applies result caps before the zone's stakeholder authorization. Keeping the raw scan to
+/// one block prevents unrelated historical activity from exhausting the cap or making one request
+/// traverse the global `TransferBlocked` history.
+pub fn validate_receipt_query(
+    filter: &Filter,
+    scope: CallerFilterScope,
+) -> Result<(), JsonRpcError> {
+    if scope == CallerFilterScope::Indexed {
+        return Ok(());
+    }
+
+    let single_block = match filter.block_option {
+        FilterBlockOption::AtBlockHash(_) => true,
+        FilterBlockOption::Range {
+            from_block: None,
+            to_block: None,
+        } => true,
+        FilterBlockOption::Range {
+            from_block: Some(from),
+            to_block: Some(to),
+        } => from
+            .as_number()
+            .zip(to.as_number())
+            .is_some_and(|(from, to)| from == to),
+        FilterBlockOption::Range { .. } => false,
+    };
+
+    if single_block {
+        Ok(())
+    } else {
+        Err(JsonRpcError::invalid_params(RECEIPT_QUERY_RANGE_ERROR))
+    }
+}
+
+/// Rejects installed filters and subscriptions that would scan global guard events before receipt
+/// authorization. Indexed receiver filters remain supported on every log endpoint.
+pub fn validate_live_filter(scope: CallerFilterScope) -> Result<(), JsonRpcError> {
+    if scope == CallerFilterScope::Indexed {
+        Ok(())
+    } else {
+        Err(JsonRpcError::invalid_params(RECEIPT_LIVE_FILTER_ERROR))
+    }
 }
 
 #[cfg(test)]
@@ -276,7 +360,7 @@ mod tests {
     use super::*;
     use alloy_consensus::ReceiptWithBloom;
     use alloy_primitives::{Address, Bytes, LogData, TxHash, U256, address, keccak256};
-    use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionReceipt};
     use alloy_sol_types::SolValue;
     use tempo_alloy::rpc::TempoTransactionReceipt;
     use tempo_primitives::{TempoReceipt, TempoTxType};
@@ -923,9 +1007,28 @@ mod tests {
 
         scope_filter_for_caller(&mut filter, &caller).unwrap();
 
-        assert_eq!(filter.topics[0].len(), WHITELISTED_TOPICS.len());
+        assert_eq!(
+            filter.topics[0],
+            FilterSet::from(TOPIC1_CALLER_TOPICS.to_vec())
+        );
         assert_eq!(filter.topics[1], FilterSet::from(caller_topic));
         assert_eq!(filter.topics[2], FilterSet::from(other_topic));
+    }
+
+    #[test]
+    fn transfer_blocked_topic1_is_not_treated_as_caller_indexed() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter {
+            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
+            ..Default::default()
+        };
+        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+        filter.topics[1] = FilterSet::from(caller_word(&caller));
+
+        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
+        validate_live_filter(scope).unwrap_err();
     }
 
     #[test]
@@ -953,8 +1056,9 @@ mod tests {
         filter.topics[0] = FilterSet::from(vec![TRANSFER_TOPIC, TRANSFER_BLOCKED_TOPIC]);
         filter.topics[2] = FilterSet::from(caller_word(&caller));
 
-        scope_filter_for_caller(&mut filter, &caller).unwrap();
+        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
 
+        assert_eq!(scope, CallerFilterScope::Indexed);
         assert!(filter.topics[0].contains(&TRANSFER_TOPIC));
         assert!(filter.topics[0].contains(&TRANSFER_BLOCKED_TOPIC));
         assert_eq!(filter.topics[2], FilterSet::from(caller_word(&caller)));
@@ -965,10 +1069,16 @@ mod tests {
         let caller = address!("0x0000000000000000000000000000000000000001");
         let mut filter = Filter::default();
         filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+        scope_filter_addresses(&mut filter, &[]).unwrap();
 
-        scope_filter_for_caller(&mut filter, &caller).unwrap();
+        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
 
+        assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
         assert_eq!(filter.topics[0], FilterSet::from(TRANSFER_BLOCKED_TOPIC));
+        assert_eq!(
+            filter.address,
+            FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS)
+        );
     }
 
     #[test]
@@ -986,10 +1096,153 @@ mod tests {
         filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
 
         scope_filter_addresses(&mut filter, &[]).unwrap();
-        scope_filter_for_caller(&mut filter, &originator).unwrap();
+        let scope = scope_filter_for_caller(&mut filter, &originator).unwrap();
+        validate_receipt_query(&filter, scope).unwrap();
 
         assert_eq!(filter_logs(vec![log.clone()], &originator).len(), 1);
         assert!(filter_logs(vec![log], &outsider).is_empty());
+    }
+
+    #[test]
+    fn receipt_post_filter_rejects_multi_block_query() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default().select(10u64..=11u64);
+        filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
+        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+        scope_filter_addresses(&mut filter, &[]).unwrap();
+        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        let err = validate_receipt_query(&filter, scope).unwrap_err();
+
+        assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
+        assert_eq!(err.code, JsonRpcError::invalid_params("").code);
+        assert_eq!(err.message, RECEIPT_QUERY_RANGE_ERROR);
+    }
+
+    #[test]
+    fn receipt_post_filter_rejects_open_ended_query() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        for block_option in [
+            FilterBlockOption::default().with_from_block(10u64.into()),
+            FilterBlockOption::default().with_to_block(10u64.into()),
+        ] {
+            let mut filter = Filter {
+                block_option,
+                ..Default::default()
+            };
+            filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
+            filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+            scope_filter_addresses(&mut filter, &[]).unwrap();
+            let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+            let err = validate_receipt_query(&filter, scope).unwrap_err();
+
+            assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
+            assert_eq!(err.message, RECEIPT_QUERY_RANGE_ERROR);
+        }
+    }
+
+    #[test]
+    fn receipt_post_filter_allows_exact_block_queries() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        for block_option in [
+            FilterBlockOption::from(10u64),
+            FilterBlockOption::AtBlockHash(B256::with_last_byte(1)),
+            FilterBlockOption::default(),
+        ] {
+            let mut filter = Filter {
+                block_option,
+                ..Default::default()
+            };
+            filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
+            filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+            scope_filter_addresses(&mut filter, &[]).unwrap();
+            let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+            validate_receipt_query(&filter, scope).unwrap();
+            assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
+        }
+    }
+
+    #[test]
+    fn receipt_post_filter_rejects_dynamic_block_tags() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        for tag in [
+            BlockNumberOrTag::Earliest,
+            BlockNumberOrTag::Pending,
+            BlockNumberOrTag::Latest,
+            BlockNumberOrTag::Safe,
+            BlockNumberOrTag::Finalized,
+        ] {
+            let mut filter = Filter {
+                block_option: FilterBlockOption::Range {
+                    from_block: Some(tag),
+                    to_block: Some(tag),
+                },
+                address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
+                ..Default::default()
+            };
+            filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+            scope_filter_addresses(&mut filter, &[]).unwrap();
+            let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+            let err = validate_receipt_query(&filter, scope).unwrap_err();
+
+            assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
+            assert_eq!(err.message, RECEIPT_QUERY_RANGE_ERROR);
+        }
+    }
+
+    #[test]
+    fn receipt_post_filter_rejected_for_installed_and_live_filters() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter {
+            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
+            ..Default::default()
+        };
+        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+        scope_filter_addresses(&mut filter, &[]).unwrap();
+        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        let err = validate_live_filter(scope).unwrap_err();
+
+        assert_eq!(err.code, JsonRpcError::invalid_params("").code);
+        assert_eq!(err.message, RECEIPT_LIVE_FILTER_ERROR);
+    }
+
+    #[test]
+    fn indexed_receiver_filter_remains_available_for_broad_and_live_queries() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default().select(0u64..=1_000_000u64);
+        filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
+        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+        filter.topics[2] = FilterSet::from(caller_word(&caller));
+        scope_filter_addresses(&mut filter, &[]).unwrap();
+        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        assert_eq!(scope, CallerFilterScope::Indexed);
+        validate_receipt_query(&filter, scope).unwrap();
+        validate_live_filter(scope).unwrap();
+    }
+
+    #[test]
+    fn transfer_blocked_at_non_guard_address_is_scoped_to_no_match() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let zone_token = address!("0x20c0000000000000000000000000000000000001");
+        let mut filter = Filter {
+            address: FilterSet::from(zone_token),
+            ..Default::default()
+        };
+        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+        scope_filter_addresses(&mut filter, &[zone_token]).unwrap();
+
+        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        assert_eq!(scope, CallerFilterScope::Indexed);
+        assert_eq!(filter.address, FilterSet::from(zone_token));
+        assert_eq!(filter.topics[0], FilterSet::from(B256::ZERO));
+        validate_receipt_query(&filter, scope).unwrap();
+        validate_live_filter(scope).unwrap();
     }
 
     #[test]

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -1,14 +1,16 @@
 //! Privacy-enforced log filtering for the zone's redacted RPC.
 //!
-//! Only whitelisted TIP-20 event logs are returned to callers, and only when
-//! the caller's address appears in an eligible indexed topic position for that
-//! event type. This prevents users from observing other users' token activity.
+//! Only whitelisted TIP-20 and receipt-recovery event logs are returned to callers. A caller must
+//! appear in an eligible indexed topic or, for `TransferBlocked`, be a stakeholder encoded in the
+//! claim receipt. This prevents users from observing other users' token activity.
 
 use alloy_consensus::TxReceipt;
 use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, B256, b256};
 use alloy_rpc_types_eth::{Filter, FilterSet, Log};
+use alloy_sol_types::SolEvent;
 use tempo_alloy::rpc::TempoTransactionReceipt;
+use tempo_contracts::precompiles::{IReceivePolicyGuard, RECEIVE_POLICY_GUARD_ADDRESS};
 
 use crate::types::JsonRpcError;
 
@@ -32,16 +34,25 @@ pub const MINT_TOPIC: B256 =
 pub const BURN_TOPIC: B256 =
     b256!("0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5");
 
-/// All whitelisted TIP-20 event topic hashes.
-pub const WHITELISTED_TOPICS: [B256; 5] = [
+/// `TransferBlocked(address,address,uint64,uint256,uint8,bytes)`.
+pub const TRANSFER_BLOCKED_TOPIC: B256 = IReceivePolicyGuard::TransferBlocked::SIGNATURE_HASH;
+
+/// All event topic hashes exposed by the redacted RPC.
+pub const WHITELISTED_TOPICS: [B256; 6] = [
     TRANSFER_TOPIC,
     APPROVAL_TOPIC,
     TRANSFER_WITH_MEMO_TOPIC,
     MINT_TOPIC,
     BURN_TOPIC,
+    TRANSFER_BLOCKED_TOPIC,
 ];
 
-const TWO_PARTY_TOPICS: [B256; 3] = [TRANSFER_TOPIC, APPROVAL_TOPIC, TRANSFER_WITH_MEMO_TOPIC];
+const TOPIC2_CALLER_TOPICS: [B256; 4] = [
+    TRANSFER_TOPIC,
+    APPROVAL_TOPIC,
+    TRANSFER_WITH_MEMO_TOPIC,
+    TRANSFER_BLOCKED_TOPIC,
+];
 const CALLER_SCOPED_FILTER_ERROR: &str =
     "private log filter must include authenticated caller in topic1 or topic2";
 
@@ -53,6 +64,8 @@ const CALLER_SCOPED_FILTER_ERROR: &str =
 /// - **Approval**: topic1 (owner) or topic2 (spender)
 /// - **Mint**: topic1 (to)
 /// - **Burn**: topic1 (from)
+/// - **TransferBlocked**: the indexed receiver, or the originator/recovery authority encoded in
+///   the receipt
 pub fn is_caller_eligible(log: &Log, caller: &Address) -> bool {
     let topics = log.topics();
     let topic0 = match topics.first() {
@@ -61,6 +74,10 @@ pub fn is_caller_eligible(log: &Log, caller: &Address) -> bool {
     };
 
     let caller_word = B256::left_padding_from(caller.as_slice());
+
+    if *topic0 == TRANSFER_BLOCKED_TOPIC {
+        return is_transfer_blocked_caller_eligible(log, caller);
+    }
 
     if *topic0 == TRANSFER_TOPIC || *topic0 == APPROVAL_TOPIC || *topic0 == TRANSFER_WITH_MEMO_TOPIC
     {
@@ -72,6 +89,34 @@ pub fn is_caller_eligible(log: &Log, caller: &Address) -> bool {
     } else {
         false
     }
+}
+
+/// Returns whether the authenticated caller is a stakeholder in a receipt-bearing
+/// `ReceivePolicyGuard.TransferBlocked` log.
+fn is_transfer_blocked_caller_eligible(log: &Log, caller: &Address) -> bool {
+    if log.address() != RECEIVE_POLICY_GUARD_ADDRESS {
+        return false;
+    }
+
+    let Ok(event) = IReceivePolicyGuard::TransferBlocked::decode_log(&log.inner) else {
+        return false;
+    };
+    let event = event.data;
+    let Ok(receipt) = IReceivePolicyGuard::ClaimReceiptV1::try_from(event.receipt) else {
+        return false;
+    };
+
+    // Refuse malformed or inconsistent witnesses even if one field happens to name the caller.
+    if event.token != receipt.token
+        || event.blockedNonce != receipt.blockedNonce
+        || event.receiptVersion != receipt.version
+    {
+        return false;
+    }
+
+    *caller == event.receiver
+        || *caller == receipt.originator
+        || (receipt.recoveryAuthority != Address::ZERO && *caller == receipt.recoveryAuthority)
 }
 
 /// Filters logs to only those the caller is allowed to see.
@@ -131,7 +176,7 @@ pub fn filter_receipt_logs(mut receipt: TempoTransactionReceipt) -> TempoTransac
     receipt
 }
 
-/// Scopes a user-supplied filter to only match enabled zone token addresses.
+/// Scopes a user-supplied filter to enabled zone tokens and the receive-policy guard.
 pub fn scope_filter_addresses(
     filter: &mut Filter,
     zone_tokens: &[Address],
@@ -139,13 +184,15 @@ pub fn scope_filter_addresses(
     let requested_addresses: Vec<Address> = filter.address.iter().copied().collect();
 
     if requested_addresses.is_empty() {
-        filter.address = FilterSet::from(zone_tokens.to_vec());
+        let mut allowed_addresses = zone_tokens.to_vec();
+        allowed_addresses.push(RECEIVE_POLICY_GUARD_ADDRESS);
+        filter.address = FilterSet::from(allowed_addresses);
         return Ok(());
     }
 
     if requested_addresses
         .iter()
-        .all(|address| zone_tokens.contains(address))
+        .all(|address| zone_tokens.contains(address) || *address == RECEIVE_POLICY_GUARD_ADDRESS)
     {
         Ok(())
     } else {
@@ -153,7 +200,7 @@ pub fn scope_filter_addresses(
     }
 }
 
-/// Scopes a user-supplied filter to only match whitelisted TIP-20 event topics.
+/// Scopes a user-supplied filter to only match whitelisted event topics.
 ///
 /// Intersects the user's requested topic0 with [`WHITELISTED_TOPICS`].
 /// If the user omitted topic0, restricts to the whitelisted set.
@@ -184,9 +231,11 @@ pub fn scope_filter(filter: &mut Filter) {
     }
 }
 
-/// Scopes a user-supplied filter to whitelisted event topics and requires the
-/// authenticated caller to appear in an eligible indexed topic before backend
-/// log retrieval.
+/// Scopes a user-supplied filter to whitelisted event topics.
+///
+/// The authenticated caller must normally appear in an eligible indexed topic before backend log
+/// retrieval. An explicit `TransferBlocked` filter is also allowed because the originator and
+/// recovery authority can only be authorized by decoding the returned receipt.
 pub fn scope_filter_for_caller(filter: &mut Filter, caller: &Address) -> Result<(), JsonRpcError> {
     scope_filter(filter);
     if filter.topics[0].len() == 1 && filter.topics[0].contains(&B256::ZERO) {
@@ -203,13 +252,20 @@ pub fn scope_filter_for_caller(filter: &mut Filter, caller: &Address) -> Result<
         let topic0 = filter.topics[0]
             .iter()
             .copied()
-            .filter(|topic| TWO_PARTY_TOPICS.contains(topic))
+            .filter(|topic| TOPIC2_CALLER_TOPICS.contains(topic))
             .collect::<Vec<_>>();
         if !topic0.is_empty() {
             filter.topics[0] = FilterSet::from(topic0);
             filter.topics[2] = FilterSet::from(caller_word);
             return Ok(());
         }
+    }
+
+    // The originator and recovery authority are encoded in the receipt rather than indexed.
+    // Permit an explicitly TransferBlocked-only query and enforce stakeholder access after the
+    // backend returns the logs by decoding each receipt in `is_log_visible`.
+    if filter.topics[0].len() == 1 && filter.topics[0].contains(&TRANSFER_BLOCKED_TOPIC) {
+        return Ok(());
     }
 
     Err(JsonRpcError::invalid_params(CALLER_SCOPED_FILTER_ERROR))
@@ -219,8 +275,9 @@ pub fn scope_filter_for_caller(filter: &mut Filter, caller: &Address) -> Result<
 mod tests {
     use super::*;
     use alloy_consensus::ReceiptWithBloom;
-    use alloy_primitives::{Address, Bytes, LogData, TxHash, address, keccak256};
+    use alloy_primitives::{Address, Bytes, LogData, TxHash, U256, address, keccak256};
     use alloy_rpc_types_eth::TransactionReceipt;
+    use alloy_sol_types::SolValue;
     use tempo_alloy::rpc::TempoTransactionReceipt;
     use tempo_primitives::{TempoReceipt, TempoTxType};
 
@@ -249,6 +306,48 @@ mod tests {
         log.transaction_index = Some(42);
         log.log_index = Some(log_index);
         log
+    }
+
+    fn make_transfer_blocked_log(
+        emitter: Address,
+        receiver: Address,
+        originator: Address,
+        recovery_authority: Address,
+    ) -> Log {
+        let token = address!("0x20c0000000000000000000000000000000000001");
+        let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
+            token,
+            recovery_authority,
+            originator,
+            receiver,
+            1_234,
+            42,
+            1,
+            IReceivePolicyGuard::InboundKind::TRANSFER,
+            B256::ZERO,
+        );
+        let event = IReceivePolicyGuard::TransferBlocked {
+            token,
+            receiver,
+            blockedNonce: receipt.blockedNonce,
+            amount: U256::from(100),
+            receiptVersion: receipt.version,
+            receipt: receipt.abi_encode().into(),
+        };
+
+        Log {
+            inner: alloy_primitives::Log {
+                address: emitter,
+                data: event.encode_log_data(),
+            },
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        }
     }
 
     fn caller_word(addr: &Address) -> B256 {
@@ -303,6 +402,10 @@ mod tests {
         );
         assert_eq!(MINT_TOPIC, keccak256(b"Mint(address,uint256)"));
         assert_eq!(BURN_TOPIC, keccak256(b"Burn(address,uint256)"));
+        assert_eq!(
+            TRANSFER_BLOCKED_TOPIC,
+            keccak256(b"TransferBlocked(address,address,uint64,uint256,uint8,bytes)")
+        );
     }
 
     // ---------------------------------------------------------------
@@ -459,6 +562,66 @@ mod tests {
         let other = address!("0x0000000000000000000000000000000000000002");
         let log = make_log(Address::ZERO, vec![BURN_TOPIC, caller_word(&other)]);
         assert!(!is_caller_eligible(&log, &caller));
+    }
+
+    // ---------------------------------------------------------------
+    // is_caller_eligible — TransferBlocked
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn transfer_blocked_visible_to_receipt_stakeholders_only() {
+        let receiver = address!("0x0000000000000000000000000000000000000001");
+        let originator = address!("0x0000000000000000000000000000000000000002");
+        let recovery = address!("0x0000000000000000000000000000000000000003");
+        let outsider = address!("0x0000000000000000000000000000000000000004");
+        let log =
+            make_transfer_blocked_log(RECEIVE_POLICY_GUARD_ADDRESS, receiver, originator, recovery);
+
+        assert!(is_log_visible(&log, &receiver));
+        assert!(is_log_visible(&log, &originator));
+        assert!(is_log_visible(&log, &recovery));
+        assert!(!is_log_visible(&log, &outsider));
+    }
+
+    #[test]
+    fn transfer_blocked_rejected_from_wrong_emitter() {
+        let receiver = address!("0x0000000000000000000000000000000000000001");
+        let log = make_transfer_blocked_log(
+            address!("0x00000000000000000000000000000000000000ff"),
+            receiver,
+            Address::ZERO,
+            Address::ZERO,
+        );
+
+        assert!(!is_log_visible(&log, &receiver));
+    }
+
+    #[test]
+    fn transfer_blocked_rejected_with_malformed_receipt() {
+        let receiver = address!("0x0000000000000000000000000000000000000001");
+        let event = IReceivePolicyGuard::TransferBlocked {
+            token: address!("0x20c0000000000000000000000000000000000001"),
+            receiver,
+            blockedNonce: 42,
+            amount: U256::from(100),
+            receiptVersion: 1,
+            receipt: Bytes::from_static(b"not a claim receipt"),
+        };
+        let log = Log {
+            inner: alloy_primitives::Log {
+                address: RECEIVE_POLICY_GUARD_ADDRESS,
+                data: event.encode_log_data(),
+            },
+            block_hash: None,
+            block_number: None,
+            block_timestamp: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            removed: false,
+        };
+
+        assert!(!is_log_visible(&log, &receiver));
     }
 
     // ---------------------------------------------------------------
@@ -686,6 +849,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn filter_receipt_logs_keeps_transfer_blocked_for_originator() {
+        let receiver = address!("0x0000000000000000000000000000000000000001");
+        let originator = address!("0x0000000000000000000000000000000000000002");
+        let recovery = address!("0x0000000000000000000000000000000000000003");
+        let blocked =
+            make_transfer_blocked_log(RECEIVE_POLICY_GUARD_ADDRESS, receiver, originator, recovery);
+
+        let filtered = filter_receipt_logs(make_receipt(originator, vec![blocked]));
+
+        assert_eq!(filtered.inner.logs().len(), 1);
+        assert_eq!(
+            filtered.inner.logs()[0].topic0(),
+            Some(&TRANSFER_BLOCKED_TOPIC)
+        );
+    }
+
     // ---------------------------------------------------------------
     // scope_filter
     // ---------------------------------------------------------------
@@ -767,6 +947,52 @@ mod tests {
     }
 
     #[test]
+    fn scope_filter_for_caller_scopes_transfer_blocked_to_indexed_receiver() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default();
+        filter.topics[0] = FilterSet::from(vec![TRANSFER_TOPIC, TRANSFER_BLOCKED_TOPIC]);
+        filter.topics[2] = FilterSet::from(caller_word(&caller));
+
+        scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        assert!(filter.topics[0].contains(&TRANSFER_TOPIC));
+        assert!(filter.topics[0].contains(&TRANSFER_BLOCKED_TOPIC));
+        assert_eq!(filter.topics[2], FilterSet::from(caller_word(&caller)));
+    }
+
+    #[test]
+    fn scope_filter_for_caller_allows_receipt_scoped_transfer_blocked_query() {
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut filter = Filter::default();
+        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+
+        scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        assert_eq!(filter.topics[0], FilterSet::from(TRANSFER_BLOCKED_TOPIC));
+    }
+
+    #[test]
+    fn transfer_blocked_query_returns_only_authorized_receipts() {
+        let receiver = address!("0x0000000000000000000000000000000000000001");
+        let originator = address!("0x0000000000000000000000000000000000000002");
+        let recovery = address!("0x0000000000000000000000000000000000000003");
+        let outsider = address!("0x0000000000000000000000000000000000000004");
+        let log =
+            make_transfer_blocked_log(RECEIVE_POLICY_GUARD_ADDRESS, receiver, originator, recovery);
+        let mut filter = Filter {
+            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
+            ..Default::default()
+        };
+        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
+
+        scope_filter_addresses(&mut filter, &[]).unwrap();
+        scope_filter_for_caller(&mut filter, &originator).unwrap();
+
+        assert_eq!(filter_logs(vec![log.clone()], &originator).len(), 1);
+        assert!(filter_logs(vec![log], &outsider).is_empty());
+    }
+
+    #[test]
     fn scope_filter_for_caller_rejects_wrong_caller() {
         let caller = address!("0x0000000000000000000000000000000000000001");
         let a = address!("0x0000000000000000000000000000000000000002");
@@ -805,7 +1031,8 @@ mod tests {
 
         assert!(filter.address.contains(&token_a));
         assert!(filter.address.contains(&token_b));
-        assert_eq!(filter.address.len(), 2);
+        assert!(filter.address.contains(&RECEIVE_POLICY_GUARD_ADDRESS));
+        assert_eq!(filter.address.len(), 3);
     }
 
     #[test]
@@ -819,6 +1046,21 @@ mod tests {
         scope_filter_addresses(&mut filter, &[token]).unwrap();
 
         assert_eq!(filter.address, FilterSet::from(token));
+    }
+
+    #[test]
+    fn scope_filter_addresses_allows_receive_policy_guard() {
+        let mut filter = Filter {
+            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
+            ..Default::default()
+        };
+
+        scope_filter_addresses(&mut filter, &[]).unwrap();
+
+        assert_eq!(
+            filter.address,
+            FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS)
+        );
     }
 
     #[test]

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -7,7 +7,7 @@
 use alloy_consensus::TxReceipt;
 use alloy_network::ReceiptResponse;
 use alloy_primitives::{Address, B256, b256};
-use alloy_rpc_types_eth::{Filter, FilterBlockOption, FilterSet, Log};
+use alloy_rpc_types_eth::{Filter, FilterSet, Log};
 use alloy_sol_types::SolEvent;
 use tempo_alloy::rpc::TempoTransactionReceipt;
 use tempo_contracts::precompiles::{IReceivePolicyGuard, RECEIVE_POLICY_GUARD_ADDRESS};
@@ -47,14 +47,7 @@ pub const WHITELISTED_TOPICS: [B256; 6] = [
     TRANSFER_BLOCKED_TOPIC,
 ];
 
-const TOPIC1_CALLER_TOPICS: [B256; 5] = [
-    TRANSFER_TOPIC,
-    APPROVAL_TOPIC,
-    TRANSFER_WITH_MEMO_TOPIC,
-    MINT_TOPIC,
-    BURN_TOPIC,
-];
-const TOPIC2_CALLER_TOPICS: [B256; 4] = [
+const TWO_PARTY_TOPICS: [B256; 4] = [
     TRANSFER_TOPIC,
     APPROVAL_TOPIC,
     TRANSFER_WITH_MEMO_TOPIC,
@@ -62,19 +55,6 @@ const TOPIC2_CALLER_TOPICS: [B256; 4] = [
 ];
 const CALLER_SCOPED_FILTER_ERROR: &str =
     "private log filter must include authenticated caller in topic1 or topic2";
-const RECEIPT_QUERY_RANGE_ERROR: &str = "private TransferBlocked discovery requires blockHash, matching numeric block bounds, or no block bounds";
-const RECEIPT_LIVE_FILTER_ERROR: &str =
-    "private TransferBlocked discovery without indexed receiver is only supported by eth_getLogs";
-
-/// Describes whether the backend filter is already tied to an indexed caller topic or still needs
-/// receipt decoding to authorize each result.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CallerFilterScope {
-    /// The backend query is correlated to an indexed caller topic.
-    Indexed,
-    /// The originator/recovery authority can only be identified after decoding each receipt.
-    ReceiptPostFilter,
-}
 
 /// Returns `true` if `caller` appears in an eligible indexed-topic position
 /// for the log's event type.
@@ -251,18 +231,13 @@ pub fn scope_filter(filter: &mut Filter) {
     }
 }
 
-/// Scopes a user-supplied filter to whitelisted event topics.
-///
-/// The authenticated caller must normally appear in an eligible indexed topic before backend log
-/// retrieval. An explicit `TransferBlocked` filter is also allowed because the originator and
-/// recovery authority can only be authorized by decoding the returned receipt.
-pub fn scope_filter_for_caller(
-    filter: &mut Filter,
-    caller: &Address,
-) -> Result<CallerFilterScope, JsonRpcError> {
+/// Scopes a user-supplied filter to whitelisted event topics and requires the
+/// authenticated caller to appear in an eligible indexed topic before backend
+/// log retrieval.
+pub fn scope_filter_for_caller(filter: &mut Filter, caller: &Address) -> Result<(), JsonRpcError> {
     scope_filter(filter);
     if filter.topics[0].len() == 1 && filter.topics[0].contains(&B256::ZERO) {
-        return Ok(CallerFilterScope::Indexed);
+        return Ok(());
     }
 
     let caller_word = B256::left_padding_from(caller.as_slice());
@@ -270,12 +245,12 @@ pub fn scope_filter_for_caller(
         let topic0 = filter.topics[0]
             .iter()
             .copied()
-            .filter(|topic| TOPIC1_CALLER_TOPICS.contains(topic))
+            .filter(|topic| *topic != TRANSFER_BLOCKED_TOPIC)
             .collect::<Vec<_>>();
         if !topic0.is_empty() {
             filter.topics[0] = FilterSet::from(topic0);
             filter.topics[1] = FilterSet::from(caller_word);
-            return Ok(CallerFilterScope::Indexed);
+            return Ok(());
         }
     }
 
@@ -283,76 +258,16 @@ pub fn scope_filter_for_caller(
         let topic0 = filter.topics[0]
             .iter()
             .copied()
-            .filter(|topic| TOPIC2_CALLER_TOPICS.contains(topic))
+            .filter(|topic| TWO_PARTY_TOPICS.contains(topic))
             .collect::<Vec<_>>();
         if !topic0.is_empty() {
             filter.topics[0] = FilterSet::from(topic0);
             filter.topics[2] = FilterSet::from(caller_word);
-            return Ok(CallerFilterScope::Indexed);
+            return Ok(());
         }
-    }
-
-    // The originator and recovery authority are encoded in the receipt rather than indexed.
-    // Permit an explicitly TransferBlocked-only query and enforce stakeholder access after the
-    // backend returns the logs by decoding each receipt in `is_log_visible`.
-    if filter.topics[0].len() == 1 && filter.topics[0].contains(&TRANSFER_BLOCKED_TOPIC) {
-        if filter.address.contains(&RECEIVE_POLICY_GUARD_ADDRESS) {
-            filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
-            return Ok(CallerFilterScope::ReceiptPostFilter);
-        }
-
-        // An explicitly different allowed address cannot emit the canonical guard event.
-        filter.topics[0] = FilterSet::from(B256::ZERO);
-        return Ok(CallerFilterScope::Indexed);
     }
 
     Err(JsonRpcError::invalid_params(CALLER_SCOPED_FILTER_ERROR))
-}
-
-/// Bounds one-shot queries that require receipt post-filtering to a single block.
-///
-/// Reth applies result caps before the zone's stakeholder authorization. Keeping the raw scan to
-/// one block prevents unrelated historical activity from exhausting the cap or making one request
-/// traverse the global `TransferBlocked` history.
-pub fn validate_receipt_query(
-    filter: &Filter,
-    scope: CallerFilterScope,
-) -> Result<(), JsonRpcError> {
-    if scope == CallerFilterScope::Indexed {
-        return Ok(());
-    }
-
-    let single_block = match filter.block_option {
-        FilterBlockOption::AtBlockHash(_) => true,
-        FilterBlockOption::Range {
-            from_block: None,
-            to_block: None,
-        } => true,
-        FilterBlockOption::Range {
-            from_block: Some(from),
-            to_block: Some(to),
-        } => from
-            .as_number()
-            .zip(to.as_number())
-            .is_some_and(|(from, to)| from == to),
-        FilterBlockOption::Range { .. } => false,
-    };
-
-    if single_block {
-        Ok(())
-    } else {
-        Err(JsonRpcError::invalid_params(RECEIPT_QUERY_RANGE_ERROR))
-    }
-}
-
-/// Rejects installed filters and subscriptions that would scan global guard events before receipt
-/// authorization. Indexed receiver filters remain supported on every log endpoint.
-pub fn validate_live_filter(scope: CallerFilterScope) -> Result<(), JsonRpcError> {
-    if scope == CallerFilterScope::Indexed {
-        Ok(())
-    } else {
-        Err(JsonRpcError::invalid_params(RECEIPT_LIVE_FILTER_ERROR))
-    }
 }
 
 #[cfg(test)]
@@ -360,7 +275,7 @@ mod tests {
     use super::*;
     use alloy_consensus::ReceiptWithBloom;
     use alloy_primitives::{Address, Bytes, LogData, TxHash, U256, address, keccak256};
-    use alloy_rpc_types_eth::{BlockNumberOrTag, TransactionReceipt};
+    use alloy_rpc_types_eth::TransactionReceipt;
     use alloy_sol_types::SolValue;
     use tempo_alloy::rpc::TempoTransactionReceipt;
     use tempo_primitives::{TempoReceipt, TempoTxType};
@@ -418,20 +333,9 @@ mod tests {
             receiptVersion: receipt.version,
             receipt: receipt.abi_encode().into(),
         };
-
-        Log {
-            inner: alloy_primitives::Log {
-                address: emitter,
-                data: event.encode_log_data(),
-            },
-            block_hash: None,
-            block_number: None,
-            block_timestamp: None,
-            transaction_hash: None,
-            transaction_index: None,
-            log_index: None,
-            removed: false,
-        }
+        let mut log = make_log(emitter, Vec::new());
+        log.inner.data = event.encode_log_data();
+        log
     }
 
     fn caller_word(addr: &Address) -> B256 {
@@ -653,7 +557,7 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    fn transfer_blocked_visible_to_receipt_stakeholders_only() {
+    fn transfer_blocked_visibility_is_receipt_scoped() {
         let receiver = address!("0x0000000000000000000000000000000000000001");
         let originator = address!("0x0000000000000000000000000000000000000002");
         let recovery = address!("0x0000000000000000000000000000000000000003");
@@ -665,47 +569,17 @@ mod tests {
         assert!(is_log_visible(&log, &originator));
         assert!(is_log_visible(&log, &recovery));
         assert!(!is_log_visible(&log, &outsider));
-    }
 
-    #[test]
-    fn transfer_blocked_rejected_from_wrong_emitter() {
-        let receiver = address!("0x0000000000000000000000000000000000000001");
-        let log = make_transfer_blocked_log(
-            address!("0x00000000000000000000000000000000000000ff"),
-            receiver,
-            Address::ZERO,
-            Address::ZERO,
-        );
+        let filtered = filter_receipt_logs(make_receipt(originator, vec![log.clone()]));
+        assert_eq!(filtered.inner.logs().len(), 1);
 
-        assert!(!is_log_visible(&log, &receiver));
-    }
+        let mut spoofed = log.clone();
+        spoofed.inner.address = Address::ZERO;
+        assert!(!is_log_visible(&spoofed, &receiver));
 
-    #[test]
-    fn transfer_blocked_rejected_with_malformed_receipt() {
-        let receiver = address!("0x0000000000000000000000000000000000000001");
-        let event = IReceivePolicyGuard::TransferBlocked {
-            token: address!("0x20c0000000000000000000000000000000000001"),
-            receiver,
-            blockedNonce: 42,
-            amount: U256::from(100),
-            receiptVersion: 1,
-            receipt: Bytes::from_static(b"not a claim receipt"),
-        };
-        let log = Log {
-            inner: alloy_primitives::Log {
-                address: RECEIVE_POLICY_GUARD_ADDRESS,
-                data: event.encode_log_data(),
-            },
-            block_hash: None,
-            block_number: None,
-            block_timestamp: None,
-            transaction_hash: None,
-            transaction_index: None,
-            log_index: None,
-            removed: false,
-        };
-
-        assert!(!is_log_visible(&log, &receiver));
+        let mut malformed = log;
+        malformed.inner.data.data = Bytes::new();
+        assert!(!is_log_visible(&malformed, &receiver));
     }
 
     // ---------------------------------------------------------------
@@ -933,23 +807,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn filter_receipt_logs_keeps_transfer_blocked_for_originator() {
-        let receiver = address!("0x0000000000000000000000000000000000000001");
-        let originator = address!("0x0000000000000000000000000000000000000002");
-        let recovery = address!("0x0000000000000000000000000000000000000003");
-        let blocked =
-            make_transfer_blocked_log(RECEIVE_POLICY_GUARD_ADDRESS, receiver, originator, recovery);
-
-        let filtered = filter_receipt_logs(make_receipt(originator, vec![blocked]));
-
-        assert_eq!(filtered.inner.logs().len(), 1);
-        assert_eq!(
-            filtered.inner.logs()[0].topic0(),
-            Some(&TRANSFER_BLOCKED_TOPIC)
-        );
-    }
-
     // ---------------------------------------------------------------
     // scope_filter
     // ---------------------------------------------------------------
@@ -1007,28 +864,10 @@ mod tests {
 
         scope_filter_for_caller(&mut filter, &caller).unwrap();
 
-        assert_eq!(
-            filter.topics[0],
-            FilterSet::from(TOPIC1_CALLER_TOPICS.to_vec())
-        );
+        assert!(!filter.topics[0].contains(&TRANSFER_BLOCKED_TOPIC));
+        assert_eq!(filter.topics[0].len(), WHITELISTED_TOPICS.len() - 1);
         assert_eq!(filter.topics[1], FilterSet::from(caller_topic));
         assert_eq!(filter.topics[2], FilterSet::from(other_topic));
-    }
-
-    #[test]
-    fn transfer_blocked_topic1_is_not_treated_as_caller_indexed() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter {
-            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
-            ..Default::default()
-        };
-        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-        filter.topics[1] = FilterSet::from(caller_word(&caller));
-
-        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-        assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
-        validate_live_filter(scope).unwrap_err();
     }
 
     #[test]
@@ -1038,211 +877,19 @@ mod tests {
         let caller_topic = caller_word(&caller);
         let other_topic = caller_word(&other);
         let mut filter = Filter::default();
-        filter.topics[0] = FilterSet::from(vec![TRANSFER_TOPIC, MINT_TOPIC]);
+        filter.topics[0] =
+            FilterSet::from(vec![TRANSFER_TOPIC, TRANSFER_BLOCKED_TOPIC, MINT_TOPIC]);
         filter.topics[1] = FilterSet::from(other_topic);
         filter.topics[2] = FilterSet::from(vec![caller_topic, caller_word(&other)]);
 
         scope_filter_for_caller(&mut filter, &caller).unwrap();
 
-        assert_eq!(filter.topics[0], FilterSet::from(TRANSFER_TOPIC));
+        assert_eq!(
+            filter.topics[0],
+            FilterSet::from(vec![TRANSFER_TOPIC, TRANSFER_BLOCKED_TOPIC])
+        );
         assert_eq!(filter.topics[1], FilterSet::from(other_topic));
         assert_eq!(filter.topics[2], FilterSet::from(caller_topic));
-    }
-
-    #[test]
-    fn scope_filter_for_caller_scopes_transfer_blocked_to_indexed_receiver() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter::default();
-        filter.topics[0] = FilterSet::from(vec![TRANSFER_TOPIC, TRANSFER_BLOCKED_TOPIC]);
-        filter.topics[2] = FilterSet::from(caller_word(&caller));
-
-        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-        assert_eq!(scope, CallerFilterScope::Indexed);
-        assert!(filter.topics[0].contains(&TRANSFER_TOPIC));
-        assert!(filter.topics[0].contains(&TRANSFER_BLOCKED_TOPIC));
-        assert_eq!(filter.topics[2], FilterSet::from(caller_word(&caller)));
-    }
-
-    #[test]
-    fn scope_filter_for_caller_allows_receipt_scoped_transfer_blocked_query() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter::default();
-        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-        scope_filter_addresses(&mut filter, &[]).unwrap();
-
-        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-        assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
-        assert_eq!(filter.topics[0], FilterSet::from(TRANSFER_BLOCKED_TOPIC));
-        assert_eq!(
-            filter.address,
-            FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS)
-        );
-    }
-
-    #[test]
-    fn transfer_blocked_query_returns_only_authorized_receipts() {
-        let receiver = address!("0x0000000000000000000000000000000000000001");
-        let originator = address!("0x0000000000000000000000000000000000000002");
-        let recovery = address!("0x0000000000000000000000000000000000000003");
-        let outsider = address!("0x0000000000000000000000000000000000000004");
-        let log =
-            make_transfer_blocked_log(RECEIVE_POLICY_GUARD_ADDRESS, receiver, originator, recovery);
-        let mut filter = Filter {
-            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
-            ..Default::default()
-        };
-        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-
-        scope_filter_addresses(&mut filter, &[]).unwrap();
-        let scope = scope_filter_for_caller(&mut filter, &originator).unwrap();
-        validate_receipt_query(&filter, scope).unwrap();
-
-        assert_eq!(filter_logs(vec![log.clone()], &originator).len(), 1);
-        assert!(filter_logs(vec![log], &outsider).is_empty());
-    }
-
-    #[test]
-    fn receipt_post_filter_rejects_multi_block_query() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter::default().select(10u64..=11u64);
-        filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
-        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-        scope_filter_addresses(&mut filter, &[]).unwrap();
-        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-        let err = validate_receipt_query(&filter, scope).unwrap_err();
-
-        assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
-        assert_eq!(err.code, JsonRpcError::invalid_params("").code);
-        assert_eq!(err.message, RECEIPT_QUERY_RANGE_ERROR);
-    }
-
-    #[test]
-    fn receipt_post_filter_rejects_open_ended_query() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        for block_option in [
-            FilterBlockOption::default().with_from_block(10u64.into()),
-            FilterBlockOption::default().with_to_block(10u64.into()),
-        ] {
-            let mut filter = Filter {
-                block_option,
-                ..Default::default()
-            };
-            filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
-            filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-            scope_filter_addresses(&mut filter, &[]).unwrap();
-            let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-            let err = validate_receipt_query(&filter, scope).unwrap_err();
-
-            assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
-            assert_eq!(err.message, RECEIPT_QUERY_RANGE_ERROR);
-        }
-    }
-
-    #[test]
-    fn receipt_post_filter_allows_exact_block_queries() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        for block_option in [
-            FilterBlockOption::from(10u64),
-            FilterBlockOption::AtBlockHash(B256::with_last_byte(1)),
-            FilterBlockOption::default(),
-        ] {
-            let mut filter = Filter {
-                block_option,
-                ..Default::default()
-            };
-            filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
-            filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-            scope_filter_addresses(&mut filter, &[]).unwrap();
-            let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-            validate_receipt_query(&filter, scope).unwrap();
-            assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
-        }
-    }
-
-    #[test]
-    fn receipt_post_filter_rejects_dynamic_block_tags() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        for tag in [
-            BlockNumberOrTag::Earliest,
-            BlockNumberOrTag::Pending,
-            BlockNumberOrTag::Latest,
-            BlockNumberOrTag::Safe,
-            BlockNumberOrTag::Finalized,
-        ] {
-            let mut filter = Filter {
-                block_option: FilterBlockOption::Range {
-                    from_block: Some(tag),
-                    to_block: Some(tag),
-                },
-                address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
-                ..Default::default()
-            };
-            filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-            scope_filter_addresses(&mut filter, &[]).unwrap();
-            let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-            let err = validate_receipt_query(&filter, scope).unwrap_err();
-
-            assert_eq!(scope, CallerFilterScope::ReceiptPostFilter);
-            assert_eq!(err.message, RECEIPT_QUERY_RANGE_ERROR);
-        }
-    }
-
-    #[test]
-    fn receipt_post_filter_rejected_for_installed_and_live_filters() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter {
-            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
-            ..Default::default()
-        };
-        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-        scope_filter_addresses(&mut filter, &[]).unwrap();
-        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-        let err = validate_live_filter(scope).unwrap_err();
-
-        assert_eq!(err.code, JsonRpcError::invalid_params("").code);
-        assert_eq!(err.message, RECEIPT_LIVE_FILTER_ERROR);
-    }
-
-    #[test]
-    fn indexed_receiver_filter_remains_available_for_broad_and_live_queries() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let mut filter = Filter::default().select(0u64..=1_000_000u64);
-        filter.address = FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS);
-        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-        filter.topics[2] = FilterSet::from(caller_word(&caller));
-        scope_filter_addresses(&mut filter, &[]).unwrap();
-        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-        assert_eq!(scope, CallerFilterScope::Indexed);
-        validate_receipt_query(&filter, scope).unwrap();
-        validate_live_filter(scope).unwrap();
-    }
-
-    #[test]
-    fn transfer_blocked_at_non_guard_address_is_scoped_to_no_match() {
-        let caller = address!("0x0000000000000000000000000000000000000001");
-        let zone_token = address!("0x20c0000000000000000000000000000000000001");
-        let mut filter = Filter {
-            address: FilterSet::from(zone_token),
-            ..Default::default()
-        };
-        filter.topics[0] = FilterSet::from(TRANSFER_BLOCKED_TOPIC);
-        scope_filter_addresses(&mut filter, &[zone_token]).unwrap();
-
-        let scope = scope_filter_for_caller(&mut filter, &caller).unwrap();
-
-        assert_eq!(scope, CallerFilterScope::Indexed);
-        assert_eq!(filter.address, FilterSet::from(zone_token));
-        assert_eq!(filter.topics[0], FilterSet::from(B256::ZERO));
-        validate_receipt_query(&filter, scope).unwrap();
-        validate_live_filter(scope).unwrap();
     }
 
     #[test]
@@ -1289,31 +936,18 @@ mod tests {
     }
 
     #[test]
-    fn scope_filter_addresses_allows_enabled_token_address() {
+    fn scope_filter_addresses_allows_enabled_addresses() {
         let token = address!("0x00000000000000000000000000000000000000aa");
-        let mut filter = Filter {
-            address: FilterSet::from(token),
-            ..Default::default()
-        };
+        for address in [token, RECEIVE_POLICY_GUARD_ADDRESS] {
+            let mut filter = Filter {
+                address: FilterSet::from(address),
+                ..Default::default()
+            };
 
-        scope_filter_addresses(&mut filter, &[token]).unwrap();
+            scope_filter_addresses(&mut filter, &[token]).unwrap();
 
-        assert_eq!(filter.address, FilterSet::from(token));
-    }
-
-    #[test]
-    fn scope_filter_addresses_allows_receive_policy_guard() {
-        let mut filter = Filter {
-            address: FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS),
-            ..Default::default()
-        };
-
-        scope_filter_addresses(&mut filter, &[]).unwrap();
-
-        assert_eq!(
-            filter.address,
-            FilterSet::from(RECEIVE_POLICY_GUARD_ADDRESS)
-        );
+            assert_eq!(filter.address, FilterSet::from(address));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Whitelist ReceivePolicyGuard.TransferBlocked and the guard address in the redacted RPC.
- Reuse the existing caller-scoped log path: topic2 permits indexed receiver queries, while topic1 remains excluded because it contains the token.
- Decode the embedded claim receipt in the existing visibility check and expose valid logs only to the receiver, originator, or nonzero recovery authority.
- Reject malformed receipts, unrelated callers, and lookalike events from other emitters.

## Why

The redacted RPC previously removed TransferBlocked from the originating transaction receipt, hiding the claim receipt bytes required to recover funds held by ReceivePolicyGuard.

This makes the claim receipt visible through the existing redaction model without adding an unindexed log-discovery path.

Closes [ZONE-256](https://linear.app/tempoxyz/issue/ZONE-256/cyclops-redacted-rpc-hides-receivepolicyguard-claim-receipts-allowing).