### PR TITLE
ci(bench): remove unsupported private transfer

### DIFF
--- a/contrib/bench/neobank/private-flow-scenario.yml
+++ b/contrib/bench/neobank/private-flow-scenario.yml
@@ -39,8 +39,6 @@ scenario:
   bindings:
     account:
       account: { pool: users, select: lease }
-    recipient:
-      account: { pool: users, select: random }
     onramp_action_id:
       bytes32: { random_bytes: 32 }
     earn_deposit_action_id:
@@ -61,27 +59,6 @@ scenario:
         fee_token: "${ZONES_BENCH_DLUSD}"
         amount: ${ZONES_BENCH_DEPOSIT_AMOUNT}
         memo: { var: onramp_action_id }
-
-    - id: private_transfer
-      depends_on: [onramp.zone_deposit.processed]
-      submit:
-        chain: zone
-        template: private_transfer
-        with:
-          from: { var: account.ref }
-          fee_token: "${ZONES_BENCH_DLUSD}"
-          call:
-            args: [${ZONES_BENCH_PRIVATE_TRANSFER_RECIPIENT}, ${ZONES_BENCH_ACTIVITY_AMOUNT}]
-      save: private_transfer
-
-    - id: private_transfer_receipt
-      depends_on: [private_transfer]
-      wait_receipt:
-        chain: zone
-        transaction_hash: { var: private_transfer.tx_hash }
-        sender: { var: private_transfer.sender }
-      timeout: 45s
-      save: private_transfer_receipt
 
     - use: earn-deposit-and-return
       as: earn_deposit
@@ -189,7 +166,6 @@ scenario:
 
     - id: journey_complete
       depends_on:
-        - private_transfer_receipt
         - offramp_result
         - offramp_processed
       checkpoint: { chain: l1 }

--- a/contrib/bench/neobank/zone-flow.yml
+++ b/contrib/bench/neobank/zone-flow.yml
@@ -53,19 +53,6 @@ templates:
         - "${ZONES_BENCH_OUTBOX}"
         - "115792089237316195423570985008687907853269984665640564039457584007913129639935"
 
-  private_transfer:
-    type: tempo
-    from: { var: account.ref }
-    gas_limit: 500000
-    fee_token: "${ZONES_BENCH_TOKEN}"
-    expiring_nonce: true
-    valid_for_secs: 25
-    call:
-      to: "${ZONES_BENCH_TOKEN}"
-      abi: TIP20
-      function: "transfer(address,uint256)"
-      args: [{ var: recipient.address }, ${ZONES_BENCH_ACTIVITY_AMOUNT}]
-
   gateway_deposit:
     type: tempo
     from: { var: account.ref }


### PR DESCRIPTION
## Summary

- remove the direct TIP-20 transfer and receipt steps from the full neobank journey
- remove the unused private transfer workload template and recipient binding
- complete the journey from the supported onramp, Earn, and offramp paths

## Validation

- `git diff --check`
- parsed both edited scenario files after environment placeholder substitution

Prompted by: @shekhirin