### PR TITLE
feat(xtask): support separate encryption keys

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -864,7 +864,8 @@ deploy-zone name token="" access_enforced="false" gateway_enforced="false":
     echo "Step 5: Registering sequencer encryption key on ZonePortal..."
     PRIVATE_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
         --l1-rpc-url "$HTTP_RPC" \
-        --portal "$PORTAL"
+        --portal "$PORTAL" \
+        --encryption-private-key "$SEQUENCER_KEY"
     echo ""
 
     # Step 6: Display summary

--- a/crates/sequencer/src/encryption_key.rs
+++ b/crates/sequencer/src/encryption_key.rs
@@ -9,18 +9,20 @@ use alloy_sol_types::SolValue;
 use tempo_alloy::TempoNetwork;
 use tempo_zone_contracts::ZonePortal;
 
-/// Registers `signer` as the sequencer encryption key on `portal`.
+/// Registers the encryption public key corresponding to `encryption_signer` on `portal`.
 ///
 /// Derives the secp256k1 public key, signs a proof-of-possession over
-/// `(portal, x, yParity)`, and returns the registration transaction hash.
+/// `(portal, x, yParity)`, and returns the registration transaction hash. The
+/// provider's wallet signs and sends the transaction, so it may be distinct
+/// from `encryption_signer`.
 pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
     provider: &P,
     portal: Address,
-    signer: &PrivateKeySigner,
+    encryption_signer: &PrivateKeySigner,
 ) -> eyre::Result<B256> {
     use k256::{AffinePoint, ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
 
-    let secret = k256::SecretKey::from_slice(signer.to_bytes().as_slice())?;
+    let secret = k256::SecretKey::from_slice(encryption_signer.to_bytes().as_slice())?;
     let scalar: Scalar = *secret.to_nonzero_scalar();
     let public = AffinePoint::from(ProjectivePoint::GENERATOR * scalar);
     let encoded = public.to_encoded_point(true);
@@ -28,7 +30,7 @@ pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
     let y_parity: u8 = encoded.as_bytes()[0]; // 0x02 or 0x03
 
     let message = keccak256((portal, x, U256::from(y_parity)).abi_encode());
-    let signature = signer.sign_hash_sync(&message)?;
+    let signature = encryption_signer.sign_hash_sync(&message)?;
     let pop_v = signature.v() as u8 + 27;
     let pop_r = B256::from(signature.r().to_be_bytes::<32>());
     let pop_s = B256::from(signature.s().to_be_bytes::<32>());

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -267,13 +267,14 @@ Encrypted deposits hide the recipient address and memo on-chain using ECIES encr
 # For manual setup:
 PRIVATE_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
   --portal "$L1_PORTAL_ADDRESS" \
-  --l1-rpc-url "$L1_RPC_URL"
+  --l1-rpc-url "$L1_RPC_URL" \
+  --encryption-private-key "$SEQUENCER_KEY"
 
 # To sign from the admin or an active sequencer but register a separate encryption public key:
-PRIVATE_KEY="$PORTAL_CALLER_KEY" ENCRYPTION_PRIVATE_KEY="$ENCRYPTION_KEY" \
-  cargo run -p tempo-xtask -- set-encryption-key \
+PRIVATE_KEY="$PORTAL_CALLER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
     --portal "$L1_PORTAL_ADDRESS" \
-    --l1-rpc-url "$L1_RPC_URL"
+    --l1-rpc-url "$L1_RPC_URL" \
+    --encryption-private-key "$ENCRYPTION_KEY"
 
 # Send a deposit
 just send-deposit 1000000                       # to your own address

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -257,23 +257,30 @@ just send-deposit 1000000                       # deposit to your own address
 just send-deposit 1000000 <recipient-address>   # deposit to a specific address
 ```
 
-#### Encryption Key Setup
+#### Encryption Public-Key Setup
 
 Encrypted deposits hide the recipient address and memo on-chain using ECIES encryption to the sequencer's public key. Only the sequencer can decrypt them during block building.
 
 ```bash
-# The sequencer must first register their encryption key (done automatically by deploy-zone)
+# The sequencer must first register their encryption public key (done automatically by deploy-zone).
+# The private key is retained by the sequencer for decryption and proof of possession.
 # For manual setup:
 PRIVATE_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
   --portal "$L1_PORTAL_ADDRESS" \
   --l1-rpc-url "$L1_RPC_URL"
+
+# To sign from the admin or an active sequencer but register a separate encryption public key:
+PRIVATE_KEY="$PORTAL_CALLER_KEY" ENCRYPTION_PRIVATE_KEY="$ENCRYPTION_KEY" \
+  cargo run -p tempo-xtask -- set-encryption-key \
+    --portal "$L1_PORTAL_ADDRESS" \
+    --l1-rpc-url "$L1_RPC_URL"
 
 # Send a deposit
 just send-deposit 1000000                       # to your own address
 just send-deposit 1000000 <recipient-address>   # to a specific address
 ```
 
-Before registering a replacement encryption key, add its private key to
+Before registering a replacement encryption public key, add its encryption private key to
 `--deposit-decryption-keys-file`, restart every node that may sequence, and confirm the nodes are
 healthy. Keep each previous key in the file while the Portal still accepts deposits for it during
 the rotation grace period. File order does not matter: finalized Portal registrations bind each

--- a/xtask/src/set_encryption_key.rs
+++ b/xtask/src/set_encryption_key.rs
@@ -1,15 +1,18 @@
-//! Registers the sequencer's encryption key on the ZonePortal.
+//! Registers an encryption public key on the ZonePortal from its corresponding private key.
 //!
 //! Calls the shared sequencer registration helper, which derives the secp256k1
 //! public key, constructs the proof-of-possession signature, and submits it to
 //! the portal contract.
 
 use alloy::{
-    network::EthereumWallet, primitives::Address, providers::ProviderBuilder,
+    network::EthereumWallet,
+    primitives::Address,
+    providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
 };
 use eyre::WrapErr as _;
 use tempo_alloy::TempoNetwork;
+use tempo_chainspec::constants::{mainnet::MAINNET_CHAIN_ID, moderato::MODERATO_CHAIN_ID};
 use zone_sequencer::register_encryption_key;
 
 #[derive(Debug, clap::Parser)]
@@ -22,31 +25,27 @@ pub(crate) struct SetEncryptionKey {
     #[arg(long, env = "L1_PORTAL_ADDRESS")]
     portal: Address,
 
-    /// Encryption private key (hex). Also signs the transaction unless
-    /// `transaction_private_key` is provided.
+    /// Admin or active sequencer private key (hex) used to sign the transaction.
     #[arg(long, env = "PRIVATE_KEY", hide_env_values = true)]
     private_key: String,
 
-    /// Private key of the active sequencer that submits the L1 transaction.
-    /// Defaults to `private_key` for single-sequencer zones.
-    #[arg(long, env = "TRANSACTION_PRIVATE_KEY", hide_env_values = true)]
-    transaction_private_key: Option<String>,
+    /// Encryption private key (hex) whose public key is registered.
+    #[arg(long, hide_env_values = true)]
+    encryption_private_key: String,
 }
 
 impl SetEncryptionKey {
     pub(crate) async fn run(self) -> eyre::Result<()> {
-        let encryption_signer = parse_private_key(&self.private_key)?;
-        let transaction_signer = parse_private_key(
-            self.transaction_private_key
-                .as_deref()
-                .unwrap_or(&self.private_key),
-        )?;
-
+        let transaction_signer =
+            parse_private_key(&self.private_key, "--private-key / PRIVATE_KEY")?;
+        let encryption_signer =
+            parse_private_key(&self.encryption_private_key, "--encryption-private-key")?;
         let wallet = EthereumWallet::from(transaction_signer);
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
             .connect(&self.l1_rpc_url)
             .await?;
+        let chain_id = provider.get_chain_id().await?;
 
         println!(
             "Sending setSequencerEncryptionKey to portal {}...",
@@ -56,18 +55,26 @@ impl SetEncryptionKey {
             .await
             .wrap_err("failed to send setSequencerEncryptionKey")?;
 
-        println!("Encryption key registered!");
-        println!("Explorer: https://explore.moderato.tempo.xyz/tx/{tx_hash}");
+        println!("Encryption public key registered!");
+        match chain_id {
+            MAINNET_CHAIN_ID => println!("Explorer: https://explore.tempo.xyz/tx/{tx_hash}"),
+            MODERATO_CHAIN_ID => {
+                println!("Explorer: https://explore.moderato.tempo.xyz/tx/{tx_hash}")
+            }
+            _ => println!("Transaction: {tx_hash}"),
+        }
 
         Ok(())
     }
 }
 
-fn parse_private_key(private_key: &str) -> eyre::Result<PrivateKeySigner> {
-    Ok(private_key
+fn parse_private_key(private_key: &str, source: &str) -> eyre::Result<PrivateKeySigner> {
+    private_key
+        .trim()
         .strip_prefix("0x")
-        .unwrap_or(private_key)
-        .parse()?)
+        .unwrap_or(private_key.trim())
+        .parse()
+        .wrap_err_with(|| format!("invalid {source}"))
 }
 
 #[cfg(test)]
@@ -79,8 +86,10 @@ mod tests {
         let key = "1111111111111111111111111111111111111111111111111111111111111111";
 
         assert_eq!(
-            parse_private_key(key).unwrap().to_bytes(),
-            parse_private_key(&format!("0x{key}")).unwrap().to_bytes()
+            parse_private_key(key, "test key").unwrap().to_bytes(),
+            parse_private_key(&format!("0x{key}"), "test key")
+                .unwrap()
+                .to_bytes()
         );
     }
 }


### PR DESCRIPTION
## Summary

- Allow `set-encryption-key` to sign the transaction with the admin or sequencer key while registering a separate encryption private key.
- Print an explorer URL only for known Tempo chain specifications.

## Stack

This PR is stacked on #1106, which contains the Portal ABI and authorization changes.