### PR TITLE
feat(prover): measure shadow prover stage timings

### DIFF
--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -17,8 +17,29 @@ pub(crate) struct SequencerMetrics {
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_zone_prover")]
 pub(crate) struct ProverMetrics {
+    /// Time a finalized batch candidate spends waiting for the prover worker.
+    pub(crate) queue_duration_seconds: Histogram,
+
     /// End-to-end latency of a prover validation attempt in seconds.
     pub(crate) validation_duration_seconds: Histogram,
+
+    /// Time spent loading and decoding canonical Zone blocks.
+    pub(crate) zone_inputs_duration_seconds: Histogram,
+
+    /// Time spent generating and combining Zone execution witnesses.
+    pub(crate) zone_witness_duration_seconds: Histogram,
+
+    /// Time spent fetching and validating Tempo checkpoints and ancestry.
+    pub(crate) tempo_headers_duration_seconds: Histogram,
+
+    /// Time spent fetching and combining Tempo state proofs.
+    pub(crate) tempo_witness_duration_seconds: Histogram,
+
+    /// Time spent executing the SPF over a generated batch witness.
+    pub(crate) spf_execution_duration_seconds: Histogram,
+
+    /// Time spent comparing SPF output with the finalized batch candidate.
+    pub(crate) output_validation_duration_seconds: Histogram,
 
     /// Number of finalized batch candidates that failed prover validation.
     pub(crate) validation_failure_total: Counter,

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -75,6 +75,7 @@ struct ProverJob {
     from: u64,
     to: u64,
     batch: BatchData,
+    enqueued_at: Instant,
 }
 
 #[derive(Debug)]
@@ -119,7 +120,7 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
         queue_capacity = SHADOW_PROVER_QUEUE_CAPACITY,
         "Shadow prover enabled"
     );
-    let (sender, mut receiver) = mpsc::channel(SHADOW_PROVER_QUEUE_CAPACITY);
+    let (sender, mut receiver) = mpsc::channel::<ProverJob>(SHADOW_PROVER_QUEUE_CAPACITY);
     let context = ProverContext {
         config,
         portal,
@@ -131,8 +132,11 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
 
     tokio::spawn(async move {
         while let Some(job) = receiver.recv().await {
+            metrics
+                .queue_duration_seconds
+                .record(job.enqueued_at.elapsed().as_secs_f64());
             let started = Instant::now();
-            let result = validate_candidate(&context, &job).await;
+            let result = validate_candidate(&context, &job, &metrics).await;
             metrics
                 .validation_duration_seconds
                 .record(started.elapsed().as_secs_f64());
@@ -186,6 +190,7 @@ impl ShadowProver {
             from,
             to,
             batch: batch.clone(),
+            enqueued_at: Instant::now(),
         }) {
             error!(
                 target: "zone::sequencer::prover",
@@ -207,6 +212,7 @@ impl ShadowProver {
 async fn validate_candidate<P: ZoneSequencerProvider>(
     context: &ProverContext<P>,
     job: &ProverJob,
+    metrics: &ProverMetrics,
 ) -> Result<ValidationStats> {
     ensure!(
         job.batch.zone_height == job.to,
@@ -219,11 +225,14 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         "first Zone batch must use the zero portal prev_block_hash sentinel, found {}",
         job.batch.prev_block_hash
     );
+
     let zone_provider = context.zone_provider.clone();
     let from = job.from;
     let to = job.to;
     let expected_prev_hash = job.batch.prev_block_hash;
     let expected_next_hash = job.batch.next_block_hash;
+
+    let started = Instant::now();
     let zone_inputs = tokio::task::spawn_blocking(move || {
         build_zone_inputs(
             &zone_provider,
@@ -235,45 +244,67 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     })
     .await
     .context("Zone input worker panicked")??;
+    metrics
+        .zone_inputs_duration_seconds
+        .record(started.elapsed().as_secs_f64());
 
+    let started = Instant::now();
     let (zone_state_witness, tempo_reads) =
         zone_witnesses(context.config.debug_api.as_ref(), from, to).await?;
+    metrics
+        .zone_witness_duration_seconds
+        .record(started.elapsed().as_secs_f64());
 
-    let initial_tempo_header = tempo_header(&context.l1_provider, zone_inputs.initial_tempo_number)
-        .await
-        .context("fetch initial Tempo checkpoint")?;
-    ensure!(
-        initial_tempo_header.hash_slow() == zone_inputs.initial_tempo_hash,
-        "parent Zone state commits Tempo block {} hash {}, but L1 returned {}",
-        zone_inputs.initial_tempo_number,
-        zone_inputs.initial_tempo_hash,
-        initial_tempo_header.hash_slow()
-    );
+    let started = Instant::now();
+    let (initial_tempo_header, final_tempo_header, anchor) = async {
+        let initial_tempo_header =
+            tempo_header(&context.l1_provider, zone_inputs.initial_tempo_number)
+                .await
+                .context("fetch initial Tempo checkpoint")?;
+        ensure!(
+            initial_tempo_header.hash_slow() == zone_inputs.initial_tempo_hash,
+            "parent Zone state commits Tempo block {} hash {}, but L1 returned {}",
+            zone_inputs.initial_tempo_number,
+            zone_inputs.initial_tempo_hash,
+            initial_tempo_header.hash_slow()
+        );
 
-    let final_tempo_header = zone_inputs
-        .blocks
-        .last()
-        .map(|block| decode_tempo_header(&block.tempo_header_rlp))
-        .transpose()?
-        .unwrap_or_else(|| initial_tempo_header.clone());
-    ensure!(
-        final_tempo_header.number() == job.batch.tempo_block_number,
-        "candidate Tempo block is {}, but the final advanceTempo header is {}",
-        job.batch.tempo_block_number,
-        final_tempo_header.number()
-    );
+        let final_tempo_header = zone_inputs
+            .blocks
+            .last()
+            .map(|block| decode_tempo_header(&block.tempo_header_rlp))
+            .transpose()?
+            .unwrap_or_else(|| initial_tempo_header.clone());
+        ensure!(
+            final_tempo_header.number() == job.batch.tempo_block_number,
+            "candidate Tempo block is {}, but the final advanceTempo header is {}",
+            job.batch.tempo_block_number,
+            final_tempo_header.number()
+        );
 
-    let anchor = resolve_anchor(
-        &context.l1_provider,
-        final_tempo_header.number(),
-        final_tempo_header.hash_slow(),
-        context.anchor_config,
-    )
+        let anchor = resolve_anchor(
+            &context.l1_provider,
+            final_tempo_header.number(),
+            final_tempo_header.hash_slow(),
+            context.anchor_config,
+        )
+        .await?;
+        Ok::<_, eyre::Report>((initial_tempo_header, final_tempo_header, anchor))
+    }
     .await?;
+    metrics
+        .tempo_headers_duration_seconds
+        .record(started.elapsed().as_secs_f64());
 
-    let reads = collect_l1_reads(tempo_reads, &zone_inputs.checkpoint_by_zone_block)?;
-    let tempo_state_witness =
-        tempo_state_witness(&context.l1_provider, &initial_tempo_header, reads).await?;
+    let started = Instant::now();
+    let tempo_state_witness = async {
+        let reads = collect_l1_reads(tempo_reads, &zone_inputs.checkpoint_by_zone_block)?;
+        tempo_state_witness(&context.l1_provider, &initial_tempo_header, reads).await
+    }
+    .await?;
+    metrics
+        .tempo_witness_duration_seconds
+        .record(started.elapsed().as_secs_f64());
     let witness = BatchWitness {
         public_inputs: PublicInputs {
             parent_chain_id: context.config.parent_chain_id,
@@ -292,13 +323,21 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     };
 
     let spf_config = SpfConfig::new(context.config.chain_spec.clone(), context.portal);
+    let started = Instant::now();
     let attempt = witness.clone();
     let output = tokio::task::spawn_blocking(move || prove_zone_batch(&spf_config, attempt))
         .await
         .context("SPF worker panicked")?
         .context("SPF rejected generated witness")?;
+    metrics
+        .spf_execution_duration_seconds
+        .record(started.elapsed().as_secs_f64());
 
+    let started = Instant::now();
     compare_output(&output, &job.batch, witness.parent_header.hash_slow())?;
+    metrics
+        .output_validation_duration_seconds
+        .record(started.elapsed().as_secs_f64());
 
     Ok(ValidationStats {
         witness_bytes: witness_size(&witness),


### PR DESCRIPTION
Closes ZONE-494

## Summary

Add Prometheus histograms for shadow prover queue time and validation stages, including Zone inputs, witnesses, Tempo headers and witnesses, SPF execution, and output validation.

Record timings for each stage alongside the existing end-to-end validation duration.