### PR TITLE
fix(portal): align zone token metadata limits

### DIFF
--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -14,12 +14,8 @@ use zone_primitives::constants::EMPTY_SENTINEL;
 pub const MAX_DEPOSITS_PER_TEMPO_BLOCK: usize = 230;
 /// Maximum number of token enablements imported from one Tempo block.
 pub const MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK: usize = 8;
-/// Maximum UTF-8 byte length of an enabled token name.
-pub const MAX_TOKEN_NAME_BYTES: usize = 64;
-/// Maximum UTF-8 byte length of an enabled token symbol.
-pub const MAX_TOKEN_SYMBOL_BYTES: usize = 31;
-/// Maximum UTF-8 byte length of an enabled token currency code.
-pub const MAX_TOKEN_CURRENCY_BYTES: usize = 31;
+/// Maximum UTF-8 byte length of each enabled token metadata string.
+pub const MAX_TOKEN_METADATA_BYTES: usize = 31;
 
 crate::sol! {
     #[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -235,7 +235,7 @@ fn maximum_metadata_token(index: u16) -> EnabledToken {
     token[18..].copy_from_slice(&index.to_be_bytes());
     EnabledToken {
         token: Address::from(token),
-        name: "n".repeat(64),
+        name: "n".repeat(31),
         symbol: "s".repeat(31),
         currency: "c".repeat(31),
     }

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -627,9 +627,7 @@ interface IZonePortal {
     error DepositTooSmall();
     error DepositBlockCapacityExceeded(uint64 maximum);
     error TokenEnablementBlockCapacityExceeded(uint64 maximum);
-    error TokenNameTooLong(uint256 actual, uint256 maximum);
-    error TokenSymbolTooLong(uint256 actual, uint256 maximum);
-    error TokenCurrencyTooLong(uint256 actual, uint256 maximum);
+    error TokenMetadataTooLong();
     error GasFeeRateTooHigh();
     error TokenNotEnabled();
     error DepositsNotActive();
@@ -677,14 +675,8 @@ interface IZonePortal {
     /// @notice Maximum tokens enabled by this portal in one Tempo block.
     function MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK() external view returns (uint64);
 
-    /// @notice Maximum byte length accepted for a bridged token name.
-    function MAX_TOKEN_NAME_BYTES() external view returns (uint256);
-
-    /// @notice Maximum byte length accepted for a bridged token symbol.
-    function MAX_TOKEN_SYMBOL_BYTES() external view returns (uint256);
-
-    /// @notice Maximum byte length accepted for a bridged token currency.
-    function MAX_TOKEN_CURRENCY_BYTES() external view returns (uint256);
+    /// @notice Maximum byte length accepted for each bridged token metadata string.
+    function MAX_TOKEN_METADATA_BYTES() external view returns (uint256);
 
     /// @notice Maximum callback gas accepted for withdrawals
     function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);

--- a/specs/ref-impls/src/tempo/ZonePortal.sol
+++ b/specs/ref-impls/src/tempo/ZonePortal.sol
@@ -63,15 +63,12 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Maximum tokens that may be enabled for this portal in one Tempo block.
     /// @dev Under T9, processing 230 worst-case deposits plus 8 token enablements with maximum
-    ///      metadata uses 218,815,278 gas, below the buffered 225,000,000 gas ceiling.
+    ///      metadata uses 214,832,282 gas, below the buffered 225,000,000 gas ceiling.
     uint64 public constant MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK = 8;
 
-    /// @notice Maximum token metadata sizes copied into the zone, measured in bytes.
-    /// @dev Symbol and currency stay within Solidity's one-slot short-string representation.
-    ///      A maximum-size name has a bounded three-slot representation.
-    uint256 public constant MAX_TOKEN_NAME_BYTES = 64;
-    uint256 public constant MAX_TOKEN_SYMBOL_BYTES = 31;
-    uint256 public constant MAX_TOKEN_CURRENCY_BYTES = 31;
+    /// @notice Maximum byte length of each token metadata string copied into the zone.
+    /// @dev Keeps name, symbol, and currency in Solidity's one-slot short-string representation.
+    uint256 public constant MAX_TOKEN_METADATA_BYTES = 31;
 
     /// @dev Reserves enough capacity for one maximum-size sequencer withdrawal batch to bounce.
     ///      The 20M batch gas ceiling fits at most 19 simple withdrawals (plus one slot of margin).
@@ -581,17 +578,12 @@ contract ZonePortal is IZonePortal {
         string memory name = ITIP20(_token).name();
         string memory symbol = ITIP20(_token).symbol();
         string memory currency = ITIP20(_token).currency();
-        uint256 nameLength = bytes(name).length;
-        uint256 symbolLength = bytes(symbol).length;
-        uint256 currencyLength = bytes(currency).length;
-        if (nameLength > MAX_TOKEN_NAME_BYTES) {
-            revert TokenNameTooLong(nameLength, MAX_TOKEN_NAME_BYTES);
-        }
-        if (symbolLength > MAX_TOKEN_SYMBOL_BYTES) {
-            revert TokenSymbolTooLong(symbolLength, MAX_TOKEN_SYMBOL_BYTES);
-        }
-        if (currencyLength > MAX_TOKEN_CURRENCY_BYTES) {
-            revert TokenCurrencyTooLong(currencyLength, MAX_TOKEN_CURRENCY_BYTES);
+        if (
+            bytes(name).length > MAX_TOKEN_METADATA_BYTES
+                || bytes(symbol).length > MAX_TOKEN_METADATA_BYTES
+                || bytes(currency).length > MAX_TOKEN_METADATA_BYTES
+        ) {
+            revert TokenMetadataTooLong();
         }
 
         address[] memory tokens = new address[](1);

--- a/specs/ref-impls/test/tempo/ZonePortal.t.sol
+++ b/specs/ref-impls/test/tempo/ZonePortal.t.sol
@@ -1493,10 +1493,11 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_enableToken_acceptsMaximumMetadataLengths() public {
+        uint256 maximum = portal.MAX_TOKEN_METADATA_BYTES();
         address token = _createEnablementToken(
-            _stringOfLength(portal.MAX_TOKEN_NAME_BYTES()),
-            _stringOfLength(portal.MAX_TOKEN_SYMBOL_BYTES()),
-            _stringOfLength(portal.MAX_TOKEN_CURRENCY_BYTES()),
+            _stringOfLength(maximum),
+            _stringOfLength(maximum),
+            _stringOfLength(maximum),
             bytes32("max metadata")
         );
 
@@ -1507,45 +1508,39 @@ contract ZonePortalTest is BaseTest {
     }
 
     function test_enableToken_rejectsOversizedName() public {
-        uint256 maximum = portal.MAX_TOKEN_NAME_BYTES();
+        uint256 maximum = portal.MAX_TOKEN_METADATA_BYTES();
         address token = _createEnablementToken(
             _stringOfLength(maximum + 1), "T", "USD", bytes32("long name")
         );
 
         vm.prank(admin);
-        vm.expectRevert(
-            abi.encodeWithSelector(IZonePortal.TokenNameTooLong.selector, maximum + 1, maximum)
-        );
+        vm.expectRevert(IZonePortal.TokenMetadataTooLong.selector);
         portal.enableToken(token);
 
         assertFalse(portal.isTokenEnabled(token));
     }
 
     function test_enableToken_rejectsOversizedSymbol() public {
-        uint256 maximum = portal.MAX_TOKEN_SYMBOL_BYTES();
+        uint256 maximum = portal.MAX_TOKEN_METADATA_BYTES();
         address token = _createEnablementToken(
             "Token", _stringOfLength(maximum + 1), "USD", bytes32("long symbol")
         );
 
         vm.prank(admin);
-        vm.expectRevert(
-            abi.encodeWithSelector(IZonePortal.TokenSymbolTooLong.selector, maximum + 1, maximum)
-        );
+        vm.expectRevert(IZonePortal.TokenMetadataTooLong.selector);
         portal.enableToken(token);
 
         assertFalse(portal.isTokenEnabled(token));
     }
 
     function test_enableToken_rejectsOversizedCurrency() public {
-        uint256 maximum = portal.MAX_TOKEN_CURRENCY_BYTES();
+        uint256 maximum = portal.MAX_TOKEN_METADATA_BYTES();
         address token = _createEnablementToken(
             "Token", "T", _stringOfLength(maximum + 1), bytes32("long currency")
         );
 
         vm.prank(admin);
-        vm.expectRevert(
-            abi.encodeWithSelector(IZonePortal.TokenCurrencyTooLong.selector, maximum + 1, maximum)
-        );
+        vm.expectRevert(IZonePortal.TokenMetadataTooLong.selector);
         portal.enableToken(token);
 
         assertFalse(portal.isTokenEnabled(token));

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -340,7 +340,7 @@ The admin manages which TIP-20 tokens are available on the zone (see [Access Con
 - `pauseDeposits(token)`: Pause new deposits for a token. Does not affect withdrawals.
 - `resumeDeposits(token)`: Resume deposits for a previously paused token.
 
-The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin can halt deposits but cannot disable withdrawals for an enabled token. To keep the mandatory zone-side `advanceTempo()` call within its fixed system gas budget, each portal accepts at most `MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK` (8) token enablements in one Tempo block, including the initial token enabled during portal creation. Metadata copied into the zone is bounded by encoded byte length: 64 bytes for `name` and 31 bytes each for `symbol` and `currency`. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
+The portal maintains a `TokenConfig` per token with an `enabled` flag and a configurable `depositsActive` flag, along with an append-only `enabledTokens` list. The admin can halt deposits but cannot disable withdrawals for an enabled token. To keep the mandatory zone-side `advanceTempo()` call within its fixed system gas budget, each portal accepts at most `MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK` (8) token enablements in one Tempo block, including the initial token enabled during portal creation. Each metadata string copied into the zone (`name`, `symbol`, and `currency`) is bounded to 31 encoded bytes. Note that token issuers can independently restrict transfers via TIP-403 policies, which may cause withdrawals to fail and bounce back (see [Withdrawal Failures and Bounce-Back](#withdrawal-failures-and-bounce-back)).
 
 ### Token Enablement Commitment
 
@@ -1747,9 +1747,7 @@ interface IZonePortal {
     error DepositTooSmall();
     error DepositBlockCapacityExceeded(uint64 maximum);
     error TokenEnablementBlockCapacityExceeded(uint64 maximum);
-    error TokenNameTooLong(uint256 actual, uint256 maximum);
-    error TokenSymbolTooLong(uint256 actual, uint256 maximum);
-    error TokenCurrencyTooLong(uint256 actual, uint256 maximum);
+    error TokenMetadataTooLong();
     error GasFeeRateTooHigh();
     error TokenNotEnabled();
     error DepositsNotActive();
@@ -1763,9 +1761,7 @@ interface IZonePortal {
     function FIXED_DEPOSIT_GAS() external view returns (uint64);
     function MAX_DEPOSITS_PER_TEMPO_BLOCK() external view returns (uint64);
     function MAX_TOKENS_ENABLED_PER_TEMPO_BLOCK() external view returns (uint64);
-    function MAX_TOKEN_NAME_BYTES() external view returns (uint256);
-    function MAX_TOKEN_SYMBOL_BYTES() external view returns (uint256);
-    function MAX_TOKEN_CURRENCY_BYTES() external view returns (uint256);
+    function MAX_TOKEN_METADATA_BYTES() external view returns (uint256);
     function MAX_WITHDRAWAL_GAS_LIMIT() external view returns (uint64);
     function MAX_GAS_FEE_RATE() external view returns (uint128);
 
@@ -1982,7 +1978,7 @@ interface IZoneInbox {
 }
 ```
 
-`EnabledToken` carries the token address and exact metadata bytes committed by `ZonePortal.tokenEnablementHash` for direct activation of zone-side TIP-20 precompiles by `ZoneInbox`. The array passed to `advanceTempo` is untrusted until the Inbox verifies that applying the canonical hash transition from `processedTokenEnablementHash` reaches the portal commitment at the imported Tempo state. `ZonePortal` admits at most 8 such activations per Tempo block and rejects metadata whose encoded byte length exceeds 64 bytes for `name` or 31 bytes for `symbol` or `currency`.
+`EnabledToken` carries the token address and exact metadata bytes committed by `ZonePortal.tokenEnablementHash` for direct activation of zone-side TIP-20 precompiles by `ZoneInbox`. The array passed to `advanceTempo` is untrusted until the Inbox verifies that applying the canonical hash transition from `processedTokenEnablementHash` reaches the portal commitment at the imported Tempo state. `ZonePortal` admits at most 8 such activations per Tempo block and rejects any `name`, `symbol`, or `currency` whose encoded byte length exceeds 31 bytes.
 
 ### IZoneOutbox
 


### PR DESCRIPTION
Depends on #985 and aligns the portal runtime with tempoxyz/tempo#7150.

Uses one 31-byte bound for token name, symbol, and currency metadata and one `TokenMetadataTooLong` error, keeping every accepted metadata string in Solidity's short-string representation. Simplifies https://github.com/tempoxyz/zones/pull/998.