### PR TITLE
fix(bench): align benchmark dependency revisions

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -228,7 +228,7 @@ jobs:
           INPUT_SETUP_SETTLEMENT_TIMEOUT_SECS: ${{ inputs.setup-settlement-timeout-secs || '120' }}
           INPUT_DRAIN_TIMEOUT: ${{ inputs.drain-timeout || '300' }}
           INPUT_SEED: ${{ inputs.seed || '' }}
-          INPUT_TEMPO_REF: a80c1438241e9edd67d8a96c6c07d3697fcf77d8
+          INPUT_TEMPO_REF: c40ff801741d28ab74452db261f5b6ffe4ec334a
           INPUT_TXGEN_REF: 072877b673f60b5f559f17da098296f1841b6732
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -229,11 +229,12 @@ jobs:
           INPUT_DRAIN_TIMEOUT: ${{ inputs.drain-timeout || '300' }}
           INPUT_SEED: ${{ inputs.seed || '' }}
           INPUT_TEMPO_REF: c40ff801741d28ab74452db261f5b6ffe4ec334a
-          INPUT_TXGEN_REF: 072877b673f60b5f559f17da098296f1841b6732
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
+
+          INPUT_TXGEN_REF="$(git ls-remote https://github.com/tempoxyz/txgen HEAD | awk '{print $1}')"
 
           neobank_preset="$INPUT_PRESET"
           case "$neobank_preset" in
@@ -708,7 +709,7 @@ jobs:
             echo "ZONES_BENCH_L1_CACHE_GENERATION=$ZONES_BENCH_L1_CACHE_GENERATION"
           } >> "$GITHUB_ENV"
 
-      - name: Install pinned txgen
+      - name: Install latest txgen
         run: |
           set -euo pipefail
           cargo_bin_dir="${CARGO_HOME:-$HOME/.cargo}/bin"

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -228,7 +228,7 @@ jobs:
           INPUT_SETUP_SETTLEMENT_TIMEOUT_SECS: ${{ inputs.setup-settlement-timeout-secs || '120' }}
           INPUT_DRAIN_TIMEOUT: ${{ inputs.drain-timeout || '300' }}
           INPUT_SEED: ${{ inputs.seed || '' }}
-          INPUT_TEMPO_REF: c40ff801741d28ab74452db261f5b6ffe4ec334a
+          INPUT_TEMPO_REF: de760926aa6520c5e1cdb85f453c206057ea0e72
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11330,7 +11330,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11376,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11400,7 +11400,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11412,7 +11412,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11459,7 +11459,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11471,7 +11471,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11569,7 +11569,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11589,7 +11589,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11612,7 +11612,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11655,7 +11655,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11678,7 +11678,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c40ff801741d28ab74452db261f5b6ffe4ec334a#c40ff801741d28ab74452db261f5b6ffe4ec334a"
+source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,25 +96,25 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "c40ff801741d28ab74452db261f5b6ffe4ec334a", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }

--- a/contrib/bench/neobank/neobank-scenario-fragments.yml
+++ b/contrib/bench/neobank/neobank-scenario-fragments.yml
@@ -193,7 +193,7 @@ fragments:
         timeout: 45s
         save: request_result
       - id: l1_processed_locator
-        depends_on: [l1_before, request]
+        depends_on: [l1_before, request, request_result]
         wait_log:
           chain: l1
           from_block: { var: l1_before.block_number }
@@ -204,8 +204,11 @@ fragments:
             to: "${ZONES_BENCH_EARN_ROUTER}"
             senderTag:
               keccak256_packed:
-                types: [address, bytes32]
-                values: [{ param: sender_address }, { var: request.tx_hash }]
+                types: [address, bytes32, uint64]
+                values:
+                  - { param: sender_address }
+                  - { var: request.tx_hash }
+                  - { var: request_result.args.fallbackNonce }
             token: { param: input_token }
             amount: { param: amount }
             callbackSuccess: true
@@ -225,8 +228,11 @@ fragments:
                 to: "${ZONES_BENCH_EARN_ROUTER}"
                 senderTag:
                   keccak256_packed:
-                    types: [address, bytes32]
-                    values: [{ param: sender_address }, { var: request.tx_hash }]
+                    types: [address, bytes32, uint64]
+                    values:
+                      - { param: sender_address }
+                      - { var: request.tx_hash }
+                      - { var: request_result.args.fallbackNonce }
                 token: { param: input_token }
                 amount: { param: amount }
                 callbackSuccess: true
@@ -340,7 +346,7 @@ fragments:
         timeout: 45s
         save: request_result
       - id: l1_processed_locator
-        depends_on: [l1_before, request]
+        depends_on: [l1_before, request, request_result]
         wait_log:
           chain: l1
           from_block: { var: l1_before.block_number }
@@ -351,8 +357,11 @@ fragments:
             to: "${ZONES_BENCH_EARN_ROUTER}"
             senderTag:
               keccak256_packed:
-                types: [address, bytes32]
-                values: [{ param: sender_address }, { var: request.tx_hash }]
+                types: [address, bytes32, uint64]
+                values:
+                  - { param: sender_address }
+                  - { var: request.tx_hash }
+                  - { var: request_result.args.fallbackNonce }
             token: "${ZONES_BENCH_EARN_TOKEN}"
             amount: { param: amount }
             callbackSuccess: true
@@ -372,8 +381,11 @@ fragments:
                 to: "${ZONES_BENCH_EARN_ROUTER}"
                 senderTag:
                   keccak256_packed:
-                    types: [address, bytes32]
-                    values: [{ param: sender_address }, { var: request.tx_hash }]
+                    types: [address, bytes32, uint64]
+                    values:
+                      - { param: sender_address }
+                      - { var: request.tx_hash }
+                      - { var: request_result.args.fallbackNonce }
                 token: "${ZONES_BENCH_EARN_TOKEN}"
                 amount: { param: amount }
                 callbackSuccess: true
@@ -485,7 +497,7 @@ fragments:
         timeout: 45s
         save: request_result
       - id: l1_processed_locator
-        depends_on: [l1_before, request]
+        depends_on: [l1_before, request, request_result]
         wait_log:
           chain: l1
           from_block: { var: l1_before.block_number }
@@ -496,8 +508,11 @@ fragments:
             to: "${ZONES_BENCH_EARN_ROUTER}"
             senderTag:
               keccak256_packed:
-                types: [address, bytes32]
-                values: [{ param: sender_address }, { var: request.tx_hash }]
+                types: [address, bytes32, uint64]
+                values:
+                  - { param: sender_address }
+                  - { var: request.tx_hash }
+                  - { var: request_result.args.fallbackNonce }
             token: { param: input_token }
             amount: { param: amount }
             callbackSuccess: false
@@ -517,8 +532,11 @@ fragments:
                 to: "${ZONES_BENCH_EARN_ROUTER}"
                 senderTag:
                   keccak256_packed:
-                    types: [address, bytes32]
-                    values: [{ param: sender_address }, { var: request.tx_hash }]
+                    types: [address, bytes32, uint64]
+                    values:
+                      - { param: sender_address }
+                      - { var: request.tx_hash }
+                      - { var: request_result.args.fallbackNonce }
                 token: { param: input_token }
                 amount: { param: amount }
                 callbackSuccess: false

--- a/contrib/bench/neobank/private-flow-scenario.yml
+++ b/contrib/bench/neobank/private-flow-scenario.yml
@@ -165,7 +165,7 @@ scenario:
       save: offramp_result
 
     - id: offramp_processed
-      depends_on: [l1_before_offramp, offramp]
+      depends_on: [l1_before_offramp, offramp, offramp_result]
       wait_log:
         chain: l1
         from_block: { var: l1_before_offramp.block_number }
@@ -176,8 +176,11 @@ scenario:
           to: "${ZONES_BENCH_BRIDGE_WALLET}"
           senderTag:
             keccak256_packed:
-              types: [address, bytes32]
-              values: [{ var: account.address }, { var: offramp.tx_hash }]
+              types: [address, bytes32, uint64]
+              values:
+                - { var: account.address }
+                - { var: offramp.tx_hash }
+                - { var: offramp_result.args.fallbackNonce }
           token: "${ZONES_BENCH_DLUSD}"
           amount: { var: earn_redeem.zone_return.processed.args.amount }
           callbackSuccess: true


### PR DESCRIPTION
## Summary

- Bump the benchmark Tempo checkout and all Zones Tempo dependencies to `de760926`, the merge of tempoxyz/tempo#7106.
- This follows the revert of the Nushell command bump, restoring compatibility with Nushell 0.112 on the benchmark runners while keeping Zone runtime validation aligned.
- Resolve the latest `tempoxyz/txgen` default-branch commit for every benchmark run and record its exact SHA.
- Include each withdrawal fallback nonce in benchmark `senderTag` matching, aligning the neobank scenarios with authenticated withdrawal linkage introduced by #975.

## Validation

- `git diff --check`
- `cargo metadata --locked --no-deps`
- All 16 neobank scenarios render successfully with txgen `6a36516fd31e8a4196b1e2f44739fa713dfdd684`.
- Zones benchmark run [31174144491](https://github.com/tempoxyz/zones/actions/runs/31174144491) passed.

Prompted by: @shekhirin