### PR TITLE
fix(replication): preserve durable leader handoffs

### DIFF
--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use tempo_alloy::TempoNetwork;
 use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use zone_l1::{DepositQueue, L1BlockTracker, L1PortalEvents, TempoStateExt as _};
@@ -87,9 +87,25 @@ pub(crate) struct EncodedPersistedBlock {
     encoded: Vec<u8>,
 }
 
+/// The one shutdown decision the role controller makes for a leader's block broadcaster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BroadcasterShutdown {
+    /// The engine has stopped, so wait for its frozen canonical tail to become durable.
+    Drain,
+    /// The engine stop was not proven; flush only the durable prefix and abandon the rest.
+    Stop,
+}
+
 /// Interface used by the replication task to keep track of blocks that are persisted vs broadcast
 pub(crate) trait PersistedBlockSource: Clone + Send + Sync + 'static {
     fn last_block_number(&self) -> eyre::Result<u64>;
+    /// The canonical head, which may be ahead of the persisted head (reth persists lazily).
+    ///
+    /// This is a drain *target*, never a broadcast height: a canonical-only block lives in
+    /// reth's volatile in-memory state and would vanish from this node on restart. Read it only
+    /// after the engine has stopped, and publish the blocks it names through the persisted
+    /// stream.
+    fn canonical_block_number(&self) -> eyre::Result<u64>;
     fn persisted_block_stream(&self) -> BoxStream<'static, PersistedTip>;
     fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock>;
 }
@@ -100,6 +116,10 @@ where
 {
     fn last_block_number(&self) -> eyre::Result<u64> {
         Ok(BlockNumReader::last_block_number(self)?)
+    }
+
+    fn canonical_block_number(&self) -> eyre::Result<u64> {
+        Ok(BlockNumReader::best_block_number(self)?)
     }
 
     fn persisted_block_stream(&self) -> BoxStream<'static, PersistedTip> {
@@ -125,10 +145,20 @@ where
 }
 
 /// Broadcast every newly persisted leader block in canonical order until cancelled.
+///
+/// A single shutdown command decides how to handle the leader's final block:
+///
+/// * [`BroadcasterShutdown::Drain`] is the graceful path. The role controller sends it only
+///   after the engine task has returned, which freezes the canonical head and lets this task wait
+///   for the final block to persist before publishing it.
+/// * [`BroadcasterShutdown::Stop`] is the abrupt path. It flushes what is already durable and
+///   abandons the rest.
+///
+/// Neither path ever broadcasts a canonical-only block.
 pub(crate) async fn broadcast_persisted_blocks<P>(
     provider: P,
     commands: mpsc::Sender<P2pCommand>,
-    stop: CancellationToken,
+    mut shutdown: oneshot::Receiver<BroadcasterShutdown>,
 ) where
     P: PersistedBlockSource,
 {
@@ -162,28 +192,50 @@ pub(crate) async fn broadcast_persisted_blocks<P>(
     loop {
         let persisted_tip = tokio::select! {
             biased;
-            () = stop.cancelled() => {
-                // The block generation is stopping (leader demotion). Flush all persisted
-                // blocks to ensure the new leader can take over properly.
-                match provider.last_block_number() {
-                    Ok(persisted) => {
-                        if let Err(err) = broadcast_persisted_range(
+            command = &mut shutdown => {
+                match command {
+                    Ok(BroadcasterShutdown::Drain) => {
+                        if let Err(err) = drain_persisted_blocks_after_engine_stop(
                             &provider,
                             &commands,
                             &mut last_broadcast,
-                            persisted,
-                            None,
+                            &mut persisted,
                         )
                         .await
                         {
-                            tracing::error!(target: "zone::p2p", %err, "Failed flushing persisted zone blocks on stop");
+                            tracing::error!(target: "zone::p2p", %err, "Failed draining persisted zone blocks after the leader engine stopped");
                         }
                     }
-                    Err(err) => {
-                        tracing::error!(target: "zone::p2p", %err, "Failed reading the persisted zone head for the stop flush");
+                    Ok(BroadcasterShutdown::Stop) => {
+                        // Stopped without an engine-complete drain, so the canonical head is
+                        // still moving and cannot be a flush target. Publish what is already
+                        // durable and abandon the rest: a canonical-only block would disappear
+                        // from this node on restart, leaving followers on a height no replica can
+                        // serve.
+                        match provider.last_block_number() {
+                            Ok(persisted_head) => {
+                                if let Err(err) = broadcast_persisted_range(
+                                    &provider,
+                                    &commands,
+                                    &mut last_broadcast,
+                                    persisted_head,
+                                    None,
+                                )
+                                .await
+                                {
+                                    tracing::error!(target: "zone::p2p", %err, "Failed flushing persisted zone blocks on stop");
+                                }
+                            }
+                            Err(err) => {
+                                tracing::error!(target: "zone::p2p", %err, "Failed reading the persisted zone head for the stop flush");
+                            }
+                        }
+                        debug!(target: "zone::p2p", "Persisted block broadcaster stopped");
+                    }
+                    Err(_) => {
+                        debug!(target: "zone::p2p", "Persisted block broadcaster shutdown control dropped");
                     }
                 }
-                debug!(target: "zone::p2p", "Persisted block broadcaster stopped");
                 return;
             }
             tip = persisted.next() => match tip {
@@ -215,6 +267,53 @@ pub(crate) async fn broadcast_persisted_blocks<P>(
         }
     }
     debug!(target: "zone::p2p", "Persisted block stream closed");
+}
+
+/// Publish the outgoing leader's final blocks once they are durable.
+///
+/// The caller must have observed the engine task return before signalling this, which is what
+/// makes the loop terminate: cancelling the generation token is not a block boundary, because an
+/// in-flight advance still completes before the engine yields. Only a stopped engine pins the
+/// canonical head, and only a pinned target can be waited for.
+///
+/// Blocks still go out through [`broadcast_persisted_range`] with the hash the persisted stream
+/// reported, so the durable-source invariant holds on this path too.
+async fn drain_persisted_blocks_after_engine_stop<P>(
+    provider: &P,
+    commands: &mpsc::Sender<P2pCommand>,
+    last_broadcast: &mut u64,
+    persisted: &mut BoxStream<'static, PersistedTip>,
+) -> eyre::Result<()>
+where
+    P: PersistedBlockSource,
+{
+    let canonical = provider.canonical_block_number()?;
+    let persisted_head = provider.last_block_number()?;
+    broadcast_persisted_range(provider, commands, last_broadcast, persisted_head, None).await?;
+
+    while *last_broadcast < canonical {
+        let persisted_tip = persisted.next().await.ok_or_else(|| {
+            eyre::eyre!("persisted zone block stream closed before the canonical tail persisted")
+        })?;
+        if persisted_tip.number < *last_broadcast {
+            eyre::bail!(
+                "persisted zone head moved backwards while draining after the leader engine stopped: persisted={}, last_broadcast={}",
+                persisted_tip.number,
+                *last_broadcast,
+            );
+        }
+        broadcast_persisted_range(
+            provider,
+            commands,
+            last_broadcast,
+            persisted_tip.number,
+            Some(persisted_tip.hash),
+        )
+        .await?;
+    }
+
+    debug!(target: "zone::p2p", canonical, broadcast = *last_broadcast, "Drained the canonical tail after the leader engine stopped");
+    Ok(())
 }
 
 async fn broadcast_persisted_range<P>(
@@ -1226,16 +1325,17 @@ fn decode_advance_tempo(
 mod tests {
     use std::sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     };
 
     use alloy_eips::NumHash;
     use futures::{StreamExt as _, stream};
+    use tokio::sync::{oneshot, watch};
 
     use super::{
-        AdvanceTempoPortalInputs, BackfillProgress, EncodedPersistedBlock, MAX_PENDING_BLOCKS,
-        PersistedBlockSource, PersistedTip, broadcast_persisted_blocks, buffer_pending_block,
-        validate_live_block_sender, wait_for_validated_peer_anchor,
+        AdvanceTempoPortalInputs, BackfillProgress, BroadcasterShutdown, EncodedPersistedBlock,
+        MAX_PENDING_BLOCKS, PersistedBlockSource, PersistedTip, broadcast_persisted_blocks,
+        buffer_pending_block, validate_live_block_sender, wait_for_validated_peer_anchor,
     };
     use alloy_primitives::B256;
     use zone_l1::{L1BlockTracker, L1PortalEvents};
@@ -1257,6 +1357,10 @@ mod tests {
             })
         }
 
+        fn canonical_block_number(&self) -> eyre::Result<u64> {
+            Ok(self.tip.number)
+        }
+
         fn persisted_block_stream(&self) -> futures::stream::BoxStream<'static, PersistedTip> {
             stream::iter([self.tip]).boxed()
         }
@@ -1266,6 +1370,55 @@ mod tests {
             Ok(EncodedPersistedBlock {
                 number,
                 hash: self.tip.hash,
+                encoded: vec![number as u8],
+            })
+        }
+    }
+
+    /// A provider whose canonical head sits above its persisted head, which is the window the
+    /// stop flush and the demotion drain both have to get right.
+    #[derive(Clone)]
+    struct DivergentHeadSource {
+        canonical: u64,
+        persisted: Arc<AtomicU64>,
+        /// The persisted head observed while the broadcaster subscribes. Subsequent reads see
+        /// `persisted`, allowing tests to model a block that becomes durable during shutdown.
+        startup_persisted: u64,
+        startup_reads: Arc<AtomicUsize>,
+        updates: watch::Receiver<PersistedTip>,
+    }
+
+    impl PersistedBlockSource for DivergentHeadSource {
+        fn last_block_number(&self) -> eyre::Result<u64> {
+            let read = self.startup_reads.fetch_add(1, Ordering::SeqCst);
+            Ok(if read < 2 {
+                self.startup_persisted
+            } else {
+                self.persisted.load(Ordering::SeqCst)
+            })
+        }
+
+        fn canonical_block_number(&self) -> eyre::Result<u64> {
+            Ok(self.canonical)
+        }
+
+        fn persisted_block_stream(&self) -> futures::stream::BoxStream<'static, PersistedTip> {
+            stream::unfold(self.updates.clone(), |mut updates| async move {
+                updates.changed().await.ok()?;
+                let tip = *updates.borrow_and_update();
+                Some((tip, updates))
+            })
+            .boxed()
+        }
+
+        fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock> {
+            assert!(
+                number <= self.persisted.load(Ordering::SeqCst),
+                "encoded a block that is not durable yet: {number}"
+            );
+            Ok(EncodedPersistedBlock {
+                number,
+                hash: B256::repeat_byte(number as u8),
                 encoded: vec![number as u8],
             })
         }
@@ -1600,14 +1753,100 @@ mod tests {
             },
         };
         let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);
+        let (_shutdown, shutdown_rx) = oneshot::channel();
 
-        broadcast_persisted_blocks(source, commands, tokio_util::sync::CancellationToken::new())
-            .await;
+        broadcast_persisted_blocks(source, commands, shutdown_rx).await;
 
         assert_eq!(
             command_rx.recv().await,
             Some(P2pCommand::BroadcastBlock(vec![1]))
         );
+        assert_eq!(command_rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn stop_flush_never_broadcasts_a_canonical_only_block() {
+        // Exactly the reported window: block N is canonical but only N-1 is durable.
+        let source = DivergentHeadSource {
+            canonical: 2,
+            persisted: Arc::new(AtomicU64::new(1)),
+            startup_persisted: 0,
+            startup_reads: Arc::new(AtomicUsize::new(0)),
+            updates: watch::channel(PersistedTip {
+                number: 1,
+                hash: B256::repeat_byte(1),
+            })
+            .1,
+        };
+        let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);
+        let (shutdown, shutdown_rx) = oneshot::channel();
+        shutdown
+            .send(BroadcasterShutdown::Stop)
+            .expect("the broadcaster must retain the shutdown receiver");
+
+        broadcast_persisted_blocks(source, commands, shutdown_rx).await;
+
+        // Block 1 is durable and must be flushed; block 2 exists only in memory and would be
+        // lost on restart, stranding any follower that imported it.
+        assert_eq!(
+            command_rx.recv().await,
+            Some(P2pCommand::BroadcastBlock(vec![1]))
+        );
+        assert_eq!(
+            command_rx.recv().await,
+            None,
+            "the stop flush broadcast a canonical-but-unpersisted block"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_after_engine_stop_waits_for_the_canonical_tail_to_persist() {
+        let persisted = Arc::new(AtomicU64::new(1));
+        let (updates, update_rx) = watch::channel(PersistedTip {
+            number: 1,
+            hash: B256::repeat_byte(1),
+        });
+        let source = DivergentHeadSource {
+            canonical: 2,
+            persisted: persisted.clone(),
+            startup_persisted: 0,
+            startup_reads: Arc::new(AtomicUsize::new(0)),
+            updates: update_rx,
+        };
+        let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);
+        let (shutdown, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(broadcast_persisted_blocks(source, commands, shutdown_rx));
+
+        shutdown
+            .send(BroadcasterShutdown::Drain)
+            .expect("the broadcaster must retain the shutdown receiver");
+
+        // The durable prefix goes out immediately.
+        assert_eq!(
+            command_rx.recv().await,
+            Some(P2pCommand::BroadcastBlock(vec![1]))
+        );
+        // The canonical tail must not, until it persists.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), command_rx.recv())
+                .await
+                .is_err(),
+            "the drain broadcast the canonical tail before it was durable"
+        );
+
+        persisted.store(2, Ordering::SeqCst);
+        updates
+            .send(PersistedTip {
+                number: 2,
+                hash: B256::repeat_byte(2),
+            })
+            .expect("the broadcaster must retain the persisted-block stream");
+
+        assert_eq!(
+            command_rx.recv().await,
+            Some(P2pCommand::BroadcastBlock(vec![2]))
+        );
+        task.await.expect("the broadcaster task must not panic");
         assert_eq!(command_rx.recv().await, None);
     }
 

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -24,7 +24,10 @@ use reth_provider::HeaderProvider;
 use reth_storage_api::{BlockNumReader, BlockReader, ReceiptProvider, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 use tempo_primitives::{Block, TempoHeader};
-use tokio::{sync::mpsc, task::JoinSet};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinSet,
+};
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
 use tracing::{debug, error, info, warn};
 use zone_chainspec::ZoneChainSpec;
@@ -47,7 +50,7 @@ mod zone_transaction_pool_alias {
 use crate::{
     EngineExit, ProductionPermit, ZoneEngine, ZoneSequencerAddOnsConfig,
     replication::{
-        AttestationContext, PeerTipRegistry, broadcast_persisted_blocks,
+        AttestationContext, BroadcasterShutdown, PeerTipRegistry, broadcast_persisted_blocks,
         collect_follower_settlement_signatures, run_follower_block_sync,
     },
     settlement_attestation::collect_leader_settlements,
@@ -308,6 +311,16 @@ enum TaskEnd {
     Ended(&'static str),
 }
 
+/// Whether a generation stopped with its canonical-state boundary proven.
+///
+/// A failed stop must fence the role controller: an aborted engine task may have an already
+/// enqueued Engine API message that Reth can still apply after the task has gone away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GenerationStopOutcome {
+    Stopped,
+    Failed,
+}
+
 /// Supervise the two long-running sequencer children as one role-generation task.
 ///
 /// An unexpected child exit must restart the whole generation immediately. During an intentional
@@ -356,18 +369,77 @@ async fn supervise_sequencer_tasks(
     }
 }
 
+/// Leader-only controls that must either both exist or both be absent.
+struct LeaderShutdown {
+    /// Fires when the leader engine task returns.
+    engine_done: oneshot::Receiver<()>,
+    /// Receives exactly one shutdown decision for the persisted-block broadcaster.
+    broadcaster: oneshot::Sender<BroadcasterShutdown>,
+}
+
 struct RunningGeneration {
     id: u64,
     role: DesiredRole,
     token: CancellationToken,
+    leader_shutdown: Option<LeaderShutdown>,
     tasks: JoinSet<TaskEnd>,
 }
 
 impl RunningGeneration {
-    async fn stop(mut self, sinks: &EventSinks) {
+    async fn stop(mut self, sinks: &EventSinks) -> GenerationStopOutcome {
         sinks.clear();
         self.token.cancel();
         let deadline = tokio::time::Instant::now() + GENERATION_STOP_TIMEOUT;
+
+        let mut outcome = GenerationStopOutcome::Stopped;
+
+        // Cancellation is not a block boundary: an in-flight advance still completes before the
+        // engine returns, so the canonical head keeps moving after `token.cancel()`. The
+        // broadcaster can only be given a drain target once the engine has actually stopped.
+        let mut leader_shutdown = self.leader_shutdown.take();
+        let draining = match leader_shutdown.as_mut() {
+            Some(LeaderShutdown { engine_done, .. }) => {
+                match tokio::time::timeout_at(deadline, engine_done).await {
+                    Ok(Ok(())) => true,
+                    Ok(Err(_)) => {
+                        outcome = GenerationStopOutcome::Failed;
+                        error!(
+                            target: "zone::role",
+                            generation = self.id,
+                            "Engine task ended without acknowledging a clean stop; fencing role controller"
+                        );
+                        false
+                    }
+                    Err(_) => {
+                        outcome = GenerationStopOutcome::Failed;
+                        error!(
+                            target: "zone::role",
+                            generation = self.id,
+                            "Engine did not stop within the timeout; fencing role controller"
+                        );
+                        false
+                    }
+                }
+            }
+            // Not a leader generation, so there is no canonical tail to drain.
+            None => false,
+        };
+        if let Some(LeaderShutdown { broadcaster, .. }) = leader_shutdown {
+            let command = if draining {
+                BroadcasterShutdown::Drain
+            } else {
+                BroadcasterShutdown::Stop
+            };
+            if broadcaster.send(command).is_err() {
+                outcome = GenerationStopOutcome::Failed;
+                error!(
+                    target: "zone::role",
+                    generation = self.id,
+                    ?command,
+                    "Persisted block broadcaster exited before its shutdown could be acknowledged; fencing role controller"
+                );
+            }
+        }
         loop {
             match tokio::time::timeout_at(deadline, self.tasks.join_next()).await {
                 Ok(Some(result)) => {
@@ -384,14 +456,41 @@ impl RunningGeneration {
                         generation = self.id,
                         "Generation did not stop within the timeout; aborting remaining tasks"
                     );
+                    outcome = GenerationStopOutcome::Failed;
                     self.tasks.abort_all();
                     while self.tasks.join_next().await.is_some() {}
                     break;
                 }
             }
         }
-        info!(target: "zone::role", generation = self.id, role = self.role.name(), "Role generation stopped");
+        match outcome {
+            GenerationStopOutcome::Stopped => {
+                info!(target: "zone::role", generation = self.id, role = self.role.name(), "Role generation stopped");
+            }
+            GenerationStopOutcome::Failed => {
+                error!(target: "zone::role", generation = self.id, role = self.role.name(), "Role generation teardown was not proven safe");
+            }
+        }
+        outcome
     }
+}
+
+/// Stop the active generation and keep the controller fenced if its teardown is unproven.
+///
+/// Returns `false` when the controller must exit rather than allow a successor generation to
+/// start after a failed teardown.
+async fn stop_current_generation(
+    current: &mut Option<RunningGeneration>,
+    sinks: &EventSinks,
+) -> bool {
+    if let Some(generation) = current.take()
+        && generation.stop(sinks).await == GenerationStopOutcome::Failed
+    {
+        error!(target: "zone::role", "Role controller exiting after an unproven generation teardown");
+        return false;
+    }
+
+    true
 }
 
 /// Derive the desired role for the next anchor from local canonical state and the schedule.
@@ -586,8 +685,8 @@ pub(crate) async fn run_role_controller<P, Pool>(
             .as_ref()
             .is_some_and(|generation| generation.role.same_variant(desired))
         {
-            if let Some(generation) = current.take() {
-                generation.stop(&sinks).await;
+            if !stop_current_generation(&mut current, &sinks).await {
+                return;
             }
             generation_id += 1;
             match start_generation(&context, &sinks, desired, generation_id).await {
@@ -683,6 +782,12 @@ pub(crate) async fn run_role_controller<P, Pool>(
                             epoch,
                             "Engine halted at the activation boundary; demoting"
                         );
+                        // Stop here rather than letting the next iteration notice the role
+                        // change, so the broadcaster drains this leader's final blocks before
+                        // the successor starts producing.
+                        if !stop_current_generation(&mut current, &sinks).await {
+                            return;
+                        }
                         // The next loop iteration derives Follower from the same schedule.
                     }
                     Some(Ok(TaskEnd::Engine(EngineExit::Fenced { tempo_anchor }))) => {
@@ -691,8 +796,8 @@ pub(crate) async fn run_role_controller<P, Pool>(
                             tempo_anchor,
                             "Engine fenced on an ungoverned anchor"
                         );
-                        if let Some(generation) = current.take() {
-                            generation.stop(&sinks).await;
+                        if !stop_current_generation(&mut current, &sinks).await {
+                            return;
                         }
                         tokio::time::sleep(GENERATION_RESTART_BACKOFF).await;
                     }
@@ -702,15 +807,15 @@ pub(crate) async fn run_role_controller<P, Pool>(
                         // A generation task ended while its generation is still desired:
                         // restart the whole generation to keep the task graph coherent.
                         error!(target: "zone::role", task = name, "Generation task ended unexpectedly; restarting generation");
-                        if let Some(generation) = current.take() {
-                            generation.stop(&sinks).await;
+                        if !stop_current_generation(&mut current, &sinks).await {
+                            return;
                         }
                         tokio::time::sleep(GENERATION_RESTART_BACKOFF).await;
                     }
                     Some(Err(err)) => {
                         error!(target: "zone::role", %err, "Generation task panicked; restarting generation");
-                        if let Some(generation) = current.take() {
-                            generation.stop(&sinks).await;
+                        if !stop_current_generation(&mut current, &sinks).await {
+                            return;
                         }
                         tokio::time::sleep(GENERATION_RESTART_BACKOFF).await;
                     }
@@ -750,6 +855,7 @@ where
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
 {
     let token = CancellationToken::new();
+    let mut leader_shutdown = None;
     let mut tasks = JoinSet::new();
 
     match desired {
@@ -874,13 +980,26 @@ where
             // Canonical head writer: the engine with the per-anchor production permit.
             let engine = build_engine(context, sequencer, last_header);
             let engine_token = token.clone();
-            tasks.spawn(async move { TaskEnd::Engine(engine.run_until(engine_token).await) });
+            let (engine_done_tx, engine_done_rx) = oneshot::channel();
+            tasks.spawn(async move {
+                let exit = engine.run_until(engine_token).await;
+                // Signalled before the task resolves so `stop` learns the canonical head is
+                // pinned without having to drain the JoinSet first.
+                let _ = engine_done_tx.send(());
+                TaskEnd::Engine(exit)
+            });
 
-            let broadcast_token = token.clone();
+            // The broadcaster outlives the generation token on purpose: it must still be able to
+            // publish the engine's final blocks after every other task has been cancelled.
+            let (broadcaster_tx, broadcaster_rx) = oneshot::channel();
+            leader_shutdown = Some(LeaderShutdown {
+                engine_done: engine_done_rx,
+                broadcaster: broadcaster_tx,
+            });
             let provider = context.provider.clone();
             let commands = context.commands.clone();
             tasks.spawn(async move {
-                broadcast_persisted_blocks(provider, commands, broadcast_token).await;
+                broadcast_persisted_blocks(provider, commands, broadcaster_rx).await;
                 TaskEnd::Ended("block-broadcast")
             });
 
@@ -959,6 +1078,7 @@ where
         id,
         role: desired,
         token,
+        leader_shutdown,
         tasks,
     })
 }


### PR DESCRIPTION
Completes the persisted-only replication invariant during leader shutdown and a responder that has not reached the requested backfill range.

It waits for the leader engine to stop, then broadcasts each final block only after it persists. If a responder completes below the requested start, the follower retains its catch-up state and immediately falls back from the preferred leader.

Fixes ZONE-265.