### PR TITLE
feat(sequencer): expose PathUSD balance metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13958,6 +13958,7 @@ dependencies = [
  "serde_json",
  "tempo-alloy",
  "tempo-chainspec",
+ "tempo-contracts",
  "tempo-primitives",
  "tempo-zone-contracts",
  "tokio",

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # tempo
 tempo-alloy.workspace = true
 tempo-chainspec.workspace = true
+tempo-contracts.workspace = true
 tempo-primitives.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
 zone-evm.workspace = true

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -5,6 +5,14 @@ use reth_metrics::{
     metrics::{Counter, Gauge, Histogram},
 };
 
+/// Metrics emitted for the sequencer account.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "tempo_zone_sequencer")]
+pub(crate) struct SequencerMetrics {
+    /// Current PathUSD balance of the sequencer account on Tempo L1, in base units.
+    pub(crate) pathusd_balance: Gauge,
+}
+
 /// Metrics emitted by the prover.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_zone_prover")]

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -361,7 +361,7 @@ impl WithdrawalProcessor {
                 error!(error = %e, "Withdrawal processing cycle failed");
             }
 
-            if let Err(error) = self.refresh_sequencer_pathusd_balance().await {
+            if let Err(error) = self.update_sequencer_metrics().await {
                 warn!(
                     %error,
                     sequencer = %self.config.sequencer_address,
@@ -371,8 +371,8 @@ impl WithdrawalProcessor {
         }
     }
 
-    /// Refresh the sequencer's Tempo L1 PathUSD balance metric.
-    async fn refresh_sequencer_pathusd_balance(&self) -> eyre::Result<()> {
+    /// Update sequencer metrics from Tempo L1 state.
+    async fn update_sequencer_metrics(&self) -> eyre::Result<()> {
         let balance = ITIP20::new(PATH_USD_ADDRESS, &self.provider)
             .balanceOf(self.config.sequencer_address)
             .call()

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -1151,21 +1151,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refreshes_sequencer_pathusd_balance() {
-        let l1 = Asserter::new();
-        l1.push_success(&abi_encode_u64(1_500_000));
-        let processor = test_processor(
-            l1.clone(),
-            SharedWithdrawalStore::new(),
-            Arc::new(Notify::new()),
-        );
-
-        processor.refresh_sequencer_pathusd_balance().await.unwrap();
-
-        assert!(l1.read_q().is_empty());
-    }
-
-    #[tokio::test]
     async fn process_queue_requests_repair_when_store_data_mismatches_slot_hash() {
         let l1 = Asserter::new();
         // head = 5, tail = 6, slot hash that matches no suffix of the stored batch.

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -357,16 +357,16 @@ impl WithdrawalProcessor {
                 }
             }
 
+            if let Err(e) = self.process_queue().await {
+                error!(error = %e, "Withdrawal processing cycle failed");
+            }
+
             if let Err(error) = self.refresh_sequencer_pathusd_balance().await {
                 warn!(
                     %error,
                     sequencer = %self.config.sequencer_address,
                     "Failed to refresh sequencer PathUSD balance metric"
                 );
-            }
-
-            if let Err(e) = self.process_queue().await {
-                error!(error = %e, "Withdrawal processing cycle failed");
             }
         }
     }

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -37,12 +37,13 @@ use alloy_provider::{DynProvider, Provider};
 use futures::{StreamExt, stream::FuturesUnordered};
 use parking_lot::Mutex;
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderExt};
+use tempo_contracts::precompiles::{ITIP20, PATH_USD_ADDRESS};
 use tokio::sync::Notify;
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::{
     abi::{self, EMPTY_SENTINEL, MAX_WITHDRAWAL_GAS_LIMIT, ZonePortal},
-    metrics::WithdrawalProcessorMetrics,
+    metrics::{SequencerMetrics, WithdrawalProcessorMetrics},
     nonce_keys::PROCESS_WITHDRAWAL_NONCE_KEY,
     settlement::{WITHDRAWAL_QUEUE_CAPACITY, find_processed_offset},
 };
@@ -283,6 +284,7 @@ pub struct WithdrawalProcessor {
     notify: Arc<Notify>,
     repair_notify: Arc<Notify>,
     metrics: WithdrawalProcessorMetrics,
+    sequencer_metrics: SequencerMetrics,
 }
 
 impl WithdrawalProcessor {
@@ -307,6 +309,7 @@ impl WithdrawalProcessor {
             notify,
             repair_notify,
             metrics: WithdrawalProcessorMetrics::default(),
+            sequencer_metrics: SequencerMetrics::default(),
         }
     }
 
@@ -354,10 +357,30 @@ impl WithdrawalProcessor {
                 }
             }
 
+            if let Err(error) = self.refresh_sequencer_pathusd_balance().await {
+                warn!(
+                    %error,
+                    sequencer = %self.config.sequencer_address,
+                    "Failed to refresh sequencer PathUSD balance metric"
+                );
+            }
+
             if let Err(e) = self.process_queue().await {
                 error!(error = %e, "Withdrawal processing cycle failed");
             }
         }
+    }
+
+    /// Refresh the sequencer's Tempo L1 PathUSD balance metric.
+    async fn refresh_sequencer_pathusd_balance(&self) -> eyre::Result<()> {
+        let balance = ITIP20::new(PATH_USD_ADDRESS, &self.provider)
+            .balanceOf(self.config.sequencer_address)
+            .call()
+            .await?;
+        self.sequencer_metrics
+            .pathusd_balance
+            .set(f64::from(balance));
+        Ok(())
     }
 
     /// Drain the portal's withdrawal queue on Tempo L1, slot by slot, until the
@@ -1124,6 +1147,21 @@ mod tests {
         timeout(Duration::from_millis(50), repair_notify.notified())
             .await
             .expect("missing head slot should request a monitor resync");
+        assert!(l1.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn refreshes_sequencer_pathusd_balance() {
+        let l1 = Asserter::new();
+        l1.push_success(&abi_encode_u64(1_500_000));
+        let processor = test_processor(
+            l1.clone(),
+            SharedWithdrawalStore::new(),
+            Arc::new(Notify::new()),
+        );
+
+        processor.refresh_sequencer_pathusd_balance().await.unwrap();
+
         assert!(l1.read_q().is_empty());
     }
 


### PR DESCRIPTION
## Summary

- expose `tempo_zone_sequencer_pathusd_balance` with the sequencer account's Tempo L1 PathUSD balance in base units
- refresh the gauge from the withdrawal processor's existing L1 provider and polling cadence
- keep balance-read failures non-blocking so observability cannot interrupt withdrawal processing

## Motivation

Sequencer deployments currently need a separate chain-tracking container to monitor whether the account can continue paying L1 transaction fees. Publishing the balance from the sequencer process makes low-balance alerting available through the existing metrics endpoint.