### PR TITLE
feat(xtask): add portal access lockdown

### DIFF
--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -627,6 +627,24 @@ Zones inherit the Tempo L1 EVM but replace, disable, or pass through each precom
 
 The xtasks use this Moderato `ZoneFactory` as their built-in default: `create-zone` and `zone-info` point at it automatically, and `deploy-router` uses `zoneFactory` from `zone.json` before falling back to this address. Pass `--zone-factory` or set `ZONE_FACTORY` to override it.
 
+### Emergency portal access lockdown
+
+To immediately close an open portal and remove every currently allowed account, replay the portal's
+role history and revoke all current `Account` roles:
+
+```bash
+PRIVATE_KEY="<portal-admin-key>" cargo run -p tempo-xtask -- lock-down-access \
+  --l1-rpc-url "$L1_RPC_URL" \
+  --portal "$L1_PORTAL_ADDRESS" \
+  --from-block <portal-creation-block>
+```
+
+`RoleUpdated` is the source of truth for this backfill because portal roles are stored in a mapping.
+Set `--from-block` at or before the portal initialization block; choosing a later block can miss an
+already-allowed account. The command first enables access enforcement when the portal is open, then
+replays events through that transaction's block, revokes current account roles, and verifies the
+result. Callback gateway roles are not changed.
+
 ### Verifying the ZoneFactory
 
 TIP-1091 makes the factory and its shared dependencies protocol-managed accounts. Verify them at their fixed addresses:

--- a/xtask/src/lock_down_access.rs
+++ b/xtask/src/lock_down_access.rs
@@ -1,0 +1,213 @@
+//! Closes a ZonePortal's account access and revokes every discovered account role.
+//!
+//! ZonePortal stores roles in a mapping, so account membership cannot be enumerated from contract
+//! state.  This command rebuilds the candidate set from `RoleUpdated` events (including the events
+//! emitted during portal initialization), then reads each candidate's current role before revoking
+//! only `Account` roles.
+
+use std::collections::BTreeSet;
+
+use alloy::{
+    network::{EthereumWallet, ReceiptResponse as _},
+    primitives::Address,
+    providers::{Provider, ProviderBuilder},
+    rpc::types::Filter,
+    signers::local::PrivateKeySigner,
+    sol_types::SolEvent,
+};
+use eyre::{WrapErr as _, ensure};
+use futures::{StreamExt as _, TryStreamExt as _};
+use tempo_alloy::TempoNetwork;
+use tempo_zone_contracts::{ZonePortal, ZonePortal::Role as PortalRole};
+
+/// Close account access and clear the portal account allowlist during an incident.
+#[derive(Debug, clap::Parser)]
+pub(crate) struct LockDownAccess {
+    /// Tempo L1 HTTP RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, env = "L1_PORTAL_ADDRESS")]
+    portal: Address,
+
+    /// Portal admin private key (hex) used to sign the transactions.
+    #[arg(long, env = "PRIVATE_KEY", hide_env_values = true)]
+    private_key: String,
+
+    /// First L1 block to replay for `RoleUpdated` events. This must be at or before portal
+    /// initialization, otherwise pre-existing allowed accounts cannot be discovered.
+    #[arg(long, default_value_t = 0)]
+    from_block: u64,
+
+    /// Maximum simultaneous RPC requests for role reads, transaction submission, and receipt
+    /// polling. Transactions are assigned explicit sequential nonces before submission.
+    #[arg(long, default_value_t = 16)]
+    max_concurrent_requests: usize,
+}
+
+impl LockDownAccess {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        ensure!(
+            self.max_concurrent_requests > 0,
+            "--max-concurrent-requests must be greater than zero"
+        );
+        let signer: PrivateKeySigner = self
+            .private_key
+            .strip_prefix("0x")
+            .unwrap_or(&self.private_key)
+            .parse()
+            .wrap_err("PRIVATE_KEY is not a valid private key")?;
+        let admin = signer.address();
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .wallet(EthereumWallet::from(signer))
+            .connect(&self.l1_rpc_url)
+            .await
+            .wrap_err("failed connecting to Tempo L1 RPC")?;
+        let portal = ZonePortal::new(self.portal, &provider);
+
+        let onchain_admin = portal
+            .admin()
+            .call()
+            .await
+            .wrap_err("failed querying ZonePortal admin")?;
+        ensure!(
+            admin == onchain_admin,
+            "PRIVATE_KEY resolves to {admin}, but portal {} is administered by {onchain_admin}",
+            self.portal
+        );
+
+        // Close the portal before taking the replay snapshot. This prevents an open portal from
+        // admitting accounts while the mapping backfill and revocations are in progress.
+        let snapshot_block = if portal
+            .isAccessEnforced()
+            .call()
+            .await
+            .wrap_err("failed querying ZonePortal access mode")?
+        {
+            provider
+                .get_block_number()
+                .await
+                .wrap_err("failed querying Tempo L1 block number")?
+        } else {
+            println!(
+                "Closing account access enforcement on portal {}...",
+                self.portal
+            );
+            let receipt = portal
+                .setAccessMode(true)
+                .send()
+                .await
+                .wrap_err("failed sending ZonePortal.setAccessMode(true)")?
+                .get_receipt()
+                .await
+                .wrap_err("failed waiting for ZonePortal.setAccessMode(true) receipt")?;
+            ensure!(receipt.status(), "ZonePortal.setAccessMode(true) reverted");
+            receipt.block_number.ok_or_else(|| {
+                eyre::eyre!("setAccessMode receipt did not include a block number")
+            })?
+        };
+
+        println!(
+            "Replaying RoleUpdated events from block {} through {}...",
+            self.from_block, snapshot_block
+        );
+        let filter = Filter::new()
+            .address(self.portal)
+            .event_signature(ZonePortal::RoleUpdated::SIGNATURE_HASH)
+            .from_block(self.from_block)
+            .to_block(snapshot_block);
+        let logs = provider
+            .get_logs(&filter)
+            .await
+            .wrap_err("failed fetching ZonePortal RoleUpdated logs")?;
+
+        let mut candidates = BTreeSet::new();
+        for log in logs {
+            let event = ZonePortal::RoleUpdated::decode_log(&log.inner)
+                .wrap_err("failed decoding ZonePortal RoleUpdated log")?;
+            candidates.insert(event.account);
+        }
+
+        let accounts = futures::stream::iter(candidates)
+            .map(|account| {
+                let portal = portal.clone();
+                async move {
+                    let role = portal
+                        .role(account)
+                        .call()
+                        .await
+                        .wrap_err_with(|| format!("failed querying role for {account}"))?;
+                    Ok::<_, eyre::Report>((account, role))
+                }
+            })
+            .buffer_unordered(self.max_concurrent_requests)
+            .try_filter_map(|(account, role)| async move {
+                Ok((role == PortalRole::Account).then_some(account))
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        println!("Revoking {} allowed account(s)...", accounts.len());
+        let account_count = accounts.len();
+        let next_nonce = provider
+            .get_transaction_count(admin)
+            .await
+            .wrap_err("failed querying portal admin transaction count")?;
+        let pending = futures::stream::iter(accounts.iter().copied().enumerate())
+            .map(|(index, account)| {
+                let portal = portal.clone();
+                async move {
+                    let pending = portal
+                        .setAllowedAccount(account, false)
+                        .nonce(next_nonce + index as u64)
+                        .send()
+                        .await
+                        .wrap_err_with(|| {
+                            format!("failed submitting revoke transaction for {account}")
+                        })?;
+                    Ok::<_, eyre::Report>((index, account, pending))
+                }
+            })
+            .buffer_unordered(self.max_concurrent_requests)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        futures::stream::iter(pending)
+            .map(|(index, account, pending)| async move {
+                let receipt = pending
+                    .get_receipt()
+                    .await
+                    .wrap_err_with(|| format!("failed waiting for revoke receipt for {account}"))?;
+                ensure!(
+                    receipt.status(),
+                    "ZonePortal.setAllowedAccount({account}, false) reverted"
+                );
+                Ok::<_, eyre::Report>((index, account))
+            })
+            .buffer_unordered(self.max_concurrent_requests)
+            .try_for_each(|(index, account)| async move {
+                println!("  [{}/{}] revoked {account}", index + 1, account_count);
+                Ok(())
+            })
+            .await?;
+
+        ensure!(
+            portal.isAccessEnforced().call().await?,
+            "ZonePortal access enforcement is not enabled after lockdown"
+        );
+        for account in &accounts {
+            ensure!(
+                portal.role(*account).call().await? != PortalRole::Account,
+                "account {account} remained allowed after lockdown"
+            );
+        }
+
+        println!(
+            "Portal {} is locked down; access enforcement is enabled and {} allowed account(s) were revoked.",
+            self.portal,
+            accounts.len()
+        );
+        Ok(())
+    }
+}

--- a/xtask/src/lock_down_access.rs
+++ b/xtask/src/lock_down_access.rs
@@ -11,14 +11,15 @@ use alloy::{
     network::{EthereumWallet, ReceiptResponse as _},
     primitives::Address,
     providers::{Provider, ProviderBuilder},
-    rpc::types::Filter,
     signers::local::PrivateKeySigner,
-    sol_types::SolEvent,
 };
 use eyre::{WrapErr as _, ensure};
 use futures::{StreamExt as _, TryStreamExt as _};
 use tempo_alloy::TempoNetwork;
 use tempo_zone_contracts::{ZonePortal, ZonePortal::Role as PortalRole};
+
+/// Bounded `eth_getLogs` range to accommodate providers that reject long historical queries.
+const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
 
 /// Close account access and clear the portal account allowlist during an incident.
 #[derive(Debug, clap::Parser)]
@@ -112,20 +113,18 @@ impl LockDownAccess {
             "Replaying RoleUpdated events from block {} through {}...",
             self.from_block, snapshot_block
         );
-        let filter = Filter::new()
-            .address(self.portal)
-            .event_signature(ZonePortal::RoleUpdated::SIGNATURE_HASH)
+        let logs = portal
+            .RoleUpdated_filter()
             .from_block(self.from_block)
-            .to_block(snapshot_block);
-        let logs = provider
-            .get_logs(&filter)
+            .to_block(snapshot_block)
+            .chunked()
+            .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+            .query()
             .await
             .wrap_err("failed fetching ZonePortal RoleUpdated logs")?;
 
         let mut candidates = BTreeSet::new();
-        for log in logs {
-            let event = ZonePortal::RoleUpdated::decode_log(&log.inner)
-                .wrap_err("failed decoding ZonePortal RoleUpdated log")?;
+        for (event, _) in logs {
             candidates.insert(event.account);
         }
 

--- a/xtask/src/lock_down_access.rs
+++ b/xtask/src/lock_down_access.rs
@@ -132,18 +132,18 @@ impl LockDownAccess {
             .map(|account| {
                 let portal = portal.clone();
                 async move {
-                    let role = portal
-                        .role(account)
+                    let is_account = portal
+                        .hasRole(account, PortalRole::Account)
                         .call()
                         .await
                         .wrap_err_with(|| format!("failed querying role for {account}"))?;
-                    Ok::<_, eyre::Report>((account, role))
+                    Ok::<_, eyre::Report>((account, is_account))
                 }
             })
             .buffer_unordered(self.max_concurrent_requests)
-            .try_filter_map(|(account, role)| async move {
-                Ok((role == PortalRole::Account).then_some(account))
-            })
+            .try_filter_map(
+                |(account, is_account)| async move { Ok(is_account.then_some(account)) },
+            )
             .try_collect::<Vec<_>>()
             .await?;
 
@@ -197,7 +197,7 @@ impl LockDownAccess {
         );
         for account in &accounts {
             ensure!(
-                portal.role(*account).call().await? != PortalRole::Account,
+                !portal.hasRole(*account, PortalRole::Account).call().await?,
                 "account {account} remained allowed after lockdown"
             );
         }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,8 +6,8 @@ use crate::{
     deploy_neobank_fixtures::DeployNeobankFixtures, deploy_router::DeployRouter, deposit::Deposit,
     generate_p2p_key::GenerateP2pKey, generate_zone_genesis::GenerateZoneGenesis,
     install_reference_zone_factory::InstallReferenceZoneFactory, lock_down_access::LockDownAccess,
-    portal_pause::PausePortal, set_encryption_key::SetEncryptionKey,
-    spam_deposits::SpamDeposits, verify_closed_loop::VerifyClosedLoop, zone_info::ZoneInfoCmd,
+    portal_pause::PausePortal, set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits,
+    verify_closed_loop::VerifyClosedLoop, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,9 +5,9 @@ use crate::{
     demo_blacklist::DemoBlacklist, demo_swap_and_deposit::DemoSwapAndDeposit,
     deploy_neobank_fixtures::DeployNeobankFixtures, deploy_router::DeployRouter, deposit::Deposit,
     generate_p2p_key::GenerateP2pKey, generate_zone_genesis::GenerateZoneGenesis,
-    install_reference_zone_factory::InstallReferenceZoneFactory, portal_pause::PausePortal,
-    set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits,
-    verify_closed_loop::VerifyClosedLoop, zone_info::ZoneInfoCmd,
+    install_reference_zone_factory::InstallReferenceZoneFactory, lock_down_access::LockDownAccess,
+    portal_pause::PausePortal, set_encryption_key::SetEncryptionKey,
+    spam_deposits::SpamDeposits, verify_closed_loop::VerifyClosedLoop, zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;
@@ -24,6 +24,7 @@ mod deposit;
 mod generate_p2p_key;
 mod generate_zone_genesis;
 mod install_reference_zone_factory;
+mod lock_down_access;
 mod portal_pause;
 mod set_encryption_key;
 mod spam_deposits;
@@ -64,6 +65,7 @@ async fn main() -> eyre::Result<()> {
         Action::InstallReferenceZoneFactory(args) => args
             .run()
             .wrap_err("failed to install reference ZoneFactory"),
+        Action::LockDownAccess(args) => args.run().await.wrap_err("failed to lock down access"),
         Action::PausePortal(args) => args.run().await.wrap_err("failed to pause portal"),
         Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
         Action::SpamDeposits(args) => args.run().await.wrap_err("failed to spam deposits"),
@@ -98,6 +100,7 @@ enum Action {
     GenerateP2pKey(GenerateP2pKey),
     GenerateZoneGenesis(GenerateZoneGenesis),
     InstallReferenceZoneFactory(InstallReferenceZoneFactory),
+    LockDownAccess(LockDownAccess),
     PausePortal(PausePortal),
     SetEncryptionKey(SetEncryptionKey),
     SpamDeposits(SpamDeposits),


### PR DESCRIPTION
## Summary

- Add a `lock-down-access` incident-response xtask.
- Close access enforcement, reconstruct account membership from `RoleUpdated` logs, and revoke current account roles.
- Submit bounded concurrent reads and explicitly-nonced revocations; document safe backfill use.

## Validation

- `cargo test -p tempo-xtask`
- `cargo +nightly clippy -p tempo-xtask --all-targets`
- `cargo +nightly fmt --all -- --check`
- `cargo run -p tempo-xtask -- lock-down-access --help`
- `git diff --check`

A full local native-L1 E2E attempt was interrupted at requester direction after the standalone dev binary hit an unrelated `OpcodeNotFound` provisioning incompatibility.

Prompted by: @0xalpharush
