### PR TITLE
fix(rpc): enforce JSON-RPC request conformance

### DIFF
--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -3,7 +3,7 @@
 //! Each handler calls the underlying EthApi via the [`ZoneRpcApi`] trait,
 //! which performs typed privacy redactions internally before serialization.
 
-use alloy_primitives::{Address, B256, Bytes, keccak256};
+use alloy_primitives::{Address, B256, Bytes, U64, keccak256};
 use alloy_rpc_types_eth::{BlockId, BlockNumberOrTag, Filter, FilterId, state::StateOverride};
 use serde_json::{Value, value::RawValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
@@ -224,7 +224,112 @@ impl<'de> serde::Deserialize<'de> for CallParams {
                     .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 let block = seq.next_element::<Option<BlockId>>()?.flatten();
                 let state_override = seq.next_element::<Option<StateOverride>>()?.flatten();
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(4, &self));
+                }
                 Ok(CallParams(request, block, state_override))
+            }
+        }
+        deserializer.deserialize_seq(Vis)
+    }
+}
+
+/// Params for `eth_feeHistory`: `[blockCount, newestBlock, rewardPercentiles?]`.
+struct FeeHistoryParams(U64, BlockNumberOrTag, Option<Vec<f64>>);
+
+struct QuantityU64(U64);
+
+impl<'de> serde::Deserialize<'de> for QuantityU64 {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Vis;
+        impl serde::de::Visitor<'_> for Vis {
+            type Value = QuantityU64;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a canonical 0x-prefixed Ethereum quantity")
+            }
+
+            fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                let Some(digits) = value.strip_prefix("0x") else {
+                    return Err(E::invalid_value(serde::de::Unexpected::Str(value), &self));
+                };
+                if digits.is_empty()
+                    || (digits.len() > 1 && digits.starts_with('0'))
+                    || !digits.bytes().all(|byte| byte.is_ascii_hexdigit())
+                {
+                    return Err(E::invalid_value(serde::de::Unexpected::Str(value), &self));
+                }
+
+                value
+                    .parse::<U64>()
+                    .map(QuantityU64)
+                    .map_err(|_| E::invalid_value(serde::de::Unexpected::Str(value), &self))
+            }
+        }
+        deserializer.deserialize_str(Vis)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for FeeHistoryParams {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = FeeHistoryParams;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("[blockCount, newestBlock, rewardPercentiles?]")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let block_count = seq
+                    .next_element::<QuantityU64>()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let newest_block = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                let reward_percentiles = seq.next_element::<Option<Vec<f64>>>()?.flatten();
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(4, &self));
+                }
+                Ok(FeeHistoryParams(
+                    block_count.0,
+                    newest_block,
+                    reward_percentiles,
+                ))
+            }
+        }
+        deserializer.deserialize_seq(Vis)
+    }
+}
+
+/// Params for account state queries: `[address, block?]`.
+struct AccountBlockParams(Address, Option<BlockId>);
+
+impl<'de> serde::Deserialize<'de> for AccountBlockParams {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = AccountBlockParams;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("[address, block?]")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let address = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let block = seq.next_element::<Option<BlockId>>()?.flatten();
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &self));
+                }
+                Ok(AccountBlockParams(address, block))
             }
         }
         deserializer.deserialize_seq(Vis)
@@ -276,26 +381,37 @@ pub async fn dispatch(
     // Raw params JSON — handlers deserialize directly, no intermediate Vec<Value>.
     let raw = req.params.as_deref().map(|p| p.get()).unwrap_or("[]");
 
+    macro_rules! no_params {
+        ($response:expr) => {
+            match parse_params::<[Value; 0]>(raw, &id, "expected no parameters") {
+                Ok(_) => $response,
+                Err(response) => response,
+            }
+        };
+    }
+
     match req.method.as_str() {
         // Simple passthrough methods (no params, no auth scoping)
-        "eth_blockNumber" => api_result(id, "eth_blockNumber", api.block_number().await),
-        "eth_chainId" => api_result(id, "eth_chainId", api.chain_id().await),
-        "eth_gasPrice" => api_result(id, "eth_gasPrice", api.gas_price().await),
-        "eth_maxPriorityFeePerGas" => api_result(
+        "eth_blockNumber" => {
+            no_params!(api_result(id, "eth_blockNumber", api.block_number().await))
+        }
+        "eth_chainId" => no_params!(api_result(id, "eth_chainId", api.chain_id().await)),
+        "eth_gasPrice" => no_params!(api_result(id, "eth_gasPrice", api.gas_price().await)),
+        "eth_maxPriorityFeePerGas" => no_params!(api_result(
             id,
             "eth_maxPriorityFeePerGas",
             api.max_priority_fee_per_gas().await,
-        ),
-        "net_version" => api_result(id, "net_version", api.net_version().await),
-        "net_listening" => api_result(id, "net_listening", crate::types::to_raw(&true)),
-        "eth_syncing" => api_result(id, "eth_syncing", api.syncing().await),
-        "eth_coinbase" => api_result(id, "eth_coinbase", api.coinbase().await),
+        )),
+        "net_version" => no_params!(api_result(id, "net_version", api.net_version().await)),
+        "net_listening" => no_params!(api_result(id, "net_listening", crate::types::to_raw(&true))),
+        "eth_syncing" => no_params!(api_result(id, "eth_syncing", api.syncing().await)),
+        "eth_coinbase" => no_params!(api_result(id, "eth_coinbase", api.coinbase().await)),
         "web3_sha3" => handle_web3_sha3(id, raw).await,
-        "web3_clientVersion" => api_result(
+        "web3_clientVersion" => no_params!(api_result(
             id,
             "web3_clientVersion",
             crate::types::to_raw(&"tempo-zone/v0.1.0"),
-        ),
+        )),
 
         // Fee history
         "eth_feeHistory" => handle_fee_history(id, raw, api).await,
@@ -326,23 +442,23 @@ pub async fn dispatch(
         "eth_newFilter" => handle_new_filter(id, raw, auth, api).await,
         "eth_getFilterLogs" => handle_get_filter_logs(id, raw, auth, api).await,
         "eth_getFilterChanges" => handle_get_filter_changes(id, raw, auth, api).await,
-        "eth_newBlockFilter" => handle_new_block_filter(id, auth, api).await,
+        "eth_newBlockFilter" => no_params!(handle_new_block_filter(id, auth, api).await),
         "eth_uninstallFilter" => handle_uninstall_filter(id, raw, auth, api).await,
-        "zone_getAuthorizationTokenInfo" => api_result(
+        "zone_getAuthorizationTokenInfo" => no_params!(api_result(
             id,
             "zone_getAuthorizationTokenInfo",
             api.zone_get_authorization_token_info(auth.clone()).await,
-        ),
-        "zone_getZoneInfo" => api_result(
+        )),
+        "zone_getZoneInfo" => no_params!(api_result(
             id,
             "zone_getZoneInfo",
             api.zone_get_zone_info(auth.clone()).await,
-        ),
-        "zone_getEncryptionKey" => api_result(
+        )),
+        "zone_getEncryptionKey" => no_params!(api_result(
             id,
             "zone_getEncryptionKey",
             api.zone_get_encryption_key(auth.clone()).await,
-        ),
+        )),
         _ => {
             // Method is whitelisted but not yet implemented via direct API
             JsonRpcResponse::error(
@@ -570,8 +686,8 @@ async fn handle_send_raw_transaction_sync(
 
 /// Handle `eth_feeHistory`. Public method, no auth scoping needed.
 async fn handle_fee_history(id: Value, raw: &str, api: &dyn ZoneRpcApi) -> JsonRpcResponse {
-    let (block_count, newest_block, reward_percentiles) =
-        match parse_params::<(u64, BlockNumberOrTag, Option<Vec<f64>>)>(
+    let FeeHistoryParams(block_count, newest_block, reward_percentiles) =
+        match parse_params::<FeeHistoryParams>(
             raw,
             &id,
             "expected [blockCount, newestBlock, rewardPercentiles?]",
@@ -583,7 +699,7 @@ async fn handle_fee_history(id: Value, raw: &str, api: &dyn ZoneRpcApi) -> JsonR
     api_result(
         id,
         "eth_feeHistory",
-        api.fee_history(block_count, newest_block, reward_percentiles)
+        api.fee_history(block_count.to::<u64>(), newest_block, reward_percentiles)
             .await,
     )
 }
@@ -596,8 +712,8 @@ async fn handle_get_balance(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
-    let (address, block) =
-        match parse_params::<(Address, Option<BlockId>)>(raw, &id, "expected [address, block?]") {
+    let AccountBlockParams(address, block) =
+        match parse_params::<AccountBlockParams>(raw, &id, "expected [address, block?]") {
             Ok(v) => v,
             Err(resp) => return resp,
         };
@@ -617,8 +733,8 @@ async fn handle_get_transaction_count(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> JsonRpcResponse {
-    let (address, block) =
-        match parse_params::<(Address, Option<BlockId>)>(raw, &id, "expected [address, block?]") {
+    let AccountBlockParams(address, block) =
+        match parse_params::<AccountBlockParams>(raw, &id, "expected [address, block?]") {
             Ok(v) => v,
             Err(resp) => return resp,
         };
@@ -753,7 +869,9 @@ mod tests {
     use crate::types::to_raw;
 
     #[derive(Default)]
-    struct MockZoneRpcApi;
+    struct MockZoneRpcApi {
+        fee_history_block_counts: parking_lot::Mutex<Vec<u64>>,
+    }
 
     macro_rules! stub {
         ($method:ident $(, $arg:ident : $ty:ty)*) => {
@@ -773,9 +891,33 @@ mod tests {
         stub!(net_version);
         stub!(gas_price);
         stub!(max_priority_fee_per_gas);
-        stub!(fee_history, _block_count: u64, _newest_block: BlockNumberOrTag, _reward_percentiles: Option<Vec<f64>>);
-        stub!(get_balance, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
-        stub!(get_transaction_count, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
+        fn fee_history(
+            &self,
+            block_count: u64,
+            _newest_block: BlockNumberOrTag,
+            _reward_percentiles: Option<Vec<f64>>,
+        ) -> BoxFut<'_> {
+            self.fee_history_block_counts.lock().push(block_count);
+            Box::pin(async move { to_raw(&json!({"oldestBlock": "0x0"})) })
+        }
+
+        fn get_balance(
+            &self,
+            _address: Address,
+            _block: Option<BlockId>,
+            _auth: AuthContext,
+        ) -> BoxFut<'_> {
+            Box::pin(async move { to_raw(&"0x1") })
+        }
+
+        fn get_transaction_count(
+            &self,
+            _address: Address,
+            _block: Option<BlockId>,
+            _auth: AuthContext,
+        ) -> BoxFut<'_> {
+            Box::pin(async move { to_raw(&"0x2") })
+        }
         stub!(block_by_number, _number: BlockNumberOrTag, _full: bool, _auth: AuthContext);
         stub!(block_by_hash, _hash: B256, _full: bool, _auth: AuthContext);
         stub!(transaction_by_hash, _hash: B256, _auth: AuthContext);
@@ -903,6 +1045,107 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<Value>(sha3.result.as_ref().unwrap().get()).unwrap(),
             "0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
+        );
+    }
+
+    #[tokio::test]
+    async fn fee_history_decodes_quantity_and_optional_reward_percentiles() {
+        let cases = [
+            (json!(["0x10", "latest"]), Some(16)),
+            (json!(["0x0", "latest", null]), Some(0)),
+            (json!(["0x2", "latest", [25.0, 75.0]]), Some(2)),
+            (json!(["0x", "latest"]), None),
+            (json!(["0x00", "latest"]), None),
+            (json!([16, "latest"]), None),
+            (json!(["16", "latest"]), None),
+            (json!(["not-a-quantity", "latest"]), None),
+            (json!(["0x10000000000000000", "latest"]), None),
+            (json!(["0x10", "latest", [], true]), None),
+        ];
+
+        for (params, expected_block_count) in cases {
+            let api = MockZoneRpcApi::default();
+            let params_label = params.to_string();
+            let response = dispatch(&request("eth_feeHistory", params), &auth(), &api).await;
+
+            match expected_block_count {
+                Some(expected) => {
+                    assert!(response.error.is_none());
+                    assert_eq!(api.fee_history_block_counts.lock().as_slice(), &[expected]);
+                }
+                None => {
+                    let error = response
+                        .error
+                        .unwrap_or_else(|| panic!("accepted invalid params: {params_label}"));
+                    assert_eq!(error.code, -32602, "{params_label}");
+                    assert!(api.fee_history_block_counts.lock().is_empty());
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn account_block_parameters_are_optional_but_bounded() {
+        let address = format!("{:#x}", Address::repeat_byte(0x11));
+        let cases = [
+            (json!([address]), true),
+            (json!([address, null]), true),
+            (json!([address, "latest"]), true),
+            (json!([address, "latest", true]), false),
+        ];
+
+        for method in ["eth_getBalance", "eth_getTransactionCount"] {
+            for (params, is_valid) in &cases {
+                let api = MockZoneRpcApi::default();
+                let response = dispatch(&request(method, params.clone()), &auth(), &api).await;
+                if *is_valid {
+                    assert!(response.error.is_none(), "{method} rejected {params}");
+                } else {
+                    assert_eq!(response.error.unwrap().code, -32602);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn no_param_methods_reject_non_empty_params() {
+        let api = MockZoneRpcApi::default();
+        for method in [
+            "eth_blockNumber",
+            "eth_chainId",
+            "eth_gasPrice",
+            "eth_maxPriorityFeePerGas",
+            "net_version",
+            "net_listening",
+            "eth_syncing",
+            "eth_coinbase",
+            "web3_clientVersion",
+            "eth_newBlockFilter",
+            "zone_getAuthorizationTokenInfo",
+            "zone_getZoneInfo",
+            "zone_getEncryptionKey",
+        ] {
+            let response = dispatch(&request(method, json!(["unexpected"])), &auth(), &api).await;
+            assert_eq!(response.error.unwrap().code, -32602, "{method}");
+        }
+
+        let without_params: JsonRpcRequest = serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "net_listening",
+            "id": 1
+        }))
+        .unwrap();
+        assert!(
+            dispatch(&without_params, &auth(), &api)
+                .await
+                .error
+                .is_none()
+        );
+        assert!(
+            dispatch(&request("net_listening", json!([])), &auth(), &api)
+                .await
+                .error
+                .is_none()
         );
     }
 

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -35,6 +35,7 @@ use crate::{
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse},
     ws::handle_ws_upgrade,
 };
+use serde_json::value::RawValue;
 
 /// Maximum number of requests in a single JSON-RPC batch.
 pub(crate) const MAX_BATCH_SIZE: usize = 100;
@@ -86,6 +87,7 @@ pub async fn start_redacted_rpc(
 
 /// Result of processing a JSON-RPC text payload (single or batch).
 pub(crate) enum RpcResult {
+    NoResponse,
     Single(JsonRpcResponse),
     Batch(Vec<JsonRpcResponse>),
 }
@@ -93,8 +95,85 @@ pub(crate) enum RpcResult {
 impl IntoResponse for RpcResult {
     fn into_response(self) -> axum::response::Response {
         match self {
+            Self::NoResponse => StatusCode::NO_CONTENT.into_response(),
             Self::Single(resp) => axum::Json(resp).into_response(),
             Self::Batch(resps) => axum::Json(resps).into_response(),
+        }
+    }
+}
+
+/// Parsed request entry. Invalid batch members retain their own error response.
+pub(crate) enum ParsedRpcRequest {
+    Request(JsonRpcRequest),
+    Invalid(JsonRpcResponse),
+}
+
+/// Parsed JSON-RPC payload shared by HTTP and WebSocket transports.
+pub(crate) enum ParsedRpcText {
+    Single(ParsedRpcRequest),
+    Batch(Vec<ParsedRpcRequest>),
+    Error(JsonRpcResponse),
+}
+
+fn parse_request(raw: &str) -> ParsedRpcRequest {
+    match serde_json::from_str::<JsonRpcRequest>(raw) {
+        Ok(request) if request.jsonrpc == "2.0" => ParsedRpcRequest::Request(request),
+        Ok(_) | Err(_) => ParsedRpcRequest::Invalid(JsonRpcResponse::error(
+            serde_json::Value::Null,
+            JsonRpcError::invalid_request(),
+        )),
+    }
+}
+
+/// Parse a JSON-RPC text payload and validate its request shape and version.
+pub(crate) fn parse_rpc_text(text: &str) -> ParsedRpcText {
+    let trimmed = text.trim_start();
+
+    if trimmed.starts_with('[') {
+        match serde_json::from_str::<Vec<Box<RawValue>>>(trimmed) {
+            Ok(requests) if requests.is_empty() => ParsedRpcText::Error(JsonRpcResponse::error(
+                serde_json::Value::Null,
+                JsonRpcError::parse_error("empty batch"),
+            )),
+            Ok(requests) if requests.len() > MAX_BATCH_SIZE => {
+                ParsedRpcText::Error(JsonRpcResponse::error(
+                    serde_json::Value::Null,
+                    JsonRpcError::invalid_params(format!(
+                        "batch too large ({} > {MAX_BATCH_SIZE})",
+                        requests.len()
+                    )),
+                ))
+            }
+            Ok(requests) => ParsedRpcText::Batch(
+                requests
+                    .iter()
+                    .map(|request| parse_request(request.get()))
+                    .collect(),
+            ),
+            Err(err) => ParsedRpcText::Error(JsonRpcResponse::error(
+                serde_json::Value::Null,
+                JsonRpcError::parse_error(format!("parse error: {err}")),
+            )),
+        }
+    } else {
+        match serde_json::from_str::<JsonRpcRequest>(trimmed) {
+            Ok(request) if request.jsonrpc == "2.0" => {
+                ParsedRpcText::Single(ParsedRpcRequest::Request(request))
+            }
+            Ok(_) => ParsedRpcText::Single(ParsedRpcRequest::Invalid(JsonRpcResponse::error(
+                serde_json::Value::Null,
+                JsonRpcError::invalid_request(),
+            ))),
+            Err(request_err) => match serde_json::from_str::<serde_json::Value>(trimmed) {
+                Ok(_) => ParsedRpcText::Single(ParsedRpcRequest::Invalid(JsonRpcResponse::error(
+                    serde_json::Value::Null,
+                    JsonRpcError::invalid_request(),
+                ))),
+                Err(_) => ParsedRpcText::Error(JsonRpcResponse::error(
+                    serde_json::Value::Null,
+                    JsonRpcError::parse_error(format!("parse error: {request_err}")),
+                )),
+            },
         }
     }
 }
@@ -106,42 +185,37 @@ pub(crate) async fn process_rpc_text(
     auth: &AuthContext,
     api: &dyn ZoneRpcApi,
 ) -> RpcResult {
-    let trimmed = text.trim_start();
-
-    if trimmed.starts_with('[') {
-        match serde_json::from_str::<Vec<JsonRpcRequest>>(trimmed) {
-            Ok(requests) if requests.is_empty() => RpcResult::Single(JsonRpcResponse::error(
-                serde_json::Value::Null,
-                JsonRpcError::parse_error("empty batch"),
-            )),
-            Ok(requests) if requests.len() > MAX_BATCH_SIZE => {
-                RpcResult::Single(JsonRpcResponse::error(
-                    serde_json::Value::Null,
-                    JsonRpcError::invalid_params(format!(
-                        "batch too large ({} > {MAX_BATCH_SIZE})",
-                        requests.len()
-                    )),
-                ))
+    match parse_rpc_text(text) {
+        ParsedRpcText::Error(response) => RpcResult::Single(response),
+        ParsedRpcText::Single(ParsedRpcRequest::Invalid(response)) => RpcResult::Single(response),
+        ParsedRpcText::Single(ParsedRpcRequest::Request(request)) => {
+            let is_notification = request.is_notification();
+            let response = dispatch_request(&request, auth, api).await;
+            if is_notification {
+                RpcResult::NoResponse
+            } else {
+                RpcResult::Single(response)
             }
-            Ok(requests) => {
-                let mut responses = Vec::with_capacity(requests.len());
-                for req in &requests {
-                    responses.push(dispatch_request(req, auth, api).await);
+        }
+        ParsedRpcText::Batch(requests) => {
+            let mut responses = Vec::with_capacity(requests.len());
+            for request in requests {
+                match request {
+                    ParsedRpcRequest::Invalid(response) => responses.push(response),
+                    ParsedRpcRequest::Request(request) => {
+                        let is_notification = request.is_notification();
+                        let response = dispatch_request(&request, auth, api).await;
+                        if !is_notification {
+                            responses.push(response);
+                        }
+                    }
                 }
+            }
+            if responses.is_empty() {
+                RpcResult::NoResponse
+            } else {
                 RpcResult::Batch(responses)
             }
-            Err(e) => RpcResult::Single(JsonRpcResponse::error(
-                serde_json::Value::Null,
-                JsonRpcError::parse_error(format!("parse error: {e}")),
-            )),
-        }
-    } else {
-        match serde_json::from_str::<JsonRpcRequest>(trimmed) {
-            Ok(request) => RpcResult::Single(dispatch_request(&request, auth, api).await),
-            Err(e) => RpcResult::Single(JsonRpcResponse::error(
-                serde_json::Value::Null,
-                JsonRpcError::parse_error(format!("parse error: {e}")),
-            )),
         }
     }
 }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -39,7 +39,7 @@ pub struct TempoStorageRead {
 }
 
 /// A JSON-RPC 2.0 request.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct JsonRpcRequest {
     /// The JSON-RPC version (must be "2.0").
     pub jsonrpc: String,
@@ -49,6 +49,60 @@ pub struct JsonRpcRequest {
     pub params: Option<Box<serde_json::value::RawValue>>,
     /// The request ID.
     pub id: Value,
+    /// Whether the request omitted its ID and is therefore a notification.
+    is_notification: bool,
+}
+
+#[derive(Default)]
+enum RequestId {
+    #[default]
+    Missing,
+    Present(Value),
+}
+
+impl<'de> Deserialize<'de> for RequestId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Value::deserialize(deserializer).map(Self::Present)
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonRpcRequest {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct WireRequest {
+            jsonrpc: String,
+            method: String,
+            params: Option<Box<RawValue>>,
+            #[serde(default)]
+            id: RequestId,
+        }
+
+        let WireRequest {
+            jsonrpc,
+            method,
+            params,
+            id,
+        } = WireRequest::deserialize(deserializer)?;
+        let (id, is_notification) = match id {
+            RequestId::Missing => (Value::Null, true),
+            RequestId::Present(id) => (id, false),
+        };
+
+        Ok(Self {
+            jsonrpc,
+            method,
+            params,
+            id,
+            is_notification,
+        })
+    }
+}
+
+impl JsonRpcRequest {
+    /// Returns true when the request omitted the `id` member.
+    pub fn is_notification(&self) -> bool {
+        self.is_notification
+    }
 }
 
 /// A JSON-RPC 2.0 response.
@@ -107,6 +161,15 @@ impl std::fmt::Display for JsonRpcError {
 }
 
 impl JsonRpcError {
+    /// Invalid request (-32600).
+    pub fn invalid_request() -> Self {
+        Self {
+            code: -32600,
+            message: "Invalid Request".to_string(),
+            data: None,
+        }
+    }
+
     /// Method not found (-32601).
     pub fn method_not_found() -> Self {
         Self {

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -36,7 +36,8 @@ use tracing::warn;
 use crate::{
     auth::{self, AuthContext, AuthError},
     server::{
-        MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request, validate_keychain_key_info,
+        ParsedRpcRequest, ParsedRpcText, RpcState, authenticate_token, dispatch_request,
+        parse_rpc_text, validate_keychain_key_info,
     },
     subscription::WsSubscriptionStream,
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
@@ -120,11 +121,35 @@ impl WsSession {
     }
 }
 
-#[derive(serde::Deserialize)]
-struct SubscribeParams(
-    SubscriptionKind,
-    #[serde(default)] Option<SubscriptionParams>,
-);
+struct SubscribeParams(SubscriptionKind, Option<SubscriptionParams>);
+
+impl<'de> serde::Deserialize<'de> for SubscribeParams {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Vis;
+        impl<'de> serde::de::Visitor<'de> for Vis {
+            type Value = SubscribeParams;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("[subscription, params?]")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let kind = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let params = seq.next_element::<Option<SubscriptionParams>>()?.flatten();
+                if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                    return Err(serde::de::Error::invalid_length(3, &self));
+                }
+                Ok(SubscribeParams(kind, params))
+            }
+        }
+        deserializer.deserialize_seq(Vis)
+    }
+}
 
 fn success_response<T: serde::Serialize>(id: Value, result: &T) -> JsonRpcResponse {
     match to_raw(result) {
@@ -369,71 +394,46 @@ async fn process_ws_text(
     auth: &AuthContext,
     state: &Arc<RpcState>,
     session: &mut WsSession,
-) -> (String, Vec<PendingSubscription>) {
-    let trimmed = text.trim_start();
-
-    if trimmed.starts_with('[') {
-        match serde_json::from_str::<Vec<JsonRpcRequest>>(trimmed) {
-            Ok(requests) if requests.is_empty() => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::parse_error("empty batch"),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
-                Vec::new(),
+) -> (Option<String>, Vec<PendingSubscription>) {
+    match parse_rpc_text(text) {
+        ParsedRpcText::Error(response)
+        | ParsedRpcText::Single(ParsedRpcRequest::Invalid(response)) => (
+            Some(
+                serde_json::to_string(&response)
+                    .expect("JsonRpcResponse serialization is infallible"),
             ),
-            Ok(requests) if requests.len() > MAX_BATCH_SIZE => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::invalid_params(format!(
-                        "batch too large ({} > {MAX_BATCH_SIZE})",
-                        requests.len()
-                    )),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
-                Vec::new(),
-            ),
-            Ok(requests) => {
-                let mut responses = Vec::with_capacity(requests.len());
-                let mut pending_subscriptions = Vec::new();
-                for req in &requests {
-                    let result = dispatch_ws_request(req, auth, state, session).await;
-                    responses.push(result.response);
-                    pending_subscriptions.extend(result.pending_subscriptions);
-                }
-                (
-                    serde_json::to_string(&responses)
-                        .expect("JsonRpcResponse serialization is infallible"),
-                    pending_subscriptions,
-                )
-            }
-            Err(err) => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::parse_error(format!("parse error: {err}")),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
-                Vec::new(),
-            ),
+            Vec::new(),
+        ),
+        ParsedRpcText::Single(ParsedRpcRequest::Request(request)) => {
+            let is_notification = request.is_notification();
+            let result = dispatch_ws_request(&request, auth, state, session).await;
+            let response = (!is_notification).then(|| {
+                serde_json::to_string(&result.response)
+                    .expect("JsonRpcResponse serialization is infallible")
+            });
+            (response, result.pending_subscriptions)
         }
-    } else {
-        match serde_json::from_str::<JsonRpcRequest>(trimmed) {
-            Ok(request) => {
-                let result = dispatch_ws_request(&request, auth, state, session).await;
-                (
-                    serde_json::to_string(&result.response)
-                        .expect("JsonRpcResponse serialization is infallible"),
-                    result.pending_subscriptions,
-                )
+        ParsedRpcText::Batch(requests) => {
+            let mut responses = Vec::with_capacity(requests.len());
+            let mut pending_subscriptions = Vec::new();
+            for request in requests {
+                match request {
+                    ParsedRpcRequest::Invalid(response) => responses.push(response),
+                    ParsedRpcRequest::Request(request) => {
+                        let is_notification = request.is_notification();
+                        let result = dispatch_ws_request(&request, auth, state, session).await;
+                        if !is_notification {
+                            responses.push(result.response);
+                        }
+                        pending_subscriptions.extend(result.pending_subscriptions);
+                    }
+                }
             }
-            Err(err) => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::parse_error(format!("parse error: {err}")),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
-                Vec::new(),
-            ),
+            let response = (!responses.is_empty()).then(|| {
+                serde_json::to_string(&responses)
+                    .expect("JsonRpcResponse serialization is infallible")
+            });
+            (response, pending_subscriptions)
         }
     }
 }
@@ -589,7 +589,9 @@ async fn handle_ws_session(
             let (response_json, pending_subscriptions) =
                 process_ws_text(&text, &auth, &state, &mut session).await;
 
-            if !try_queue_notification(&notifications, &close_session, response_json) {
+            if let Some(response_json) = response_json
+                && !try_queue_notification(&notifications, &close_session, response_json)
+            {
                 break;
             }
 

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 use alloy_primitives::{Address, b256};
 use alloy_signer::SignerSync;
@@ -40,6 +47,7 @@ struct MockZoneRpcApi {
     key_lookup_error: Option<&'static str>,
     ws_subscriptions_enabled: bool,
     blocking_rpc_started: Option<Arc<Notify>>,
+    block_number_calls: AtomicUsize,
 }
 
 impl MockZoneRpcApi {
@@ -60,6 +68,7 @@ impl MockZoneRpcApi {
             key_lookup_error: None,
             ws_subscriptions_enabled: false,
             blocking_rpc_started: None,
+            block_number_calls: AtomicUsize::new(0),
         }
     }
 
@@ -80,6 +89,7 @@ impl MockZoneRpcApi {
             key_lookup_error: Some(message),
             ws_subscriptions_enabled: false,
             blocking_rpc_started: None,
+            block_number_calls: AtomicUsize::new(0),
         }
     }
 
@@ -89,6 +99,7 @@ impl MockZoneRpcApi {
             key_lookup_error: None,
             ws_subscriptions_enabled: true,
             blocking_rpc_started: None,
+            block_number_calls: AtomicUsize::new(0),
         }
     }
 
@@ -128,6 +139,7 @@ impl ZoneRpcApi for MockZoneRpcApi {
     }
 
     fn block_number(&self) -> BoxFut<'_> {
+        self.block_number_calls.fetch_add(1, Ordering::Relaxed);
         Box::pin(async { zone_rpc::types::to_raw(&"0x42") })
     }
 
@@ -316,6 +328,20 @@ impl TestContext {
     fn ws_url(&self) -> String {
         format!("ws://{}", self.addr)
     }
+
+    fn http_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+}
+
+async fn post_rpc(ctx: &TestContext, body: impl Into<reqwest::Body>) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(ctx.http_url())
+        .header("x-authorization-token", ctx.build_token())
+        .body(body)
+        .send()
+        .await
+        .expect("HTTP RPC request failed")
 }
 
 /// Build a JSON-RPC request string.
@@ -488,6 +514,132 @@ async fn ws_batch_request() {
 }
 
 #[tokio::test]
+async fn http_rejects_invalid_or_missing_jsonrpc_versions() {
+    let ctx = TestContext::start(MockZoneRpcApi::default()).await;
+    let requests = [
+        json!({"jsonrpc":"1.0","method":"eth_blockNumber","params":[],"id":1}),
+        json!({"jsonrpc":2.0,"method":"eth_blockNumber","params":[],"id":1}),
+        json!({"method":"eth_blockNumber","params":[],"id":1}),
+    ];
+
+    for request in requests {
+        let response = post_rpc(&ctx, request.to_string()).await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["error"]["code"], -32600);
+        assert_eq!(body["id"], Value::Null);
+    }
+}
+
+#[tokio::test]
+async fn http_omits_notification_responses() {
+    let api = Arc::new(MockZoneRpcApi::default());
+    let ctx = TestContext::start_shared(api.clone()).await;
+
+    let notification = json!({
+        "jsonrpc":"2.0",
+        "method":"eth_blockNumber",
+        "params":[]
+    });
+    let response = post_rpc(&ctx, notification.to_string()).await;
+    assert_eq!(response.status(), reqwest::StatusCode::NO_CONTENT);
+    assert!(response.bytes().await.unwrap().is_empty());
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 1);
+
+    let null_id_request = json!({
+        "jsonrpc":"2.0",
+        "method":"eth_blockNumber",
+        "params":[],
+        "id":null
+    });
+    let response = post_rpc(&ctx, null_id_request.to_string()).await;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(response.json::<Value>().await.unwrap()["id"], Value::Null);
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 2);
+
+    let mixed_batch = json!([
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[]},
+        {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":2}
+    ]);
+    let response = post_rpc(&ctx, mixed_batch.to_string()).await;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.unwrap();
+    let responses = body.as_array().unwrap();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], 2);
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 3);
+
+    let all_notifications = json!([
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[]},
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}
+    ]);
+    let response = post_rpc(&ctx, all_notifications.to_string()).await;
+    assert_eq!(response.status(), reqwest::StatusCode::NO_CONTENT);
+    assert!(response.bytes().await.unwrap().is_empty());
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 5);
+}
+
+#[tokio::test]
+async fn ws_omits_notification_responses() {
+    let api = Arc::new(MockZoneRpcApi::default());
+    let ctx = TestContext::start_shared(api.clone()).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    let notification = json!({
+        "jsonrpc":"2.0",
+        "method":"eth_blockNumber",
+        "params":[]
+    });
+    ws.send(tungstenite::Message::Text(notification.to_string().into()))
+        .await
+        .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), ws.next())
+            .await
+            .is_err()
+    );
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 1);
+
+    let mixed_batch = json!([
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[]},
+        {"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":2}
+    ]);
+    ws.send(tungstenite::Message::Text(mixed_batch.to_string().into()))
+        .await
+        .unwrap();
+    let response = parse_response(ws.next().await.unwrap().unwrap());
+    let responses = response.as_array().unwrap();
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0]["id"], 2);
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 2);
+
+    let all_notifications = json!([
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[]},
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[]}
+    ]);
+    ws.send(tungstenite::Message::Text(
+        all_notifications.to_string().into(),
+    ))
+    .await
+    .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), ws.next())
+            .await
+            .is_err()
+    );
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 4);
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc("eth_blockNumber", 9).into(),
+    ))
+    .await
+    .unwrap();
+    let response = parse_response(ws.next().await.unwrap().unwrap());
+    assert_eq!(response["id"], 9);
+    assert_eq!(api.block_number_calls.load(Ordering::Relaxed), 5);
+}
+
+#[tokio::test]
 async fn ws_invalid_json() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let mut ws = connect_with_header(&ctx).await;
@@ -655,7 +807,11 @@ async fn ws_subscribe_rejects_invalid_param_shapes() {
     let ctx = TestContext::start(MockZoneRpcApi::with_ws_subscriptions()).await;
     let mut ws = connect_with_header(&ctx).await;
 
-    for (id, params) in [(1, json!(["newHeads", false])), (2, json!(["logs", false]))] {
+    for (id, params) in [
+        (1, json!(["newHeads", false])),
+        (2, json!(["logs", false])),
+        (3, json!(["newHeads", null, true])),
+    ] {
         ws.send(tungstenite::Message::Text(
             jsonrpc_with_params("eth_subscribe", params, id).into(),
         ))


### PR DESCRIPTION
## Summary

- decode `eth_feeHistory` block counts as canonical Ethereum quantities and convert to `u64` only at the internal API boundary
- accept omitted or `null` optional positional parameters while rejecting excess arguments
- validate JSON-RPC 2.0 request shape and no-parameter method arity
- dispatch notifications without emitting HTTP bodies or WebSocket frames, including mixed and all-notification batches
- add focused table-driven and transport tests for the corrected behavior

## Why

The handwritten redacted transport required every request to carry an ID, did not validate the `jsonrpc` version, parsed `eth_feeHistory` block counts as JSON numbers, and used parameter decoders whose treatment of omitted and excess positional arguments did not match the documented RPC shapes. Both transports also serialized a response for every dispatched request, including notifications.

## Impact

Standards-conforming Ethereum JSON-RPC clients can now use normal quantity encoding and documented optional arguments. Notification traffic is processed without spurious responses, while authentication, privacy redaction, access tiers, batching limits, metrics, and existing method error behavior remain unchanged.