### PR TITLE
perf: enable optimized keccak features

### DIFF
--- a/bin/tempo-zone-spf/Cargo.toml
+++ b/bin/tempo-zone-spf/Cargo.toml
@@ -43,3 +43,9 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[features]
+default = ["asm-keccak", "keccak-cache-global"]
+
+asm-keccak = ["alloy-primitives/asm-keccak"]
+keccak-cache-global = ["alloy-primitives/keccak-cache-global"]

--- a/bin/tempo-zone/Cargo.toml
+++ b/bin/tempo-zone/Cargo.toml
@@ -27,6 +27,8 @@ name = "tempo-zone"
 path = "src/main.rs"
 
 [features]
-default = ["jemalloc"]
+default = ["asm-keccak", "jemalloc", "keccak-cache-global"]
 
+asm-keccak = ["zone-node/asm-keccak"]
 jemalloc = ["reth-cli-util/jemalloc", "zone-node/jemalloc"]
+keccak-cache-global = ["zone-node/keccak-cache-global"]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -126,6 +126,7 @@ url = "2"
 
 [features]
 default = []
+asm-keccak = ["alloy-primitives/asm-keccak"]
 cli = [
   "dep:clap",
   "dep:reth-consensus",
@@ -136,6 +137,7 @@ cli = [
   "zone-chainspec/cli",
 ]
 jemalloc = ["reth-ethereum?/jemalloc"]
+keccak-cache-global = ["alloy-primitives/keccak-cache-global"]
 test-utils = [
   "reth-chainspec/test-utils",
   "reth-ethereum?/test-utils",


### PR DESCRIPTION
Enable assembly-backed Keccak and the global Keccak cache by default in both `tempo-zone` and `tempo-zone-spf`, matching the performance defaults used by upstream Reth and Tempo.

The features remain explicitly forwarded through the binary and node manifests, so builds can still opt out with `--no-default-features`.

SPF profile:

<img width="939" height="846" alt="image" src="https://github.com/user-attachments/assets/aec1dd60-0ca6-4fe8-9eac-a9e4827210f6" />
