### PR TITLE
perf(contracts): batch enabled-token reads through Multicall3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11627,7 +11627,6 @@ dependencies = [
  "alloy-sol-types",
  "alloy-transport",
  "const-hex",
- "futures",
  "serde",
  "tokio",
  "zone-primitives",

--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -21,7 +21,6 @@ alloy-contract = { workspace = true, optional = true }
 alloy-network = { workspace = true, optional = true }
 alloy-provider = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
@@ -43,6 +42,5 @@ rpc = [
     "dep:alloy-network",
     "dep:alloy-provider",
     "dep:alloy-rpc-types-eth",
-    "dep:futures",
     "dep:tokio",
 ]

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -310,8 +310,8 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
 {
     /// Returns all token addresses currently enabled for bridging on this [`ZonePortal`].
     ///
-    /// Calls [`enabledTokenCount`](ZonePortal::enabledTokenCountCall) followed by
-    /// [`enabledTokenAt`](ZonePortal::enabledTokenAtCall) for each index concurrently.
+    /// Calls [`enabledTokenCount`](ZonePortal::enabledTokenCountCall) followed by a Multicall3
+    /// batch of [`enabledTokenAt`](ZonePortal::enabledTokenAtCall) reads.
     pub async fn enabled_tokens(
         &self,
     ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
@@ -324,20 +324,37 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
     /// Callers that pair the returned token list with other historical L1 reads
     /// should use this instead of [`enabled_tokens`](Self::enabled_tokens), so
     /// future `TokenEnabled` events are not mixed into older state snapshots.
+    ///
+    /// The index reads go through Multicall3 so they execute in a single EVM call and observe
+    /// one state snapshot even when `block_id` is a moving tag like `latest`.
     pub async fn enabled_tokens_at(
         &self,
         block_id: alloy_rpc_types_eth::BlockId,
     ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
-        let count = self.enabledTokenCount().block(block_id).call().await?;
-        let futs: alloc::vec::Vec<_> = (0..count.to::<u64>())
-            .map(|i| async move {
-                self.enabledTokenAt(alloy_primitives::U256::from(i))
-                    .block(block_id)
-                    .call()
-                    .await
-            })
-            .collect();
-        futures::future::try_join_all(futs).await
+        let count = self
+            .enabledTokenCount()
+            .block(block_id)
+            .call()
+            .await?
+            .to::<u64>();
+        if count == 0 {
+            return Ok(alloc::vec::Vec::new());
+        }
+        let mut multicall = self
+            .provider()
+            .multicall()
+            .dynamic::<ZonePortal::enabledTokenAtCall>()
+            .block(block_id);
+        for i in 0..count {
+            multicall = multicall.add_dynamic(self.enabledTokenAt(alloy_primitives::U256::from(i)));
+        }
+        multicall.aggregate().await.map_err(|err| match err {
+            alloy_provider::MulticallError::TransportError(err) => err.into(),
+            alloy_provider::MulticallError::DecodeError(err) => err.into(),
+            err => {
+                alloy_provider::transport::TransportErrorKind::custom_str(&err.to_string()).into()
+            }
+        })
     }
 
     /// Fetches the active sequencer encryption key and its index from one L1 snapshot.
@@ -377,7 +394,7 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
 mod tests {
     use super::*;
     use alloy_primitives::U256;
-    use alloy_provider::ProviderBuilder;
+    use alloy_provider::{ProviderBuilder, bindings::IMulticall3};
     use alloy_sol_types::SolCall;
     use alloy_transport::mock::Asserter;
 
@@ -403,6 +420,33 @@ mod tests {
         assert_eq!(key.x, expected.x);
         assert_eq!(key.yParity, expected.yParity);
         assert_eq!(key_index, expected.keyIndex);
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn enabled_tokens_at_batches_index_reads_through_multicall() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        let tokens = [Address::repeat_byte(0xaa), Address::repeat_byte(0xbb)];
+
+        asserter.push_success(&Bytes::from(U256::from(tokens.len()).abi_encode()));
+        asserter.push_success(&Bytes::from(
+            IMulticall3::aggregateCall::abi_encode_returns(&IMulticall3::aggregateReturn {
+                blockNumber: U256::ZERO,
+                returnData: tokens
+                    .iter()
+                    .map(|token| token.abi_encode().into())
+                    .collect(),
+            }),
+        ));
+
+        let portal = ZonePortal::new(Address::ZERO, &provider);
+        let enabled = portal
+            .enabled_tokens_at(alloy_rpc_types_eth::BlockId::latest())
+            .await
+            .unwrap();
+
+        assert_eq!(enabled, tokens);
         assert!(asserter.read_q().is_empty());
     }
 }

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -310,8 +310,8 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
 {
     /// Returns all token addresses currently enabled for bridging on this [`ZonePortal`].
     ///
-    /// Calls [`enabledTokenCount`](ZonePortal::enabledTokenCountCall) followed by a Multicall3
-    /// batch of [`enabledTokenAt`](ZonePortal::enabledTokenAtCall) reads.
+    /// Equivalent to [`enabled_tokens_at`](Self::enabled_tokens_at) pinned to the `latest`
+    /// block tag.
     pub async fn enabled_tokens(
         &self,
     ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
@@ -325,8 +325,16 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
     /// should use this instead of [`enabled_tokens`](Self::enabled_tokens), so
     /// future `TokenEnabled` events are not mixed into older state snapshots.
     ///
-    /// The index reads go through Multicall3 so they execute in a single EVM call and observe
-    /// one state snapshot even when `block_id` is a moving tag like `latest`.
+    /// Issues two RPC requests regardless of registry size: an
+    /// [`enabledTokenCount`](ZonePortal::enabledTokenCountCall) read, then one Multicall3
+    /// `aggregate` batching an [`enabledTokenAt`](ZonePortal::enabledTokenAtCall) call per
+    /// index. The batch executes as a single EVM call, so all index reads observe the same
+    /// state snapshot; only the count read can race the batch when `block_id` is a moving tag
+    /// like `latest`. If any index read reverts, the whole call errors.
+    ///
+    /// Requires Multicall3 at the canonical
+    /// [`MULTICALL3_ADDRESS`](alloy_provider::MULTICALL3_ADDRESS) on the portal's chain; all
+    /// Tempo networks predeploy it at genesis.
     pub async fn enabled_tokens_at(
         &self,
         block_id: alloy_rpc_types_eth::BlockId,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3,7 +3,7 @@ use alloy_consensus::Header;
 use alloy_eips::NumHash;
 use alloy_network::{EthereumWallet, ReceiptResponse};
 use alloy_primitives::{Address, B256, U256, address, keccak256};
-use alloy_provider::{DynProvider, Provider, ProviderBuilder};
+use alloy_provider::{DynProvider, Provider, ProviderBuilder, bindings::IMulticall3};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, TransactionRequest};
 use alloy_signer_local::{MnemonicBuilder, PrivateKeySigner, coins_bip39::English};
@@ -379,21 +379,34 @@ async fn handle_test_l1_rpc_request(
                 .and_then(|input| const_hex::decode(input.trim_start_matches("0x")).ok())
                 .unwrap_or_default();
 
-            if input.starts_with(&ZonePortal::enabledTokenCountCall::SELECTOR) {
-                serde_json::json!(const_hex::encode_prefixed(
-                    U256::from(enabled_tokens.len()).abi_encode()
-                ))
-            } else if input.starts_with(&ZonePortal::enabledTokenAtCall::SELECTOR) {
-                let index = input
-                    .get(4..36)
-                    .map(U256::from_be_slice)
-                    .map(|index| index.to::<u64>() as usize);
-                index
-                    .and_then(|index| enabled_tokens.get(index))
-                    .map(|token| serde_json::json!(const_hex::encode_prefixed(token.abi_encode())))
+            if input.starts_with(&IMulticall3::aggregateCall::SELECTOR) {
+                IMulticall3::aggregateCall::abi_decode(&input)
+                    .ok()
+                    .and_then(|aggregate| {
+                        aggregate
+                            .calls
+                            .iter()
+                            .map(|call| {
+                                answer_portal_call(&call.callData, &enabled_tokens)
+                                    .map(alloy_primitives::Bytes::from)
+                            })
+                            .collect::<Option<Vec<_>>>()
+                    })
+                    .map(|return_data| {
+                        serde_json::json!(const_hex::encode_prefixed(
+                            IMulticall3::aggregateCall::abi_encode_returns(
+                                &IMulticall3::aggregateReturn {
+                                    blockNumber: U256::ZERO,
+                                    returnData: return_data,
+                                }
+                            )
+                        ))
+                    })
                     .unwrap_or(serde_json::Value::Null)
             } else {
-                serde_json::Value::Null
+                answer_portal_call(&input, &enabled_tokens)
+                    .map(|data| serde_json::json!(const_hex::encode_prefixed(data)))
+                    .unwrap_or(serde_json::Value::Null)
             }
         }
         _ => serde_json::Value::Null,
@@ -410,6 +423,19 @@ async fn handle_test_l1_rpc_request(
         body
     );
     let _ = stream.write_all(response.as_bytes()).await;
+}
+
+/// Answers a [`ZonePortal`] enabled-token view call against the mock registry, either issued
+/// directly or as an inner call of a Multicall3 `aggregate` batch.
+fn answer_portal_call(input: &[u8], enabled_tokens: &[Address]) -> Option<Vec<u8>> {
+    if input.starts_with(&ZonePortal::enabledTokenCountCall::SELECTOR) {
+        Some(U256::from(enabled_tokens.len()).abi_encode())
+    } else if input.starts_with(&ZonePortal::enabledTokenAtCall::SELECTOR) {
+        let index = input.get(4..36).map(U256::from_be_slice)?.to::<u64>() as usize;
+        enabled_tokens.get(index).map(|token| token.abi_encode())
+    } else {
+        None
+    }
 }
 
 /// Helper to check TIP-403 authorization via TIP-20 operations.


### PR DESCRIPTION
`enabled_tokens_at` resolved the token registry with one `eth_call` per index after the count read, so a portal with N enabled tokens cost 1 + N round trips, and when reached through `enabled_tokens` with the `latest` tag each index read could observe a different L1 state: a token disabled mid-flight could revert an index read or assemble a list mixing two snapshots.

The index reads now go through a single Multicall3 `aggregate`, bringing discovery down to two requests and executing all index reads in one EVM call against one snapshot. Relying on Multicall3 at the canonical address is not a new assumption: the sequencer settlement path already batches portal reads through it, and it is a genesis predeploy on all Tempo networks, so pinned historical block ids (the node's L1-anchor discovery at startup) resolve it as well.

The it-test L1 mock now answers `aggregate` batches by dispatching each inner call through the existing selector handlers, and the crate drops its `futures` dependency, which the removed `try_join_all` was the last use of.