### PR TITLE
perf(contracts): batch sequencer reads through Multicall3

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -422,7 +422,7 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
 mod tests {
     use super::*;
     use alloy_primitives::U256;
-    use alloy_provider::{ProviderBuilder, bindings::IMulticall3};
+    use alloy_provider::ProviderBuilder;
     use alloy_sol_types::SolCall;
     use alloy_transport::mock::Asserter;
 
@@ -448,33 +448,6 @@ mod tests {
         assert_eq!(key.x, expected.x);
         assert_eq!(key.yParity, expected.yParity);
         assert_eq!(key_index, expected.keyIndex);
-        assert!(asserter.read_q().is_empty());
-    }
-
-    #[tokio::test]
-    async fn sequencers_at_batches_index_reads_through_multicall() {
-        let asserter = Asserter::new();
-        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
-        let sequencers = [Address::repeat_byte(0xaa), Address::repeat_byte(0xbb)];
-
-        asserter.push_success(&Bytes::from(U256::from(sequencers.len()).abi_encode()));
-        asserter.push_success(&Bytes::from(
-            IMulticall3::aggregateCall::abi_encode_returns(&IMulticall3::aggregateReturn {
-                blockNumber: U256::ZERO,
-                returnData: sequencers
-                    .iter()
-                    .map(|sequencer| sequencer.abi_encode().into())
-                    .collect(),
-            }),
-        ));
-
-        let portal = ZonePortal::new(Address::ZERO, &provider);
-        let registered = portal
-            .sequencers_at(alloy_rpc_types_eth::BlockId::latest())
-            .await
-            .unwrap();
-
-        assert_eq!(registered, sequencers);
         assert!(asserter.read_q().is_empty());
     }
 }

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -340,6 +340,51 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
         futures::future::try_join_all(futs).await
     }
 
+    /// Returns all sequencer addresses currently registered on this [`ZonePortal`].
+    ///
+    /// Calls [`sequencerCount`](ZonePortal::sequencerCountCall) followed by a Multicall3
+    /// batch of [`sequencerAt`](ZonePortal::sequencerAtCall) reads.
+    pub async fn sequencers(
+        &self,
+    ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
+        self.sequencers_at(alloy_rpc_types_eth::BlockId::latest())
+            .await
+    }
+
+    /// Returns all sequencer addresses registered at `block_id`.
+    ///
+    /// The index reads go through Multicall3 so they execute in a single EVM call and observe
+    /// one state snapshot even when `block_id` is a moving tag like `latest`.
+    pub async fn sequencers_at(
+        &self,
+        block_id: alloy_rpc_types_eth::BlockId,
+    ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
+        let count = self
+            .sequencerCount()
+            .block(block_id)
+            .call()
+            .await?
+            .to::<u64>();
+        if count == 0 {
+            return Ok(alloc::vec::Vec::new());
+        }
+        let mut multicall = self
+            .provider()
+            .multicall()
+            .dynamic::<ZonePortal::sequencerAtCall>()
+            .block(block_id);
+        for i in 0..count {
+            multicall = multicall.add_dynamic(self.sequencerAt(alloy_primitives::U256::from(i)));
+        }
+        multicall.aggregate().await.map_err(|err| match err {
+            alloy_provider::MulticallError::TransportError(err) => err.into(),
+            alloy_provider::MulticallError::DecodeError(err) => err.into(),
+            err => {
+                alloy_provider::transport::TransportErrorKind::custom_str(&err.to_string()).into()
+            }
+        })
+    }
+
     /// Fetches the active sequencer encryption key and its index from one L1 snapshot.
     ///
     /// Reads the current L1 block number, then pins an atomic
@@ -377,7 +422,7 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
 mod tests {
     use super::*;
     use alloy_primitives::U256;
-    use alloy_provider::ProviderBuilder;
+    use alloy_provider::{ProviderBuilder, bindings::IMulticall3};
     use alloy_sol_types::SolCall;
     use alloy_transport::mock::Asserter;
 
@@ -403,6 +448,33 @@ mod tests {
         assert_eq!(key.x, expected.x);
         assert_eq!(key.yParity, expected.yParity);
         assert_eq!(key_index, expected.keyIndex);
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sequencers_at_batches_index_reads_through_multicall() {
+        let asserter = Asserter::new();
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
+        let sequencers = [Address::repeat_byte(0xaa), Address::repeat_byte(0xbb)];
+
+        asserter.push_success(&Bytes::from(U256::from(sequencers.len()).abi_encode()));
+        asserter.push_success(&Bytes::from(
+            IMulticall3::aggregateCall::abi_encode_returns(&IMulticall3::aggregateReturn {
+                blockNumber: U256::ZERO,
+                returnData: sequencers
+                    .iter()
+                    .map(|sequencer| sequencer.abi_encode().into())
+                    .collect(),
+            }),
+        ));
+
+        let portal = ZonePortal::new(Address::ZERO, &provider);
+        let registered = portal
+            .sequencers_at(alloy_rpc_types_eth::BlockId::latest())
+            .await
+            .unwrap();
+
+        assert_eq!(registered, sequencers);
         assert!(asserter.read_q().is_empty());
     }
 }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -235,20 +235,10 @@ async fn zone_sequencers(
     portal_address: Address,
     l1_provider: &DynProvider<TempoNetwork>,
 ) -> Result<Vec<Address>, JsonRpcError> {
-    let portal = ZonePortal::new(portal_address, l1_provider);
-    let count = portal.sequencerCount().call().await.map_err(internal)?;
-    let count = count.to::<usize>();
-    let mut sequencers = Vec::with_capacity(count);
-    for index in 0..count {
-        sequencers.push(
-            portal
-                .sequencerAt(U256::from(index))
-                .call()
-                .await
-                .map_err(internal)?,
-        );
-    }
-    Ok(sequencers)
+    ZonePortal::new(portal_address, l1_provider)
+        .sequencers()
+        .await
+        .map_err(internal)
 }
 
 /// Builds the Zone metadata shared by the operator and redacted RPC surfaces.


### PR DESCRIPTION
`zone_getZoneInfo` read the sequencer set with one `eth_call` per index after `sequencerCount`. The index reads now go through a single Multicall3 `aggregate`, following the same pattern as #1008 for enabled tokens.

The logic lives on `ZonePortalInstance` as `sequencers`/`sequencers_at` next to `enabled_tokens_at`, so `zone_sequencers` in the node RPC becomes a thin wrapper. The batch is pinned to the requested block id, so the index reads observe one state snapshot even when querying `latest`. The it-test L1 mock needs no changes: the only tests exercising this path run against the real test L1, where Multicall3 is already available.