### PR TITLE
fix(prover): allow anchor == checkpoint

### DIFF
--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -607,7 +607,7 @@ async fn resolve_anchor(
 ) -> Result<Anchor> {
     let tip = provider.get_block_number().await?;
     ensure!(
-        checkpoint_number < tip,
+        checkpoint_number <= tip,
         "Tempo checkpoint {checkpoint_number} is not yet confirmed behind tip {tip}"
     );
     let gap = tip - checkpoint_number;


### PR DESCRIPTION
Previous `checkpoint < tip` condition is required only for verifying the proof in the portal when using the direct mode, i.e. EIP-2935 window of hashes. For generating a proof, it doesn't matter what current L1 tip is.

When we actually submit the proof onchain from the prover, we would need to make sure that L1 tip is at least one block ahead of the block the proof is anchored to, so that EIP-2935 data is available.