### PR TITLE
fix(precompiles): pin ReceivePolicyGuard claim gas

### DIFF
--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -17,17 +17,13 @@ use tempo_zone_contracts::Unauthorized;
 /// Stakeholder-only admission for receipt balance lookups.
 pub(crate) struct ReceivePolicyGuardRules;
 
-/// Fixed gas charged for claims that release blocked funds through an internal TIP-20 transfer.
-///
-/// The fixed charge hides destination balance-slot initialization from gas estimates, matching
-/// the envelope used by direct Zone TIP-20 transfers.
-pub(crate) const RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS: u64 = TIP20_FIXED_TRANSFER_GAS;
-
 impl CallRules for ReceivePolicyGuardRules {
+    // Fixed gas hides destination balance-slot initialization from claim gas estimates, matching
+    // the envelope used by direct Zone TIP-20 transfers.
     fn fixed_gas(&self, selector: Option<[u8; 4]>) -> Option<u64> {
         selector
             .is_some_and(|selector| selector == IReceivePolicyGuard::claimCall::SELECTOR)
-            .then_some(RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS)
+            .then_some(TIP20_FIXED_TRANSFER_GAS)
     }
 
     fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
@@ -197,7 +193,7 @@ mod tests {
 
         assert_eq!(
             rules.fixed_gas(Some(IReceivePolicyGuard::claimCall::SELECTOR)),
-            Some(RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS)
+            Some(TIP20_FIXED_TRANSFER_GAS)
         );
         assert_eq!(
             rules.fixed_gas(Some(IReceivePolicyGuard::balanceOfCall::SELECTOR)),
@@ -328,10 +324,9 @@ mod tests {
         }
         .abi_encode()
         .into();
-        let claimed =
-            harness.call_with_gas(RECEIVER, claim, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS, false)?;
+        let claimed = harness.call_with_gas(RECEIVER, claim, TIP20_FIXED_TRANSFER_GAS, false)?;
         assert!(claimed.is_success());
-        assert_eq!(claimed.gas_used, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS);
+        assert_eq!(claimed.gas_used, TIP20_FIXED_TRANSFER_GAS);
 
         let balance = harness.balance_of(RECEIVER)?;
         assert_eq!(decode_balance(&balance)?, U256::ZERO);
@@ -350,10 +345,9 @@ mod tests {
         .abi_encode()
         .into();
 
-        let result =
-            harness.call_with_gas(RECEIVER, claim, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS, false)?;
+        let result = harness.call_with_gas(RECEIVER, claim, TIP20_FIXED_TRANSFER_GAS, false)?;
         assert!(result.is_revert());
-        assert_eq!(result.gas_used, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS);
+        assert_eq!(result.gas_used, TIP20_FIXED_TRANSFER_GAS);
         Ok(())
     }
 }

--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -4,7 +4,10 @@
 //! `balanceOf(bytes)` before the upstream balance lookup prevents unrelated callers from using
 //! the return value as a receipt-existence and amount oracle.
 
-use crate::execution::{CallCheck, CallRules};
+use crate::{
+    execution::{CallCheck, CallRules},
+    ztip20::TIP20_FIXED_TRANSFER_GAS,
+};
 use alloy_primitives::Address;
 use alloy_sol_types::{SolCall, SolError};
 use tempo_contracts::precompiles::IReceivePolicyGuard;
@@ -14,7 +17,19 @@ use tempo_zone_contracts::Unauthorized;
 /// Stakeholder-only admission for receipt balance lookups.
 pub(crate) struct ReceivePolicyGuardRules;
 
+/// Fixed gas charged for claims that release blocked funds through an internal TIP-20 transfer.
+///
+/// The fixed charge hides destination balance-slot initialization from gas estimates, matching
+/// the envelope used by direct Zone TIP-20 transfers.
+pub(crate) const RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS: u64 = TIP20_FIXED_TRANSFER_GAS;
+
 impl CallRules for ReceivePolicyGuardRules {
+    fn fixed_gas(&self, selector: Option<[u8; 4]>) -> Option<u64> {
+        selector
+            .is_some_and(|selector| selector == IReceivePolicyGuard::claimCall::SELECTOR)
+            .then_some(RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS)
+    }
+
     fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
         if selector_from_calldata(data) != Some(IReceivePolicyGuard::balanceOfCall::SELECTOR) {
             return CallCheck::Continue;
@@ -176,6 +191,21 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn fixed_gas_applies_only_to_claim() {
+        let rules = ReceivePolicyGuardRules;
+
+        assert_eq!(
+            rules.fixed_gas(Some(IReceivePolicyGuard::claimCall::SELECTOR)),
+            Some(RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS)
+        );
+        assert_eq!(
+            rules.fixed_gas(Some(IReceivePolicyGuard::balanceOfCall::SELECTOR)),
+            None
+        );
+        assert_eq!(rules.fixed_gas(None), None);
+    }
+
     struct GuardHarness {
         ctx: TestContext,
         precompile: DynPrecompile,
@@ -226,12 +256,22 @@ mod tests {
         }
 
         fn call(&mut self, caller: Address, data: Bytes, is_static: bool) -> PrecompileResult {
+            self.call_with_gas(caller, data, u64::MAX, is_static)
+        }
+
+        fn call_with_gas(
+            &mut self,
+            caller: Address,
+            data: Bytes,
+            gas: u64,
+            is_static: bool,
+        ) -> PrecompileResult {
             call_precompile(
                 &mut self.ctx,
                 &self.precompile,
                 caller,
                 &data,
-                u64::MAX,
+                gas,
                 is_static,
                 RECEIVE_POLICY_GUARD_ADDRESS,
                 RECEIVE_POLICY_GUARD_ADDRESS,
@@ -288,11 +328,32 @@ mod tests {
         }
         .abi_encode()
         .into();
-        let claimed = harness.call(RECEIVER, claim, false)?;
+        let claimed =
+            harness.call_with_gas(RECEIVER, claim, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS, false)?;
         assert!(claimed.is_success());
+        assert_eq!(claimed.gas_used, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS);
 
         let balance = harness.balance_of(RECEIVER)?;
         assert_eq!(decode_balance(&balance)?, U256::ZERO);
+        Ok(())
+    }
+
+    #[test]
+    fn wrapper_pins_claim_revert_gas() -> eyre::Result<()> {
+        let mut harness = GuardHarness::new()?;
+        let mut absent = harness.receipt.clone();
+        absent.blockedNonce += 1;
+        let claim = IReceivePolicyGuard::claimCall {
+            to: RECEIVER,
+            receipt: absent.abi_encode().into(),
+        }
+        .abi_encode()
+        .into();
+
+        let result =
+            harness.call_with_gas(RECEIVER, claim, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS, false)?;
+        assert!(result.is_revert());
+        assert_eq!(result.gas_used, RECEIVE_POLICY_GUARD_FIXED_CLAIM_GAS);
         Ok(())
     }
 }


### PR DESCRIPTION
ref: `ZONE-341`

## Summary

- Apply the existing 100,000-gas privacy envelope to `ReceivePolicyGuard.claim`.
- Pin gas on both successful and ordinary reverting claims.
- Add selector and end-to-end regression coverage.

Addresses ZONE-341.

## Testing

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-precompiles receive_policy_guard::tests --offline -- --nocapture` *(blocked: pinned `alloy-evm` dependency is unavailable in the sandbox cache)*

Prompted by: @0xrusowsky