### PR TITLE
fix(primitives): evaluate production chain IDs before generic parent bounds in validate_chain_id

### DIFF
--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -185,17 +185,28 @@ pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChai
 }
 
 fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {
-    if parent_chain_id == 0 || parent_chain_id > MAX_GENERIC_PARENT_CHAIN_ID {
-        return Err(ZoneChainIdError::InvalidParentChainId(parent_chain_id));
+    if parent_chain_id == MAINNET_CHAIN_ID {
+        if zone_id as u64 >= ZONE_CHAIN_ID_RANGE {
+            return Err(ZoneChainIdError::ZoneIdOutOfRange {
+                parent_chain_id,
+                zone_id,
+            });
+        }
+        return Ok(());
     }
 
-    if (parent_chain_id == MAINNET_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE)
-        || (parent_chain_id == MODERATO_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE_TESTNET)
-    {
-        return Err(ZoneChainIdError::ZoneIdOutOfRange {
-            parent_chain_id,
-            zone_id,
-        });
+    if parent_chain_id == MODERATO_CHAIN_ID {
+        if zone_id as u64 >= ZONE_CHAIN_ID_RANGE_TESTNET {
+            return Err(ZoneChainIdError::ZoneIdOutOfRange {
+                parent_chain_id,
+                zone_id,
+            });
+        }
+        return Ok(());
+    }
+
+    if parent_chain_id == 0 || parent_chain_id > MAX_GENERIC_PARENT_CHAIN_ID {
+        return Err(ZoneChainIdError::InvalidParentChainId(parent_chain_id));
     }
 
     Ok(())


### PR DESCRIPTION
Refactored validate_chain_id in crates/primitives/src/constants.rs to evaluate production chain branches (MAINNET_CHAIN_ID and MODERATO_CHAIN_ID) before applying the generic parent chain ID limit. This ensures that production zone ID range validation logic is evaluated with high priority and returns the proper ZoneIdOutOfRange error when out of bounds.