### PR TITLE
ZONE-201: Enforce response size limits over WebSocket

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -100,7 +100,7 @@ fn serialize_response(response: JsonRpcResponse) -> String {
     serde_json::to_string(&response).expect("JsonRpcResponse serialization is infallible")
 }
 
-fn append_batch_response(
+pub(crate) fn append_batch_response(
     batch: &mut String,
     response: JsonRpcResponse,
     max_response_size: usize,

--- a/crates/rpc/src/ws.rs
+++ b/crates/rpc/src/ws.rs
@@ -36,7 +36,8 @@ use tracing::warn;
 use crate::{
     auth::{self, AuthContext, AuthError},
     server::{
-        MAX_BATCH_SIZE, RpcState, authenticate_token, dispatch_request, validate_keychain_key_info,
+        MAX_BATCH_SIZE, RpcState, append_batch_response, authenticate_token, dispatch_request,
+        serialize_response_with_limit, validate_keychain_key_info,
     },
     subscription::WsSubscriptionStream,
     types::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, to_raw},
@@ -111,6 +112,10 @@ impl WsSession {
         self.pending_subscription_count = self.pending_subscription_count.saturating_sub(1);
         self.subscriptions
             .insert(subscription_id, ActiveSubscription { task });
+    }
+
+    fn discard_pending_subscriptions(&mut self, count: usize) {
+        self.pending_subscription_count = self.pending_subscription_count.saturating_sub(count);
     }
 
     fn cleanup(self) {
@@ -371,48 +376,55 @@ async fn process_ws_text(
     session: &mut WsSession,
 ) -> (String, Vec<PendingSubscription>) {
     let trimmed = text.trim_start();
+    let max_response_size = state.config.max_response_size;
 
     if trimmed.starts_with('[') {
         match serde_json::from_str::<Vec<JsonRpcRequest>>(trimmed) {
             Ok(requests) if requests.is_empty() => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::parse_error("empty batch"),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
+                serialize_response_with_limit(
+                    JsonRpcResponse::error(Value::Null, JsonRpcError::parse_error("empty batch")),
+                    max_response_size,
+                ),
                 Vec::new(),
             ),
             Ok(requests) if requests.len() > MAX_BATCH_SIZE => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::invalid_params(format!(
-                        "batch too large ({} > {MAX_BATCH_SIZE})",
-                        requests.len()
-                    )),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
+                serialize_response_with_limit(
+                    JsonRpcResponse::error(
+                        Value::Null,
+                        JsonRpcError::invalid_params(format!(
+                            "batch too large ({} > {MAX_BATCH_SIZE})",
+                            requests.len()
+                        )),
+                    ),
+                    max_response_size,
+                ),
                 Vec::new(),
             ),
             Ok(requests) => {
-                let mut responses = Vec::with_capacity(requests.len());
+                let mut responses = String::from("[");
                 let mut pending_subscriptions = Vec::new();
                 for req in &requests {
                     let result = dispatch_ws_request(req, auth, state, session).await;
-                    responses.push(result.response);
                     pending_subscriptions.extend(result.pending_subscriptions);
+                    if let Err(error) =
+                        append_batch_response(&mut responses, result.response, max_response_size)
+                    {
+                        session.discard_pending_subscriptions(pending_subscriptions.len());
+                        return (error, Vec::new());
+                    }
                 }
-                (
-                    serde_json::to_string(&responses)
-                        .expect("JsonRpcResponse serialization is infallible"),
-                    pending_subscriptions,
-                )
+                responses.pop();
+                responses.push(']');
+                (responses, pending_subscriptions)
             }
             Err(err) => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::parse_error(format!("parse error: {err}")),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
+                serialize_response_with_limit(
+                    JsonRpcResponse::error(
+                        Value::Null,
+                        JsonRpcError::parse_error(format!("parse error: {err}")),
+                    ),
+                    max_response_size,
+                ),
                 Vec::new(),
             ),
         }
@@ -421,17 +433,18 @@ async fn process_ws_text(
             Ok(request) => {
                 let result = dispatch_ws_request(&request, auth, state, session).await;
                 (
-                    serde_json::to_string(&result.response)
-                        .expect("JsonRpcResponse serialization is infallible"),
+                    serialize_response_with_limit(result.response, max_response_size),
                     result.pending_subscriptions,
                 )
             }
             Err(err) => (
-                serde_json::to_string(&JsonRpcResponse::error(
-                    Value::Null,
-                    JsonRpcError::parse_error(format!("parse error: {err}")),
-                ))
-                .expect("JsonRpcResponse serialization is infallible"),
+                serialize_response_with_limit(
+                    JsonRpcResponse::error(
+                        Value::Null,
+                        JsonRpcError::parse_error(format!("parse error: {err}")),
+                    ),
+                    max_response_size,
+                ),
                 Vec::new(),
             ),
         }
@@ -567,11 +580,13 @@ async fn handle_ws_session(
                         if !try_queue_notification(
                             &notifications,
                             &close_session,
-                            serde_json::to_string(&JsonRpcResponse::error(
-                                Value::Null,
-                                JsonRpcError::parse_error("invalid UTF-8"),
-                            ))
-                            .expect("JsonRpcResponse serialization is infallible"),
+                            serialize_response_with_limit(
+                                JsonRpcResponse::error(
+                                    Value::Null,
+                                    JsonRpcError::parse_error("invalid UTF-8"),
+                                ),
+                                state.config.max_response_size,
+                            ),
                         ) {
                             break;
                         }

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -281,13 +281,24 @@ impl TestContext {
     }
 
     async fn start_shared(api: Arc<MockZoneRpcApi>) -> Self {
+        Self::start_shared_with_max_response_size(api, 160 * 1024 * 1024).await
+    }
+
+    async fn start_with_max_response_size(api: MockZoneRpcApi, max_response_size: usize) -> Self {
+        Self::start_shared_with_max_response_size(Arc::new(api), max_response_size).await
+    }
+
+    async fn start_shared_with_max_response_size(
+        api: Arc<MockZoneRpcApi>,
+        max_response_size: usize,
+    ) -> Self {
         let signer = PrivateKeySigner::random();
         let config = RedactedRpcConfig {
             listen_addr: ([127, 0, 0, 1], 0).into(),
             zone_id: ZONE_ID,
             chain_id: CHAIN_ID,
             max_auth_token_validity: zone_rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY,
-            max_response_size: 160 * 1024 * 1024,
+            max_response_size,
             zone_portal: Address::ZERO,
         };
         let addr = start_redacted_rpc(config, api).await.unwrap();
@@ -487,6 +498,51 @@ async fn ws_batch_request() {
 }
 
 #[tokio::test]
+async fn ws_oversized_response_matches_jsonrpsee_error() {
+    let ctx = TestContext::start_with_max_response_size(MockZoneRpcApi::default(), 64).await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc("zone_getZoneInfo", 7).into(),
+    ))
+    .await
+    .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], 7);
+    assert_eq!(resp["error"]["code"], -32008);
+    assert_eq!(resp["error"]["message"], "Response is too big");
+    assert_eq!(resp["error"]["data"], "Exceeded max limit of 64");
+}
+
+#[tokio::test]
+async fn ws_batch_response_limit_is_aggregate() {
+    let one_response = json!({"jsonrpc":"2.0","result":"0x42","id":1}).to_string();
+    let max_response_size = one_response.len() + 2;
+    let ctx =
+        TestContext::start_with_max_response_size(MockZoneRpcApi::default(), max_response_size)
+            .await;
+    let mut ws = connect_with_header(&ctx).await;
+    let batch = json!([
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1},
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":2},
+    ]);
+
+    ws.send(tungstenite::Message::Text(batch.to_string().into()))
+        .await
+        .unwrap();
+    let resp = parse_response(ws.next().await.unwrap().unwrap());
+
+    assert_eq!(resp["id"], Value::Null);
+    assert_eq!(resp["error"]["code"], -32011);
+    assert_eq!(resp["error"]["message"], "The batch response was too large");
+    assert_eq!(
+        resp["error"]["data"],
+        format!("Exceeded max limit of {max_response_size}")
+    );
+}
+
+#[tokio::test]
 async fn ws_invalid_json() {
     let ctx = TestContext::start(MockZoneRpcApi::default()).await;
     let mut ws = connect_with_header(&ctx).await;
@@ -569,6 +625,33 @@ async fn ws_subscribe_new_heads_emits_redacted_headers() {
             .get("transactions")
             .is_none()
     );
+}
+
+#[tokio::test]
+async fn ws_subscription_notifications_match_unredacted_size_behavior() {
+    let max_response_size = 64;
+    let ctx = TestContext::start_with_max_response_size(
+        MockZoneRpcApi::with_ws_subscriptions(),
+        max_response_size,
+    )
+    .await;
+    let mut ws = connect_with_header(&ctx).await;
+
+    ws.send(tungstenite::Message::Text(
+        jsonrpc_with_params("eth_subscribe", json!(["newHeads"]), 1).into(),
+    ))
+    .await
+    .unwrap();
+    let response = parse_response(ws.next().await.unwrap().unwrap());
+    assert!(response["result"].as_str().is_some());
+
+    let notification = ws.next().await.unwrap().unwrap();
+    let tungstenite::Message::Text(text) = &notification else {
+        panic!("expected text notification");
+    };
+    assert!(text.len() > max_response_size);
+    let notification = parse_response(notification);
+    assert_eq!(notification["method"], "eth_subscription");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- apply the existing private RPC response-size limit to WebSocket method responses
- enforce aggregate batch response accounting and stop dispatch after `-32011`
- release pending subscription reservations when an oversized batch is abandoned
- leave subscription notifications uncapped to match unredacted jsonrpsee/reth behavior

Follow-up to #1099 and ZONE-201.

## Testing

- `cargo +nightly clippy -p zone-rpc --all-targets -- -D warnings`
- `cargo +nightly test -p zone-rpc --test it ws_` (27 passed)