### PR TITLE
fix: historical leader recovery for legacy zone chain IDs [do not merge]

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -852,26 +852,26 @@ struct ScheduleLeadershipSink {
 
 impl LeadershipSink for ScheduleLeadershipSink {
     fn apply_leader_transition(&self, transition: &LeaderTransition) -> eyre::Result<()> {
-        let node = self
+        let leader = self
             .manifest
-            .node_by_secp256k1_address(transition.new_leader)
+            .leader_ed25519_by_secp256k1_address(transition.new_leader)
             .ok_or_else(|| {
                 eyre::eyre!(
-                    "finalized portal leader {} (epoch {}) does not map to any manifest member",
+                    "finalized portal leader {} (epoch {}) does not map to any active or historical manifest identity",
                     transition.new_leader,
                     transition.epoch,
                 )
             })?;
         self.schedule.publish(LeadershipState::new(
             transition.epoch,
-            node.ed25519_public_key().clone(),
+            leader.clone(),
             transition.activation_tempo_block,
         ))?;
         info!(
             target: "reth::cli",
             epoch = transition.epoch,
             leader = %transition.new_leader,
-            peer = %node.ed25519_public_key(),
+            peer = %leader,
             activation_tempo_block = transition.activation_tempo_block,
             "Observed finalized leadership transition"
         );
@@ -988,24 +988,22 @@ async fn seed_leadership_schedule(
         !leader.is_zero(),
         "portal {portal_address} has no leader at finalized L1 snapshot block {snapshot_anchor}"
     );
-    let node = manifest.node_by_secp256k1_address(leader).ok_or_else(|| {
-        eyre::eyre!(
-            "finalized portal leader {leader} (epoch {epoch}) does not map to any manifest \
-             member; refusing to start with a divergent topology"
-        )
-    })?;
-    schedule.publish(LeadershipState::new(
-        epoch,
-        node.ed25519_public_key().clone(),
-        activation,
-    ))?;
+    let leader_peer = manifest
+        .leader_ed25519_by_secp256k1_address(leader)
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "finalized portal leader {leader} (epoch {epoch}) does not map to any active or \
+             historical manifest identity; refusing to start without an authenticated leader"
+            )
+        })?;
+    schedule.publish(LeadershipState::new(epoch, leader_peer.clone(), activation))?;
     info!(
         target: "reth::cli",
         snapshot_anchor,
         %leader,
         epoch,
         activation_tempo_block = activation,
-        peer = %node.ed25519_public_key(),
+        peer = %leader_peer,
         "Bootstrapped leadership from the finalized portal snapshot"
     );
     Ok(())
@@ -1701,6 +1699,7 @@ mod tests {
     use super::*;
     use alloy_consensus::{Signed, TxEip1559};
     use alloy_primitives::{Bytes, Signature, TxKind, U256};
+    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
     use reth_chainspec::EthChainSpec;
     use reth_primitives_traits::Recovered;
     use tempo_primitives::transaction::{
@@ -1738,6 +1737,61 @@ mod tests {
         assert_eq!(tempo_chain_spec_for_l1(31319).unwrap().chain().id(), 1337);
         assert!(tempo_chain_spec_for_l1(999_999).is_none());
         unsafe { std::env::remove_var("ZONE_L1_DEV_CHAIN_IDS") };
+    }
+
+    #[test]
+    fn finalized_replay_resolves_a_retired_leader_identity() {
+        let peer = |seed| PrivateKey::from_seed(seed).public_key();
+        let manifest = ZoneManifest::parse(&format!(
+            "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n\
+             [[nodes]]\nname = \"leader\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x0000000000000000000000000000000000000001\"\naddress = \"127.0.0.1:9200\"\n\
+             [[nodes]]\nname = \"follower-a\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x0000000000000000000000000000000000000002\"\naddress = \"127.0.0.1:9201\"\n\
+             [[nodes]]\nname = \"follower-b\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x0000000000000000000000000000000000000003\"\naddress = \"127.0.0.1:9202\"\n\
+             [[historical_leaders]]\ned25519_public_key = \"{}\"\nsecp256k1_address = \"0x0000000000000000000000000000000000000009\"\n",
+            peer(1),
+            peer(1),
+            peer(2),
+            peer(3),
+            peer(9),
+        ))
+        .unwrap();
+        let schedule = manifest.leadership_schedule();
+        schedule
+            .publish(LeadershipState::new(1, peer(1), 0))
+            .unwrap();
+        let sink = ScheduleLeadershipSink {
+            schedule: schedule.clone(),
+            manifest: Arc::new(manifest),
+        };
+
+        sink.apply_leader_transition(&LeaderTransition {
+            previous_leader: "0x0000000000000000000000000000000000000001"
+                .parse()
+                .unwrap(),
+            new_leader: "0x0000000000000000000000000000000000000009"
+                .parse()
+                .unwrap(),
+            epoch: 2,
+            activation_tempo_block: 100,
+        })
+        .unwrap();
+
+        assert_eq!(schedule.leader_for(100).unwrap().leader, peer(9));
+        assert!(
+            sink.apply_leader_transition(&LeaderTransition {
+                previous_leader: "0x0000000000000000000000000000000000000009"
+                    .parse()
+                    .unwrap(),
+                new_leader: "0x0000000000000000000000000000000000000008"
+                    .parse()
+                    .unwrap(),
+                epoch: 3,
+                activation_tempo_block: 200,
+            })
+            .is_err(),
+            "an unknown finalized leader must remain fail closed"
+        );
+        assert_eq!(schedule.latest_observed_epoch(), Some(2));
     }
 
     #[test]

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -104,9 +104,21 @@ name = "operator-rpc"
 ed25519_public_key = "0xrpc..."
 address = "operator-rpc.zone.internal:9200"
 rpc_only = true
+
+[[historical_leaders]]
+ed25519_public_key = "0xretired-leader..."
+secp256k1_address = "0x4444444444444444444444444444444444444444"
 ```
 
 `rpc_only` defaults to `false`, so existing manifests keep their current meaning.
+
+`historical_leaders` maps a retired Portal sequencer address to the Ed25519 identity that authored
+blocks while that address was leader. Keep an entry while any persisted node checkpoint can still
+precede the leader's removal, or while finalized leadership events that name it may need replay.
+These entries are identity history only: they are excluded from the P2P topology and settlement
+quorum, cannot be selected by `zone_setLeader` or `[forced_recovery]`, and are not checked against
+the Portal's current registered sequencer set. Once every retained checkpoint and replay window is
+past that leader's last epoch, the entry can be removed.
 
 `sequencer_set_version` must exactly match the value reported by `ZonePortal`. Version `0` is
 valid for the initial sequencer set installed atomically by `ZoneFactory`; later
@@ -136,6 +148,7 @@ The manifest loader validates that:
 - the leader is not `rpc_only`;
 - `secp256k1_address` is present on every quorum node and absent on every `rpc_only` node;
 - node names, Ed25519 public keys, and secp256k1 addresses are unique;
+- historical leader addresses do not duplicate another historical or active node address;
 - every address has a non-zero port;
 - `leader_ed25519_public_key` identifies one of the nodes;
 - the manifest's `zone_id` matches `--zone.id`; and

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -720,6 +720,17 @@ pub struct ZoneManifest {
     leader_ed25519_public_key: PublicKey,
     forced_recovery: Option<ForcedRecoveryConfig>,
     nodes: Vec<ManifestNode>,
+    historical_leaders: Vec<HistoricalLeaderIdentity>,
+}
+
+/// Identity retained only to resolve finalized leadership history.
+///
+/// Historical leaders are deliberately not manifest nodes: they have no network address, do not
+/// join the settlement quorum, and cannot be selected for forced recovery or a new leader update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HistoricalLeaderIdentity {
+    ed25519_public_key: PublicKey,
+    secp256k1_address: EthereumAddress,
 }
 
 impl ZoneManifest {
@@ -799,6 +810,30 @@ impl ZoneManifest {
             });
         }
 
+        let mut historical_leaders = Vec::with_capacity(raw.historical_leaders.len());
+        for (index, raw_leader) in raw.historical_leaders.into_iter().enumerate() {
+            let ed25519_public_key = parse_ed25519_public_key(
+                &format!("historical_leaders.{index}.ed25519_public_key"),
+                &raw_leader.ed25519_public_key,
+            )?;
+            let secp256k1_address = raw_leader
+                .secp256k1_address
+                .parse::<EthereumAddress>()
+                .map_err(
+                    |source| ManifestError::InvalidHistoricalLeaderSecp256k1Address {
+                        address: raw_leader.secp256k1_address,
+                        reason: source.to_string(),
+                    },
+                )?;
+            if !secp256k1_addresses.insert(secp256k1_address) {
+                return Err(ManifestError::DuplicateSecp256k1Address(secp256k1_address));
+            }
+            historical_leaders.push(HistoricalLeaderIdentity {
+                ed25519_public_key,
+                secp256k1_address,
+            });
+        }
+
         if !ed25519_public_keys.contains(&leader_ed25519_public_key) {
             return Err(ManifestError::LeaderEd25519PublicKeyNotFound(
                 leader_ed25519_public_key.to_string(),
@@ -844,6 +879,7 @@ impl ZoneManifest {
             leader_ed25519_public_key,
             forced_recovery,
             nodes,
+            historical_leaders,
         })
     }
 
@@ -1036,6 +1072,25 @@ impl ZoneManifest {
             .find(|node| node.secp256k1_address() == Some(secp256k1_address))
     }
 
+    /// Resolves a finalized Portal leader address to its Ed25519 block-author identity.
+    ///
+    /// Unlike [`Self::node_by_secp256k1_address`], this also consults identity-only historical
+    /// entries. Callers deciding current quorum membership, networking, routing, recovery, or a
+    /// new leader target must continue to use the active-node lookup.
+    pub fn leader_ed25519_by_secp256k1_address(
+        &self,
+        secp256k1_address: EthereumAddress,
+    ) -> Option<&PublicKey> {
+        self.node_by_secp256k1_address(secp256k1_address)
+            .map(ManifestNode::ed25519_public_key)
+            .or_else(|| {
+                self.historical_leaders
+                    .iter()
+                    .find(|leader| leader.secp256k1_address == secp256k1_address)
+                    .map(|leader| &leader.ed25519_public_key)
+            })
+    }
+
     pub(crate) fn has_dns_addresses(&self) -> bool {
         self.nodes.iter().any(|node| node.address.is_dns())
     }
@@ -1050,6 +1105,8 @@ struct RawManifest {
     leader_ed25519_public_key: String,
     #[serde(default)]
     forced_recovery: Option<RawForcedRecovery>,
+    #[serde(default)]
+    historical_leaders: Vec<RawHistoricalLeaderIdentity>,
     nodes: Vec<RawManifestNode>,
 }
 
@@ -1064,6 +1121,13 @@ struct RawForcedRecovery {
     leader: String,
     /// Exact canonical zone block hash shared by every restarting node.
     recovery_block_hash: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHistoricalLeaderIdentity {
+    ed25519_public_key: String,
+    secp256k1_address: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1153,6 +1217,9 @@ pub enum ManifestError {
         reason: String,
     },
 
+    #[error("invalid historical leader secp256k1 address `{address}`: {reason}")]
+    InvalidHistoricalLeaderSecp256k1Address { address: String, reason: String },
+
     #[error("invalid address `{address}` for node `{node}`: {reason}")]
     InvalidAddress {
         node: String,
@@ -1193,7 +1260,7 @@ pub enum ManifestError {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
+    use alloy_primitives::{Address, B256};
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
     use super::{
@@ -1573,6 +1640,14 @@ mod tests {
         )
     }
 
+    fn with_historical_leader(manifest: &str, secp256k1_seed: u64, ed25519_seed: u64) -> String {
+        format!(
+            "{manifest}\n[[historical_leaders]]\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\n",
+            ed25519_public_key(ed25519_seed),
+            secp256k1_address(secp256k1_seed),
+        )
+    }
+
     /// Builds a manifest where the fourth tuple element marks a node `rpc_only`. An `rpc_only`
     /// node declares no `secp256k1_address`, exactly as the loader requires.
     fn manifest_with_rpc_only(leader: u64, nodes: &[(u64, &str, &str, bool)]) -> String {
@@ -1652,6 +1727,66 @@ mod tests {
     }
 
     #[test]
+    fn resolves_historical_leader_without_adding_an_active_node() {
+        let base = manifest(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200"),
+                (2, "follower-a", "127.0.0.1:9201"),
+                (3, "follower-b", "127.0.0.1:9202"),
+            ],
+        );
+        let baseline_digest = ZoneManifest::parse(&base).unwrap().membership_digest();
+        let manifest = ZoneManifest::parse(&with_historical_leader(&base, 9, 8)).unwrap();
+        let historical_address = secp256k1_address(9).parse().unwrap();
+
+        assert_eq!(manifest.nodes().len(), 3);
+        assert_eq!(manifest.quorum_nodes().count(), 3);
+        assert_eq!(manifest.membership_digest(), baseline_digest);
+        assert!(
+            manifest
+                .node_by_secp256k1_address(historical_address)
+                .is_none(),
+            "historical identity must not become an active quorum or network node"
+        );
+        assert_eq!(
+            manifest.leader_ed25519_by_secp256k1_address(historical_address),
+            Some(&public_key(8))
+        );
+        assert_eq!(
+            manifest.leader_ed25519_by_secp256k1_address(secp256k1_address(2).parse().unwrap()),
+            Some(&public_key(2)),
+            "the leadership resolver must still resolve active nodes"
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_historical_leader_addresses() {
+        let base = manifest(
+            1,
+            &[
+                (1, "leader", "127.0.0.1:9200"),
+                (2, "follower-a", "127.0.0.1:9201"),
+                (3, "follower-b", "127.0.0.1:9202"),
+            ],
+        );
+
+        let duplicates_active = with_historical_leader(&base, 1, 8);
+        assert!(matches!(
+            ZoneManifest::parse(&duplicates_active),
+            Err(ManifestError::DuplicateSecp256k1Address(address))
+                if address == secp256k1_address(1).parse::<Address>().unwrap()
+        ));
+
+        let duplicates_history = with_historical_leader(&with_historical_leader(&base, 9, 8), 9, 7);
+        assert!(matches!(
+            ZoneManifest::parse(&duplicates_history),
+            Err(ManifestError::DuplicateSecp256k1Address(address))
+                if address == secp256k1_address(9).parse::<Address>().unwrap()
+        ));
+    }
+
+    #[test]
     fn accepts_factory_installed_sequencer_set_version_zero() {
         let input = format!(
             "sequencer_set_version = 0\n{}",
@@ -1728,6 +1863,7 @@ mod tests {
         let manifest: super::RawManifest = toml::from_str(example).unwrap();
         assert_eq!(manifest.zone_id, 7);
         assert_eq!(manifest.nodes.len(), 4);
+        assert_eq!(manifest.historical_leaders.len(), 1);
         assert_eq!(
             manifest.nodes.iter().filter(|node| !node.rpc_only).count(),
             MIN_QUORUM_NODES


### PR DESCRIPTION
## Purpose

Temporary firedrill compatibility branch for producing a Zone node build that can recover the existing legacy Zone database.

The current startup failure is:

```
chain ID mismatch: portal zone ID 1 on parent chain 31318 requires chain_id=134509785776129, but genesis has 421700001
```

PR #954 (`fix: derive zone chain IDs by parent L1`) introduced that validation and chain-ID derivation. The firedrill genesis predates it and persists the legacy chain ID `421700001`.

## What this contains

- Based on `42adfd2028602463ddfe1ce682d8e146f34443c6`, the commit immediately before #954's merge commit `142bd566d124d4eae3f147466dadd86fdd8fbafb`.
- Carries the historical identity-only leader mapping from #1104.
- Deliberately excludes #954 so the existing firedrill genesis can still open with its legacy chain ID.

## Important

**Do not merge this PR into current `main`.** This is a temporary deployment/image compatibility branch for recovery of the pre-#954 firedrill state. PR #1104 remains the durable fix for current `main`.

## Validation

- `rustup run nightly cargo test -p zone-p2p manifest::tests --lib` — 27 passed
- `rustup run nightly cargo test -p zone-node finalized_replay_resolves_a_retired_leader_identity --lib` — passed
- `rustup run nightly cargo clippy -p zone-p2p -p zone-node --all-targets -- -D warnings` — passed
- Formatting and diff checks passed
- Verified #954 merge commit is not an ancestor of this head
