### PR TITLE
fix(precompiles): include TIP-20 permit in fixed gas

### DIFF
--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -36,6 +36,7 @@ pub(crate) const TIP20_FIXED_GAS_SELECTORS: &[[u8; 4]] = &[
     ITIP20::transferWithMemoCall::SELECTOR,
     ITIP20::transferFromWithMemoCall::SELECTOR,
     ITIP20::approveCall::SELECTOR,
+    ITIP20::permitCall::SELECTOR,
 ];
 
 /// Zone-specific rules applied before forwarding to upstream `TIP20Token`.


### PR DESCRIPTION
ref: `ZONE-314`

## Summary

- Include `ITIP20::permitCall::SELECTOR` in the zone TIP-20 fixed-gas selector set.
- Reuse the existing selector-mapping test coverage.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Focused Rust test blocked before compilation because the sandbox could not fetch the pinned `alloy-evm` git revision; GitHub returned HTTP 401.

Fixes ZONE-314

Prompted by: @0xrusowsky