### PR TITLE
fix(precompiles): reject non-canonical deposit encodings

### DIFF
--- a/crates/precompiles/src/inbox/mod.rs
+++ b/crates/precompiles/src/inbox/mod.rs
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::{Address, B256, U256};
-use alloy_sol_types::{SolCall, SolValue};
+use alloy_sol_types::{SolCall, SolType, SolValue};
 use tempo_precompiles::{
     PATH_USD_ADDRESS,
     error::TempoPrecompileError,
@@ -347,14 +347,23 @@ impl TryFrom<QueuedDeposit> for DecodedQueuedDeposit {
     fn try_from(queued: QueuedDeposit) -> Result<Self, Self::Error> {
         match queued.depositType {
             DepositType::WithdrawalBounceBack => {
-                WithdrawalBounceBackDeposit::abi_decode(&queued.depositData)
-                    .map(Self::WithdrawalBounceBack)
+                decode_canonical(&queued.depositData).map(Self::WithdrawalBounceBack)
             }
-            DepositType::Deposit => Deposit::abi_decode(&queued.depositData).map(Self::Deposit),
+            DepositType::Deposit => decode_canonical(&queued.depositData).map(Self::Deposit),
             _ => return Err(ZonePrecompileError::MalformedCalldata),
         }
         .map_err(|_| ZonePrecompileError::MalformedCalldata)
     }
+}
+
+fn decode_canonical<T>(encoded: &[u8]) -> alloy_sol_types::Result<T>
+where
+    T: SolValue + From<<T::SolType as SolType>::RustType>,
+{
+    let value = T::abi_decode(encoded)?;
+    (value.abi_encode().as_slice() == encoded)
+        .then_some(value)
+        .ok_or(alloy_sol_types::Error::ReserMismatch)
 }
 
 fn decode_deposits(deposits: Vec<QueuedDeposit>) -> ZoneResult<Vec<DecodedQueuedDeposit>> {

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -578,6 +578,42 @@ fn malformed_nested_deposit_reverts_before_l1_reads() -> eyre::Result<()> {
 }
 
 #[test]
+fn non_canonical_encrypted_deposit_is_rejected() {
+    let deposit = Deposit {
+        token: Address::ZERO,
+        sender: Address::ZERO,
+        amount: 0,
+        tempoRefundRecipient: Address::ZERO,
+        keyIndex: U256::ZERO,
+        encrypted: tempo_zone_contracts::DepositPayload {
+            ephemeralPubkeyX: B256::ZERO,
+            ephemeralPubkeyYParity: 0,
+            ciphertext: Bytes::new(),
+            nonce: [0; 12].into(),
+            tag: [0; 16].into(),
+        },
+    };
+    let canonical = deposit.abi_encode();
+    let mut non_canonical = canonical.clone();
+    non_canonical.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+    assert!(
+        decode_deposits(vec![QueuedDeposit {
+            depositType: DepositType::Deposit,
+            depositData: canonical.into(),
+        }])
+        .is_ok()
+    );
+    assert!(
+        decode_deposits(vec![QueuedDeposit {
+            depositType: DepositType::Deposit,
+            depositData: non_canonical.into(),
+        }])
+        .is_err()
+    );
+}
+
+#[test]
 fn deposit_uses_child_anchor_key_and_mints_plaintext_recipient() -> eyre::Result<()> {
     let mut harness = Harness::new()?;
     let fixture = EncryptedDepositFixture::new();


### PR DESCRIPTION
## Summary

- require queued deposits to match their canonical ABI encoding
- reject trailing bytes and other non-canonical encodings before deposit execution
- cover the encrypted-only deposit format with a regression test

Addresses [ZONE-257](https://linear.app/tempoxyz/issue/ZONE-257/cyclops-advancetempo-deposit-calldata-has-two-different-acceptance).

## Tests

- `cargo test -p zone-precompiles`
- `cargo +nightly clippy -p zone-precompiles --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`

Prompted by: @0xrusowsky