### PR TITLE
fix: align tempo-std lock revision

### DIFF
--- a/specs/ref-impls/foundry.lock
+++ b/specs/ref-impls/foundry.lock
@@ -6,6 +6,6 @@
     }
   },
   "lib/tempo-std": {
-    "rev": "6e1bf3f499d96ea400434108be3ccfd28b46b341"
+    "rev": "96f882963ce3b0e0abc7ec2b41d03d42457877bb"
   }
 }


### PR DESCRIPTION
## Summary

- Align the `tempo-std` Foundry lock revision with the checked-in submodule revision.
- Prevent benchmark genesis generation from building conflicting ZonePortal bytecode.

## Validation

- `git diff --check`
- `forge build` unavailable locally: the sandbox Foundry build does not recognize Tempo hardfork `T8`; CI will validate the Tempo-specific build.

Prompted by: @shekhirin