### PR TITLE
fix(replication): serve backfill from persisted head

### DIFF
--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -90,8 +90,6 @@ pub(crate) struct EncodedPersistedBlock {
 /// Interface used by the replication task to keep track of blocks that are persisted vs broadcast
 pub(crate) trait PersistedBlockSource: Clone + Send + Sync + 'static {
     fn last_block_number(&self) -> eyre::Result<u64>;
-    /// The canonical head, which may be ahead of the persisted head (reth persists lazily).
-    fn canonical_block_number(&self) -> eyre::Result<u64>;
     fn persisted_block_stream(&self) -> BoxStream<'static, PersistedTip>;
     fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock>;
 }
@@ -102,10 +100,6 @@ where
 {
     fn last_block_number(&self) -> eyre::Result<u64> {
         Ok(BlockNumReader::last_block_number(self)?)
-    }
-
-    fn canonical_block_number(&self) -> eyre::Result<u64> {
-        Ok(BlockNumReader::best_block_number(self)?)
     }
 
     fn persisted_block_stream(&self) -> BoxStream<'static, PersistedTip> {
@@ -171,22 +165,22 @@ pub(crate) async fn broadcast_persisted_blocks<P>(
             () = stop.cancelled() => {
                 // The block generation is stopping (leader demotion). Flush all persisted
                 // blocks to ensure the new leader can take over properly.
-                match provider.canonical_block_number() {
-                    Ok(canonical) => {
+                match provider.last_block_number() {
+                    Ok(persisted) => {
                         if let Err(err) = broadcast_persisted_range(
                             &provider,
                             &commands,
                             &mut last_broadcast,
-                            canonical,
+                            persisted,
                             None,
                         )
                         .await
                         {
-                            tracing::error!(target: "zone::p2p", %err, "Failed flushing canonical zone blocks on stop");
+                            tracing::error!(target: "zone::p2p", %err, "Failed flushing persisted zone blocks on stop");
                         }
                     }
                     Err(err) => {
-                        tracing::error!(target: "zone::p2p", %err, "Failed reading the canonical zone head for the stop flush");
+                        tracing::error!(target: "zone::p2p", %err, "Failed reading the persisted zone head for the stop flush");
                     }
                 }
                 debug!(target: "zone::p2p", "Persisted block broadcaster stopped");
@@ -1269,10 +1263,6 @@ mod tests {
             })
         }
 
-        fn canonical_block_number(&self) -> eyre::Result<u64> {
-            Ok(self.tip.number)
-        }
-
         fn persisted_block_stream(&self) -> futures::stream::BoxStream<'static, PersistedTip> {
             stream::iter([self.tip]).boxed()
         }
@@ -1284,6 +1274,27 @@ mod tests {
                 hash: self.tip.hash,
                 encoded: vec![number as u8],
             })
+        }
+    }
+
+    #[derive(Clone)]
+    struct DemotionSource {
+        encoded_reads: Arc<AtomicUsize>,
+        persisted: u64,
+    }
+
+    impl PersistedBlockSource for DemotionSource {
+        fn last_block_number(&self) -> eyre::Result<u64> {
+            Ok(self.persisted)
+        }
+
+        fn persisted_block_stream(&self) -> futures::stream::BoxStream<'static, PersistedTip> {
+            stream::pending().boxed()
+        }
+
+        fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock> {
+            self.encoded_reads.fetch_add(1, Ordering::SeqCst);
+            eyre::bail!("stop flush tried to read unpersisted block {number}")
         }
     }
 
@@ -1668,6 +1679,23 @@ mod tests {
             command_rx.recv().await,
             Some(P2pCommand::BroadcastBlock(vec![1]))
         );
+        assert_eq!(command_rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn demotion_flush_stops_at_the_persisted_head() {
+        let encoded_reads = Arc::new(AtomicUsize::new(0));
+        let source = DemotionSource {
+            encoded_reads: encoded_reads.clone(),
+            persisted: 1,
+        };
+        let (commands, mut command_rx) = tokio::sync::mpsc::channel(1);
+        let stop = tokio_util::sync::CancellationToken::new();
+        stop.cancel();
+
+        broadcast_persisted_blocks(source, commands, stop).await;
+
+        assert_eq!(encoded_reads.load(Ordering::SeqCst), 0);
         assert_eq!(command_rx.recv().await, None);
     }
 

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -383,10 +383,6 @@ fn encoded_block_number(encoded: &[u8]) -> eyre::Result<u64> {
     Ok(block.header.number())
 }
 
-fn persisted_backfill_tip(provider: &impl BlockNumReader) -> eyre::Result<u64> {
-    Ok(provider.last_block_number()?)
-}
-
 fn serve_backfill_page<P>(
     provider: &P,
     commands: &mpsc::Sender<BackfillCommand>,
@@ -400,7 +396,7 @@ where
         + HeaderProvider<Header = TempoHeader>
         + StateProviderFactory,
 {
-    let tip = persisted_backfill_tip(provider)?;
+    let tip = provider.last_block_number()?;
     let end = tip.min(start.saturating_add(BACKFILL_PAGE_SIZE.saturating_sub(1)));
     for number in start..=end {
         let block = provider.block_by_number(number)?.ok_or_else(|| {
@@ -1235,13 +1231,11 @@ mod tests {
 
     use alloy_eips::NumHash;
     use futures::{StreamExt as _, stream};
-    use reth_chainspec::ChainInfo;
-    use reth_storage_api::{BlockHashReader, BlockNumReader, errors::provider::ProviderResult};
 
     use super::{
         AdvanceTempoPortalInputs, BackfillProgress, EncodedPersistedBlock, MAX_PENDING_BLOCKS,
         PersistedBlockSource, PersistedTip, broadcast_persisted_blocks, buffer_pending_block,
-        persisted_backfill_tip, validate_live_block_sender, wait_for_validated_peer_anchor,
+        validate_live_block_sender, wait_for_validated_peer_anchor,
     };
     use alloy_primitives::B256;
     use zone_l1::{L1BlockTracker, L1PortalEvents};
@@ -1275,71 +1269,6 @@ mod tests {
                 encoded: vec![number as u8],
             })
         }
-    }
-
-    #[derive(Clone)]
-    struct DemotionSource {
-        encoded_reads: Arc<AtomicUsize>,
-        persisted: u64,
-    }
-
-    impl PersistedBlockSource for DemotionSource {
-        fn last_block_number(&self) -> eyre::Result<u64> {
-            Ok(self.persisted)
-        }
-
-        fn persisted_block_stream(&self) -> futures::stream::BoxStream<'static, PersistedTip> {
-            stream::pending().boxed()
-        }
-
-        fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock> {
-            self.encoded_reads.fetch_add(1, Ordering::SeqCst);
-            eyre::bail!("stop flush tried to read unpersisted block {number}")
-        }
-    }
-
-    struct DivergentHeads {
-        best: u64,
-        persisted: u64,
-    }
-
-    impl BlockHashReader for DivergentHeads {
-        fn block_hash(&self, _number: u64) -> ProviderResult<Option<B256>> {
-            unreachable!("backfill tip selection must not read a block hash")
-        }
-
-        fn canonical_hashes_range(&self, _start: u64, _end: u64) -> ProviderResult<Vec<B256>> {
-            unreachable!("backfill tip selection must not read block hashes")
-        }
-    }
-
-    impl BlockNumReader for DivergentHeads {
-        fn chain_info(&self) -> ProviderResult<ChainInfo> {
-            unreachable!("backfill tip selection must not read chain info")
-        }
-
-        fn best_block_number(&self) -> ProviderResult<u64> {
-            Ok(self.best)
-        }
-
-        fn last_block_number(&self) -> ProviderResult<u64> {
-            Ok(self.persisted)
-        }
-
-        fn block_number(&self, _hash: B256) -> ProviderResult<Option<u64>> {
-            unreachable!("backfill tip selection must not resolve block numbers")
-        }
-    }
-
-    #[test]
-    fn backfill_tip_uses_the_persisted_head() {
-        let provider = DivergentHeads {
-            best: 3,
-            persisted: 2,
-        };
-
-        assert_eq!(provider.best_block_number().unwrap(), 3);
-        assert_eq!(persisted_backfill_tip(&provider).unwrap(), 2);
     }
 
     #[test]
@@ -1679,23 +1608,6 @@ mod tests {
             command_rx.recv().await,
             Some(P2pCommand::BroadcastBlock(vec![1]))
         );
-        assert_eq!(command_rx.recv().await, None);
-    }
-
-    #[tokio::test]
-    async fn demotion_flush_stops_at_the_persisted_head() {
-        let encoded_reads = Arc::new(AtomicUsize::new(0));
-        let source = DemotionSource {
-            encoded_reads: encoded_reads.clone(),
-            persisted: 1,
-        };
-        let (commands, mut command_rx) = tokio::sync::mpsc::channel(1);
-        let stop = tokio_util::sync::CancellationToken::new();
-        stop.cancel();
-
-        broadcast_persisted_blocks(source, commands, stop).await;
-
-        assert_eq!(encoded_reads.load(Ordering::SeqCst), 0);
         assert_eq!(command_rx.recv().await, None);
     }
 

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -389,6 +389,10 @@ fn encoded_block_number(encoded: &[u8]) -> eyre::Result<u64> {
     Ok(block.header.number())
 }
 
+fn persisted_backfill_tip(provider: &impl BlockNumReader) -> eyre::Result<u64> {
+    Ok(provider.last_block_number()?)
+}
+
 fn serve_backfill_page<P>(
     provider: &P,
     commands: &mpsc::Sender<BackfillCommand>,
@@ -402,11 +406,11 @@ where
         + HeaderProvider<Header = TempoHeader>
         + StateProviderFactory,
 {
-    let tip = provider.best_block_number()?;
+    let tip = persisted_backfill_tip(provider)?;
     let end = tip.min(start.saturating_add(BACKFILL_PAGE_SIZE.saturating_sub(1)));
     for number in start..=end {
         let block = provider.block_by_number(number)?.ok_or_else(|| {
-            eyre::eyre!("canonical block {number} is missing while serving backfill")
+            eyre::eyre!("persisted canonical block {number} is missing while serving backfill")
         })?;
         commands
             .blocking_send(BackfillCommand::SendBlock {
@@ -416,10 +420,10 @@ where
             })
             .map_err(|_| eyre::eyre!("P2P command channel closed"))?;
     }
-    // Advertise the tip
-    let tip_header = provider
-        .sealed_header(tip)?
-        .ok_or_else(|| eyre::eyre!("canonical head {tip} is missing while serving backfill"))?;
+    // Advertise the persisted tip.
+    let tip_header = provider.sealed_header(tip)?.ok_or_else(|| {
+        eyre::eyre!("persisted canonical head {tip} is missing while serving backfill")
+    })?;
     let tempo = provider
         .state_by_block_hash(tip_header.hash())?
         .tempo_num_hash()?;
@@ -1237,11 +1241,13 @@ mod tests {
 
     use alloy_eips::NumHash;
     use futures::{StreamExt as _, stream};
+    use reth_chainspec::ChainInfo;
+    use reth_storage_api::{BlockHashReader, BlockNumReader, errors::provider::ProviderResult};
 
     use super::{
         AdvanceTempoPortalInputs, BackfillProgress, EncodedPersistedBlock, MAX_PENDING_BLOCKS,
         PersistedBlockSource, PersistedTip, broadcast_persisted_blocks, buffer_pending_block,
-        validate_live_block_sender, wait_for_validated_peer_anchor,
+        persisted_backfill_tip, validate_live_block_sender, wait_for_validated_peer_anchor,
     };
     use alloy_primitives::B256;
     use zone_l1::{L1BlockTracker, L1PortalEvents};
@@ -1279,6 +1285,50 @@ mod tests {
                 encoded: vec![number as u8],
             })
         }
+    }
+
+    struct DivergentHeads {
+        best: u64,
+        persisted: u64,
+    }
+
+    impl BlockHashReader for DivergentHeads {
+        fn block_hash(&self, _number: u64) -> ProviderResult<Option<B256>> {
+            unreachable!("backfill tip selection must not read a block hash")
+        }
+
+        fn canonical_hashes_range(&self, _start: u64, _end: u64) -> ProviderResult<Vec<B256>> {
+            unreachable!("backfill tip selection must not read block hashes")
+        }
+    }
+
+    impl BlockNumReader for DivergentHeads {
+        fn chain_info(&self) -> ProviderResult<ChainInfo> {
+            unreachable!("backfill tip selection must not read chain info")
+        }
+
+        fn best_block_number(&self) -> ProviderResult<u64> {
+            Ok(self.best)
+        }
+
+        fn last_block_number(&self) -> ProviderResult<u64> {
+            Ok(self.persisted)
+        }
+
+        fn block_number(&self, _hash: B256) -> ProviderResult<Option<u64>> {
+            unreachable!("backfill tip selection must not resolve block numbers")
+        }
+    }
+
+    #[test]
+    fn backfill_tip_uses_the_persisted_head() {
+        let provider = DivergentHeads {
+            best: 3,
+            persisted: 2,
+        };
+
+        assert_eq!(provider.best_block_number().unwrap(), 3);
+        assert_eq!(persisted_backfill_tip(&provider).unwrap(), 2);
     }
 
     #[test]

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1235,7 +1235,7 @@ fn local_recovery_tip<P>(provider: &P) -> Result<PeerTip, JsonRpcError>
 where
     P: BlockNumReader + HeaderProvider + StateProviderFactory,
 {
-    let zone_height = provider.best_block_number().map_err(internal)?;
+    let zone_height = provider.last_block_number().map_err(internal)?;
     let zone_header = provider
         .sealed_header(zone_height)
         .map_err(internal)?

--- a/crates/p2p/src/backfill.rs
+++ b/crates/p2p/src/backfill.rs
@@ -117,6 +117,7 @@ impl BackfillJob {
         kind: RequestKind,
         now: Instant,
     ) -> Option<(u64, Vec<PublicKey>)> {
+        self.behind_until.retain(|_, until| now < *until);
         let request_peers = peers
             .iter()
             .filter(|peer| {

--- a/crates/p2p/src/backfill.rs
+++ b/crates/p2p/src/backfill.rs
@@ -23,6 +23,7 @@ const BACKFILL_RESPONSE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// Commonware sender admission does not indicate whether a peer is connected. Each accepted block
 /// refreshes this timeout, so active responses remain reserved while offline peers are retried.
 const BACKFILL_RESPONSE_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(5);
+const BACKFILL_BEHIND_COOLDOWN: Duration = Duration::from_secs(30);
 
 type CommonwareSender = lookup::Sender<PublicKey, commonware_runtime::tokio::Context>;
 type CommonwareReceiver = lookup::Receiver<PublicKey>;
@@ -88,6 +89,7 @@ enum RequestKind {
 #[derive(Debug, Clone, Copy)]
 struct OutstandingBackfill {
     request_id: u64,
+    start: u64,
     sent_at: Instant,
     last_progress_at: Instant,
     kind: RequestKind,
@@ -104,12 +106,14 @@ impl OutstandingBackfill {
 struct BackfillJob {
     next_request_id: u64,
     outstanding: HashMap<PublicKey, OutstandingBackfill>,
+    behind_until: HashMap<PublicKey, Instant>,
 }
 
 impl BackfillJob {
     fn begin_request(
         &mut self,
         peers: &[PublicKey],
+        start: u64,
         kind: RequestKind,
         now: Instant,
     ) -> Option<(u64, Vec<PublicKey>)> {
@@ -119,6 +123,7 @@ impl BackfillJob {
                 self.outstanding
                     .get(*peer)
                     .is_none_or(|request| request.expired(now))
+                    && !self.is_behind(peer, now)
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -133,6 +138,7 @@ impl BackfillJob {
                 peer.clone(),
                 OutstandingBackfill {
                     request_id,
+                    start,
                     sent_at: now,
                     last_progress_at: now,
                     kind,
@@ -178,12 +184,22 @@ impl BackfillJob {
             .is_some_and(|request| request.kind == RequestKind::LeaderOnly && !request.expired(now))
     }
 
-    fn complete(&mut self, peer: &PublicKey, request_id: u64, now: Instant) -> bool {
+    fn is_behind(&self, peer: &PublicKey, now: Instant) -> bool {
+        self.behind_until
+            .get(peer)
+            .is_some_and(|until| now < *until)
+    }
+
+    fn mark_behind(&mut self, peer: PublicKey, now: Instant) {
+        self.behind_until
+            .insert(peer, now + BACKFILL_BEHIND_COOLDOWN);
+    }
+
+    fn complete(&mut self, peer: &PublicKey, request_id: u64, now: Instant) -> Option<u64> {
         if !self.accepts(peer, request_id, now) {
-            return false;
+            return None;
         }
-        self.outstanding.remove(peer);
-        true
+        self.outstanding.remove(peer).map(|request| request.start)
     }
 }
 
@@ -327,7 +343,7 @@ where
 
             // Reserve eligible peers and assign a request ID. Peers with a live outstanding
             // request are skipped, so each peer has at most one active request.
-            let request = self.job.begin_request(&sources, kind, now);
+            let request = self.job.begin_request(&sources, start, kind, now);
             let Some((request_id, request_peers)) = request else {
                 debug!(target: "zone::p2p", start, sources = sources.len(), leader_only = kind == RequestKind::LeaderOnly, "Skipping block backfill request because all eligible peers already have outstanding responses");
                 if kind == RequestKind::LeaderOnly
@@ -418,8 +434,15 @@ where
                     .map_err(|_| eyre::eyre!("backfill response event channel closed"))?;
             }
             ResponseFrame::Complete { request_id, tip } => {
-                if !self.job.complete(&peer, request_id, received_at) {
+                let Some(requested_start) = self.job.complete(&peer, request_id, received_at)
+                else {
                     warn!(target: "zone::p2p", %peer, request_id, "Ignoring unsolicited or stale backfill completion");
+                    return Ok(());
+                };
+                if tip.zone_height < requested_start {
+                    warn!(target: "zone::p2p", %peer, request_id, requested_start, tip_height = tip.zone_height, "Backfill peer is behind the requested range; trying other eligible peers");
+                    self.job.mark_behind(peer, received_at);
+                    self.request_blocks(requested_start).await?;
                     return Ok(());
                 }
                 self.responses
@@ -436,7 +459,9 @@ where
 mod tests {
     use std::time::Duration;
 
-    use super::{BACKFILL_RESPONSE_INACTIVITY_TIMEOUT, BackfillJob, RequestKind};
+    use super::{
+        BACKFILL_BEHIND_COOLDOWN, BACKFILL_RESPONSE_INACTIVITY_TIMEOUT, BackfillJob, RequestKind,
+    };
     use crate::protocol::{PeerTip, ResponseFrame};
     use alloy_primitives::B256;
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
@@ -460,7 +485,12 @@ mod tests {
         let now = std::time::Instant::now();
         let mut job = BackfillJob::default();
         let (first, peers) = job
-            .begin_request(std::slice::from_ref(&leader), RequestKind::LeaderOnly, now)
+            .begin_request(
+                std::slice::from_ref(&leader),
+                7,
+                RequestKind::LeaderOnly,
+                now,
+            )
             .unwrap();
         job.finish_send(first, &peers);
         let before_timeout = now + BACKFILL_RESPONSE_INACTIVITY_TIMEOUT / 2;
@@ -469,10 +499,11 @@ mod tests {
         assert!(job.accepts(&leader, first, before_timeout));
         assert!(job.should_wait_for_leader(&leader, before_timeout));
         assert!(job.is_unresponsive(&leader, at_timeout));
-        assert!(!job.complete(&leader, first, at_timeout));
+        assert_eq!(job.complete(&leader, first, at_timeout), None);
         let (replacement, peers) = job
             .begin_request(
                 std::slice::from_ref(&leader),
+                8,
                 RequestKind::LeaderOnly,
                 at_timeout,
             )
@@ -480,9 +511,49 @@ mod tests {
         job.finish_send(replacement, &peers);
         assert_ne!(replacement, first);
         assert!(!job.accepts(&leader, first, at_timeout));
-        assert!(!job.complete(&leader, first, at_timeout));
+        assert_eq!(job.complete(&leader, first, at_timeout), None);
         assert!(job.accepts(&leader, replacement, at_timeout));
-        assert!(job.complete(&leader, replacement, at_timeout));
+        assert_eq!(job.complete(&leader, replacement, at_timeout), Some(8));
+    }
+
+    #[test]
+    fn behind_peer_is_bypassed_until_its_cooldown_expires() {
+        let leader = peer(1);
+        let alternate = peer(2);
+        let now = std::time::Instant::now();
+        let mut job = BackfillJob::default();
+        let (request_id, peers) = job
+            .begin_request(
+                std::slice::from_ref(&leader),
+                11,
+                RequestKind::LeaderOnly,
+                now,
+            )
+            .unwrap();
+        job.finish_send(request_id, &peers);
+
+        assert_eq!(job.complete(&leader, request_id, now), Some(11));
+        job.mark_behind(leader.clone(), now);
+
+        let (_, peers) = job
+            .begin_request(
+                &[leader.clone(), alternate.clone()],
+                11,
+                RequestKind::Fallback,
+                now,
+            )
+            .unwrap();
+        assert_eq!(peers, vec![alternate]);
+
+        assert!(
+            job.begin_request(
+                std::slice::from_ref(&leader),
+                11,
+                RequestKind::LeaderOnly,
+                now + BACKFILL_BEHIND_COOLDOWN
+            )
+            .is_some()
+        );
     }
 
     #[test]
@@ -491,7 +562,7 @@ mod tests {
         let now = std::time::Instant::now();
         let mut job = BackfillJob::default();
         let (request_id, peers) = job
-            .begin_request(std::slice::from_ref(&peer), RequestKind::Fallback, now)
+            .begin_request(std::slice::from_ref(&peer), 7, RequestKind::Fallback, now)
             .unwrap();
         job.finish_send(request_id, &peers);
 
@@ -500,7 +571,7 @@ mod tests {
         malformed.extend_from_slice(&[0; PeerTip::ENCODED_LEN - 1]);
         assert!(ResponseFrame::decode(&malformed).is_err());
         assert!(job.accepts(&peer, request_id, now));
-        assert!(job.complete(&peer, request_id, now));
+        assert_eq!(job.complete(&peer, request_id, now), Some(7));
         assert_eq!(
             ResponseFrame::decode(
                 &ResponseFrame::Complete {
@@ -523,7 +594,12 @@ mod tests {
         let now = std::time::Instant::now();
         let mut job = BackfillJob::default();
         let (request_id, peers) = job
-            .begin_request(std::slice::from_ref(&leader), RequestKind::LeaderOnly, now)
+            .begin_request(
+                std::slice::from_ref(&leader),
+                7,
+                RequestKind::LeaderOnly,
+                now,
+            )
             .unwrap();
         job.finish_send(request_id, &peers);
 
@@ -539,6 +615,7 @@ mod tests {
         assert!(
             job.begin_request(
                 std::slice::from_ref(&leader),
+                8,
                 RequestKind::LeaderOnly,
                 retry_at,
             )
@@ -559,7 +636,7 @@ mod tests {
         let now = std::time::Instant::now();
         let mut job = BackfillJob::default();
         let (first, peers) = job
-            .begin_request(&candidates, RequestKind::Fallback, now)
+            .begin_request(&candidates, 7, RequestKind::Fallback, now)
             .unwrap();
         job.finish_send(first, &peers);
 
@@ -568,7 +645,7 @@ mod tests {
 
         let retry_at = now + BACKFILL_RESPONSE_INACTIVITY_TIMEOUT;
         let (replacement, peers) = job
-            .begin_request(&candidates, RequestKind::Fallback, retry_at)
+            .begin_request(&candidates, 7, RequestKind::Fallback, retry_at)
             .unwrap();
         assert_eq!(peers, vec![silent.clone()]);
         job.finish_send(replacement, &peers);
@@ -585,17 +662,17 @@ mod tests {
         let now = std::time::Instant::now();
         let mut job = BackfillJob::default();
         let (page_one, peers) = job
-            .begin_request(&candidates, RequestKind::Fallback, now)
+            .begin_request(&candidates, 7, RequestKind::Fallback, now)
             .unwrap();
         job.finish_send(page_one, &peers);
-        assert!(job.complete(&backup, page_one, now));
+        assert_eq!(job.complete(&backup, page_one, now), Some(7));
 
         let retry_at = now + Duration::from_secs(1);
         assert!(!job.should_wait_for_leader(&leader, retry_at));
         let (page_two, peers) = job
-            .begin_request(&candidates, RequestKind::Fallback, retry_at)
+            .begin_request(&candidates, 8, RequestKind::Fallback, retry_at)
             .unwrap();
         assert_eq!(peers, vec![backup.clone()]);
-        assert!(job.complete(&backup, page_two, retry_at));
+        assert_eq!(job.complete(&backup, page_two, retry_at), Some(8));
     }
 }


### PR DESCRIPTION
## Summary

- bound backfill pages and their advertised peer tip to the database-persisted canonical head
- prevent a follower from importing an in-memory best block through backfill before the leader has durably committed it
- add a regression with divergent best and persisted heads

## Root cause

`serve_backfill_page` used `best_block_number()`, which includes Reth’s in-memory canonical head. If the leader crashed before that head was persisted, a follower could already have imported a block that disappeared when the leader restarted. The backfill path now uses `last_block_number()`, matching the persisted head used by normal persisted-block broadcasting.

## Validation

- `rustup run nightly cargo test -p zone-node --lib` (49 passed)
- `rustup run nightly cargo clippy -p zone-node --all-targets --all-features -- -D warnings`
- `rustup run nightly cargo fmt --all -- --check`

Fixes ZONE-134