### PR TITLE
fix(sequencer): derive L1 polling from chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13696,6 +13696,7 @@ name = "zone-node"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-chains",
  "alloy-consensus",
  "alloy-contract",
  "alloy-eips",
@@ -13929,6 +13930,7 @@ dependencies = [
 name = "zone-sequencer"
 version = "0.1.0"
 dependencies = [
+ "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
  "alloy-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ revm = { version = "42.0.1", features = [
 
 # alloy
 alloy = { version = "2.3.0", default-features = false }
+alloy-chains = "0.2.36"
 alloy-consensus = { version = "2.3.0", default-features = false }
 alloy-contract = { version = "2.3.0", default-features = false }
 alloy-eips = { version = "2.3.0", default-features = false }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -60,6 +60,7 @@ reth-transaction-pool.workspace = true
 reth-trie-common.workspace = true
 
 # alloy
+alloy-chains.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-genesis.workspace = true

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,7 +18,7 @@ use crate::{
         ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config, start_redacted_rpc,
     },
 };
-use alloy_chains::NamedChain;
+use alloy_chains::Chain;
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
@@ -108,20 +108,6 @@ fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
             .any(|id| id.trim().parse() == Ok(chain_id))
             .then(|| DEV.clone()),
     })
-}
-
-/// Resolve Alloy's chain metadata for a supported Tempo L1 chain ID.
-///
-/// Custom Tempo dev chain IDs use Tempo's block-time hint while retaining their configured ID
-/// for transaction signing and protocol domain separation.
-fn alloy_chain_for_tempo_l1(chain_id: u64) -> Option<NamedChain> {
-    tempo_chain_spec_for_l1(chain_id)?;
-    Some(
-        NamedChain::try_from(chain_id)
-            .ok()
-            .filter(|chain| chain.is_tempo())
-            .unwrap_or(NamedChain::Tempo),
-    )
 }
 
 /// Network primitives for Zone Nodes
@@ -560,8 +546,7 @@ where
             .await?
             .erased();
         let l1_chain_id = l1_provider.get_chain_id().await?;
-        let l1_chain = alloy_chain_for_tempo_l1(l1_chain_id)
-            .ok_or_else(|| eyre::eyre!("unsupported parent Tempo chain ID {l1_chain_id}"))?;
+        let l1_chain = Chain::from_id(l1_chain_id);
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
@@ -664,18 +649,24 @@ where
             let relayer = match individual_signer {
                 Some(signer) => {
                     use tempo_alloy::provider::ext::TempoProviderBuilderExt as _;
-                    Some(
+                    let provider =
                         alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
                             .with_nonce_key_filler()
-                            .with_chain(l1_chain)
                             .wallet(alloy_network::EthereumWallet::from(signer))
                             .connect_with_config(
                                 &self.l1_config.l1_rpc_url,
                                 rpc_connection_config(self.l1_config.retry_connection_interval),
                             )
                             .await?
-                            .erased(),
-                    )
+                            .erased();
+                    if !provider.client().is_local()
+                        && let Some(avg_block_time) = l1_chain.average_blocktime_hint()
+                    {
+                        provider
+                            .client()
+                            .set_poll_interval(avg_block_time.mul_f32(0.6));
+                    }
+                    Some(provider)
                 }
                 None => None,
             };
@@ -1120,7 +1111,7 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
-        l1_chain: NamedChain,
+        l1_chain: Chain,
         attestation_store: AttestationStore,
         prover_config: Option<ShadowProverConfig>,
     ) -> eyre::Result<LeaderSequencerDeps> {
@@ -1330,7 +1321,7 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
-        l1_chain: NamedChain,
+        l1_chain: Chain,
         sequencer_addr: Address,
         attestation_store: Option<AttestationStore>,
         prover_config: Option<ShadowProverConfig>,
@@ -1746,24 +1737,11 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(1337).unwrap().chain().id(), 1337);
         assert_eq!(tempo_chain_spec_for_l1(31337).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
-        assert_eq!(alloy_chain_for_tempo_l1(4217), Some(NamedChain::Tempo));
-        assert_eq!(
-            alloy_chain_for_tempo_l1(42431),
-            Some(NamedChain::TempoModerato)
-        );
-        assert_eq!(alloy_chain_for_tempo_l1(1337), Some(NamedChain::Tempo));
-        assert_eq!(alloy_chain_for_tempo_l1(31337), Some(NamedChain::Tempo));
-        assert_eq!(alloy_chain_for_tempo_l1(999_999), None);
 
         // SAFETY: test-only env mutation; no other test reads this variable.
         unsafe { std::env::set_var("ZONE_L1_DEV_CHAIN_IDS", "31318, 31319") };
         assert_eq!(tempo_chain_spec_for_l1(31318).unwrap().chain().id(), 1337);
         assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
-        assert_eq!(
-            alloy_chain_for_tempo_l1(31318),
-            Some(NamedChain::TempoDevnet)
-        );
-        assert_eq!(alloy_chain_for_tempo_l1(31319), Some(NamedChain::Tempo));
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
         unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
     }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,6 +18,7 @@ use crate::{
         ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config, start_redacted_rpc,
     },
 };
+use alloy_chains::NamedChain;
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
@@ -107,6 +108,20 @@ fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
             .any(|id| id.trim().parse() == Ok(chain_id))
             .then(|| DEV.clone()),
     })
+}
+
+/// Resolve Alloy's chain metadata for a supported Tempo L1 chain ID.
+///
+/// Custom Tempo dev chain IDs use Tempo's block-time hint while retaining their configured ID
+/// for transaction signing and protocol domain separation.
+fn alloy_chain_for_tempo_l1(chain_id: u64) -> Option<NamedChain> {
+    tempo_chain_spec_for_l1(chain_id)?;
+    Some(
+        NamedChain::try_from(chain_id)
+            .ok()
+            .filter(|chain| chain.is_tempo())
+            .unwrap_or(NamedChain::Tempo),
+    )
 }
 
 /// Network primitives for Zone Nodes
@@ -544,6 +559,9 @@ where
             )
             .await?
             .erased();
+        let l1_chain_id = l1_provider.get_chain_id().await?;
+        let l1_chain = alloy_chain_for_tempo_l1(l1_chain_id)
+            .ok_or_else(|| eyre::eyre!("unsupported parent Tempo chain ID {l1_chain_id}"))?;
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
@@ -595,7 +613,6 @@ where
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let mut p2p_runtime = None;
         if let Some(config) = self.p2p_config.take() {
-            let l1_chain_id = l1_provider.get_chain_id().await?;
             let network_id = P2pNetworkId::new(l1_chain_id, self.portal_address);
             let attestation_domain = AttestationDomain {
                 l1_chain_id,
@@ -650,6 +667,7 @@ where
                     Some(
                         alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
                             .with_nonce_key_filler()
+                            .with_chain(l1_chain)
                             .wallet(alloy_network::EthereumWallet::from(signer))
                             .connect_with_config(
                                 &self.l1_config.l1_rpc_url,
@@ -773,6 +791,7 @@ where
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.portal_address,
                     self.l1_config.retry_connection_interval,
+                    l1_chain,
                     attestation.store.clone(),
                     prover_config.clone(),
                 )?),
@@ -824,6 +843,7 @@ where
                 self.l1_config.l1_rpc_url,
                 self.l1_config.portal_address,
                 self.l1_config.retry_connection_interval,
+                l1_chain,
                 sequencer_addr,
                 None,
                 prover_config,
@@ -1100,12 +1120,14 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
+        l1_chain: NamedChain,
         attestation_store: AttestationStore,
         prover_config: Option<ShadowProverConfig>,
     ) -> eyre::Result<LeaderSequencerDeps> {
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
+            l1_chain,
             retry_connection_interval,
             zone_poll_interval: config.zone_poll_interval,
             withdrawal_poll_interval: config.withdrawal_poll_interval,
@@ -1308,6 +1330,7 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
+        l1_chain: NamedChain,
         sequencer_addr: Address,
         attestation_store: Option<AttestationStore>,
         prover_config: Option<ShadowProverConfig>,
@@ -1316,6 +1339,7 @@ where
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
+            l1_chain,
             retry_connection_interval,
             zone_poll_interval: config.zone_poll_interval,
             withdrawal_poll_interval: config.withdrawal_poll_interval,
@@ -1722,11 +1746,24 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(1337).unwrap().chain().id(), 1337);
         assert_eq!(tempo_chain_spec_for_l1(31337).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
+        assert_eq!(alloy_chain_for_tempo_l1(4217), Some(NamedChain::Tempo));
+        assert_eq!(
+            alloy_chain_for_tempo_l1(42431),
+            Some(NamedChain::TempoModerato)
+        );
+        assert_eq!(alloy_chain_for_tempo_l1(1337), Some(NamedChain::Tempo));
+        assert_eq!(alloy_chain_for_tempo_l1(31337), Some(NamedChain::Tempo));
+        assert_eq!(alloy_chain_for_tempo_l1(999_999), None);
 
         // SAFETY: test-only env mutation; no other test reads this variable.
         unsafe { std::env::set_var("ZONE_L1_DEV_CHAIN_IDS", "31318, 31319") };
         assert_eq!(tempo_chain_spec_for_l1(31318).unwrap().chain().id(), 1337);
         assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
+        assert_eq!(
+            alloy_chain_for_tempo_l1(31318),
+            Some(NamedChain::TempoDevnet)
+        );
+        assert_eq!(alloy_chain_for_tempo_l1(31319), Some(NamedChain::Tempo));
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
         unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
     }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -545,9 +545,6 @@ where
             )
             .await?
             .erased();
-        let l1_chain_id = l1_provider.get_chain_id().await?;
-        let l1_chain = Chain::from_id(l1_chain_id);
-
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
         if let Some(keys) = self.l1_config.encryption_keys.clone() {
@@ -598,6 +595,7 @@ where
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let mut p2p_runtime = None;
         if let Some(config) = self.p2p_config.take() {
+            let l1_chain_id = l1_provider.get_chain_id().await?;
             let network_id = P2pNetworkId::new(l1_chain_id, self.portal_address);
             let attestation_domain = AttestationDomain {
                 l1_chain_id,
@@ -660,7 +658,8 @@ where
                             .await?
                             .erased();
                     if !provider.client().is_local()
-                        && let Some(avg_block_time) = l1_chain.average_blocktime_hint()
+                        && let Some(avg_block_time) =
+                            Chain::from_id(l1_chain_id).average_blocktime_hint()
                     {
                         provider
                             .client()
@@ -782,7 +781,6 @@ where
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.portal_address,
                     self.l1_config.retry_connection_interval,
-                    l1_chain,
                     attestation.store.clone(),
                     prover_config.clone(),
                 )?),
@@ -834,7 +832,6 @@ where
                 self.l1_config.l1_rpc_url,
                 self.l1_config.portal_address,
                 self.l1_config.retry_connection_interval,
-                l1_chain,
                 sequencer_addr,
                 None,
                 prover_config,
@@ -1111,14 +1108,12 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
-        l1_chain: Chain,
         attestation_store: AttestationStore,
         prover_config: Option<ShadowProverConfig>,
     ) -> eyre::Result<LeaderSequencerDeps> {
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
-            l1_chain,
             retry_connection_interval,
             zone_poll_interval: config.zone_poll_interval,
             withdrawal_poll_interval: config.withdrawal_poll_interval,
@@ -1321,7 +1316,6 @@ where
         l1_rpc_url: String,
         portal_address: Address,
         retry_connection_interval: Duration,
-        l1_chain: Chain,
         sequencer_addr: Address,
         attestation_store: Option<AttestationStore>,
         prover_config: Option<ShadowProverConfig>,
@@ -1330,7 +1324,6 @@ where
         let sequencer_config = ZoneSequencerConfig {
             portal_address,
             l1_rpc_url,
-            l1_chain,
             retry_connection_interval,
             zone_poll_interval: config.zone_poll_interval,
             withdrawal_poll_interval: config.withdrawal_poll_interval,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3410,7 +3410,6 @@ pub(crate) async fn spawn_sequencer_with_config(
     let config = zone_sequencer::ZoneSequencerConfig {
         portal_address,
         l1_rpc_url: l1.http_url().to_string(),
-        l1_chain: alloy_chains::Chain::tempo_mainnet(),
         retry_connection_interval: Duration::from_millis(100),
         zone_poll_interval: Duration::from_secs(1),
         withdrawal_poll_interval: Duration::from_millis(500),

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3410,6 +3410,7 @@ pub(crate) async fn spawn_sequencer_with_config(
     let config = zone_sequencer::ZoneSequencerConfig {
         portal_address,
         l1_rpc_url: l1.http_url().to_string(),
+        l1_chain: alloy_chains::NamedChain::Tempo,
         retry_connection_interval: Duration::from_millis(100),
         zone_poll_interval: Duration::from_secs(1),
         withdrawal_poll_interval: Duration::from_millis(500),

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3410,7 +3410,7 @@ pub(crate) async fn spawn_sequencer_with_config(
     let config = zone_sequencer::ZoneSequencerConfig {
         portal_address,
         l1_rpc_url: l1.http_url().to_string(),
-        l1_chain: alloy_chains::NamedChain::Tempo,
+        l1_chain: alloy_chains::Chain::tempo_mainnet(),
         retry_connection_interval: Duration::from_millis(100),
         zone_poll_interval: Duration::from_secs(1),
         withdrawal_poll_interval: Duration::from_millis(500),

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -28,6 +28,7 @@ reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 
 # alloy
+alloy-chains.workspace = true
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-network.workspace = true

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -256,37 +256,10 @@ mod tests {
     };
     use tokio_tungstenite::{accept_async, tungstenite::Message};
 
-    #[test]
-    fn chain_metadata_sets_remote_poll_interval() {
-        let client = alloy_rpc_client::RpcClient::new(
-            alloy_transport::mock::MockTransport::new(alloy_transport::mock::Asserter::new()),
-            false,
-        );
-        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .with_nonce_key_filler()
-            .wallet(alloy_network::EthereumWallet::from(
-                PrivateKeySigner::random(),
-            ))
-            .connect_client(client);
-        let l1_chain = Chain::from_id(42431);
-        if !provider.client().is_local()
-            && let Some(avg_block_time) = l1_chain.average_blocktime_hint()
-        {
-            provider
-                .client()
-                .set_poll_interval(avg_block_time.mul_f32(0.6));
-        }
-
-        assert_eq!(
-            provider.client().poll_interval(),
-            Duration::from_millis(300)
-        );
-    }
-
-    async fn serve_l1_rpc(
+    async fn serve_block_number(
         stream: TcpStream,
-        block_number: &'static str,
-        close_after_block_number: bool,
+        result: &'static str,
+        close_after_response: bool,
     ) {
         let mut ws = accept_async(stream).await.unwrap();
         while let Some(message) = ws.next().await {
@@ -295,22 +268,22 @@ mod tests {
                 continue;
             };
             let request: Value = serde_json::from_str(&text).unwrap();
-            let result = match request["method"].as_str() {
+            let rpc_result = match request["method"].as_str() {
                 Some("eth_chainId") => "0xa5bf",
-                Some("eth_blockNumber") => block_number,
+                Some("eth_blockNumber") => result,
                 _ => continue,
             };
 
             let response = json!({
                 "jsonrpc": "2.0",
                 "id": request["id"].clone(),
-                "result": result,
+                "result": rpc_result,
             });
             ws.send(Message::Text(response.to_string().into()))
                 .await
                 .unwrap();
 
-            if close_after_block_number && request["method"] == "eth_blockNumber" {
+            if close_after_response && request["method"] == "eth_blockNumber" {
                 let _ = ws.close(None).await;
                 break;
             }
@@ -335,14 +308,14 @@ mod tests {
             // listener comes back; Alloy's default 3s interval would miss the
             // test timeout.
             drop(listener);
-            serve_l1_rpc(first_stream, "0x1", true).await;
+            serve_block_number(first_stream, "0x1", true).await;
 
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             let listener = TcpListener::bind(addr).await.unwrap();
             let (second_stream, _) = listener.accept().await.unwrap();
             server_connections.fetch_add(1, Ordering::SeqCst);
-            serve_l1_rpc(second_stream, "0x2", false).await;
+            serve_block_number(second_stream, "0x2", false).await;
         });
 
         let provider =

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -94,8 +94,6 @@ pub struct ZoneSequencerConfig {
     pub portal_address: Address,
     /// Tempo L1 RPC URL.
     pub l1_rpc_url: String,
-    /// Resolved Tempo L1 chain used to configure chain-aware provider behavior.
-    pub l1_chain: Chain,
     /// Interval between WebSocket reconnection attempts for long-lived RPC clients.
     pub retry_connection_interval: Duration,
     /// Fallback interval for reconciling the canonical Zone head.
@@ -153,7 +151,6 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     // processor use this provider, ensuring nonces are tracked in one place.
     let l1_provider = connect_l1_provider(
         &config.l1_rpc_url,
-        config.l1_chain,
         config.retry_connection_interval,
         signer.clone(),
     )
@@ -221,7 +218,6 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
 /// Build the shared L1 provider used by all sequencer-side L1 transaction tasks.
 async fn connect_l1_provider(
     l1_rpc_url: &str,
-    l1_chain: Chain,
     retry_connection_interval: Duration,
     signer: PrivateKeySigner,
 ) -> TransportResult<DynProvider<TempoNetwork>> {
@@ -232,6 +228,7 @@ async fn connect_l1_provider(
         .connect_with_config(l1_rpc_url, rpc_connection_config(retry_connection_interval))
         .await?
         .erased();
+    let l1_chain = Chain::from_id(provider.get_chain_id().await?);
     if !provider.client().is_local()
         && let Some(avg_block_time) = l1_chain.average_blocktime_hint()
     {
@@ -286,10 +283,10 @@ mod tests {
         );
     }
 
-    async fn serve_block_number(
+    async fn serve_l1_rpc(
         stream: TcpStream,
-        result: &'static str,
-        close_after_response: bool,
+        block_number: &'static str,
+        close_after_block_number: bool,
     ) {
         let mut ws = accept_async(stream).await.unwrap();
         while let Some(message) = ws.next().await {
@@ -298,9 +295,11 @@ mod tests {
                 continue;
             };
             let request: Value = serde_json::from_str(&text).unwrap();
-            if request["method"] != "eth_blockNumber" {
-                continue;
-            }
+            let result = match request["method"].as_str() {
+                Some("eth_chainId") => "0xa5bf",
+                Some("eth_blockNumber") => block_number,
+                _ => continue,
+            };
 
             let response = json!({
                 "jsonrpc": "2.0",
@@ -311,7 +310,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            if close_after_response {
+            if close_after_block_number && request["method"] == "eth_blockNumber" {
                 let _ = ws.close(None).await;
                 break;
             }
@@ -336,24 +335,20 @@ mod tests {
             // listener comes back; Alloy's default 3s interval would miss the
             // test timeout.
             drop(listener);
-            serve_block_number(first_stream, "0x1", true).await;
+            serve_l1_rpc(first_stream, "0x1", true).await;
 
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             let listener = TcpListener::bind(addr).await.unwrap();
             let (second_stream, _) = listener.accept().await.unwrap();
             server_connections.fetch_add(1, Ordering::SeqCst);
-            serve_block_number(second_stream, "0x2", false).await;
+            serve_l1_rpc(second_stream, "0x2", false).await;
         });
 
-        let provider = connect_l1_provider(
-            &url,
-            Chain::from_id(42431),
-            Duration::from_millis(10),
-            PrivateKeySigner::random(),
-        )
-        .await
-        .unwrap();
+        let provider =
+            connect_l1_provider(&url, Duration::from_millis(10), PrivateKeySigner::random())
+                .await
+                .unwrap();
 
         assert_eq!(provider.get_block_number().await.unwrap(), 1);
         assert_eq!(

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use alloy_chains::NamedChain;
 use alloy_primitives::Address;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
@@ -93,6 +94,8 @@ pub struct ZoneSequencerConfig {
     pub portal_address: Address,
     /// Tempo L1 RPC URL.
     pub l1_rpc_url: String,
+    /// Resolved Tempo L1 chain used to configure chain-aware provider behavior.
+    pub l1_chain: NamedChain,
     /// Interval between WebSocket reconnection attempts for long-lived RPC clients.
     pub retry_connection_interval: Duration,
     /// Fallback interval for reconciling the canonical Zone head.
@@ -150,6 +153,7 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     // processor use this provider, ensuring nonces are tracked in one place.
     let l1_provider = connect_l1_provider(
         &config.l1_rpc_url,
+        config.l1_chain,
         config.retry_connection_interval,
         signer.clone(),
     )
@@ -217,12 +221,14 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
 /// Build the shared L1 provider used by all sequencer-side L1 transaction tasks.
 async fn connect_l1_provider(
     l1_rpc_url: &str,
+    l1_chain: NamedChain,
     retry_connection_interval: Duration,
     signer: PrivateKeySigner,
 ) -> TransportResult<DynProvider<TempoNetwork>> {
     let wallet = alloy_network::EthereumWallet::from(signer);
     let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
         .with_nonce_key_filler()
+        .with_chain(l1_chain)
         .wallet(wallet)
         .connect_with_config(l1_rpc_url, rpc_connection_config(retry_connection_interval))
         .await?
@@ -246,6 +252,26 @@ mod tests {
         time::{Duration, timeout},
     };
     use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    #[test]
+    fn chain_metadata_sets_remote_poll_interval() {
+        let client = alloy_rpc_client::RpcClient::new(
+            alloy_transport::mock::MockTransport::new(alloy_transport::mock::Asserter::new()),
+            false,
+        );
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .with_nonce_key_filler()
+            .with_chain(NamedChain::TempoModerato)
+            .wallet(alloy_network::EthereumWallet::from(
+                PrivateKeySigner::random(),
+            ))
+            .connect_client(client);
+
+        assert_eq!(
+            provider.client().poll_interval(),
+            Duration::from_millis(300)
+        );
+    }
 
     async fn serve_block_number(
         stream: TcpStream,
@@ -307,12 +333,21 @@ mod tests {
             serve_block_number(second_stream, "0x2", false).await;
         });
 
-        let provider =
-            connect_l1_provider(&url, Duration::from_millis(10), PrivateKeySigner::random())
-                .await
-                .unwrap();
+        let provider = connect_l1_provider(
+            &url,
+            NamedChain::TempoModerato,
+            Duration::from_millis(10),
+            PrivateKeySigner::random(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(provider.get_block_number().await.unwrap(), 1);
+        assert_eq!(
+            provider.client().poll_interval(),
+            Duration::from_millis(250),
+            "chain metadata must not override Alloy's local transport interval"
+        );
 
         let second_block = timeout(Duration::from_secs(2), provider.get_block_number())
             .await

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -5,7 +5,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_chains::NamedChain;
+use alloy_chains::Chain;
 use alloy_primitives::Address;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
@@ -95,7 +95,7 @@ pub struct ZoneSequencerConfig {
     /// Tempo L1 RPC URL.
     pub l1_rpc_url: String,
     /// Resolved Tempo L1 chain used to configure chain-aware provider behavior.
-    pub l1_chain: NamedChain,
+    pub l1_chain: Chain,
     /// Interval between WebSocket reconnection attempts for long-lived RPC clients.
     pub retry_connection_interval: Duration,
     /// Fallback interval for reconciling the canonical Zone head.
@@ -221,18 +221,24 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
 /// Build the shared L1 provider used by all sequencer-side L1 transaction tasks.
 async fn connect_l1_provider(
     l1_rpc_url: &str,
-    l1_chain: NamedChain,
+    l1_chain: Chain,
     retry_connection_interval: Duration,
     signer: PrivateKeySigner,
 ) -> TransportResult<DynProvider<TempoNetwork>> {
     let wallet = alloy_network::EthereumWallet::from(signer);
     let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
         .with_nonce_key_filler()
-        .with_chain(l1_chain)
         .wallet(wallet)
         .connect_with_config(l1_rpc_url, rpc_connection_config(retry_connection_interval))
         .await?
         .erased();
+    if !provider.client().is_local()
+        && let Some(avg_block_time) = l1_chain.average_blocktime_hint()
+    {
+        provider
+            .client()
+            .set_poll_interval(avg_block_time.mul_f32(0.6));
+    }
 
     Ok(provider)
 }
@@ -261,11 +267,18 @@ mod tests {
         );
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .with_nonce_key_filler()
-            .with_chain(NamedChain::TempoModerato)
             .wallet(alloy_network::EthereumWallet::from(
                 PrivateKeySigner::random(),
             ))
             .connect_client(client);
+        let l1_chain = Chain::from_id(42431);
+        if !provider.client().is_local()
+            && let Some(avg_block_time) = l1_chain.average_blocktime_hint()
+        {
+            provider
+                .client()
+                .set_poll_interval(avg_block_time.mul_f32(0.6));
+        }
 
         assert_eq!(
             provider.client().poll_interval(),
@@ -335,7 +348,7 @@ mod tests {
 
         let provider = connect_l1_provider(
             &url,
-            NamedChain::TempoModerato,
+            Chain::from_id(42431),
             Duration::from_millis(10),
             PrivateKeySigner::random(),
         )


### PR DESCRIPTION
## Summary

- Resolve the parent Tempo L1 chain from `eth_chainId` while constructing wallet-backed providers.
- Keep sequencer chain discovery inside `connect_l1_provider` instead of threading metadata through `ZoneSequencerConfig`.
- Derive remote polling cadence from the registered chain block-time hint while preserving Alloy’s local-transport behavior.

## Why

The transaction filler resolves `eth_chainId` for signing, but that does not configure the provider client polling interval. As a result, wallet-backed providers connected through remote Tempo RPC hostnames retain Alloy’s generic 7-second polling interval for pending-transaction receipt fallback.

After connecting, the sequencer provider queries its own chain ID and wraps it in `alloy_chains::Chain`. Registered Tempo chains expose a 500 ms block-time hint, producing a 300 ms poll interval for remote endpoints, while local endpoints keep Alloy’s faster local default.