### PR TITLE
feat(xtask): derive zone genesis anchor from portal

### DIFF
--- a/xtask/src/create_zone.rs
+++ b/xtask/src/create_zone.rs
@@ -4,12 +4,11 @@
 
 use alloy::{
     network::{EthereumWallet, primitives::ReceiptResponse},
-    primitives::{Address, address, keccak256},
+    primitives::{Address, address},
     providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
     sol_types::SolEvent,
 };
-use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::BlockId;
 use eyre::{WrapErr as _, ensure, eyre};
 use std::path::PathBuf;
@@ -22,7 +21,10 @@ use tempo_zone_contracts::{
 };
 use zone_primitives::constants::zone_chain_id;
 
-use crate::zone_utils::{MODERATO_ZONE_FACTORY, write_owner_only};
+use crate::{
+    generate_zone_genesis::wait_for_finalized_pre_creation_anchor,
+    zone_utils::{MODERATO_ZONE_FACTORY, write_owner_only},
+};
 
 #[derive(Debug, clap::Parser)]
 pub(crate) struct CreateZone {
@@ -202,19 +204,6 @@ impl CreateZone {
             ));
         }
 
-        // Anchor before createZone so the zone replays the creation block and its
-        // initial TokenEnabled event during L1 backfill.
-        let anchor_block_number = provider.get_block_number().await?;
-        let anchor_header = provider
-            .get_header_by_number(anchor_block_number.into())
-            .await?
-            .ok_or_else(|| eyre!("anchor header {anchor_block_number} not found"))?
-            .inner
-            .inner;
-        let mut genesis_header_rlp = Vec::new();
-        anchor_header.encode(&mut genesis_header_rlp);
-        let anchor_hash = keccak256(&genesis_header_rlp);
-
         println!("Admin: {}", self.admin);
         println!("Sequencers: {:?}", self.sequencers);
         println!("Threshold: {}", self.threshold);
@@ -294,18 +283,23 @@ impl CreateZone {
         );
         println!("Sequencer set version: {sequencer_set_version}");
 
+        println!("Waiting for creation block {creation_block} to finalize...");
+        let anchor =
+            wait_for_finalized_pre_creation_anchor(&provider, portal, creation_block).await?;
         println!(
-            "Using pre-creation block {} (hash: {anchor_hash}) as genesis anchor",
-            anchor_header.inner.number
+            "Using pre-creation block {} (hash: {}) as genesis anchor",
+            anchor.block_number, anchor.hash
         );
 
-        let header_rlp_hex = const_hex::encode(&genesis_header_rlp);
+        let header_rlp_hex = const_hex::encode(&anchor.rlp);
 
         let genesis_cmd = crate::generate_zone_genesis::GenerateZoneGenesis {
             output: self.output.clone(),
             chain_id,
             base_fee_per_gas: self.base_fee_per_gas,
             gas_limit: self.gas_limit,
+            tempo_portal: None,
+            l1_rpc_url: None,
             default_fee_token: self.initial_token,
             tempo_genesis_header_rlp: Some(header_rlp_hex),
             admin: self.admin,
@@ -332,7 +326,7 @@ impl CreateZone {
             "sequencers": self.sequencers.iter().map(ToString::to_string).collect::<Vec<_>>(),
             "sequencerThreshold": self.threshold,
             "sequencerSetVersion": sequencer_set_version,
-            "tempoAnchorBlock": anchor_header.inner.number,
+            "tempoAnchorBlock": anchor.block_number,
             "zoneFactory": format!("{}", self.zone_factory),
             "rpcUrl": self.rpc_url,
         });
@@ -359,7 +353,7 @@ impl CreateZone {
         if !self.rpc_url.is_empty() {
             println!("  RPC URL: {}", self.rpc_url);
         }
-        println!("  Tempo anchor block: {}", anchor_header.inner.number);
+        println!("  Tempo anchor block: {}", anchor.block_number);
         println!(
             "  Genesis written to: {}",
             self.output.join("genesis.json").display()

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -1,8 +1,13 @@
 use alloy::{
+    consensus::BlockHeader as _,
     genesis::{ChainConfig, Genesis, GenesisAccount},
-    primitives::{Address, Bytes, U256, address},
+    primitives::{Address, B256, Bytes, U256, address, keccak256},
+    providers::{Provider, ProviderBuilder},
 };
-use eyre::{WrapErr as _, eyre};
+use alloy_eips::BlockNumberOrTag;
+use alloy_rlp::Encodable;
+use alloy_rpc_types_eth::BlockId;
+use eyre::{WrapErr as _, ensure, eyre};
 use reth_evm::{
     Evm as _, EvmEnv, EvmFactory,
     revm::{
@@ -12,7 +17,8 @@ use reth_evm::{
         state::{AccountInfo, Bytecode},
     },
 };
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf, time::Duration};
+use tempo_alloy::TempoNetwork;
 use tempo_chainspec::{hardfork::TempoHardfork, spec::TEMPO_T0_BASE_FEE};
 use tempo_contracts::{
     ARACHNID_CREATE2_FACTORY_ADDRESS, CREATEX_ADDRESS, MULTICALL3_ADDRESS, PERMIT2_ADDRESS,
@@ -34,10 +40,13 @@ use tempo_precompiles::{
 };
 use tempo_primitives::TempoHeader;
 use tempo_revm::TempoBlockEnv;
+use tempo_zone_contracts::ZonePortal;
 use zone_precompiles::{
     TempoState as NativeTempoState, ZoneFeeManager, ZoneInbox as NativeZoneInbox,
     ZoneOutbox as NativeZoneOutbox,
 };
+
+use crate::zone_utils::find_zone_deployment_block;
 
 const TEMPO_STATE_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000000");
 const ZONE_INBOX_ADDRESS: Address = address!("0x1c00000000000000000000000000000000000001");
@@ -59,11 +68,28 @@ pub(crate) struct GenerateZoneGenesis {
     #[arg(long, default_value_t = 30_000_000)]
     pub(crate) gas_limit: u64,
 
+    /// Existing ZonePortal used to derive the pre-creation genesis anchor.
+    #[arg(
+        long,
+        requires = "l1_rpc_url",
+        conflicts_with = "tempo_genesis_header_rlp"
+    )]
+    pub(crate) tempo_portal: Option<Address>,
+
+    /// Tempo L1 HTTP RPC URL used to derive the pre-creation genesis anchor.
+    #[arg(
+        long,
+        requires = "tempo_portal",
+        conflicts_with = "tempo_genesis_header_rlp"
+    )]
+    pub(crate) l1_rpc_url: Option<String>,
+
     /// Canonical fee token used when a zone transaction omits `fee_token`.
     #[arg(long, default_value_t = PATH_USD_ADDRESS)]
     pub(crate) default_fee_token: Address,
 
-    /// RLP-encoded Tempo genesis header. Defaults to `TempoHeader::default()`.
+    /// RLP-encoded Tempo genesis header. When omitted, `--tempo-portal` derives its pre-creation
+    /// anchor from L1; otherwise the development genesis uses `TempoHeader::default()`.
     #[arg(long)]
     pub(crate) tempo_genesis_header_rlp: Option<String>,
 
@@ -94,11 +120,19 @@ impl GenerateZoneGenesis {
             return Err(eyre!("--admin must not be the zero address"));
         }
 
-        let header_rlp = match &self.tempo_genesis_header_rlp {
-            Some(header_rlp) => {
+        let header_rlp = match (
+            &self.tempo_genesis_header_rlp,
+            self.tempo_portal,
+            self.l1_rpc_url.as_deref(),
+        ) {
+            (Some(header_rlp), None, None) => {
                 const_hex::decode(header_rlp).wrap_err("failed to decode hex string")?
             }
-            None => alloy_rlp::encode(TempoHeader::default()),
+            (None, Some(portal), Some(l1_rpc_url)) => {
+                derive_pre_creation_anchor(l1_rpc_url, portal).await?.rlp
+            }
+            (None, None, None) => alloy_rlp::encode(TempoHeader::default()),
+            _ => unreachable!("clap validates genesis anchor arguments"),
         };
 
         let mut evm = setup_zone_evm(self.chain_id, self.gas_limit);
@@ -270,6 +304,154 @@ impl GenerateZoneGenesis {
 
         Ok(())
     }
+}
+
+pub(crate) struct PreCreationAnchor {
+    pub(crate) block_number: u64,
+    pub(crate) hash: B256,
+    pub(crate) rlp: Vec<u8>,
+}
+
+async fn derive_pre_creation_anchor(
+    l1_rpc_url: &str,
+    portal: Address,
+) -> eyre::Result<PreCreationAnchor> {
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect(l1_rpc_url)
+        .await
+        .wrap_err_with(|| format!("failed to connect to Tempo L1 RPC {l1_rpc_url}"))?;
+    finalized_pre_creation_anchor(&provider, portal, None).await
+}
+
+pub(crate) async fn finalized_pre_creation_anchor<P: Provider<TempoNetwork>>(
+    provider: &P,
+    portal: Address,
+    expected_creation_block: Option<u64>,
+) -> eyre::Result<PreCreationAnchor> {
+    let finalized_header = provider
+        .get_header_by_number(BlockNumberOrTag::Finalized)
+        .await
+        .wrap_err("failed to fetch finalized Tempo L1 block")?
+        .ok_or_else(|| eyre!("Tempo L1 returned no finalized block"))?;
+    let finalized_block = finalized_header.number();
+    if let Some(expected) = expected_creation_block {
+        ensure!(
+            expected <= finalized_block,
+            "ZonePortal creation block {expected} is not finalized yet (finalized Tempo block: {finalized_block})"
+        );
+    }
+    let finalized_block_id = BlockId::number(finalized_block);
+
+    ensure!(
+        !provider
+            .get_code_at(portal)
+            .block_id(finalized_block_id)
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed to fetch code for portal {portal} at finalized block {finalized_block}"
+                )
+            })?
+            .is_empty(),
+        "portal {portal} has no code at finalized Tempo block {finalized_block}; check --tempo-portal and --l1-rpc-url"
+    );
+
+    let zone_id = ZonePortal::new(portal, provider)
+        .zoneId()
+        .block(finalized_block_id)
+        .call()
+        .await
+        .wrap_err_with(|| {
+            format!("failed to read Zone ID from portal {portal} at block {finalized_block}")
+        })?;
+    let creation_block =
+        find_zone_deployment_block(provider, zone_id, portal, finalized_block).await?;
+    if let Some(expected) = expected_creation_block {
+        ensure!(
+            creation_block == expected,
+            "ZoneCreated event is in block {creation_block}, but the creation receipt reported block {expected}"
+        );
+    }
+    let anchor_block = creation_block.checked_sub(1).ok_or_else(|| {
+        eyre!("portal {portal} exists at genesis, so no pre-creation anchor is available")
+    })?;
+    let anchor_block_id = BlockId::number(anchor_block);
+    ensure!(
+        provider
+            .get_code_at(portal)
+            .block_id(anchor_block_id)
+            .await
+            .wrap_err_with(|| {
+                format!("failed to fetch portal code at Tempo anchor block {anchor_block}")
+            })?
+            .is_empty(),
+        "portal {portal} already has code at proposed pre-creation anchor block {anchor_block}"
+    );
+    ensure!(
+        !provider
+            .get_code_at(portal)
+            .block_id(BlockId::number(creation_block))
+            .await
+            .wrap_err_with(|| {
+                format!("failed to fetch portal code at creation block {creation_block}")
+            })?
+            .is_empty(),
+        "portal {portal} has no code at ZoneCreated block {creation_block}"
+    );
+
+    let anchor_header_response = provider
+        .get_header_by_number(anchor_block.into())
+        .await
+        .wrap_err_with(|| format!("failed to fetch Tempo anchor header {anchor_block}"))?
+        .ok_or_else(|| eyre!("Tempo anchor header {anchor_block} was not found"))?;
+    ensure!(
+        anchor_header_response.number() == anchor_block,
+        "Tempo RPC returned header {} for requested anchor block {anchor_block}",
+        anchor_header_response.number()
+    );
+    let response_hash = anchor_header_response.hash;
+    let anchor_header = anchor_header_response.inner.inner;
+    let mut header_rlp = Vec::new();
+    anchor_header.encode(&mut header_rlp);
+    let anchor_hash = keccak256(&header_rlp);
+    ensure!(
+        anchor_hash == response_hash,
+        "Tempo anchor header RLP hash {anchor_hash} does not match RPC block hash {response_hash}"
+    );
+    println!(
+        "Derived pre-creation Tempo anchor block {anchor_block} (hash: {anchor_hash}) for portal {portal}"
+    );
+    Ok(PreCreationAnchor {
+        block_number: anchor_block,
+        hash: anchor_hash,
+        rlp: header_rlp,
+    })
+}
+
+pub(crate) async fn wait_for_finalized_pre_creation_anchor<P: Provider<TempoNetwork>>(
+    provider: &P,
+    portal: Address,
+    creation_block: u64,
+) -> eyre::Result<PreCreationAnchor> {
+    const ATTEMPTS: usize = 600;
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+    for _ in 0..ATTEMPTS {
+        let finalized = provider
+            .get_header_by_number(BlockNumberOrTag::Finalized)
+            .await
+            .wrap_err("failed to fetch finalized Tempo L1 block")?
+            .ok_or_else(|| eyre!("Tempo L1 returned no finalized block"))?;
+        if finalized.number() >= creation_block {
+            return finalized_pre_creation_anchor(provider, portal, Some(creation_block)).await;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    Err(eyre!(
+        "ZonePortal creation block {creation_block} was not finalized within {} seconds",
+        ATTEMPTS as u128 * POLL_INTERVAL.as_millis() / 1_000
+    ))
 }
 
 fn setup_zone_evm(chain_id: u64, gas_limit: u64) -> TempoEvm<CacheDB<EmptyDB>> {

--- a/xtask/src/verify_closed_loop.rs
+++ b/xtask/src/verify_closed_loop.rs
@@ -1,7 +1,7 @@
 //! Verifies an existing Earn deployment's closed-loop ZonePortal configuration.
 
 use alloy::{
-    primitives::{Address, B256, U256},
+    primitives::{Address, U256},
     providers::{Provider, ProviderBuilder},
 };
 use alloy_rpc_types_eth::BlockId;
@@ -12,7 +12,7 @@ use tempo_zone_contracts::{
     ZONE_FACTORY_ADDRESS, ZoneFactory, ZonePortal, ZonePortal::Role as PortalRole,
 };
 
-use crate::zone_utils::normalize_http_rpc;
+use crate::zone_utils::{find_zone_deployment_block, normalize_http_rpc};
 
 const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
 
@@ -288,39 +288,6 @@ impl VerifyClosedLoop {
 
         checks.finish()
     }
-}
-
-async fn find_zone_deployment_block<P: Provider<TempoNetwork>>(
-    provider: &P,
-    zone_id: u32,
-    portal: Address,
-    snapshot_block: u64,
-) -> eyre::Result<u64> {
-    let events = ZoneFactory::new(ZONE_FACTORY_ADDRESS, provider)
-        .ZoneCreated_filter()
-        .topic1(B256::from(U256::from(zone_id)))
-        .topic2(portal.into_word())
-        .from_block(0)
-        .to_block(snapshot_block)
-        .chunked()
-        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
-        .query()
-        .await
-        .wrap_err("failed scanning ZoneFactory ZoneCreated events")?;
-
-    ensure!(
-        events.len() == 1,
-        "expected exactly one ZoneCreated event for Zone {zone_id} and portal {portal}, found {}",
-        events.len()
-    );
-    let (event, log) = &events[0];
-    ensure!(
-        event.zoneId == zone_id && event.portal == portal,
-        "ZoneCreated event does not match Zone {zone_id} and portal {portal}"
-    );
-    ensure!(!log.removed, "ZoneCreated query returned a removed log");
-    log.block_number
-        .ok_or_else(|| eyre::eyre!("ZoneCreated log is missing its block number"))
 }
 
 async fn read_role_updates<P: Provider<TempoNetwork>>(

--- a/xtask/src/zone_utils.rs
+++ b/xtask/src/zone_utils.rs
@@ -1,6 +1,7 @@
 use alloy::{
+    consensus::BlockHeader as _,
     network::primitives::ReceiptResponse,
-    primitives::{Address, U256, address},
+    primitives::{Address, B256, U256, address},
     providers::Provider,
     rpc::types::Filter,
     sol_types::SolEvent,
@@ -13,7 +14,7 @@ use std::{
 };
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP20 as TIP20Token;
-use tempo_zone_contracts::{IZoneInbox, ZONE_FACTORY_ADDRESS, ZonePortal};
+use tempo_zone_contracts::{IZoneInbox, ZONE_FACTORY_ADDRESS, ZoneFactory, ZonePortal};
 
 /// Write a file that may contain key material with owner-only permissions on Unix.
 ///
@@ -55,6 +56,56 @@ pub(crate) const STABLECOIN_DEX_ADDRESS: Address =
 pub(crate) const ROUTER_CALLBACK_GAS_LIMIT: u64 = 2_000_000;
 const DEFAULT_WAIT_ATTEMPTS: usize = 120;
 const DEFAULT_WAIT_POLL: Duration = Duration::from_millis(500);
+const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
+
+pub(crate) async fn find_zone_deployment_block<P: Provider<TempoNetwork>>(
+    provider: &P,
+    zone_id: u32,
+    portal: Address,
+    snapshot_block: u64,
+) -> eyre::Result<u64> {
+    let events = ZoneFactory::new(ZONE_FACTORY_ADDRESS, provider)
+        .ZoneCreated_filter()
+        .topic1(B256::from(U256::from(zone_id)))
+        .topic2(portal.into_word())
+        .from_block(0)
+        .to_block(snapshot_block)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .query()
+        .await
+        .wrap_err("failed scanning ZoneFactory ZoneCreated events")?;
+
+    eyre::ensure!(
+        events.len() == 1,
+        "expected exactly one ZoneCreated event for Zone {zone_id} and portal {portal}, found {}",
+        events.len()
+    );
+    let (event, log) = &events[0];
+    eyre::ensure!(
+        event.zoneId == zone_id && event.portal == portal,
+        "ZoneCreated event does not match Zone {zone_id} and portal {portal}"
+    );
+    eyre::ensure!(!log.removed, "ZoneCreated query returned a removed log");
+    let block_number = log
+        .block_number
+        .ok_or_else(|| eyre!("ZoneCreated log is missing its block number"))?;
+    let block_hash = log
+        .block_hash
+        .ok_or_else(|| eyre!("ZoneCreated log is missing its block hash"))?;
+    let header = provider
+        .get_header_by_number(block_number.into())
+        .await
+        .wrap_err_with(|| format!("failed reading ZoneCreated block {block_number}"))?
+        .ok_or_else(|| eyre!("ZoneCreated block {block_number} was not found"))?;
+    eyre::ensure!(
+        header.number() == block_number && header.hash == block_hash,
+        "ZoneCreated log block ({block_number}, {block_hash}) does not match canonical header ({}, {})",
+        header.number(),
+        header.hash
+    );
+    Ok(block_number)
+}
 
 pub(crate) struct ZoneMetadata {
     path: PathBuf,


### PR DESCRIPTION
## Summary
- derive the genesis anchor from the canonical finalized `ZoneCreated` block
- make `create-zone` wait for finality and use the same `creation block - 1` anchor as regeneration
- require an explicit `--l1-rpc-url` when deriving from `--tempo-portal`
- verify event, deployment-code, header-number, and header-hash post-conditions before writing genesis

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo check -p tempo-xtask`
- `cargo +nightly clippy -p tempo-xtask --all-targets --no-deps` (passes with pre-existing future-incompatibility warnings)

Prompted by: @kuyziss