### PR TITLE
test(rpc): consolidate ZoneRpcApi fixtures

### DIFF
--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -750,78 +750,18 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::types::to_raw;
 
-    #[derive(Default)]
-    struct MockZoneRpcApi;
+    #[allow(dead_code)]
+    mod test_api {
+        use crate as rpc;
 
-    macro_rules! stub {
-        ($method:ident $(, $arg:ident : $ty:ty)*) => {
-            fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
-                Box::pin(async { Err(JsonRpcError::internal("not implemented")) })
-            }
-        };
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test-utils/zone_rpc_api.rs"
+        ));
     }
 
-    impl ZoneRpcApi for MockZoneRpcApi {
-        fn get_keychain_key(&self, _account: Address, _key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
-            Box::pin(async { Err(eyre::eyre!("not implemented")) })
-        }
-
-        stub!(block_number);
-        stub!(chain_id);
-        stub!(net_version);
-        stub!(gas_price);
-        stub!(max_priority_fee_per_gas);
-        stub!(fee_history, _block_count: u64, _newest_block: BlockNumberOrTag, _reward_percentiles: Option<Vec<f64>>);
-        stub!(get_balance, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
-        stub!(get_transaction_count, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
-        stub!(block_by_number, _number: BlockNumberOrTag, _full: bool, _auth: AuthContext);
-        stub!(block_by_hash, _hash: B256, _full: bool, _auth: AuthContext);
-        stub!(transaction_by_hash, _hash: B256, _auth: AuthContext);
-        stub!(transaction_receipt, _hash: B256, _auth: AuthContext);
-        stub!(call, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
-        stub!(estimate_gas, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
-        stub!(send_raw_transaction, _data: Bytes, _auth: AuthContext);
-        stub!(send_raw_transaction_sync, _data: Bytes, _auth: AuthContext);
-        stub!(fill_transaction, _request: TempoTransactionRequest, _auth: AuthContext);
-        stub!(get_logs, _filter: Filter, _auth: AuthContext);
-        stub!(new_filter, _filter: Filter, _auth: AuthContext);
-        stub!(get_filter_logs, _id: FilterId, _auth: AuthContext);
-        stub!(get_filter_changes, _id: FilterId, _auth: AuthContext);
-        stub!(new_block_filter, _auth: AuthContext);
-        stub!(uninstall_filter, _id: FilterId, _auth: AuthContext);
-        fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
-            Box::pin(async move {
-                to_raw(&json!({
-                    "account": auth.caller,
-                    "expiresAt": alloy_primitives::U64::from(auth.expires_at),
-                }))
-            })
-        }
-
-        fn syncing(&self) -> BoxFut<'_> {
-            Box::pin(async move { to_raw(&false) })
-        }
-
-        fn coinbase(&self) -> BoxFut<'_> {
-            Box::pin(async move { to_raw(&Address::repeat_byte(0xbb)) })
-        }
-
-        fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
-            Box::pin(async move {
-                to_raw(&json!({
-                    "zoneId": "0x1",
-                    "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
-                    "sequencers": [format!("{:#x}", Address::repeat_byte(0x22))],
-                    "chainId": "0x2a",
-                    "tempoBlockNumber": "0x7",
-                }))
-            })
-        }
-
-        stub!(zone_get_encryption_key, _auth: AuthContext);
-    }
+    use test_api::TestZoneRpcApi as MockZoneRpcApi;
 
     fn auth() -> AuthContext {
         AuthContext {
@@ -850,7 +790,7 @@ mod tests {
         assert_eq!(classify_method("zone_getSequencerInfo"), None);
         assert_eq!(classify_method("zone_setLeader"), None);
 
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
         let excluded = dispatch(&request("zone_setLeader", json!([])), &auth(), &api).await;
         assert_eq!(excluded.error.unwrap().code, -32601);
 
@@ -860,7 +800,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_zone_get_authorization_token_info() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
         let resp = dispatch(
             &request("zone_getAuthorizationTokenInfo", json!([])),
             &auth(),
@@ -880,7 +820,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_allowed_compatibility_methods() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
 
         let syncing = dispatch(&request("eth_syncing", json!([])), &auth(), &api).await;
         assert_eq!(
@@ -908,7 +848,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_zone_get_zone_info() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
         let resp = dispatch(&request("zone_getZoneInfo", json!([])), &auth(), &api).await;
 
         assert!(resp.error.is_none());
@@ -929,7 +869,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_pending_transaction_filter_endpoint() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
 
         let resp = dispatch(
             &request("eth_newPendingTransactionFilter", json!([])),
@@ -944,7 +884,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_state_override_for_eth_call() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
         let resp = dispatch(
             &request(
                 "eth_call",
@@ -967,7 +907,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_state_override_for_estimate_gas() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
         let resp = dispatch(
             &request(
                 "eth_estimateGas",
@@ -990,7 +930,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_extra_block_override_param_for_eth_call() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
         let resp = dispatch(
             &request(
                 "eth_call",
@@ -1013,7 +953,7 @@ mod tests {
     }
     #[tokio::test]
     async fn classifies_spec_disabled_and_restricted_methods() {
-        let api = MockZoneRpcApi::default();
+        let api = MockZoneRpcApi::for_handler_tests();
 
         for method in [
             "eth_getProof",

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -763,6 +763,10 @@ mod tests {
 
     use test_api::TestZoneRpcApi as MockZoneRpcApi;
 
+    fn handler_api() -> MockZoneRpcApi {
+        MockZoneRpcApi::handlers()
+    }
+
     fn auth() -> AuthContext {
         AuthContext {
             caller: Address::repeat_byte(0xaa),
@@ -790,7 +794,7 @@ mod tests {
         assert_eq!(classify_method("zone_getSequencerInfo"), None);
         assert_eq!(classify_method("zone_setLeader"), None);
 
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
         let excluded = dispatch(&request("zone_setLeader", json!([])), &auth(), &api).await;
         assert_eq!(excluded.error.unwrap().code, -32601);
 
@@ -800,7 +804,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_zone_get_authorization_token_info() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
         let resp = dispatch(
             &request("zone_getAuthorizationTokenInfo", json!([])),
             &auth(),
@@ -820,7 +824,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_allowed_compatibility_methods() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
 
         let syncing = dispatch(&request("eth_syncing", json!([])), &auth(), &api).await;
         assert_eq!(
@@ -848,7 +852,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatches_zone_get_zone_info() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
         let resp = dispatch(&request("zone_getZoneInfo", json!([])), &auth(), &api).await;
 
         assert!(resp.error.is_none());
@@ -869,7 +873,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_pending_transaction_filter_endpoint() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
 
         let resp = dispatch(
             &request("eth_newPendingTransactionFilter", json!([])),
@@ -884,7 +888,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_state_override_for_eth_call() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
         let resp = dispatch(
             &request(
                 "eth_call",
@@ -907,7 +911,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_state_override_for_estimate_gas() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
         let resp = dispatch(
             &request(
                 "eth_estimateGas",
@@ -930,7 +934,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_extra_block_override_param_for_eth_call() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
         let resp = dispatch(
             &request(
                 "eth_call",
@@ -953,7 +957,7 @@ mod tests {
     }
     #[tokio::test]
     async fn classifies_spec_disabled_and_restricted_methods() {
-        let api = MockZoneRpcApi::for_handler_tests();
+        let api = handler_api();
 
         for method in [
             "eth_getProof",

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -299,19 +299,11 @@ pub(crate) fn now_unix_seconds() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::authenticate_token;
-    use crate::{
-        RedactedRpcConfig,
-        auth::build_token_fields,
-        error::AuthenticateError,
-        handlers::ZoneRpcApi,
-        types::{BoxEyreFut, BoxFut, JsonRpcError},
-    };
-    use alloy_primitives::{Address, Bytes};
+    use crate::{RedactedRpcConfig, auth::build_token_fields, error::AuthenticateError};
+    use alloy_primitives::Address;
     use axum::http::StatusCode;
     use p256::ecdsa::SigningKey as P256SigningKey;
-    use parking_lot::Mutex;
     use rand::thread_rng;
-    use std::collections::HashMap;
     use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
         KeyInfo, SignatureType as KeyInfoSignatureType,
     };
@@ -326,78 +318,21 @@ mod tests {
 
     use auth_tokens::{build_token_with_signature, now_secs, sign_keychain_signature};
 
+    #[allow(dead_code)]
+    mod test_api {
+        use crate as rpc;
+
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test-utils/zone_rpc_api.rs"
+        ));
+    }
+
+    use test_api::TestZoneRpcApi as TestApi;
+
     const ZONE_ID: u32 = 7;
     const CHAIN_ID: u64 = 99;
     const PORTAL: Address = Address::repeat_byte(0x22);
-
-    struct TestApi {
-        key_infos: Mutex<HashMap<(Address, Address), KeyInfo>>,
-    }
-
-    impl TestApi {
-        fn with_key_info(account: Address, key_id: Address, key_info: KeyInfo) -> Self {
-            let mut key_infos = HashMap::new();
-            key_infos.insert((account, key_id), key_info);
-            Self {
-                key_infos: Mutex::new(key_infos),
-            }
-        }
-    }
-
-    macro_rules! stub {
-        ($method:ident $(, $arg:ident : $ty:ty)*) => {
-            fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
-                Box::pin(async { Err(JsonRpcError::internal("not implemented")) })
-            }
-        };
-    }
-
-    impl ZoneRpcApi for TestApi {
-        fn get_keychain_key(&self, account: Address, key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
-            let key_info = self
-                .key_infos
-                .lock()
-                .get(&(account, key_id))
-                .cloned()
-                .unwrap_or(KeyInfo {
-                    signatureType: KeyInfoSignatureType::Secp256k1,
-                    keyId: Address::ZERO,
-                    expiry: 0,
-                    enforceLimits: false,
-                    isRevoked: false,
-                });
-            Box::pin(async move { Ok(key_info) })
-        }
-
-        stub!(block_number);
-        stub!(chain_id);
-        stub!(net_version);
-        stub!(syncing);
-        stub!(coinbase);
-        stub!(gas_price);
-        stub!(max_priority_fee_per_gas);
-        stub!(fee_history, _a: u64, _b: alloy_rpc_types_eth::BlockNumberOrTag, _c: Option<Vec<f64>>);
-        stub!(get_balance, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: crate::auth::AuthContext);
-        stub!(get_transaction_count, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: crate::auth::AuthContext);
-        stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _b: bool, _c: crate::auth::AuthContext);
-        stub!(block_by_hash, _a: alloy_primitives::B256, _b: bool, _c: crate::auth::AuthContext);
-        stub!(transaction_by_hash, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
-        stub!(transaction_receipt, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
-        stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
-        stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
-        stub!(send_raw_transaction, _a: Bytes, _c: crate::auth::AuthContext);
-        stub!(send_raw_transaction_sync, _a: Bytes, _c: crate::auth::AuthContext);
-        stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: crate::auth::AuthContext);
-        stub!(get_logs, _a: alloy_rpc_types_eth::Filter, _c: crate::auth::AuthContext);
-        stub!(new_filter, _a: alloy_rpc_types_eth::Filter, _c: crate::auth::AuthContext);
-        stub!(get_filter_logs, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
-        stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
-        stub!(new_block_filter, _c: crate::auth::AuthContext);
-        stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: crate::auth::AuthContext);
-        stub!(zone_get_authorization_token_info, _c: crate::auth::AuthContext);
-        stub!(zone_get_zone_info, _c: crate::auth::AuthContext);
-        stub!(zone_get_encryption_key, _c: crate::auth::AuthContext);
-    }
 
     fn test_config() -> RedactedRpcConfig {
         RedactedRpcConfig {
@@ -422,9 +357,7 @@ mod tests {
         let mut blob = vec![0u8; 65];
         blob.extend_from_slice(&fields);
         let token = alloy_primitives::hex::encode(blob);
-        let api = TestApi {
-            key_infos: Mutex::new(HashMap::new()),
-        };
+        let api = TestApi::default();
 
         let err = authenticate_token(&token, &config, &api)
             .await
@@ -452,9 +385,7 @@ mod tests {
         let mut blob = vec![0u8; 65];
         blob.extend_from_slice(&fields);
         let token = alloy_primitives::hex::encode(blob);
-        let api = TestApi {
-            key_infos: Mutex::new(HashMap::new()),
-        };
+        let api = TestApi::default();
 
         let err = authenticate_token(&token, &config, &api)
             .await

--- a/crates/rpc/test-utils/zone_rpc_api.rs
+++ b/crates/rpc/test-utils/zone_rpc_api.rs
@@ -41,14 +41,14 @@ pub(super) struct TestZoneRpcApi {
 }
 
 impl TestZoneRpcApi {
-    pub(super) fn for_handler_tests() -> Self {
+    pub(super) fn handlers() -> Self {
         Self {
             profile: ResponseProfile::Handler,
             ..Self::default()
         }
     }
 
-    pub(super) fn for_websocket_tests() -> Self {
+    pub(super) fn websocket() -> Self {
         Self {
             profile: ResponseProfile::WebSocket,
             ..Self::default()
@@ -66,7 +66,7 @@ impl TestZoneRpcApi {
         key_id: Address,
         signature_type: KeyInfoSignatureType,
     ) -> Self {
-        let api = Self::for_websocket_tests();
+        let api = Self::websocket();
         api.key_infos.lock().insert(
             (account, key_id),
             KeyInfo {
@@ -99,7 +99,7 @@ impl TestZoneRpcApi {
         }
     }
 
-    pub(super) fn with_ws_subscriptions() -> Self {
+    pub(super) fn subscriptions() -> Self {
         Self {
             profile: ResponseProfile::WebSocket,
             ws_subscriptions_enabled: true,
@@ -124,6 +124,47 @@ macro_rules! stub {
             self.unimplemented()
         }
     };
+}
+
+fn new_head_payload() -> serde_json::Value {
+    serde_json::json!({
+        "hash": format!(
+            "{:#x}",
+            b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
+        ),
+        "number": "0x42",
+        "parentHash": format!("{:#x}", B256::ZERO),
+        "logsBloom": format!("0x{}", "0".repeat(512)),
+        "gasUsed": "0x0",
+        "size": "0x0",
+        "transactionsRoot": format!("{:#x}", B256::ZERO),
+        "receiptsRoot": format!("{:#x}", B256::ZERO),
+        "stateRoot": format!("{:#x}", B256::ZERO),
+        "extraData": "0x",
+    })
+}
+
+fn log_payload() -> serde_json::Value {
+    serde_json::json!({
+        "address": format!("{:#x}", Address::ZERO),
+        "topics": [format!(
+            "{:#x}",
+            b256!("0x1111111111111111111111111111111111111111111111111111111111111111")
+        )],
+        "data": "0x",
+        "blockHash": format!(
+            "{:#x}",
+            b256!("0x2222222222222222222222222222222222222222222222222222222222222222")
+        ),
+        "blockNumber": "0x42",
+        "transactionHash": format!(
+            "{:#x}",
+            b256!("0x3333333333333333333333333333333333333333333333333333333333333333")
+        ),
+        "transactionIndex": "0x0",
+        "logIndex": "0x0",
+        "removed": false,
+    })
 }
 
 impl ZoneRpcApi for TestZoneRpcApi {
@@ -223,21 +264,7 @@ impl ZoneRpcApi for TestZoneRpcApi {
                 return Err(JsonRpcError::method_disabled());
             }
 
-            let stream = stream::iter(vec![to_raw(&serde_json::json!({
-                "hash": format!(
-                    "{:#x}",
-                    b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
-                ),
-                "number": "0x42",
-                "parentHash": format!("{:#x}", B256::ZERO),
-                "logsBloom": format!("0x{}", "0".repeat(512)),
-                "gasUsed": "0x0",
-                "size": "0x0",
-                "transactionsRoot": format!("{:#x}", B256::ZERO),
-                "receiptsRoot": format!("{:#x}", B256::ZERO),
-                "stateRoot": format!("{:#x}", B256::ZERO),
-                "extraData": "0x",
-            }))]);
+            let stream = stream::iter(vec![to_raw(&new_head_payload())]);
             let stream: WsSubscriptionStream = Box::pin(stream);
             Ok(stream)
         })
@@ -254,26 +281,7 @@ impl ZoneRpcApi for TestZoneRpcApi {
                 return Err(JsonRpcError::method_disabled());
             }
 
-            let stream = stream::iter(vec![to_raw(&serde_json::json!({
-                "address": format!("{:#x}", Address::ZERO),
-                "topics": [format!(
-                    "{:#x}",
-                    b256!("0x1111111111111111111111111111111111111111111111111111111111111111")
-                )],
-                "data": "0x",
-                "blockHash": format!(
-                    "{:#x}",
-                    b256!("0x2222222222222222222222222222222222222222222222222222222222222222")
-                ),
-                "blockNumber": "0x42",
-                "transactionHash": format!(
-                    "{:#x}",
-                    b256!("0x3333333333333333333333333333333333333333333333333333333333333333")
-                ),
-                "transactionIndex": "0x0",
-                "logIndex": "0x0",
-                "removed": false,
-            }))]);
+            let stream = stream::iter(vec![to_raw(&log_payload())]);
             let stream: WsSubscriptionStream = Box::pin(stream);
             Ok(stream)
         })

--- a/crates/rpc/test-utils/zone_rpc_api.rs
+++ b/crates/rpc/test-utils/zone_rpc_api.rs
@@ -1,0 +1,321 @@
+use std::{collections::HashMap, sync::Arc};
+
+use alloy_primitives::{Address, B256, Bytes, b256};
+use alloy_rpc_types_eth::{
+    BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride,
+};
+use futures::stream;
+use parking_lot::Mutex;
+use tempo_alloy::rpc::TempoTransactionRequest;
+use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
+    KeyInfo, SignatureType as KeyInfoSignatureType,
+};
+use tokio::sync::Notify;
+
+use rpc::{
+    auth::AuthContext,
+    handlers::ZoneRpcApi,
+    subscription::{BoxWsSubscriptionFut, WsSubscriptionStream},
+    types::{BoxEyreFut, BoxFut, JsonRpcError, to_raw},
+};
+
+#[derive(Clone, Copy, Default)]
+enum ResponseProfile {
+    #[default]
+    Stub,
+    Handler,
+    WebSocket,
+}
+
+/// Reusable [`ZoneRpcApi`] fixture shared by unit and integration tests.
+///
+/// Profiles keep each suite's successful responses explicit while all other
+/// methods retain the common "not implemented" failure behavior.
+#[derive(Default)]
+pub(super) struct TestZoneRpcApi {
+    profile: ResponseProfile,
+    key_infos: Mutex<HashMap<(Address, Address), KeyInfo>>,
+    key_lookup_error: Option<&'static str>,
+    ws_subscriptions_enabled: bool,
+    blocking_rpc_started: Option<Arc<Notify>>,
+}
+
+impl TestZoneRpcApi {
+    pub(super) fn for_handler_tests() -> Self {
+        Self {
+            profile: ResponseProfile::Handler,
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn for_websocket_tests() -> Self {
+        Self {
+            profile: ResponseProfile::WebSocket,
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn with_key_info(account: Address, key_id: Address, key_info: KeyInfo) -> Self {
+        let api = Self::default();
+        api.key_infos.lock().insert((account, key_id), key_info);
+        api
+    }
+
+    pub(super) fn with_key(
+        account: Address,
+        key_id: Address,
+        signature_type: KeyInfoSignatureType,
+    ) -> Self {
+        let api = Self::for_websocket_tests();
+        api.key_infos.lock().insert(
+            (account, key_id),
+            KeyInfo {
+                signatureType: signature_type,
+                keyId: key_id,
+                expiry: u64::MAX,
+                enforceLimits: false,
+                isRevoked: false,
+            },
+        );
+        api
+    }
+
+    pub(super) fn with_key_and_blocking_request(
+        account: Address,
+        key_id: Address,
+        signature_type: KeyInfoSignatureType,
+    ) -> (Self, Arc<Notify>) {
+        let mut api = Self::with_key(account, key_id, signature_type);
+        let started = Arc::new(Notify::new());
+        api.blocking_rpc_started = Some(started.clone());
+        (api, started)
+    }
+
+    pub(super) fn with_key_lookup_error(message: &'static str) -> Self {
+        Self {
+            profile: ResponseProfile::WebSocket,
+            key_lookup_error: Some(message),
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn with_ws_subscriptions() -> Self {
+        Self {
+            profile: ResponseProfile::WebSocket,
+            ws_subscriptions_enabled: true,
+            ..Self::default()
+        }
+    }
+
+    pub(super) fn revoke_key(&self, account: Address, key_id: Address) {
+        if let Some(key_info) = self.key_infos.lock().get_mut(&(account, key_id)) {
+            key_info.isRevoked = true;
+        }
+    }
+
+    fn unimplemented(&self) -> BoxFut<'_> {
+        Box::pin(async { Err(JsonRpcError::internal("not implemented")) })
+    }
+}
+
+macro_rules! stub {
+    ($method:ident $(, $arg:ident : $ty:ty)*) => {
+        fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
+            self.unimplemented()
+        }
+    };
+}
+
+impl ZoneRpcApi for TestZoneRpcApi {
+    fn get_keychain_key(&self, account: Address, key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
+        if matches!(self.profile, ResponseProfile::Handler) {
+            return Box::pin(async { Err(eyre::eyre!("not implemented")) });
+        }
+        if let Some(message) = self.key_lookup_error {
+            return Box::pin(async move { Err(eyre::eyre!(message)) });
+        }
+
+        let key_info = self
+            .key_infos
+            .lock()
+            .get(&(account, key_id))
+            .cloned()
+            .unwrap_or(KeyInfo {
+                signatureType: KeyInfoSignatureType::Secp256k1,
+                keyId: Address::ZERO,
+                expiry: 0,
+                enforceLimits: false,
+                isRevoked: false,
+            });
+        Box::pin(async move { Ok(key_info) })
+    }
+
+    fn block_number(&self) -> BoxFut<'_> {
+        if matches!(self.profile, ResponseProfile::WebSocket) {
+            Box::pin(async { to_raw(&"0x42") })
+        } else {
+            self.unimplemented()
+        }
+    }
+
+    fn chain_id(&self) -> BoxFut<'_> {
+        if matches!(self.profile, ResponseProfile::WebSocket) {
+            Box::pin(async { to_raw(&"0x1") })
+        } else {
+            self.unimplemented()
+        }
+    }
+
+    stub!(net_version);
+
+    fn syncing(&self) -> BoxFut<'_> {
+        if matches!(self.profile, ResponseProfile::Handler) {
+            Box::pin(async { to_raw(&false) })
+        } else {
+            self.unimplemented()
+        }
+    }
+
+    fn coinbase(&self) -> BoxFut<'_> {
+        if matches!(self.profile, ResponseProfile::Handler) {
+            Box::pin(async { to_raw(&Address::repeat_byte(0xbb)) })
+        } else {
+            self.unimplemented()
+        }
+    }
+
+    stub!(gas_price);
+    stub!(max_priority_fee_per_gas);
+    stub!(fee_history, _block_count: u64, _newest_block: BlockNumberOrTag, _reward_percentiles: Option<Vec<f64>>);
+    stub!(get_balance, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
+    stub!(get_transaction_count, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
+    stub!(block_by_number, _number: BlockNumberOrTag, _full: bool, _auth: AuthContext);
+    stub!(block_by_hash, _hash: B256, _full: bool, _auth: AuthContext);
+    stub!(transaction_by_hash, _hash: B256, _auth: AuthContext);
+    stub!(transaction_receipt, _hash: B256, _auth: AuthContext);
+    stub!(call, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
+    stub!(estimate_gas, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
+    stub!(send_raw_transaction, _data: Bytes, _auth: AuthContext);
+
+    fn send_raw_transaction_sync(&self, _data: Bytes, _auth: AuthContext) -> BoxFut<'_> {
+        let started = self.blocking_rpc_started.clone();
+        Box::pin(async move {
+            if let Some(started) = started {
+                started.notify_one();
+                std::future::pending::<()>().await;
+            }
+            Err(JsonRpcError::internal("not implemented"))
+        })
+    }
+
+    stub!(fill_transaction, _request: TempoTransactionRequest, _auth: AuthContext);
+    stub!(get_logs, _filter: Filter, _auth: AuthContext);
+    stub!(new_filter, _filter: Filter, _auth: AuthContext);
+    stub!(get_filter_logs, _id: FilterId, _auth: AuthContext);
+    stub!(get_filter_changes, _id: FilterId, _auth: AuthContext);
+    stub!(new_block_filter, _auth: AuthContext);
+    stub!(uninstall_filter, _id: FilterId, _auth: AuthContext);
+
+    fn ws_subscribe_new_heads(&self, _auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
+        let enabled = self.ws_subscriptions_enabled;
+        Box::pin(async move {
+            if !enabled {
+                return Err(JsonRpcError::method_disabled());
+            }
+
+            let stream = stream::iter(vec![to_raw(&serde_json::json!({
+                "hash": format!(
+                    "{:#x}",
+                    b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
+                ),
+                "number": "0x42",
+                "parentHash": format!("{:#x}", B256::ZERO),
+                "logsBloom": format!("0x{}", "0".repeat(512)),
+                "gasUsed": "0x0",
+                "size": "0x0",
+                "transactionsRoot": format!("{:#x}", B256::ZERO),
+                "receiptsRoot": format!("{:#x}", B256::ZERO),
+                "stateRoot": format!("{:#x}", B256::ZERO),
+                "extraData": "0x",
+            }))]);
+            let stream: WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
+        })
+    }
+
+    fn ws_subscribe_logs(
+        &self,
+        _filter: Filter,
+        _auth: AuthContext,
+    ) -> BoxWsSubscriptionFut<'_> {
+        let enabled = self.ws_subscriptions_enabled;
+        Box::pin(async move {
+            if !enabled {
+                return Err(JsonRpcError::method_disabled());
+            }
+
+            let stream = stream::iter(vec![to_raw(&serde_json::json!({
+                "address": format!("{:#x}", Address::ZERO),
+                "topics": [format!(
+                    "{:#x}",
+                    b256!("0x1111111111111111111111111111111111111111111111111111111111111111")
+                )],
+                "data": "0x",
+                "blockHash": format!(
+                    "{:#x}",
+                    b256!("0x2222222222222222222222222222222222222222222222222222222222222222")
+                ),
+                "blockNumber": "0x42",
+                "transactionHash": format!(
+                    "{:#x}",
+                    b256!("0x3333333333333333333333333333333333333333333333333333333333333333")
+                ),
+                "transactionIndex": "0x0",
+                "logIndex": "0x0",
+                "removed": false,
+            }))]);
+            let stream: WsSubscriptionStream = Box::pin(stream);
+            Ok(stream)
+        })
+    }
+
+    fn zone_get_authorization_token_info(&self, auth: AuthContext) -> BoxFut<'_> {
+        if matches!(
+            self.profile,
+            ResponseProfile::Handler | ResponseProfile::WebSocket
+        ) {
+            Box::pin(async move {
+                to_raw(&serde_json::json!({
+                    "account": auth.caller,
+                    "expiresAt": alloy_primitives::U64::from(auth.expires_at),
+                }))
+            })
+        } else {
+            self.unimplemented()
+        }
+    }
+
+    fn zone_get_zone_info(&self, _auth: AuthContext) -> BoxFut<'_> {
+        match self.profile {
+            ResponseProfile::Handler => Box::pin(async {
+                to_raw(&serde_json::json!({
+                    "zoneId": "0x1",
+                    "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
+                    "sequencers": [format!("{:#x}", Address::repeat_byte(0x22))],
+                    "chainId": "0x2a",
+                    "tempoBlockNumber": "0x7",
+                }))
+            }),
+            ResponseProfile::WebSocket => Box::pin(async {
+                to_raw(&serde_json::json!({
+                    "zoneId": "0x1",
+                    "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
+                    "chainId": "0x2a",
+                }))
+            }),
+            ResponseProfile::Stub => self.unimplemented(),
+        }
+    }
+
+    stub!(zone_get_encryption_key, _auth: AuthContext);
+}

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -1,26 +1,15 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use alloy_primitives::{Address, b256};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
-use futures::{SinkExt, StreamExt, stream};
+use futures::{SinkExt, StreamExt};
 use p256::ecdsa::SigningKey as P256SigningKey;
-use parking_lot::Mutex;
 use rand::thread_rng;
 use serde_json::{Value, json};
-use tempo_contracts::precompiles::account_keychain::IAccountKeychain::{
-    KeyInfo, SignatureType as KeyInfoSignatureType,
-};
-use tokio::sync::Notify;
+use tempo_contracts::precompiles::account_keychain::IAccountKeychain::SignatureType as KeyInfoSignatureType;
 use tokio_tungstenite::{connect_async, tungstenite};
-use zone_rpc::{
-    RedactedRpcConfig,
-    auth::build_token_fields,
-    handlers::ZoneRpcApi,
-    start_redacted_rpc,
-    subscription::{BoxWsSubscriptionFut, WsSubscriptionStream},
-    types::{BoxEyreFut, BoxFut, JsonRpcError},
-};
+use zone_rpc::{RedactedRpcConfig, auth::build_token_fields, start_redacted_rpc};
 
 #[path = "../../test-utils/auth_tokens.rs"]
 mod auth_tokens;
@@ -30,237 +19,17 @@ use auth_tokens::{
     sign_webauthn_signature,
 };
 
-// ---------------------------------------------------------------------------
-// Mock API
-// ---------------------------------------------------------------------------
+#[allow(dead_code)]
+mod test_api {
+    use zone_rpc as rpc;
 
-#[derive(Default)]
-struct MockZoneRpcApi {
-    key_infos: Mutex<HashMap<(Address, Address), KeyInfo>>,
-    key_lookup_error: Option<&'static str>,
-    ws_subscriptions_enabled: bool,
-    blocking_rpc_started: Option<Arc<Notify>>,
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/test-utils/zone_rpc_api.rs"
+    ));
 }
 
-impl MockZoneRpcApi {
-    fn with_key(account: Address, key_id: Address, signature_type: KeyInfoSignatureType) -> Self {
-        let mut key_infos = HashMap::new();
-        key_infos.insert(
-            (account, key_id),
-            KeyInfo {
-                signatureType: signature_type,
-                keyId: key_id,
-                expiry: u64::MAX,
-                enforceLimits: false,
-                isRevoked: false,
-            },
-        );
-        Self {
-            key_infos: Mutex::new(key_infos),
-            key_lookup_error: None,
-            ws_subscriptions_enabled: false,
-            blocking_rpc_started: None,
-        }
-    }
-
-    fn with_key_and_blocking_request(
-        account: Address,
-        key_id: Address,
-        signature_type: KeyInfoSignatureType,
-    ) -> (Self, Arc<Notify>) {
-        let mut api = Self::with_key(account, key_id, signature_type);
-        let started = Arc::new(Notify::new());
-        api.blocking_rpc_started = Some(started.clone());
-        (api, started)
-    }
-
-    fn with_key_lookup_error(message: &'static str) -> Self {
-        Self {
-            key_infos: Mutex::new(HashMap::new()),
-            key_lookup_error: Some(message),
-            ws_subscriptions_enabled: false,
-            blocking_rpc_started: None,
-        }
-    }
-
-    fn with_ws_subscriptions() -> Self {
-        Self {
-            key_infos: Mutex::new(HashMap::new()),
-            key_lookup_error: None,
-            ws_subscriptions_enabled: true,
-            blocking_rpc_started: None,
-        }
-    }
-
-    fn revoke_key(&self, account: Address, key_id: Address) {
-        if let Some(key_info) = self.key_infos.lock().get_mut(&(account, key_id)) {
-            key_info.isRevoked = true;
-        }
-    }
-}
-
-macro_rules! stub {
-    ($method:ident $(, $arg:ident : $ty:ty)*) => {
-        fn $method(&self $(, $arg: $ty)*) -> BoxFut<'_> {
-            Box::pin(async { Err(JsonRpcError::internal("not implemented")) })
-        }
-    };
-}
-
-impl ZoneRpcApi for MockZoneRpcApi {
-    fn get_keychain_key(&self, account: Address, key_id: Address) -> BoxEyreFut<'_, KeyInfo> {
-        if let Some(message) = self.key_lookup_error {
-            return Box::pin(async move { Err(eyre::eyre!(message)) });
-        }
-        let key_info = self
-            .key_infos
-            .lock()
-            .get(&(account, key_id))
-            .cloned()
-            .unwrap_or(KeyInfo {
-                signatureType: KeyInfoSignatureType::Secp256k1,
-                keyId: Address::ZERO,
-                expiry: 0,
-                enforceLimits: false,
-                isRevoked: false,
-            });
-        Box::pin(async move { Ok(key_info) })
-    }
-
-    fn block_number(&self) -> BoxFut<'_> {
-        Box::pin(async { zone_rpc::types::to_raw(&"0x42") })
-    }
-
-    fn chain_id(&self) -> BoxFut<'_> {
-        Box::pin(async { zone_rpc::types::to_raw(&"0x1") })
-    }
-
-    stub!(net_version);
-    stub!(syncing);
-    stub!(coinbase);
-    stub!(gas_price);
-    stub!(max_priority_fee_per_gas);
-    stub!(fee_history, _a: u64, _b: alloy_rpc_types_eth::BlockNumberOrTag, _c: Option<Vec<f64>>);
-    stub!(get_balance, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
-    stub!(get_transaction_count, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
-    stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _b: bool, _c: zone_rpc::auth::AuthContext);
-    stub!(block_by_hash, _a: alloy_primitives::B256, _b: bool, _c: zone_rpc::auth::AuthContext);
-    stub!(transaction_by_hash, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
-    stub!(transaction_receipt, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
-    stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
-    stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
-    stub!(send_raw_transaction, _a: alloy_primitives::Bytes, _c: zone_rpc::auth::AuthContext);
-    fn send_raw_transaction_sync(
-        &self,
-        _data: alloy_primitives::Bytes,
-        _auth: zone_rpc::auth::AuthContext,
-    ) -> BoxFut<'_> {
-        let started = self.blocking_rpc_started.clone();
-        Box::pin(async move {
-            if let Some(started) = started {
-                started.notify_one();
-                std::future::pending::<()>().await;
-            }
-            Err(JsonRpcError::internal("not implemented"))
-        })
-    }
-    stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: zone_rpc::auth::AuthContext);
-    stub!(get_logs, _a: alloy_rpc_types_eth::Filter, _c: zone_rpc::auth::AuthContext);
-    stub!(new_filter, _a: alloy_rpc_types_eth::Filter, _c: zone_rpc::auth::AuthContext);
-    stub!(get_filter_logs, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
-    stub!(get_filter_changes, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
-    stub!(new_block_filter, _c: zone_rpc::auth::AuthContext);
-    stub!(uninstall_filter, _a: alloy_rpc_types_eth::FilterId, _c: zone_rpc::auth::AuthContext);
-
-    fn ws_subscribe_new_heads(
-        &self,
-        _auth: zone_rpc::auth::AuthContext,
-    ) -> BoxWsSubscriptionFut<'_> {
-        let enabled = self.ws_subscriptions_enabled;
-        Box::pin(async move {
-            if !enabled {
-                return Err(JsonRpcError::method_disabled());
-            }
-
-            let stream = stream::iter(vec![zone_rpc::types::to_raw(&json!({
-                "hash": format!(
-                    "{:#x}",
-                    b256!("0x4444444444444444444444444444444444444444444444444444444444444444")
-                ),
-                "number": "0x42",
-                "parentHash": format!("{:#x}", alloy_primitives::B256::ZERO),
-                "logsBloom": format!("0x{}", "0".repeat(512)),
-                "gasUsed": "0x0",
-                "size": "0x0",
-                "transactionsRoot": format!("{:#x}", alloy_primitives::B256::ZERO),
-                "receiptsRoot": format!("{:#x}", alloy_primitives::B256::ZERO),
-                "stateRoot": format!("{:#x}", alloy_primitives::B256::ZERO),
-                "extraData": "0x",
-            }))]);
-            let stream: WsSubscriptionStream = Box::pin(stream);
-            Ok(stream)
-        })
-    }
-
-    fn ws_subscribe_logs(
-        &self,
-        _filter: alloy_rpc_types_eth::Filter,
-        _auth: zone_rpc::auth::AuthContext,
-    ) -> BoxWsSubscriptionFut<'_> {
-        let enabled = self.ws_subscriptions_enabled;
-        Box::pin(async move {
-            if !enabled {
-                return Err(JsonRpcError::method_disabled());
-            }
-
-            let stream = stream::iter(vec![zone_rpc::types::to_raw(&json!({
-                "address": format!("{:#x}", Address::ZERO),
-                "topics": [format!(
-                    "{:#x}",
-                    b256!("0x1111111111111111111111111111111111111111111111111111111111111111")
-                )],
-                "data": "0x",
-                "blockHash": format!(
-                    "{:#x}",
-                    b256!("0x2222222222222222222222222222222222222222222222222222222222222222")
-                ),
-                "blockNumber": "0x42",
-                "transactionHash": format!(
-                    "{:#x}",
-                    b256!("0x3333333333333333333333333333333333333333333333333333333333333333")
-                ),
-                "transactionIndex": "0x0",
-                "logIndex": "0x0",
-                "removed": false
-            }))]);
-            let stream: WsSubscriptionStream = Box::pin(stream);
-            Ok(stream)
-        })
-    }
-
-    fn zone_get_authorization_token_info(&self, auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
-        Box::pin(async move {
-            zone_rpc::types::to_raw(&serde_json::json!({
-                "account": auth.caller,
-                "expiresAt": alloy_primitives::U64::from(auth.expires_at),
-            }))
-        })
-    }
-
-    fn zone_get_zone_info(&self, _auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
-        Box::pin(async move {
-            zone_rpc::types::to_raw(&serde_json::json!({
-                "zoneId": "0x1",
-                "zoneTokens": [format!("{:#x}", Address::repeat_byte(0x11))],
-                "chainId": "0x2a",
-            }))
-        })
-    }
-
-    fn zone_get_encryption_key(&self, _auth: zone_rpc::auth::AuthContext) -> BoxFut<'_> {
-        Box::pin(async { Err(zone_rpc::types::JsonRpcError::internal("not implemented")) })
-    }
-}
+use test_api::TestZoneRpcApi as MockZoneRpcApi;
 
 // ---------------------------------------------------------------------------
 // Test context
@@ -376,7 +145,7 @@ fn parse_response(msg: tungstenite::Message) -> Value {
 
 #[tokio::test]
 async fn ws_roundtrip_with_header_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -392,7 +161,7 @@ async fn ws_roundtrip_with_header_auth() {
 
 #[tokio::test]
 async fn ws_roundtrip_with_query_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let token = ctx.build_token();
     let url = format!("{}/?token={token}", ctx.ws_url());
 
@@ -411,7 +180,7 @@ async fn ws_roundtrip_with_query_auth() {
 
 #[tokio::test]
 async fn ws_reject_no_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let result = connect_async(ctx.ws_url()).await;
     // Server should reject the upgrade — tungstenite surfaces this as an error
     // with the HTTP 401 status.
@@ -424,7 +193,7 @@ async fn ws_reject_no_auth() {
 
 #[tokio::test]
 async fn ws_reject_invalid_token() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let req = tungstenite::http::Request::builder()
         .uri(ctx.ws_url())
         .header("x-authorization-token", "deadbeef")
@@ -450,7 +219,7 @@ async fn ws_reject_invalid_token() {
 
 #[tokio::test]
 async fn ws_multiple_requests() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     for i in 1..=5 {
@@ -467,7 +236,7 @@ async fn ws_multiple_requests() {
 
 #[tokio::test]
 async fn ws_batch_request() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     let batch = serde_json::json!([
@@ -489,7 +258,7 @@ async fn ws_batch_request() {
 
 #[tokio::test]
 async fn ws_invalid_json() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text("{broken".into()))
@@ -502,7 +271,7 @@ async fn ws_invalid_json() {
 
 #[tokio::test]
 async fn ws_unknown_method() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(jsonrpc("eth_foobar", 1).into()))
@@ -516,7 +285,7 @@ async fn ws_unknown_method() {
 
 #[tokio::test]
 async fn ws_disabled_subscription_method() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -713,7 +482,7 @@ async fn ws_subscribe_rejects_too_many_active_subscriptions() {
 
 #[tokio::test]
 async fn ws_empty_batch() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text("[]".into()))
@@ -726,7 +495,7 @@ async fn ws_empty_batch() {
 
 #[tokio::test]
 async fn ws_roundtrip_with_p256_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
@@ -751,7 +520,7 @@ async fn ws_roundtrip_with_p256_auth() {
 
 #[tokio::test]
 async fn ws_roundtrip_with_webauthn_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
@@ -806,7 +575,7 @@ async fn ws_roundtrip_with_keychain_auth() {
 
 #[tokio::test]
 async fn ws_closes_when_auth_token_expires() {
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let now = now_secs();
     let token = ctx.build_token_expiring_at(now, now + 1);
     let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
@@ -884,7 +653,7 @@ async fn ws_closes_when_keychain_key_is_revoked_during_request() {
 async fn ws_reject_unauthorized_keychain_token() {
     let root_account = Address::repeat_byte(0x44);
     let access_signer = P256SigningKey::random(&mut thread_rng());
-    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
     let now = now_secs();
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let (signature, _key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -44,7 +44,11 @@ struct TestContext {
 }
 
 impl TestContext {
-    async fn start(api: MockZoneRpcApi) -> Self {
+    async fn start() -> Self {
+        Self::start_with(MockZoneRpcApi::websocket()).await
+    }
+
+    async fn start_with(api: MockZoneRpcApi) -> Self {
         Self::start_shared(Arc::new(api)).await
     }
 
@@ -145,7 +149,7 @@ fn parse_response(msg: tungstenite::Message) -> Value {
 
 #[tokio::test]
 async fn ws_roundtrip_with_header_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -161,7 +165,7 @@ async fn ws_roundtrip_with_header_auth() {
 
 #[tokio::test]
 async fn ws_roundtrip_with_query_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let token = ctx.build_token();
     let url = format!("{}/?token={token}", ctx.ws_url());
 
@@ -180,7 +184,7 @@ async fn ws_roundtrip_with_query_auth() {
 
 #[tokio::test]
 async fn ws_reject_no_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let result = connect_async(ctx.ws_url()).await;
     // Server should reject the upgrade — tungstenite surfaces this as an error
     // with the HTTP 401 status.
@@ -193,7 +197,7 @@ async fn ws_reject_no_auth() {
 
 #[tokio::test]
 async fn ws_reject_invalid_token() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let req = tungstenite::http::Request::builder()
         .uri(ctx.ws_url())
         .header("x-authorization-token", "deadbeef")
@@ -219,7 +223,7 @@ async fn ws_reject_invalid_token() {
 
 #[tokio::test]
 async fn ws_multiple_requests() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     for i in 1..=5 {
@@ -236,7 +240,7 @@ async fn ws_multiple_requests() {
 
 #[tokio::test]
 async fn ws_batch_request() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     let batch = serde_json::json!([
@@ -258,7 +262,7 @@ async fn ws_batch_request() {
 
 #[tokio::test]
 async fn ws_invalid_json() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text("{broken".into()))
@@ -271,7 +275,7 @@ async fn ws_invalid_json() {
 
 #[tokio::test]
 async fn ws_unknown_method() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(jsonrpc("eth_foobar", 1).into()))
@@ -285,7 +289,7 @@ async fn ws_unknown_method() {
 
 #[tokio::test]
 async fn ws_disabled_subscription_method() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -301,7 +305,7 @@ async fn ws_disabled_subscription_method() {
 
 #[tokio::test]
 async fn ws_subscribe_new_heads_emits_redacted_headers() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let ctx = TestContext::start_with(MockZoneRpcApi::subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -343,7 +347,7 @@ async fn ws_subscribe_new_heads_emits_redacted_headers() {
 
 #[tokio::test]
 async fn ws_subscribe_logs_emits_notifications() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let ctx = TestContext::start_with(MockZoneRpcApi::subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -370,7 +374,7 @@ async fn ws_subscribe_logs_emits_notifications() {
 
 #[tokio::test]
 async fn ws_subscribe_pending_transactions_is_disabled() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let ctx = TestContext::start_with(MockZoneRpcApi::subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     for (id, params) in [
@@ -392,7 +396,7 @@ async fn ws_subscribe_pending_transactions_is_disabled() {
 
 #[tokio::test]
 async fn ws_unsubscribe_removes_subscription() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let ctx = TestContext::start_with(MockZoneRpcApi::subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text(
@@ -421,7 +425,7 @@ async fn ws_unsubscribe_removes_subscription() {
 
 #[tokio::test]
 async fn ws_subscribe_rejects_invalid_param_shapes() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let ctx = TestContext::start_with(MockZoneRpcApi::subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     for (id, params) in [(1, json!(["newHeads", false])), (2, json!(["logs", false]))] {
@@ -438,7 +442,7 @@ async fn ws_subscribe_rejects_invalid_param_shapes() {
 
 #[tokio::test]
 async fn ws_subscribe_rejects_too_many_active_subscriptions() {
-    let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
+    let ctx = TestContext::start_with(MockZoneRpcApi::subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
     for id in 1..=32 {
@@ -482,7 +486,7 @@ async fn ws_subscribe_rejects_too_many_active_subscriptions() {
 
 #[tokio::test]
 async fn ws_empty_batch() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let mut ws = connect_with_header(&ctx).await;
 
     ws.send(tungstenite::Message::Text("[]".into()))
@@ -495,7 +499,7 @@ async fn ws_empty_batch() {
 
 #[tokio::test]
 async fn ws_roundtrip_with_p256_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
@@ -520,7 +524,7 @@ async fn ws_roundtrip_with_p256_auth() {
 
 #[tokio::test]
 async fn ws_roundtrip_with_webauthn_auth() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let signing_key = P256SigningKey::random(&mut thread_rng());
     let now = now_secs();
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
@@ -551,7 +555,7 @@ async fn ws_roundtrip_with_keychain_auth() {
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let (signature, key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)
         .expect("keychain signing should succeed");
-    let ctx = TestContext::start(MockZoneRpcApi::with_key(
+    let ctx = TestContext::start_with(MockZoneRpcApi::with_key(
         root_account,
         key_id,
         KeyInfoSignatureType::P256,
@@ -575,7 +579,7 @@ async fn ws_roundtrip_with_keychain_auth() {
 
 #[tokio::test]
 async fn ws_closes_when_auth_token_expires() {
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let now = now_secs();
     let token = ctx.build_token_expiring_at(now, now + 1);
     let mut ws = connect_with_token(&ctx.ws_url(), ctx.addr, &token)
@@ -653,7 +657,7 @@ async fn ws_closes_when_keychain_key_is_revoked_during_request() {
 async fn ws_reject_unauthorized_keychain_token() {
     let root_account = Address::repeat_byte(0x44);
     let access_signer = P256SigningKey::random(&mut thread_rng());
-    let ctx = TestContext::start(MockZoneRpcApi::for_websocket_tests()).await;
+    let ctx = TestContext::start().await;
     let now = now_secs();
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let (signature, _key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)
@@ -673,7 +677,8 @@ async fn ws_reject_unauthorized_keychain_token() {
 async fn ws_keychain_lookup_failure_returns_500() {
     let root_account = Address::repeat_byte(0x66);
     let access_signer = P256SigningKey::random(&mut thread_rng());
-    let ctx = TestContext::start(MockZoneRpcApi::with_key_lookup_error("key lookup failed")).await;
+    let ctx =
+        TestContext::start_with(MockZoneRpcApi::with_key_lookup_error("key lookup failed")).await;
     let now = now_secs();
     let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
     let (signature, _key_id) = sign_keychain_signature(digest, &access_signer, root_account, 0x04)


### PR DESCRIPTION
## Summary

- add a private, reusable `TestZoneRpcApi` fixture under RPC test support
- replace the handler, server authentication, and WebSocket suites' local full-trait mocks with explicit fixture profiles
- preserve keychain lookup, compatibility response, subscription stream, revocation, and blocking-request behavior

## Why

The three suites independently repeated nearly every `ZoneRpcApi` method even though most methods shared the same unimplemented stub. Keeping those copies synchronized made trait changes noisy and obscured the behavior each suite actually customizes.

## Impact

This is a test-only refactor. The production `ZoneRpcApi` contract, public API, RPC behavior, and existing coverage remain unchanged.