### PR TITLE
fix(p2p): keep RPC followers inbound-only

### DIFF
--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -1,8 +1,11 @@
 use std::{net::SocketAddr, time::Duration};
 
 use alloy_primitives::Address as EthereumAddress;
-use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
-use commonware_p2p::{Address, authenticated::lookup};
+use commonware_cryptography::{
+    Signer as _,
+    ed25519::{PrivateKey, PublicKey},
+};
+use commonware_p2p::{AddressableTrackedPeers, authenticated::lookup};
 use commonware_runtime::{Metrics as _, Quota};
 use commonware_utils::{NZU32, ordered::Map};
 use eyre::WrapErr as _;
@@ -82,7 +85,7 @@ fn setup_commonware_config(
     config.allowed_handshake_rate_per_subnet = Quota::per_second(NZU32!(32));
     // Ten-second pings detect idle broken connections with negligible overhead.
     config.ping_frequency = Duration::from_secs(10);
-    // One dial per 250 ms reconnects a full five-node mesh in about one second per node.
+    // One dial per 250 ms reconnects a small primary-peer set in about one second per node.
     config.dial_frequency = Duration::from_millis(250);
 
     config
@@ -95,27 +98,52 @@ pub(crate) fn instantiate(
     listen: SocketAddr,
     bypass_ip_check: bool,
     network_id: P2pNetworkId,
-) -> eyre::Result<(Network, Oracle, Map<PublicKey, Address>)> {
+) -> eyre::Result<(Network, Oracle, AddressableTrackedPeers<PublicKey>)> {
     let namespace = namespace(manifest.zone_id(), network_id);
     // Logged, not bound into the namespace: a mismatch between nodes stalls settlement loudly at
     // the next batch boundary, and making it a handshake failure would turn every membership edit
     // into a coordinated fleet restart. Compare this across nodes to diagnose one.
     tracing::info!(target: "zone::p2p", membership_digest = %manifest.membership_digest(), "Zone P2P membership");
+    let local_ed25519_public_key = ed25519_private_key.public_key();
     let config = setup_commonware_config(ed25519_private_key, &namespace, listen, bypass_ip_check);
+    let peers = peer_sets(manifest, &local_ed25519_public_key)?;
+    let (network, oracle) = lookup::Network::new(context.with_label("network"), config);
+    Ok((network, oracle, peers))
+}
 
-    let peers = manifest
+fn peer_sets(
+    manifest: &ZoneManifest,
+    local_ed25519_public_key: &PublicKey,
+) -> eyre::Result<AddressableTrackedPeers<PublicKey>> {
+    let (primary, secondary): (Vec<_>, Vec<_>) = manifest
         .nodes()
         .iter()
         .map(|node| {
             (
+                node.is_rpc_only(),
                 node.ed25519_public_key().clone(),
                 node.address().to_commonware(),
             )
         })
-        .collect::<Vec<_>>();
-    let peers = Map::try_from(peers).wrap_err("manifest contains duplicate P2P identities")?;
-    let (network, oracle) = lookup::Network::new(context.with_label("network"), config);
-    Ok((network, oracle, peers))
+        // RPC-only nodes initiate their own replication connections. Quorum members retain the
+        // RPC-only members as secondary peers so their inbound connection is authenticated, but
+        // they never create reverse P2P dials into the public RPC environment.
+        .partition(|(rpc_only, public_key, _)| !rpc_only || public_key == local_ed25519_public_key);
+    let primary = Map::try_from(
+        primary
+            .into_iter()
+            .map(|(_, public_key, address)| (public_key, address))
+            .collect::<Vec<_>>(),
+    )
+    .wrap_err("manifest contains duplicate primary P2P identities")?;
+    let secondary = Map::try_from(
+        secondary
+            .into_iter()
+            .map(|(_, public_key, address)| (public_key, address))
+            .collect::<Vec<_>>(),
+    )
+    .wrap_err("manifest contains duplicate secondary P2P identities")?;
+    Ok(AddressableTrackedPeers::new(primary, secondary))
 }
 
 fn namespace(zone_id: u32, network_id: P2pNetworkId) -> Vec<u8> {
@@ -157,8 +185,36 @@ pub(crate) fn settlement_quota() -> Quota {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::address;
+    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
-    use super::{NETWORK_NAMESPACE_PREFIX, P2pNetworkId, WIRE_PROTOCOL_VERSION, namespace};
+    use super::{
+        NETWORK_NAMESPACE_PREFIX, P2pNetworkId, WIRE_PROTOCOL_VERSION, namespace, peer_sets,
+    };
+    use crate::ZoneManifest;
+
+    fn ed25519_public_key(seed: u64) -> String {
+        let key = PrivateKey::from_seed(seed).public_key();
+        const_hex::encode_prefixed(key.as_ref())
+    }
+
+    fn manifest_with_rpc_follower() -> ZoneManifest {
+        let mut manifest = format!(
+            "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n",
+            ed25519_public_key(1)
+        );
+        for seed in 1..=3 {
+            manifest.push_str(&format!(
+                "\n[[nodes]]\nname = \"seq-{seed}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x{seed:040x}\"\naddress = \"127.0.0.1:{}\"\n",
+                ed25519_public_key(seed),
+                9200 + seed,
+            ));
+        }
+        manifest.push_str(&format!(
+            "\n[[nodes]]\nname = \"rpc\"\ned25519_public_key = \"{}\"\naddress = \"rpc.example:19200\"\nrpc_only = true\n",
+            ed25519_public_key(4),
+        ));
+        ZoneManifest::parse(&manifest).unwrap()
+    }
 
     #[test]
     fn namespace_separates_l1_environments_and_portals() {
@@ -183,5 +239,22 @@ mod tests {
             namespace[NETWORK_NAMESPACE_PREFIX.len()],
             WIRE_PROTOCOL_VERSION
         );
+    }
+
+    #[test]
+    fn rpc_follower_dials_quorum_but_quorum_does_not_dial_rpc_follower() {
+        let manifest = manifest_with_rpc_follower();
+        let quorum_member = PrivateKey::from_seed(1).public_key();
+        let rpc_follower = PrivateKey::from_seed(4).public_key();
+
+        let quorum_peers = peer_sets(&manifest, &quorum_member).unwrap();
+        assert!(quorum_peers.primary.position(&quorum_member).is_some());
+        assert!(quorum_peers.primary.position(&rpc_follower).is_none());
+        assert!(quorum_peers.secondary.position(&rpc_follower).is_some());
+
+        let rpc_peers = peer_sets(&manifest, &rpc_follower).unwrap();
+        assert!(rpc_peers.primary.position(&quorum_member).is_some());
+        assert!(rpc_peers.primary.position(&rpc_follower).is_some());
+        assert!(rpc_peers.secondary.is_empty());
     }
 }


### PR DESCRIPTION
## What

- Classify `rpc_only` manifest members as secondary peers on quorum nodes.
- Keep an RPC follower's own entry and every quorum peer primary.
- Add coverage for the directed connection policy.

## Why

Public Zone RPCs must initiate authenticated P2P replication toward staging sequencers. Staging must still recognize those RPC keys for inbound traffic, but must not create a reverse staging-to-public dial or require a public ingress.

## Validation

- `cargo fmt --check`
- `cargo test -p zone-p2p`
- `cargo build -p tempo-zone`

## Rollout dependency

The staging and public Zone-RPC infrastructure drafts depend on an image containing this change; they remain unmerged and unactivated.