### PR TITLE
feat(sequencer): add shadow prover latency metric

### DIFF
--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -5,10 +5,10 @@ use reth_metrics::{
     metrics::{Counter, Gauge, Histogram},
 };
 
-/// Metrics emitted by the shadow prover.
+/// Metrics emitted by the prover.
 #[derive(Metrics, Clone)]
-#[metrics(scope = "tempo_zone_shadow_prover")]
-pub(crate) struct ShadowProverMetrics {
+#[metrics(scope = "tempo_zone_prover")]
+pub(crate) struct ProverMetrics {
     /// End-to-end latency of a shadow prover validation attempt in seconds.
     pub(crate) validation_duration_seconds: Histogram,
 }

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -5,6 +5,14 @@ use reth_metrics::{
     metrics::{Counter, Gauge, Histogram},
 };
 
+/// Metrics emitted by the shadow prover.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "tempo_zone_shadow_prover")]
+pub(crate) struct ShadowProverMetrics {
+    /// End-to-end latency of a shadow prover validation attempt in seconds.
+    pub(crate) validation_duration_seconds: Histogram,
+}
+
 /// Metrics emitted by the withdrawal processor.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_zone_withdrawal_processor")]

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -32,7 +32,7 @@ use zone_spf::{
     ZoneStateWitness, prove_zone_batch,
 };
 
-use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider};
+use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider, metrics::ShadowProverMetrics};
 
 /// Number of candidates allowed to wait behind the active validation.
 const SHADOW_PROVER_QUEUE_CAPACITY: usize = 2;
@@ -124,11 +124,16 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
         zone_provider,
         l1_provider,
     };
+    let metrics = ShadowProverMetrics::default();
 
     tokio::spawn(async move {
         while let Some(job) = receiver.recv().await {
             let started = Instant::now();
-            match validate_candidate(&context, &job).await {
+            let result = validate_candidate(&context, &job).await;
+            metrics
+                .validation_duration_seconds
+                .record(started.elapsed().as_secs_f64());
+            match result {
                 Ok(stats) => {
                     info!(
                         target: "zone::sequencer::prover",

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -32,7 +32,7 @@ use zone_spf::{
     ZoneStateWitness, prove_zone_batch,
 };
 
-use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider, metrics::ShadowProverMetrics};
+use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider, metrics::ProverMetrics};
 
 /// Number of candidates allowed to wait behind the active validation.
 const SHADOW_PROVER_QUEUE_CAPACITY: usize = 2;
@@ -124,7 +124,7 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
         zone_provider,
         l1_provider,
     };
-    let metrics = ShadowProverMetrics::default();
+    let metrics = ProverMetrics::default();
 
     tokio::spawn(async move {
         while let Some(job) = receiver.recv().await {


### PR DESCRIPTION
## Summary

- add a `tempo_zone_prover_validation_duration_seconds` histogram
- record end-to-end latency for successful and failed validation attempts

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test -p zone-sequencer`
- `cargo +nightly clippy -p zone-sequencer --all-targets`

Prompted by: @rkrasiuk