### PR TITLE
ci: harden private fork workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,11 @@ env:
 jobs:
   build-and-push:
     name: Build and Push Docker Images
+    # Private copies retain PR image builds, but must not publish shared images
+    # or run the upstream's scheduled refreshes.
+    if: >-
+      github.repository == 'tempoxyz/zones' ||
+      (github.event_name != 'schedule' && github.event_name != 'push')
     runs-on: depot-ubuntu-latest-16
     permissions:
       contents: read
@@ -79,6 +84,7 @@ jobs:
             type=ref,event=pr
 
       - name: Log in to Container Registry
+        if: github.repository == 'tempoxyz/zones'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -97,7 +103,7 @@ jobs:
             ${{ steps.meta-tempo-zone-xtask.outputs.bake-file }}
           targets: default
           project: 0c6tg19qsp
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.repository == 'tempoxyz/zones' && github.event_name != 'pull_request' }}
           # Scheduled builds refresh moving external tools and base images. All
           # commit/tag/manual builds can safely reuse Depot's content-addressed
           # layer cache and will still invalidate layers when inputs change.

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -17,17 +17,20 @@ jobs:
   # Label-triggered audit -> read-only shared reusable
   audit:
     if: >-
+      github.repository == 'tempoxyz/zones' &&
       (
+        (
         github.event_name == 'pull_request' &&
         (
           github.event.label.name == 'cyclops' ||
           github.event.label.name == 'agentic-audit'
         )
-      ) ||
-      (
-        github.event_name == 'pull_request_target' ||
-        github.event_name == 'pull_request_review' ||
-        github.event_name == 'merge_group'
+        ) ||
+        (
+          github.event_name == 'pull_request_target' ||
+          github.event_name == 'pull_request_review' ||
+          github.event_name == 'merge_group'
+        )
       )
     permissions:
       contents: read
@@ -47,6 +50,7 @@ jobs:
   # Comment-command audit -> caller-owned privileged job using the composite
   audit-comment:
     if: >-
+      github.repository == 'tempoxyz/zones' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       (

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -18,6 +18,8 @@ permissions: {}
 jobs:
   scan:
     name: Scan GitHub Actions
+    # Only the upstream repository runs the recurring organization-wide scan.
+    if: github.event_name != 'schedule' || github.repository == 'tempoxyz/zones'
     uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@98b1081dcf34361b576aca2ab3041772708582ef
     permissions:
       actions: read

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,0 +1,38 @@
+# This workflow is intended for forks or private copies of tempoxyz/zones.
+# It keeps their main branch aligned with the upstream repository every hour.
+
+name: Sync main branch with upstream
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    if: ${{ github.repository != 'tempoxyz/zones' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-workflows: write
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Sync main with upstream
+        run: |
+          git remote add upstream https://github.com/tempoxyz/zones.git
+          git fetch upstream main
+          git checkout main
+          git reset --hard upstream/main
+          git push origin main --force

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -28,11 +28,14 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync main with upstream
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git remote add upstream https://github.com/tempoxyz/zones.git
           git fetch upstream main
           git checkout main
           git reset --hard upstream/main
-          git push origin main --force
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" main --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,18 +24,25 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
+      - name: Mint read-only Earn token
+        id: earn-token
+        uses: tempoxyz/gh-actions/actions/github-sts@main
+        with:
+          scope: tempoxyz/earn
+          policy: zones-read
       - name: Check out Earn contracts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/earn
           ref: main
           path: earn
-          ssh-key: ${{ secrets.EARN_DEPLOY_KEY }}
+          token: ${{ steps.earn-token.outputs.token }}
           persist-credentials: false
           submodules: true
       - uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: recursive
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@main
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ env:
 jobs:
   build-test-artifacts:
     name: build test artifacts
+    # Keep private-copy PR validation while avoiding a full test run for every
+    # hourly mirror update to its main branch.
+    if: github.repository == 'tempoxyz/zones' || github.event_name != 'push'
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 30
     permissions:
@@ -142,7 +145,9 @@ jobs:
   test-success:
     name: test success
     runs-on: ubuntu-latest
-    if: always()
+    if: >-
+      always() &&
+      (github.repository == 'tempoxyz/zones' || github.event_name != 'push')
     permissions: {}
     needs:
       - build-test-artifacts

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -166,6 +166,9 @@ env:
 jobs:
   authorize:
     name: Resolve benchmark request
+    # Scheduled benchmarks use upstream-only infrastructure and credentials.
+    # Private copies can still run an explicitly dispatched benchmark.
+    if: github.repository == 'tempoxyz/zones' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
       neobank-preset: ${{ steps.config.outputs.neobank-preset }}

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -437,6 +437,9 @@ jobs:
     needs: authorize
     runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
     timeout-minutes: 300
+    permissions:
+      contents: read
+      id-token: write
     env:
       ZONES_BENCH_PHASE: neobank-e2e
       ZONES_BENCH_NEOBANK_PRESET: ${{ needs.authorize.outputs.neobank-preset }}
@@ -489,13 +492,19 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
+      - name: Mint read-only Earn token
+        id: earn-token
+        uses: tempoxyz/gh-actions/actions/github-sts@main
+        with:
+          scope: tempoxyz/earn
+          policy: zones-read
       - name: Check out Earn contracts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/earn
           ref: main
           path: earn
-          ssh-key: ${{ secrets.EARN_DEPLOY_KEY }}
+          token: ${{ steps.earn-token.outputs.token }}
           persist-credentials: false
           submodules: true
 

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -495,7 +495,7 @@ jobs:
 
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@main
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read


### PR DESCRIPTION
## Summary

- skip private-copy scheduled and publishing paths while retaining PR validation
- restrict audit event credentials to the upstream Zones repository
- pin the Earn STS action to an immutable commit

## Validation

- `git diff --check`
- `actionlint .github/workflows/docker.yml .github/workflows/zones-benchmark.yml .github/workflows/scan-github-actions.yml .github/workflows/pr-audit.yml .github/workflows/test.yml`