### PR TITLE
fix(rpc): stabilize private log indices

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -527,9 +527,16 @@ fn stale_filter_owner_ids(
         .collect()
 }
 
+#[derive(Clone)]
+struct OwnedFilter {
+    caller: Address,
+    /// The scoped user filter for log filters. Block filters do not need post-filtering.
+    log_filter: Option<Filter>,
+}
+
 async fn prune_filter_owners<Api: EthApiTypes + 'static>(
     filter: &EthFilter<Api>,
-    owners: &Mutex<HashMap<FilterId, Address>>,
+    owners: &Mutex<HashMap<FilterId, OwnedFilter>>,
 ) {
     let owner_ids = {
         let owners = owners.lock().await;
@@ -582,9 +589,9 @@ pub struct ZoneRpc<Api: EthApiTypes> {
     config: zone_rpc::RedactedRpcConfig,
     enabled_tokens: EnabledTokenRegistry,
     l1_provider: DynProvider<TempoNetwork>,
-    /// Maps filter IDs to the authenticated account that created them.
+    /// Maps filter IDs to their authenticated owner and scoped user log filter.
     /// The reth filter registry remains the source of truth for filter liveness.
-    filter_owners: Arc<Mutex<HashMap<FilterId, Address>>>,
+    filter_owners: Arc<Mutex<HashMap<FilterId, OwnedFilter>>>,
 }
 
 impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
@@ -620,7 +627,8 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
         Api: Send + Sync + 'static,
     {
         let filter = self.filter().clone();
-        let owners: Weak<Mutex<HashMap<FilterId, Address>>> = Arc::downgrade(&self.filter_owners);
+        let owners: Weak<Mutex<HashMap<FilterId, OwnedFilter>>> =
+            Arc::downgrade(&self.filter_owners);
         tokio::spawn(async move {
             let mut prune_interval = interval(FILTER_OWNER_PRUNE_INTERVAL);
             prune_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -639,23 +647,23 @@ impl<Api: EthApiTypes + 'static> ZoneRpc<Api> {
 
     /// Verify that the filter belongs to the authenticated caller.
     ///
-    /// Returns `Ok(())` if the caller owns the filter or is the sequencer.
+    /// Returns the original scoped log filter if the caller owns an active filter.
     /// Returns an error indistinguishable from "filter not found" to avoid
     /// leaking filter existence to non-owners.
     async fn ensure_filter_owner(
         &self,
         id: &FilterId,
         auth: &AuthContext,
-    ) -> Result<(), JsonRpcError> {
-        let owner_matches = {
+    ) -> Result<Option<Filter>, JsonRpcError> {
+        let log_filter = {
             let owners = self.filter_owners.lock().await;
-            matches!(owners.get(id), Some(owner) if *owner == auth.caller)
+            match owners.get(id) {
+                Some(owner) if owner.caller == auth.caller => owner.log_filter.clone(),
+                _ => return Err(filter_not_found_error()),
+            }
         };
-        if !owner_matches {
-            return Err(filter_not_found_error());
-        }
         if self.filter_is_active(id).await {
-            Ok(())
+            Ok(log_filter)
         } else {
             self.filter_owners.lock().await.remove(id);
             Err(filter_not_found_error())
@@ -991,10 +999,11 @@ where
             let zone_tokens = self.zone_tokens();
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
-            let logs = EthFilterApiServer::logs(&self.eth.filter, filter)
+            let indexing_filter = zone_rpc::filter::log_indexing_filter(&filter, &zone_tokens);
+            let logs = EthFilterApiServer::logs(&self.eth.filter, indexing_filter)
                 .await
                 .map_err(internal)?;
-            let filtered = zone_rpc::filter::filter_logs(logs, &auth.caller);
+            let filtered = zone_rpc::filter::filter_logs_for_query(logs, &auth.caller, &filter);
             to_raw(&filtered)
         })
     }
@@ -1004,20 +1013,24 @@ where
             let zone_tokens = self.zone_tokens();
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter_for_caller(&mut filter, &auth.caller)?;
-            let id = EthFilterApiServer::new_filter(&self.eth.filter, filter)
+            let indexing_filter = zone_rpc::filter::log_indexing_filter(&filter, &zone_tokens);
+            let id = EthFilterApiServer::new_filter(&self.eth.filter, indexing_filter)
                 .await
                 .map_err(internal)?;
-            self.filter_owners
-                .lock()
-                .await
-                .insert(id.clone(), auth.caller);
+            self.filter_owners.lock().await.insert(
+                id.clone(),
+                OwnedFilter {
+                    caller: auth.caller,
+                    log_filter: Some(filter),
+                },
+            );
             to_raw(&id)
         })
     }
 
     fn get_filter_logs(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            self.ensure_filter_owner(&id, &auth).await?;
+            let filter = self.ensure_filter_owner(&id, &auth).await?;
 
             let logs = self
                 .filter()
@@ -1025,14 +1038,15 @@ where
                 .await
                 .map_err(map_eth_filter_error)?;
 
-            let filtered = zone_rpc::filter::filter_logs(logs, &auth.caller);
+            let filter = filter.ok_or_else(filter_not_found_error)?;
+            let filtered = zone_rpc::filter::filter_logs_for_query(logs, &auth.caller, &filter);
             to_raw(&filtered)
         })
     }
 
     fn get_filter_changes(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            self.ensure_filter_owner(&id, &auth).await?;
+            let filter = self.ensure_filter_owner(&id, &auth).await?;
 
             let changes = self
                 .filter()
@@ -1042,7 +1056,9 @@ where
 
             match changes {
                 FilterChanges::Logs(logs) => {
-                    let filtered = zone_rpc::filter::filter_logs(logs, &auth.caller);
+                    let filter = filter.ok_or_else(filter_not_found_error)?;
+                    let filtered =
+                        zone_rpc::filter::filter_logs_for_query(logs, &auth.caller, &filter);
                     to_raw(&FilterChanges::<
                         alloy_rpc_types_eth::Transaction<TempoTxEnvelope>,
                     >::Logs(filtered))
@@ -1066,17 +1082,20 @@ where
             let id = EthFilterApiServer::new_block_filter(&self.eth.filter)
                 .await
                 .map_err(internal)?;
-            self.filter_owners
-                .lock()
-                .await
-                .insert(id.clone(), auth.caller);
+            self.filter_owners.lock().await.insert(
+                id.clone(),
+                OwnedFilter {
+                    caller: auth.caller,
+                    log_filter: None,
+                },
+            );
             to_raw(&id)
         })
     }
 
     fn uninstall_filter(&self, id: FilterId, auth: AuthContext) -> BoxFut<'_> {
         Box::pin(async move {
-            self.ensure_filter_owner(&id, &auth).await?;
+            let _ = self.ensure_filter_owner(&id, &auth).await?;
 
             let result = EthFilterApiServer::uninstall_filter(&self.eth.filter, id.clone())
                 .await
@@ -1137,13 +1156,14 @@ where
             let zone_tokens = self.zone_tokens();
             zone_rpc::filter::scope_filter_addresses(&mut filter, &zone_tokens)?;
             zone_rpc::filter::scope_filter_for_caller(&mut filter, &caller)?;
+            let indexing_filter = zone_rpc::filter::log_indexing_filter(&filter, &zone_tokens);
 
             let stream = provider
                 .canonical_state_stream()
                 .flat_map(|canon_state| futures::stream::iter(canon_state.block_receipts()))
                 .flat_map(move |(block_receipts, removed)| {
                     let all_logs = logs_utils::matching_block_logs_with_tx_hashes(
-                        &filter,
+                        &indexing_filter,
                         block_receipts.block,
                         block_receipts.timestamp,
                         block_receipts
@@ -1152,20 +1172,13 @@ where
                             .map(|(tx, receipt)| (*tx, receipt)),
                         removed,
                     );
-                    futures::stream::iter(all_logs)
+                    let filtered =
+                        zone_rpc::filter::filter_logs_for_query(all_logs, &caller, &filter)
+                            .into_iter()
+                            .map(|log| to_raw(&log))
+                            .collect::<Vec<_>>();
+                    futures::stream::iter(filtered)
                 });
-
-            // Renumber `log_index` per-transaction so a log seen live over the
-            // subscription carries the same `(transactionHash, logIndex)` it would
-            // via `eth_getLogs`/`eth_getTransactionReceipt`.
-            // Logs arrive in block order grouped by tx, which is what `LogOrderingRedactor` needs.
-            let mut log_redactor = zone_rpc::filter::LogOrderingRedactor::default();
-            let stream = stream.filter_map(move |log| {
-                std::future::ready(
-                    zone_rpc::filter::is_log_visible(&log, &caller)
-                        .then(|| to_raw(&log_redactor.redact(log))),
-                )
-            });
             let stream: zone_rpc::WsSubscriptionStream = Box::pin(stream);
             Ok(stream)
         })

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -152,6 +152,18 @@ pub fn filter_logs(logs: Vec<Log>, caller: &Address) -> Vec<Log> {
         .collect()
 }
 
+/// Filters a complete log superset for `caller`, assigns query-independent ordering fields, then
+/// applies the caller's scoped filter.
+///
+/// The input must contain every potentially visible whitelisted log for the selected blocks. This
+/// ensures a narrower address or topic filter cannot change a log's redacted `log_index`.
+pub fn filter_logs_for_query(logs: Vec<Log>, caller: &Address, filter: &Filter) -> Vec<Log> {
+    filter_logs(logs, caller)
+        .into_iter()
+        .filter(|log| filter.rpc_matches(log))
+        .collect()
+}
+
 /// Filters a receipt's logs for its sender and recomputes `logsBloom`.
 pub fn filter_receipt_logs(mut receipt: TempoTransactionReceipt) -> TempoTransactionReceipt {
     let caller = receipt.from();
@@ -185,6 +197,24 @@ pub fn scope_filter_addresses(
     } else {
         Err(JsonRpcError::invalid_params("invalid filter address"))
     }
+}
+
+/// Builds the internal filter used to derive stable private-RPC log indices.
+///
+/// Only the caller's block selection is retained. Address and topic constraints are widened to all
+/// events the private RPC may expose so ordering is computed before the original user filter is
+/// applied.
+pub fn log_indexing_filter(filter: &Filter, zone_tokens: &[Address]) -> Filter {
+    let mut indexing_filter = Filter {
+        block_option: filter.block_option.clone(),
+        ..Default::default()
+    };
+
+    let mut allowed_addresses = zone_tokens.to_vec();
+    allowed_addresses.push(RECEIVE_POLICY_GUARD_ADDRESS);
+    indexing_filter.address = FilterSet::from(allowed_addresses);
+    indexing_filter.topics[0] = FilterSet::from(WHITELISTED_TOPICS.to_vec());
+    indexing_filter
 }
 
 /// Scopes a user-supplied filter to only match whitelisted event topics.
@@ -716,6 +746,48 @@ mod tests {
     }
 
     #[test]
+    fn query_filter_is_applied_after_log_index_redaction() {
+        let zone_token = address!("0x000000000000000000000000000000000000aaaa");
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let other = address!("0x0000000000000000000000000000000000000002");
+        let tx_hash = B256::with_last_byte(0xaa);
+        let block_hash = B256::with_last_byte(0xbb);
+
+        let mut outgoing = make_log_in_tx(
+            zone_token,
+            vec![TRANSFER_TOPIC, caller_word(&caller), caller_word(&other)],
+            tx_hash,
+            7,
+        );
+        outgoing.block_hash = Some(block_hash);
+        outgoing.block_number = Some(12);
+
+        let mut incoming = make_log_in_tx(
+            zone_token,
+            vec![TRANSFER_TOPIC, caller_word(&other), caller_word(&caller)],
+            tx_hash,
+            8,
+        );
+        incoming.block_hash = Some(block_hash);
+        incoming.block_number = Some(12);
+
+        let mut filter = Filter {
+            address: FilterSet::from(zone_token),
+            ..Default::default()
+        };
+        filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
+        filter.topics[2] = FilterSet::from(caller_word(&caller));
+        scope_filter_for_caller(&mut filter, &caller).unwrap();
+
+        let result = filter_logs_for_query(vec![outgoing, incoming], &caller, &filter);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].transaction_hash, Some(tx_hash));
+        assert_eq!(result[0].transaction_index, Some(0));
+        assert_eq!(result[0].log_index, Some(1));
+    }
+
+    #[test]
     fn filter_receipt_logs_recomputes_logs_and_bloom() {
         let caller = address!("0x0000000000000000000000000000000000000001");
         let other = address!("0x0000000000000000000000000000000000000002");
@@ -924,5 +996,36 @@ mod tests {
 
         assert_eq!(err.code, JsonRpcError::invalid_params("").code);
         assert_eq!(err.message, "invalid filter address");
+    }
+
+    #[test]
+    fn log_indexing_filter_widens_addresses_and_topics_but_preserves_blocks() {
+        let token_a = address!("0x00000000000000000000000000000000000000aa");
+        let token_b = address!("0x00000000000000000000000000000000000000bb");
+        let caller = address!("0x0000000000000000000000000000000000000001");
+        let mut user_filter = Filter {
+            block_option: (10u64..=20u64).into(),
+            address: FilterSet::from(token_a),
+            ..Default::default()
+        };
+        user_filter.topics[0] = FilterSet::from(TRANSFER_TOPIC);
+        user_filter.topics[1] = FilterSet::from(caller_word(&caller));
+
+        let indexing_filter = log_indexing_filter(&user_filter, &[token_a, token_b]);
+
+        assert_eq!(indexing_filter.block_option, user_filter.block_option);
+        assert_eq!(indexing_filter.address.len(), 3);
+        assert!(indexing_filter.address.contains(&token_a));
+        assert!(indexing_filter.address.contains(&token_b));
+        assert!(
+            indexing_filter
+                .address
+                .contains(&RECEIVE_POLICY_GUARD_ADDRESS)
+        );
+        assert_eq!(indexing_filter.topics[0].len(), WHITELISTED_TOPICS.len());
+        for topic in WHITELISTED_TOPICS {
+            assert!(indexing_filter.topics[0].contains(&topic));
+        }
+        assert!(indexing_filter.topics[1..].iter().all(FilterSet::is_empty));
     }
 }

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -988,6 +988,8 @@ To avoid leaking how much activity occurred in a block, some fields of returned 
 - `transactionIndex` is set to `0` on every log, so the caller cannot infer its transaction's position among, or the number of, other transactions in the block.
 - `logIndex` is renumbered per transaction rather than exposing the log's global position in the block. `(transactionHash, logIndex)` is stable and consistent for a given log across `eth_getLogs`, `eth_getFilterLogs`, `eth_getFilterChanges`, `eth_getTransactionReceipt`, and `eth_subscribe("logs")`.
 
+For log queries and subscriptions, the server first selects all whitelisted events from allowed addresses for the requested blocks, filters that superset to events visible to the authenticated caller, and assigns the per-transaction `logIndex`. The caller's requested address and topic constraints are applied last. Consequently, changing the query filter cannot change the identity of a returned log.
+
 
 ### WebSocket Subscriptions
 


### PR DESCRIPTION
## Summary

Private RPC log queries now derive redacted `logIndex` values from the complete caller-visible set of whitelisted logs in each transaction before applying the caller's requested address and topic filter.

Persisted filters retain the scoped user filter for post-index matching, and WebSocket subscriptions use the same ordering pipeline.

## Root cause

The previous implementation passed the already-filtered query result into the log-ordering redactor, so a log's ordinal depended on the filter shape. The same log could therefore receive different `(transactionHash, logIndex)` identities across receipts, queries, filters, and subscriptions.

## Impact

Log identity is stable across private RPC surfaces without exposing block-global ordering. Narrowing a query no longer renumbers matching logs, preventing deduplication and reconciliation errors in downstream consumers.

Closes ZONE-306