### PR TITLE
ci: add Cyclops super-fast audit trigger

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -19,7 +19,7 @@ jobs:
       )
     permissions:
       contents: read
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@5829d6b46418710f752eb8b25218af9812b78428
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@3b800600d386a7178afd2a322e3b99b7ffd3bb1f
     with:
       required-labels: |
         cyclops
@@ -45,7 +45,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@5829d6b46418710f752eb8b25218af9812b78428
+      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@3b800600d386a7178afd2a322e3b99b7ffd3bb1f
         with:
           command-regex: '^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b'
           permission-check-mode: association


### PR DESCRIPTION
## Summary

- update the pinned Cyclops shared workflow and comment action to `3b800600d386a7178afd2a322e3b99b7ffd3bb1f`
- enable `cyclops audit super-fast` using the canonical five-minute, one-iteration profile

## Validation

- parsed the workflow as YAML
- `git diff --check`

Upstream support: https://github.com/tempoxyz/gh-actions/pull/54