### PR TITLE
fix(node): report rpc-only nodes as not promotion-ready

### DIFF
--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -657,7 +657,7 @@ pub(crate) async fn run_role_controller<P, Pool>(
         let mut promotion_reasons = if can_lead {
             Vec::new()
         } else {
-            vec!["node lacks sequencer resources or quorum membership".to_owned()]
+            vec!["rpc-only nodes cannot get promoted".to_owned()]
         };
         if let DesiredRole::Leader { epoch, next_anchor } = desired
             && !current

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -654,7 +654,11 @@ pub(crate) async fn run_role_controller<P, Pool>(
 
         // Only forced recovery has an additional promotion barrier. Normal transitions are
         // complete when the local next anchor is assigned to this node.
-        let mut promotion_reasons = Vec::new();
+        let mut promotion_reasons = if can_lead {
+            Vec::new()
+        } else {
+            vec!["node lacks sequencer resources or quorum membership".to_owned()]
+        };
         if let DesiredRole::Leader { epoch, next_anchor } = desired
             && !current
                 .as_ref()


### PR DESCRIPTION
## Summary

- Report RPC-only nodes as not ready for promotion.
- Return `rpc-only nodes cannot get promoted` as the readiness reason.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test -p zone-node role::tests`
- `cargo +nightly clippy -p zone-node --lib`

Prompted by: aditya