### PR TITLE
feat(sequencer): configure L1 fee token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11330,7 +11330,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11376,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11400,7 +11400,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11412,7 +11412,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11459,7 +11459,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11471,7 +11471,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11569,7 +11569,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11589,7 +11589,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11612,7 +11612,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11655,7 +11655,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11678,7 +11678,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=de760926aa6520c5e1cdb85f453c206057ea0e72#de760926aa6520c5e1cdb85f453c206057ea0e72"
+source = "git+https://github.com/tempoxyz/tempo?rev=3070d6d676fb662f58e44fe06e130170d73705a4#3070d6d676fb662f58e44fe06e130170d73705a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,26 +96,26 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "de760926aa6520c5e1cdb85f453c206057ea0e72", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "3070d6d676fb662f58e44fe06e130170d73705a4", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -13,6 +13,7 @@ use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
 use zone_evm::ZoneEvmConfig;
 use zone_p2p::{MAX_TRANSACTION_MESSAGE_SIZE, P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
+use zone_primitives::constants::ZONE_TOKEN_ADDRESS;
 
 use crate::{
     ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig, dev::DevCommand,
@@ -207,6 +208,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             node = node.with_sequencer(ZoneSequencerAddOnsConfig {
                 sequencer_signer,
                 l1_transaction_signer,
+                fee_token: args.sequencer_fee_token,
                 zone_id: args.zone_id,
                 zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
                 batch_anchor_config: BatchAnchorConfig::default(),
@@ -311,6 +313,14 @@ pub struct ZoneArgs {
         value_name = "PATH"
     )]
     pub sequencer_key_file: Option<PathBuf>,
+
+    /// Fee token used for sequencer-submitted L1 transactions.
+    #[arg(
+        long = "sequencer.fee-token",
+        env = "SEQUENCER_FEE_TOKEN",
+        default_value_t = ZONE_TOKEN_ADDRESS
+    )]
+    pub sequencer_fee_token: Address,
 
     /// File containing additional deposit decryption keys, one hex key per line.
     #[arg(
@@ -530,11 +540,13 @@ fn validate_portal_address(portal_address: Address) -> eyre::Result<()> {
 mod tests {
     use std::{io::Write as _, process::Command, thread, time::Duration};
 
+    use alloy_primitives::Address;
     use clap::Parser as _;
 
     use super::{
-        Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, sequencer_enabled,
-        validate_l1_rpc_url, validate_p2p_transaction_size_limit, validate_portal_address,
+        Role, ZONE_TOKEN_ADDRESS, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer,
+        sequencer_enabled, validate_l1_rpc_url, validate_p2p_transaction_size_limit,
+        validate_portal_address,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -608,6 +620,30 @@ mod tests {
             ZoneArgsParser::try_parse_from(common.into_iter().chain(["--sequencer-key", "0x01"]))
                 .unwrap_err();
         assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+    }
+
+    #[test]
+    fn sequencer_fee_token_defaults_to_pathusd_and_accepts_an_override() {
+        let common = [
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+        ];
+
+        let parsed = ZoneArgsParser::try_parse_from(common).unwrap();
+        assert_eq!(parsed.zone.sequencer_fee_token, ZONE_TOKEN_ADDRESS);
+
+        let fee_token = Address::repeat_byte(0x42);
+        let fee_token_arg = fee_token.to_string();
+        let parsed = ZoneArgsParser::try_parse_from(
+            common
+                .into_iter()
+                .chain(["--sequencer.fee-token", fee_token_arg.as_str()]),
+        )
+        .unwrap();
+        assert_eq!(parsed.zone.sequencer_fee_token, fee_token);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -191,6 +191,8 @@ pub struct ZoneSequencerAddOnsConfig {
     pub sequencer_signer: PrivateKeySigner,
     /// Individual manifest-node signer used for L1 settlement transactions.
     pub l1_transaction_signer: Option<PrivateKeySigner>,
+    /// Default fee token for sequencer-submitted L1 transactions.
+    pub fee_token: Address,
     /// Zone ID used by sequencer encryption.
     pub zone_id: u32,
     /// Fallback interval for reconciling the canonical Zone head.
@@ -692,6 +694,10 @@ where
             let manifest = config.manifest().clone();
             let local_secp256k1_address = config.secp256k1_address();
             let individual_signer = config.block_attestation_signer();
+            let sequencer_fee_token = self
+                .sequencer_config
+                .as_ref()
+                .map(|config| config.fee_token);
             // Created before the network starts so requests arriving ahead of the serving
             // task (spawned once the provider exists) buffer instead of dropping.
             let (backfill_requests_tx, backfill_requests_rx) =
@@ -706,10 +712,15 @@ where
             let peer_tips = PeerTipRegistry::default();
             let relayer = match individual_signer {
                 Some(signer) => {
-                    use tempo_alloy::provider::ext::TempoProviderBuilderExt as _;
+                    use tempo_alloy::{
+                        fillers::FeeTokenFiller, provider::ext::TempoProviderBuilderExt as _,
+                    };
                     let provider =
                         alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
                             .with_nonce_key_filler()
+                            .filler(FeeTokenFiller::new(sequencer_fee_token.expect(
+                                "quorum members with an L1 signer have sequencer configuration",
+                            )))
                             .wallet(alloy_network::EthereumWallet::from(signer))
                             .connect_with_config(
                                 &self.l1_config.l1_rpc_url,
@@ -1182,6 +1193,7 @@ where
             portal_address,
             l1_rpc_url,
             retry_connection_interval,
+            fee_token: config.fee_token,
             zone_poll_interval: config.zone_poll_interval,
             withdrawal_poll_interval: config.withdrawal_poll_interval,
             withdrawal_batch_limits: config.withdrawal_batch_limits,
@@ -1396,6 +1408,7 @@ where
             portal_address,
             l1_rpc_url,
             retry_connection_interval,
+            fee_token: config.fee_token,
             zone_poll_interval: config.zone_poll_interval,
             withdrawal_poll_interval: config.withdrawal_poll_interval,
             withdrawal_batch_limits: config.withdrawal_batch_limits,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1352,6 +1352,7 @@ impl ZoneTestNode {
                 .with_sequencer(ZoneSequencerAddOnsConfig {
                     sequencer_signer: sequencer_signer.clone(),
                     l1_transaction_signer,
+                    fee_token: PATH_USD_ADDRESS,
                     zone_id,
                     zone_poll_interval: Duration::from_secs(1),
                     batch_anchor_config: Default::default(),
@@ -3459,6 +3460,7 @@ pub(crate) async fn spawn_sequencer_with_config(
         portal_address,
         l1_rpc_url: l1.http_url().to_string(),
         retry_connection_interval: Duration::from_millis(100),
+        fee_token: PATH_USD_ADDRESS,
         zone_poll_interval: Duration::from_secs(1),
         withdrawal_poll_interval: Duration::from_millis(500),
         withdrawal_batch_limits,

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -12,7 +12,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_transport::TransportResult;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_storage_api::{BlockReader, StateProviderFactory};
-use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
+use tempo_alloy::{TempoNetwork, fillers::FeeTokenFiller, provider::ext::TempoProviderBuilderExt};
 use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope};
 use tokio::sync::Notify;
 
@@ -96,6 +96,8 @@ pub struct ZoneSequencerConfig {
     pub l1_rpc_url: String,
     /// Interval between WebSocket reconnection attempts for long-lived RPC clients.
     pub retry_connection_interval: Duration,
+    /// Default fee token for sequencer-submitted L1 transactions.
+    pub fee_token: Address,
     /// Fallback interval for reconciling the canonical Zone head.
     ///
     /// Canonical-state notifications normally trigger reconciliation immediately.
@@ -152,6 +154,7 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     let l1_provider = connect_l1_provider(
         &config.l1_rpc_url,
         config.retry_connection_interval,
+        config.fee_token,
         signer.clone(),
     )
     .await
@@ -219,11 +222,13 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
 async fn connect_l1_provider(
     l1_rpc_url: &str,
     retry_connection_interval: Duration,
+    fee_token: Address,
     signer: PrivateKeySigner,
 ) -> TransportResult<DynProvider<TempoNetwork>> {
     let wallet = alloy_network::EthereumWallet::from(signer);
     let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
         .with_nonce_key_filler()
+        .filler(FeeTokenFiller::new(fee_token))
         .wallet(wallet)
         .connect_with_config(l1_rpc_url, rpc_connection_config(retry_connection_interval))
         .await?

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -323,10 +323,14 @@ mod tests {
             serve_block_number(second_stream, "0x2", false).await;
         });
 
-        let provider =
-            connect_l1_provider(&url, Duration::from_millis(10), PrivateKeySigner::random())
-                .await
-                .unwrap();
+        let provider = connect_l1_provider(
+            &url,
+            Duration::from_millis(10),
+            Address::ZERO,
+            PrivateKeySigner::random(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(provider.get_block_number().await.unwrap(), 1);
         assert_eq!(


### PR DESCRIPTION
## Summary
- bump Tempo dependencies to merged commit `3070d6d676fb662f58e44fe06e130170d73705a4`
- add `--sequencer.fee-token` / `SEQUENCER_FEE_TOKEN`, defaulting to pathUSD
- apply `FeeTokenFiller` to sequencer settlement, withdrawal, and multi-sequencer relayer transactions

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo check -p zone-node -p zone-sequencer`
- `cargo test -p zone-node --features cli --lib sequencer_fee_token_defaults_to_pathusd_and_accepts_an_override`
- `cargo +nightly clippy -p zone-node -p zone-sequencer --features zone-node/cli --no-deps`

Prompted by: @klkvr