### PR TITLE
chore: rename SPF tooling to prover utilities

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -668,7 +668,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo build --target-dir "$ZONES_BENCH_ZONES_TARGET_DIR" \
-            --profile profiling -p tempo-zone -p tempo-zone-spf -p tempo-xtask
+            --profile profiling -p tempo-zone -p tempo-zone-prover-utils -p tempo-xtask
           nu -c "source '$TEMPO_ROOT/tempo.nu'; build-in-worktree --no-default-features \
             '$TEMPO_ROOT' '$ZONES_BENCH_TEMPO_REF' profiling \
             'jemalloc,asm-keccak,keccak-cache-global,otlp' \
@@ -677,7 +677,7 @@ jobs:
             --manifest-path "$TEMPO_ROOT/Cargo.toml" --profile profiling -p tempo-xtask
           {
             echo "ZONE_BIN=$ZONES_BENCH_ZONES_TARGET_DIR/profiling/tempo-zone"
-            echo "SPF_BIN=$ZONES_BENCH_ZONES_TARGET_DIR/profiling/tempo-zone-spf"
+            echo "SPF_BIN=$ZONES_BENCH_ZONES_TARGET_DIR/profiling/tempo-zone-prover-utils"
             echo "ZONES_XTASK_BIN=$ZONES_BENCH_ZONES_TARGET_DIR/profiling/tempo-xtask"
             echo "TEMPO_BIN=$TEMPO_ROOT/target/profiling/tempo"
             echo "TEMPO_XTASK_BIN=$ZONES_BENCH_TEMPO_TARGET_DIR/profiling/tempo-xtask"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11776,7 +11776,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempo-zone-spf"
+name = "tempo-zone-prover-utils"
 version = "0.1.0"
 dependencies = [
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [workspace]
 members = [
-  "bin/tempo-zone-spf",
+  "bin/prover/utils",
   "bin/tempo-zone",
   "crates/chainspec",
   "crates/contracts",

--- a/bin/prover/utils/Cargo.toml
+++ b/bin/prover/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "tempo-zone-spf"
-description = "SPF development and input-generation tools for Tempo Zones"
+name = "tempo-zone-prover-utils"
+description = "Prover development and input-generation utilities for Tempo Zones"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -47,14 +47,17 @@ type RpcBlock = Block<Transaction<TempoTxEnvelope>, TempoHeaderResponse>;
 type L1Reads = BTreeMap<u64, BTreeMap<Address, BTreeSet<B256>>>;
 
 #[derive(Debug, Parser)]
-#[command(name = "tempo-zone-spf", about = "Tempo Zone SPF development tools")]
+#[command(
+    name = "tempo-zone-prover-utils",
+    about = "Tempo Zone prover development utilities"
+)]
 struct Cli {
     /// Tracing filter. Can also be set with RUST_LOG.
     #[arg(
         long,
         global = true,
         env = "RUST_LOG",
-        default_value = "tempo_zone_spf=info"
+        default_value = "tempo_zone_prover_utils=info"
     )]
     log_filter: String,
 
@@ -1221,7 +1224,7 @@ mod tests {
         let mut genesis = Genesis::default();
         genesis.config.chain_id = 31_318;
         let path = std::env::temp_dir().join(format!(
-            "tempo-zone-spf-genesis-{}.json",
+            "tempo-zone-prover-utils-genesis-{}.json",
             std::process::id()
         ));
         std::fs::write(&path, serde_json::to_vec(&genesis).unwrap()).unwrap();


### PR DESCRIPTION
## Summary

Rename prover related tooling bin to `tempo-zone-prover-utils`.