### PR TITLE
Allow zone admins to update the leader

### DIFF
--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -774,8 +774,8 @@ interface IZonePortal {
     function leaderActivationTempoBlock() external view returns (uint64);
 
     /// @notice Transfer block-production leadership to another sequencer-set member.
-    /// @dev Only callable by an active sequencer. A call naming the already-active leader is a
-    ///      successful no-op so operators can fan the same request out to every node.
+    /// @dev Only callable by the admin or an active sequencer. A call naming the already-active
+    ///      leader is a successful no-op so operators can fan the same request out to every node.
     /// @param newLeader The individual sequencer address of the new leader.
     /// @param expectedEpoch The finalized leaderEpoch the caller observed (compare-and-set).
     function setLeader(address newLeader, uint64 expectedEpoch) external;

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -276,6 +276,11 @@ contract ZonePortal is IZonePortal {
         _;
     }
 
+    modifier onlySequencerOrAdmin() {
+        if (msg.sender != admin && !isSequencer[msg.sender]) revert NotSequencer();
+        _;
+    }
+
     modifier onlyAdmin() {
         if (msg.sender != admin) revert NotAdmin();
         _;
@@ -368,7 +373,7 @@ contract ZonePortal is IZonePortal {
     }
 
     /// @inheritdoc IZonePortal
-    function setLeader(address newLeader, uint64 expectedEpoch) external onlySequencer {
+    function setLeader(address newLeader, uint64 expectedEpoch) external onlySequencerOrAdmin {
         if (!isSequencer[newLeader]) revert InvalidLeader();
         // Idempotent fanout: every node relays the same target, only the first call transitions.
         if (newLeader == leader) return;

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -1149,7 +1149,20 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.leaderActivationTempoBlock(), uint64(block.number));
     }
 
-    function test_setLeader_revertsForNonSequencerCaller() public {
+    function test_setLeader_allowsAdminCaller() public {
+        address[] memory signers = _activateSequencerSet(2);
+        uint64 epoch = portal.leaderEpoch();
+
+        vm.roll(block.number + 1);
+        vm.prank(admin);
+        portal.setLeader(signers[1], epoch);
+
+        assertEq(portal.leader(), signers[1]);
+        assertEq(portal.leaderEpoch(), epoch + 1);
+        assertEq(portal.leaderActivationTempoBlock(), uint64(block.number));
+    }
+
+    function test_setLeader_revertsForUnauthorizedCaller() public {
         address[] memory signers = _activateSequencerSet(2);
         uint64 epoch = portal.leaderEpoch();
 


### PR DESCRIPTION
## Summary

- allow `ZonePortal.setLeader` to be called by the current portal admin as well as any registered sequencer
- keep the new leader restricted to the active sequencer set
- preserve the existing unauthorized-caller revert behavior and document the expanded caller set
- add focused coverage for admin-authorized transitions and unrelated-account rejection

## Why

Leader rotation was previously relayable only by registered sequencer keys. Allowing the zone admin key to submit the same compare-and-set transition provides an administrative recovery path while retaining the existing target membership, epoch fencing, and one-transition-per-block checks.

## Validation

- `forge fmt --check`
- `forge test --match-path test/tempo/ZonePortal.t.sol --match-test 'test_setLeader' -vv` (8 passed)
- `forge test --match-path test/tempo/ZonePortal.t.sol -q`
- `git diff --check`