### PR TITLE
refactor: derive zone identity from chain ID

### DIFF
--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -950,7 +950,6 @@ provision_up() {
         --chain "$zone_genesis" --datadir "$zone_db" \
         --l1.rpc-url ws://127.0.0.1:8545 \
         --l1.portal-address "$portal" \
-        --zone.id "$zone_id" \
         --http --http.addr 127.0.0.1 --http.port 8546 \
         --http.api all \
         --ws --ws.addr 127.0.0.1 --ws.port 8546 \

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -20,7 +20,7 @@ use tempo_chainspec::{
 };
 use tempo_primitives::TempoHeader;
 pub use zone_hardfork::ZoneHardfork;
-use zone_primitives::constants::{ZoneChainIdError, decode_l1_chain_id};
+use zone_primitives::constants::{ZoneChainIdError, decode_l1_chain_id, decode_zone_chain_id};
 
 /// Chain specification for a Tempo Zone.
 ///
@@ -75,6 +75,13 @@ impl ZoneChainSpec {
         Ok(Self {
             inner: Arc::new(zone),
         })
+    }
+
+    /// Zone identifier encoded in the genesis chain ID.
+    pub fn zone_id(&self) -> u32 {
+        decode_zone_chain_id(self.inner.genesis().config.chain_id)
+            .expect("ZoneChainSpec validates its chain ID during construction")
+            .1
     }
 }
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -106,6 +106,8 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
 
         validate_l1_rpc_url(&args.l1_rpc_url)?;
         validate_portal_address(args.portal_address)?;
+        let zone_id = builder.config().chain.zone_id();
+        validate_deprecated_zone_id(args.zone_id, zone_id)?;
 
         let p2p_config = args
             .sequencer_manifest
@@ -122,7 +124,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                     args.secp256k1_key.as_ref(),
                     args.p2p_listen,
                     args.p2p_bypass_ip_check,
-                    args.zone_id,
+                    zone_id,
                     args.sequencer_role,
                 )
             })
@@ -187,7 +189,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         .with_withdrawal_batch_interval_blocks(args.zone_batch_interval_blocks)
         .with_redacted_rpc(ZoneRedactedRpcConfig {
             redacted_rpc_port: args.redacted_rpc_port,
-            zone_id: args.zone_id,
+            zone_id,
             max_auth_token_validity: Duration::from_secs(
                 args.redacted_rpc_max_auth_token_validity_secs,
             ),
@@ -207,7 +209,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             node = node.with_sequencer(ZoneSequencerAddOnsConfig {
                 sequencer_signer,
                 l1_transaction_signer,
-                zone_id: args.zone_id,
+                zone_id,
                 zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
                 batch_anchor_config: BatchAnchorConfig::default(),
                 withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
@@ -443,9 +445,9 @@ pub struct ZoneArgs {
     )]
     pub l1_retry_connection_interval_ms: u64,
 
-    /// Zone ID used for chain identity and redacted RPC authentication.
-    #[arg(long = "zone.id", env = "ZONE_ID", default_value_t = 0)]
-    pub zone_id: u32,
+    /// Deprecated: validates the Zone ID encoded in the genesis chain ID.
+    #[arg(long = "zone.id", env = "ZONE_ID")]
+    pub zone_id: Option<u32>,
 
     /// Port for the redacted zone RPC server (0 for OS-assigned).
     #[arg(
@@ -536,6 +538,16 @@ fn validate_portal_address(portal_address: Address) -> eyre::Result<()> {
     Ok(())
 }
 
+fn validate_deprecated_zone_id(configured: Option<u32>, derived: u32) -> eyre::Result<()> {
+    if let Some(configured) = configured {
+        eyre::ensure!(
+            configured == derived,
+            "deprecated --zone.id value {configured} does not match zone ID {derived} encoded in the genesis chain ID"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{io::Write as _, process::Command, thread, time::Duration};
@@ -544,7 +556,8 @@ mod tests {
 
     use super::{
         Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, sequencer_enabled,
-        validate_l1_rpc_url, validate_p2p_transaction_size_limit, validate_portal_address,
+        validate_deprecated_zone_id, validate_l1_rpc_url, validate_p2p_transaction_size_limit,
+        validate_portal_address,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -572,6 +585,25 @@ mod tests {
     fn portal_address_must_be_nonzero() {
         assert!(validate_portal_address(alloy_primitives::Address::ZERO).is_err());
         assert!(validate_portal_address(alloy_primitives::Address::repeat_byte(0x11)).is_ok());
+    }
+
+    #[test]
+    fn deprecated_zone_id_is_optional_and_validated() {
+        assert!(validate_deprecated_zone_id(None, 7).is_ok());
+        assert!(validate_deprecated_zone_id(Some(7), 7).is_ok());
+        assert!(validate_deprecated_zone_id(Some(8), 7).is_err());
+
+        let parsed = ZoneArgsParser::try_parse_from([
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "7",
+        ])
+        .unwrap();
+        assert_eq!(parsed.zone.zone_id, Some(7));
     }
 
     #[test]

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -425,8 +425,6 @@ mod command {
                 &self.l1_rpc_url,
                 "--l1.portal-address",
                 &provisioned.portal.to_string(),
-                "--zone.id",
-                &provisioned.zone_id.to_string(),
                 "--http",
                 "--http.addr",
                 &self.http_addr,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -514,7 +514,9 @@ where
             .await?
             .erased();
         let l1_chain_id = l1_provider.get_chain_id().await?;
-        let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
+        let chain_spec = ctx.node.provider().chain_spec();
+        let chain_id = chain_spec.genesis().config.chain_id;
+        let genesis_zone_id = chain_spec.zone_id();
         // The CLI rejects a zero portal address. Programmatic test/dev nodes use it as an
         // explicit sentinel because they have no on-chain portal to bind against.
         if self.portal_address.is_zero() {
@@ -534,8 +536,9 @@ where
                     )
                 })?;
 
+            validate_configured_zone_id("genesis", genesis_zone_id, portal_zone_id)?;
             validate_configured_zone_id(
-                "--zone.id/redacted RPC configuration",
+                "redacted RPC configuration",
                 self.redacted_rpc_config.zone_id,
                 portal_zone_id,
             )?;
@@ -547,7 +550,7 @@ where
                 )?;
             }
             if let Some(config) = self.p2p_config.as_ref() {
-                validate_configured_zone_id("P2P manifest", config.zone_id(), portal_zone_id)?;
+                validate_configured_zone_id("P2P configuration", config.zone_id(), portal_zone_id)?;
             }
             validate_zone_chain_id(l1_chain_id, portal_zone_id, chain_id)?;
         }
@@ -625,8 +628,7 @@ where
             let attestation_domain = AttestationDomain {
                 l1_chain_id,
                 portal_address: self.portal_address,
-                zone_id: config.zone_id(),
-                sequencer_set_version: config.sequencer_set_version(),
+                zone_id: genesis_zone_id,
             };
             let anchor_config = self
                 .sequencer_config
@@ -637,15 +639,17 @@ where
             // decides whose signatures count and how many are needed. Reconcile them before any
             // role task starts, so a disagreement fails at startup instead of stalling
             // settlement at the next batch boundary.
-            crate::settlement_attestation::validate_registered_sequencer_set(
-                config.manifest(),
-                self.portal_address,
-                &l1_provider,
-            )
-            .await?;
+            let pinned_sequencer_set_version =
+                crate::settlement_attestation::validate_registered_sequencer_set(
+                    config.manifest(),
+                    self.portal_address,
+                    &l1_provider,
+                )
+                .await?;
             // Every node holds an attestation store so it can be promoted anytime.
             let attestation = AttestationContext::new(
                 attestation_domain,
+                pinned_sequencer_set_version,
                 config.block_attestation_signer(),
                 config.block_attestation_addresses(),
                 AttestationStore::default(),
@@ -700,6 +704,7 @@ where
                     role_status.clone(),
                     peer_tips.clone(),
                     manifest,
+                    pinned_sequencer_set_version,
                     local_secp256k1_address,
                     local_ed25519_public_key.clone(),
                     relayer,
@@ -760,6 +765,7 @@ where
                     NodeZoneDebugApi::new(container.registry.eth_api().clone()).into_rpc(),
                 )?;
                 container.modules.merge_http(operator_zone_rpc_module(
+                    genesis_zone_id,
                     portal_address,
                     operator_rpc_slot,
                     operator_rpc_provider,

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -47,6 +47,8 @@ use crate::settlement_attestation::build_settlement_attestation;
 #[derive(Clone)]
 pub(crate) struct AttestationContext {
     pub(crate) domain: AttestationDomain,
+    /// Portal sequencer-set version validated against the manifest at startup.
+    pub(crate) pinned_sequencer_set_version: Option<u64>,
     /// `None` on an rpc-only member: it holds no individual key and never signs.
     pub(crate) signer: Option<PrivateKeySigner>,
     pub(crate) addresses: HashMap<zone_p2p::P2pPeerId, alloy_primitives::Address>,
@@ -58,6 +60,7 @@ pub(crate) struct AttestationContext {
 impl AttestationContext {
     pub(crate) fn new(
         domain: AttestationDomain,
+        pinned_sequencer_set_version: Option<u64>,
         signer: Option<PrivateKeySigner>,
         addresses: HashMap<zone_p2p::P2pPeerId, alloy_primitives::Address>,
         store: AttestationStore,
@@ -66,6 +69,7 @@ impl AttestationContext {
     ) -> Self {
         Self {
             domain,
+            pinned_sequencer_set_version,
             signer,
             addresses,
             store,

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -86,6 +86,8 @@ pub struct SequencerRpcContext {
     pub(crate) peer_tips: PeerTipRegistry,
     /// Validated static topology manifest.
     pub manifest: Arc<ZoneManifest>,
+    /// Portal sequencer-set version validated against the manifest at startup.
+    pub pinned_sequencer_set_version: Option<u64>,
     /// This node's individual secp256k1 address (the `setLeader` relayer identity).
     ///
     /// `None` on an rpc-only member: it holds no individual key, so it cannot relay.
@@ -105,6 +107,7 @@ impl SequencerRpcContext {
         status: SharedRoleStatus,
         peer_tips: PeerTipRegistry,
         manifest: Arc<ZoneManifest>,
+        pinned_sequencer_set_version: Option<u64>,
         local_secp256k1_address: Option<Address>,
         local_ed25519_public_key: zone_p2p::P2pPeerId,
         relayer: Option<DynProvider<TempoNetwork>>,
@@ -115,6 +118,7 @@ impl SequencerRpcContext {
             status,
             peer_tips,
             manifest,
+            pinned_sequencer_set_version,
             local_secp256k1_address,
             local_ed25519_public_key,
             relayer,
@@ -196,6 +200,7 @@ where
 
 /// Build the unauthenticated Zone extension installed on the node's operator HTTP RPC.
 pub(crate) fn operator_zone_rpc_module<P>(
+    zone_id: u32,
     portal_address: Address,
     sequencer: Arc<std::sync::OnceLock<SequencerRpcContext>>,
     provider: P,
@@ -218,7 +223,7 @@ where
         let sequencer = sequencer.clone();
         let provider = provider.clone();
         async move {
-            get_sequencer_info(portal_address, sequencer.as_ref(), &provider)
+            get_sequencer_info(zone_id, portal_address, sequencer.as_ref(), &provider)
                 .map_err(operator_rpc_error)
         }
     })?;
@@ -420,6 +425,7 @@ async fn encryption_key(
 }
 
 fn get_sequencer_info<P>(
+    zone_id: u32,
     portal_address: Address,
     sequencer: &std::sync::OnceLock<SequencerRpcContext>,
     provider: &P,
@@ -490,8 +496,8 @@ where
     Ok(SequencerInfoResponse {
         mode: "multi".to_owned(),
         portal: portal_address,
-        manifest_zone_id: Some(U64::from(context.manifest.zone_id())),
-        manifest_sequencer_set_version: Some(U64::from(context.manifest.sequencer_set_version())),
+        manifest_zone_id: Some(U64::from(zone_id)),
+        manifest_sequencer_set_version: context.pinned_sequencer_set_version.map(U64::from),
         manifest_membership_digest: Some(context.manifest.membership_digest()),
         decryption_keys: Some({
             let status = context.encryption_keys.public_status();
@@ -1514,6 +1520,7 @@ mod tests {
     #[tokio::test]
     async fn operator_rpc_module_exposes_sequencer_methods_without_auth() {
         let module = operator_zone_rpc_module(
+            7,
             Address::repeat_byte(0x11),
             Arc::new(std::sync::OnceLock::new()),
             Arc::new(reth_provider::test_utils::MockEthProvider::default()),

--- a/crates/node/src/settlement_attestation.rs
+++ b/crates/node/src/settlement_attestation.rs
@@ -41,12 +41,12 @@ pub(crate) async fn validate_registered_sequencer_set(
     manifest: &zone_p2p::ZoneManifest,
     portal_address: alloy_primitives::Address,
     l1_provider: &alloy_provider::DynProvider<tempo_alloy::TempoNetwork>,
-) -> eyre::Result<()> {
+) -> eyre::Result<Option<u64>> {
     // Programmatic synthetic test harnesses use zero to mean no Portal; the production CLI
     // rejects a zero address before node launch.
     if portal_address.is_zero() {
         info!(target: "zone::p2p", "No ZonePortal configured; skipping the manifest quorum check");
-        return Ok(());
+        return Ok(None);
     }
     let portal_code = l1_provider
         .get_code_at(portal_address)
@@ -62,6 +62,11 @@ pub(crate) async fn validate_registered_sequencer_set(
     // harmless for a startup sanity check.
     let portal = ZonePortal::new(portal_address, l1_provider);
     let quorum: Vec<_> = manifest.quorum_nodes().collect();
+    let sequencer_set_version = portal
+        .sequencerSetVersion()
+        .call()
+        .await
+        .wrap_err("failed reading the ZonePortal sequencer-set version")?;
     let threshold_call = portal.sequencerThreshold();
     let count_call = portal.sequencerCount();
     let registered = futures::future::try_join_all(quorum.iter().map(|(node, address)| {
@@ -72,6 +77,15 @@ pub(crate) async fn validate_registered_sequencer_set(
     let (threshold, registered_count, registered) =
         tokio::try_join!(threshold_call.call(), count_call.call(), registered)
             .wrap_err("failed reading the registered sequencer set from ZonePortal")?;
+    let validated_version = portal
+        .sequencerSetVersion()
+        .call()
+        .await
+        .wrap_err("failed re-reading the ZonePortal sequencer-set version")?;
+    eyre::ensure!(
+        validated_version == sequencer_set_version,
+        "ZonePortal sequencer set changed during startup validation ({sequencer_set_version} -> {validated_version})"
+    );
 
     for (name, address, is_registered) in registered {
         eyre::ensure!(
@@ -93,8 +107,8 @@ pub(crate) async fn validate_registered_sequencer_set(
         );
     }
 
-    info!(target: "zone::p2p", threshold, quorum_nodes = quorum.len(), "Checked the manifest quorum against ZonePortal");
-    Ok(())
+    info!(target: "zone::p2p", threshold, sequencer_set_version, quorum_nodes = quorum.len(), "Checked the manifest quorum against ZonePortal");
+    Ok(Some(sequencer_set_version))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -214,11 +228,7 @@ where
         verifier_call.call(),
         portal_tip_call.call(),
     )?;
-    eyre::ensure!(
-        set_version == context.domain.sequencer_set_version,
-        "portal signer-set version {set_version} does not match manifest version {}",
-        context.domain.sequencer_set_version
-    );
+    validate_sequencer_set_version(context.pinned_sequencer_set_version, set_version)?;
     eyre::ensure!(
         portal_tip == previous_tip,
         "proposal does not extend the portal batch tip"
@@ -278,6 +288,19 @@ where
         withdrawalQueueHash: withdrawal_queue_hash,
         verifierConfigHash: alloy_primitives::keccak256(Bytes::new()),
     }))
+}
+
+fn validate_sequencer_set_version(
+    pinned_version: Option<u64>,
+    live_version: u64,
+) -> eyre::Result<()> {
+    if let Some(pinned_version) = pinned_version {
+        eyre::ensure!(
+            live_version == pinned_version,
+            "portal signer-set version {live_version} does not match startup-pinned version {pinned_version}"
+        );
+    }
+    Ok(())
 }
 
 /// Verify that the proposed Tempo and anchor endpoints are canonical and that the anchor remains
@@ -651,18 +674,29 @@ mod tests {
             .connect_mocked_client(asserter.clone())
             .erased();
 
-        validate_registered_sequencer_set(
+        let pinned_version = validate_registered_sequencer_set(
             &test_manifest(),
             alloy_primitives::Address::ZERO,
             &provider,
         )
         .await
         .expect("synthetic nodes have no configured ZonePortal");
+        assert_eq!(pinned_version, None);
 
         assert!(
             asserter.read_q().is_empty(),
             "the zero-address test bypass must not issue an L1 request"
         );
+    }
+
+    #[test]
+    fn settlement_rejects_runtime_sequencer_set_rotation() {
+        validate_sequencer_set_version(Some(7), 7).expect("unchanged version must remain valid");
+        let err = validate_sequencer_set_version(Some(7), 8)
+            .expect_err("runtime rotation must fail closed");
+        assert!(err.to_string().contains("startup-pinned version 7"));
+        validate_sequencer_set_version(None, 8)
+            .expect("synthetic nodes without a Portal have no pinned version");
     }
 
     #[tokio::test]

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -87,8 +87,6 @@ The manifest is TOML and must contain at least three quorum nodes. The following
 the configuration shape:
 
 ```toml
-zone_id = 7
-sequencer_set_version = 0
 leader_ed25519_public_key = "0xleader..."
 
 [[nodes]]
@@ -130,11 +128,6 @@ quorum, cannot be selected by `zone_setLeader` or `[forced_recovery]`, and are n
 the Portal's current registered sequencer set. Once every retained checkpoint and replay window is
 past that leader's last epoch, the entry can be removed.
 
-`sequencer_set_version` must exactly match the value reported by `ZonePortal`. Version `0` is
-valid for the initial sequencer set installed atomically by `ZoneFactory`; later
-`setSequencerSet` calls increment it. The field defaults to `1` for compatibility with existing
-manifests that omitted it.
-
 To recover a crashed leader, add this top-level table before restarting the fleet:
 
 ```toml
@@ -164,7 +157,6 @@ The manifest loader validates that:
   their Ed25519 identities do not alias an `rpc_only` node;
 - every address has a non-zero port;
 - `leader_ed25519_public_key` identifies one of the nodes;
-- the manifest's `zone_id` matches `--zone.id`; and
 - both local private keys correspond to the same manifest member.
 
 At P2P startup, the node requires the configured `ZonePortal` to be deployed at the current L1 tip,

--- a/crates/p2p/src/manifest.rs
+++ b/crates/p2p/src/manifest.rs
@@ -715,8 +715,6 @@ impl ManifestNode {
 /// A parsed and intrinsically validated zone manifest.
 #[derive(Debug, Clone)]
 pub struct ZoneManifest {
-    zone_id: u32,
-    sequencer_set_version: u64,
     leader_ed25519_public_key: PublicKey,
     forced_recovery: Option<ForcedRecoveryConfig>,
     nodes: Vec<ManifestNode>,
@@ -872,8 +870,6 @@ impl ZoneManifest {
         };
 
         Ok(Self {
-            zone_id: raw.zone_id,
-            sequencer_set_version: raw.sequencer_set_version,
             leader_ed25519_public_key,
             forced_recovery,
             nodes,
@@ -898,18 +894,10 @@ impl ZoneManifest {
     /// a quorum member without it could never settle.
     pub fn validate_node(
         &self,
-        expected_zone_id: u32,
         local_ed25519_public_key: &PublicKey,
         local_secp256k1_address: Option<EthereumAddress>,
         asserted_role: Option<Role>,
     ) -> Result<Role, ManifestError> {
-        if self.zone_id != expected_zone_id {
-            return Err(ManifestError::ZoneIdMismatch {
-                manifest: self.zone_id,
-                cli: expected_zone_id,
-            });
-        }
-
         let local_node = self
             .node_by_ed25519_public_key(local_ed25519_public_key)
             .ok_or_else(|| {
@@ -941,16 +929,6 @@ impl ZoneManifest {
             });
         }
         Ok(role)
-    }
-
-    /// Zone identifier used to domain-separate the P2P network.
-    pub const fn zone_id(&self) -> u32 {
-        self.zone_id
-    }
-
-    /// Version of the registered L1 attester set used in EIP-712 statements.
-    pub const fn sequencer_set_version(&self) -> u64 {
-        self.sequencer_set_version
     }
 
     /// Ed25519 Commonware public key of the configured initial leader.
@@ -1092,19 +1070,18 @@ impl ZoneManifest {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawManifest {
-    zone_id: u32,
-    #[serde(default = "default_sequencer_set_version")]
-    sequencer_set_version: u64,
+    /// Deprecated compatibility field. Zone identity comes from the genesis chain ID.
+    #[serde(default, rename = "zone_id")]
+    _legacy_zone_id: Option<u32>,
+    /// Deprecated compatibility field. The signer-set version comes from `ZonePortal`.
+    #[serde(default, rename = "sequencer_set_version")]
+    _legacy_sequencer_set_version: Option<u64>,
     leader_ed25519_public_key: String,
     #[serde(default)]
     forced_recovery: Option<RawForcedRecovery>,
     #[serde(default)]
     historical_leaders: Vec<RawHistoricalLeaderIdentity>,
     nodes: Vec<RawManifestNode>,
-}
-
-const fn default_sequencer_set_version() -> u64 {
-    1
 }
 
 #[derive(Debug, Deserialize)]
@@ -1225,9 +1202,6 @@ pub enum ManifestError {
 
     #[error("manifest leader Ed25519 public key `{0}` does not match any node")]
     LeaderEd25519PublicKeyNotFound(String),
-
-    #[error("zone ID mismatch: manifest has {manifest}, but --zone.id is {cli}")]
-    ZoneIdMismatch { manifest: u32, cli: u32 },
 
     #[error("this node's Ed25519 public key `{0}` is not present in the sequencer manifest")]
     LocalNodeNotFound(String),
@@ -1648,7 +1622,7 @@ mod tests {
     /// node declares no `secp256k1_address`, exactly as the loader requires.
     fn manifest_with_rpc_only(leader: u64, nodes: &[(u64, &str, &str, bool)]) -> String {
         let mut value = format!(
-            "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             ed25519_public_key(leader)
         );
         for (key, name, address, rpc_only) in nodes {
@@ -1700,19 +1674,13 @@ mod tests {
         );
         assert_eq!(
             manifest
-                .validate_node(
-                    7,
-                    &leader,
-                    Some(secp256k1_address(1).parse().unwrap()),
-                    None
-                )
+                .validate_node(&leader, Some(secp256k1_address(1).parse().unwrap()), None)
                 .unwrap(),
             Role::Leader
         );
         assert_eq!(
             manifest
                 .validate_node(
-                    7,
                     &follower,
                     Some(secp256k1_address(2).parse().unwrap()),
                     Some(Role::Follower),
@@ -1802,9 +1770,9 @@ mod tests {
     }
 
     #[test]
-    fn accepts_factory_installed_sequencer_set_version_zero() {
+    fn accepts_ignored_legacy_identity_fields() {
         let input = format!(
-            "sequencer_set_version = 0\n{}",
+            "zone_id = 7\nsequencer_set_version = 42\n{}",
             manifest(
                 1,
                 &[
@@ -1816,7 +1784,8 @@ mod tests {
         );
 
         let manifest = ZoneManifest::parse(&input).unwrap();
-        assert_eq!(manifest.sequencer_set_version(), 0);
+
+        assert_eq!(manifest.bootstrap_role_of(&public_key(1)), Role::Leader);
     }
 
     #[test]
@@ -1876,7 +1845,6 @@ mod tests {
 
         // The example uses placeholder keys, so only its shape can be checked.
         let manifest: super::RawManifest = toml::from_str(example).unwrap();
-        assert_eq!(manifest.zone_id, 7);
         assert_eq!(manifest.nodes.len(), 4);
         assert_eq!(manifest.historical_leaders.len(), 1);
         assert_eq!(
@@ -1945,12 +1913,12 @@ mod tests {
         // Its role assertion must name the standby role, not `follower`.
         assert_eq!(
             manifest
-                .validate_node(7, &rpc_follower, None, Some(Role::RpcFollower))
+                .validate_node(&rpc_follower, None, Some(Role::RpcFollower))
                 .unwrap(),
             Role::RpcFollower
         );
         assert!(matches!(
-            manifest.validate_node(7, &rpc_follower, None, Some(Role::Follower)),
+            manifest.validate_node(&rpc_follower, None, Some(Role::Follower)),
             Err(ManifestError::RoleMismatch { .. })
         ));
     }
@@ -2108,13 +2076,12 @@ mod tests {
 
         // A quorum member started without --secp256k1.key cannot sign.
         assert!(matches!(
-            manifest.validate_node(7, &public_key(2), None, None),
+            manifest.validate_node(&public_key(2), None, None),
             Err(ManifestError::LocalSecp256k1KeyMissing(node)) if node == "follower-a"
         ));
         // A standby started with one holds key material it must not have.
         assert!(matches!(
             manifest.validate_node(
-                7,
                 &public_key(4),
                 Some(secp256k1_address(4).parse().unwrap()),
                 None
@@ -2162,40 +2129,20 @@ mod tests {
         let follower = PrivateKey::from_seed(2).public_key();
         assert!(matches!(
             valid.validate_node(
-                7,
                 &follower,
                 Some(secp256k1_address(2).parse().unwrap()),
                 Some(Role::Leader),
             ),
             Err(ManifestError::RoleMismatch { .. })
         ));
-        assert!(matches!(
-            valid.validate_node(
-                8,
-                &follower,
-                Some(secp256k1_address(2).parse().unwrap()),
-                None,
-            ),
-            Err(ManifestError::ZoneIdMismatch { .. })
-        ));
         let unknown = PrivateKey::from_seed(99).public_key();
         assert!(matches!(
-            valid.validate_node(
-                7,
-                &unknown,
-                Some(secp256k1_address(99).parse().unwrap()),
-                None,
-            ),
+            valid.validate_node(&unknown, Some(secp256k1_address(99).parse().unwrap()), None,),
             Err(ManifestError::LocalNodeNotFound(_))
         ));
 
         assert!(matches!(
-            valid.validate_node(
-                7,
-                &follower,
-                Some(secp256k1_address(3).parse().unwrap()),
-                None,
-            ),
+            valid.validate_node(&follower, Some(secp256k1_address(3).parse().unwrap()), None,),
             Err(ManifestError::LocalSecp256k1AddressMismatch { .. })
         ));
     }

--- a/crates/p2p/src/network.rs
+++ b/crates/p2p/src/network.rs
@@ -102,12 +102,13 @@ fn setup_commonware_config(
 pub(crate) fn instantiate(
     context: &commonware_runtime::tokio::Context,
     manifest: &ZoneManifest,
+    zone_id: u32,
     ed25519_private_key: PrivateKey,
     listen: SocketAddr,
     bypass_ip_check: bool,
     network_id: P2pNetworkId,
 ) -> eyre::Result<(Network, Oracle, AddressableTrackedPeers<PublicKey>)> {
-    let namespace = namespace(manifest.zone_id(), network_id);
+    let namespace = namespace(zone_id, network_id);
     // Logged, not bound into the namespace: a mismatch between nodes stalls settlement loudly at
     // the next batch boundary, and making it a handshake failure would turn every membership edit
     // into a coordinated fleet restart. Compare this across nodes to diagnose one.
@@ -208,7 +209,7 @@ mod tests {
 
     fn manifest_with_rpc_follower() -> ZoneManifest {
         let mut manifest = format!(
-            "zone_id = 7\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             ed25519_public_key(1)
         );
         for seed in 1..=3 {

--- a/crates/p2p/src/routing.rs
+++ b/crates/p2p/src/routing.rs
@@ -185,10 +185,7 @@ mod tests {
     }
 
     fn manifest() -> ZoneManifest {
-        let mut input = format!(
-            "zone_id = 7\nleader_ed25519_public_key = \"0x{}\"\n",
-            hex(key(1))
-        );
+        let mut input = format!("leader_ed25519_public_key = \"0x{}\"\n", hex(key(1)));
         for (seed, rpc_only) in [(1, false), (2, false), (3, false), (4, true)] {
             input.push_str(&format!(
                 "\n[[nodes]]\nname = \"node-{seed}\"\ned25519_public_key = \"0x{}\"\naddress = \"127.0.0.1:{}\"\nrpc_only = {rpc_only}\n",

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -64,6 +64,7 @@ struct BackfillNodeChannels {
 /// Fully validated configuration for one node's Zone P2P runtime.
 #[derive(Clone)]
 pub struct P2pConfig {
+    zone_id: u32,
     manifest: Arc<ZoneManifest>,
     ed25519_identity: Ed25519Identity,
     // This individual node key will be used to sign zone blocks for the on-chain quorum.
@@ -76,8 +77,8 @@ pub struct P2pConfig {
 }
 
 impl P2pConfig {
-    /// Loads the Commonware Ed25519 key and manifest, then validates this node's
-    /// membership, zone ID, and optional role assertion.
+    /// Loads the Commonware Ed25519 key and manifest, then validates this node's membership and
+    /// optional role assertion. `zone_id` comes from the node's genesis configuration.
     ///
     /// `secp256k1_key_path` is required for a quorum member and rejected for an `rpc_only`
     /// node; [`ZoneManifest::validate_node`] enforces the correspondence.
@@ -87,7 +88,7 @@ impl P2pConfig {
         secp256k1_key_path: Option<impl AsRef<Path>>,
         listen: SocketAddr,
         bypass_ip_check: bool,
-        expected_zone_id: u32,
+        zone_id: u32,
         asserted_role: Option<Role>,
     ) -> eyre::Result<Self> {
         let ed25519_identity = Ed25519Identity::read_from_file(ed25519_key_path)?;
@@ -97,7 +98,6 @@ impl P2pConfig {
         let manifest = ZoneManifest::read_from_file(manifest_path)?;
         validate_ip_check_configuration(&manifest, bypass_ip_check)?;
         manifest.validate_node(
-            expected_zone_id,
             &ed25519_identity.ed25519_public_key(),
             secp256k1_identity.as_ref().map(Secp256k1Identity::address),
             asserted_role,
@@ -107,6 +107,7 @@ impl P2pConfig {
         // local Tempo checkpoint before any role-dependent task starts.
         let leadership = manifest.leadership_schedule();
         Ok(Self {
+            zone_id,
             manifest: Arc::new(manifest),
             ed25519_identity,
             secp256k1_identity,
@@ -168,19 +169,14 @@ impl P2pConfig {
 
     /// Zone ID included in each block attestation.
     pub fn zone_id(&self) -> u32 {
-        self.manifest.zone_id()
-    }
-
-    /// Registered signer-set version included in each block attestation.
-    pub fn sequencer_set_version(&self) -> u64 {
-        self.manifest.sequencer_set_version()
+        self.zone_id
     }
 }
 
 impl std::fmt::Debug for P2pConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("P2pConfig")
-            .field("zone_id", &self.manifest.zone_id())
+            .field("zone_id", &self.zone_id)
             .field("ed25519_public_key", &self.ed25519_public_key())
             .field("secp256k1_address", &self.secp256k1_address())
             .field("listen", &self.listen)
@@ -392,6 +388,7 @@ fn run(
         let (mut commonware, mut oracle, peers) = network::instantiate(
             &context,
             &config.manifest,
+            config.zone_id,
             config.ed25519_identity.into_private_key(),
             config.listen,
             config.bypass_ip_check,
@@ -438,7 +435,7 @@ fn run(
 
         info!(
             target: "zone::p2p",
-            zone_id = config.manifest.zone_id(),
+            zone_id = config.zone_id,
             ed25519_public_key = %local_ed25519_public_key,
             listen = %config.listen,
             peers = config.manifest.nodes().len(),
@@ -967,7 +964,7 @@ mod tests {
         standby: usize,
     ) -> String {
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
@@ -995,6 +992,7 @@ mod tests {
         let input = manifest_with_standby(&identities, &addresses, 41, 3);
         let manifest = Arc::new(ZoneManifest::parse(&input).unwrap());
         let config = P2pConfig {
+            zone_id: 9,
             manifest: manifest.clone(),
             ed25519_identity: ed25519_identity(41),
             secp256k1_identity: Some(secp256k1_identity(41)),
@@ -1018,7 +1016,7 @@ mod tests {
             ed25519_identity(3),
         ];
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, identity) in identities.iter().enumerate() {
@@ -1113,7 +1111,7 @@ mod tests {
             ed25519_identity(3),
         ];
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
@@ -1133,7 +1131,6 @@ mod tests {
                 let secp256k1_identity = secp256k1_identity(index as u64 + 1);
                 manifest
                     .validate_node(
-                        9,
                         &identity.ed25519_public_key(),
                         Some(secp256k1_identity.address()),
                         None,
@@ -1141,6 +1138,7 @@ mod tests {
                     .unwrap();
                 spawn_p2p(
                     P2pConfig {
+                        zone_id: 9,
                         manifest: manifest.clone(),
                         ed25519_identity: identity,
                         secp256k1_identity: Some(secp256k1_identity),
@@ -1371,7 +1369,7 @@ mod tests {
             ed25519_identity(23),
         ];
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
@@ -1402,6 +1400,7 @@ mod tests {
                 leadership.record_applied_anchor(10);
                 spawn_p2p(
                     P2pConfig {
+                        zone_id: 9,
                         manifest: manifest.clone(),
                         ed25519_identity: identity,
                         secp256k1_identity: Some(secp256k1_identity(index as u64 + 21)),
@@ -1608,6 +1607,7 @@ mod tests {
                 leadership.publish(manifest.bootstrap_leadership()).unwrap();
                 spawn_p2p(
                     P2pConfig {
+                        zone_id: 9,
                         manifest: manifest.clone(),
                         ed25519_identity: identity,
                         // The standby is provisioned without quorum key material at all.
@@ -1762,7 +1762,7 @@ mod tests {
         ];
         let identities = [51_u64, 52, 53].map(ed25519_identity);
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
@@ -1779,6 +1779,7 @@ mod tests {
             .map(|index| {
                 spawn_p2p(
                     P2pConfig {
+                        zone_id: 9,
                         manifest: manifest.clone(),
                         ed25519_identity: ed25519_identity(index as u64 + 51),
                         secp256k1_identity: Some(secp256k1_identity(index as u64 + 51)),
@@ -1847,7 +1848,7 @@ mod tests {
             ed25519_identity(13),
         ];
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
@@ -1869,7 +1870,6 @@ mod tests {
                 let secp256k1_identity = secp256k1_identity(index as u64 + 11);
                 let role = manifest
                     .validate_node(
-                        9,
                         &identity.ed25519_public_key(),
                         Some(secp256k1_identity.address()),
                         None,
@@ -1878,6 +1878,7 @@ mod tests {
                 assert_eq!(role, crate::Role::Follower);
                 spawn_p2p(
                     P2pConfig {
+                        zone_id: 9,
                         manifest: manifest.clone(),
                         ed25519_identity: identity,
                         secp256k1_identity: Some(secp256k1_identity),
@@ -1949,7 +1950,7 @@ mod tests {
             ed25519_identity(63),
         ];
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
@@ -1967,6 +1968,7 @@ mod tests {
         let spawn_node = |index: usize| {
             spawn_p2p(
                 P2pConfig {
+                    zone_id: 9,
                     manifest: manifest.clone(),
                     ed25519_identity: ed25519_identity(index as u64 + 61),
                     secp256k1_identity: Some(secp256k1_identity(index as u64 + 61)),
@@ -2047,6 +2049,7 @@ mod tests {
         for attempt in 0..10 {
             match spawn_p2p(
                 P2pConfig {
+                    zone_id: 9,
                     manifest: manifest.clone(),
                     ed25519_identity: ed25519_identity(63),
                     secp256k1_identity: Some(secp256k1_identity(63)),
@@ -2116,7 +2119,7 @@ mod tests {
             ed25519_identity(73),
         ];
         let mut input = format!(
-            "zone_id = 9\nleader_ed25519_public_key = \"{}\"\n",
+            "leader_ed25519_public_key = \"{}\"\n",
             const_hex::encode_prefixed(identities[0].ed25519_public_key().as_ref())
         );
         for (index, (identity, address)) in identities.iter().zip(addresses).enumerate() {
@@ -2137,6 +2140,7 @@ mod tests {
             .map(|index| {
                 spawn_p2p(
                     P2pConfig {
+                        zone_id: 9,
                         manifest: manifest.clone(),
                         ed25519_identity: ed25519_identity(index as u64 + 71),
                         secp256k1_identity: Some(secp256k1_identity(index as u64 + 71)),
@@ -2191,6 +2195,7 @@ mod tests {
 
         let mut leader = spawn_p2p(
             P2pConfig {
+                zone_id: 9,
                 manifest: manifest.clone(),
                 ed25519_identity: ed25519_identity(71),
                 secp256k1_identity: Some(secp256k1_identity(71)),

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -114,8 +114,8 @@ pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChai
     Ok(chain_id)
 }
 
-/// Decodes the parent Tempo chain ID from a Zone chain ID.
-pub fn decode_l1_chain_id(chain_id: u64) -> Result<u64, ZoneChainIdError> {
+/// Decodes the parent Tempo chain ID and ZoneFactory ID from a Zone chain ID.
+pub fn decode_zone_chain_id(chain_id: u64) -> Result<(u64, u32), ZoneChainIdError> {
     let (parent_chain_id, zone_id) =
         if (ZONE_CHAIN_ID_BASE..ZONE_CHAIN_ID_BASE + ZONE_CHAIN_ID_RANGE).contains(&chain_id) {
             (MAINNET_CHAIN_ID, (chain_id - ZONE_CHAIN_ID_BASE) as u32)
@@ -134,10 +134,15 @@ pub fn decode_l1_chain_id(chain_id: u64) -> Result<u64, ZoneChainIdError> {
         };
 
     if zone_chain_id(parent_chain_id, zone_id) == Ok(chain_id) {
-        Ok(parent_chain_id)
+        Ok((parent_chain_id, zone_id))
     } else {
         Err(ZoneChainIdError::InvalidZoneChainId(chain_id))
     }
+}
+
+/// Decodes the parent Tempo chain ID from a Zone chain ID.
+pub fn decode_l1_chain_id(chain_id: u64) -> Result<u64, ZoneChainIdError> {
+    decode_zone_chain_id(chain_id).map(|(parent_chain_id, _)| parent_chain_id)
 }
 
 fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {
@@ -210,6 +215,10 @@ mod tests {
             (MAX_GENERIC_PARENT_CHAIN_ID, u32::MAX),
         ] {
             let chain_id = zone_chain_id(parent_chain_id, zone_id).unwrap();
+            assert_eq!(
+                decode_zone_chain_id(chain_id),
+                Ok((parent_chain_id, zone_id))
+            );
             assert_eq!(decode_l1_chain_id(chain_id), Ok(parent_chain_id));
         }
 

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -355,10 +355,10 @@ pub struct SequencerInfoResponse {
     pub mode: String,
     /// ZonePortal address on Tempo L1.
     pub portal: Address,
-    /// Zone ID declared by the loaded manifest (multi-sequencer mode only).
+    /// Canonical Zone ID derived from the genesis chain ID (multi-sequencer mode only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_zone_id: Option<U64>,
-    /// Sequencer-set version declared by the loaded manifest (multi-sequencer mode only).
+    /// Sequencer-set version validated and pinned at node startup (multi-sequencer mode only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_sequencer_set_version: Option<U64>,
     /// Digest of the loaded manifest's settlement-relevant membership.

--- a/crates/sequencer/src/attestation.rs
+++ b/crates/sequencer/src/attestation.rs
@@ -47,7 +47,6 @@ pub struct AttestationDomain {
     pub l1_chain_id: u64,
     pub portal_address: Address,
     pub zone_id: u32,
-    pub sequencer_set_version: u64,
 }
 
 impl AttestationDomain {
@@ -324,7 +323,6 @@ mod tests {
             l1_chain_id: 1337,
             portal_address: Address::repeat_byte(0x11),
             zone_id: 7,
-            sequencer_set_version: 3,
         }
     }
 

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -185,7 +185,7 @@ just create-zone my-zone alphausd
 ```
 
 This creates `generated/my-zone/` containing:
-- **`genesis.json`** — Zone L2 genesis state (system contracts, fee token, etc.)
+- **`genesis.json`** — Zone L2 genesis state (system contracts, fee token, chain ID, etc.)
 - **`zone.json`** — Deployment metadata (portal address, zone ID, anchor block, `zoneFactory`, public `admin` / `sequencer` addresses, and optional saved keys/router metadata)
 
 This initial token controls the first L1 TIP-20 the portal accepts and mirrors onto the zone. The zone's fee token in genesis remains `pathUSD`.
@@ -648,7 +648,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | 0 | Zone ID from ZoneFactory. At startup it must match `ZonePortal.zoneId()`; `0` does not bypass validation. |
+| `--zone.id` | (deprecated) | Optional compatibility check against the zone ID encoded in the genesis chain ID. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
 | `--deposit-decryption-keys-file` | (optional) | File containing additional historical or pre-provisioned deposit decryption keys, one hex key per line |

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -303,7 +303,7 @@ else:
     # 0 < parent_chain_id <= 1048574
 ```
 
-The production ranges reject exhaustion rather than wrapping. Generic IDs are at least `2^32` and cannot collide with the sub-`2^31` production ranges. The generic-parent ceiling ensures that even the largest `zone_id` keeps the EIP-155 legacy signature `v` value below JavaScript's `Number.MAX_SAFE_INTEGER`. Distinct devnets MUST use distinct parent chain IDs. This prevents replay between zones and between mainnet, Moderato, and devnets. The chain ID is set in genesis and validated at startup against both the connected parent and the zone ID returned by the configured `ZonePortal.zoneId()`.
+The production ranges reject exhaustion rather than wrapping. Generic IDs are at least `2^32` and cannot collide with the sub-`2^31` production ranges. The generic-parent ceiling ensures that even the largest `zone_id` keeps the EIP-155 legacy signature `v` value below JavaScript's `Number.MAX_SAFE_INTEGER`. Distinct devnets MUST use distinct parent chain IDs. This prevents replay between zones and between mainnet, Moderato, and devnets. The chain ID is set in genesis; the parent and zone IDs decoded from it are validated at startup against the connected parent and the configured `ZonePortal.zoneId()`.
 
 ### Tempo Contracts
 

--- a/xtask/src/admin/invariants.rs
+++ b/xtask/src/admin/invariants.rs
@@ -912,7 +912,7 @@ fn append_manifest_invariants(
     live_nodes: &[(&NodeSnapshot, &ZoneInfoResponse, &SequencerInfoResponse)],
 ) {
     let portal_members = address_set(&portal.sequencers);
-    let node_manifest_zones = live_nodes
+    let node_zone_ids = live_nodes
         .iter()
         .map(|(node, _, info)| {
             format!(
@@ -926,19 +926,16 @@ fn append_manifest_invariants(
     add_check(
         results,
         "manifest_zone",
-        manifest.zone_id() == config.zone_id
-            && live_nodes.iter().all(|(_, _, info)| {
-                info.manifest_zone_id.map(|id| id.to::<u32>()) == Some(config.zone_id)
-            }),
-        format!("manifest and all nodes declare Zone {}", config.zone_id),
+        live_nodes.iter().all(|(_, _, info)| {
+            info.manifest_zone_id.map(|id| id.to::<u32>()) == Some(config.zone_id)
+        }),
+        format!("all nodes report canonical Zone {}", config.zone_id),
         format!(
-            "expected Zone {}; file={}, nodes=[{}]",
-            config.zone_id,
-            manifest.zone_id(),
-            node_manifest_zones
+            "expected canonical Zone {}; nodes=[{}]",
+            config.zone_id, node_zone_ids
         ),
     );
-    let node_manifest_versions = live_nodes
+    let node_sequencer_set_versions = live_nodes
         .iter()
         .map(|(node, _, info)| {
             format!(
@@ -953,21 +950,18 @@ fn append_manifest_invariants(
     add_check(
         results,
         "manifest_version",
-        manifest.sequencer_set_version() == portal.sequencer_set_version
-            && live_nodes.iter().all(|(_, _, info)| {
-                info.manifest_sequencer_set_version
-                    .map(|version| version.to::<u64>())
-                    == Some(manifest.sequencer_set_version())
-            }),
+        live_nodes.iter().all(|(_, _, info)| {
+            info.manifest_sequencer_set_version
+                .map(|version| version.to::<u64>())
+                == Some(portal.sequencer_set_version)
+        }),
         format!(
-            "manifest, Portal, and all nodes report version {}",
-            manifest.sequencer_set_version()
+            "Portal and all nodes report sequencer-set version {}",
+            portal.sequencer_set_version
         ),
         format!(
-            "expected version {}; Portal={}, nodes=[{}]",
-            manifest.sequencer_set_version(),
-            portal.sequencer_set_version,
-            node_manifest_versions
+            "expected finalized Portal version {}; nodes=[{}]",
+            portal.sequencer_set_version, node_sequencer_set_versions
         ),
     );
     let digest = manifest.membership_digest();

--- a/xtask/src/admin/leader.rs
+++ b/xtask/src/admin/leader.rs
@@ -133,12 +133,6 @@ impl LeaderSet {
                     "--rolling-membership requires --zone-manifest with the finalized next manifest"
                 )
             })?;
-            ensure!(
-                manifest.sequencer_set_version() == view.portal.sequencer_set_version,
-                "rolling manifest version {} does not match finalized Portal version {}",
-                manifest.sequencer_set_version(),
-                view.portal.sequencer_set_version
-            );
             let manifest_members = manifest
                 .quorum_nodes()
                 .map(|(_, address)| address)

--- a/xtask/src/admin/sequencer_set.rs
+++ b/xtask/src/admin/sequencer_set.rs
@@ -299,21 +299,9 @@ fn validate(
         proposed.len()
     );
 
-    let next_version = command
-        .expected_version
-        .checked_add(1)
-        .ok_or_else(|| eyre!("expected sequencer-set version cannot be incremented"))?;
     ensure!(
-        next_manifest.zone_id() == view.config.zone_id,
-        "next manifest declares Zone {}, expected {}",
-        next_manifest.zone_id(),
-        view.config.zone_id
-    );
-    ensure!(
-        next_manifest.sequencer_set_version() == next_version,
-        "next manifest sequencer_set_version is {}, expected {}",
-        next_manifest.sequencer_set_version(),
-        next_version
+        command.expected_version != u64::MAX,
+        "expected sequencer-set version cannot be incremented"
     );
     let manifest_members = next_manifest
         .quorum_nodes()


### PR DESCRIPTION
## Summary

- derive the parent Tempo chain ID and zone ID from the genesis `chainId`, including the reserved mainnet and Moderato ranges
- validate the derived zone ID against `ZonePortal.zoneId()` and use it for node, RPC, P2P, sequencing, and SPF configuration
- remove manifest identity as a source of truth while continuing to accept legacy `zone_id` and `sequencer_set_version` fields
- keep `zone_getSequencerInfo` compatibility fields populated from the chain-derived zone ID and startup-pinned Portal sequencer-set version
- update admin invariants and sequencer-set validation to stop reading removed manifest identity fields
- pin the Portal sequencer-set version during startup membership validation and fail closed if it changes before settlement
- retain `--zone.id` / `ZONE_ID` as a deprecated compatibility check instead of removing it

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo check -p zone-primitives -p zone-chainspec -p zone-p2p -p zone-node`
- `cargo test -p zone-primitives -p zone-chainspec -p zone-p2p -p zone-node --lib`
- `cargo test -p zone-node --features cli cli::tests::deprecated_zone_id_is_optional_and_validated -- --exact`
- `cargo +nightly clippy -p zone-primitives -p zone-chainspec -p zone-p2p -p zone-node -p zone-sequencer --all-features --tests` (passes with pre-existing warnings)
- `cargo check --workspace --all-features --locked`
- `cargo test -p tempo-xtask --locked`
- `cargo test -p zone-node operator_rpc_module_exposes_sequencer_methods_without_auth --locked`
- `cargo test -p zone-node settlement_attestation::tests::settlement_rejects_runtime_sequencer_set_rotation --locked -- --exact`
- `cargo test -p zone-node settlement_attestation::tests::synthetic_test_harness_can_skip_an_unconfigured_portal --locked -- --exact`
- `cargo +nightly clippy -p zone-node --all-targets --all-features --locked` (passes with pre-existing warnings)
- `cargo +nightly clippy --all-targets --all-features --locked` (passes with pre-existing warnings)
- `git diff --check`

Prompted by: @klkvr
