### PR TITLE
fix(genesis): remove account prefunding

### DIFF
--- a/crates/node/assets/zone-dev-genesis.json
+++ b/crates/node/assets/zone-dev-genesis.json
@@ -74,7 +74,7 @@
       "nonce": "0x1"
     },
     "0xaaaaaaaa00000000000000000000000000000000": {
-      "balance": "0x3635c9adc5dea00000",
+      "balance": "0x0",
       "code": "0xef",
       "nonce": "0x0"
     },

--- a/xtask/src/generate_zone_genesis.rs
+++ b/xtask/src/generate_zone_genesis.rs
@@ -249,13 +249,6 @@ impl GenerateZoneGenesis {
             );
         }
 
-        if let Some(sequencer) = self.sequencer {
-            genesis_alloc.entry(sequencer).or_default().balance =
-                U256::from(1_000_000_000_000_000_000_000u128);
-        }
-        genesis_alloc.entry(self.admin).or_default().balance =
-            U256::from(1_000_000_000_000_000_000_000u128);
-
         let chain_config = ChainConfig {
             chain_id: self.chain_id,
             homestead_block: Some(0),

--- a/zone-genesis/genesis.json
+++ b/zone-genesis/genesis.json
@@ -75,7 +75,7 @@
       "nonce": "0x1"
     },
     "0xaaaaaaaa00000000000000000000000000000000": {
-      "balance": "0x3635c9adc5dea00000",
+      "balance": "0x0",
       "code": "0xef",
       "nonce": "0x0"
     },


### PR DESCRIPTION
## What changed

Remove the hard-coded native balance assignments for the zone admin and sequencer from generated genesis allocations. Refresh the bundled node genesis and checked-in root genesis fixture so both reflect the generator output.

## Why

Zones charge transaction fees in the configured TIP-20 fee token, so these operational accounts do not need placeholder native balances. Keeping the assignments unnecessarily mutates the generated genesis state and suggests that native funds are required.

## Impact

Newly generated zone genesis files no longer prefund the admin or sequencer with native balance. The bundled development genesis now has the same behavior. Existing deployed zones are unaffected.