### PR TITLE
fix(p2p): derive bootstrap leader from named node

### DIFF
--- a/crates/node/src/settlement_attestation.rs
+++ b/crates/node/src/settlement_attestation.rs
@@ -580,14 +580,16 @@ mod tests {
 
     fn test_manifest() -> ZoneManifest {
         let public_keys = [1_u64, 2, 3].map(|seed| PrivateKey::from_seed(seed).public_key());
-        let mut input = format!(
-            "zone_id = 7\nsequencer_set_version = 0\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(public_keys[0].as_ref())
-        );
+        let mut input = "zone_id = 7\nsequencer_set_version = 0\n".to_owned();
         for (index, public_key) in public_keys.iter().enumerate() {
             let number = index + 1;
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{number}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{number}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x{number:040x}\"\naddress = \"127.0.0.1:{}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x{number:040x}\"\naddress = \"127.0.0.1:{}\"\n",
                 const_hex::encode_prefixed(public_key.as_ref()),
                 9200 + index,
             ));

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3768,18 +3768,20 @@ pub(crate) async fn start_real_p2p_cluster_with_active_nodes(
     ));
     std::fs::create_dir_all(&config_dir)?;
     let manifest_path = config_dir.join("manifest.toml");
-    let mut manifest = format!(
-        "zone_id = {zone_id}\nsequencer_set_version = 0\nleader_ed25519_public_key = \"{}\"\n",
-        const_hex::encode_prefixed(public_keys[0].as_ref())
-    );
+    let mut manifest = format!("zone_id = {zone_id}\nsequencer_set_version = 0\n");
     for (index, ((public_key, signer), address)) in public_keys
         .iter()
         .zip(&attestation_signers)
         .zip(addresses)
         .enumerate()
     {
+        let name = if index == 0 {
+            "leader".to_owned()
+        } else {
+            format!("node-{index}")
+        };
         manifest.push_str(&format!(
-            "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+            "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
             const_hex::encode_prefixed(public_key.as_ref()),
             signer.address(),
         ));
@@ -3877,18 +3879,20 @@ pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2
     ));
     std::fs::create_dir_all(&config_dir)?;
     let manifest_path = config_dir.join("manifest.toml");
-    let mut manifest = format!(
-        "zone_id = 0\nleader_ed25519_public_key = \"{}\"\n",
-        const_hex::encode_prefixed(public_keys[0].as_ref())
-    );
+    let mut manifest = "zone_id = 0\n".to_owned();
     for (index, ((public_key, secp256k1_signer), address)) in public_keys
         .iter()
         .zip(&secp256k1_signers)
         .zip(addresses)
         .enumerate()
     {
+        let name = if index == 0 {
+            "leader".to_owned()
+        } else {
+            format!("node-{index}")
+        };
         manifest.push_str(&format!(
-            "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+            "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
             const_hex::encode_prefixed(public_key.as_ref()),
             secp256k1_signer.address(),
         ));
@@ -3977,18 +3981,20 @@ pub(crate) fn leader_p2p_config(listen: SocketAddr) -> eyre::Result<P2pConfig> {
     std::fs::create_dir_all(&config_dir)?;
     let manifest_path = config_dir.join("manifest.toml");
     let key_path = config_dir.join("leader.key");
-    let mut manifest = format!(
-        "zone_id = 0\nleader_ed25519_public_key = \"{}\"\n",
-        const_hex::encode_prefixed(public_keys[0].as_ref())
-    );
+    let mut manifest = "zone_id = 0\n".to_owned();
     for (index, ((public_key, secp256k1_signer), address)) in public_keys
         .iter()
         .zip(&secp256k1_signers)
         .zip(addresses)
         .enumerate()
     {
+        let name = if index == 0 {
+            "leader".to_owned()
+        } else {
+            format!("node-{index}")
+        };
         manifest.push_str(&format!(
-            "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+            "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
             const_hex::encode_prefixed(public_key.as_ref()),
             secp256k1_signer.address(),
         ));

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -43,9 +43,9 @@ operation — provision an individual secp256k1 key, register it with `ZonePorta
 from the manifest, and restart.
 
 Roles are dynamic: a node promotes or demotes at finalized leadership activation
-boundaries, driven by the node's role controller. The manifest's
-`leader_ed25519_public_key` is only a legacy bootstrap used until the portal reports a
-nonzero leader; the (optional) `--sequencer.role` CLI argument is only an assertion checked
+boundaries, driven by the node's role controller. The Ed25519 public key of the manifest node
+named `leader` is the bootstrap leader until the portal reports a nonzero leader; the
+(optional) `--sequencer.role` CLI argument is only an assertion checked
 against that bootstrap — `leader`, `follower`, or `rpc-follower`. There is no automatic election:
 leadership changes only through an operator-triggered `setLeader` transaction finalized on L1.
  
@@ -79,8 +79,6 @@ the configuration shape:
 ```toml
 zone_id = 7
 sequencer_set_version = 0
-leader_ed25519_public_key = "0xleader..."
-
 [[nodes]]
 name = "leader"
 ed25519_public_key = "0xleader..."

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -727,8 +727,6 @@ impl ZoneManifest {
     pub fn parse(input: &str) -> Result<Self, ManifestError> {
         let raw: RawManifest = toml::from_str(input).map_err(ManifestError::Toml)?;
 
-        let leader_ed25519_public_key =
-            parse_ed25519_public_key("leader_ed25519_public_key", &raw.leader_ed25519_public_key)?;
         let mut names = BTreeSet::new();
         let mut ed25519_public_keys = BTreeSet::new();
         let mut secp256k1_addresses = BTreeSet::new();
@@ -787,7 +785,7 @@ impl ZoneManifest {
                         address: raw_node.address.clone(),
                         reason,
                     })?;
-            if raw_node.rpc_only && ed25519_public_key == leader_ed25519_public_key {
+            if raw_node.rpc_only && raw_node.name == "leader" {
                 return Err(ManifestError::RpcOnlyLeader(raw_node.name));
             }
             nodes.push(ManifestNode {
@@ -799,11 +797,11 @@ impl ZoneManifest {
             });
         }
 
-        if !ed25519_public_keys.contains(&leader_ed25519_public_key) {
-            return Err(ManifestError::LeaderEd25519PublicKeyNotFound(
-                leader_ed25519_public_key.to_string(),
-            ));
-        }
+        let leader_ed25519_public_key = nodes
+            .iter()
+            .find(|node| node.name == "leader")
+            .map(|node| node.ed25519_public_key.clone())
+            .ok_or(ManifestError::LeaderNodeNotFound)?;
 
         // RPC-only members are not registered with `ZonePortal`, so they cannot make up for a
         // quorum that is too small to settle.
@@ -1047,7 +1045,6 @@ struct RawManifest {
     zone_id: u32,
     #[serde(default = "default_sequencer_set_version")]
     sequencer_set_version: u64,
-    leader_ed25519_public_key: String,
     #[serde(default)]
     forced_recovery: Option<RawForcedRecovery>,
     nodes: Vec<RawManifestNode>,
@@ -1160,8 +1157,8 @@ pub enum ManifestError {
         reason: String,
     },
 
-    #[error("manifest leader Ed25519 public key `{0}` does not match any node")]
-    LeaderEd25519PublicKeyNotFound(String),
+    #[error("sequencer manifest must contain a node named `leader`")]
+    LeaderNodeNotFound,
 
     #[error("zone ID mismatch: manifest has {manifest}, but --zone.id is {cli}")]
     ZoneIdMismatch { manifest: u32, cli: u32 },
@@ -1576,10 +1573,12 @@ mod tests {
     /// Builds a manifest where the fourth tuple element marks a node `rpc_only`. An `rpc_only`
     /// node declares no `secp256k1_address`, exactly as the loader requires.
     fn manifest_with_rpc_only(leader: u64, nodes: &[(u64, &str, &str, bool)]) -> String {
-        let mut value = format!(
-            "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n",
-            ed25519_public_key(leader)
+        assert!(
+            nodes
+                .iter()
+                .any(|(key, name, _, _)| *key == leader && *name == "leader")
         );
+        let mut value = "zone_id = 7\n".to_owned();
         for (key, name, address, rpc_only) in nodes {
             value.push_str(&format!(
                 "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\naddress = \"{address}\"\nrpc_only = {rpc_only}\n",
@@ -1649,6 +1648,42 @@ mod tests {
                 .unwrap(),
             Role::Follower
         );
+    }
+
+    #[test]
+    fn derives_bootstrap_leader_from_named_node() {
+        let input = manifest(
+            1,
+            &[
+                (2, "follower-a", "127.0.0.1:9201"),
+                (1, "leader", "127.0.0.1:9200"),
+                (3, "follower-b", "127.0.0.1:9202"),
+            ],
+        );
+        let manifest = ZoneManifest::parse(&input).unwrap();
+
+        assert_eq!(
+            manifest.leader_ed25519_public_key(),
+            &PrivateKey::from_seed(1).public_key()
+        );
+    }
+
+    #[test]
+    fn rejects_manifest_without_named_leader() {
+        let input = manifest(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200"),
+                (2, "follower-b", "127.0.0.1:9201"),
+                (3, "follower-c", "127.0.0.1:9202"),
+            ],
+        )
+        .replace("name = \"leader\"", "name = \"follower-a\"");
+
+        assert!(matches!(
+            ZoneManifest::parse(&input),
+            Err(ManifestError::LeaderNodeNotFound)
+        ));
     }
 
     #[test]

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -207,13 +207,15 @@ mod tests {
     }
 
     fn manifest_with_rpc_follower() -> ZoneManifest {
-        let mut manifest = format!(
-            "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n",
-            ed25519_public_key(1)
-        );
+        let mut manifest = "zone_id = 7\n".to_owned();
         for seed in 1..=3 {
+            let name = if seed == 1 {
+                "leader".to_owned()
+            } else {
+                format!("seq-{seed}")
+            };
             manifest.push_str(&format!(
-                "\n[[nodes]]\nname = \"seq-{seed}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x{seed:040x}\"\naddress = \"127.0.0.1:{}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x{seed:040x}\"\naddress = \"127.0.0.1:{}\"\n",
                 ed25519_public_key(seed),
                 9200 + seed,
             ));

--- a/crates/p2p/src/routing.rs
+++ b/crates/p2p/src/routing.rs
@@ -185,13 +185,15 @@ mod tests {
     }
 
     fn manifest() -> ZoneManifest {
-        let mut input = format!(
-            "zone_id = 7\nleader_ed25519_public_key = \"0x{}\"\n",
-            hex(key(1))
-        );
+        let mut input = "zone_id = 7\n".to_owned();
         for (seed, rpc_only) in [(1, false), (2, false), (3, false), (4, true)] {
+            let name = if seed == 1 {
+                "leader".to_owned()
+            } else {
+                format!("node-{seed}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{seed}\"\ned25519_public_key = \"0x{}\"\naddress = \"127.0.0.1:{}\"\nrpc_only = {rpc_only}\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"0x{}\"\naddress = \"127.0.0.1:{}\"\nrpc_only = {rpc_only}\n",
                 hex(key(seed)),
                 9000 + seed,
             ));

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -966,14 +966,16 @@ mod tests {
         seed_base: u64,
         standby: usize,
     ) -> String {
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
             let rpc_only = index == standby;
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\naddress = \"{address}\"\nrpc_only = {rpc_only}\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\naddress = \"{address}\"\nrpc_only = {rpc_only}\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
             ));
             if !rpc_only {
@@ -1017,14 +1019,16 @@ mod tests {
             ed25519_identity(2),
             ed25519_identity(3),
         ];
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, identity) in identities.iter().enumerate() {
             let secp256k1_identity = secp256k1_identity(index as u64 + 1);
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"node-{index}.zone.local:9200\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"node-{index}.zone.local:9200\"\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
                 secp256k1_identity.address(),
             ));
@@ -1112,14 +1116,16 @@ mod tests {
             ed25519_identity(2),
             ed25519_identity(3),
         ];
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
             let secp256k1_identity = secp256k1_identity(index as u64 + 1);
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
                 secp256k1_identity.address(),
             ));
@@ -1370,14 +1376,16 @@ mod tests {
             ed25519_identity(22),
             ed25519_identity(23),
         ];
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
             let secp256k1_identity = secp256k1_identity(index as u64 + 21);
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
                 secp256k1_identity.address(),
             ));
@@ -1761,13 +1769,15 @@ mod tests {
             available_address(),
         ];
         let identities = [51_u64, 52, 53].map(ed25519_identity);
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
                 secp256k1_identity(index as u64 + 51).address(),
             ));
@@ -1846,14 +1856,16 @@ mod tests {
             ed25519_identity(12),
             ed25519_identity(13),
         ];
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
             let secp256k1_identity = secp256k1_identity(index as u64 + 11);
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
                 secp256k1_identity.address(),
             ));
@@ -1948,14 +1960,16 @@ mod tests {
             ed25519_identity(62),
             ed25519_identity(63),
         ];
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
             let secp256k1_identity = secp256k1_identity(index as u64 + 61);
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
                 secp256k1_identity.address(),
             ));
@@ -2115,14 +2129,16 @@ mod tests {
             ed25519_identity(72),
             ed25519_identity(73),
         ];
-        let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
-            const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
-        );
+        let mut input = "zone_id = 9\n".to_owned();
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
             let secp256k1_identity = secp256k1_identity(index as u64 + 71);
+            let name = if index == 0 {
+                "leader".to_owned()
+            } else {
+                format!("node-{index}")
+            };
             input.push_str(&format!(
-                "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                "\n[[nodes]]\nname = \"{name}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
                 const_hex::encode_prefixed(identity.ed25519_public_key().as_ref()),
                 secp256k1_identity.address(),
             ));


### PR DESCRIPTION
## Summary
- remove the top-level `leader_ed25519_public_key` manifest field
- derive the bootstrap leader from the `ed25519_public_key` of the node named `leader`
- update manifest examples and test builders, and reject manifests without a named leader

## Testing
- `cargo test -p zone-p2p`
- `cargo +nightly clippy -p zone-p2p --all-targets -- -D warnings`
- `cargo test -p zone-node --no-run`
- `cargo +nightly fmt --all -- --check`

Prompted by: @0xalpharush