### PR TITLE
fix(rpc): set caller for operator balance calls

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -14,9 +14,10 @@ use crate::{
         run_role_controller,
     },
     rpc::{
-        NodeZoneDebugApi, OperatorWeb3Api, OperatorZoneApi, SequencerRpcContext,
-        ZoneApiServer as _, ZoneRpc, ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config,
-        start_redacted_rpc,
+        NodeZoneDebugApi, OperatorWeb3Api, OperatorZoneApi, OperatorZoneBalanceApi,
+        SequencerRpcContext,
+        ZoneApiServer as _, ZoneBalanceApiServer as _, ZoneRpc, ZoneRpcApi,
+        operator_zone_rpc_module, rpc_connection_config, start_redacted_rpc,
     },
 };
 use alloy_chains::Chain;
@@ -791,11 +792,13 @@ where
                     portal_address,
                     operator_l1_provider,
                     operator_zone_provider,
-                    container.registry.eth_api().clone(),
                 );
                 container
                     .modules
                     .merge_configured(operator_zone_api.into_rpc())?;
+                container.modules.merge_http(
+                    OperatorZoneBalanceApi::new(container.registry.eth_api().clone()).into_rpc(),
+                )?;
                 container.modules.merge_configured(
                     NodeZoneDebugApi::new(container.registry.eth_api().clone()).into_rpc(),
                 )?;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -14,9 +14,8 @@ use crate::{
         run_role_controller,
     },
     rpc::{
-        NodeZoneDebugApi, OperatorWeb3Api, OperatorZoneApi, OperatorZoneBalanceApi,
-        SequencerRpcContext,
-        ZoneApiServer as _, ZoneBalanceApiServer as _, ZoneRpc, ZoneRpcApi,
+        NodeZoneDebugApi, OperatorEthCall, OperatorEthCallApiServer as _, OperatorWeb3Api,
+        OperatorZoneApi, SequencerRpcContext, ZoneApiServer as _, ZoneRpc, ZoneRpcApi,
         operator_zone_rpc_module, rpc_connection_config, start_redacted_rpc,
     },
 };
@@ -796,8 +795,8 @@ where
                 container
                     .modules
                     .merge_configured(operator_zone_api.into_rpc())?;
-                container.modules.merge_http(
-                    OperatorZoneBalanceApi::new(container.registry.eth_api().clone()).into_rpc(),
+                container.modules.replace_http(
+                    OperatorEthCall::new(container.registry.eth_api().clone()).into_rpc(),
                 )?;
                 container.modules.merge_configured(
                     NodeZoneDebugApi::new(container.registry.eth_api().clone()).into_rpc(),

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -773,13 +773,9 @@ where
         let payload_builder = ctx.node.payload_builder_handle().clone();
         let operator_rpc_slot = sequencer_rpc_slot.clone();
         let operator_rpc_provider = provider.clone();
-        let operator_zone_api = OperatorZoneApi::new(
-            self.redacted_rpc_config.zone_id,
-            chain_id,
-            self.portal_address,
-            l1_provider.clone(),
-            provider.clone(),
-        );
+        let operator_zone_provider = provider.clone();
+        let operator_zone_id = self.redacted_rpc_config.zone_id;
+        let operator_l1_provider = l1_provider.clone();
         let portal_address = self.portal_address;
         let evm_chain_spec = ctx.node.evm_config().chain_spec().clone();
         let handle = self
@@ -789,6 +785,14 @@ where
                     reth_rpc_builder::RethRpcModule::Web3,
                     OperatorWeb3Api.into_rpc(),
                 )?;
+                let operator_zone_api = OperatorZoneApi::new(
+                    operator_zone_id,
+                    chain_id,
+                    portal_address,
+                    operator_l1_provider,
+                    operator_zone_provider,
+                    container.registry.eth_api().clone(),
+                );
                 container
                     .modules
                     .merge_configured(operator_zone_api.into_rpc())?;

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -45,7 +45,7 @@ use tempo_alloy::{
 };
 use tempo_chainspec::spec::{TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE};
 use tempo_contracts::precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, ITIP20,
     account_keychain::IAccountKeychain::{self, KeyInfo, getKeyCall},
 };
 use tempo_primitives::{TempoPrimitives, TempoTxEnvelope};
@@ -129,25 +129,36 @@ pub(crate) trait ZoneApi {
     /// Returns the encryption key active at the current Tempo L1 head.
     #[method(name = "getEncryptionKey")]
     async fn get_encryption_key(&self) -> RpcResult<ZonePortal::encryptionKeyAtBlockReturn>;
+
+    /// Returns a private TIP-20 balance through the trusted operator RPC.
+    #[method(name = "getBalance")]
+    async fn get_balance(
+        &self,
+        token: Address,
+        account: Address,
+        block: Option<BlockId>,
+    ) -> RpcResult<U256>;
 }
 
 /// Public Zone API backed directly by the node and Tempo L1 providers.
 #[derive(Clone)]
-pub(crate) struct OperatorZoneApi<P> {
+pub(crate) struct OperatorZoneApi<P, E> {
     zone_id: u32,
     chain_id: u64,
     portal_address: Address,
     l1_provider: DynProvider<TempoNetwork>,
     zone_provider: P,
+    eth_api: E,
 }
 
-impl<P> OperatorZoneApi<P> {
+impl<P, E> OperatorZoneApi<P, E> {
     pub(crate) const fn new(
         zone_id: u32,
         chain_id: u64,
         portal_address: Address,
         l1_provider: DynProvider<TempoNetwork>,
         zone_provider: P,
+        eth_api: E,
     ) -> Self {
         Self {
             zone_id,
@@ -155,14 +166,28 @@ impl<P> OperatorZoneApi<P> {
             portal_address,
             l1_provider,
             zone_provider,
+            eth_api,
         }
     }
 }
 
+fn operator_balance_request(token: Address, account: Address) -> TempoTransactionRequest {
+    TempoTransactionRequest {
+        inner: TransactionRequest {
+            from: Some(account),
+            to: Some(token.into()),
+            input: ITIP20::balanceOfCall { account }.abi_encode().into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
 #[jsonrpsee::core::async_trait]
-impl<P> ZoneApiServer for OperatorZoneApi<P>
+impl<P, E> ZoneApiServer for OperatorZoneApi<P, E>
 where
     P: StateProviderFactory + Clone + Send + Sync + 'static,
+    E: FullEthApi<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
 {
     async fn get_zone_info(&self) -> RpcResult<ZoneInfoResponse> {
         let tempo_block_number = self
@@ -187,6 +212,20 @@ where
         encryption_key(self.portal_address, &self.l1_provider)
             .await
             .map_err(operator_rpc_error)
+    }
+
+    async fn get_balance(
+        &self,
+        token: Address,
+        account: Address,
+        block: Option<BlockId>,
+    ) -> RpcResult<U256> {
+        let request = operator_balance_request(token, account);
+        let output = EthCall::call(&self.eth_api, request, block, EvmOverrides::default())
+            .await
+            .map_err(|error| operator_rpc_error(internal(error)))?;
+        ITIP20::balanceOfCall::abi_decode_returns(&output)
+            .map_err(|error| operator_rpc_error(internal(error)))
     }
 }
 
@@ -1435,7 +1474,6 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_provider::ProviderBuilder;
 
     #[test]
     fn records_block_hashes_as_eip2935_storage_targets() {
@@ -1530,24 +1568,17 @@ mod tests {
     }
 
     #[test]
-    fn operator_zone_api_exposes_only_metadata_methods_without_auth() {
-        let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-            .connect_http("http://127.0.0.1:1".parse().expect("valid URL"))
-            .erased();
-        let module = OperatorZoneApi::new(
-            1,
-            42431,
-            Address::repeat_byte(0x11),
-            l1_provider,
-            Arc::new(reth_provider::test_utils::MockEthProvider::default()),
-        )
-        .into_rpc();
+    fn operator_balance_request_uses_account_as_trusted_call_context() {
+        let token = Address::repeat_byte(0x11);
+        let account = Address::repeat_byte(0x22);
+        let request = operator_balance_request(token, account);
 
-        let methods = module.method_names().collect::<HashSet<_>>();
-        assert_eq!(methods.len(), 2);
-        assert!(methods.contains("zone_getZoneInfo"));
-        assert!(methods.contains("zone_getEncryptionKey"));
-        assert!(!methods.contains("zone_getAuthorizationTokenInfo"));
+        assert_eq!(request.inner.from, Some(account));
+        assert_eq!(request.inner.to, Some(token.into()));
+        assert_eq!(
+            ITIP20::balanceOfCall::abi_decode(&request.inner.input.input().unwrap()),
+            Ok(ITIP20::balanceOfCall { account })
+        );
     }
 
     #[test]

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -129,7 +129,11 @@ pub(crate) trait ZoneApi {
     /// Returns the encryption key active at the current Tempo L1 head.
     #[method(name = "getEncryptionKey")]
     async fn get_encryption_key(&self) -> RpcResult<ZonePortal::encryptionKeyAtBlockReturn>;
+}
 
+/// Trusted operator-only Zone balance API.
+#[rpc(server, namespace = "zone")]
+pub(crate) trait ZoneBalanceApi {
     /// Returns a private TIP-20 balance through the trusted operator RPC.
     #[method(name = "getBalance")]
     async fn get_balance(
@@ -142,23 +146,21 @@ pub(crate) trait ZoneApi {
 
 /// Public Zone API backed directly by the node and Tempo L1 providers.
 #[derive(Clone)]
-pub(crate) struct OperatorZoneApi<P, E> {
+pub(crate) struct OperatorZoneApi<P> {
     zone_id: u32,
     chain_id: u64,
     portal_address: Address,
     l1_provider: DynProvider<TempoNetwork>,
     zone_provider: P,
-    eth_api: E,
 }
 
-impl<P, E> OperatorZoneApi<P, E> {
+impl<P> OperatorZoneApi<P> {
     pub(crate) const fn new(
         zone_id: u32,
         chain_id: u64,
         portal_address: Address,
         l1_provider: DynProvider<TempoNetwork>,
         zone_provider: P,
-        eth_api: E,
     ) -> Self {
         Self {
             zone_id,
@@ -166,8 +168,19 @@ impl<P, E> OperatorZoneApi<P, E> {
             portal_address,
             l1_provider,
             zone_provider,
-            eth_api,
         }
+    }
+}
+
+/// Trusted operator balance API backed by reth's Eth API.
+#[derive(Clone)]
+pub(crate) struct OperatorZoneBalanceApi<E> {
+    eth_api: E,
+}
+
+impl<E> OperatorZoneBalanceApi<E> {
+    pub(crate) const fn new(eth_api: E) -> Self {
+        Self { eth_api }
     }
 }
 
@@ -184,10 +197,9 @@ fn operator_balance_request(token: Address, account: Address) -> TempoTransactio
 }
 
 #[jsonrpsee::core::async_trait]
-impl<P, E> ZoneApiServer for OperatorZoneApi<P, E>
+impl<P> ZoneApiServer for OperatorZoneApi<P>
 where
     P: StateProviderFactory + Clone + Send + Sync + 'static,
-    E: FullEthApi<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
 {
     async fn get_zone_info(&self) -> RpcResult<ZoneInfoResponse> {
         let tempo_block_number = self
@@ -213,7 +225,13 @@ where
             .await
             .map_err(operator_rpc_error)
     }
+}
 
+#[jsonrpsee::core::async_trait]
+impl<E> ZoneBalanceApiServer for OperatorZoneBalanceApi<E>
+where
+    E: FullEthApi<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
+{
     async fn get_balance(
         &self,
         token: Address,
@@ -1474,6 +1492,7 @@ pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> Conn
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_provider::ProviderBuilder;
 
     #[test]
     fn records_block_hashes_as_eip2935_storage_targets() {
@@ -1568,6 +1587,28 @@ mod tests {
     }
 
     #[test]
+    fn operator_zone_api_exposes_only_metadata_methods_without_auth() {
+        let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("http://127.0.0.1:1".parse().expect("valid URL"))
+            .erased();
+        let module = OperatorZoneApi::new(
+            1,
+            42431,
+            Address::repeat_byte(0x11),
+            l1_provider,
+            Arc::new(reth_provider::test_utils::MockEthProvider::default()),
+        )
+        .into_rpc();
+
+        let methods = module.method_names().collect::<HashSet<_>>();
+        assert_eq!(methods.len(), 2);
+        assert!(methods.contains("zone_getZoneInfo"));
+        assert!(methods.contains("zone_getEncryptionKey"));
+        assert!(!methods.contains("zone_getAuthorizationTokenInfo"));
+        assert!(!methods.contains("zone_getBalance"));
+    }
+
+    #[test]
     fn operator_balance_request_uses_account_as_trusted_call_context() {
         let token = Address::repeat_byte(0x11);
         let account = Address::repeat_byte(0x22);
@@ -1576,7 +1617,7 @@ mod tests {
         assert_eq!(request.inner.from, Some(account));
         assert_eq!(request.inner.to, Some(token.into()));
         assert_eq!(
-            ITIP20::balanceOfCall::abi_decode(&request.inner.input.input().unwrap()),
+            ITIP20::balanceOfCall::abi_decode(request.inner.input.input().unwrap()),
             Ok(ITIP20::balanceOfCall { account })
         );
     }

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -17,8 +17,8 @@ use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U64, U256, keccak256};
 use alloy_provider::{DynProvider, Provider};
 use alloy_rpc_types_eth::{
-    Block, BlockId, BlockNumberOrTag, BlockTransactions, FeeHistory, Filter, FilterChanges,
-    FilterId, TransactionRequest,
+    Block, BlockId, BlockNumberOrTag, BlockOverrides, BlockTransactions, FeeHistory, Filter,
+    FilterChanges, FilterId, TransactionRequest,
     state::{EvmOverrides, StateOverride},
 };
 use alloy_sol_types::SolCall;
@@ -131,17 +131,18 @@ pub(crate) trait ZoneApi {
     async fn get_encryption_key(&self) -> RpcResult<ZonePortal::encryptionKeyAtBlockReturn>;
 }
 
-/// Trusted operator-only Zone balance API.
-#[rpc(server, namespace = "zone")]
-pub(crate) trait ZoneBalanceApi {
-    /// Returns a private TIP-20 balance through the trusted operator RPC.
-    #[method(name = "getBalance")]
-    async fn get_balance(
+/// Operator `eth_call` override that supplies the private-balance call context.
+#[rpc(server, namespace = "eth")]
+pub(crate) trait OperatorEthCallApi {
+    /// Executes a call, deriving `from` for TIP-20 `balanceOf` when omitted.
+    #[method(name = "call")]
+    async fn call(
         &self,
-        token: Address,
-        account: Address,
-        block: Option<BlockId>,
-    ) -> RpcResult<U256>;
+        request: TempoTransactionRequest,
+        block_number: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
+    ) -> RpcResult<Bytes>;
 }
 
 /// Public Zone API backed directly by the node and Tempo L1 providers.
@@ -172,27 +173,26 @@ impl<P> OperatorZoneApi<P> {
     }
 }
 
-/// Trusted operator balance API backed by reth's Eth API.
+/// Trusted operator `eth_call` API backed by reth's Eth API.
 #[derive(Clone)]
-pub(crate) struct OperatorZoneBalanceApi<E> {
+pub(crate) struct OperatorEthCall<E> {
     eth_api: E,
 }
 
-impl<E> OperatorZoneBalanceApi<E> {
+impl<E> OperatorEthCall<E> {
     pub(crate) const fn new(eth_api: E) -> Self {
         Self { eth_api }
     }
 }
 
-fn operator_balance_request(token: Address, account: Address) -> TempoTransactionRequest {
-    TempoTransactionRequest {
-        inner: TransactionRequest {
-            from: Some(account),
-            to: Some(token.into()),
-            input: ITIP20::balanceOfCall { account }.abi_encode().into(),
-            ..Default::default()
-        },
-        ..Default::default()
+fn apply_operator_call_context(request: &mut TempoTransactionRequest) {
+    if request.inner.from.is_some() {
+        return;
+    }
+    if let Some(input) = request.inner.input.input()
+        && let Ok(call) = ITIP20::balanceOfCall::abi_decode(input)
+    {
+        request.inner.from = Some(call.account);
     }
 }
 
@@ -228,22 +228,26 @@ where
 }
 
 #[jsonrpsee::core::async_trait]
-impl<E> ZoneBalanceApiServer for OperatorZoneBalanceApi<E>
+impl<E> OperatorEthCallApiServer for OperatorEthCall<E>
 where
     E: FullEthApi<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
 {
-    async fn get_balance(
+    async fn call(
         &self,
-        token: Address,
-        account: Address,
-        block: Option<BlockId>,
-    ) -> RpcResult<U256> {
-        let request = operator_balance_request(token, account);
-        let output = EthCall::call(&self.eth_api, request, block, EvmOverrides::default())
-            .await
-            .map_err(|error| operator_rpc_error(internal(error)))?;
-        ITIP20::balanceOfCall::abi_decode_returns(&output)
-            .map_err(|error| operator_rpc_error(internal(error)))
+        mut request: TempoTransactionRequest,
+        block_number: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
+    ) -> RpcResult<Bytes> {
+        apply_operator_call_context(&mut request);
+        EthCall::call(
+            &self.eth_api,
+            request,
+            block_number,
+            EvmOverrides::new(state_overrides, block_overrides),
+        )
+        .await
+        .map_err(|error| operator_rpc_error(internal(error)))
     }
 }
 
@@ -1609,17 +1613,55 @@ mod tests {
     }
 
     #[test]
-    fn operator_balance_request_uses_account_as_trusted_call_context() {
+    fn operator_call_context_defaults_balance_of_from_to_account() {
         let token = Address::repeat_byte(0x11);
         let account = Address::repeat_byte(0x22);
-        let request = operator_balance_request(token, account);
+        let mut request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                to: Some(token.into()),
+                input: ITIP20::balanceOfCall { account }.abi_encode().into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        apply_operator_call_context(&mut request);
 
         assert_eq!(request.inner.from, Some(account));
         assert_eq!(request.inner.to, Some(token.into()));
-        assert_eq!(
-            ITIP20::balanceOfCall::abi_decode(request.inner.input.input().unwrap()),
-            Ok(ITIP20::balanceOfCall { account })
-        );
+    }
+
+    #[test]
+    fn operator_call_context_preserves_explicit_from() {
+        let account = Address::repeat_byte(0x22);
+        let caller = Address::repeat_byte(0x33);
+        let mut request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(caller),
+                input: ITIP20::balanceOfCall { account }.abi_encode().into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        apply_operator_call_context(&mut request);
+
+        assert_eq!(request.inner.from, Some(caller));
+    }
+
+    #[test]
+    fn operator_call_context_ignores_non_balance_calls() {
+        let mut request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                input: ITIP20::nameCall {}.abi_encode().into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        apply_operator_call_context(&mut request);
+
+        assert_eq!(request.inner.from, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the operator HTTP RPC `eth_call` handler with a Zone-aware wrapper
- when a TIP-20 `balanceOf(account)` call omits `from`, execute it with `from = account`
- preserve explicit callers and leave all non-`balanceOf` calls unchanged

## Validation

- `cargo check -p zone-node`
- `cargo test -p zone-node operator_call_context --lib`
- `cargo test -p zone-node operator_zone_api_exposes_only_metadata_methods_without_auth --lib`
- `cargo +nightly fmt --all -- --check`

Prompted by: @struong