### PR TITLE
fix(rpc): share enabled token registry with redacted RPC

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -714,6 +714,7 @@ where
             self.l1_config.l1_rpc_url.clone(),
             self.l1_config.retry_connection_interval,
             self.l1_config.portal_address,
+            self.l1_config.enabled_tokens.clone(),
             chain_id,
         )
         .await?;
@@ -1233,6 +1234,7 @@ where
         l1_rpc_url: String,
         retry_connection_interval: Duration,
         portal_address: Address,
+        enabled_tokens: EnabledTokenRegistry,
         chain_id: u64,
     ) -> eyre::Result<()> {
         let eth_handlers = handle.eth_handlers().clone();
@@ -1251,8 +1253,9 @@ where
             max_auth_token_validity: config.max_auth_token_validity,
             zone_portal: portal_address,
         };
-        let api: Arc<dyn ZoneRpcApi> =
-            Arc::new(ZoneRpc::new(eth_handlers, redacted_rpc_config.clone()).await?);
+        let api: Arc<dyn ZoneRpcApi> = Arc::new(
+            ZoneRpc::new(eth_handlers, redacted_rpc_config.clone(), enabled_tokens).await?,
+        );
         let local_addr = start_redacted_rpc(redacted_rpc_config, api).await?;
         info!(target: "reth::cli", %local_addr, "Redacted zone RPC server started");
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -597,7 +597,12 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
     }
 
     fn zone_tokens(&self) -> Vec<Address> {
-        cached_zone_tokens(self.config.zone_portal, &self.enabled_tokens)
+        // Preserve the default token when running without an L1 portal.
+        if self.config.zone_portal.is_zero() {
+            return vec![ZONE_TOKEN_ADDRESS];
+        }
+
+        self.enabled_tokens.read().iter().copied().collect()
     }
 
     fn enforce_authorized(
@@ -1320,51 +1325,9 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
         )
 }
 
-fn cached_zone_tokens(
-    portal_address: Address,
-    enabled_tokens: &EnabledTokenRegistry,
-) -> Vec<Address> {
-    if portal_address.is_zero() {
-        return vec![ZONE_TOKEN_ADDRESS];
-    }
-
-    enabled_tokens.read().iter().copied().collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cached_zone_tokens_reflect_registry_updates() {
-        let registry = EnabledTokenRegistry::default();
-        let first = Address::repeat_byte(0x11);
-        let second = Address::repeat_byte(0x22);
-        registry.write().insert(first);
-
-        assert_eq!(
-            cached_zone_tokens(Address::repeat_byte(1), &registry),
-            vec![first]
-        );
-
-        registry.write().insert(second);
-        assert_eq!(
-            cached_zone_tokens(Address::repeat_byte(1), &registry)
-                .into_iter()
-                .collect::<HashSet<_>>(),
-            HashSet::from([first, second]),
-        );
-    }
-
-    #[test]
-    fn cached_zone_tokens_preserve_portalless_default() {
-        let registry = EnabledTokenRegistry::default();
-
-        assert_eq!(
-            cached_zone_tokens(Address::ZERO, &registry),
-            vec![ZONE_TOKEN_ADDRESS]
-        );
-    }
 
     #[tokio::test]
     async fn operator_rpc_module_exposes_sequencer_methods_without_auth() {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -47,7 +47,7 @@ use tokio::{
     sync::Mutex,
     time::{MissedTickBehavior, interval},
 };
-use zone_l1::TempoStateExt as _;
+use zone_l1::{TempoStateExt as _, state::EnabledTokenRegistry};
 
 use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
 use tempo_zone_contracts::{TEMPO_STATE_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
@@ -491,6 +491,7 @@ async fn prune_filter_owners<Api: EthApiTypes + 'static>(
 pub struct ZoneRpc<Api: EthApiTypes> {
     eth: EthHandlers<Api>,
     config: zone_rpc::RedactedRpcConfig,
+    enabled_tokens: EnabledTokenRegistry,
     l1_provider: DynProvider<TempoNetwork>,
     tempo_state: tempo_zone_contracts::TempoState::TempoStateInstance<
         DynProvider<TempoNetwork>,
@@ -506,6 +507,7 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
     pub async fn new(
         eth: EthHandlers<Api>,
         config: zone_rpc::RedactedRpcConfig,
+        enabled_tokens: EnabledTokenRegistry,
     ) -> eyre::Result<Self> {
         let l1_rpc_url = config.l1_rpc_url.clone();
         let zone_rpc_url = config.zone_rpc_url.clone();
@@ -529,6 +531,7 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
         let rpc = Self {
             eth,
             config,
+            enabled_tokens,
             l1_provider,
             tempo_state,
             filter_owners: Arc::new(Mutex::new(HashMap::new())),
@@ -593,8 +596,8 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
         }
     }
 
-    async fn zone_tokens(&self) -> Result<Vec<Address>, JsonRpcError> {
-        zone_tokens(self.config.zone_portal, &self.l1_provider).await
+    fn zone_tokens(&self) -> Vec<Address> {
+        cached_zone_tokens(self.config.zone_portal, &self.enabled_tokens)
     }
 
     fn enforce_authorized(
@@ -917,7 +920,7 @@ where
 
     fn get_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            let zone_tokens = self.zone_tokens().await?;
+            let zone_tokens = self.zone_tokens();
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
             let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
@@ -930,7 +933,7 @@ where
 
     fn new_filter(&self, mut filter: Filter, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            let zone_tokens = self.zone_tokens().await?;
+            let zone_tokens = self.zone_tokens();
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
             let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
@@ -1063,7 +1066,7 @@ where
             let provider = self.eth.api.provider().clone();
             let caller = auth.caller;
 
-            let zone_tokens = self.zone_tokens().await?;
+            let zone_tokens = self.zone_tokens();
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter_for_caller(&mut filter, &caller)?;
 
@@ -1317,9 +1320,51 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
         )
 }
 
+fn cached_zone_tokens(
+    portal_address: Address,
+    enabled_tokens: &EnabledTokenRegistry,
+) -> Vec<Address> {
+    if portal_address.is_zero() {
+        return vec![ZONE_TOKEN_ADDRESS];
+    }
+
+    enabled_tokens.read().iter().copied().collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cached_zone_tokens_reflect_registry_updates() {
+        let registry = EnabledTokenRegistry::default();
+        let first = Address::repeat_byte(0x11);
+        let second = Address::repeat_byte(0x22);
+        registry.write().insert(first);
+
+        assert_eq!(
+            cached_zone_tokens(Address::repeat_byte(1), &registry),
+            vec![first]
+        );
+
+        registry.write().insert(second);
+        assert_eq!(
+            cached_zone_tokens(Address::repeat_byte(1), &registry)
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            HashSet::from([first, second]),
+        );
+    }
+
+    #[test]
+    fn cached_zone_tokens_preserve_portalless_default() {
+        let registry = EnabledTokenRegistry::default();
+
+        assert_eq!(
+            cached_zone_tokens(Address::ZERO, &registry),
+            vec![ZONE_TOKEN_ADDRESS]
+        );
+    }
 
     #[tokio::test]
     async fn operator_rpc_module_exposes_sequencer_methods_without_auth() {

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1383,13 +1383,14 @@ impl ZoneTestNode {
         // Build the real redacted RPC API while the handle is still concrete,
         // before type-erasing it into Box<dyn TestNodeHandle>.
         let eth_handlers = node_handle.node.eth_handlers().clone();
+        let rpc_enabled_tokens = enabled_tokens.clone();
         let rpc_api_factory = Arc::new(move |config: zone_node::rpc::RedactedRpcConfig| {
             let eth_handlers = eth_handlers.clone();
+            let enabled_tokens = rpc_enabled_tokens.clone();
             Box::pin(async move {
-                Ok(
-                    Arc::new(zone_node::rpc::ZoneRpc::new(eth_handlers, config).await?)
-                        as Arc<dyn zone_node::rpc::ZoneRpcApi>,
-                )
+                Ok(Arc::new(
+                    zone_node::rpc::ZoneRpc::new(eth_handlers, config, enabled_tokens).await?,
+                ) as Arc<dyn zone_node::rpc::ZoneRpcApi>)
             })
                 as Pin<Box<dyn Future<Output = eyre::Result<Arc<dyn zone_node::rpc::ZoneRpcApi>>>>>
         });


### PR DESCRIPTION
## Summary

- pass the node's shared enabled-token registry into the redacted RPC
- use the registry to scope `eth_getLogs`, `eth_newFilter`, and log subscriptions
- preserve live L1 metadata reads for `zone_getZoneInfo` and the portal-less development fallback

## Why

The redacted log paths enumerated every enabled token from L1 on each request before caller-scoped filter validation. That allowed a cheap invalid request to fan out into `1 + enabledTokenCount` L1 calls.

The node already seeds an `EnabledTokenRegistry` from its processed L1 anchor and updates it from confirmed `TokenEnabled` events. Sharing that registry with RPC removes the per-request L1 work while keeping filter validation aligned with the node's processed state.

Linear: ZONE-285