### PR TITLE
feat(rpc): expose correct `web3_clientVersion` in operator RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13799,6 +13799,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "reth-rpc",
+ "reth-rpc-api",
  "reth-rpc-builder",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4
   "optional-checks",
 ] }
 reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
 reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
 reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
 reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -50,6 +50,7 @@ reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-revm = { workspace = true, features = ["witness"] }
 reth-rpc.workspace = true
+reth-rpc-api.workspace = true
 reth-rpc-builder.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-rpc-eth-types.workspace = true

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -14,8 +14,9 @@ use crate::{
         run_role_controller,
     },
     rpc::{
-        NodeZoneDebugApi, OperatorZoneApi, SequencerRpcContext, ZoneApiServer as _, ZoneRpc,
-        ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config, start_redacted_rpc,
+        NodeZoneDebugApi, OperatorWeb3Api, OperatorZoneApi, SequencerRpcContext,
+        ZoneApiServer as _, ZoneRpc, ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config,
+        start_redacted_rpc,
     },
 };
 use alloy_chains::Chain;
@@ -42,6 +43,7 @@ use reth_node_builder::{
 };
 use reth_primitives_traits::SealedHeader;
 use reth_provider::ChainSpecProvider;
+use reth_rpc_api::Web3ApiServer as _;
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
 use reth_storage_api::{
@@ -783,6 +785,10 @@ where
         let handle = self
             .inner
             .launch_add_ons_with(ctx, move |container| {
+                container.modules.add_or_replace_if_module_configured(
+                    reth_rpc_builder::RethRpcModule::Web3,
+                    OperatorWeb3Api.into_rpc(),
+                )?;
                 container
                     .modules
                     .merge_configured(operator_zone_api.into_rpc())?;

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -29,6 +29,7 @@ use reth_evm::{ConfigureEvm as _, execute::Executor as _};
 use reth_provider::{CanonStateSubscriptions, HeaderProvider};
 use reth_revm::{db::State, witness::ExecutionWitnessRecord};
 use reth_rpc::{EthFilter, eth::filter::EthFilterError};
+use reth_rpc_api::Web3ApiServer;
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, RpcConvert,
@@ -218,6 +219,21 @@ where
         }
     })?;
     Ok(module)
+}
+
+/// Operator Web3 API backed by the globally initialized Zone version metadata.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct OperatorWeb3Api;
+
+#[jsonrpsee::core::async_trait]
+impl Web3ApiServer for OperatorWeb3Api {
+    async fn client_version(&self) -> RpcResult<String> {
+        Ok(crate::version::client_version().to_owned())
+    }
+
+    fn sha3(&self, input: Bytes) -> RpcResult<B256> {
+        Ok(keccak256(input))
+    }
 }
 
 /// Zone-specific debug API.

--- a/crates/node/src/version.rs
+++ b/crates/node/src/version.rs
@@ -53,9 +53,11 @@ fn extra_data() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rpc::OperatorWeb3Api;
+    use reth_rpc_api::Web3ApiServer as _;
 
-    #[test]
-    fn uses_tempo_zone_version_defaults() {
+    #[tokio::test]
+    async fn uses_tempo_zone_version_defaults() {
         init_version_metadata();
         let metadata = version_metadata();
 
@@ -80,5 +82,15 @@ mod tests {
         );
         assert_eq!(client_version(), metadata.p2p_client_version);
         assert_ne!(client_version(), "reth-test");
+
+        let rpc_client_version = OperatorWeb3Api
+            .into_rpc()
+            .call::<_, String>(
+                "web3_clientVersion",
+                jsonrpsee::core::EmptyServerParams::new(),
+            )
+            .await
+            .expect("operator client version should be available");
+        assert_eq!(rpc_client_version, client_version());
     }
 }


### PR DESCRIPTION
## Summary

Add the `web3_clientVersion` and `web3_sha3` methods to the operator RPC, with the client version sourced from the zone’s initialized version metadata.