### PR TITLE
fix(xtask): register encryption key during zone creation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -169,7 +169,7 @@ create-zone name token="" access_enforced="false" gateway_enforced="false":
     for gateway in "${GATEWAYS[@]}"; do
         [[ -n "$gateway" ]] && CREATE_ARGS+=(--zone-gateway "$gateway")
     done
-    ZONE_FACTORY_OWNER_KEY="$PK" cargo run -p tempo-xtask -- create-zone \
+    ZONE_FACTORY_OWNER_KEY="$PK" SEQUENCER_KEY="$SEQ_KEY" cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
@@ -833,7 +833,7 @@ deploy-zone name token="" access_enforced="false" gateway_enforced="false":
     for gateway in "${GATEWAYS[@]}"; do
         [[ -n "$gateway" ]] && CREATE_ARGS+=(--zone-gateway "$gateway")
     done
-    ZONE_FACTORY_OWNER_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- create-zone \
+    ZONE_FACTORY_OWNER_KEY="$SEQUENCER_KEY" SEQUENCER_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- create-zone \
         --output "$OUTPUT" \
         --l1-rpc-url "$HTTP_RPC" \
         --initial-token "$ZONE_TOKEN_L1" \
@@ -857,14 +857,7 @@ deploy-zone name token="" access_enforced="false" gateway_enforced="false":
     ZONE_ID=$(jq -r '.zoneId' "$OUTPUT/zone.json")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$OUTPUT/zone.json")
 
-    # Step 5: Register sequencer encryption key on the portal
-    echo "Step 5: Registering sequencer encryption key on ZonePortal..."
-    PRIVATE_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
-        --l1-rpc-url "$HTTP_RPC" \
-        --portal "$PORTAL"
-    echo ""
-
-    # Step 6: Display summary
+    # Step 5: Display summary
     echo "============================================"
     echo "  Zone Deployed Successfully!"
     echo "============================================"

--- a/crates/sequencer/src/encryption_key.rs
+++ b/crates/sequencer/src/encryption_key.rs
@@ -54,16 +54,18 @@ pub fn prove_encryption_key_possession(
     })
 }
 
-/// Registers `signer` as the sequencer encryption key on `portal`.
+/// Registers `encryption_signer` as the sequencer encryption key on `portal`.
 ///
 /// Derives the secp256k1 public key, signs a proof-of-possession over
-/// `(portal, x, yParity)`, and returns the registration transaction hash.
+/// `(portal, x, yParity)`, and returns the registration transaction hash. The provider must use
+/// the portal admin or an active sequencer as its transaction signer; that signer may differ from
+/// the shared encryption key in a multi-sequencer deployment.
 pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
     provider: &P,
     portal: Address,
-    signer: &PrivateKeySigner,
+    encryption_signer: &PrivateKeySigner,
 ) -> eyre::Result<B256> {
-    let proof = prove_encryption_key_possession(portal, signer)?;
+    let proof = prove_encryption_key_possession(portal, encryption_signer)?;
     let receipt = ZonePortal::new(portal, provider)
         .setSequencerEncryptionKey(
             proof.x,

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -194,7 +194,8 @@ You can also run the xtask directly for more control. Set `ZONE_FACTORY_OWNER_KE
 invocation instead of passing a key argument:
 
 ```bash
-ZONE_FACTORY_OWNER_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- create-zone \
+ZONE_FACTORY_OWNER_KEY="$SEQUENCER_KEY" SEQUENCER_KEY="$SEQUENCER_KEY" \
+  cargo run -p tempo-xtask -- create-zone \
   --output generated/my-zone \
   --initial-token 0x20c0000000000000000000000000000000000001 \
   --admin "$ADMIN_ADDR" \
@@ -203,7 +204,8 @@ ZONE_FACTORY_OWNER_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- create-zone 
 
 `create-zone` requires the admin address explicitly. Keep the matching `ADMIN_KEY`
 available for admin-only portal calls such as changing either mode or account roles,
-enabling tokens, and pausing or resuming deposits.
+enabling tokens, and pausing or resuming deposits. When `SEQUENCER_KEY` is set (or
+`--sequencer-key` is passed), `create-zone` also registers that sequencer's encryption key.
 
 ### 5. Start the Zone Node
 
@@ -262,8 +264,8 @@ just send-deposit 1000000 <recipient-address>   # deposit to a specific address
 Encrypted deposits hide the recipient address and memo on-chain using ECIES encryption to the sequencer's public key. Only the sequencer can decrypt them during block building.
 
 ```bash
-# The sequencer must first register their encryption key (done automatically by deploy-zone)
-# For manual setup:
+# Zone creation registers the initial key automatically when SEQUENCER_KEY is set.
+# Use the standalone command for manual setup or key rotation:
 PRIVATE_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
   --portal "$L1_PORTAL_ADDRESS" \
   --l1-rpc-url "$L1_RPC_URL"

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -206,6 +206,10 @@ ZONE_FACTORY_OWNER_KEY="$SEQUENCER_KEY" SEQUENCER_KEY="$SEQUENCER_KEY" \
 available for admin-only portal calls such as changing either mode or account roles,
 enabling tokens, and pausing or resuming deposits. When `SEQUENCER_KEY` is set (or
 `--sequencer-key` is passed), `create-zone` also registers that sequencer's encryption key.
+For a multi-sequencer zone, also pass `--transaction-private-key` (or set
+`TRANSACTION_PRIVATE_KEY`) to the portal admin or an individual key whose address is in the
+configured sequencer set. The shared `SEQUENCER_KEY` remains the encryption key and does not need
+to be a portal sequencer address.
 
 ### 5. Start the Zone Node
 
@@ -273,6 +277,16 @@ PRIVATE_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
 # Send a deposit
 just send-deposit 1000000                       # to your own address
 just send-deposit 1000000 <recipient-address>   # to a specific address
+```
+
+For a multi-sequencer zone, sign the portal transaction with the admin or one node's individual
+key while using the shared key only for the encryption-key proof of possession:
+
+```bash
+PRIVATE_KEY="$SEQUENCER_KEY" TRANSACTION_PRIVATE_KEY="$TRANSACTION_PRIVATE_KEY" \
+  cargo run -p tempo-xtask -- set-encryption-key \
+  --portal "$L1_PORTAL_ADDRESS" \
+  --l1-rpc-url "$L1_RPC_URL"
 ```
 
 For shared-key rotations, pass the currently deployed
@@ -669,8 +683,9 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `L1_RPC_URL` | Yes | Certified Tempo follower WebSocket RPC URL (`wss://...`) |
-| `SEQUENCER_KEY` | For short-lived tooling | Sequencer private key for `just create-zone` and xtasks; not accepted by the node |
+| `SEQUENCER_KEY` | For short-lived tooling | Shared block-production and ECIES encryption key for `just create-zone` and xtasks; not accepted by the node |
 | `SEQUENCER_KEY_FILE` | For sequencing | Owner-readable file or FIFO containing the sequencer private key |
+| `TRANSACTION_PRIVATE_KEY` | Short-lived multi-sequencer tooling | Portal admin or individual registered sequencer key used to submit encryption-key registration transactions |
 | `DEPOSIT_DECRYPTION_KEYS_FILE` | During encryption-key rotation | Additional historical or pre-provisioned deposit decryption keys, one hex key per line |
 | `ADMIN_KEY` | For portal governance | Portal admin private key for `enableToken` / deposit pause controls. `SEQUENCER_KEY` only works for legacy zones where admin == sequencer. |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -89,10 +89,20 @@ pub(crate) struct CreateZone {
     #[arg(long, env = "ZONE_FACTORY_OWNER_KEY", hide_env_values = true)]
     private_key: String,
 
-    /// Optional sequencer private key (hex). When provided, registers its public key for
-    /// encrypted deposits after creating the zone. The key must belong to the sequencer set.
+    /// Optional shared sequencer private key (hex). When provided, registers its public key for
+    /// encrypted deposits after creating the zone.
     #[arg(long, env = "SEQUENCER_KEY", hide_env_values = true)]
     sequencer_key: Option<String>,
+
+    /// Optional portal admin or active sequencer private key that sends the encryption-key
+    /// registration transaction. Defaults to the encryption key when it has either role.
+    #[arg(
+        long,
+        env = "TRANSACTION_PRIVATE_KEY",
+        hide_env_values = true,
+        requires = "sequencer_key"
+    )]
+    transaction_private_key: Option<String>,
 
     /// Base fee per gas for the zone L2.
     #[arg(long, default_value_t = TEMPO_T0_BASE_FEE.into())]
@@ -148,8 +158,12 @@ impl CreateZone {
             ));
         }
 
-        let sequencer_signer =
-            parse_sequencer_key(self.sequencer_key.as_deref(), &self.sequencers)?;
+        let encryption_key_registration = parse_encryption_key_registration(
+            self.sequencer_key.as_deref(),
+            self.transaction_private_key.as_deref(),
+            self.admin,
+            &self.sequencers,
+        )?;
         if self.sequencers.len() > 1 && self.threshold < 2 {
             // With threshold 1 a leader can settle blocks no follower holds, so an
             // empty-disk leader recovery cannot reconstruct the settled chain from
@@ -352,14 +366,14 @@ impl CreateZone {
         )
         .wrap_err("failed writing zone.json")?;
 
-        if let Some(signer) = sequencer_signer {
+        if let Some((encryption_signer, portal_signer)) = encryption_key_registration {
             let sequencer_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-                .wallet(EthereumWallet::from(signer.clone()))
+                .wallet(EthereumWallet::from(portal_signer))
                 .connect(&self.l1_rpc_url)
                 .await
                 .wrap_err("failed connecting to Tempo L1 RPC for encryption-key registration")?;
             println!("Registering sequencer encryption key on ZonePortal...");
-            let tx_hash = register_encryption_key(&sequencer_provider, portal, &signer)
+            let tx_hash = register_encryption_key(&sequencer_provider, portal, &encryption_signer)
                 .await
                 .wrap_err("failed to register sequencer encryption key")?;
             println!("Encryption key registered  [tx: {tx_hash}]");
@@ -399,18 +413,35 @@ fn parse_private_key(key: &str) -> eyre::Result<PrivateKeySigner> {
         .map_err(Into::into)
 }
 
-fn parse_sequencer_key(
-    key: Option<&str>,
+fn parse_encryption_key_registration(
+    encryption_key: Option<&str>,
+    transaction_private_key: Option<&str>,
+    admin: Address,
     sequencers: &[Address],
-) -> eyre::Result<Option<PrivateKeySigner>> {
-    let Some(key) = key else { return Ok(None) };
-    let signer = parse_private_key(key).wrap_err("SEQUENCER_KEY is not a valid private key")?;
+) -> eyre::Result<Option<(PrivateKeySigner, PrivateKeySigner)>> {
+    let Some(encryption_key) = encryption_key else {
+        ensure!(
+            transaction_private_key.is_none(),
+            "TRANSACTION_PRIVATE_KEY requires SEQUENCER_KEY"
+        );
+        return Ok(None);
+    };
+    let encryption_signer =
+        parse_private_key(encryption_key).wrap_err("SEQUENCER_KEY is not a valid private key")?;
+    let (portal_signer, portal_signer_source) = match transaction_private_key {
+        Some(key) => (
+            parse_private_key(key)
+                .wrap_err("TRANSACTION_PRIVATE_KEY is not a valid private key")?,
+            "TRANSACTION_PRIVATE_KEY",
+        ),
+        None => (encryption_signer.clone(), "SEQUENCER_KEY"),
+    };
     ensure!(
-        sequencers.contains(&signer.address()),
-        "SEQUENCER_KEY resolves to {}, but that address is not in the configured sequencer set",
-        signer.address()
+        portal_signer.address() == admin || sequencers.contains(&portal_signer.address()),
+        "{portal_signer_source} resolves to {}, but that address is neither the portal admin nor in the configured sequencer set; set TRANSACTION_PRIVATE_KEY to an authorized portal signer",
+        portal_signer.address(),
     );
-    Ok(Some(signer))
+    Ok(Some((encryption_signer, portal_signer)))
 }
 
 #[cfg(test)]
@@ -439,6 +470,7 @@ mod tests {
             rpc_url: String::new(),
             private_key: String::new(),
             sequencer_key: None,
+            transaction_private_key: None,
             base_fee_per_gas: 1,
             gas_limit: 30_000_000,
         };
@@ -449,18 +481,59 @@ mod tests {
     }
 
     #[test]
-    fn accepts_encryption_key_in_the_sequencer_set() {
+    fn defaults_portal_signer_to_encryption_key() {
         let key = "0000000000000000000000000000000000000000000000000000000000000001";
         let signer = parse_private_key(key).unwrap();
-        let parsed = parse_sequencer_key(Some(key), &[signer.address()]).unwrap();
+        let (encryption_signer, portal_signer) =
+            parse_encryption_key_registration(Some(key), None, Address::ZERO, &[signer.address()])
+                .unwrap()
+                .unwrap();
 
-        assert_eq!(parsed.unwrap().address(), signer.address());
+        assert_eq!(encryption_signer.address(), signer.address());
+        assert_eq!(portal_signer.address(), signer.address());
     }
 
     #[test]
-    fn rejects_encryption_key_outside_the_sequencer_set() {
-        let error = parse_sequencer_key(
+    fn supports_distinct_encryption_and_portal_signers() {
+        let encryption_key = "0000000000000000000000000000000000000000000000000000000000000001";
+        let portal_key = "0000000000000000000000000000000000000000000000000000000000000002";
+        let portal_signer = parse_private_key(portal_key).unwrap();
+        let (encryption_signer, parsed_portal_signer) = parse_encryption_key_registration(
+            Some(encryption_key),
+            Some(portal_key),
+            Address::ZERO,
+            &[portal_signer.address()],
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_ne!(encryption_signer.address(), portal_signer.address());
+        assert_eq!(parsed_portal_signer.address(), portal_signer.address());
+    }
+
+    #[test]
+    fn accepts_portal_admin_as_transaction_signer() {
+        let encryption_key = "0000000000000000000000000000000000000000000000000000000000000001";
+        let admin_key = "0000000000000000000000000000000000000000000000000000000000000002";
+        let admin = parse_private_key(admin_key).unwrap();
+        let (_, portal_signer) = parse_encryption_key_registration(
+            Some(encryption_key),
+            Some(admin_key),
+            admin.address(),
+            &[address!("0x2000000000000000000000000000000000000002")],
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(portal_signer.address(), admin.address());
+    }
+
+    #[test]
+    fn rejects_portal_signer_outside_the_sequencer_set() {
+        let error = parse_encryption_key_registration(
             Some("0000000000000000000000000000000000000000000000000000000000000001"),
+            Some("0000000000000000000000000000000000000000000000000000000000000002"),
+            address!("0x3000000000000000000000000000000000000003"),
             &[address!("0x2000000000000000000000000000000000000002")],
         )
         .unwrap_err();
@@ -468,7 +541,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("is not in the configured sequencer set")
+                .contains("TRANSACTION_PRIVATE_KEY resolves to")
         );
     }
 }

--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -21,6 +21,7 @@ use tempo_zone_contracts::{
     ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactory, ZonePortal,
 };
 use zone_primitives::constants::zone_chain_id;
+use zone_sequencer::register_encryption_key;
 
 use crate::zone_utils::{MODERATO_ZONE_FACTORY, write_owner_only};
 
@@ -88,6 +89,11 @@ pub(crate) struct CreateZone {
     #[arg(long, env = "ZONE_FACTORY_OWNER_KEY", hide_env_values = true)]
     private_key: String,
 
+    /// Optional sequencer private key (hex). When provided, registers its public key for
+    /// encrypted deposits after creating the zone. The key must belong to the sequencer set.
+    #[arg(long, env = "SEQUENCER_KEY", hide_env_values = true)]
+    sequencer_key: Option<String>,
+
     /// Base fee per gas for the zone L2.
     #[arg(long, default_value_t = TEMPO_T0_BASE_FEE.into())]
     base_fee_per_gas: u128,
@@ -141,6 +147,9 @@ impl CreateZone {
                 self.threshold
             ));
         }
+
+        let sequencer_signer =
+            parse_sequencer_key(self.sequencer_key.as_deref(), &self.sequencers)?;
         if self.sequencers.len() > 1 && self.threshold < 2 {
             // With threshold 1 a leader can settle blocks no follower holds, so an
             // empty-disk leader recovery cannot reconstruct the settled chain from
@@ -343,6 +352,19 @@ impl CreateZone {
         )
         .wrap_err("failed writing zone.json")?;
 
+        if let Some(signer) = sequencer_signer {
+            let sequencer_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+                .wallet(EthereumWallet::from(signer.clone()))
+                .connect(&self.l1_rpc_url)
+                .await
+                .wrap_err("failed connecting to Tempo L1 RPC for encryption-key registration")?;
+            println!("Registering sequencer encryption key on ZonePortal...");
+            let tx_hash = register_encryption_key(&sequencer_provider, portal, &signer)
+                .await
+                .wrap_err("failed to register sequencer encryption key")?;
+            println!("Encryption key registered  [tx: {tx_hash}]");
+        }
+
         println!("Zone created successfully!");
         println!("  Zone ID: {zone_id}");
         println!("  Chain ID: {chain_id}");
@@ -370,6 +392,27 @@ impl CreateZone {
     }
 }
 
+fn parse_private_key(key: &str) -> eyre::Result<PrivateKeySigner> {
+    key.strip_prefix("0x")
+        .unwrap_or(key)
+        .parse()
+        .map_err(Into::into)
+}
+
+fn parse_sequencer_key(
+    key: Option<&str>,
+    sequencers: &[Address],
+) -> eyre::Result<Option<PrivateKeySigner>> {
+    let Some(key) = key else { return Ok(None) };
+    let signer = parse_private_key(key).wrap_err("SEQUENCER_KEY is not a valid private key")?;
+    ensure!(
+        sequencers.contains(&signer.address()),
+        "SEQUENCER_KEY resolves to {}, but that address is not in the configured sequencer set",
+        signer.address()
+    );
+    Ok(Some(signer))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -395,6 +438,7 @@ mod tests {
             admin: address!("0x5000000000000000000000000000000000000005"),
             rpc_url: String::new(),
             private_key: String::new(),
+            sequencer_key: None,
             base_fee_per_gas: 1,
             gas_limit: 30_000_000,
         };
@@ -402,5 +446,29 @@ mod tests {
         let params = command.factory_params();
         assert_eq!(params.sequencers, sequencers);
         assert_eq!(params.threshold, 2);
+    }
+
+    #[test]
+    fn accepts_encryption_key_in_the_sequencer_set() {
+        let key = "0000000000000000000000000000000000000000000000000000000000000001";
+        let signer = parse_private_key(key).unwrap();
+        let parsed = parse_sequencer_key(Some(key), &[signer.address()]).unwrap();
+
+        assert_eq!(parsed.unwrap().address(), signer.address());
+    }
+
+    #[test]
+    fn rejects_encryption_key_outside_the_sequencer_set() {
+        let error = parse_sequencer_key(
+            Some("0000000000000000000000000000000000000000000000000000000000000001"),
+            &[address!("0x2000000000000000000000000000000000000002")],
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("is not in the configured sequencer set")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- let `create-zone` accept the shared encryption key through `--sequencer-key` / `SEQUENCER_KEY`
- optionally accept `--transaction-private-key` / `TRANSACTION_PRIVATE_KEY` for the portal admin or an individual registered sequencer that submits the registration transaction, matching current Portal authorization
- validate the portal transaction signer is authorized before creating the zone
- keep the single-sequencer flow backward compatible by using the encryption key for both roles when no separate transaction signer is supplied
- update zone creation, deployment recipes, and operator documentation

## Why

The deployment docs say encryption-key setup is automatic, but `create-zone` did not call the existing registration flow. This left manual zone creation unable to accept encrypted deposits until operators ran a separate command.

Multi-sequencer deployments also separate the shared block-production/ECIES key from the individual portal transaction keys. The integrated flow therefore must use an authorized Portal signer for the transaction while using the shared key only for the encryption-key proof of possession.

Context: https://tempoxyz.slack.com/archives/C0AC9PZN01M/p1786376505866099?thread_ts=1786357372.481179&cid=C0AC9PZN01M

## Validation

- `rustup run nightly cargo fmt --check`
- `rustup run nightly cargo test -p tempo-xtask` (48 passed)
- `rustup run nightly cargo test -p zone-sequencer encryption_key` (1 passed)
- `rustup run nightly cargo clippy -p tempo-xtask --all-targets -- -D warnings`
- `git diff --check`

`just` is not installed in the local environment, so the recipe changes were inspected but not executed locally.