### PR TITLE
chore(ci): require Cyclops audit before merge

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -3,6 +3,11 @@ name: Pull request audit
 on:
   pull_request:
     types: [labeled]
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+  merge_group:
   issue_comment:
     types: [created]
 
@@ -12,18 +17,28 @@ jobs:
   # Label-triggered audit -> read-only shared reusable
   audit:
     if: >-
-      github.event_name == 'pull_request' &&
       (
-        github.event.label.name == 'cyclops' ||
-        github.event.label.name == 'agentic-audit'
+        github.event_name == 'pull_request' &&
+        (
+          github.event.label.name == 'cyclops' ||
+          github.event.label.name == 'agentic-audit'
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request_target' ||
+        github.event_name == 'pull_request_review' ||
+        github.event_name == 'merge_group'
       )
     permissions:
       contents: read
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@3b800600d386a7178afd2a322e3b99b7ffd3bb1f
+      pull-requests: read
+      statuses: write
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@7216a21c7e97d3f0c4d091ac5b894a407c600b91
     with:
       required-labels: |
         cyclops
         agentic-audit
+      require-completed-audit: true
     secrets:
       EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
       EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
@@ -45,7 +60,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@3b800600d386a7178afd2a322e3b99b7ffd3bb1f
+      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@7216a21c7e97d3f0c4d091ac5b894a407c600b91
         with:
           command-regex: '^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b'
           permission-check-mode: association


### PR DESCRIPTION
## Summary

- update the shared `pr-audit.yml` workflow and comment action to `tempoxyz/gh-actions@7216a21c7e97d3f0c4d091ac5b894a407c600b91`
- enable `require-completed-audit` and grant the audit status permissions
- add pull request review, target, and merge queue triggers for recalculation

## Validation

- `actionlint`
- `zizmor --persona=regular --offline .github/workflows/pr-audit.yml`
- `git diff --check`

## Rollout

After this merges and `Cyclops audit run` is emitted for open pull requests, add that context to the required status checks in the active `Protect main` repository ruleset. Delaying the ruleset change avoids blocking existing pull requests before the default-branch workflow can publish the status.

Prompted by: @grandizzy