### PR TITLE
ci: normalize AST ids in storage layout check

### DIFF
--- a/.github/workflows/storage-layout.yml
+++ b/.github/workflows/storage-layout.yml
@@ -31,6 +31,23 @@ jobs:
       - name: Check storage layout
         working-directory: specs/ref-impls
         run: |
+          set -o pipefail
+          normalizer='
+            def strip_ast_id: gsub("(?<prefix>t_(?:struct|enum|contract|userDefinedValueType)\\([^)]*\\))[0-9]+"; "\(.prefix)");
+            del(.. | .astId?)
+            | walk(if type == "string" then strip_ast_id else . end)
+            | .types |= (to_entries | map(.key |= strip_ast_id)
+              | if (map(.key) | unique | length) == length then from_entries
+                else error("type-key collision while stripping AST IDs") end)
+          '
+          expected_layout="$RUNNER_TEMP/ZonePortal.expected.json"
+          generated_layout="$RUNNER_TEMP/ZonePortal.generated.json"
+
+          jq --sort-keys "$normalizer" storage-layouts/ZonePortal.json > "$expected_layout"
           forge inspect ZonePortal storage-layout --json \
-            | jq . > storage-layouts/ZonePortal.json
-          git diff --exit-code -- storage-layouts/ZonePortal.json
+            | jq --sort-keys "$normalizer" > "$generated_layout"
+
+          diff --unified \
+            --label storage-layouts/ZonePortal.json \
+            --label generated/ZonePortal.json \
+            "$expected_layout" "$generated_layout"


### PR DESCRIPTION
this PR normalizes AST ids in the solidity layout check so that we don't need to constantly regenerate when there are non-breaking changes