### PR TITLE
refactor(node): validate zones with Tempo consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11352,7 +11352,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11398,7 +11398,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11422,7 +11422,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11434,7 +11434,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11446,7 +11446,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11481,7 +11481,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11493,7 +11493,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11553,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11591,7 +11591,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11611,7 +11611,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11634,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11645,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11677,7 +11677,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11700,7 +11700,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72#ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72"
+source = "git+https://github.com/tempoxyz/tempo?rev=6ab24b4e2be093b756734fa79f74d45641842a36#6ab24b4e2be093b756734fa79f74d45641842a36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13815,7 +13815,6 @@ dependencies = [
  "reqwest",
  "reth-chain-state",
  "reth-chainspec",
- "reth-consensus",
  "reth-eth-wire-types",
  "reth-ethereum",
  "reth-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,26 +98,26 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "ebdd6e95a0c08f0eac6a1b92b272a3f9df4b5b72", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "6ab24b4e2be093b756734fa79f74d45641842a36", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -13,7 +13,9 @@ use reth_chainspec::{
 };
 use reth_network_peers::NodeRecord;
 use std::{fmt::Display, sync::Arc};
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork, spec::TempoHardforks};
+use tempo_chainspec::{
+    TempoChainSpec, TempoConsensusSpec, hardfork::TempoHardfork, spec::TempoHardforks,
+};
 use tempo_primitives::TempoHeader;
 
 /// Chain specification for a Tempo Zone.
@@ -151,6 +153,21 @@ impl TempoHardforks for ZoneChainSpec {
     }
 }
 
+impl TempoConsensusSpec for ZoneChainSpec {
+    fn shared_gas_limit_at(&self, _timestamp: u64, _gas_limit: u64) -> u64 {
+        0
+    }
+
+    fn general_gas_limit_at(
+        &self,
+        _timestamp: u64,
+        _gas_limit: u64,
+        _shared_gas_limit: u64,
+    ) -> u64 {
+        0
+    }
+}
+
 impl EthExecutorSpec for ZoneChainSpec {
     fn deposit_contract_address(&self) -> Option<Address> {
         self.inner.deposit_contract_address()
@@ -203,6 +220,14 @@ mod tests {
 
         assert_ne!(DEV.next_block_base_fee(parent, timestamp), Some(0));
         assert_eq!(zone.next_block_base_fee(parent, timestamp), Some(0));
+    }
+
+    #[test]
+    fn consensus_gas_limits_disable_tempo_gas_sections() {
+        let zone = dev_zone_spec(3);
+
+        assert_eq!(zone.shared_gas_limit_at(0, 30_000_000), 0);
+        assert_eq!(zone.general_gas_limit_at(0, 30_000_000, 0), 0);
     }
 
     #[cfg(feature = "cli")]

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn consensus_gas_limits_disable_tempo_gas_sections() {
-        let zone = dev_zone_spec(3);
+        let zone = ZoneChainSpec::from(DEV.clone());
 
         assert_eq!(zone.shared_gas_limit_at(0, 30_000_000), 0);
         assert_eq!(zone.general_gas_limit_at(0, 30_000_000, 0), 0);

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -34,7 +34,6 @@ zone-sequencer.workspace = true
 # reth
 reth-chain-state.workspace = true
 reth-chainspec.workspace = true
-reth-consensus = { workspace = true, optional = true }
 reth-eth-wire-types.workspace = true
 reth-ethereum = { workspace = true, features = [
   "node",
@@ -135,7 +134,6 @@ default = []
 asm-keccak = ["alloy-primitives/asm-keccak"]
 cli = [
   "dep:clap",
-  "dep:reth-consensus",
   "dep:reth-ethereum",
   "dep:reth-tracing",
   "dep:url",

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -5,6 +5,7 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::{Args, CommandFactory, FromArgMatches};
+use reth_chainspec::EthChainSpec;
 use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
 use tempo_evm::consensus::TempoConsensus;
@@ -13,10 +14,11 @@ use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
 use zone_evm::ZoneEvmConfig;
 use zone_p2p::{MAX_TRANSACTION_MESSAGE_SIZE, P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
+use zone_primitives::constants::decode_l1_chain_id;
 
 use crate::{
     ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig, dev::DevCommand,
-    rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
+    node::tempo_chain_spec_for_l1, rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 use zone_sequencer::{
     BatchAnchorConfig, DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
@@ -95,6 +97,15 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
     prepend_log_filter(&mut cli.logs.log_file_filter, ZONE_LOG_FILTER_DIRECTIVES);
 
     let components = |spec: Arc<ZoneChainSpec>| {
+        let l1_chain_id = decode_l1_chain_id(spec.chain().id())
+            .expect("CLI components require a valid Zone chain ID");
+        let l1_spec = tempo_chain_spec_for_l1(l1_chain_id)
+            .expect("CLI components require a supported parent Tempo chain ID");
+        let spec = Arc::new(
+            spec.as_ref()
+                .clone()
+                .with_tempo_hardforks_from(l1_spec.as_ref()),
+        );
         (
             ZoneEvmConfig::new_without_l1(spec.clone()),
             TempoConsensus::new(spec),

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -5,9 +5,9 @@ use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::{Args, CommandFactory, FromArgMatches};
-use reth_consensus::noop::NoopConsensus;
 use reth_ethereum::cli::Cli;
 use reth_tracing::tracing::info;
+use tempo_evm::consensus::TempoConsensus;
 use zeroize::Zeroizing;
 use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
 use zone_evm::ZoneEvmConfig;
@@ -96,8 +96,8 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
 
     let components = |spec: Arc<ZoneChainSpec>| {
         (
-            ZoneEvmConfig::new_without_l1(spec),
-            NoopConsensus::default(),
+            ZoneEvmConfig::new_without_l1(spec.clone()),
+            TempoConsensus::new(spec),
         )
     };
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -35,7 +35,7 @@ use reth_node_api::{
 use reth_node_builder::{
     BuilderContext, DebugNode, Node, NodeAdapter,
     components::{
-        BasicPayloadServiceBuilder, ComponentsBuilder, ExecutorBuilder, NoopConsensusBuilder,
+        BasicPayloadServiceBuilder, ComponentsBuilder, ConsensusBuilder, ExecutorBuilder,
         NoopNetworkBuilder, PoolBuilder, spawn_maintenance_tasks,
     },
     rpc::{
@@ -58,7 +58,7 @@ use reth_transaction_pool::{
 use std::{num::NonZeroU32, sync::Arc, time::Duration};
 use tempo_alloy::TempoNetwork;
 use tempo_chainspec::spec::{DEV, TempoChainSpec, chainspec_from_chain_id};
-use tempo_evm::TempoInvalidTransaction;
+use tempo_evm::{TempoInvalidTransaction, consensus::TempoConsensus};
 use tempo_node::{
     DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoEthApiBuilder,
 };
@@ -416,7 +416,7 @@ impl ZoneNode {
         BasicPayloadServiceBuilder<ZonePayloadFactory>,
         NoopNetworkBuilder<ZoneNetworkPrimitives>,
         ZoneExecutorBuilder,
-        NoopConsensusBuilder,
+        ZoneConsensusBuilder,
     >
     where
         N: FullNodeTypes<Types = Self>,
@@ -433,11 +433,12 @@ impl ZoneNode {
         BasicPayloadServiceBuilder<ZonePayloadFactory>,
         NoopNetworkBuilder<ZoneNetworkPrimitives>,
         ZoneExecutorBuilder,
-        NoopConsensusBuilder,
+        ZoneConsensusBuilder,
     >
     where
         N: FullNodeTypes<Types = Self>,
     {
+        let consensus_builder = ZoneConsensusBuilder::new();
         ComponentsBuilder::default()
             .node_types::<N>()
             .pool(ZonePoolBuilder::new(
@@ -446,7 +447,7 @@ impl ZoneNode {
             .executor(executor_builder)
             .payload(BasicPayloadServiceBuilder::new(payload_factory))
             .network(NoopNetworkBuilder::<ZoneNetworkPrimitives>::default())
-            .noop_consensus()
+            .consensus(consensus_builder)
     }
 }
 
@@ -1532,7 +1533,7 @@ where
         BasicPayloadServiceBuilder<ZonePayloadFactory>,
         NoopNetworkBuilder<ZoneNetworkPrimitives>,
         ZoneExecutorBuilder,
-        NoopConsensusBuilder,
+        ZoneConsensusBuilder,
     >;
     type AddOns = ZoneAddOns<NodeAdapter<N>>;
 
@@ -1618,6 +1619,28 @@ impl ZoneExecutorBuilder {
             l1_state_cache,
             enabled_tokens,
         }
+    }
+}
+
+/// Builds Tempo consensus using the fully configured Zone chain specification.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ZoneConsensusBuilder;
+
+impl ZoneConsensusBuilder {
+    const fn new() -> Self {
+        Self
+    }
+}
+
+impl<Node> ConsensusBuilder<Node> for ZoneConsensusBuilder
+where
+    Node: FullNodeTypes<Types = ZoneNode>,
+{
+    type Consensus = TempoConsensus<ZoneChainSpec>;
+
+    async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
+        Ok(TempoConsensus::new(ctx.chain_spec()))
     }
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -438,7 +438,8 @@ impl ZoneNode {
     where
         N: FullNodeTypes<Types = Self>,
     {
-        let consensus_builder = ZoneConsensusBuilder::new();
+        let consensus_builder =
+            ZoneConsensusBuilder::new(executor_builder.l1_state_provider_config.clone());
         ComponentsBuilder::default()
             .node_types::<N>()
             .pool(ZonePoolBuilder::new(
@@ -1622,14 +1623,18 @@ impl ZoneExecutorBuilder {
     }
 }
 
-/// Builds Tempo consensus using the fully configured Zone chain specification.
+/// Builds Tempo consensus from the Zone chain spec with Tempo fork activations inherited from L1.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct ZoneConsensusBuilder;
+pub struct ZoneConsensusBuilder {
+    l1_state_provider_config: L1StateProviderConfig,
+}
 
 impl ZoneConsensusBuilder {
-    const fn new() -> Self {
-        Self
+    fn new(l1_state_provider_config: L1StateProviderConfig) -> Self {
+        Self {
+            l1_state_provider_config,
+        }
     }
 }
 
@@ -1640,7 +1645,28 @@ where
     type Consensus = TempoConsensus<ZoneChainSpec>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
-        Ok(TempoConsensus::new(ctx.chain_spec()))
+        let l1_chain_id = match self.l1_state_provider_config.chain_id {
+            Some(chain_id) => chain_id,
+            None => {
+                let l1_provider = L1StateProvider::new(
+                    self.l1_state_provider_config,
+                    L1StateCache::new(),
+                    tokio::runtime::Handle::current(),
+                )
+                .await?;
+                l1_provider.chain_id().await?
+            }
+        };
+        let tempo_chain_spec = tempo_chain_spec_for_l1(l1_chain_id)
+            .ok_or_else(|| eyre::eyre!("unsupported parent Tempo chain ID {l1_chain_id}"))?;
+        let chain_spec = Arc::new(
+            ctx.chain_spec()
+                .as_ref()
+                .clone()
+                .with_tempo_hardforks_from(tempo_chain_spec.as_ref()),
+        );
+
+        Ok(TempoConsensus::new(chain_spec))
     }
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -90,7 +90,7 @@ use zone_payload::{
     DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, WithdrawalRevealEncryptor, ZonePayloadAttributes,
     ZonePayloadFactory, ZonePayloadTypes,
 };
-use zone_primitives::constants::zone_chain_id;
+use zone_primitives::constants::{decode_l1_chain_id, zone_chain_id};
 use zone_rpc::ZoneDebugApiRpcServer;
 use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
@@ -100,11 +100,9 @@ use zone_sequencer::{
 /// Returns a known Tempo chain spec for an L1 chain ID.
 ///
 /// Tempo Anvil uses chain ID 31337 and the same hardfork schedule as Tempo DEV (1337).
-///
-/// Additional dev-schedule L1 chain IDs (devnets that activate all Tempo
-/// hardforks at genesis) can be allowed via the `ZONE_L1_DEV_CHAIN_IDS`
+/// Additional dev-schedule L1 chain IDs can be allowed via the `ZONE_L1_DEV_CHAIN_IDS`
 /// environment variable as a comma-separated list.
-fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
+pub(crate) fn tempo_chain_spec_for_l1(chain_id: u64) -> Option<Arc<TempoChainSpec>> {
     chainspec_from_chain_id(chain_id).or_else(|| match chain_id {
         1337 | 31337 => Some(DEV.clone()),
         _ => std::env::var("ZONE_L1_DEV_CHAIN_IDS")
@@ -406,49 +404,6 @@ impl ZoneNode {
     /// Returns the shared encrypted-deposit key ring, when configured.
     pub fn deposit_decryption_keys(&self) -> Option<EncryptionKeyRing> {
         self.l1_config.encryption_keys.clone()
-    }
-    /// Returns a [`ComponentsBuilder`] configured for a Zone node.
-    pub fn components<N>(
-        executor_builder: ZoneExecutorBuilder,
-    ) -> ComponentsBuilder<
-        N,
-        ZonePoolBuilder,
-        BasicPayloadServiceBuilder<ZonePayloadFactory>,
-        NoopNetworkBuilder<ZoneNetworkPrimitives>,
-        ZoneExecutorBuilder,
-        ZoneConsensusBuilder,
-    >
-    where
-        N: FullNodeTypes<Types = Self>,
-    {
-        Self::components_with_payload_factory(executor_builder, ZonePayloadFactory::default())
-    }
-
-    fn components_with_payload_factory<N>(
-        executor_builder: ZoneExecutorBuilder,
-        payload_factory: ZonePayloadFactory,
-    ) -> ComponentsBuilder<
-        N,
-        ZonePoolBuilder,
-        BasicPayloadServiceBuilder<ZonePayloadFactory>,
-        NoopNetworkBuilder<ZoneNetworkPrimitives>,
-        ZoneExecutorBuilder,
-        ZoneConsensusBuilder,
-    >
-    where
-        N: FullNodeTypes<Types = Self>,
-    {
-        let consensus_builder =
-            ZoneConsensusBuilder::new(executor_builder.l1_state_provider_config.clone());
-        ComponentsBuilder::default()
-            .node_types::<N>()
-            .pool(ZonePoolBuilder::new(
-                executor_builder.enabled_tokens.clone(),
-            ))
-            .executor(executor_builder)
-            .payload(BasicPayloadServiceBuilder::new(payload_factory))
-            .network(NoopNetworkBuilder::<ZoneNetworkPrimitives>::default())
-            .consensus(consensus_builder)
     }
 }
 
@@ -1548,7 +1503,15 @@ where
         if let Some(encryptor) = self.withdrawal_reveal_encryptor.clone() {
             payload_factory = payload_factory.with_withdrawal_reveal_encryptor(encryptor);
         }
-        Self::components_with_payload_factory(executor_builder, payload_factory)
+        ComponentsBuilder::default()
+            .node_types::<N>()
+            .pool(ZonePoolBuilder::new(
+                executor_builder.enabled_tokens.clone(),
+            ))
+            .executor(executor_builder)
+            .payload(BasicPayloadServiceBuilder::new(payload_factory))
+            .network(NoopNetworkBuilder::<ZoneNetworkPrimitives>::default())
+            .consensus(ZoneConsensusBuilder::default())
     }
 
     fn add_ons(&self) -> Self::AddOns {
@@ -1626,15 +1589,11 @@ impl ZoneExecutorBuilder {
 /// Builds Tempo consensus from the Zone chain spec with Tempo fork activations inherited from L1.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct ZoneConsensusBuilder {
-    l1_state_provider_config: L1StateProviderConfig,
-}
+pub struct ZoneConsensusBuilder;
 
-impl ZoneConsensusBuilder {
-    fn new(l1_state_provider_config: L1StateProviderConfig) -> Self {
-        Self {
-            l1_state_provider_config,
-        }
+impl Default for ZoneConsensusBuilder {
+    fn default() -> Self {
+        Self
     }
 }
 
@@ -1645,18 +1604,7 @@ where
     type Consensus = TempoConsensus<ZoneChainSpec>;
 
     async fn build_consensus(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::Consensus> {
-        let l1_chain_id = match self.l1_state_provider_config.chain_id {
-            Some(chain_id) => chain_id,
-            None => {
-                let l1_provider = L1StateProvider::new(
-                    self.l1_state_provider_config,
-                    L1StateCache::new(),
-                    tokio::runtime::Handle::current(),
-                )
-                .await?;
-                l1_provider.chain_id().await?
-            }
-        };
+        let l1_chain_id = decode_l1_chain_id(ctx.chain_spec().chain().id())?;
         let tempo_chain_spec = tempo_chain_spec_for_l1(l1_chain_id)
             .ok_or_else(|| eyre::eyre!("unsupported parent Tempo chain ID {l1_chain_id}"))?;
         let chain_spec = Arc::new(

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1451,7 +1451,7 @@ mod tests {
             decryptions: vec![],
             enabled_tokens: vec![],
         };
-        let tx = zone_payload::build_advance_tempo_tx(&prepared);
+        let tx = zone_payload::build_advance_tempo_tx(&prepared, 1337);
         let block = SealedBlock::seal_slow(Block {
             header: TempoHeader::default(),
             body: alloy_consensus::BlockBody {
@@ -1544,7 +1544,7 @@ mod tests {
             enabled_tokens: vec![],
         };
         let TempoTxEnvelope::Legacy(system_tx) =
-            zone_payload::build_advance_tempo_tx(&prepared).into_inner()
+            zone_payload::build_advance_tempo_tx(&prepared, 1337).into_inner()
         else {
             unreachable!("advanceTempo builder must produce a legacy transaction")
         };

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -22,6 +22,7 @@ use tempo_zone_contracts::{
     ZONE_OUTBOX_ADDRESS,
 };
 use zone_l1::ChainTempoStateExt;
+use zone_primitives::constants::zone_chain_id;
 
 use crate::utils::{
     DEFAULT_POLL, DEFAULT_TIMEOUT, L1Fixture, TIP20_TX_GAS, WITHDRAWAL_TX_GAS, ZoneTestNode,
@@ -603,8 +604,8 @@ async fn test_two_zones_independent_deposits() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     // Start two zones with different chain IDs
-    let zone1 = ZoneTestNode::start_local_with_chain_id(71001).await?;
-    let zone2 = ZoneTestNode::start_local_with_chain_id(71002).await?;
+    let zone1 = ZoneTestNode::start_local_with_chain_id(zone_chain_id(1_337, 1)?).await?;
+    let zone2 = ZoneTestNode::start_local_with_chain_id(zone_chain_id(1_337, 2)?).await?;
 
     // Shared L1 fixture — same header timeline for both zones
     let mut fixture = L1Fixture::new();

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -87,11 +87,12 @@ pub(crate) use auth_tokens::{
     sign_webauthn_signature,
 };
 
-/// Atomic counter for unique chain IDs across concurrent tests.
-static NEXT_CHAIN_ID: AtomicU64 = AtomicU64::new(71_000);
+/// Atomic counter for unique zone IDs across concurrent tests.
+static NEXT_ZONE_ID: AtomicU64 = AtomicU64::new(71_000);
 
 fn next_unique_chain_id() -> u64 {
-    NEXT_CHAIN_ID.fetch_add(1, Ordering::Relaxed)
+    derive_zone_chain_id(1_337, NEXT_ZONE_ID.fetch_add(1, Ordering::Relaxed) as u32)
+        .expect("test zone ID fits in u32")
 }
 
 fn l1_dev_signer() -> alloy_signer_local::PrivateKeySigner {
@@ -3933,7 +3934,7 @@ pub(crate) async fn start_local_p2p_cluster(seed_blocks: u64) -> eyre::Result<P2
         })
         .collect();
 
-    let unique = NEXT_CHAIN_ID.fetch_add(1, Ordering::Relaxed);
+    let unique = NEXT_ZONE_ID.fetch_add(1, Ordering::Relaxed);
     let config_dir = std::env::temp_dir().join(format!(
         "tempo-zone-p2p-test-{}-{unique}",
         std::process::id()

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -16,7 +16,7 @@ use alloy_sol_types::SolCall;
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, MissingPayloadBehaviour, PayloadBuilder, PayloadConfig,
 };
-use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_errors::ProviderError;
 use reth_evm::{
     ConfigureEvm, Database, NextBlockEnvAttributes,
@@ -195,6 +195,7 @@ where
             .build();
 
         let chain_spec = self.provider.chain_spec();
+        let chain_id = chain_spec.chain().id();
 
         let block_gas_limit = parent_header.gas_limit();
 
@@ -209,10 +210,9 @@ where
                 extra_data: attributes.extra_data(),
                 slot_number: attributes.slot_number(),
             },
-            // Zones don't use L1 gas sections. These fields are required
-            // by TempoNextBlockEnvAttributes but ignored by the zone executor.
+            // Zones don't use Tempo L1 gas sections.
             general_gas_limit: 0,
-            shared_gas_limit: block_gas_limit,
+            shared_gas_limit: 0,
             timestamp_millis_part: attributes.timestamp_millis_part(),
             consensus_context: None,
             subblock_fee_recipients: Default::default(),
@@ -236,7 +236,7 @@ where
 
         // Execute advanceTempo system transaction — exactly one per zone block.
         builder
-            .execute_transaction(build_advance_tempo_tx(prepared))
+            .execute_transaction(build_advance_tempo_tx(prepared, chain_id))
             .map(|_| ())
             .map_err(PayloadBuilderError::evm)
             .map_err(|err| {
@@ -278,6 +278,7 @@ where
             block_number,
             self.withdrawal_batch_interval_blocks,
             self.withdrawal_reveal_encryptor.as_deref(),
+            chain_id,
         )?;
 
         let BlockBuilderOutcome {
@@ -535,6 +536,7 @@ fn finalize_withdrawal_batch_if_needed<B>(
     block_number: u64,
     interval_blocks: u64,
     encryptor: Option<&dyn WithdrawalRevealEncryptor>,
+    chain_id: u64,
 ) -> Result<(), PayloadBuilderError>
 where
     B: BlockBuilder<Primitives = tempo_primitives::TempoPrimitives>,
@@ -574,7 +576,8 @@ where
         })
         .collect::<Result<Vec<_>, _>>()?;
     let count = U256::from(pending_withdrawals.len());
-    let finalize_tx = build_finalize_withdrawal_batch_tx(count, block_number, encrypted_senders);
+    let finalize_tx =
+        build_finalize_withdrawal_batch_tx(count, block_number, encrypted_senders, chain_id);
     builder
         .execute_transaction(finalize_tx)
         .map(|_| ())
@@ -604,6 +607,7 @@ pub(crate) fn build_finalize_withdrawal_batch_tx(
     count: U256,
     block_number: u64,
     encrypted_senders: Vec<Bytes>,
+    chain_id: u64,
 ) -> Recovered<TempoTxEnvelope> {
     let calldata = abi::IZoneOutbox::finalizeWithdrawalBatchCall {
         count,
@@ -613,7 +617,7 @@ pub(crate) fn build_finalize_withdrawal_batch_tx(
     .abi_encode();
 
     let tx = TxLegacy {
-        chain_id: None,
+        chain_id: Some(chain_id),
         nonce: 0,
         gas_price: 0,
         gas_limit: 0,
@@ -679,7 +683,10 @@ where
 /// Takes a [`PreparedL1Block`] where all ECIES decryption and ABI encoding have
 /// already been performed. TIP-403 policy is enforced during `advanceTempo` when
 /// the deposits mint TIP-20 tokens.
-pub fn build_advance_tempo_tx(prepared: &PreparedL1Block) -> Recovered<TempoTxEnvelope> {
+pub fn build_advance_tempo_tx(
+    prepared: &PreparedL1Block,
+    chain_id: u64,
+) -> Recovered<TempoTxEnvelope> {
     // RLP-encode the Tempo header
     let mut header_rlp = Vec::new();
     prepared.header.header().encode(&mut header_rlp);
@@ -693,7 +700,7 @@ pub fn build_advance_tempo_tx(prepared: &PreparedL1Block) -> Recovered<TempoTxEn
     .abi_encode();
 
     let tx = TxLegacy {
-        chain_id: None,
+        chain_id: Some(chain_id),
         nonce: 0,
         gas_price: 0,
         gas_limit: 0,
@@ -910,12 +917,15 @@ mod tests {
             enabled_tokens: vec![],
         };
 
-        let recovered_tx = super::build_advance_tempo_tx(&prepared);
+        let recovered_tx = super::build_advance_tempo_tx(&prepared, 1337);
 
         // Decode the calldata to verify structure.
         let envelope = recovered_tx.inner();
         let input = match envelope {
-            tempo_primitives::TempoTxEnvelope::Legacy(signed) => &signed.tx().input,
+            tempo_primitives::TempoTxEnvelope::Legacy(signed) => {
+                assert_eq!(signed.tx().chain_id, Some(1337));
+                &signed.tx().input
+            }
             _ => panic!("expected Legacy tx"),
         };
         let decoded = IZoneInbox::advanceTempoCall::abi_decode(input)

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -169,6 +169,9 @@ pub enum ZoneChainIdError {
     /// Generic parent chain IDs must fit the supported tooling-safe range.
     #[error("generic parent chain ID must be in 1..={MAX_GENERIC_PARENT_CHAIN_ID}, got {0}")]
     InvalidParentChainId(u64),
+    /// The chain ID is not a valid Zone chain ID.
+    #[error("chain ID {0} is not a valid zone chain ID")]
+    InvalidZoneChainId(u64),
 }
 
 /// Derives a zone EIP-155 chain ID from its parent Tempo chain and ZoneFactory ID.
@@ -185,6 +188,32 @@ pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChai
     };
 
     Ok(chain_id)
+}
+
+/// Decodes the parent Tempo chain ID from a Zone chain ID.
+pub fn decode_l1_chain_id(chain_id: u64) -> Result<u64, ZoneChainIdError> {
+    let (parent_chain_id, zone_id) =
+        if (ZONE_CHAIN_ID_BASE..ZONE_CHAIN_ID_BASE + ZONE_CHAIN_ID_RANGE).contains(&chain_id) {
+            (MAINNET_CHAIN_ID, (chain_id - ZONE_CHAIN_ID_BASE) as u32)
+        } else if (ZONE_CHAIN_ID_BASE_TESTNET
+            ..ZONE_CHAIN_ID_BASE_TESTNET + ZONE_CHAIN_ID_RANGE_TESTNET)
+            .contains(&chain_id)
+        {
+            (
+                MODERATO_CHAIN_ID,
+                (chain_id - ZONE_CHAIN_ID_BASE_TESTNET) as u32,
+            )
+        } else if chain_id >= 1 << 32 {
+            (chain_id >> 32, chain_id as u32)
+        } else {
+            return Err(ZoneChainIdError::InvalidZoneChainId(chain_id));
+        };
+
+    if zone_chain_id(parent_chain_id, zone_id) == Ok(chain_id) {
+        Ok(parent_chain_id)
+    } else {
+        Err(ZoneChainIdError::InvalidZoneChainId(chain_id))
+    }
 }
 
 fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChainIdError> {
@@ -246,5 +275,22 @@ mod tests {
         let max_generic_chain_id = zone_chain_id(MAX_GENERIC_PARENT_CHAIN_ID, u32::MAX).unwrap();
         let max_legacy_v = max_generic_chain_id * 2 + 36;
         assert!(max_legacy_v < (1 << 53));
+    }
+
+    #[test]
+    fn decodes_parent_chain_id() {
+        for (parent_chain_id, zone_id) in [
+            (MAINNET_CHAIN_ID, 7),
+            (MODERATO_CHAIN_ID, 8),
+            (1_337, 9),
+            (MAX_GENERIC_PARENT_CHAIN_ID, u32::MAX),
+        ] {
+            let chain_id = zone_chain_id(parent_chain_id, zone_id).unwrap();
+            assert_eq!(decode_l1_chain_id(chain_id), Ok(parent_chain_id));
+        }
+
+        assert!(decode_l1_chain_id(ZONE_CHAIN_ID_BASE - 1).is_err());
+        assert!(decode_l1_chain_id(1 << 31).is_err());
+        assert!(decode_l1_chain_id((MAINNET_CHAIN_ID << 32) | 7).is_err());
     }
 }

--- a/crates/spf/src/execution/evm.rs
+++ b/crates/spf/src/execution/evm.rs
@@ -190,7 +190,7 @@ pub(crate) fn next_block_env_attributes(
         },
         general_gas_limit: 0,
         shared_gas_limit: 0,
-        timestamp_millis_part: header.timestamp_millis_part,
+        timestamp_millis_part: block.timestamp_millis_part,
         consensus_context: None,
         subblock_fee_recipients: HashMap::new(),
     })

--- a/crates/spf/src/execution/evm.rs
+++ b/crates/spf/src/execution/evm.rs
@@ -105,6 +105,7 @@ pub(crate) fn execute_zone_block(
         .map_err(|_| Error::EvmEnvironment)?;
     // The parent and Zone IDs are verifier-bound independently of the local chain specification.
     env.cfg_env.chain_id = zone_chain_id(parent_chain_id, zone_id)?;
+    let chain_id = env.cfg_env.chain_id;
     let assembly_env = env.clone();
     let block_gas_limit = env.block_env.inner.gas_limit;
     let evm = BlockExecutorFactory::evm_factory(&evm_config).create_evm(&mut *zone_state, env);
@@ -128,6 +129,7 @@ pub(crate) fn execute_zone_block(
         &block.tempo_header_rlp,
         block,
         zone_block_index,
+        chain_id,
     )?);
     transactions.extend(execute_user_transactions(
         &mut executor,
@@ -141,6 +143,7 @@ pub(crate) fn execute_zone_block(
             block.number,
             block.finalize_withdrawal_batch_encrypted_senders.clone(),
             zone_block_index,
+            chain_id,
         )?);
     }
 
@@ -186,8 +189,8 @@ pub(crate) fn next_block_env_attributes(
             slot_number: None,
         },
         general_gas_limit: 0,
-        shared_gas_limit: block_gas_limit,
-        timestamp_millis_part: block.timestamp_millis_part,
+        shared_gas_limit: 0,
+        timestamp_millis_part: header.timestamp_millis_part,
         consensus_context: None,
         subblock_fee_recipients: HashMap::new(),
     })
@@ -196,7 +199,7 @@ pub(crate) fn next_block_env_attributes(
 pub(crate) fn next_block_execution_context(
     chain_spec: &zone_chainspec::ZoneChainSpec,
     block: &ZoneBlock,
-    gas_limit: u64,
+    _gas_limit: u64,
 ) -> TempoBlockExecutionCtx<'static> {
     TempoBlockExecutionCtx {
         inner: EthBlockExecutionCtx {
@@ -213,7 +216,7 @@ pub(crate) fn next_block_execution_context(
             slot_number: None,
         },
         general_gas_limit: 0,
-        shared_gas_limit: gas_limit,
+        shared_gas_limit: 0,
         validator_set: None,
         consensus_context: None,
         subblock_fee_recipients: HashMap::new(),
@@ -225,6 +228,7 @@ fn execute_advance_tempo<'a, 'db, I>(
     header: &Bytes,
     block: &ZoneBlock,
     block_index: usize,
+    chain_id: u64,
 ) -> Result<TempoTxEnvelope, Error>
 where
     I: alloy_evm::revm::Inspector<WitnessContext<'db>>,
@@ -237,7 +241,7 @@ where
     }
     .abi_encode();
     let transaction = TxLegacy {
-        chain_id: None,
+        chain_id: Some(chain_id),
         nonce: 0,
         gas_price: 0,
         gas_limit: 0,
@@ -264,6 +268,7 @@ fn execute_finalize_withdrawal_batch<'a, 'db, I>(
     block_number: u64,
     encrypted_senders: Vec<Bytes>,
     block_index: usize,
+    chain_id: u64,
 ) -> Result<TempoTxEnvelope, Error>
 where
     I: alloy_evm::revm::Inspector<WitnessContext<'db>>,
@@ -275,7 +280,7 @@ where
     }
     .abi_encode();
     let transaction = TxLegacy {
-        chain_id: None,
+        chain_id: Some(chain_id),
         nonce: 0,
         gas_price: 0,
         gas_limit: 0,

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -615,7 +615,7 @@ mod tests {
                 gas_limit: 30_000_000,
                 ..Default::default()
             },
-            shared_gas_limit: 30_000_000,
+            shared_gas_limit: 0,
             ..Default::default()
         };
 
@@ -1027,10 +1027,7 @@ mod tests {
         assert_eq!(attributes.suggested_fee_recipient, Address::ZERO);
         assert_eq!(attributes.gas_limit, 30_000_000);
         assert_eq!(attributes.general_gas_limit, 0);
-        assert_eq!(
-            attributes.shared_gas_limit,
-            witness.parent_header.inner.gas_limit
-        );
+        assert_eq!(attributes.shared_gas_limit, 0);
         assert_eq!(attributes.timestamp_millis_part, 321);
 
         let tempo_database =


### PR DESCRIPTION
## Summary
- reuse generic `TempoConsensus<ZoneChainSpec>` instead of noop consensus
- configure Zone consensus gas sections and domain-separated system transaction chain IDs
- update the Tempo dependency to the generic consensus implementation

## Validation
- `cargo +nightly fmt --check`
- `cargo +nightly clippy -p zone-node --all-targets -- -D warnings`