### PR TITLE
ci: sync private copies from upstream

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,0 +1,38 @@
+# This workflow is intended for forks or private copies of tempoxyz/zones.
+# It keeps their main branch aligned with the upstream repository every hour.
+
+name: Sync main branch with upstream
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    if: ${{ github.repository != 'tempoxyz/zones' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-workflows: write
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Sync main with upstream
+        run: |
+          git remote add upstream https://github.com/tempoxyz/zones.git
+          git fetch upstream main
+          git checkout main
+          git reset --hard upstream/main
+          git push origin main --force

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -28,11 +28,14 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync main with upstream
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git remote add upstream https://github.com/tempoxyz/zones.git
           git fetch upstream main
           git checkout main
           git reset --hard upstream/main
-          git push origin main --force
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" main --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,18 +24,25 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Mint read-only Earn token
+        id: earn-token
+        uses: tempoxyz/gh-actions/actions/github-sts@main
+        with:
+          scope: tempoxyz/earn
+          policy: zones-read
       - name: Check out Earn contracts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/earn
           ref: main
           path: earn
-          ssh-key: ${{ secrets.EARN_DEPLOY_KEY }}
+          token: ${{ steps.earn-token.outputs.token }}
           persist-credentials: false
           submodules: true
       - uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: recursive
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@main
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -437,6 +437,9 @@ jobs:
     needs: authorize
     runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
     timeout-minutes: 300
+    permissions:
+      contents: read
+      id-token: write
     env:
       ZONES_BENCH_PHASE: neobank-e2e
       ZONES_BENCH_NEOBANK_PRESET: ${{ needs.authorize.outputs.neobank-preset }}
@@ -489,13 +492,19 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
+      - name: Mint read-only Earn token
+        id: earn-token
+        uses: tempoxyz/gh-actions/actions/github-sts@main
+        with:
+          scope: tempoxyz/earn
+          policy: zones-read
       - name: Check out Earn contracts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/earn
           ref: main
           path: earn
-          ssh-key: ${{ secrets.EARN_DEPLOY_KEY }}
+          token: ${{ steps.earn-token.outputs.token }}
           persist-credentials: false
           submodules: true
 

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -495,7 +495,7 @@ jobs:
 
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@main
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read


### PR DESCRIPTION
## Summary

- add an hourly, manually dispatchable upstream-sync workflow for forks and private copies of `tempoxyz/zones`
- authenticate mirror pushes with a GitHub App token that can update both contents and workflow files
- replace the long-lived `EARN_DEPLOY_KEY` checkout credential with a short-lived STS token in test and benchmark workflows
- skip the mirror job in the public upstream repository

## Why

A private mirror must retain the sync workflow after each force-reset to upstream `main`. STS grants each job only temporary read access to `tempoxyz/earn`, avoiding a deploy key in Zones and its private mirror.

## Dependency

Requires `tempoxyz/earn` PR for the `zones-read` STS policy to merge first.

## Validation

- `git diff --check`
- `actionlint` (with the existing custom benchmark runner label ignored)
- STS policy YAML parse