### PR TITLE
fix: resume forced recovery after restart

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -10,8 +10,8 @@ use crate::{
     },
     role::{
         EventSinks, LeaderSequencerDeps, RoleControllerContext, SharedRoleStatus,
-        route_backfill_requests, route_backfill_responses, route_events_to_generations,
-        run_role_controller,
+        canonical_recovery_height, route_backfill_requests, route_backfill_responses,
+        route_events_to_generations, run_role_controller,
     },
     rpc::{
         NodeZoneDebugApi, OperatorWeb3Api, OperatorZoneApi, SequencerRpcContext,
@@ -596,7 +596,7 @@ where
                     .map(|header| header.number())
                     .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
             };
-            let (historical_replay_through, ()) = tokio::try_join!(
+            let (historical_replay_through, portal_leadership) = tokio::try_join!(
                 finalized_replay_boundary,
                 seed_leadership_schedule(
                     &l1_provider,
@@ -611,10 +611,14 @@ where
             schedule.record_applied_anchor(snapshot_anchor);
             install_manifest_forced_recovery(
                 ctx.node.provider(),
+                &l1_provider,
+                self.portal_address,
                 snapshot_anchor,
+                portal_leadership,
                 p2p.manifest(),
                 &schedule,
-            )?;
+            )
+            .await?;
             self.l1_config.leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
                 schedule,
                 manifest: p2p.manifest().clone(),
@@ -948,60 +952,118 @@ impl LeadershipSink for ScheduleLeadershipSink {
 
 /// Install the manifest's temporary runtime authority before any role-dependent task starts.
 ///
-/// The selected block must be the persisted canonical head. The schedule was seeded from the
-/// portal at that block's Tempo anchor immediately before this call, so its latest epoch is the
-/// portal state being overridden.
-fn install_manifest_forced_recovery<P>(
+/// The selected block must remain in the persisted canonical chain. Its historical state restores
+/// the original Tempo anchor and portal epoch, while the current portal snapshot distinguishes an
+/// in-progress recovery from a completed directive left in the manifest after restart.
+///
+/// Canonical ancestry is intentionally a local restart check. Cross-node convergence still relies
+/// on the operational invariant that every descendant was produced on the same chain by the
+/// selected, non-equivocating recovery leader.
+async fn install_manifest_forced_recovery<P>(
     provider: &P,
+    l1_provider: &alloy_provider::DynProvider<TempoNetwork>,
+    portal_address: Address,
     snapshot_anchor: u64,
+    portal_leadership: Option<LeadershipState>,
     manifest: &ZoneManifest,
     schedule: &LeadershipSchedule,
 ) -> eyre::Result<()>
 where
-    P: BlockNumReader + HeaderProvider<Header = TempoHeader>,
+    P: BlockNumReader + HeaderProvider<Header = TempoHeader> + StateProviderFactory,
 {
     let Some(recovery) = manifest.forced_recovery() else {
         return Ok(());
     };
-    let portal_epoch = schedule.latest().map(|record| record.epoch).ok_or_else(|| {
+    let portal_leadership = portal_leadership.ok_or_else(|| {
         eyre::eyre!(
             "forced recovery requires a portal leadership snapshot at the local Tempo checkpoint"
         )
     })?;
-    let zone_height = provider.best_block_number()?;
-    let zone_header = provider
-        .sealed_header(zone_height)?
-        .ok_or_else(|| eyre::eyre!("local canonical zone header {zone_height} is missing"))?;
-    eyre::ensure!(
-        zone_header.hash() == recovery.recovery_block_hash(),
-        "forced recovery block hash {} does not equal local canonical head {} at height {}",
-        recovery.recovery_block_hash(),
-        zone_header.hash(),
-        zone_height,
-    );
-
-    let recovery_start_tempo_block = snapshot_anchor
+    let recovery_zone_height = canonical_recovery_height(provider, recovery.recovery_block_hash())?;
+    let recovery_anchor = provider
+        .history_by_block_number(recovery_zone_height)?
+        .tempo_block_number()?;
+    let recovery_start_tempo_block = recovery_anchor
         .checked_add(1)
         .ok_or_else(|| eyre::eyre!("forced recovery Tempo anchor overflow"))?;
-    let recovery_epoch = portal_epoch
+
+    let recovery_portal_epoch = if recovery_anchor == snapshot_anchor {
+        portal_leadership.epoch
+    } else {
+        ZonePortal::new(portal_address, l1_provider)
+            .leaderEpoch()
+            .block(alloy_rpc_types_eth::BlockId::number(recovery_anchor))
+            .call()
+            .await
+            .map_err(|err| {
+                eyre::eyre!(
+                    "failed to read portal epoch at recovery Tempo block {recovery_anchor}: {err}"
+                )
+            })?
+    };
+    let recovery_epoch = recovery_portal_epoch
         .checked_add(1)
         .ok_or_else(|| eyre::eyre!("forced recovery epoch overflow"))?;
-    schedule.install_forced_recovery(
-        recovery_epoch,
-        recovery.leader().clone(),
-        recovery.recovery_block_hash(),
-        recovery_start_tempo_block,
-    )?;
+
+    match forced_recovery_restart_state(recovery_epoch, snapshot_anchor, &portal_leadership)? {
+        ForcedRecoveryRestartState::Completed => {
+            warn!(
+                target: "reth::cli",
+                leader = %recovery.leader(),
+                recovery_epoch,
+                recovery_zone_height,
+                recovery_zone_hash = %recovery.recovery_block_hash(),
+                snapshot_anchor,
+                portal_epoch = portal_leadership.epoch,
+                portal_activation_tempo_block = portal_leadership.activation_tempo_block,
+                "Skipping completed manifest forced recovery; remove the stale directive"
+            );
+            metrics::counter!("zone_forced_recovery_directives_total", "result" => "completed")
+                .increment(1);
+            return Ok(());
+        }
+        ForcedRecoveryRestartState::Install => schedule.install_forced_recovery(
+            recovery_epoch,
+            recovery.leader().clone(),
+            recovery.recovery_block_hash(),
+            recovery_start_tempo_block,
+        )?,
+    };
     info!(
         target: "reth::cli",
         leader = %recovery.leader(),
-        portal_epoch,
-        recovery_zone_height = zone_height,
+        recovery_portal_epoch,
+        recovery_zone_height,
         recovery_zone_hash = %recovery.recovery_block_hash(),
         recovery_start_tempo_block,
+        resumed = snapshot_anchor >= recovery_start_tempo_block,
         "Installed manifest forced recovery"
     );
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ForcedRecoveryRestartState {
+    Install,
+    Completed,
+}
+
+fn forced_recovery_restart_state(
+    recovery_epoch: u64,
+    snapshot_anchor: u64,
+    portal: &LeadershipState,
+) -> eyre::Result<ForcedRecoveryRestartState> {
+    eyre::ensure!(
+        portal.activation_tempo_block <= snapshot_anchor,
+        "portal epoch {} activates at Tempo block {}, after historical snapshot anchor \
+         {snapshot_anchor}",
+        portal.epoch,
+        portal.activation_tempo_block,
+    );
+    if portal.epoch < recovery_epoch {
+        return Ok(ForcedRecoveryRestartState::Install);
+    }
+    Ok(ForcedRecoveryRestartState::Completed)
 }
 
 /// Seed the leadership schedule from the portal snapshot at the local Tempo anchor.
@@ -1013,7 +1075,7 @@ async fn seed_leadership_schedule(
     snapshot_anchor: u64,
     manifest: &Arc<ZoneManifest>,
     schedule: &LeadershipSchedule,
-) -> eyre::Result<()> {
+) -> eyre::Result<Option<LeadershipState>> {
     let block_id = alloy_rpc_types_eth::BlockId::number(snapshot_anchor);
     let portal_code = if snapshot_anchor == 0 {
         Default::default()
@@ -1036,7 +1098,7 @@ async fn seed_leadership_schedule(
             "Portal is not deployed at the local Tempo anchor; leadership stays fenced until \
              the creation block replays"
         );
-        return Ok(());
+        return Ok(None);
     }
 
     let portal = ZonePortal::new(portal_address, l1_provider);
@@ -1063,7 +1125,8 @@ async fn seed_leadership_schedule(
              historical manifest identity; refusing to start without an authenticated leader"
             )
         })?;
-    schedule.publish(LeadershipState::new(epoch, leader_peer.clone(), activation))?;
+    let leadership = LeadershipState::new(epoch, leader_peer.clone(), activation);
+    schedule.publish(leadership.clone())?;
     info!(
         target: "reth::cli",
         snapshot_anchor,
@@ -1073,7 +1136,7 @@ async fn seed_leadership_schedule(
         peer = %leader_peer,
         "Bootstrapped leadership from the finalized portal snapshot"
     );
-    Ok(())
+    Ok(Some(leadership))
 }
 
 impl<N> ZoneAddOns<N>
@@ -1933,6 +1996,75 @@ mod tests {
         assert!(validate_configured_zone_id("test", 7, 7).is_ok());
         assert!(validate_configured_zone_id("test", 0, 7).is_err());
         assert!(validate_configured_zone_id("test", 8, 7).is_err());
+    }
+
+    #[test]
+    fn forced_recovery_installs_before_the_next_portal_epoch() {
+        let state = forced_recovery_restart_state(
+            2,
+            24_284,
+            &LeadershipState::new(1, PrivateKey::from_seed(1).public_key(), 0),
+        )
+        .unwrap();
+
+        assert_eq!(state, ForcedRecoveryRestartState::Install);
+    }
+
+    #[test]
+    fn forced_recovery_restart_preserves_one_window_across_different_heads() {
+        let recovery_leader = PrivateKey::from_seed(2).public_key();
+        let portal_leader = PrivateKey::from_seed(3).public_key();
+        let recovery_epoch = 2;
+        let recovery_start = 23_333;
+        let recovery_hash = alloy_primitives::B256::repeat_byte(0x42);
+
+        let restart_schedule = |snapshot_anchor| {
+            let portal = LeadershipState::new(1, portal_leader.clone(), 0);
+            let schedule = LeadershipSchedule::seeded(LeadershipState::new(
+                portal.epoch,
+                portal_leader.clone(),
+                portal.activation_tempo_block,
+            ));
+            schedule.record_applied_anchor(snapshot_anchor);
+            match forced_recovery_restart_state(recovery_epoch, snapshot_anchor, &portal).unwrap() {
+                ForcedRecoveryRestartState::Install => schedule
+                    .install_forced_recovery(
+                        recovery_epoch,
+                        recovery_leader.clone(),
+                        recovery_hash,
+                        recovery_start,
+                    )
+                    .unwrap(),
+                ForcedRecoveryRestartState::Completed => unreachable!(),
+            };
+            schedule
+        };
+
+        let lagging = restart_schedule(24_284);
+        let advanced = restart_schedule(26_000);
+
+        for (schedule, next_anchor) in [(lagging, 24_285), (advanced, 26_001)] {
+            let recovery = schedule.forced_recovery().unwrap();
+            assert_eq!(recovery.epoch, recovery_epoch);
+            assert_eq!(recovery.recovery_start_tempo_block, recovery_start);
+            assert_eq!(recovery.recovery_block_hash, recovery_hash);
+            assert_eq!(
+                schedule.leader_for(next_anchor).unwrap().leader,
+                recovery_leader
+            );
+        }
+    }
+
+    #[test]
+    fn forced_recovery_is_complete_after_the_portal_activation() {
+        let state = forced_recovery_restart_state(
+            2,
+            29_123,
+            &LeadershipState::new(2, PrivateKey::from_seed(3).public_key(), 27_599),
+        )
+        .unwrap();
+
+        assert_eq!(state, ForcedRecoveryRestartState::Completed);
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1003,13 +1003,6 @@ where
         .checked_add(1)
         .ok_or_else(|| eyre::eyre!("forced recovery epoch overflow"))?;
 
-    eyre::ensure!(
-        portal_leadership.activation_tempo_block <= snapshot_anchor,
-        "portal epoch {} activates at Tempo block {}, after historical snapshot anchor \
-         {snapshot_anchor}",
-        portal_leadership.epoch,
-        portal_leadership.activation_tempo_block,
-    );
     if portal_leadership.epoch >= recovery_epoch {
         warn!(
             target: "reth::cli",

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1003,30 +1003,35 @@ where
         .checked_add(1)
         .ok_or_else(|| eyre::eyre!("forced recovery epoch overflow"))?;
 
-    match forced_recovery_restart_state(recovery_epoch, snapshot_anchor, &portal_leadership)? {
-        ForcedRecoveryRestartState::Completed => {
-            warn!(
-                target: "reth::cli",
-                leader = %recovery.leader(),
-                recovery_epoch,
-                recovery_zone_height,
-                recovery_zone_hash = %recovery.recovery_block_hash(),
-                snapshot_anchor,
-                portal_epoch = portal_leadership.epoch,
-                portal_activation_tempo_block = portal_leadership.activation_tempo_block,
-                "Skipping completed manifest forced recovery; remove the stale directive"
-            );
-            metrics::counter!("zone_forced_recovery_directives_total", "result" => "completed")
-                .increment(1);
-            return Ok(());
-        }
-        ForcedRecoveryRestartState::Install => schedule.install_forced_recovery(
+    eyre::ensure!(
+        portal_leadership.activation_tempo_block <= snapshot_anchor,
+        "portal epoch {} activates at Tempo block {}, after historical snapshot anchor \
+         {snapshot_anchor}",
+        portal_leadership.epoch,
+        portal_leadership.activation_tempo_block,
+    );
+    if portal_leadership.epoch >= recovery_epoch {
+        warn!(
+            target: "reth::cli",
+            leader = %recovery.leader(),
             recovery_epoch,
-            recovery.leader().clone(),
-            recovery.recovery_block_hash(),
-            recovery_start_tempo_block,
-        )?,
-    };
+            recovery_zone_height,
+            recovery_zone_hash = %recovery.recovery_block_hash(),
+            snapshot_anchor,
+            portal_epoch = portal_leadership.epoch,
+            portal_activation_tempo_block = portal_leadership.activation_tempo_block,
+            "Skipping completed manifest forced recovery; remove the stale directive"
+        );
+        metrics::counter!("zone_forced_recovery_directives_total", "result" => "completed")
+            .increment(1);
+        return Ok(());
+    }
+    schedule.install_forced_recovery(
+        recovery_epoch,
+        recovery.leader().clone(),
+        recovery.recovery_block_hash(),
+        recovery_start_tempo_block,
+    )?;
     info!(
         target: "reth::cli",
         leader = %recovery.leader(),
@@ -1038,30 +1043,6 @@ where
         "Installed manifest forced recovery"
     );
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ForcedRecoveryRestartState {
-    Install,
-    Completed,
-}
-
-fn forced_recovery_restart_state(
-    recovery_epoch: u64,
-    snapshot_anchor: u64,
-    portal: &LeadershipState,
-) -> eyre::Result<ForcedRecoveryRestartState> {
-    eyre::ensure!(
-        portal.activation_tempo_block <= snapshot_anchor,
-        "portal epoch {} activates at Tempo block {}, after historical snapshot anchor \
-         {snapshot_anchor}",
-        portal.epoch,
-        portal.activation_tempo_block,
-    );
-    if portal.epoch < recovery_epoch {
-        return Ok(ForcedRecoveryRestartState::Install);
-    }
-    Ok(ForcedRecoveryRestartState::Completed)
 }
 
 /// Seed the leadership schedule from the portal snapshot at the local Tempo anchor.
@@ -1997,18 +1978,6 @@ mod tests {
     }
 
     #[test]
-    fn forced_recovery_installs_before_the_next_portal_epoch() {
-        let state = forced_recovery_restart_state(
-            2,
-            24_284,
-            &LeadershipState::new(1, PrivateKey::from_seed(1).public_key(), 0),
-        )
-        .unwrap();
-
-        assert_eq!(state, ForcedRecoveryRestartState::Install);
-    }
-
-    #[test]
     fn forced_recovery_restart_preserves_one_window_across_different_heads() {
         let recovery_leader = PrivateKey::from_seed(2).public_key();
         let portal_leader = PrivateKey::from_seed(3).public_key();
@@ -2024,17 +1993,14 @@ mod tests {
                 portal.activation_tempo_block,
             ));
             schedule.record_applied_anchor(snapshot_anchor);
-            match forced_recovery_restart_state(recovery_epoch, snapshot_anchor, &portal).unwrap() {
-                ForcedRecoveryRestartState::Install => schedule
-                    .install_forced_recovery(
-                        recovery_epoch,
-                        recovery_leader.clone(),
-                        recovery_hash,
-                        recovery_start,
-                    )
-                    .unwrap(),
-                ForcedRecoveryRestartState::Completed => unreachable!(),
-            };
+            schedule
+                .install_forced_recovery(
+                    recovery_epoch,
+                    recovery_leader.clone(),
+                    recovery_hash,
+                    recovery_start,
+                )
+                .unwrap();
             schedule
         };
 
@@ -2051,18 +2017,6 @@ mod tests {
                 recovery_leader
             );
         }
-    }
-
-    #[test]
-    fn forced_recovery_is_complete_after_the_portal_activation() {
-        let state = forced_recovery_restart_state(
-            2,
-            29_123,
-            &LeadershipState::new(2, PrivateKey::from_seed(3).public_key(), 27_599),
-        )
-        .unwrap();
-
-        assert_eq!(state, ForcedRecoveryRestartState::Completed);
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -596,7 +596,7 @@ where
                     .map(|header| header.number())
                     .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
             };
-            let (historical_replay_through, portal_leadership) = tokio::try_join!(
+            let (historical_replay_through, ()) = tokio::try_join!(
                 finalized_replay_boundary,
                 seed_leadership_schedule(
                     &l1_provider,
@@ -614,7 +614,6 @@ where
                 &l1_provider,
                 self.portal_address,
                 snapshot_anchor,
-                portal_leadership,
                 p2p.manifest(),
                 &schedule,
             )
@@ -964,7 +963,6 @@ async fn install_manifest_forced_recovery<P>(
     l1_provider: &alloy_provider::DynProvider<TempoNetwork>,
     portal_address: Address,
     snapshot_anchor: u64,
-    portal_leadership: Option<LeadershipState>,
     manifest: &ZoneManifest,
     schedule: &LeadershipSchedule,
 ) -> eyre::Result<()>
@@ -974,7 +972,7 @@ where
     let Some(recovery) = manifest.forced_recovery() else {
         return Ok(());
     };
-    let portal_leadership = portal_leadership.ok_or_else(|| {
+    let portal_leadership = schedule.latest().ok_or_else(|| {
         eyre::eyre!(
             "forced recovery requires a portal leadership snapshot at the local Tempo checkpoint"
         )
@@ -1075,7 +1073,7 @@ async fn seed_leadership_schedule(
     snapshot_anchor: u64,
     manifest: &Arc<ZoneManifest>,
     schedule: &LeadershipSchedule,
-) -> eyre::Result<Option<LeadershipState>> {
+) -> eyre::Result<()> {
     let block_id = alloy_rpc_types_eth::BlockId::number(snapshot_anchor);
     let portal_code = if snapshot_anchor == 0 {
         Default::default()
@@ -1098,7 +1096,7 @@ async fn seed_leadership_schedule(
             "Portal is not deployed at the local Tempo anchor; leadership stays fenced until \
              the creation block replays"
         );
-        return Ok(None);
+        return Ok(());
     }
 
     let portal = ZonePortal::new(portal_address, l1_provider);
@@ -1126,7 +1124,7 @@ async fn seed_leadership_schedule(
             )
         })?;
     let leadership = LeadershipState::new(epoch, leader_peer.clone(), activation);
-    schedule.publish(leadership.clone())?;
+    schedule.publish(leadership)?;
     info!(
         target: "reth::cli",
         snapshot_anchor,
@@ -1136,7 +1134,7 @@ async fn seed_leadership_schedule(
         peer = %leader_peer,
         "Bootstrapped leadership from the finalized portal snapshot"
     );
-    Ok(Some(leadership))
+    Ok(())
 }
 
 impl<N> ZoneAddOns<N>

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -547,9 +547,11 @@ enum Readiness {
 
 /// Evaluate the promotion barrier
 ///
-/// Forced-recovery promotion requires the local canonical head to remain exactly at the
-/// operator-selected block. Normal transitions need no additional evidence: the next-anchor rule
-/// and one-to-one zone/L1 block mapping ensure all earlier leaders' blocks are already local.
+/// Forced-recovery promotion requires the operator-selected block to remain in the local canonical
+/// chain. The node may have advanced beyond that checkpoint before restarting, so requiring it to
+/// remain the head would make every in-progress recovery restart fatal. Normal transitions need no
+/// additional evidence: the next-anchor rule and one-to-one zone/L1 block mapping ensure all
+/// earlier leaders' blocks are already local.
 fn promotion_readiness<P>(
     provider: &P,
     schedule: &LeadershipSchedule,
@@ -566,39 +568,43 @@ where
                 .portal_activation_tempo_block
                 .is_none_or(|activation| next_anchor < activation)
     }) {
-        let local_height = match provider.best_block_number() {
-            Ok(height) => height,
-            Err(err) => {
-                return Readiness::Conflicted(format!(
-                    "cannot read the local head for forced recovery: {err}"
-                ));
-            }
-        };
-        let header = match provider.sealed_header(local_height) {
-            Ok(Some(header)) => header,
-            Ok(None) => {
-                return Readiness::Conflicted(format!(
-                    "forced recovery local header {local_height} is missing"
-                ));
-            }
-            Err(err) => {
-                return Readiness::Conflicted(format!(
-                    "cannot read forced recovery local header {local_height}: {err}"
-                ));
-            }
-        };
-        if header.hash() != recovery.recovery_block_hash {
+        if let Err(err) = canonical_recovery_height(provider, recovery.recovery_block_hash) {
             return Readiness::Conflicted(format!(
-                "forced recovery canonical head mismatch at height {local_height}: expected {}, \
-                 found {}",
-                recovery.recovery_block_hash,
-                header.hash(),
+                "forced recovery checkpoint is not canonical: {err}"
             ));
         }
         return Readiness::Ready;
     }
 
     Readiness::Ready
+}
+
+/// Resolve an operator-selected recovery hash to its canonical header.
+///
+/// The hash-to-number index can contain a known non-canonical block, so the header at the resolved
+/// height is read through the canonical number index and compared again before the checkpoint is
+/// trusted. This proves local ancestry only: restart safety additionally assumes that participating
+/// nodes advanced on the same non-equivocating recovery-leader chain.
+pub(crate) fn canonical_recovery_height<P>(
+    provider: &P,
+    recovery_block_hash: alloy_primitives::B256,
+) -> eyre::Result<u64>
+where
+    P: BlockNumReader + HeaderProvider<Header = TempoHeader>,
+{
+    let recovery_height = provider
+        .block_number(recovery_block_hash)?
+        .ok_or_else(|| eyre::eyre!("recovery block {recovery_block_hash} is unknown"))?;
+    let header = provider.sealed_header(recovery_height)?.ok_or_else(|| {
+        eyre::eyre!("canonical header at recovery height {recovery_height} is missing")
+    })?;
+    eyre::ensure!(
+        header.hash() == recovery_block_hash,
+        "recovery block {recovery_block_hash} is not canonical at height {recovery_height}; \
+         canonical hash is {}",
+        header.hash(),
+    );
+    Ok(recovery_height)
 }
 
 /// Run the role controller until the process shuts down.
@@ -1131,16 +1137,17 @@ mod tests {
     use std::{future::pending, time::Duration};
 
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+    use reth_primitives_traits::SealedHeader;
     use reth_provider::test_utils::MockEthProvider;
-    use tempo_primitives::TempoPrimitives;
+    use tempo_primitives::{TempoHeader, TempoPrimitives};
     use tokio::sync::{mpsc, oneshot};
     use tokio_util::sync::CancellationToken;
     use zone_p2p::{BackfillRequest, BackfillResponse};
     use zone_sequencer::ZoneSequencerHandle;
 
     use super::{
-        EventSinks, TaskEnd, latest_sealed_header, route_backfill_requests,
-        route_backfill_responses, supervise_sequencer_tasks,
+        EventSinks, TaskEnd, canonical_recovery_height, latest_sealed_header,
+        route_backfill_requests, route_backfill_responses, supervise_sequencer_tasks,
     };
 
     struct DropSignal(Option<oneshot::Sender<()>>);
@@ -1161,6 +1168,37 @@ mod tests {
             latest_sealed_header(&provider).is_err(),
             "leader startup must fail when its canonical head cannot be read"
         );
+    }
+
+    #[test]
+    fn recovery_checkpoint_may_be_a_canonical_ancestor() {
+        let provider = MockEthProvider::<TempoPrimitives>::new();
+        let mut recovery_header = TempoHeader::default();
+        recovery_header.inner.number = 7;
+        let recovery_hash = SealedHeader::seal_slow(recovery_header.clone()).hash();
+        provider.add_header(recovery_hash, recovery_header);
+
+        let mut head = TempoHeader::default();
+        head.inner.number = 9;
+        let head_hash = SealedHeader::seal_slow(head.clone()).hash();
+        provider.add_header(head_hash, head);
+
+        assert_eq!(
+            canonical_recovery_height(&provider, recovery_hash).unwrap(),
+            7
+        );
+    }
+
+    #[test]
+    fn recovery_checkpoint_rejects_a_known_noncanonical_hash() {
+        let provider = MockEthProvider::<TempoPrimitives>::new();
+        let mut header = TempoHeader::default();
+        header.inner.number = 7;
+        let noncanonical_hash = alloy_primitives::B256::repeat_byte(0x42);
+        provider.add_header(noncanonical_hash, header);
+
+        let error = canonical_recovery_height(&provider, noncanonical_hash).unwrap_err();
+        assert!(error.to_string().contains("is not canonical at height 7"));
     }
 
     #[tokio::test]

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -12,15 +12,25 @@ is retained in an activation-indexed `LeadershipSchedule`.
 
 For manual crashed-leader recovery, the operator stops the nodes, selects a canonical tip shared by
 the survivors, adds the same `[forced_recovery]` directive to every manifest, and restarts them.
-Each node verifies that its local canonical head has the configured hash before any role task
-starts. The selected replacement governs from the next Tempo anchor until the first subsequent
-finalized portal transition reaches its activation anchor. Nodes never submit that transition
-automatically: the operator may call the ordinary `zone_setLeader` RPC whenever the zone is ready
-to return to the on-chain schedule.
+Each node verifies that the configured hash remains in its local canonical chain before any role
+task starts. On the initial recovery start it should be the canonical head shared by every
+survivor. On a later restart it may be an ancestor of the local head; the node reconstructs the
+original recovery anchor and epoch instead of starting a new recovery window. The selected
+replacement governs from the next Tempo anchor until the first subsequent finalized portal
+transition reaches its activation anchor. Nodes never submit that transition automatically: the
+operator may call the ordinary `zone_setLeader` RPC whenever the zone is ready to return to the
+on-chain schedule.
 
-The configured hash must be the local canonical head at startup. After a normal portal transition
-ends recovery, the operator must remove the directive before restarting the nodes. Restarting with
-the directive after the replacement has produced past `recovery_block_hash` is unsupported.
+Restarting during recovery assumes every participating node's descendants of
+`recovery_block_hash` belong to the same chain produced by the selected, non-equivocating recovery
+leader. Canonical ancestry is local evidence and cannot prove cross-node convergence; operators
+must compare the survivors' heads before restarting if that assumption is in doubt. The configured
+L1 RPC must also serve historical Portal state at the Tempo block embedded in the recovery
+checkpoint. A node fails closed if the checkpoint is unknown or non-canonical, historical state is
+unavailable, or skipped Portal epochs make the recovery boundary ambiguous.
+
+After a normal Portal transition ends recovery, a restart skips the completed stale directive and
+logs a removal warning. Operators should still remove the directive from every manifest promptly.
 
 If a manifest is not specified, `tempo-zone` retains its existing single-sequencer startup
 behavior.
@@ -133,9 +143,11 @@ leader = "follower-a"
 recovery_block_hash = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 ```
 
-`leader` is a manifest node name and must identify a quorum member. Because the configured hash
-must be the current head, the first recovery anchor and portal epoch are taken from the node's
-persisted checkpoint; no independently configured height or epoch can disagree with the hash.
+`leader` is a manifest node name and must identify a quorum member. The hash must be the shared
+canonical head on the first recovery start. On subsequent restarts it may be a canonical ancestor;
+the first recovery anchor and Portal epoch are recovered from the zone state and historical Portal
+state at that checkpoint, so no independently configured height or epoch can disagree with the
+hash.
 
 An `rpc_only` entry declares no `secp256k1_address` and the node is started without
 `--secp256k1.key`. It never signs a settlement attestation, so the key would be dead weight —


### PR DESCRIPTION
## Summary

- accept a configured recovery checkpoint when it remains a canonical ancestor of the local head
- reconstruct the original Tempo anchor and Portal epoch so an in-progress recovery resumes after restart
- skip a completed stale directive, while failing closed for unknown, non-canonical, or unavailable history
- document the cross-node convergence and historical-L1-state requirements

This keeps one recovery window across nodes that restart at different points on the same recovery-leader chain. It assumes the selected recovery leader does not equivocate; local canonical ancestry cannot prove that descendants on separate nodes converge.

## Validation

- `rustup run nightly cargo test -p zone-node --lib` (69 passed)
- `rustup run nightly cargo test -p zone-p2p` (58 passed)
- `rustup run nightly cargo clippy -p zone-node -p zone-p2p --all-targets -- -D warnings`
- `rustup run nightly cargo build --bin tempo-zone --features jemalloc`
- `rustup run nightly cargo fmt --all -- --check`
- `git diff --check`