### PR TITLE
refactor(sequencer): simplify withdrawal queue reconciliation

### DIFF
--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -27,7 +27,10 @@ use std::{collections::BTreeMap, fmt, sync::OnceLock};
 
 use crate::{
     ZoneSequencerProvider,
-    abi::{self, BlockTransition, DepositQueueTransition, IZoneInbox, IZoneOutbox, ZonePortal},
+    abi::{
+        self, BlockTransition, DepositQueueTransition, EMPTY_SENTINEL, IZoneInbox, IZoneOutbox,
+        ZonePortal,
+    },
     attestation::{AttestationStore, SettlementAttestation, SettlementCertificate},
 };
 use alloy_consensus::{Transaction, TxReceipt as _, transaction::TxHashRef as _};
@@ -1402,16 +1405,18 @@ fn resolve_pending_slots(
 
 /// Find the offset into `withdrawals` where the remaining hash chain matches
 /// `current_slot_hash`. Returns `Some(0)` if no withdrawals have been processed,
-/// `Some(n)` if n have been processed (n remaining), or `None` if no match is
-/// found.
-///
-/// Also checks `offset == len` (all consumed, hash chain = `B256::ZERO`).
+/// `Some(n)` if n have been processed, or `None` if no match is found.
 pub(crate) fn find_processed_offset(
     withdrawals: &[abi::Withdrawal],
     current_slot_hash: B256,
 ) -> Option<usize> {
-    for offset in 0..=withdrawals.len() {
-        let hash = abi::Withdrawal::queue_hash(&withdrawals[offset..]);
+    if current_slot_hash == B256::ZERO {
+        return Some(withdrawals.len());
+    }
+
+    let mut hash = EMPTY_SENTINEL;
+    for (offset, withdrawal) in withdrawals.iter().enumerate().rev() {
+        hash = withdrawal.hash_with_tail(hash);
         if hash == current_slot_hash {
             return Some(offset);
         }
@@ -2235,55 +2240,45 @@ mod tests {
     }
 
     #[test]
-    fn find_offset_no_withdrawals_processed() {
-        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
-        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
-        let withdrawals = vec![w0, w1];
-        let full_hash = abi::Withdrawal::queue_hash(&withdrawals);
-        assert_eq!(find_processed_offset(&withdrawals, full_hash), Some(0));
+    fn finds_processed_withdrawal_offset() {
+        let withdrawals = vec![
+            test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100),
+            test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200),
+            test_withdrawal(address!("0x0000000000000000000000000000000000000003"), 300),
+        ];
+        let cases = [
+            (
+                "full queue",
+                abi::Withdrawal::queue_hash(&withdrawals),
+                Some(0),
+            ),
+            (
+                "partial queue",
+                abi::Withdrawal::queue_hash(&withdrawals[1..]),
+                Some(1),
+            ),
+            (
+                "partial queue suffix",
+                abi::Withdrawal::queue_hash(&withdrawals[2..]),
+                Some(2),
+            ),
+            ("fully consumed", B256::ZERO, Some(withdrawals.len())),
+            ("corrupted hash", B256::repeat_byte(0xde), None),
+        ];
+
+        for (case, current_slot_hash, expected) in cases {
+            assert_eq!(
+                find_processed_offset(&withdrawals, current_slot_hash),
+                expected,
+                "{case}"
+            );
+        }
     }
 
     #[test]
-    fn find_offset_one_processed() {
-        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
-        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
-        let withdrawals = vec![w0, w1];
-        let hash = abi::Withdrawal::queue_hash(&withdrawals[1..]);
-        assert_eq!(find_processed_offset(&withdrawals, hash), Some(1));
-    }
-
-    #[test]
-    fn find_offset_all_processed() {
-        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
-        let withdrawals = vec![w0];
-        // B256::ZERO = queue_hash(&[]), meaning all withdrawals have been consumed.
-        assert_eq!(find_processed_offset(&withdrawals, B256::ZERO), Some(1));
-    }
-
-    #[test]
-    fn find_offset_no_match() {
-        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
-        let withdrawals = vec![w0];
-        let random_hash = B256::from([0xdeu8; 32]);
-        assert_eq!(find_processed_offset(&withdrawals, random_hash), None);
-    }
-
-    #[test]
-    fn find_offset_single_withdrawal_unprocessed() {
-        let w = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 999);
-        let withdrawals = vec![w];
-        let hash = abi::Withdrawal::queue_hash(&withdrawals);
-        assert_eq!(find_processed_offset(&withdrawals, hash), Some(0));
-    }
-
-    #[test]
-    fn find_offset_partial_three_withdrawals() {
-        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
-        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000002"), 200);
-        let w2 = test_withdrawal(address!("0x0000000000000000000000000000000000000003"), 300);
-        let withdrawals = vec![w0, w1, w2];
-        let hash = abi::Withdrawal::queue_hash(&withdrawals[2..]);
-        assert_eq!(find_processed_offset(&withdrawals, hash), Some(2));
+    fn finds_processed_offset_for_empty_queue() {
+        assert_eq!(find_processed_offset(&[], B256::ZERO), Some(0));
+        assert_eq!(find_processed_offset(&[], EMPTY_SENTINEL), None);
     }
 
     #[test]

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -32,7 +32,7 @@ use std::{
 };
 
 use alloy_network::ReceiptResponse;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, U256};
 use alloy_provider::{DynProvider, Provider};
 use futures::{StreamExt, stream::FuturesUnordered};
 use parking_lot::Mutex;
@@ -251,23 +251,6 @@ impl Default for WithdrawalStore {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Compute the remaining queue hash after removing the first `processed_count` withdrawals.
-///
-/// This value is passed as `remainingQueue` to `processWithdrawals` on the portal contract.
-///
-/// - If `processed_count >= withdrawals.len()`, returns `B256::ZERO` (no remaining items).
-/// - Otherwise, computes the hash chain over `withdrawals[processed_count..]` via
-///   [`abi::Withdrawal::queue_hash`].
-pub fn compute_remaining_queue(withdrawals: &[abi::Withdrawal], processed_count: usize) -> B256 {
-    if processed_count >= withdrawals.len() {
-        return B256::ZERO;
-    }
-
-    let remaining = &withdrawals[processed_count..];
-
-    abi::Withdrawal::queue_hash(remaining)
 }
 
 // ---------------------------------------------------------------------------
@@ -589,7 +572,7 @@ impl WithdrawalProcessor {
                 let nonce = first_nonce + submitted as u64;
                 let absolute_start = offset + batch.start;
                 let batch_withdrawals = withdrawals[batch.start..batch.end].to_vec();
-                let remaining_queue = compute_remaining_queue(withdrawals, batch.end);
+                let remaining_queue = abi::Withdrawal::queue_hash(&withdrawals[batch.end..]);
 
                 for (item_index, withdrawal) in batch_withdrawals.iter().enumerate() {
                     if withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT {
@@ -862,7 +845,7 @@ enum SubmitOutcome {
 mod tests {
     use super::*;
     use crate::abi::EMPTY_SENTINEL;
-    use alloy_primitives::{Bytes, U256, address, keccak256};
+    use alloy_primitives::{B256, Bytes, U256, address, keccak256};
     use alloy_provider::{Provider, ProviderBuilder};
     use alloy_sol_types::SolValue;
     use alloy_transport::mock::Asserter;
@@ -947,34 +930,6 @@ mod tests {
     }
 
     #[test]
-    fn remaining_queue_single_item_is_hash() {
-        let w = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 1000);
-        let expected = abi::Withdrawal::queue_hash(std::slice::from_ref(&w));
-        assert_eq!(compute_remaining_queue(&[w], 0), expected);
-    }
-
-    #[test]
-    fn remaining_queue_all_consumed() {
-        let w = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 1000);
-        assert_eq!(
-            compute_remaining_queue(std::slice::from_ref(&w), 1),
-            B256::ZERO
-        );
-        assert_eq!(compute_remaining_queue(&[w], 5), B256::ZERO);
-    }
-
-    #[test]
-    fn remaining_queue_partial() {
-        let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000042"), 100);
-        let w1 = test_withdrawal(address!("0x0000000000000000000000000000000000000043"), 200);
-        let w2 = test_withdrawal(address!("0x0000000000000000000000000000000000000044"), 300);
-
-        let remaining = compute_remaining_queue(&[w0, w1.clone(), w2.clone()], 1);
-        let expected = abi::Withdrawal::queue_hash(&[w1, w2]);
-        assert_eq!(remaining, expected);
-    }
-
-    #[test]
     fn withdrawal_gas_limits_are_classified_and_bounded() {
         let at_cap = PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS
             + process_withdrawal_item_gas(MAX_WITHDRAWAL_GAS_LIMIT, 1);
@@ -1022,11 +977,11 @@ mod tests {
         assert_eq!(batches[1].start, 2);
         assert_eq!(batches[1].end, 3);
         assert_eq!(
-            compute_remaining_queue(&withdrawals, batches[0].end),
+            abi::Withdrawal::queue_hash(&withdrawals[batches[0].end..]),
             abi::Withdrawal::queue_hash(&withdrawals[2..])
         );
         assert_eq!(
-            compute_remaining_queue(&withdrawals, batches[1].end),
+            abi::Withdrawal::queue_hash(&withdrawals[batches[1].end..]),
             B256::ZERO
         );
     }
@@ -1059,7 +1014,7 @@ mod tests {
         assert_eq!(batches[0].end, 1);
         assert!(batches[0].gas_limit > 1_000_000);
         assert_eq!(
-            compute_remaining_queue(&withdrawals, batches[0].end),
+            abi::Withdrawal::queue_hash(&withdrawals[batches[0].end..]),
             abi::Withdrawal::queue_hash(&withdrawals[1..])
         );
     }

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -976,14 +976,6 @@ mod tests {
         assert_eq!(batches[0].end, 2);
         assert_eq!(batches[1].start, 2);
         assert_eq!(batches[1].end, 3);
-        assert_eq!(
-            abi::Withdrawal::queue_hash(&withdrawals[batches[0].end..]),
-            abi::Withdrawal::queue_hash(&withdrawals[2..])
-        );
-        assert_eq!(
-            abi::Withdrawal::queue_hash(&withdrawals[batches[1].end..]),
-            B256::ZERO
-        );
     }
 
     #[test]
@@ -1013,10 +1005,6 @@ mod tests {
         assert_eq!(batches[0].start, 0);
         assert_eq!(batches[0].end, 1);
         assert!(batches[0].gas_limit > 1_000_000);
-        assert_eq!(
-            abi::Withdrawal::queue_hash(&withdrawals[batches[0].end..]),
-            abi::Withdrawal::queue_hash(&withdrawals[1..])
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace repeated suffix rehashing during withdrawal queue reconciliation with one backward hash-chain walk.
- Inline the remaining queue suffix hash at the withdrawal submission call site and remove the redundant wrapper.
- Consolidate reconciliation offset cases into table-driven coverage.

## Why

`find_processed_offset` previously recomputed the queue hash for every candidate suffix. Those suffixes overlap, so the helper repeatedly hashed the same withdrawals and took O(n²) work. Reusing the tail hash while walking backward makes reconciliation O(n).

## Impact

Protocol behavior is unchanged: full, partial, fully consumed, empty, corrupted, and sentinel-related queue states retain their existing semantics, and an empty submitted suffix still hashes to `B256::ZERO`.