### PR TITLE
fix(rpc): validate redacted fee history percentiles

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -414,6 +414,19 @@ type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHe
 const FILTER_OWNER_PRUNE_INTERVAL: Duration = Duration::from_secs(60);
 const MAX_WS_FRAME_AND_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
+fn validate_reward_percentiles(percentiles: &[f64], max_count: u64) -> Result<(), JsonRpcError> {
+    if percentiles.len() as u64 > max_count
+        || percentiles
+            .iter()
+            .any(|percentile| *percentile < 0.0 || *percentile > 100.0)
+        || percentiles.windows(2).any(|window| window[0] > window[1])
+    {
+        return Err(JsonRpcError::invalid_params("invalid reward percentiles"));
+    }
+
+    Ok(())
+}
+
 fn filter_not_found_error() -> JsonRpcError {
     JsonRpcError::invalid_params("filter not found")
 }
@@ -709,6 +722,17 @@ where
         reward_percentiles: Option<Vec<f64>>,
     ) -> BoxFut<'_> {
         Box::pin(async move {
+            if let Some(reward_percentiles) = reward_percentiles.as_deref() {
+                validate_reward_percentiles(
+                    reward_percentiles,
+                    self.eth
+                        .api
+                        .gas_oracle()
+                        .config()
+                        .max_reward_percentile_count,
+                )?;
+            }
+
             // Avoid loading private block bodies to calculate reward percentiles.
             let mut history = EthFees::fee_history(&self.eth.api, block_count, newest_block, None)
                 .await

--- a/crates/node/tests/it/redacted_rpc_e2e.rs
+++ b/crates/node/tests/it/redacted_rpc_e2e.rs
@@ -281,6 +281,56 @@ async fn test_auth_rejection() -> eyre::Result<()> {
     Ok(())
 }
 
+/// `eth_feeHistory` validates reward percentiles before constructing the redacted reward matrix.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fee_history_validates_reward_percentiles() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let ctx = start_zone_with_redacted_rpc().await?;
+    let user_signer = PrivateKeySigner::random();
+
+    let invalid_percentiles = [vec![0.0; 101], vec![-0.1], vec![100.1], vec![50.0, 49.0]];
+    for percentiles in invalid_percentiles {
+        let response = ctx
+            .call_as_user(
+                "eth_feeHistory",
+                json!([1, "latest", percentiles]),
+                &user_signer,
+            )
+            .await?;
+        assert_eq!(
+            response["error"]["code"].as_i64(),
+            Some(-32602),
+            "invalid reward percentiles should be rejected: {response}",
+        );
+        assert_eq!(
+            response["error"]["message"].as_str(),
+            Some("invalid reward percentiles"),
+            "the redacted RPC should match reth's validation error: {response}",
+        );
+    }
+
+    let valid_percentiles: Vec<f64> = (0..100).map(f64::from).collect();
+    let response = ctx
+        .call_as_user(
+            "eth_feeHistory",
+            json!([1, "latest", valid_percentiles]),
+            &user_signer,
+        )
+        .await?;
+    assert!(
+        response.get("error").is_none(),
+        "valid reward percentiles should remain supported: {response}",
+    );
+    assert_eq!(
+        response["result"]["reward"][0].as_array().map(Vec::len),
+        Some(100),
+        "the redacted reward matrix should preserve the requested shape: {response}",
+    );
+
+    Ok(())
+}
+
 /// Pool admission requires the transaction sender to hold an enabled zone token.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_send_raw_transaction_requires_enabled_token_balance() -> eyre::Result<()> {


### PR DESCRIPTION
## Summary

- validate `rewardPercentiles` against Reth's configured count limit, range, and ordering rules before constructing the redacted reward matrix
- return Reth-compatible invalid-params errors while preserving valid reward response shapes
- cover invalid inputs and the valid 100-entry boundary through the authenticated redacted RPC

## Root cause and impact

The redacted `eth_feeHistory` path intentionally passes `None` to Reth so reward calculation does not load private block bodies. That also bypassed Reth's input validation, while the redaction layer still used the caller-provided array length to preserve the response shape. Validating locally keeps the privacy behavior and prevents unexpectedly large reward-matrix allocations.

Closes ZONE-415