### PR TITLE
fix(evm): reject authorization lists during block execution

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -15,7 +15,7 @@ mod zone_evm;
 
 pub use database::{L1OverlayDB, ZoneDbError};
 pub use executor::{ZoneBlockExecutor, ZoneTxResult};
-pub use zone_evm::{ZoneEvm, contract_creation::validate_transaction};
+pub use zone_evm::{ZoneEvm, validate_transaction};
 
 use crate::{
     fee_manager::ZoneProtocolFeeManager,

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -1,4 +1,4 @@
-//! Contract creation validation and runtime enforcement.
+//! Zone transaction validation and contract creation runtime enforcement.
 
 use alloy_evm::Database;
 use alloy_primitives::Address;
@@ -48,11 +48,22 @@ fn create<const IS_CREATE2: bool, DB: Database>(
     revm_create::<IS_CREATE2, EthInterpreter, TempoContext<DB>>(context)
 }
 
-/// Reject transaction-level contract creation unless its deployer is explicitly allowed.
+/// Validates Zone transaction policies shared by pool admission and block execution.
 pub fn validate_transaction(
     tx: &TempoTxEnv,
     allowlist: &[Address],
 ) -> Result<(), TempoInvalidTransaction> {
+    let has_eip7702_authorizations = !tx.inner.authorization_list.is_empty();
+    let has_tempo_authorizations = tx
+        .tempo_tx_env
+        .as_ref()
+        .is_some_and(|env| !env.tempo_authorization_list.is_empty());
+    if has_eip7702_authorizations || has_tempo_authorizations {
+        return Err(TempoInvalidTransaction::CallsValidation(
+            "authorization lists are not supported",
+        ));
+    }
+
     if contract_creation_deployer(tx).is_some_and(|deployer| !allowlist.contains(&deployer)) {
         return Err(TempoInvalidTransaction::CallsValidation(
             "contract creation is not supported",

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -1,10 +1,9 @@
-//! Zone transaction validation and contract creation runtime enforcement.
+//! Contract creation runtime enforcement.
 
 use alloy_evm::Database;
 use alloy_primitives::Address;
 use revm::{
     bytecode::opcode::{CREATE, CREATE2},
-    context::Transaction,
     interpreter::{
         Instruction, InstructionContext, InstructionResult,
         instructions::contract::create as revm_create, interpreter::EthInterpreter,
@@ -12,7 +11,7 @@ use revm::{
     },
 };
 use tempo_evm::evm::TempoEvm;
-use tempo_revm::{TempoInvalidTransaction, TempoTxEnv, evm::TempoContext};
+use tempo_revm::evm::TempoContext;
 use zone_primitives::constants::CONTRACT_DEPLOYER_ALLOWLIST;
 
 type ZoneInstructionCtx<'a, DB> = InstructionContext<'a, TempoContext<DB>, EthInterpreter>;
@@ -48,43 +47,10 @@ fn create<const IS_CREATE2: bool, DB: Database>(
     revm_create::<IS_CREATE2, EthInterpreter, TempoContext<DB>>(context)
 }
 
-/// Validates Zone transaction policies shared by pool admission and block execution.
-pub fn validate_transaction(
-    tx: &TempoTxEnv,
-    allowlist: &[Address],
-) -> Result<(), TempoInvalidTransaction> {
-    let has_eip7702_authorizations = !tx.inner.authorization_list.is_empty();
-    let has_tempo_authorizations = tx
-        .tempo_tx_env
-        .as_ref()
-        .is_some_and(|env| !env.tempo_authorization_list.is_empty());
-    if has_eip7702_authorizations || has_tempo_authorizations {
-        return Err(TempoInvalidTransaction::CallsValidation(
-            "authorization lists are not supported",
-        ));
-    }
-
-    if contract_creation_deployer(tx).is_some_and(|deployer| !allowlist.contains(&deployer)) {
-        return Err(TempoInvalidTransaction::CallsValidation(
-            "contract creation is not supported",
-        ));
-    }
-
-    Ok(())
-}
-
-fn contract_creation_deployer(tx: &TempoTxEnv) -> Option<Address> {
-    let creates = match tx.tempo_tx_env.as_ref() {
-        Some(aa) => aa.aa_calls.iter().any(|call| call.to.is_create()),
-        None => tx.kind().is_create(),
-    };
-    creates.then_some(tx.caller)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{L1OverlayDB, ZoneEvm};
+    use crate::{L1OverlayDB, ZoneEvm, zone_evm::validation::validate_transaction};
     use alloy_evm::{Evm, EvmEnv};
     use alloy_primitives::{Address, Bytes, TxKind, U256, bytes};
     use revm::{
@@ -99,7 +65,7 @@ mod tests {
     };
     use tempo_evm::{TempoBlockEnv, TempoHaltReason, TempoPoolValidationEvm};
     use tempo_primitives::transaction::Call;
-    use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
+    use tempo_revm::{TempoBatchCallEnv, TempoInvalidTransaction, TempoTxEnv};
     use zone_precompiles::test_utils::MockL1Reader as TestL1;
 
     type TestDb = CacheDB<EmptyDB>;

--- a/crates/evm/src/zone_evm/mod.rs
+++ b/crates/evm/src/zone_evm/mod.rs
@@ -1,6 +1,9 @@
 //! Zone runtime EVM and its private execution policies.
 
 pub(crate) mod contract_creation;
+mod validation;
+
+pub use validation::validate_transaction;
 
 use crate::{
     TempoCtx,
@@ -105,8 +108,7 @@ where
         &mut self,
         tx: TempoTxEnv,
     ) -> (TempoPoolValidationResult<DB::Error>, TempoTxEnv) {
-        if let Err(err) = contract_creation::validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)
-        {
+        if let Err(err) = validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST) {
             return (Err(EVMError::Transaction(err)), tx);
         }
         let (result, tx) = self.inner.validate_pool_transaction(tx);
@@ -147,7 +149,7 @@ where
         &mut self,
         tx: Self::Tx,
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
-        contract_creation::validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)?;
+        validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)?;
         let tx_hash = match tx.execution_context() {
             ExecutionContext::Transaction { tx_hash } => tx_hash,
             ExecutionContext::Simulation => B256::repeat_byte(0xff),

--- a/crates/evm/src/zone_evm/mod.rs
+++ b/crates/evm/src/zone_evm/mod.rs
@@ -105,21 +105,6 @@ where
         &mut self,
         tx: TempoTxEnv,
     ) -> (TempoPoolValidationResult<DB::Error>, TempoTxEnv) {
-        let has_eip7702_authorizations = !tx.inner.authorization_list.is_empty();
-        let has_tempo_authorizations = tx
-            .tempo_tx_env
-            .as_ref()
-            .is_some_and(|env| !env.tempo_authorization_list.is_empty());
-        if has_eip7702_authorizations || has_tempo_authorizations {
-            return (
-                Err(EVMError::Transaction(
-                    TempoInvalidTransaction::CallsValidation(
-                        "authorization lists are not supported",
-                    ),
-                )),
-                tx,
-            );
-        }
         if let Err(err) = contract_creation::validate_transaction(&tx, CONTRACT_DEPLOYER_ALLOWLIST)
         {
             return (Err(EVMError::Transaction(err)), tx);
@@ -219,13 +204,22 @@ mod tests {
     use alloy_evm::EvmEnv;
     use alloy_primitives::U256;
     use revm::{
-        context::result::{ExecutionResult, HaltReason, Output, ResultGas, SuccessReason},
+        context::{
+            TxEnv,
+            result::{ExecutionResult, HaltReason, Output, ResultGas, SuccessReason},
+            transaction::{Authorization, SignedAuthorization},
+        },
+        context_interface::either::Either,
         database::EmptyDB,
         inspector::NoOpInspector,
         primitives::AddressMap,
         state::{Account, EvmStorageSlot},
     };
     use tempo_precompiles::TIP403_REGISTRY_ADDRESS;
+    use tempo_primitives::transaction::{
+        RecoveredTempoAuthorization, TempoSignature, TempoSignedAuthorization,
+    };
+    use tempo_revm::TempoBatchCallEnv;
     use zone_precompiles::test_utils::MockL1Reader;
 
     fn test_evm() -> ZoneEvm<EmptyDB, NoOpInspector, MockL1Reader> {
@@ -244,6 +238,73 @@ mod tests {
             },
         );
         AddressMap::from_iter([(TIP403_REGISTRY_ADDRESS, account)])
+    }
+
+    fn transactions_with_authorization_lists() -> [TempoTxEnv; 2] {
+        let authorization = Authorization {
+            chain_id: U256::ZERO,
+            address: Address::ZERO,
+            nonce: 0,
+        };
+
+        let eip7702 = TempoTxEnv {
+            inner: TxEnv {
+                authorization_list: vec![Either::Left(SignedAuthorization::new_unchecked(
+                    authorization.clone(),
+                    0,
+                    U256::ONE,
+                    U256::ONE,
+                ))],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let tempo = TempoTxEnv {
+            tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+                tempo_authorization_list: vec![RecoveredTempoAuthorization::new(
+                    TempoSignedAuthorization::new_unchecked(
+                        authorization,
+                        TempoSignature::default(),
+                    ),
+                )],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        [eip7702, tempo]
+    }
+
+    #[test]
+    fn pool_validation_rejects_authorization_lists() {
+        for tx in transactions_with_authorization_lists() {
+            let (result, _) = test_evm().validate_pool_transaction(tx);
+
+            assert!(matches!(
+                result,
+                Err(EVMError::Transaction(
+                    TempoInvalidTransaction::CallsValidation(
+                        "authorization lists are not supported"
+                    )
+                ))
+            ));
+        }
+    }
+
+    #[test]
+    fn block_execution_rejects_authorization_lists() {
+        for tx in transactions_with_authorization_lists() {
+            let err = test_evm()
+                .transact_raw(tx)
+                .expect_err("authorization list must be rejected before execution");
+
+            assert!(matches!(
+                err,
+                EVMError::Transaction(TempoInvalidTransaction::CallsValidation(
+                    "authorization lists are not supported"
+                ))
+            ));
+        }
     }
 
     #[test]

--- a/crates/evm/src/zone_evm/validation.rs
+++ b/crates/evm/src/zone_evm/validation.rs
@@ -1,0 +1,40 @@
+//! Zone transaction policies shared by pool admission and block execution.
+
+use alloy_primitives::Address;
+use revm::context::Transaction;
+use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
+
+/// Validates transaction policies enforced by the Zone EVM.
+pub fn validate_transaction(
+    tx: &TempoTxEnv,
+    contract_deployer_allowlist: &[Address],
+) -> Result<(), TempoInvalidTransaction> {
+    let has_eip7702_authorizations = !tx.inner.authorization_list.is_empty();
+    let has_tempo_authorizations = tx
+        .tempo_tx_env
+        .as_ref()
+        .is_some_and(|env| !env.tempo_authorization_list.is_empty());
+    if has_eip7702_authorizations || has_tempo_authorizations {
+        return Err(TempoInvalidTransaction::CallsValidation(
+            "authorization lists are not supported",
+        ));
+    }
+
+    if contract_creation_deployer(tx)
+        .is_some_and(|deployer| !contract_deployer_allowlist.contains(&deployer))
+    {
+        return Err(TempoInvalidTransaction::CallsValidation(
+            "contract creation is not supported",
+        ));
+    }
+
+    Ok(())
+}
+
+fn contract_creation_deployer(tx: &TempoTxEnv) -> Option<Address> {
+    let creates = match tx.tempo_tx_env.as_ref() {
+        Some(aa) => aa.aa_calls.iter().any(|call| call.to.is_create()),
+        None => tx.kind().is_create(),
+    };
+    creates.then_some(tx.caller)
+}


### PR DESCRIPTION
## Summary

- move the Zone authorization-list policy into the transaction validator shared by pool admission and block execution
- reject both EIP-7702 and Tempo authorization lists before replicated block execution
- cover both authorization formats through the pool and direct execution entry points

## Root cause

PR #993 enforced the policy only in `TempoPoolValidationEvm::validate_pool_transaction`. Transactions imported from replicated blocks execute through `Evm::transact_raw`, so followers could still accept authorization-list transactions that public admission rejected.

## Impact

Pool admission and block import now enforce the same Zone transaction policy. This closes the remaining authorization-list portion of [ZONE-149](https://linear.app/tempoxyz/issue/ZONE-149/t1-015-follower-block-import-omits-zone-specific-bans-on-ethereum); PR #992 already addressed the separate withdrawals case.

## Validation

- `rustup run nightly cargo fmt --all -- --check`
- `rustup run nightly cargo test -p zone-evm authorization_lists -- --nocapture`
- `rustup run nightly cargo test -p zone-evm`
- `rustup run nightly cargo clippy -p zone-evm --all-targets --all-features -- -D warnings`

Fixes ZONE-149.
