### PR TITLE
feat(xtask): add portal access lockdown

### DIFF
--- a/crates/contracts/Cargo.toml
+++ b/crates/contracts/Cargo.toml
@@ -21,8 +21,11 @@ alloy-contract = { workspace = true, optional = true }
 alloy-network = { workspace = true, optional = true }
 alloy-provider = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
+alloy-signer = { workspace = true, optional = true }
+alloy-transport = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+k256 = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-transport.workspace = true
@@ -42,5 +45,8 @@ rpc = [
     "dep:alloy-network",
     "dep:alloy-provider",
     "dep:alloy-rpc-types-eth",
+    "dep:alloy-signer",
+    "dep:alloy-transport",
+    "dep:k256",
     "dep:tokio",
 ]

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -305,7 +305,10 @@ crate::sol! {
         function pendingAdmin() external view returns (address);
         function refunds(address token, address owner) external view returns (uint128);
 
-        function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+        function sequencerEncryptionKey()
+            external
+            view
+            returns (bytes32 x, uint8 yParity, address pubkey);
 
         function encryptionKeyCount() external view returns (uint256);
         function encryptionKeyAt(uint256 index)
@@ -447,10 +450,23 @@ impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>
             .block(alloy_rpc_types_eth::BlockId::number(block_number))
             .call()
             .await?;
+        let mut compressed = [0; 33];
+        compressed[0] = key.yParity;
+        compressed[1..].copy_from_slice(key.x.as_slice());
+        let verifying_key =
+            k256::ecdsa::VerifyingKey::from_sec1_bytes(&compressed).map_err(|err| {
+                alloy_contract::Error::TransportError(
+                    alloy_transport::TransportErrorKind::custom_str(&format!(
+                        "invalid Portal encryption public key: {err}"
+                    ))
+                    .into(),
+                )
+            })?;
         Ok((
             ZonePortal::sequencerEncryptionKeyReturn {
                 x: key.x,
                 yParity: key.yParity,
+                pubkey: alloy_signer::utils::public_key_to_address(&verifying_key),
             },
             key.keyIndex,
         ))
@@ -464,15 +480,20 @@ mod tests {
     use alloy_provider::{ProviderBuilder, bindings::IMulticall3};
     use alloy_sol_types::SolCall;
     use alloy_transport::mock::Asserter;
+    use k256::elliptic_curve::sec1::ToEncodedPoint as _;
 
     #[tokio::test]
     async fn encryption_key_reads_key_and_index_from_one_snapshot() {
         let asserter = Asserter::new();
         let provider = ProviderBuilder::new().connect_mocked_client(asserter.clone());
         let block_number = 42_u64;
+        let private_key = k256::SecretKey::from_slice(&[0x11; 32]).unwrap();
+        let compressed = private_key.public_key().to_encoded_point(true);
+        let verifying_key =
+            k256::ecdsa::VerifyingKey::from_sec1_bytes(compressed.as_bytes()).unwrap();
         let expected = ZonePortal::encryptionKeyAtBlockReturn {
-            x: B256::repeat_byte(0x11),
-            yParity: 1,
+            x: B256::from_slice(compressed.x().unwrap()),
+            yParity: compressed.as_bytes()[0],
             keyIndex: U256::from(7),
         };
 
@@ -486,6 +507,10 @@ mod tests {
 
         assert_eq!(key.x, expected.x);
         assert_eq!(key.yParity, expected.yParity);
+        assert_eq!(
+            key.pubkey,
+            alloy_signer::utils::public_key_to_address(&verifying_key)
+        );
         assert_eq!(key_index, expected.keyIndex);
         assert!(asserter.read_q().is_empty());
     }

--- a/crates/sequencer/src/encryption_key.rs
+++ b/crates/sequencer/src/encryption_key.rs
@@ -9,18 +9,20 @@ use alloy_sol_types::SolValue;
 use tempo_alloy::TempoNetwork;
 use tempo_zone_contracts::ZonePortal;
 
-/// Registers `signer` as the sequencer encryption key on `portal`.
+/// Registers the encryption public key corresponding to `encryption_signer` on `portal`.
 ///
 /// Derives the secp256k1 public key, signs a proof-of-possession over
-/// `(portal, x, yParity)`, and returns the registration transaction hash.
+/// `(portal, x, yParity)`, and returns the registration transaction hash. The
+/// provider's wallet signs and sends the transaction, so it may be distinct
+/// from `encryption_signer`.
 pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
     provider: &P,
     portal: Address,
-    signer: &PrivateKeySigner,
+    encryption_signer: &PrivateKeySigner,
 ) -> eyre::Result<B256> {
     use k256::{AffinePoint, ProjectivePoint, Scalar, elliptic_curve::sec1::ToEncodedPoint};
 
-    let secret = k256::SecretKey::from_slice(signer.to_bytes().as_slice())?;
+    let secret = k256::SecretKey::from_slice(encryption_signer.to_bytes().as_slice())?;
     let scalar: Scalar = *secret.to_nonzero_scalar();
     let public = AffinePoint::from(ProjectivePoint::GENERATOR * scalar);
     let encoded = public.to_encoded_point(true);
@@ -28,7 +30,7 @@ pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
     let y_parity: u8 = encoded.as_bytes()[0]; // 0x02 or 0x03
 
     let message = keccak256((portal, x, U256::from(y_parity)).abi_encode());
-    let signature = signer.sign_hash_sync(&message)?;
+    let signature = encryption_signer.sign_hash_sync(&message)?;
     let pop_v = signature.v() as u8 + 27;
     let pop_r = B256::from(signature.r().to_be_bytes::<32>());
     let pop_s = B256::from(signature.s().to_be_bytes::<32>());

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -248,23 +248,30 @@ just send-deposit 1000000                       # deposit to your own address
 just send-deposit 1000000 <recipient-address>   # deposit to a specific address
 ```
 
-#### Encryption Key Setup
+#### Encryption Public-Key Setup
 
 Encrypted deposits hide the recipient address and memo on-chain using ECIES encryption to the sequencer's public key. Only the sequencer can decrypt them during block building.
 
 ```bash
-# The sequencer must first register their encryption key (done automatically by deploy-zone)
+# The sequencer must first register their encryption public key (done automatically by deploy-zone).
+# The private key is retained by the sequencer for decryption and proof of possession.
 # For manual setup:
 PRIVATE_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- set-encryption-key \
   --portal "$L1_PORTAL_ADDRESS" \
   --l1-rpc-url "$L1_RPC_URL"
+
+# To sign from the admin or an active sequencer but register a separate encryption public key:
+PRIVATE_KEY="$PORTAL_CALLER_KEY" ENCRYPTION_PRIVATE_KEY="$ENCRYPTION_KEY" \
+  cargo run -p tempo-xtask -- set-encryption-key \
+    --portal "$L1_PORTAL_ADDRESS" \
+    --l1-rpc-url "$L1_RPC_URL"
 
 # Send a deposit
 just send-deposit 1000000                       # to your own address
 just send-deposit 1000000 <recipient-address>   # to a specific address
 ```
 
-Before registering a replacement encryption key, add its private key to
+Before registering a replacement encryption public key, add its encryption private key to
 `--deposit-decryption-keys-file`, restart every node that may sequence, and confirm the nodes are
 healthy. Keep each previous key in the file while the Portal still accepts deposits for it during
 the rotation grace period. File order does not matter: finalized Portal registrations bind each

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -606,6 +606,24 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 
 The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` uses `zoneFactory` from `zone.json` before falling back to this address. Pass `--zone-factory` or set `ZONE_FACTORY` to override it.
 
+### Emergency portal access lockdown
+
+To immediately close an open portal and remove every currently allowed account, replay the portal's
+role history and revoke all current `Account` roles:
+
+```bash
+PRIVATE_KEY="<portal-admin-key>" cargo run -p tempo-xtask -- lock-down-access \
+  --l1-rpc-url "$L1_RPC_URL" \
+  --portal "$L1_PORTAL_ADDRESS" \
+  --from-block <portal-creation-block>
+```
+
+`RoleUpdated` is the source of truth for this backfill because portal roles are stored in a mapping.
+Set `--from-block` at or before the portal initialization block; choosing a later block can miss an
+already-allowed account. The command first enables access enforcement when the portal is open, then
+replays events through that transaction's block, revokes current account roles, and verifies the
+result. Callback gateway roles are not changed.
+
 ### Verifying the ZoneFactory
 
 TIP-1091 makes the factory and its shared dependencies protocol-managed accounts. Verify them at their fixed addresses:

--- a/invariants.md
+++ b/invariants.md
@@ -29,7 +29,7 @@ for auditors, invariant/fuzz test authors, and production monitoring.
 |---|---|---|---|
 | `TEMPO-ZONE-ADMIN-NONZERO` | Portal `admin != address(0)` for every zone | 🟡 | Token governance can become permanently unavailable |
 | `TEMPO-ZONE-ADMIN-ONLY-GOVERNANCE` | Only `admin` can govern tokens and access modes or set `zoneGasRate`, `maxTempoGasRate`, and `bouncebackGas` | 🟡 | A sequencer or user can enable malicious assets, reopen paused deposits, alter access policy, or exceed governance fee bounds |
-| `TEMPO-ZONE-SEQUENCER-ONLY-OPS` | Only the registered sequencer can set `tempoGasRate`, set encryption keys, set RPC URL, submit batches, and process withdrawals | 🟡 | Unauthorized operators can censor, misprice, settle, or drain queued work |
+| `TEMPO-ZONE-SEQUENCER-ONLY-OPS` | Only a registered sequencer can set `tempoGasRate`, set RPC URL, submit batches, and process withdrawals; the portal admin or a registered sequencer can set encryption keys | 🟡 | Unauthorized operators can censor, misprice, settle, or drain queued work |
 | `TEMPO-ZONE-GAS-RATE-BOUNDED` | `zoneGasRate` and `maxTempoGasRate` never exceed `MAX_GAS_FEE_RATE`, and `tempoGasRate` never exceeds the finalized `maxTempoGasRate` | 🟢 | Deposit or withdrawal fee math may overflow or become economically unusable |
 
 ### Token Registry and Supply

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -834,7 +834,7 @@ interface IZonePortal {
     /// @return yParity The Y coordinate parity (0x02 or 0x03)
     function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
 
-    /// @notice Set the sequencer's encryption public key. Only callable by sequencer.
+    /// @notice Set the sequencer's encryption public key. Only callable by an active sequencer or admin.
     /// @dev Appends to key history. The new key becomes active at the current Tempo block.
     /// @param x The X coordinate of the secp256k1 public key
     /// @param yParity The Y coordinate parity (0x02 or 0x03)

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -832,7 +832,11 @@ interface IZonePortal {
     /// @notice Get the sequencer's current encryption public key for deposits
     /// @return x The X coordinate of the secp256k1 public key
     /// @return yParity The Y coordinate parity (0x02 or 0x03)
-    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+    /// @return pubkey The Ethereum address derived from the public key
+    function sequencerEncryptionKey()
+        external
+        view
+        returns (bytes32 x, uint8 yParity, address pubkey);
 
     /// @notice Set the sequencer's encryption public key. Only callable by an active sequencer or admin.
     /// @dev Appends to key history. The new key becomes active at the current Tempo block.

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -133,7 +133,7 @@ contract ZonePortal is IZonePortal {
     /// @dev Packed into the unused bytes in slot 4. Defaults to zero.
     uint64 public bouncebackGas;
 
-    /// @notice Historical encryption keys with activation blocks
+    /// @notice Historical encryption public keys with activation blocks
     /// @dev Users specify which key they encrypted to (by index). Maintained for key rotation.
     ///      Stored at slot 5 in the ZonePortal storage layout.
     EncryptionKeyEntry[] internal _encryptionKeys;
@@ -273,6 +273,11 @@ contract ZonePortal is IZonePortal {
 
     modifier onlySequencer() {
         if (!isSequencer[msg.sender]) revert NotSequencer();
+        _;
+    }
+
+    modifier onlySequencerOrAdmin() {
+        if (!isSequencer[msg.sender] && msg.sender != admin) revert NotSequencer();
         _;
     }
 
@@ -637,8 +642,8 @@ contract ZonePortal is IZonePortal {
         return (current.x, current.yParity);
     }
 
-    /// @notice Set the sequencer's encryption public key with proof of possession
-    /// @dev Only callable by the sequencer. Appends to key history.
+    /// @notice Set the sequencer's encryption public key with proof of possession from its private key
+    /// @dev Only callable by an active sequencer or the admin. Appends to key history.
     ///      No reentrancy guard is needed because this function makes no unrestricted external
     ///      calls; its only external calls are to fixed cryptographic precompiles.
     ///      Requires a valid ECDSA signature over keccak256(abi.encode(address(this), x, yParity))
@@ -657,7 +662,7 @@ contract ZonePortal is IZonePortal {
         bytes32 popS
     )
         external
-        onlySequencer
+        onlySequencerOrAdmin
     {
         // Validate yParity
         if (!Secp256k1Lib.isCompressedYParity(yParity)) revert InvalidEphemeralPubkey();
@@ -665,7 +670,7 @@ contract ZonePortal is IZonePortal {
         // Validate x is on the secp256k1 curve
         if (!Secp256k1Lib.isValidX(x)) revert InvalidEphemeralPubkey();
 
-        // Verify proof of possession: the sequencer must sign with the encryption key's private key
+        // Verify proof of possession: the caller must prove control of the encryption private key.
         bytes32 message = keccak256(abi.encode(address(this), x, yParity));
         address recovered = ecrecover(message, popV, popR, popS);
         address expected = Secp256k1Lib.deriveAddress(x, yParity);

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -636,10 +636,15 @@ contract ZonePortal is IZonePortal {
     /// @notice Get the sequencer's current encryption public key
     /// @return x The X coordinate
     /// @return yParity The Y coordinate parity (0x02 or 0x03)
-    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity) {
+    /// @return pubkey The Ethereum address derived from the public key
+    function sequencerEncryptionKey()
+        external
+        view
+        returns (bytes32 x, uint8 yParity, address pubkey)
+    {
         if (_encryptionKeys.length == 0) revert NoEncryptionKeySet();
         EncryptionKeyEntry storage current = _encryptionKeys[_encryptionKeys.length - 1];
-        return (current.x, current.yParity);
+        return (current.x, current.yParity, Secp256k1Lib.deriveAddress(current.x, current.yParity));
     }
 
     /// @notice Set the sequencer's encryption public key with proof of possession from its private key

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -4382,10 +4382,27 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.encryptionKeyCount(), 1);
     }
 
-    function test_setSequencerEncryptionKey_onlySequencer() public {
+    function test_setSequencerEncryptionKey_revertsForCallerThatIsNeitherAdminNorSequencer()
+        public
+    {
         vm.prank(alice);
         vm.expectRevert(IZonePortal.NotSequencer.selector);
         portal.setSequencerEncryptionKey(bytes32(uint256(1)), 0x02, 27, bytes32(0), bytes32(0));
+    }
+
+    function test_setSequencerEncryptionKey_adminCanSet() public {
+        Vm.Wallet memory w = vm.createWallet(ENC_KEY_1);
+        bytes32 x = bytes32(w.publicKeyX);
+        uint8 yParity = w.publicKeyY % 2 == 0 ? 0x02 : 0x03;
+        bytes32 message = keccak256(abi.encode(address(portal), x, yParity));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(w.privateKey, message);
+
+        vm.prank(admin);
+        portal.setSequencerEncryptionKey(x, yParity, v, r, s);
+
+        (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
+        assertEq(storedX, x);
+        assertEq(storedYParity, yParity);
     }
 
     function test_setSequencerEncryptionKey_multipleKeys() public {

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -1563,10 +1563,8 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_sequencerGovernance_revertsIfAdmin() public {
-        // Inverse of test_tokenGovernance_revertsIfNotAdmin: the admin role must
-        // not be able to perform any sequencer-only action. Locks in the
-        // admin/sequencer separation from both directions. (onlySequencer reverts
-        // at the modifier, so the call arguments below are otherwise irrelevant.)
+        // Admin may rotate the deposit-encryption key, but must not perform the other
+        // sequencer-only actions below.
         Withdrawal memory w =
             _withdrawal(address(pathUSD), alice, bob, 500e6, bytes32(0), 0, alice, "");
         // Read state used as call args up front so the staticcall isn't mistaken
@@ -1577,9 +1575,6 @@ contract ZonePortalTest is BaseTest {
 
         vm.expectRevert(IZonePortal.NotSequencer.selector);
         portal.setRpcUrl("https://rpc.example");
-
-        vm.expectRevert(IZonePortal.NotSequencer.selector);
-        portal.setSequencerEncryptionKey(bytes32(uint256(1)), 0x02, 27, bytes32(0), bytes32(0));
 
         vm.expectRevert(IZonePortal.NotSequencer.selector);
         portal.submitBatch(
@@ -4376,9 +4371,10 @@ contract ZonePortalTest is BaseTest {
     function test_setSequencerEncryptionKey_success() public {
         (bytes32 x, uint8 yParity) = _setEncKeyWithPoP(ENC_KEY_1);
 
-        (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
+        (bytes32 storedX, uint8 storedYParity, address pubkey) = portal.sequencerEncryptionKey();
         assertEq(storedX, x);
         assertEq(storedYParity, yParity);
+        assertEq(pubkey, vm.createWallet(ENC_KEY_1).addr);
         assertEq(portal.encryptionKeyCount(), 1);
     }
 
@@ -4400,9 +4396,10 @@ contract ZonePortalTest is BaseTest {
         vm.prank(admin);
         portal.setSequencerEncryptionKey(x, yParity, v, r, s);
 
-        (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
+        (bytes32 storedX, uint8 storedYParity, address pubkey) = portal.sequencerEncryptionKey();
         assertEq(storedX, x);
         assertEq(storedYParity, yParity);
+        assertEq(pubkey, w.addr);
     }
 
     function test_setSequencerEncryptionKey_multipleKeys() public {
@@ -4413,9 +4410,10 @@ contract ZonePortalTest is BaseTest {
         assertEq(portal.encryptionKeyCount(), 2);
 
         // sequencerEncryptionKey returns the latest key
-        (bytes32 storedX, uint8 storedYParity) = portal.sequencerEncryptionKey();
+        (bytes32 storedX, uint8 storedYParity, address pubkey) = portal.sequencerEncryptionKey();
         assertEq(storedX, x2);
         assertEq(storedYParity, yParity2);
+        assertEq(pubkey, vm.createWallet(ENC_KEY_2).addr);
     }
 
     function test_setSequencerEncryptionKey_emitsEvent() public {

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -188,7 +188,7 @@ Each zone has two privileged roles registered on the [`ZonePortal`](#izoneportal
 - Are configured at creation as a nonempty set of at most eight unique addresses and a nonzero threshold no greater than the set size.
 - May be replaced atomically by the admin together with the threshold. The configuration nonce starts at `0`; each later replacement increments `sequencerSetVersion` and invalidates certificates from earlier configurations.
 - Any active sequencer may perform a sequencer-authorized portal operation. Batch settlement additionally requires a threshold certificate.
-- Hold the encryption private keys used to decrypt [deposits](#deposits).
+- Hold the encryption private keys corresponding to the portal's encryption public keys and used to decrypt [deposits](#deposits).
 
 A zone MAY include its admin in the sequencer set. The protocol still treats each privileged call as belonging to its role.
 
@@ -210,7 +210,7 @@ The following table lists every privileged action and the role authorized to inv
 | `setZoneGasRate(rate)` | [`ZonePortal`](#izoneportal) | **admin** |
 | `setMaxTempoGasRate(rate)` | [`ZonePortal`](#izoneportal) | **admin** |
 | `setBouncebackGas(gasAmount)` | [`ZonePortal`](#izoneportal) | **admin** |
-| `setSequencerEncryptionKey(...)` | [`ZonePortal`](#izoneportal) | **any active sequencer** |
+| `setSequencerEncryptionKey(...)` | [`ZonePortal`](#izoneportal) | **admin or any active sequencer** |
 | `setRpcUrl(url)` | [`ZonePortal`](#izoneportal) | **any active sequencer** |
 | `submitBatch(...)` | [`ZonePortal`](#izoneportal) | **any active sequencer with a threshold certificate** |
 | `processWithdrawals(...)` | [`ZonePortal`](#izoneportal) | **any active sequencer** |
@@ -223,7 +223,7 @@ Rationale notes:
 
 - **Token enablement and deposit pause/resume are admin-only** because they govern what the zone is and which deposit flows are open. A compromised sequencer hot key MUST NOT be able to enable arbitrary tokens or unilaterally re-open paused deposits.
 - **Withdrawal gas rates are sequencer-controlled within an admin ceiling** so the sequencer can react quickly to Tempo gas-price fluctuations while the admin retains control over the maximum user fee. The admin directly controls the Tempo-side deposit and bounce-back fee parameters.
-- **Encryption key management is sequencer-only** because the proof of possession requires the encryption private key.
+- **Encryption public-key management is admin- or sequencer-authorized**. Both paths require a proof of possession from the corresponding encryption private key, so neither role can register a public key it cannot decrypt with.
 - **Zone-side system calls** to `ZoneOutbox` use `msg.sender == address(0)`. Withdrawal finalization is system-only; sequencers may call the gas-rate and withdrawal-limit setters directly.
 - **Withdrawal processing is sequencer-only** today; whether to make it permissionless once the proof has settled is tracked separately.
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1819,7 +1819,8 @@ interface IZonePortal {
 
     // Encryption keys
     function setSequencerEncryptionKey(bytes32 x, uint8 yParity, uint8 popV, bytes32 popR, bytes32 popS) external;
-    function sequencerEncryptionKey() external view returns (bytes32 x, uint8 yParity);
+    function sequencerEncryptionKey()
+        external view returns (bytes32 x, uint8 yParity, address pubkey);
     
     function encryptionKeyCount() external view returns (uint256);
     function encryptionKeyAt(uint256 index) external view returns (EncryptionKeyEntry memory entry);

--- a/xtask/src/lock_down_access.rs
+++ b/xtask/src/lock_down_access.rs
@@ -1,0 +1,213 @@
+//! Closes a ZonePortal's account access and revokes every discovered account role.
+//!
+//! ZonePortal stores roles in a mapping, so account membership cannot be enumerated from contract
+//! state.  This command rebuilds the candidate set from `RoleUpdated` events (including the events
+//! emitted during portal initialization), then reads each candidate's current role before revoking
+//! only `Account` roles.
+
+use std::collections::BTreeSet;
+
+use alloy::{
+    network::{EthereumWallet, ReceiptResponse as _},
+    primitives::Address,
+    providers::{Provider, ProviderBuilder},
+    rpc::types::Filter,
+    signers::local::PrivateKeySigner,
+    sol_types::SolEvent,
+};
+use eyre::{WrapErr as _, ensure};
+use futures::{StreamExt as _, TryStreamExt as _};
+use tempo_alloy::TempoNetwork;
+use tempo_zone_contracts::{ZonePortal, ZonePortal::Role as PortalRole};
+
+/// Close account access and clear the portal account allowlist during an incident.
+#[derive(Debug, clap::Parser)]
+pub(crate) struct LockDownAccess {
+    /// Tempo L1 HTTP RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, env = "L1_PORTAL_ADDRESS")]
+    portal: Address,
+
+    /// Portal admin private key (hex) used to sign the transactions.
+    #[arg(long, env = "PRIVATE_KEY", hide_env_values = true)]
+    private_key: String,
+
+    /// First L1 block to replay for `RoleUpdated` events. This must be at or before portal
+    /// initialization, otherwise pre-existing allowed accounts cannot be discovered.
+    #[arg(long, default_value_t = 0)]
+    from_block: u64,
+
+    /// Maximum simultaneous RPC requests for role reads, transaction submission, and receipt
+    /// polling. Transactions are assigned explicit sequential nonces before submission.
+    #[arg(long, default_value_t = 16)]
+    max_concurrent_requests: usize,
+}
+
+impl LockDownAccess {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        ensure!(
+            self.max_concurrent_requests > 0,
+            "--max-concurrent-requests must be greater than zero"
+        );
+        let signer: PrivateKeySigner = self
+            .private_key
+            .strip_prefix("0x")
+            .unwrap_or(&self.private_key)
+            .parse()
+            .wrap_err("PRIVATE_KEY is not a valid private key")?;
+        let admin = signer.address();
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(EthereumWallet::from(signer))
+            .connect(&self.l1_rpc_url)
+            .await
+            .wrap_err("failed connecting to Tempo L1 RPC")?;
+        let portal = ZonePortal::new(self.portal, &provider);
+
+        let onchain_admin = portal
+            .admin()
+            .call()
+            .await
+            .wrap_err("failed querying ZonePortal admin")?;
+        ensure!(
+            admin == onchain_admin,
+            "PRIVATE_KEY resolves to {admin}, but portal {} is administered by {onchain_admin}",
+            self.portal
+        );
+
+        // Close the portal before taking the replay snapshot. This prevents an open portal from
+        // admitting accounts while the mapping backfill and revocations are in progress.
+        let snapshot_block = if portal
+            .isAccessEnforced()
+            .call()
+            .await
+            .wrap_err("failed querying ZonePortal access mode")?
+        {
+            provider
+                .get_block_number()
+                .await
+                .wrap_err("failed querying Tempo L1 block number")?
+        } else {
+            println!(
+                "Closing account access enforcement on portal {}...",
+                self.portal
+            );
+            let receipt = portal
+                .setAccessMode(true)
+                .send()
+                .await
+                .wrap_err("failed sending ZonePortal.setAccessMode(true)")?
+                .get_receipt()
+                .await
+                .wrap_err("failed waiting for ZonePortal.setAccessMode(true) receipt")?;
+            ensure!(receipt.status(), "ZonePortal.setAccessMode(true) reverted");
+            receipt.block_number.ok_or_else(|| {
+                eyre::eyre!("setAccessMode receipt did not include a block number")
+            })?
+        };
+
+        println!(
+            "Replaying RoleUpdated events from block {} through {}...",
+            self.from_block, snapshot_block
+        );
+        let filter = Filter::new()
+            .address(self.portal)
+            .event_signature(ZonePortal::RoleUpdated::SIGNATURE_HASH)
+            .from_block(self.from_block)
+            .to_block(snapshot_block);
+        let logs = provider
+            .get_logs(&filter)
+            .await
+            .wrap_err("failed fetching ZonePortal RoleUpdated logs")?;
+
+        let mut candidates = BTreeSet::new();
+        for log in logs {
+            let event = ZonePortal::RoleUpdated::decode_log(&log.inner)
+                .wrap_err("failed decoding ZonePortal RoleUpdated log")?;
+            candidates.insert(event.account);
+        }
+
+        let accounts = futures::stream::iter(candidates)
+            .map(|account| {
+                let portal = portal.clone();
+                async move {
+                    let role = portal
+                        .role(account)
+                        .call()
+                        .await
+                        .wrap_err_with(|| format!("failed querying role for {account}"))?;
+                    Ok::<_, eyre::Report>((account, role))
+                }
+            })
+            .buffer_unordered(self.max_concurrent_requests)
+            .try_filter_map(|(account, role)| async move {
+                Ok((role == PortalRole::Account).then_some(account))
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        println!("Revoking {} allowed account(s)...", accounts.len());
+        let account_count = accounts.len();
+        let next_nonce = provider
+            .get_transaction_count(admin)
+            .await
+            .wrap_err("failed querying portal admin transaction count")?;
+        let pending = futures::stream::iter(accounts.iter().copied().enumerate())
+            .map(|(index, account)| {
+                let portal = portal.clone();
+                async move {
+                    let pending = portal
+                        .setAllowedAccount(account, false)
+                        .nonce(next_nonce + index as u64)
+                        .send()
+                        .await
+                        .wrap_err_with(|| {
+                            format!("failed submitting revoke transaction for {account}")
+                        })?;
+                    Ok::<_, eyre::Report>((index, account, pending))
+                }
+            })
+            .buffer_unordered(self.max_concurrent_requests)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        futures::stream::iter(pending)
+            .map(|(index, account, pending)| async move {
+                let receipt = pending
+                    .get_receipt()
+                    .await
+                    .wrap_err_with(|| format!("failed waiting for revoke receipt for {account}"))?;
+                ensure!(
+                    receipt.status(),
+                    "ZonePortal.setAllowedAccount({account}, false) reverted"
+                );
+                Ok::<_, eyre::Report>((index, account))
+            })
+            .buffer_unordered(self.max_concurrent_requests)
+            .try_for_each(|(index, account)| async move {
+                println!("  [{}/{}] revoked {account}", index + 1, account_count);
+                Ok(())
+            })
+            .await?;
+
+        ensure!(
+            portal.isAccessEnforced().call().await?,
+            "ZonePortal access enforcement is not enabled after lockdown"
+        );
+        for account in &accounts {
+            ensure!(
+                portal.role(*account).call().await? != PortalRole::Account,
+                "account {account} remained allowed after lockdown"
+            );
+        }
+
+        println!(
+            "Portal {} is locked down; access enforcement is enabled and {} allowed account(s) were revoked.",
+            self.portal,
+            accounts.len()
+        );
+        Ok(())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@ use crate::{
     demo_swap_and_deposit::DemoSwapAndDeposit, deploy_neobank_fixtures::DeployNeobankFixtures,
     deploy_router::DeployRouter, deposit::Deposit, generate_p2p_key::GenerateP2pKey,
     generate_zone_genesis::GenerateZoneGenesis,
-    install_reference_zone_factory::InstallReferenceZoneFactory,
+    install_reference_zone_factory::InstallReferenceZoneFactory, lock_down_access::LockDownAccess,
     set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
@@ -22,6 +22,7 @@ mod deposit;
 mod generate_p2p_key;
 mod generate_zone_genesis;
 mod install_reference_zone_factory;
+mod lock_down_access;
 mod set_encryption_key;
 mod spam_deposits;
 mod zone_info;
@@ -59,6 +60,7 @@ async fn main() -> eyre::Result<()> {
         Action::InstallReferenceZoneFactory(args) => args
             .run()
             .wrap_err("failed to install reference ZoneFactory"),
+        Action::LockDownAccess(args) => args.run().await.wrap_err("failed to lock down access"),
         Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
         Action::SpamDeposits(args) => args.run().await.wrap_err("failed to spam deposits"),
         Action::ZoneInfo(args) => args.run().await.wrap_err("failed to fetch zone info"),
@@ -88,6 +90,7 @@ enum Action {
     GenerateP2pKey(GenerateP2pKey),
     GenerateZoneGenesis(GenerateZoneGenesis),
     InstallReferenceZoneFactory(InstallReferenceZoneFactory),
+    LockDownAccess(LockDownAccess),
     SetEncryptionKey(SetEncryptionKey),
     SpamDeposits(SpamDeposits),
     ZoneInfo(ZoneInfoCmd),

--- a/xtask/src/set_encryption_key.rs
+++ b/xtask/src/set_encryption_key.rs
@@ -1,15 +1,18 @@
-//! Registers the sequencer's encryption key on the ZonePortal.
+//! Registers an encryption public key on the ZonePortal from its corresponding private key.
 //!
 //! Calls the shared sequencer registration helper, which derives the secp256k1
 //! public key, constructs the proof-of-possession signature, and submits it to
 //! the portal contract.
 
 use alloy::{
-    network::EthereumWallet, primitives::Address, providers::ProviderBuilder,
+    network::EthereumWallet,
+    primitives::Address,
+    providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
 };
 use eyre::WrapErr as _;
 use tempo_alloy::TempoNetwork;
+use tempo_chainspec::constants::{mainnet::MAINNET_CHAIN_ID, moderato::MODERATO_CHAIN_ID};
 use zone_sequencer::register_encryption_key;
 
 #[derive(Debug, clap::Parser)]
@@ -22,38 +25,48 @@ pub(crate) struct SetEncryptionKey {
     #[arg(long, env = "L1_PORTAL_ADDRESS")]
     portal: Address,
 
-    /// Sequencer private key (hex). Used both as the signing key for the
-    /// transaction and as the encryption key to register.
+    /// Admin or active sequencer private key (hex) used to sign the transaction.
     #[arg(long, env = "PRIVATE_KEY", hide_env_values = true)]
     private_key: String,
+
+    /// Encryption private key (hex) whose public key is registered. Defaults to --private-key.
+    #[arg(long, env = "ENCRYPTION_PRIVATE_KEY", hide_env_values = true)]
+    encryption_private_key: Option<String>,
 }
 
 impl SetEncryptionKey {
     pub(crate) async fn run(self) -> eyre::Result<()> {
-        let key_str = self
-            .private_key
-            .strip_prefix("0x")
+        let encryption_private_key = self
+            .encryption_private_key
+            .as_ref()
             .unwrap_or(&self.private_key);
 
-        // The sequencer key is used both to sign the tx and as the encryption key
-        let signer: PrivateKeySigner = key_str.parse()?;
+        let transaction_signer: PrivateKeySigner = self.private_key.parse()?;
+        let encryption_signer: PrivateKeySigner = encryption_private_key.parse()?;
 
-        let wallet = EthereumWallet::from(signer.clone());
+        let wallet = EthereumWallet::from(transaction_signer);
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
             .connect(&self.l1_rpc_url)
             .await?;
+        let chain_id = provider.get_chain_id().await?;
 
         println!(
             "Sending setSequencerEncryptionKey to portal {}...",
             self.portal
         );
-        let tx_hash = register_encryption_key(&provider, self.portal, &signer)
+        let tx_hash = register_encryption_key(&provider, self.portal, &encryption_signer)
             .await
             .wrap_err("failed to send setSequencerEncryptionKey")?;
 
-        println!("Encryption key registered!");
-        println!("Explorer: https://explore.moderato.tempo.xyz/tx/{tx_hash}");
+        println!("Encryption public key registered!");
+        match chain_id {
+            MAINNET_CHAIN_ID => println!("Explorer: https://explore.tempo.xyz/tx/{tx_hash}"),
+            MODERATO_CHAIN_ID => {
+                println!("Explorer: https://explore.moderato.tempo.xyz/tx/{tx_hash}")
+            }
+            _ => println!("Transaction: {tx_hash}"),
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Add a `lock-down-access` incident-response xtask.
- Close access enforcement, reconstruct account membership from `RoleUpdated` logs, and revoke current account roles.
- Submit bounded concurrent reads and explicitly-nonced revocations; document safe backfill use.

## Validation

- `cargo check -p tempo-xtask`
- `cargo run -p tempo-xtask -- lock-down-access --help`
- `git diff --check`

A full local native-L1 E2E attempt was interrupted at requester direction after the standalone dev binary hit an unrelated `OpcodeNotFound` provisioning incompatibility.
