### PR TITLE
docs: document FIFO key support

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -363,7 +363,7 @@ pub struct ZoneArgs {
     )]
     pub sequencer_manifest: Option<PathBuf>,
 
-    /// Path to this node's hex-encoded Ed25519 P2P identity key.
+    /// Path to a file or FIFO containing this node's hex-encoded Ed25519 P2P identity key.
     #[arg(
         long = "p2p.key",
         env = "P2P_KEY",
@@ -372,7 +372,7 @@ pub struct ZoneArgs {
     )]
     pub p2p_key: Option<PathBuf>,
 
-    /// Path to this node's hex-encoded individual secp256k1 private key.
+    /// Path to a file or FIFO containing this node's hex-encoded individual secp256k1 private key.
     #[arg(
         long = "secp256k1.key",
         env = "SECP256K1_KEY",

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -178,6 +178,8 @@ Add these arguments to the node's normal command:
 
 Use each node's own key files and listener address. Quorum followers use their individual
 secp256k1 keys to sign settlement attestations after importing and validating blocks.
+The paths supplied through `--p2p.key`, `--secp256k1.key`, and `--sequencer-key-file` may point
+to either regular files or FIFOs.
 
 An rpc-follower is started with **neither** key: it omits `--secp256k1.key` (it never signs an
 attestation) and `--sequencer-key`/`--sequencer-key-file` (it never produces a block). The shared


### PR DESCRIPTION
## Summary

- document FIFO support in the Ed25519 and secp256k1 CLI key-path help
- clarify in the P2P README that all three key paths accept files or FIFOs
- make no runtime behavior changes

## Validation

- `cargo +nightly fmt --check`
- `git diff --check`

Prompted by: aditya