### PR TITLE
fix(portal): reject empty withdrawal sentinel

### DIFF
--- a/specs/ref-impls/src/libraries/WithdrawalQueueLib.sol
+++ b/specs/ref-impls/src/libraries/WithdrawalQueueLib.sol
@@ -64,6 +64,9 @@ library WithdrawalQueueLib {
         if (withdrawalQueueHash == bytes32(0)) {
             return NO_QUEUE_INDEX;
         }
+        if (withdrawalQueueHash == EMPTY_SENTINEL) {
+            revert InvalidWithdrawalHash();
+        }
 
         uint256 tail = queue.tail;
 

--- a/specs/ref-impls/test/libraries/WithdrawalQueueLib.t.sol
+++ b/specs/ref-impls/test/libraries/WithdrawalQueueLib.t.sol
@@ -127,6 +127,15 @@ contract WithdrawalQueueLibTest is Test {
         assertFalse(harness.hasWithdrawals());
     }
 
+    function test_enqueue_revertsForEmptySentinel() public {
+        vm.expectRevert(WithdrawalQueueLib.InvalidWithdrawalHash.selector);
+        harness.enqueue(EMPTY_SENTINEL);
+
+        assertEq(harness.head(), 0);
+        assertEq(harness.tail(), 0);
+        assertFalse(harness.hasWithdrawals());
+    }
+
     function test_enqueue_mixedEmptyAndNonEmpty() public {
         bytes32 h1 = keccak256("batch1");
         bytes32 h2 = keccak256("batch2");

--- a/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
+++ b/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
@@ -138,8 +138,8 @@ contract WithdrawalQueueSymbolic is Test {
         assertEq(qh.hasWithdrawals(), qh.length() != 0);
     }
 
-    /// @notice A non-empty enqueue on a non-full queue advances tail by exactly one and never
-    ///         pushes length past capacity.
+    /// @notice A valid non-empty enqueue on a non-full queue advances tail by exactly one and
+    ///         never pushes length past capacity.
     function check_enqueueAdvancesTailAndRespectsCapacity(
         uint256 _head,
         uint256 _tail,
@@ -148,6 +148,7 @@ contract WithdrawalQueueSymbolic is Test {
         external
     {
         vm.assume(h != bytes32(0));
+        vm.assume(h != EMPTY_SENTINEL);
         vm.assume(_tail >= _head);
         vm.assume(_tail - _head < qh.capacity()); // not full
         vm.assume(_tail < type(uint256).max); // tail + 1 cannot overflow

--- a/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
+++ b/specs/ref-impls/test/zone/ZoneSymbolic.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import { EncryptedDepositLib } from "../../src/libraries/EncryptedDeposit.sol";
 import {
+    EMPTY_SENTINEL,
     WITHDRAWAL_QUEUE_CAPACITY,
     WithdrawalQueue,
     WithdrawalQueueLib
@@ -172,9 +173,10 @@ contract WithdrawalQueueSymbolic is Test {
         assertEq(qh.tail(), _tail);
     }
 
-    /// @notice A non-empty enqueue on a full queue always reverts, for any full state.
+    /// @notice A valid non-empty enqueue on a full queue always reverts, for any full state.
     function check_enqueueRevertsWhenFull(uint256 _head, uint256 _tail, bytes32 h) external {
         vm.assume(h != bytes32(0));
+        vm.assume(h != EMPTY_SENTINEL);
         vm.assume(_tail >= _head);
         vm.assume(_tail - _head == qh.capacity()); // full
 


### PR DESCRIPTION
This PR prevents the withdrawal queue from accepting its reserved empty-slot sentinel as a live batch root.

Closes ZONE-330.