### PR TITLE
docs(ref-impl): support batched Tempo imports

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -1117,6 +1117,7 @@ interface IZoneInbox {
     error MissingDecryptionData();
     error ExtraDecryptionData();
     error InvalidSharedSecretProof();
+    error LeaderTransitionCrossed();
     error Unauthorized();
 
     /// @notice The Tempo portal address (for reading deposit queue hash)
@@ -1141,7 +1142,8 @@ interface IZoneInbox {
     ///      3. Validates the resulting hash chain equals Tempo's currentDepositQueueHash
     ///
     ///      The system transaction is all-or-nothing and must process every pending deposit
-    ///      through the final queue head. A mismatch reverts the complete call.
+    ///      through the final queue head. A mismatch reverts the complete call. Every imported
+    ///      header must belong to one leadership epoch; an activation block may only start a range.
     ///
     ///      For user deposits, the sequencer provides DecryptionData with the
     ///      ECDH shared secret and proof. ZoneInbox derives (to, memo) onchain.

--- a/specs/ref-impls/src/zone/ZoneInbox.sol
+++ b/specs/ref-impls/src/zone/ZoneInbox.sol
@@ -18,6 +18,7 @@ import {
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     PORTAL_ENCRYPTION_KEYS_SLOT,
     PORTAL_IS_SEQUENCER_SLOT,
+    PORTAL_LEADER_ACTIVATION_TEMPO_BLOCK_SLOT,
     QueuedDeposit,
     WithdrawalBounceBackDeposit,
     ZONE_OUTBOX
@@ -215,8 +216,24 @@ contract ZoneInbox is IZoneInbox {
     {
         if (msg.sender != address(0)) revert OnlySequencer();
 
-        // Step 1: Advance Tempo state (validates chain continuity internally)
+        // Step 1: Advance Tempo state (validates chain continuity internally).
+        uint64 firstTempoBlock = _tempoState.tempoBlockNumber() + 1;
         _tempoState.finalizeTempo(headers);
+        uint64 finalTempoBlock = _tempoState.tempoBlockNumber();
+
+        // A leadership activation block may start a range but cannot appear inside one.
+        if (firstTempoBlock < finalTempoBlock) {
+            uint64 activation = uint64(
+                uint256(
+                    _tempoState.readTempoStorageSlot(
+                        tempoPortal, PORTAL_LEADER_ACTIVATION_TEMPO_BLOCK_SLOT
+                    )
+                )
+            );
+            if (firstTempoBlock < activation && activation <= finalTempoBlock) {
+                revert LeaderTransitionCrossed();
+            }
+        }
 
         // Activate new tokens directly in the Inbox.
         for (uint256 i = 0; i < enabledTokens.length; i++) {

--- a/specs/ref-impls/test/zone/ZoneInbox.t.sol
+++ b/specs/ref-impls/test/zone/ZoneInbox.t.sol
@@ -20,6 +20,7 @@ import {
     PORTAL_CURRENT_DEPOSIT_QUEUE_HASH_SLOT,
     PORTAL_ENCRYPTION_KEYS_SLOT,
     PORTAL_IS_SEQUENCER_SLOT,
+    PORTAL_LEADER_ACTIVATION_TEMPO_BLOCK_SLOT,
     QueuedDeposit,
     WithdrawalBounceBackDeposit,
     ZONE_OUTBOX
@@ -138,6 +139,35 @@ contract ZoneInboxTest is Test {
 
         // State should remain at bytes32(0)
         assertEq(inbox.processedDepositQueueHash(), bytes32(0));
+    }
+
+    function test_advanceTempo_acceptsLeadershipActivationAsFirstHeader() public {
+        tempoState.setMockStorageValue(
+            mockPortal,
+            PORTAL_LEADER_ACTIVATION_TEMPO_BLOCK_SLOT,
+            bytes32(uint256(GENESIS_TEMPO_BLOCK_NUMBER + 1))
+        );
+
+        vm.prank(sequencer);
+        inbox.advanceTempo(
+            new bytes[](2), new QueuedDeposit[](0), new DecryptionData[](0), new EnabledToken[](0)
+        );
+        assertEq(tempoState.tempoBlockNumber(), GENESIS_TEMPO_BLOCK_NUMBER + 2);
+    }
+
+    function test_advanceTempo_revertsWhenRangeCrossesLeadershipActivation() public {
+        tempoState.setMockStorageValue(
+            mockPortal,
+            PORTAL_LEADER_ACTIVATION_TEMPO_BLOCK_SLOT,
+            bytes32(uint256(GENESIS_TEMPO_BLOCK_NUMBER + 2))
+        );
+
+        vm.prank(sequencer);
+        vm.expectRevert(IZoneInbox.LeaderTransitionCrossed.selector);
+        inbox.advanceTempo(
+            new bytes[](2), new QueuedDeposit[](0), new DecryptionData[](0), new EnabledToken[](0)
+        );
+        assertEq(tempoState.tempoBlockNumber(), GENESIS_TEMPO_BLOCK_NUMBER);
     }
 
     function test_advanceTempo_singleDeposit() public {
@@ -891,6 +921,24 @@ contract ZoneInboxTest is Test {
 
         vm.prank(sequencer);
         _advanceTempoQueued(new QueuedDeposit[](0), new DecryptionData[](0), enabledTokens);
+    }
+
+    function test_advanceTempo_multiHeaderRangeAcceptsAccumulatedTokenEnablements() public {
+        EnabledToken[] memory enabledTokens = new EnabledToken[](9);
+        for (uint256 i = 0; i < enabledTokens.length; i++) {
+            address token = address(uint160(0x800 + i));
+            vm.etch(token, hex"00");
+            _mockTokenActivation(token);
+            enabledTokens[i] =
+                EnabledToken({ token: token, name: "Token", symbol: "TOK", currency: "USD" });
+        }
+
+        vm.prank(sequencer);
+        inbox.advanceTempo(
+            new bytes[](2), new QueuedDeposit[](0), new DecryptionData[](0), enabledTokens
+        );
+
+        assertEq(tempoState.tempoBlockNumber(), GENESIS_TEMPO_BLOCK_NUMBER + 2);
     }
 
     /// @notice Claiming with no refund returns zero and mints nothing.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -323,7 +323,7 @@ The admin manages which TIP-20 tokens are available on the zone (see [Access Con
 - `pauseDeposits(token)`: Pause new deposits for a token. Does not affect withdrawals.
 - `resumeDeposits(token)`: Resume deposits for a previously paused token.
 
-The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin can halt deposits but cannot disable withdrawals for an enabled token. To keep the mandatory zone-side `advanceTempo()` call within its fixed system gas budget, each portal accepts at most `MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK` (8) token enablements in one Tempo block, including the initial token enabled during portal creation. Metadata copied into the zone is bounded by encoded byte length: 64 bytes for `name` and 31 bytes each for `symbol` and `currency`. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
+The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin can halt deposits but cannot disable withdrawals for an enabled token. To bound the token activation work originating in any one Tempo block, each portal accepts at most `MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK` (8) token enablements in that block, including the initial token enabled during portal creation. The counter resets each Tempo block, allowing enablements to accumulate during sequencer downtime and be imported across multiple catch-up Zone blocks. Metadata copied into the zone is bounded by encoded byte length: 64 bytes for `name` and 31 bytes each for `symbol` and `currency`. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
 
 ### Gas Rate Configuration
 
@@ -1946,7 +1946,7 @@ interface IZoneInbox {
 }
 ```
 
-`EnabledToken` carries token metadata (`token`, `name`, `symbol`, `currency`) for direct activation of zone-side TIP-20 precompiles by `ZoneInbox`. `ZonePortal` admits at most 8 such activations per Tempo block and rejects metadata whose encoded byte length exceeds 64 bytes for `name` or 31 bytes for `symbol` or `currency`.
+`EnabledToken` carries token metadata (`token`, `name`, `symbol`, `currency`) for direct activation of zone-side TIP-20 precompiles by `ZoneInbox`. `ZonePortal` admits at most 8 such activations per Tempo block and rejects metadata whose encoded byte length exceeds 64 bytes for `name` or 31 bytes for `symbol` or `currency`. The reference `ZoneInbox` does not impose an additional token-count cap across a multi-header range; operators can split accumulated activation work across catch-up Zone blocks.
 
 ### IZoneOutbox
 


### PR DESCRIPTION
## Summary

This PR updates the Solidity protocol/reference contracts to support importing a contiguous range of Tempo headers in one Zone `advanceTempo` call as introduced in https://github.com/tempoxyz/zones/pull/981.

It intentionally contains only the protocol/reference-contract side of the change. The native Rust precompile, node, payload-builder, queue, replication, and generated Zone genesis updates will follow in a separate implementation PR.


