### PR TITLE
feat(sequencer): more prover metrics

### DIFF
--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -9,8 +9,23 @@ use reth_metrics::{
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_zone_prover")]
 pub(crate) struct ProverMetrics {
-    /// End-to-end latency of a shadow prover validation attempt in seconds.
+    /// End-to-end latency of a prover validation attempt in seconds.
     pub(crate) validation_duration_seconds: Histogram,
+
+    /// Number of finalized batch candidates that failed prover validation.
+    pub(crate) validation_failure_total: Counter,
+
+    /// Number of finalized batch candidates that passed prover validation.
+    pub(crate) validation_success_total: Counter,
+
+    /// Encoded witness size for a successfully validated batch candidate.
+    pub(crate) witness_bytes: Histogram,
+
+    /// Number of Zone state trie nodes in a successfully validated batch witness.
+    pub(crate) zone_state_nodes: Histogram,
+
+    /// Number of Tempo state trie nodes in a successfully validated batch witness.
+    pub(crate) tempo_state_nodes: Histogram,
 }
 
 /// Metrics emitted by the withdrawal processor.

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -135,6 +135,14 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                 .record(started.elapsed().as_secs_f64());
             match result {
                 Ok(stats) => {
+                    metrics.validation_success_total.increment(1);
+                    metrics.witness_bytes.record(stats.witness_bytes as f64);
+                    metrics
+                        .zone_state_nodes
+                        .record(stats.zone_state_nodes as f64);
+                    metrics
+                        .tempo_state_nodes
+                        .record(stats.tempo_state_nodes as f64);
                     info!(
                         target: "zone::sequencer::prover",
                         zone_from = job.from,
@@ -149,6 +157,7 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                     );
                 }
                 Err(err) => {
+                    metrics.validation_failure_total.increment(1);
                     error!(
                         target: "zone::sequencer::prover",
                         zone_from = job.from,


### PR DESCRIPTION
## Summary

- expose shadow-prover validation success and failure counters
- record successful-validation histograms for witness bytes, Zone state nodes, and Tempo state nodes

## Validation

- `cargo +nightly fmt --check`
- `cargo check -p zone-sequencer`
- `cargo +nightly clippy -p zone-sequencer --lib`

Prompted by: @shekhirin