### PR TITLE
perf(spf): create zone trie once

### DIFF
--- a/crates/spf/src/execution/database.rs
+++ b/crates/spf/src/execution/database.rs
@@ -49,8 +49,6 @@ impl revm::database_interface::DBErrorMarker for WitnessDatabaseError {}
 #[derive(Debug)]
 pub struct WitnessDatabase {
     state: StatelessSparseTrie,
-    pre_state_root: B256,
-    node_pool: Vec<Bytes>,
     accounts: AddressMap<Option<AccountInfo>>,
     storage: AddressMap<U256Map<U256>>,
     code_by_hash: B256Map<Bytecode>,
@@ -85,25 +83,39 @@ impl WitnessDatabase {
 
         Ok(Self {
             state,
-            pre_state_root: state_root,
-            node_pool,
             accounts: AddressMap::default(),
             storage: AddressMap::default(),
             code_by_hash,
         })
     }
 
-    /// Calculate the post-state root from the initial witness and cumulative
-    /// in-memory execution changes.
+    /// Apply one block's execution changes to the current Zone state trie and
+    /// return the resulting post-state root.
     pub(crate) fn state_root(
-        &self,
-        bundle_state: &BundleState,
+        &mut self,
+        bundle_state: BundleState,
     ) -> Result<B256, StatelessSparseTrieError> {
-        let mut trie = StatelessSparseTrie::new(self.pre_state_root, &self.node_pool)?;
+        // Advance the trie from the previous block's root using this block's changes.
         let state = reth_trie_common::HashedPostState::from_bundle_state::<
             reth_trie_common::KeccakKeyHasher,
         >(bundle_state.state());
-        trie.calculate_state_root(state)
+        let state_root = self.state.calculate_state_root(state)?;
+
+        // Keep database read caches coherent with the newly advanced trie.
+        for (address, account) in bundle_state.state() {
+            self.accounts.insert(*address, account.info.clone());
+
+            if account.status.is_storage_known() {
+                self.storage.remove(address);
+            }
+
+            let storage_entry = self.storage.entry(*address).or_default();
+            for (slot, value) in account.storage.iter() {
+                storage_entry.insert(*slot, value.present_value);
+            }
+        }
+
+        Ok(state_root)
     }
 }
 

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -169,7 +169,8 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
             }
         };
 
-        let state_root = zone_state.database.state_root(&zone_state.bundle_state)?;
+        let bundle_state = zone_state.take_bundle();
+        let state_root = zone_state.database.state_root(bundle_state)?;
         let gas_limit = executed_block.evm_env.block_env.inner.gas_limit;
         let execution_context =
             execution::evm::next_block_execution_context(config.chain_spec(), block, gas_limit);
@@ -877,7 +878,7 @@ mod tests {
             alloy_rlp::encode(expected_account),
         ))));
         assert_eq!(
-            state.database.state_root(&state.bundle_state).unwrap(),
+            state.database.state_root(state.bundle_state).unwrap(),
             expected_root
         );
     }

--- a/crates/spf/src/mpt.rs
+++ b/crates/spf/src/mpt.rs
@@ -115,8 +115,8 @@ impl StatelessSparseTrie {
         })
     }
 
-    /// Apply the cumulative execution changes to this revealed pre-state trie
-    /// and calculate the resulting state root.
+    /// Apply the supplied execution changes to this revealed state trie and
+    /// calculate the resulting state root.
     pub(crate) fn calculate_state_root(
         &mut self,
         state: HashedPostState,


### PR DESCRIPTION
Instead of re-creating the trie and applying cumulative changes from all blocks on every Zone block trie calculation, we keep an accumulated trie and only apply per-block state deltas.

Successful benchmark: https://github.com/tempoxyz/zones/actions/runs/31590825424