### PR TITLE
ci: allow transitive bitmaps advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,9 @@ ignore = [
   # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
   # and is pulled in transitively by upstream crates with no safe upgrade available.
   "RUSTSEC-2026-0173",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0247 bitmaps is unmaintained
+  # and is pulled in transitively by reth through imbl with no maintained release available.
+  "RUSTSEC-2026-0247",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Cargo deny now rejects the locked `bitmaps 3.2.1` dependency because RUSTSEC-2026-0247 marks every release unmaintained. The crate is pulled in transitively by `reth-transaction-pool` through `imbl`, and the advisory provides no safe upgrade.

Add a documented temporary advisory exception so repository lint remains usable until the upstream dependency chain replaces `bitmaps`. This keeps the repository-wide CI fix separate from the unrelated xtask changes in #1088.