### PR TITLE
fix(rpc): validate redacted fee history percentiles

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -716,14 +716,26 @@ where
                 .await
                 .map_err(internal)?;
             if let Some(reward_percentiles) = reward_percentiles.as_deref() {
-                validate_reward_percentiles(
-                    reward_percentiles,
-                    self.eth
+                // These checks mirror upstream Reth's `eth_feeHistory` validation. We repeat
+                // them here because passing `None` above avoids loading private block bodies,
+                // which also bypasses Reth's validation; validate before allocating the redacted
+                // reward matrix to bound its size.
+                if reward_percentiles.len() as u64
+                    > self
+                        .eth
                         .api
                         .gas_oracle()
                         .config()
-                        .max_reward_percentile_count,
-                )?;
+                        .max_reward_percentile_count
+                    || reward_percentiles
+                        .iter()
+                        .any(|percentile| *percentile < 0.0 || *percentile > 100.0)
+                    || reward_percentiles
+                        .windows(2)
+                        .any(|window| window[0] > window[1])
+                {
+                    return Err(JsonRpcError::invalid_params("invalid reward percentiles"));
+                }
                 history.reward = Some(vec![
                     vec![0; reward_percentiles.len()];
                     history.gas_used_ratio.len()
@@ -1282,25 +1294,6 @@ fn redact_fee_history(history: &mut FeeHistory) {
     history.blob_gas_used_ratio.fill(0.0);
 }
 
-/// Validate reward percentiles before using their length to allocate the redacted reward matrix.
-fn validate_reward_percentiles(
-    reward_percentiles: &[f64],
-    max_count: u64,
-) -> Result<(), JsonRpcError> {
-    if reward_percentiles.len() as u64 > max_count
-        || reward_percentiles
-            .iter()
-            .any(|percentile| *percentile < 0.0 || *percentile > 100.0)
-        || reward_percentiles
-            .windows(2)
-            .any(|window| window[0] > window[1])
-    {
-        return Err(JsonRpcError::invalid_params("invalid reward percentiles"));
-    }
-
-    Ok(())
-}
-
 /// Prefill missing transaction fee fields with public, deterministic values before calling reth's
 /// transaction filler, so `eth_fillTransaction` does not expose dynamic fee estimates derived from
 /// private zone activity.
@@ -1444,39 +1437,6 @@ mod tests {
         assert_eq!(history.base_fee_per_blob_gas, vec![0; 3]);
         assert_eq!(history.blob_gas_used_ratio, vec![0.0; 2]);
         assert_eq!(history.reward, Some(vec![vec![7, 8], vec![9, 10]]));
-    }
-
-    #[test]
-    fn validate_reward_percentiles_accepts_sorted_values_in_range() {
-        assert!(validate_reward_percentiles(&[0.0, 50.0, 100.0], 3).is_ok());
-    }
-
-    #[test]
-    fn validate_reward_percentiles_rejects_excessive_count() {
-        let percentiles = vec![0.0; 4];
-
-        let error = validate_reward_percentiles(&percentiles, 3).expect_err("count is invalid");
-
-        assert_eq!(error.code, -32602);
-        assert_eq!(error.message, "invalid reward percentiles");
-    }
-
-    #[test]
-    fn validate_reward_percentiles_rejects_out_of_range_values() {
-        for percentiles in [[-1.0], [100.1]] {
-            let error = validate_reward_percentiles(&percentiles, 3).expect_err("range is invalid");
-
-            assert_eq!(error.code, -32602);
-            assert_eq!(error.message, "invalid reward percentiles");
-        }
-    }
-
-    #[test]
-    fn validate_reward_percentiles_rejects_unsorted_values() {
-        let error = validate_reward_percentiles(&[50.0, 25.0], 3).expect_err("ordering is invalid");
-
-        assert_eq!(error.code, -32602);
-        assert_eq!(error.message, "invalid reward percentiles");
     }
 
     #[test]

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -29,7 +29,9 @@ use reth_rpc::{EthFilter, eth::filter::EthFilterError};
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, RpcConvert,
-    helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
+    helpers::{
+        EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi, LoadFee,
+    },
 };
 use reth_rpc_eth_types::logs_utils;
 use reth_storage_api::{BlockNumReader, StateProviderFactory};
@@ -714,6 +716,14 @@ where
                 .await
                 .map_err(internal)?;
             if let Some(reward_percentiles) = reward_percentiles.as_deref() {
+                validate_reward_percentiles(
+                    reward_percentiles,
+                    self.eth
+                        .api
+                        .gas_oracle()
+                        .config()
+                        .max_reward_percentile_count,
+                )?;
                 history.reward = Some(vec![
                     vec![0; reward_percentiles.len()];
                     history.gas_used_ratio.len()
@@ -1272,6 +1282,25 @@ fn redact_fee_history(history: &mut FeeHistory) {
     history.blob_gas_used_ratio.fill(0.0);
 }
 
+/// Validate reward percentiles before using their length to allocate the redacted reward matrix.
+fn validate_reward_percentiles(
+    reward_percentiles: &[f64],
+    max_count: u64,
+) -> Result<(), JsonRpcError> {
+    if reward_percentiles.len() as u64 > max_count
+        || reward_percentiles
+            .iter()
+            .any(|percentile| *percentile < 0.0 || *percentile > 100.0)
+        || reward_percentiles
+            .windows(2)
+            .any(|window| window[0] > window[1])
+    {
+        return Err(JsonRpcError::invalid_params("invalid reward percentiles"));
+    }
+
+    Ok(())
+}
+
 /// Prefill missing transaction fee fields with public, deterministic values before calling reth's
 /// transaction filler, so `eth_fillTransaction` does not expose dynamic fee estimates derived from
 /// private zone activity.
@@ -1415,6 +1444,39 @@ mod tests {
         assert_eq!(history.base_fee_per_blob_gas, vec![0; 3]);
         assert_eq!(history.blob_gas_used_ratio, vec![0.0; 2]);
         assert_eq!(history.reward, Some(vec![vec![7, 8], vec![9, 10]]));
+    }
+
+    #[test]
+    fn validate_reward_percentiles_accepts_sorted_values_in_range() {
+        assert!(validate_reward_percentiles(&[0.0, 50.0, 100.0], 3).is_ok());
+    }
+
+    #[test]
+    fn validate_reward_percentiles_rejects_excessive_count() {
+        let percentiles = vec![0.0; 4];
+
+        let error = validate_reward_percentiles(&percentiles, 3).expect_err("count is invalid");
+
+        assert_eq!(error.code, -32602);
+        assert_eq!(error.message, "invalid reward percentiles");
+    }
+
+    #[test]
+    fn validate_reward_percentiles_rejects_out_of_range_values() {
+        for percentiles in [[-1.0], [100.1]] {
+            let error = validate_reward_percentiles(&percentiles, 3).expect_err("range is invalid");
+
+            assert_eq!(error.code, -32602);
+            assert_eq!(error.message, "invalid reward percentiles");
+        }
+    }
+
+    #[test]
+    fn validate_reward_percentiles_rejects_unsorted_values() {
+        let error = validate_reward_percentiles(&[50.0, 25.0], 3).expect_err("ordering is invalid");
+
+        assert_eq!(error.code, -32602);
+        assert_eq!(error.message, "invalid reward percentiles");
     }
 
     #[test]

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -29,9 +29,7 @@ use reth_rpc::{EthFilter, eth::filter::EthFilterError};
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, RpcConvert,
-    helpers::{
-        EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi, LoadFee,
-    },
+    helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
 };
 use reth_rpc_eth_types::logs_utils;
 use reth_storage_api::{BlockNumReader, StateProviderFactory};

--- a/crates/node/tests/it/redacted_rpc_e2e.rs
+++ b/crates/node/tests/it/redacted_rpc_e2e.rs
@@ -577,6 +577,31 @@ async fn test_public_methods() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Excessive reward percentile requests are rejected before the redacted reward matrix is built.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fee_history_rejects_excessive_reward_percentiles() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_redacted_rpc().await?;
+    let user_signer = PrivateKeySigner::random();
+    let response = ctx
+        .call_as_user(
+            "eth_feeHistory",
+            json!([1, "latest", vec![0.0_f64; 101]]),
+            &user_signer,
+        )
+        .await?;
+
+    assert_eq!(response["error"]["code"].as_i64(), Some(-32602));
+    assert_eq!(
+        response["error"]["message"].as_str(),
+        Some("invalid reward percentiles"),
+        "excessive reward percentile request should be rejected: {response}",
+    );
+
+    Ok(())
+}
+
 /// Filter ownership is scoped to the creating account, and uninstall removes follow-up access.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_filter_ownership_and_uninstall_cleanup() -> eyre::Result<()> {


### PR DESCRIPTION
## Summary

- Inline Reth-equivalent `rewardPercentiles` count, `[0, 100]` range, and nondecreasing-order checks before constructing the redacted reward matrix.
- Document why the checks are repeated locally: passing `None` to Reth avoids loading private block bodies and bypasses its validation.
- Add an end-to-end regression test proving 101 percentiles return `-32602` before allocation.

Addresses ZONE-415.

## Testing

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo test -p zone-node --test it redacted_rpc_e2e::test_fee_history_rejects_excessive_reward_percentiles --no-run` *(blocked before compilation: Cargo could not fetch the pinned `alloy-evm` revision; GitHub returned HTTP 401)*

Prompted by: aditya