### PR TITLE
refactor(sequencer): simplify monitor control flow

### DIFF
--- a/crates/sequencer/src/attestation.rs
+++ b/crates/sequencer/src/attestation.rs
@@ -242,11 +242,9 @@ impl AttestationStore {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use alloy_primitives::{Address, B256, U256, keccak256, uint};
     use alloy_signer_local::PrivateKeySigner;
-    use alloy_sol_types::{SolStruct as _, SolValue as _};
-
-    use super::*;
 
     fn domain() -> AttestationDomain {
         AttestationDomain {

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -32,11 +32,9 @@ use tempo_alloy::TempoNetwork;
 use tokio::sync::Notify;
 use tracing::{error, info, instrument, warn};
 
-use alloy_sol_types::{ContractError, SolInterface as _};
-
 use crate::{
     AttestationStore, ZoneSequencerProvider,
-    abi::{self, NO_QUEUE_INDEX, ZonePortal},
+    abi::{self, NO_QUEUE_INDEX},
     resolve_portal_zone_anchor,
     settlement::{
         BatchAnchorConfig, BatchData, BatchSubmitter, FinalizedBatchLog, ZoneBlockSnapshot,
@@ -294,7 +292,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
         }
 
         match self.process_block_range(scan_from, latest_zone_block).await {
-            Ok(_) => self.record_observed_zone_block(latest_zone_block),
+            Ok(()) => self.record_observed_zone_block(latest_zone_block),
             Err(error) => {
                 error!(
                     from = scan_from,
@@ -380,16 +378,15 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
     /// The monitor must walk those boundaries one at a time so the L2 outbox
     /// index and L1 portal index advance in lockstep.
     #[instrument(skip(self), fields(from, to))]
-    async fn process_block_range(&mut self, from: u64, to: u64) -> Result<bool> {
+    async fn process_block_range(&mut self, from: u64, to: u64) -> Result<()> {
         let block_count = to - from + 1;
         info!(from, to, block_count, "Processing zone block range");
 
         let boundaries =
-            fetch_finalized_batch_boundaries(&self.provider, self.config.outbox_address, from, to)
-                .await?;
+            fetch_finalized_batch_boundaries(&self.provider, self.config.outbox_address, from, to)?;
         if boundaries.is_empty() {
             info!(from, to, "No finalized batch boundaries ready to submit");
-            return Ok(false);
+            return Ok(());
         }
 
         info!(
@@ -424,7 +421,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             }
         }
 
-        Ok(true)
+        Ok(())
     }
 
     /// Process one boundary-aligned finalized batch.
@@ -435,9 +432,8 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
     ) -> Result<()> {
         let to = boundary.block_number;
         let finalized_batch =
-            fetch_finalized_batch(&self.provider, self.config.outbox_address, from, &boundary)
-                .await?;
-        let end_state = self.fetch_block_snapshot(to).await?;
+            fetch_finalized_batch(&self.provider, self.config.outbox_address, from, &boundary)?;
+        let end_state = read_zone_block_snapshot(&self.provider, self.config.inbox_address, to)?;
 
         if !finalized_batch.withdrawals.is_empty() {
             info!(
@@ -465,12 +461,6 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
 
         self.submit_batch_with_retry(&batch_data, to, finalized_batch.withdrawals)
             .await
-    }
-
-    /// Read the zone state at block `to`: tempo block number, processed deposit
-    /// queue hash, and block hash.
-    async fn fetch_block_snapshot(&self, to: u64) -> Result<ZoneBlockSnapshot> {
-        read_zone_block_snapshot(&self.provider, self.config.inbox_address, to)
     }
 
     /// Submit a `submitBatch` transaction to the ZonePortal on L1 with exponential
@@ -624,10 +614,8 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                         delay *= 2;
                     } else {
                         self.metrics.batch_submit_failure_total.increment(1);
-                        let revert_reason = decode_portal_revert(&e);
                         error!(
                             error = %e,
-                            revert_reason,
                             last_zone_block,
                             tempo_block_number = batch_data.tempo_block_number,
                             prev_block_hash = %batch_data.prev_block_hash,
@@ -838,20 +826,6 @@ pub fn spawn_zone_monitor<P: ZoneSequencerProvider>(
             }
         }
     })
-}
-
-/// Try to decode a ZonePortal revert reason from an eyre error chain.
-///
-/// Extracts hex-encoded revert data from the error's display string and decodes
-/// it using alloy's `ContractError`, which handles standard `Revert(string)`,
-/// `Panic(uint256)`, and ZonePortal custom errors (`NotSequencer`, etc.).
-fn decode_portal_revert(err: &eyre::Report) -> Option<String> {
-    let msg = format!("{err}");
-    let start = msg.find("data: \"0x")? + "data: \"".len();
-    let end = msg[start..].find('"')? + start;
-    let bytes = alloy_primitives::hex::decode(&msg[start..end]).ok()?;
-    let error = ContractError::<ZonePortal::ZonePortalErrors>::abi_decode(&bytes).ok()?;
-    Some(error.to_string())
 }
 
 #[cfg(test)]

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -1012,7 +1012,7 @@ impl BatchSubmitter {
                 continue;
             };
             let withdrawals =
-                fetch_slot_withdrawals(zone_provider, outbox_address, zone_start, zone_end).await?;
+                fetch_slot_withdrawals(zone_provider, outbox_address, zone_start, zone_end)?;
             slot_withdrawals.insert(portal_slot, withdrawals);
         }
 
@@ -1487,7 +1487,7 @@ pub(crate) fn read_zone_block_snapshot<P: ZoneSequencerProvider>(
 ///
 /// This includes zero-withdrawal batches because they still advance the L2
 /// withdrawal batch index and therefore require a matching L1 `submitBatch`.
-pub(crate) async fn fetch_finalized_batch_boundaries<P: ZoneSequencerProvider>(
+pub(crate) fn fetch_finalized_batch_boundaries<P: ZoneSequencerProvider>(
     provider: &P,
     outbox_address: Address,
     from: u64,
@@ -1516,7 +1516,7 @@ pub(crate) async fn fetch_finalized_batch_boundaries<P: ZoneSequencerProvider>(
 /// Withdrawal structs are reconstructed from `WithdrawalRequested` logs in the
 /// supplied boundary-aligned range so the off-chain processor can service the
 /// portal queue.
-pub(crate) async fn fetch_finalized_batch<P: ZoneSequencerProvider>(
+pub(crate) fn fetch_finalized_batch<P: ZoneSequencerProvider>(
     zone_provider: &P,
     outbox_address: Address,
     from: u64,
@@ -1589,23 +1589,18 @@ pub(crate) async fn fetch_finalized_batch<P: ZoneSequencerProvider>(
 }
 
 /// Fetch `WithdrawalRequested` events for one portal queue slot.
-pub(crate) async fn fetch_slot_withdrawals(
+pub(crate) fn fetch_slot_withdrawals(
     zone_provider: &impl ZoneSequencerProvider,
     outbox_address: Address,
     from: u64,
     to: u64,
 ) -> Result<Vec<abi::Withdrawal>> {
-    let boundaries =
-        fetch_finalized_batch_boundaries(zone_provider, outbox_address, to, to).await?;
+    let boundaries = fetch_finalized_batch_boundaries(zone_provider, outbox_address, to, to)?;
     let target = boundaries
         .into_iter()
         .next()
         .ok_or_else(|| eyre::eyre!("zone block {to} does not contain a BatchFinalized boundary"))?;
-    Ok(
-        fetch_finalized_batch(zone_provider, outbox_address, from, &target)
-            .await?
-            .withdrawals,
-    )
+    Ok(fetch_finalized_batch(zone_provider, outbox_address, from, &target)?.withdrawals)
 }
 
 fn fetch_requested_withdrawal_logs<P: ZoneSequencerProvider>(
@@ -2493,7 +2488,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_hash_mismatch_skipped() {
+    fn resolve_hash_mismatch_is_rejected() {
         let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
         let withdrawals = vec![w0];
         let wrong_hash = B256::from([0xabu8; 32]);
@@ -2508,7 +2503,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_missing_event_skipped() {
+    fn resolve_missing_event_is_rejected() {
         let w0 = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
         let withdrawals = vec![w0];
 
@@ -2559,7 +2554,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_empty_withdrawals_vec_skipped() {
+    fn resolve_empty_withdrawals_vec_is_rejected() {
         let mut events = BTreeMap::new();
         events.insert(5, test_batch_event(B256::from([0x11u8; 32])));
 
@@ -2571,7 +2566,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_missing_withdrawals_data_skipped() {
+    fn resolve_missing_withdrawals_data_is_rejected() {
         let w = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
         let hash = abi::Withdrawal::queue_hash(std::slice::from_ref(&w));
 
@@ -2585,7 +2580,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_head_slot_corrupted_hash_skipped() {
+    fn resolve_head_slot_corrupted_hash_is_rejected() {
         let w = test_withdrawal(address!("0x0000000000000000000000000000000000000001"), 100);
         let withdrawals = vec![w];
         let full_hash = abi::Withdrawal::queue_hash(&withdrawals);


### PR DESCRIPTION
## Summary

- return `Result<()>` from monitor block-range processing because callers never consume a status value
- call synchronous native Zone reads directly and make the boundary/batch/withdrawal helper chain synchronous
- remove brittle revert-string parsing while retaining the original submission error report in logs
- clean up directly related settlement test names and unused attestation test imports

## Why

The removed boolean, async wrappers, and parsed revert field implied behavior or guarantees they did not provide. Removing them makes the control flow accurately reflect the underlying work while preserving sequencer protocol behavior.

## Impact

This is a mechanical refactor. Canonical polling, reorg handling, boundary ordering, batch submission and retry behavior, portal resync, withdrawal restoration and processing, ancestry behavior, proofs, and anchor configuration remain unchanged.