### PR TITLE
refactor(rpc): remove phantom params and fix portal-less zone info

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -340,6 +340,24 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
         futures::future::try_join_all(futs).await
     }
 
+    /// Returns all sequencer addresses currently registered on this [`ZonePortal`].
+    ///
+    /// Calls [`sequencerCount`](ZonePortal::sequencerCountCall) followed by
+    /// [`sequencerAt`](ZonePortal::sequencerAtCall) for each index concurrently.
+    pub async fn sequencers(
+        &self,
+    ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
+        let count = self.sequencerCount().call().await?;
+        let futs: alloc::vec::Vec<_> = (0..count.to::<u64>())
+            .map(|i| async move {
+                self.sequencerAt(alloy_primitives::U256::from(i))
+                    .call()
+                    .await
+            })
+            .collect();
+        futures::future::try_join_all(futs).await
+    }
+
     /// Fetches the active sequencer encryption key and its index from one L1 snapshot.
     ///
     /// Reads the current L1 block number, then pins an atomic

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -340,24 +340,6 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
         futures::future::try_join_all(futs).await
     }
 
-    /// Returns all sequencer addresses currently registered on this [`ZonePortal`].
-    ///
-    /// Calls [`sequencerCount`](ZonePortal::sequencerCountCall) followed by
-    /// [`sequencerAt`](ZonePortal::sequencerAtCall) for each index concurrently.
-    pub async fn sequencers(
-        &self,
-    ) -> Result<alloc::vec::Vec<alloy_primitives::Address>, alloy_contract::Error> {
-        let count = self.sequencerCount().call().await?;
-        let futs: alloc::vec::Vec<_> = (0..count.to::<u64>())
-            .map(|i| async move {
-                self.sequencerAt(alloy_primitives::U256::from(i))
-                    .call()
-                    .await
-            })
-            .collect();
-        futures::future::try_join_all(futs).await
-    }
-
     /// Fetches the active sequencer encryption key and its index from one L1 snapshot.
     ///
     /// Reads the current L1 block number, then pins an atomic

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -699,6 +699,7 @@ where
             self.redacted_rpc_config.zone_id,
             chain_id,
             self.portal_address,
+            self.l1_config.enabled_tokens.clone(),
             l1_provider.clone(),
             provider.clone(),
         );

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -660,15 +660,15 @@ where
                 None => None,
             };
             sequencer_rpc_slot
-                .set(SequencerRpcContext::new(
-                    schedule.clone(),
-                    role_status.clone(),
-                    peer_tips.clone(),
+                .set(SequencerRpcContext {
+                    schedule: schedule.clone(),
+                    status: role_status.clone(),
+                    peer_tips: peer_tips.clone(),
                     manifest,
                     local_secp256k1_address,
-                    local_ed25519_public_key.clone(),
+                    local_ed25519_public_key: local_ed25519_public_key.clone(),
                     relayer,
-                ))
+                })
                 .expect("the sequencer RPC context is installed exactly once");
             p2p_runtime = Some((
                 sinks,

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -17,8 +17,7 @@ use alloy_primitives::{Address, B256, Bloom, Bytes, U64, U256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rpc_types_eth::{
     Block, BlockId, BlockNumberOrTag, BlockTransactions, FeeHistory, Filter, FilterChanges,
-    FilterId, TransactionRequest,
-    state::{EvmOverrides, StateOverride},
+    FilterId, TransactionRequest, state::EvmOverrides,
 };
 use alloy_sol_types::SolCall;
 use eyre::WrapErr;
@@ -806,16 +805,11 @@ where
         })
     }
 
-    fn block_by_number(
-        &self,
-        number: BlockNumberOrTag,
-        _full: bool,
-        _auth: AuthContext,
-    ) -> BoxFut<'_> {
+    fn block_by_number(&self, number: BlockNumberOrTag, _auth: AuthContext) -> BoxFut<'_> {
         self.block_by_id(number.into())
     }
 
-    fn block_by_hash(&self, hash: B256, _full: bool, _auth: AuthContext) -> BoxFut<'_> {
+    fn block_by_hash(&self, hash: B256, _auth: AuthContext) -> BoxFut<'_> {
         self.block_by_id(hash.into())
     }
 
@@ -867,24 +861,14 @@ where
         &self,
         mut request: TempoTransactionRequest,
         block: Option<BlockId>,
-        state_override: Option<StateOverride>,
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if state_override.is_some() {
-                return Err(JsonRpcError::invalid_params("state overrides not allowed"));
-            }
-
             self.enforce_authorized(&mut request, &auth)?;
 
-            let result = EthCall::call(
-                &self.eth.api,
-                request,
-                block,
-                EvmOverrides::state(state_override),
-            )
-            .await
-            .map_err(internal)?;
+            let result = EthCall::call(&self.eth.api, request, block, EvmOverrides::default())
+                .await
+                .map_err(internal)?;
             to_raw(&result)
         })
     }
@@ -893,21 +877,16 @@ where
         &self,
         mut request: TempoTransactionRequest,
         block: Option<BlockId>,
-        state_override: Option<StateOverride>,
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            if state_override.is_some() {
-                return Err(JsonRpcError::invalid_params("state overrides not allowed"));
-            }
-
             self.enforce_authorized(&mut request, &auth)?;
 
             let result = EthCall::estimate_gas_at(
                 &self.eth.api,
                 request,
                 block.unwrap_or_default(),
-                EvmOverrides::state(state_override),
+                EvmOverrides::default(),
             )
             .await
             .map_err(internal)?;

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -111,6 +111,7 @@ pub(crate) struct OperatorZoneApi<P> {
     zone_id: u32,
     chain_id: u64,
     portal_address: Address,
+    enabled_tokens: EnabledTokenRegistry,
     l1_provider: DynProvider<TempoNetwork>,
     zone_provider: P,
 }
@@ -120,6 +121,7 @@ impl<P> OperatorZoneApi<P> {
         zone_id: u32,
         chain_id: u64,
         portal_address: Address,
+        enabled_tokens: EnabledTokenRegistry,
         l1_provider: DynProvider<TempoNetwork>,
         zone_provider: P,
     ) -> Self {
@@ -127,6 +129,7 @@ impl<P> OperatorZoneApi<P> {
             zone_id,
             chain_id,
             portal_address,
+            enabled_tokens,
             l1_provider,
             zone_provider,
         }
@@ -150,6 +153,7 @@ where
             self.zone_id,
             self.chain_id,
             self.portal_address,
+            enabled_zone_tokens(self.portal_address, &self.enabled_tokens),
             tempo_block_number,
             &self.l1_provider,
         )
@@ -288,16 +292,27 @@ async fn zone_sequencers(
     Ok(sequencers)
 }
 
+/// Returns the zone's enabled token addresses from the node's synced registry,
+/// preserving the default token when running without an L1 portal.
+fn enabled_zone_tokens(portal_address: Address, registry: &EnabledTokenRegistry) -> Vec<Address> {
+    if portal_address.is_zero() {
+        return vec![ZONE_TOKEN_ADDRESS];
+    }
+
+    registry.read().iter().copied().collect()
+}
+
 /// Builds the Zone metadata shared by the operator and redacted RPC surfaces.
 ///
-/// The caller supplies the local Zone's processed Tempo block number; the
-/// remaining dynamic fields are read directly from the ZonePortal on Tempo L1.
-/// A zero portal address (running without an L1 portal) reports static
-/// defaults without touching L1.
+/// The caller supplies the enabled token list and the local Zone's processed
+/// Tempo block number; the remaining dynamic fields are read directly from the
+/// ZonePortal on Tempo L1. A zero portal address (running without an L1
+/// portal) reports static defaults without touching L1.
 async fn zone_info(
     zone_id: u32,
     chain_id: u64,
     portal_address: Address,
+    zone_tokens: Vec<Address>,
     tempo_block_number: u64,
     l1_provider: &DynProvider<TempoNetwork>,
 ) -> Result<ZoneInfoResponse, JsonRpcError> {
@@ -306,7 +321,7 @@ async fn zone_info(
             zone_id: U64::from(zone_id),
             is_access_enforced: false,
             is_gateway_open: true,
-            zone_tokens: vec![ZONE_TOKEN_ADDRESS],
+            zone_tokens,
             sequencers: Vec::new(),
             chain_id: U64::from(chain_id),
             tempo_block_number: U64::from(tempo_block_number),
@@ -314,8 +329,7 @@ async fn zone_info(
     }
 
     let portal = ZonePortal::new(portal_address, l1_provider);
-    let (zone_tokens, sequencers, is_access_enforced, is_gateway_open) = tokio::try_join!(
-        async { portal.enabled_tokens().await.map_err(internal) },
+    let (sequencers, is_access_enforced, is_gateway_open) = tokio::try_join!(
         zone_sequencers(portal_address, l1_provider),
         async { portal.isAccessEnforced().call().await.map_err(internal) },
         async { portal.isGatewayOpen().call().await.map_err(internal) },
@@ -396,7 +410,7 @@ where
             sequencer_address: node.secp256k1_address(),
             rpc_only: node.is_rpc_only(),
             is_local: node.ed25519_public_key() == &context.local_ed25519_public_key,
-            tip: tips.get(node.ed25519_public_key()).map(peer_tip_info),
+            tip: tips.get(node.ed25519_public_key()).map(PeerTip::rpc_info),
         })
         .collect();
 
@@ -417,7 +431,7 @@ where
             role: status.role.to_owned(),
         }),
         active_leader,
-        local_tip: Some(peer_tip_info(&local_tip)),
+        local_tip: Some(local_tip.rpc_info()),
         peers,
         progress: Some(SequencerProgress {
             zone_height: U64::from(local_tip.zone_height),
@@ -439,13 +453,22 @@ where
     })
 }
 
-/// Converts hash-carrying peer tip evidence into its RPC representation.
-fn peer_tip_info(tip: &PeerTip) -> PeerTipInfo {
-    PeerTipInfo {
-        zone_height: U64::from(tip.zone_height),
-        zone_hash: tip.zone_hash,
-        tempo_block_number: U64::from(tip.tempo_block_number),
-        tempo_block_hash: tip.tempo_block_hash,
+/// Conversion into the RPC representation of hash-carrying peer tip evidence.
+///
+/// An extension trait because both [`PeerTip`] and [`PeerTipInfo`] are foreign
+/// types here, so a `From` impl is not possible.
+trait PeerTipExt {
+    fn rpc_info(&self) -> PeerTipInfo;
+}
+
+impl PeerTipExt for PeerTip {
+    fn rpc_info(&self) -> PeerTipInfo {
+        PeerTipInfo {
+            zone_height: U64::from(self.zone_height),
+            zone_hash: self.zone_hash,
+            tempo_block_number: U64::from(self.tempo_block_number),
+            tempo_block_hash: self.tempo_block_hash,
+        }
     }
 }
 
@@ -626,12 +649,7 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
     }
 
     fn zone_tokens(&self) -> Vec<Address> {
-        // Preserve the default token when running without an L1 portal.
-        if self.config.zone_portal.is_zero() {
-            return vec![ZONE_TOKEN_ADDRESS];
-        }
-
-        self.enabled_tokens.read().iter().copied().collect()
+        enabled_zone_tokens(self.config.zone_portal, &self.enabled_tokens)
     }
 }
 
@@ -1116,6 +1134,7 @@ where
                 self.config.zone_id,
                 self.config.chain_id,
                 self.config.zone_portal,
+                self.zone_tokens(),
                 tempo_block_number,
                 &self.l1_provider,
             )
@@ -1419,6 +1438,7 @@ mod tests {
             1,
             42431,
             Address::repeat_byte(0x11),
+            EnabledTokenRegistry::default(),
             l1_provider,
             Arc::new(reth_provider::test_utils::MockEthProvider::default()),
         )
@@ -1438,7 +1458,8 @@ mod tests {
             .connect_http("http://127.0.0.1:1".parse().expect("valid URL"))
             .erased();
 
-        let info = zone_info(1, 42431, Address::ZERO, 7, &l1_provider)
+        let zone_tokens = enabled_zone_tokens(Address::ZERO, &EnabledTokenRegistry::default());
+        let info = zone_info(1, 42431, Address::ZERO, zone_tokens, 7, &l1_provider)
             .await
             .expect("portal-less zone info should not require L1");
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -268,6 +268,26 @@ fn operator_rpc_error(error: JsonRpcError) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(error.code as i32, error.message, error.data)
 }
 
+async fn zone_sequencers(
+    portal_address: Address,
+    l1_provider: &DynProvider<TempoNetwork>,
+) -> Result<Vec<Address>, JsonRpcError> {
+    let portal = ZonePortal::new(portal_address, l1_provider);
+    let count = portal.sequencerCount().call().await.map_err(internal)?;
+    let count = count.to::<usize>();
+    let mut sequencers = Vec::with_capacity(count);
+    for index in 0..count {
+        sequencers.push(
+            portal
+                .sequencerAt(U256::from(index))
+                .call()
+                .await
+                .map_err(internal)?,
+        );
+    }
+    Ok(sequencers)
+}
+
 /// Builds the Zone metadata shared by the operator and redacted RPC surfaces.
 ///
 /// The caller supplies the local Zone's processed Tempo block number; the
@@ -296,7 +316,7 @@ async fn zone_info(
     let portal = ZonePortal::new(portal_address, l1_provider);
     let (zone_tokens, sequencers, is_access_enforced, is_gateway_open) = tokio::try_join!(
         async { portal.enabled_tokens().await.map_err(internal) },
-        async { portal.sequencers().await.map_err(internal) },
+        zone_sequencers(portal_address, l1_provider),
         async { portal.isAccessEnforced().call().await.map_err(internal) },
         async { portal.isGatewayOpen().call().await.map_err(internal) },
     )?;

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -60,8 +60,8 @@ use zone_rpc::{
     auth::AuthContext,
     types::{
         ActiveLeaderInfo, AuthorizationTokenInfoResponse, BoxEyreFut, BoxFut, JsonRpcError,
-        LocalSequencerInfo, PeerTipInfo, SequencerInfoResponse, SequencerPeerInfo,
-        SequencerProgress, SequencerReadiness, SetLeaderResponse,
+        LocalSequencerInfo, PeerTipInfo, SequencerInfoResponse, SequencerMode, SequencerPeerInfo,
+        SequencerProgress, SequencerReadiness, SetLeaderResponse, SetLeaderStatus,
         TempoStorageRead as RpcTempoStorageRead, ZoneExecutionWitness, ZoneInfoResponse, internal,
         raw_null, raw_zero, to_raw,
     },
@@ -91,29 +91,6 @@ pub struct SequencerRpcContext {
     pub local_ed25519_public_key: zone_p2p::P2pPeerId,
     /// Wallet-backed L1 provider signing with the individual key, when this node holds one.
     pub relayer: Option<DynProvider<TempoNetwork>>,
-}
-
-impl SequencerRpcContext {
-    /// Create the RPC context for a multi-sequencer node.
-    pub(crate) fn new(
-        schedule: LeadershipSchedule,
-        status: SharedRoleStatus,
-        peer_tips: PeerTipRegistry,
-        manifest: Arc<ZoneManifest>,
-        local_secp256k1_address: Option<Address>,
-        local_ed25519_public_key: zone_p2p::P2pPeerId,
-        relayer: Option<DynProvider<TempoNetwork>>,
-    ) -> Self {
-        Self {
-            schedule,
-            status,
-            peer_tips,
-            manifest,
-            local_secp256k1_address,
-            local_ed25519_public_key,
-            relayer,
-        }
-    }
 }
 
 /// Public, authentication-independent Zone metadata methods.
@@ -360,7 +337,7 @@ where
     let Some(context) = sequencer.get() else {
         // Single-sequencer (or not yet initialized) node: report the minimal view.
         return Ok(SequencerInfoResponse {
-            mode: "single".to_owned(),
+            mode: SequencerMode::Single,
             portal: portal_address,
             local: None,
             active_leader: None,
@@ -399,12 +376,7 @@ where
             sequencer_address: node.secp256k1_address(),
             rpc_only: node.is_rpc_only(),
             is_local: node.ed25519_public_key() == &context.local_ed25519_public_key,
-            tip: tips.get(node.ed25519_public_key()).map(|tip| PeerTipInfo {
-                zone_height: U64::from(tip.zone_height),
-                zone_hash: tip.zone_hash,
-                tempo_block_number: U64::from(tip.tempo_block_number),
-                tempo_block_hash: tip.tempo_block_hash,
-            }),
+            tip: tips.get(node.ed25519_public_key()).map(peer_tip_info),
         })
         .collect();
 
@@ -414,7 +386,7 @@ where
         .manifest
         .node_by_ed25519_public_key(&context.local_ed25519_public_key);
     Ok(SequencerInfoResponse {
-        mode: "multi".to_owned(),
+        mode: SequencerMode::Multi,
         portal: portal_address,
         local: Some(LocalSequencerInfo {
             name: local_node
@@ -425,12 +397,7 @@ where
             role: status.role.to_owned(),
         }),
         active_leader,
-        local_tip: Some(PeerTipInfo {
-            zone_height: U64::from(local_tip.zone_height),
-            zone_hash: local_tip.zone_hash,
-            tempo_block_number: U64::from(local_tip.tempo_block_number),
-            tempo_block_hash: local_tip.tempo_block_hash,
-        }),
+        local_tip: Some(peer_tip_info(&local_tip)),
         peers,
         progress: Some(SequencerProgress {
             zone_height: U64::from(local_tip.zone_height),
@@ -452,7 +419,18 @@ where
     })
 }
 
+/// Converts hash-carrying peer tip evidence into its RPC representation.
+fn peer_tip_info(tip: &PeerTip) -> PeerTipInfo {
+    PeerTipInfo {
+        zone_height: U64::from(tip.zone_height),
+        zone_hash: tip.zone_hash,
+        tempo_block_number: U64::from(tip.tempo_block_number),
+        tempo_block_hash: tip.tempo_block_hash,
+    }
+}
+
 type RpcBlock = Block<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
+type RpcFilterChanges = FilterChanges<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>>;
 const FILTER_OWNER_PRUNE_INTERVAL: Duration = Duration::from_secs(60);
 const MAX_WS_FRAME_AND_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
@@ -514,20 +492,10 @@ async fn prune_filter_owners<Api: EthApiTypes + 'static>(
 /// whitelist, so this struct effectively acts as an **enforced allowlist**
 /// of Ethereum JSON-RPC endpoints.
 ///
-/// For every allowed endpoint it applies typed privacy checks *before*
-/// serializing to JSON:
-///
-/// - **Block redaction** — zeroing `logsBloom` and clearing transaction
-///   lists for non-sequencer callers.
-/// - **Sender-scoped access** — returning `null` for transactions and
-///   receipts not owned by the authenticated caller.
-/// - **`from`-enforcement** — `eth_call` / `eth_estimateGas` may only
-///   simulate from the authenticated account (`-32004` on mismatch,
-///   auto-set when omitted); state overrides are rejected for
-///   non-sequencer callers (`-32602`).
-/// - **Sender verification** — `eth_sendRawTransaction` checks that the
-///   recovered transaction sender matches the authenticated account
-///   (`-32003` on mismatch).
+/// The per-method access rules (sender scoping, `from`-enforcement, block
+/// and receipt redaction) are documented on the [`ZoneRpcApi`] trait; this
+/// implementation applies them to typed responses *before* serializing to
+/// JSON.
 ///
 /// [`classify_method`]: zone_rpc::types::classify_method
 pub struct ZoneRpc<Api: EthApiTypes> {
@@ -615,7 +583,6 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
 
     /// Verify that the filter belongs to the authenticated caller.
     ///
-    /// Returns `Ok(())` if the caller owns the filter or is the sequencer.
     /// Returns an error indistinguishable from "filter not found" to avoid
     /// leaking filter existence to non-owners.
     async fn ensure_filter_owner(
@@ -645,14 +612,6 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
         }
 
         self.enabled_tokens.read().iter().copied().collect()
-    }
-
-    fn enforce_authorized(
-        &self,
-        request: &mut TempoTransactionRequest,
-        auth: &AuthContext,
-    ) -> Result<(), JsonRpcError> {
-        zone_rpc::policy::enforce_authorized(request, auth)
     }
 }
 
@@ -716,7 +675,7 @@ where
     fn chain_id(&self) -> BoxFut<'_> {
         Box::pin(async move {
             let chain_id = EthApiSpec::chain_id(&self.eth.api);
-            to_raw(&Some(chain_id))
+            to_raw(&chain_id)
         })
     }
 
@@ -864,7 +823,7 @@ where
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            self.enforce_authorized(&mut request, &auth)?;
+            zone_rpc::policy::enforce_authorized(&mut request, &auth)?;
 
             let result = EthCall::call(&self.eth.api, request, block, EvmOverrides::default())
                 .await
@@ -880,7 +839,7 @@ where
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            self.enforce_authorized(&mut request, &auth)?;
+            zone_rpc::policy::enforce_authorized(&mut request, &auth)?;
 
             let result = EthCall::estimate_gas_at(
                 &self.eth.api,
@@ -925,10 +884,10 @@ where
         auth: AuthContext,
     ) -> BoxFut<'_> {
         Box::pin(async move {
-            self.enforce_authorized(&mut request, &auth)?;
+            zone_rpc::policy::enforce_authorized(&mut request, &auth)?;
 
-            // Prefill the users request so the `fill_transaction` doesnt leak dynamic fee estimates via
-            // missing fee fields.
+            // Prefill the user's request so `fill_transaction` doesn't leak dynamic fee
+            // estimates via missing fee fields.
             apply_public_fee_policy(&mut request);
 
             let result = EthTransactions::fill_transaction(&self.eth.api, request)
@@ -995,20 +954,13 @@ where
             match changes {
                 FilterChanges::Logs(logs) => {
                     let filtered = zone_rpc::filter::filter_logs(logs, &auth.caller);
-                    to_raw(&FilterChanges::<
-                        alloy_rpc_types_eth::Transaction<TempoTxEnvelope>,
-                    >::Logs(filtered))
+                    to_raw(&RpcFilterChanges::Logs(filtered))
                 }
-                FilterChanges::Hashes(hashes) => to_raw(&FilterChanges::<
-                    alloy_rpc_types_eth::Transaction<TempoTxEnvelope>,
-                >::Hashes(hashes)),
+                FilterChanges::Hashes(hashes) => to_raw(&RpcFilterChanges::Hashes(hashes)),
                 // Pending transaction filters are disabled — return empty if one somehow exists
-                FilterChanges::Transactions(_) => to_raw(
-                    &FilterChanges::<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>>::Empty,
-                ),
-                FilterChanges::Empty => to_raw(
-                    &FilterChanges::<alloy_rpc_types_eth::Transaction<TempoTxEnvelope>>::Empty,
-                ),
+                FilterChanges::Transactions(_) | FilterChanges::Empty => {
+                    to_raw(&RpcFilterChanges::Empty)
+                }
             }
         })
     }
@@ -1239,7 +1191,7 @@ async fn set_leader(
 
     if leader == target {
         return Ok(SetLeaderResponse {
-            status: "alreadyActive".to_owned(),
+            status: SetLeaderStatus::AlreadyActive,
             tx_hash: None,
             relayer: relayer_address,
             requested_leader: target,
@@ -1286,7 +1238,7 @@ async fn set_leader(
         "Confirmed setLeader on the ZonePortal"
     );
     Ok(SetLeaderResponse {
-        status: "submitted".to_owned(),
+        status: SetLeaderStatus::Submitted,
         tx_hash: Some(tx_hash),
         relayer: relayer_address,
         requested_leader: target,
@@ -1408,7 +1360,7 @@ mod tests {
             )
             .await
             .expect("single-sequencer info should be available without authentication");
-        assert_eq!(info.mode, "single");
+        assert_eq!(info.mode, SequencerMode::Single);
         assert_eq!(info.portal, Address::repeat_byte(0x11));
 
         let error = module

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -292,44 +292,12 @@ fn operator_rpc_error(error: JsonRpcError) -> ErrorObjectOwned {
     ErrorObjectOwned::owned(error.code as i32, error.message, error.data)
 }
 
-async fn zone_tokens(
-    portal_address: Address,
-    l1_provider: &DynProvider<TempoNetwork>,
-) -> Result<Vec<Address>, JsonRpcError> {
-    if portal_address.is_zero() {
-        return Ok(vec![ZONE_TOKEN_ADDRESS]);
-    }
-
-    ZonePortal::new(portal_address, l1_provider)
-        .enabled_tokens()
-        .await
-        .map_err(internal)
-}
-
-async fn zone_sequencers(
-    portal_address: Address,
-    l1_provider: &DynProvider<TempoNetwork>,
-) -> Result<Vec<Address>, JsonRpcError> {
-    let portal = ZonePortal::new(portal_address, l1_provider);
-    let count = portal.sequencerCount().call().await.map_err(internal)?;
-    let count = count.to::<usize>();
-    let mut sequencers = Vec::with_capacity(count);
-    for index in 0..count {
-        sequencers.push(
-            portal
-                .sequencerAt(U256::from(index))
-                .call()
-                .await
-                .map_err(internal)?,
-        );
-    }
-    Ok(sequencers)
-}
-
 /// Builds the Zone metadata shared by the operator and redacted RPC surfaces.
 ///
 /// The caller supplies the local Zone's processed Tempo block number; the
 /// remaining dynamic fields are read directly from the ZonePortal on Tempo L1.
+/// A zero portal address (running without an L1 portal) reports static
+/// defaults without touching L1.
 async fn zone_info(
     zone_id: u32,
     chain_id: u64,
@@ -337,24 +305,24 @@ async fn zone_info(
     tempo_block_number: u64,
     l1_provider: &DynProvider<TempoNetwork>,
 ) -> Result<ZoneInfoResponse, JsonRpcError> {
+    if portal_address.is_zero() {
+        return Ok(ZoneInfoResponse {
+            zone_id: U64::from(zone_id),
+            is_access_enforced: false,
+            is_gateway_open: true,
+            zone_tokens: vec![ZONE_TOKEN_ADDRESS],
+            sequencers: Vec::new(),
+            chain_id: U64::from(chain_id),
+            tempo_block_number: U64::from(tempo_block_number),
+        });
+    }
+
     let portal = ZonePortal::new(portal_address, l1_provider);
     let (zone_tokens, sequencers, is_access_enforced, is_gateway_open) = tokio::try_join!(
-        zone_tokens(portal_address, l1_provider),
-        zone_sequencers(portal_address, l1_provider),
-        async {
-            if portal_address.is_zero() {
-                Ok(false)
-            } else {
-                portal.isAccessEnforced().call().await.map_err(internal)
-            }
-        },
-        async {
-            if portal_address.is_zero() {
-                Ok(true)
-            } else {
-                portal.isGatewayOpen().call().await.map_err(internal)
-            }
-        },
+        async { portal.enabled_tokens().await.map_err(internal) },
+        async { portal.sequencers().await.map_err(internal) },
+        async { portal.isAccessEnforced().call().await.map_err(internal) },
+        async { portal.isGatewayOpen().call().await.map_err(internal) },
     )?;
 
     Ok(ZoneInfoResponse {
@@ -1510,6 +1478,26 @@ mod tests {
         assert!(methods.contains("zone_getZoneInfo"));
         assert!(methods.contains("zone_getEncryptionKey"));
         assert!(!methods.contains("zone_getAuthorizationTokenInfo"));
+    }
+
+    #[tokio::test]
+    async fn zone_info_reports_defaults_without_portal() {
+        // The provider is unreachable; a zero portal must not touch L1 at all.
+        let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("http://127.0.0.1:1".parse().expect("valid URL"))
+            .erased();
+
+        let info = zone_info(1, 42431, Address::ZERO, 7, &l1_provider)
+            .await
+            .expect("portal-less zone info should not require L1");
+
+        assert_eq!(info.zone_id, U64::from(1));
+        assert!(!info.is_access_enforced);
+        assert!(info.is_gateway_open);
+        assert_eq!(info.zone_tokens, vec![ZONE_TOKEN_ADDRESS]);
+        assert!(info.sequencers.is_empty());
+        assert_eq!(info.chain_id, U64::from(42431));
+        assert_eq!(info.tempo_block_number, U64::from(7));
     }
 
     #[test]

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -63,8 +63,8 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `eth_getBalance(address, block)` — returns the balance of an account.
     ///
-    /// Returns `0x0` for non-sequencer callers querying an address that does
-    /// not match `auth.caller`.
+    /// Returns `0x0` whenever the queried address does not match
+    /// `auth.caller`, so account existence is not leaked.
     fn get_balance(
         &self,
         address: Address,
@@ -74,8 +74,8 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
 
     /// `eth_getTransactionCount(address, block)` — returns the nonce.
     ///
-    /// Returns `0x0` for non-sequencer callers querying an address that does
-    /// not match `auth.caller`.
+    /// Returns `0x0` whenever the queried address does not match
+    /// `auth.caller`, so account existence is not leaked.
     fn get_transaction_count(
         &self,
         address: Address,
@@ -362,7 +362,7 @@ async fn handle_web3_sha3(id: Value, raw: &str) -> JsonRpcResponse {
     api_result(id, "web3_sha3", crate::types::to_raw(&keccak256(data)))
 }
 
-/// Handle `eth_getBlockByNumber`. Rejects `full=true` for non-sequencer callers.
+/// Handle `eth_getBlockByNumber`. Rejects `full=true`.
 async fn handle_get_block_by_number(
     id: Value,
     raw: &str,
@@ -452,7 +452,7 @@ async fn handle_get_transaction_receipt(
 }
 
 /// Handle `eth_call`. Enforces `from` matches the authenticated account and
-/// rejects state overrides for non-sequencer callers.
+/// rejects state overrides.
 async fn handle_call(
     id: Value,
     raw: &str,
@@ -582,8 +582,8 @@ async fn handle_fee_history(id: Value, raw: &str, api: &dyn ZoneRpcApi) -> JsonR
     )
 }
 
-/// Handle `eth_getBalance`. Returns `0x0` for non-sequencer callers querying
-/// a different address (checked in API impl, no timing leak since check is pre-fetch).
+/// Handle `eth_getBalance`. Returns `0x0` for queries about a different
+/// address (checked in API impl, no timing leak since check is pre-fetch).
 async fn handle_get_balance(
     id: Value,
     raw: &str,
@@ -603,8 +603,8 @@ async fn handle_get_balance(
     )
 }
 
-/// Handle `eth_getTransactionCount`. Returns `0x0` for non-sequencer callers
-/// querying a different address (checked in API impl, no timing leak).
+/// Handle `eth_getTransactionCount`. Returns `0x0` for queries about a
+/// different address (checked in API impl, no timing leak).
 async fn handle_get_transaction_count(
     id: Value,
     raw: &str,

--- a/crates/rpc/src/handlers.rs
+++ b/crates/rpc/src/handlers.rs
@@ -84,15 +84,16 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
     ) -> BoxFut<'_>;
 
     /// `eth_getBlockByNumber(number, full)` — returns a block by number.
-    fn block_by_number(
-        &self,
-        number: BlockNumberOrTag,
-        full: bool,
-        auth: AuthContext,
-    ) -> BoxFut<'_>;
+    ///
+    /// `full=true` is rejected by the dispatch layer, so implementations only
+    /// ever serve hash-only (redacted) blocks.
+    fn block_by_number(&self, number: BlockNumberOrTag, auth: AuthContext) -> BoxFut<'_>;
 
     /// `eth_getBlockByHash(hash, full)` — returns a block by hash.
-    fn block_by_hash(&self, hash: B256, full: bool, auth: AuthContext) -> BoxFut<'_>;
+    ///
+    /// `full=true` is rejected by the dispatch layer, so implementations only
+    /// ever serve hash-only (redacted) blocks.
+    fn block_by_hash(&self, hash: B256, auth: AuthContext) -> BoxFut<'_>;
 
     /// `eth_getTransactionByHash(hash)` — returns a transaction by hash.
     fn transaction_by_hash(&self, hash: B256, auth: AuthContext) -> BoxFut<'_>;
@@ -100,29 +101,27 @@ pub trait ZoneRpcApi: Send + Sync + 'static {
     /// `eth_getTransactionReceipt(hash)` — returns a transaction receipt.
     fn transaction_receipt(&self, hash: B256, auth: AuthContext) -> BoxFut<'_>;
 
-    /// `eth_call(request, block, state_override)` — executes a call without
-    /// creating a transaction.
+    /// `eth_call(request, block)` — executes a call without creating a
+    /// transaction.
     ///
     /// Enforces that `from` equals the authenticated account (sets it if omitted,
-    /// rejects with `-32004` on mismatch). State/block overrides are rejected
-    /// with `-32602` for non-sequencer callers.
+    /// rejects with `-32004` on mismatch). State overrides are always rejected
+    /// with `-32602` by the dispatch layer, so implementations never see them.
     fn call(
         &self,
         request: TempoTransactionRequest,
         block: Option<BlockId>,
-        state_override: Option<StateOverride>,
         auth: AuthContext,
     ) -> BoxFut<'_>;
 
-    /// `eth_estimateGas(request, block, state_override)` — estimates gas for a transaction.
+    /// `eth_estimateGas(request, block)` — estimates gas for a transaction.
     ///
-    /// Same `from`-enforcement as [`call`](Self::call). State overrides are
-    /// rejected with `-32602` for non-sequencer callers.
+    /// Same `from`-enforcement and state-override rejection as
+    /// [`call`](Self::call).
     fn estimate_gas(
         &self,
         request: TempoTransactionRequest,
         block: Option<BlockId>,
-        state_override: Option<StateOverride>,
         auth: AuthContext,
     ) -> BoxFut<'_>;
 
@@ -387,7 +386,7 @@ async fn handle_get_block_by_number(
     api_result(
         id,
         "eth_getBlockByNumber",
-        api.block_by_number(number, full, auth.clone()).await,
+        api.block_by_number(number, auth.clone()).await,
     )
 }
 
@@ -410,7 +409,7 @@ async fn handle_get_block_by_hash(
     api_result(
         id,
         "eth_getBlockByHash",
-        api.block_by_hash(hash, full, auth.clone()).await,
+        api.block_by_hash(hash, auth.clone()).await,
     )
 }
 
@@ -473,11 +472,7 @@ async fn handle_call(
         );
     }
 
-    api_result(
-        id,
-        "eth_call",
-        api.call(request, block, state_override, auth.clone()).await,
-    )
+    api_result(id, "eth_call", api.call(request, block, auth.clone()).await)
 }
 
 /// Handle `eth_estimateGas`. Same `from`-enforcement as `eth_call`.
@@ -504,8 +499,7 @@ async fn handle_estimate_gas(
     api_result(
         id,
         "eth_estimateGas",
-        api.estimate_gas(request, block, state_override, auth.clone())
-            .await,
+        api.estimate_gas(request, block, auth.clone()).await,
     )
 }
 
@@ -776,12 +770,12 @@ mod tests {
         stub!(fee_history, _block_count: u64, _newest_block: BlockNumberOrTag, _reward_percentiles: Option<Vec<f64>>);
         stub!(get_balance, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
         stub!(get_transaction_count, _address: Address, _block: Option<BlockId>, _auth: AuthContext);
-        stub!(block_by_number, _number: BlockNumberOrTag, _full: bool, _auth: AuthContext);
-        stub!(block_by_hash, _hash: B256, _full: bool, _auth: AuthContext);
+        stub!(block_by_number, _number: BlockNumberOrTag, _auth: AuthContext);
+        stub!(block_by_hash, _hash: B256, _auth: AuthContext);
         stub!(transaction_by_hash, _hash: B256, _auth: AuthContext);
         stub!(transaction_receipt, _hash: B256, _auth: AuthContext);
-        stub!(call, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
-        stub!(estimate_gas, _request: TempoTransactionRequest, _block: Option<BlockId>, _state_override: Option<StateOverride>, _auth: AuthContext);
+        stub!(call, _request: TempoTransactionRequest, _block: Option<BlockId>, _auth: AuthContext);
+        stub!(estimate_gas, _request: TempoTransactionRequest, _block: Option<BlockId>, _auth: AuthContext);
         stub!(send_raw_transaction, _data: Bytes, _auth: AuthContext);
         stub!(send_raw_transaction_sync, _data: Bytes, _auth: AuthContext);
         stub!(fill_transaction, _request: TempoTransactionRequest, _auth: AuthContext);

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -379,12 +379,12 @@ mod tests {
         stub!(fee_history, _a: u64, _b: alloy_rpc_types_eth::BlockNumberOrTag, _c: Option<Vec<f64>>);
         stub!(get_balance, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: crate::auth::AuthContext);
         stub!(get_transaction_count, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: crate::auth::AuthContext);
-        stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _b: bool, _c: crate::auth::AuthContext);
-        stub!(block_by_hash, _a: alloy_primitives::B256, _b: bool, _c: crate::auth::AuthContext);
+        stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _c: crate::auth::AuthContext);
+        stub!(block_by_hash, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
         stub!(transaction_by_hash, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
         stub!(transaction_receipt, _a: alloy_primitives::B256, _c: crate::auth::AuthContext);
-        stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
-        stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: crate::auth::AuthContext);
+        stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: crate::auth::AuthContext);
+        stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: crate::auth::AuthContext);
         stub!(send_raw_transaction, _a: Bytes, _c: crate::auth::AuthContext);
         stub!(send_raw_transaction_sync, _a: Bytes, _c: crate::auth::AuthContext);
         stub!(fill_transaction, _a: tempo_alloy::rpc::TempoTransactionRequest, _c: crate::auth::AuthContext);

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -304,12 +304,22 @@ pub struct SequencerReadiness {
     pub reasons: Vec<String>,
 }
 
+/// Sequencer topology mode for `zone_getSequencerInfo`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SequencerMode {
+    /// Single-sequencer node (or multi-sequencer machinery not yet initialized).
+    Single,
+    /// Multi-sequencer manifest mode.
+    Multi,
+}
+
 /// Response payload for `zone_getSequencerInfo`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SequencerInfoResponse {
-    /// `multi` in manifest mode, `single` otherwise.
-    pub mode: String,
+    /// Whether this node runs in manifest (`multi`) or `single` sequencer mode.
+    pub mode: SequencerMode,
     /// ZonePortal address on Tempo L1.
     pub portal: Address,
     /// Local node identity and role (multi-sequencer mode only).
@@ -331,12 +341,22 @@ pub struct SequencerInfoResponse {
     pub readiness: Option<SequencerReadiness>,
 }
 
+/// Outcome of a `zone_setLeader` request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SetLeaderStatus {
+    /// A leadership transaction was relayed and confirmed.
+    Submitted,
+    /// Finalized no-op: the target already is the active leader.
+    AlreadyActive,
+}
+
 /// Response payload for `zone_setLeader`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetLeaderResponse {
-    /// `submitted` when a transaction was relayed, `alreadyActive` for a finalized no-op.
-    pub status: String,
+    /// Whether a transaction was relayed or the target was already active.
+    pub status: SetLeaderStatus,
     /// Hash of the relayed L1 transaction, when one was submitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tx_hash: Option<B256>,

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -143,12 +143,12 @@ impl ZoneRpcApi for MockZoneRpcApi {
     stub!(fee_history, _a: u64, _b: alloy_rpc_types_eth::BlockNumberOrTag, _c: Option<Vec<f64>>);
     stub!(get_balance, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
     stub!(get_transaction_count, _a: Address, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
-    stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _b: bool, _c: zone_rpc::auth::AuthContext);
-    stub!(block_by_hash, _a: alloy_primitives::B256, _b: bool, _c: zone_rpc::auth::AuthContext);
+    stub!(block_by_number, _a: alloy_rpc_types_eth::BlockNumberOrTag, _c: zone_rpc::auth::AuthContext);
+    stub!(block_by_hash, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
     stub!(transaction_by_hash, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
     stub!(transaction_receipt, _a: alloy_primitives::B256, _c: zone_rpc::auth::AuthContext);
-    stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
-    stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: Option<alloy_rpc_types_eth::state::StateOverride>, _d: zone_rpc::auth::AuthContext);
+    stub!(call, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
+    stub!(estimate_gas, _a: tempo_alloy::rpc::TempoTransactionRequest, _b: Option<alloy_rpc_types_eth::BlockId>, _c: zone_rpc::auth::AuthContext);
     stub!(send_raw_transaction, _a: alloy_primitives::Bytes, _c: zone_rpc::auth::AuthContext);
     fn send_raw_transaction_sync(
         &self,


### PR DESCRIPTION
Cleans up the zone RPC surface in three parts:

- Fixes zone_getZoneInfo erroring on nodes running without an L1 portal: the zero-portal case is now handled once with static defaults instead of per-read guards, one of which was missing. The token list now comes from the node's synced enabled-token registry instead of a separate L1 read, matching the log-scoping path.

- Removes parameters from ZoneRpcApi that implementations can never receive (state overrides, full block bodies) — the dispatch layer rejects both before any trait method runs. Signatures now match the actual contract; rejection behavior is unchanged.

- Corrects docs that described non-existent sequencer bypasses, and replaces the stringly-typed zone_getSequencerInfo mode and zone_setLeader status fields with enums. Wire format is unchanged.