### PR TITLE
fix(node): migrate initial token policy in dev provisioning

### DIFF
--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -13,7 +13,8 @@ use alloy_provider::{PendingTransactionBuilder, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::SolEvent;
 use tempo_alloy::TempoNetwork;
-use tempo_contracts::precompiles::{ITIP20, PATH_USD_ADDRESS};
+use tempo_contracts::precompiles::{ITIP20, ITIP403Registry, PATH_USD_ADDRESS};
+use tempo_precompiles::TIP403_REGISTRY_ADDRESS;
 use tempo_zone_contracts::{ZONE_FACTORY_ADDRESS, ZoneFactory};
 use zone_primitives::constants::zone_chain_id;
 use zone_sequencer::register_encryption_key;
@@ -104,6 +105,32 @@ pub async fn provision_zone(config: ProvisionConfig) -> eyre::Result<Provisioned
          {dev_address}; use the standard Tempo dev key or transfer factory ownership before \
          provisioning"
     );
+
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider);
+    let mut policy = registry.tokenTransferPolicyId(initial_token).call().await?;
+    if !policy.isSet {
+        tracing::info!(
+            token = %initial_token,
+            "migrating legacy transfer policy before zone creation"
+        );
+        let receipt = registry
+            .migrateTransferPolicyIds(vec![initial_token])
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(
+            receipt.status(),
+            "transfer policy migration reverted: {:?}",
+            receipt.transaction_hash
+        );
+        policy = registry.tokenTransferPolicyId(initial_token).call().await?;
+    }
+    eyre::ensure!(
+        policy.isSet,
+        "transfer policy is not set for initial token {initial_token} after migration"
+    );
+
     // Anchor before createZone so the L1 subscriber replays the creation block,
     // including the initial TokenEnabled event emitted by the portal constructor.
     let anchor_block_number = provider.get_block_number().await?;

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -19,7 +19,8 @@ use alloy_consensus::Transaction;
 use eyre::WrapErr as _;
 use futures::future::try_join_all;
 use std::{collections::HashMap, time::Duration};
-use tempo_precompiles::PATH_USD_ADDRESS;
+use tempo_contracts::precompiles::ITIP403Registry;
+use tempo_precompiles::{PATH_USD_ADDRESS, TIP403_REGISTRY_ADDRESS};
 use tempo_zone_contracts::{
     IZoneOutbox, TEMPO_STATE_ADDRESS, TempoState, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS,
     ZonePortal, ZonePortal::Role as PortalRole,
@@ -225,6 +226,45 @@ async fn test_dev_provisioner_replays_initial_token_event() -> eyre::Result<()> 
         "custom initial token should be initialized from TokenEnabled"
     );
 
+    Ok(())
+}
+
+/// The native ZoneFactory requires a TIP-403 binding, so dev provisioning must migrate
+/// pathUSD's legacy token-local policy before creating the zone.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dev_provisioner_migrates_initial_token_policy() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let l1 = L1TestNode::start_without_initial_token_policy().await?;
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, l1.provider());
+    assert!(
+        !registry
+            .tokenTransferPolicyId(PATH_USD_ADDRESS)
+            .call()
+            .await?
+            .isSet
+    );
+
+    provision_zone(ProvisionConfig {
+        l1_rpc_url: l1.ws_url().to_string(),
+        dev_key: l1.dev_signer(),
+        factory: None,
+        initial_token: PATH_USD_ADDRESS,
+        is_access_open: true,
+        is_gateway_enforced: false,
+        zone_gateways: Vec::new(),
+        allowed_accounts: Vec::new(),
+        rpc_url: String::new(),
+    })
+    .await?;
+
+    assert!(
+        registry
+            .tokenTransferPolicyId(PATH_USD_ADDRESS)
+            .call()
+            .await?
+            .isSet
+    );
     Ok(())
 }
 

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -283,6 +283,21 @@ fn install_native_zone_factory(genesis: &mut Genesis, owner: Address) -> eyre::R
     Ok(())
 }
 
+fn remove_native_zone_initial_token_policy(genesis: &mut Genesis) {
+    let token_policy_slot = keccak256(
+        (
+            PATH_USD_ADDRESS,
+            tip403_registry_slots::TOKEN_TRANSFER_POLICIES,
+        )
+            .abi_encode(),
+    );
+    let _ = genesis
+        .alloc
+        .get_mut(&TIP403_REGISTRY_ADDRESS)
+        .and_then(|account| account.storage.as_mut())
+        .and_then(|storage| storage.remove(&token_policy_slot));
+}
+
 /// Dummy L1 URL used when no real L1 is needed.
 ///
 /// The launch helper recognizes this sentinel and replaces it with a local RPC
@@ -2603,6 +2618,11 @@ impl L1TestNode {
         Self::start_with(|_| {}).await
     }
 
+    /// Start an L1 dev node with the legacy pathUSD policy layout and no TIP-403 binding.
+    pub(crate) async fn start_without_initial_token_policy() -> eyre::Result<Self> {
+        Self::start_with_policy(false, |_| {}).await
+    }
+
     /// Start an L1 dev node, applying a closure to customise the [`NodeConfig`]
     /// before launch.
     ///
@@ -2618,12 +2638,22 @@ impl L1TestNode {
     pub(crate) async fn start_with(
         f: impl FnOnce(&mut NodeConfig<TempoChainSpec>),
     ) -> eyre::Result<Self> {
+        Self::start_with_policy(true, f).await
+    }
+
+    async fn start_with_policy(
+        include_initial_token_policy: bool,
+        f: impl FnOnce(&mut NodeConfig<TempoChainSpec>),
+    ) -> eyre::Result<Self> {
         let tasks = Runtime::test();
 
         let genesis: serde_json::Value =
             serde_json::from_str(include_str!("../assets/test-genesis.json"))?;
         let mut genesis = serde_json::from_value(genesis)?;
         install_native_zone_factory(&mut genesis, l1_dev_signer().address())?;
+        if !include_initial_token_policy {
+            remove_native_zone_initial_token_policy(&mut genesis);
+        }
         let chain_spec = TempoChainSpec::from_genesis(genesis);
 
         let mut node_config = NodeConfig::new(Arc::new(chain_spec))


### PR DESCRIPTION
## Summary

- Migrate the initial token's legacy TIP-20 transfer policy into TIP-403 before native ZoneFactory creation.
- Add an integration regression test covering dev provisioning with an unset registry binding.

## Validation

- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo check -p zone-node --features cli` could not run because the pinned `alloy-evm` revision was unavailable from GitHub (401).

Prompted by: @shekhirin