### PR TITLE
fix(p2p): bound forwarded transaction frames

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -12,7 +12,7 @@ use reth_tracing::tracing::info;
 use zeroize::Zeroizing;
 use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
 use zone_evm::ZoneEvmConfig;
-use zone_p2p::{P2pConfig, Role};
+use zone_p2p::{MAX_TRANSACTION_MESSAGE_SIZE, P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
 
 use crate::{
@@ -140,6 +140,10 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         }
 
         let manifest_mode = p2p_config.is_some();
+        validate_p2p_transaction_size_limit(
+            manifest_mode,
+            builder.config().txpool.max_tx_input_bytes,
+        )?;
         if manifest_mode {
             // Replicate only durable blocks. Persist every block immediately so followers can
             // acknowledge each block without waiting for Reth's in-memory buffer to fill.
@@ -532,6 +536,19 @@ fn sequencer_enabled(cli_flag: bool, p2p_config: Option<&P2pConfig>) -> bool {
     cli_flag || p2p_config.is_some_and(|config| !config.is_rpc_only())
 }
 
+fn validate_p2p_transaction_size_limit(
+    manifest_mode: bool,
+    max_tx_input_bytes: usize,
+) -> eyre::Result<()> {
+    if manifest_mode {
+        eyre::ensure!(
+            max_tx_input_bytes <= MAX_TRANSACTION_MESSAGE_SIZE,
+            "--txpool.max-tx-input-bytes ({max_tx_input_bytes}) exceeds the multi-sequencer P2P transaction limit ({MAX_TRANSACTION_MESSAGE_SIZE})"
+        );
+    }
+    Ok(())
+}
+
 fn validate_l1_rpc_url(l1_rpc_url: &str) -> eyre::Result<()> {
     let url: url::Url = l1_rpc_url
         .parse()
@@ -560,7 +577,7 @@ mod tests {
 
     use super::{
         Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, sequencer_enabled,
-        validate_l1_rpc_url, validate_portal_address,
+        validate_l1_rpc_url, validate_p2p_transaction_size_limit, validate_portal_address,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -607,6 +624,26 @@ mod tests {
 
         assert!(args.validate_zone_id(expected).is_ok());
         assert!(args.validate_zone_id(expected + 1).is_err());
+    }
+
+    #[test]
+    fn manifest_mode_rejects_a_txpool_limit_above_the_p2p_wire_limit() {
+        assert!(
+            validate_p2p_transaction_size_limit(true, zone_p2p::MAX_TRANSACTION_MESSAGE_SIZE,)
+                .is_ok()
+        );
+        let error =
+            validate_p2p_transaction_size_limit(true, zone_p2p::MAX_TRANSACTION_MESSAGE_SIZE + 1)
+                .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("exceeds the multi-sequencer P2P transaction limit")
+        );
+        assert!(
+            validate_p2p_transaction_size_limit(false, zone_p2p::MAX_TRANSACTION_MESSAGE_SIZE + 1,)
+                .is_ok()
+        );
     }
 
     #[test]

--- a/crates/p2p/src/lib.rs
+++ b/crates/p2p/src/lib.rs
@@ -14,7 +14,7 @@ pub use manifest::{
     ForcedRecoveryConfig, ForcedRecoveryState, LeadershipSchedule, LeadershipState,
     ManifestAddress, ManifestError, ManifestNode, Role, ZoneManifest,
 };
-pub use network::P2pNetworkId;
+pub use network::{MAX_TRANSACTION_MESSAGE_SIZE, P2pNetworkId};
 pub use protocol::PeerTip;
 pub use routing::P2pPeerId;
 pub use runtime::{P2pCommand, P2pConfig, P2pEvent, P2pHandle, P2pHandleParts, spawn_p2p};

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -25,7 +25,15 @@ pub(crate) const SETTLEMENT_PROPOSAL_CHANNEL: u64 = 4;
 /// Follower-to-leader settlement signature channel.
 pub(crate) const SETTLEMENT_SIGNATURE_CHANNEL: u64 = 5;
 pub(crate) const BLOCK_BACKLOG: usize = 128;
-pub(crate) const TRANSACTION_BACKLOG: usize = 1_024;
+/// Forwarded transactions are retried from the sender's pool, so a small receive backlog bounds
+/// memory before the transaction-specific wire limit can run without sacrificing eventual relay.
+pub(crate) const TRANSACTION_BACKLOG: usize = 4;
+
+/// Maximum raw EIP-2718 transaction frame accepted from another sequencer.
+///
+/// This is eight times Reth's default 128 KiB transaction input limit, leaving room for operators
+/// to raise the pool limit without allowing block-sized frames into transaction event queues.
+pub const MAX_TRANSACTION_MESSAGE_SIZE: usize = 1024 * 1024;
 
 // At 30M gas, calldata is bounded below 7.5 MiB; leave headroom for block overhead.
 pub(crate) const MAX_MESSAGE_SIZE: u32 = 20 * 1024 * 1024;
@@ -188,7 +196,8 @@ mod tests {
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
     use super::{
-        NETWORK_NAMESPACE_PREFIX, P2pNetworkId, WIRE_PROTOCOL_VERSION, namespace, peer_sets,
+        MAX_MESSAGE_SIZE, MAX_TRANSACTION_MESSAGE_SIZE, NETWORK_NAMESPACE_PREFIX, P2pNetworkId,
+        TRANSACTION_BACKLOG, WIRE_PROTOCOL_VERSION, namespace, peer_sets,
     };
     use crate::ZoneManifest;
 
@@ -214,6 +223,15 @@ mod tests {
             ed25519_public_key(4),
         ));
         ZoneManifest::parse(&manifest).unwrap()
+    }
+
+    #[test]
+    fn transaction_channel_bounds_pre_validation_memory() {
+        assert!(MAX_TRANSACTION_MESSAGE_SIZE < MAX_MESSAGE_SIZE as usize);
+        assert_eq!(
+            TRANSACTION_BACKLOG * MAX_MESSAGE_SIZE as usize,
+            80 * 1024 * 1024,
+        );
     }
 
     #[test]

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, net::SocketAddr, path::Path, sync::Arc, time::Du
 use alloy_primitives::{Address as EthereumAddress, B256};
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_p2p::{AddressableManager as _, Recipients, Sender as _, authenticated::lookup};
-use commonware_runtime::{Runner as _, Spawner as _};
+use commonware_runtime::{IoBuf, Runner as _, Spawner as _};
 use eyre::WrapErr as _;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -18,8 +18,8 @@ use crate::{
     identity::{Ed25519Identity, Secp256k1Identity},
     network::{
         self, BACKFILL_REQUEST_CHANNEL, BACKFILL_RESPONSE_CHANNEL, BLOCK_BACKLOG, BLOCK_CHANNEL,
-        MAX_MESSAGE_SIZE, SETTLEMENT_PROPOSAL_CHANNEL, SETTLEMENT_SIGNATURE_CHANNEL,
-        TRANSACTION_BACKLOG, TRANSACTION_CHANNEL,
+        MAX_MESSAGE_SIZE, MAX_TRANSACTION_MESSAGE_SIZE, SETTLEMENT_PROPOSAL_CHANNEL,
+        SETTLEMENT_SIGNATURE_CHANNEL, TRANSACTION_BACKLOG, TRANSACTION_CHANNEL,
     },
     routing::{RoutingMembership, RoutingPolicy},
 };
@@ -32,6 +32,14 @@ const EVENT_BACKLOG: usize = 128;
 
 type CommonwareSender = lookup::Sender<PublicKey, commonware_runtime::tokio::Context>;
 type CommonwareReceiver = lookup::Receiver<PublicKey>;
+
+fn into_bounded_payload(bytes: IoBuf, max_size: usize) -> Result<Vec<u8>, usize> {
+    let size = bytes.len();
+    if size > max_size {
+        return Err(size);
+    }
+    Ok(bytes.into())
+}
 
 struct P2pSenders {
     blocks: CommonwareSender,
@@ -464,6 +472,7 @@ fn run(
             local_ed25519_public_key.clone(),
             membership.clone(),
             leadership.clone(),
+            oracle,
             P2pReceivers {
                 blocks: block_receiver,
                 settlement_proposals: settlement_proposal_receiver,
@@ -634,6 +643,22 @@ async fn run_commands(
                     }
                     continue;
                 }
+                if transaction.len() > MAX_TRANSACTION_MESSAGE_SIZE {
+                    metrics::counter!(
+                        "zone_p2p_oversized_messages_dropped_total",
+                        "channel" => "transaction",
+                        "direction" => "outbound",
+                    )
+                    .increment(1);
+                    warn!(
+                        target: "zone::p2p",
+                        ?transaction_hash,
+                        transaction_size_bytes = transaction.len(),
+                        max_transaction_size_bytes = MAX_TRANSACTION_MESSAGE_SIZE,
+                        "Dropping oversized forwarded transaction"
+                    );
+                    continue;
+                }
                 let configured = recipients.len();
                 let transaction_size = transaction.len();
                 let sent = match senders
@@ -663,15 +688,17 @@ async fn run_commands(
     Err(eyre::eyre!("P2P command channel closed unexpectedly"))
 }
 
-async fn run_receivers<R>(
+async fn run_receivers<R, B>(
     local_ed25519_public_key: PublicKey,
     membership: RoutingMembership,
     leadership: LeadershipSchedule,
+    mut blocker: B,
     receivers: P2pReceivers<R>,
     events: mpsc::Sender<P2pEvent>,
 ) -> eyre::Result<()>
 where
     R: commonware_p2p::Receiver<PublicKey = PublicKey>,
+    B: commonware_p2p::Blocker<PublicKey = PublicKey>,
 {
     let P2pReceivers {
         mut blocks,
@@ -734,6 +761,25 @@ where
             // admit these into their pools; RPC-only standbys can never become leader.
             result = transactions.recv() => {
                 let (peer, bytes) = result.map_err(|err| eyre::eyre!("transaction channel receive failed: {err}"))?;
+                let transaction = match into_bounded_payload(bytes, MAX_TRANSACTION_MESSAGE_SIZE) {
+                    Ok(transaction) => transaction,
+                    Err(size) => {
+                        metrics::counter!(
+                            "zone_p2p_oversized_messages_dropped_total",
+                            "channel" => "transaction",
+                            "direction" => "inbound",
+                        )
+                        .increment(1);
+                        commonware_p2p::block!(
+                            blocker,
+                            peer,
+                            transaction_size_bytes = size,
+                            max_transaction_size_bytes = MAX_TRANSACTION_MESSAGE_SIZE,
+                            "Blocking peer for oversized forwarded transaction"
+                        );
+                        continue;
+                    }
+                };
                 let may_accept = RoutingPolicy::new(
                     &local_ed25519_public_key,
                     &membership,
@@ -748,7 +794,7 @@ where
                 metrics::counter!("zone_p2p_transactions_received_total").increment(1);
                 P2pEvent::TransactionReceived {
                     follower_ed25519_public_key: peer,
-                    transaction: bytes.into(),
+                    transaction,
                 }
             }
         };
@@ -762,20 +808,68 @@ where
 #[cfg(test)]
 mod tests {
     use std::{
+        io,
         net::{SocketAddr, TcpListener},
-        sync::Arc,
+        sync::{Arc, Mutex},
         time::Duration,
     };
 
     use alloy_primitives::{B256, address};
     use commonware_codec::Encode as _;
-    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+    use commonware_cryptography::{
+        Signer as _,
+        ed25519::{PrivateKey, PublicKey},
+    };
+    use commonware_runtime::IoBuf;
 
-    use super::{P2pCommand, P2pConfig, P2pEvent, spawn_p2p, validate_ip_check_configuration};
+    use super::{
+        P2pCommand, P2pConfig, P2pEvent, P2pReceivers, into_bounded_payload, run_receivers,
+        spawn_p2p, validate_ip_check_configuration,
+    };
     use crate::{
         P2pHandle, P2pHandleParts, P2pNetworkId, ZoneManifest,
         identity::{Ed25519Identity, Secp256k1Identity},
+        network::MAX_TRANSACTION_MESSAGE_SIZE,
+        routing::RoutingMembership,
     };
+
+    #[derive(Debug)]
+    struct MockReceiver {
+        receiver: tokio::sync::mpsc::UnboundedReceiver<commonware_p2p::Message<PublicKey>>,
+    }
+
+    impl commonware_p2p::Receiver for MockReceiver {
+        type Error = io::Error;
+        type PublicKey = PublicKey;
+
+        async fn recv(&mut self) -> Result<commonware_p2p::Message<Self::PublicKey>, Self::Error> {
+            self.receiver
+                .recv()
+                .await
+                .ok_or_else(|| io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct RecordingBlocker {
+        blocked: Arc<Mutex<Vec<PublicKey>>>,
+    }
+
+    impl commonware_p2p::Blocker for RecordingBlocker {
+        type PublicKey = PublicKey;
+
+        async fn block(&mut self, peer: Self::PublicKey) {
+            self.blocked.lock().unwrap().push(peer);
+        }
+    }
+
+    fn mock_receiver() -> (
+        tokio::sync::mpsc::UnboundedSender<commonware_p2p::Message<PublicKey>>,
+        MockReceiver,
+    ) {
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        (sender, MockReceiver { receiver })
+    }
 
     fn test_tip(zone_height: u64) -> crate::PeerTip {
         crate::PeerTip {
@@ -798,6 +892,15 @@ mod tests {
 
     fn secp256k1_identity(seed: u64) -> Secp256k1Identity {
         Secp256k1Identity::from_hex(&format!("0x{seed:064x}")).unwrap()
+    }
+
+    #[test]
+    fn bounded_payload_rejects_oversized_frames_before_event_allocation() {
+        let accepted = into_bounded_payload(IoBuf::from(vec![0x11; 4]), 4).unwrap();
+        assert_eq!(accepted, vec![0x11; 4]);
+
+        let oversized = into_bounded_payload(IoBuf::from(vec![0x22; 5]), 4).unwrap_err();
+        assert_eq!(oversized, 5);
     }
 
     /// Resend `command` until the test drops the returned handle.
@@ -938,6 +1041,70 @@ mod tests {
         let error = validate_ip_check_configuration(&manifest, false).unwrap_err();
         assert!(error.to_string().contains("--p2p.bypass-ip-check"));
         validate_ip_check_configuration(&manifest, true).unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_inbound_transaction_blocks_peer_before_emitting_event() {
+        let addresses = [
+            available_address(),
+            available_address(),
+            available_address(),
+        ];
+        let identities = [91_u64, 92, 93].map(ed25519_identity);
+        let input = manifest_with_standby(&identities, &addresses, 91, usize::MAX);
+        let manifest = Arc::new(ZoneManifest::parse(&input).unwrap());
+        let membership = RoutingMembership::from_manifest(&manifest);
+        let leadership = crate::LeadershipSchedule::seeded(manifest.bootstrap_leadership());
+        let local_peer = identities[0].ed25519_public_key();
+        let malicious_peer = identities[1].ed25519_public_key();
+
+        let (_blocks_tx, blocks) = mock_receiver();
+        let (_proposals_tx, settlement_proposals) = mock_receiver();
+        let (_signatures_tx, settlement_signatures) = mock_receiver();
+        let (transactions_tx, transactions) = mock_receiver();
+        let (events_tx, mut events) = tokio::sync::mpsc::channel(4);
+        let blocker = RecordingBlocker::default();
+        let observed_blocker = blocker.clone();
+        let receiver_task = tokio::spawn(run_receivers(
+            local_peer,
+            membership,
+            leadership,
+            blocker,
+            P2pReceivers {
+                blocks,
+                settlement_proposals,
+                settlement_signatures,
+                transactions,
+            },
+            events_tx,
+        ));
+
+        transactions_tx
+            .send((
+                malicious_peer.clone(),
+                IoBuf::from(vec![0; MAX_TRANSACTION_MESSAGE_SIZE + 1]),
+            ))
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if observed_blocker
+                    .blocked
+                    .lock()
+                    .unwrap()
+                    .contains(&malicious_peer)
+                {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("oversized transaction sender was not blocked");
+        assert!(
+            events.try_recv().is_err(),
+            "oversized transaction reached the event queue"
+        );
+        receiver_task.abort();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1272,6 +1439,13 @@ mod tests {
         // Forwarded transactions reach every other replica. In particular, B retains C's
         // transaction before its leadership activates, while B's own forward reaches A and C.
         let transaction = vec![0x76, 0x01, 0x02, 0x03];
+        follower_commands
+            .send(P2pCommand::ForwardTransaction {
+                transaction_hash: B256::with_last_byte(3),
+                transaction: vec![0; MAX_TRANSACTION_MESSAGE_SIZE + 1],
+            })
+            .await
+            .unwrap();
         let follower_forwarder = repeat(
             follower_commands.clone(),
             P2pCommand::ForwardTransaction {


### PR DESCRIPTION
## Summary

- cap forwarded transaction frames at 1 MiB before they enter application event queues
- reduce the count-only transaction receive backlog from 1,024 frames to 4
- drop oversized local forwards and disconnect authenticated peers that violate the wire limit
- reject manifest-mode startup when the configured transaction-pool limit exceeds the P2P limit
- add focused receiver, network, and startup-configuration regressions

## Security impact

The transaction channel previously allowed roughly 20 GiB of pre-validation frame data to queue. This bounds that Commonware queue to roughly 80 MiB and prevents accepted transaction events from carrying more than 1 MiB each.

An oversized authenticated sender is blocked across Commonware protocols. Deploy this change consistently across manifest peers before raising the transaction-pool input limit; upgraded nodes now fail startup if their local pool limit would exceed the wire protocol limit.

## Validation

- rustup run nightly cargo test -p zone-p2p (50 passed)
- rustup run nightly cargo test -p zone-node --features cli manifest_mode_rejects_a_txpool_limit_above_the_p2p_wire_limit
- rustup run nightly cargo clippy -p zone-p2p --all-targets -- -D warnings
- rustup run nightly cargo clippy -p zone-node --features cli --all-targets -- -D warnings
- rustup run nightly cargo fmt --all -- --check

Fixes CYCLOPS-538