### PR TITLE
feat(ci): build deployable Nitro prover image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 contrib/
 docs/
 localnet/
-scripts/
+scripts/*
+!scripts/run-prover-host.sh
 target/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,7 +118,6 @@ jobs:
           files: |
             docker/docker-bake.hcl
             ${{ steps.meta-tempo-zone.outputs.bake-file }}
-            ${{ steps.meta-tempo-zone-prover.outputs.bake-file }}
             ${{ steps.meta-tempo-zone-xtask.outputs.bake-file }}
           targets: default
           project: 0c6tg19qsp
@@ -131,6 +130,71 @@ jobs:
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}
           VERGEN_GIT_SHA_SHORT: ${{ steps.shortsha.outputs.shortsha }}
+
+      # Nitro CLI converts an image from the runner's local Docker image store.
+      - name: Load tempo-zone-prover enclave payload
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: docker/docker-bake.hcl
+          targets: tempo-zone-prover-enclave
+          set: tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:eif-source
+          project: 0c6tg19qsp
+          load: true
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
+
+      - name: Load tempo-zone-prover EIF builder
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: docker/docker-bake.hcl
+          targets: tempo-zone-prover-eif-builder
+          set: tempo-zone-prover-eif-builder.tags=tempo-zone-prover-eif-builder:local
+          project: 0c6tg19qsp
+          load: true
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
+
+      - name: Build tempo-zone-prover EIF
+        env:
+          PROVER_IMAGE: tempo-zone-prover-enclave:eif-source
+          EIF_BUILDER_IMAGE: tempo-zone-prover-eif-builder:local
+          EIF_OUTPUT_DIR: target/tempo-zone-prover-eif
+        run: |
+          set -Eeuo pipefail
+
+          mkdir -p "$EIF_OUTPUT_DIR"
+
+          docker run --rm \
+            --platform linux/amd64 \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "$PWD/$EIF_OUTPUT_DIR:/output" \
+            "$EIF_BUILDER_IMAGE" \
+            build-enclave \
+            --docker-uri "$PROVER_IMAGE" \
+            --output-file /output/tempo-zone-prover.eif \
+            | tee "$EIF_OUTPUT_DIR/measurements.json"
+
+      - name: Build and push tempo-zone-prover
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: |
+            docker/docker-bake.hcl
+            ${{ steps.meta-tempo-zone-prover.outputs.bake-file }}
+          targets: tempo-zone-prover
+          project: 0c6tg19qsp
+          push: >-
+            ${{ github.repository == 'tempoxyz/zones' &&
+                github.event_name != 'pull_request' &&
+                github.event_name != 'merge_group' }}
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
+
+      - name: Upload tempo-zone-prover PCR measurements
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tempo-zone-prover-measurements-${{ steps.shortsha.outputs.shortsha }}
+          path: target/tempo-zone-prover-eif/measurements.json
+          if-no-files-found: error
 
       - name: Publish Zones CI event
         if: >-

--- a/bin/prover/enclave/README.md
+++ b/bin/prover/enclave/README.md
@@ -33,22 +33,48 @@ Set `SPF_TEMPO_GENESIS` to a comma-separated list or pass `--tempo-genesis` repe
 Tempo genesis JSON files. Each custom chain ID must be unique and cannot override a built-in Tempo
 network.
 
-## Image and EIF
+## Images and EIF
 
-Build the OCI image with:
+The published `ghcr.io/tempoxyz/tempo-zone-prover` image is the Nitro host image to run on an
+enclave-enabled node. It contains the enclave EIF, Nitro CLI, and the TCP-to-vsock proxy. The
+enclave payload is an intermediate image and is not published separately.
 
-```console
-docker buildx bake tempo-zone-prover
-```
-
-Release images are published as `ghcr.io/tempoxyz/tempo-zone-prover`. Resolve an immutable image
-digest and convert it to an Enclave Image File on Linux with the Nitro CLI:
+To build the same artifacts locally, first load the payload into the local Docker image store:
 
 ```console
-nitro-cli build-enclave \
-  --docker-uri ghcr.io/tempoxyz/tempo-zone-prover@sha256:<digest> \
-  --output-file tempo-zone-prover.eif
+docker buildx bake \
+  --load \
+  --set tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:local \
+  tempo-zone-prover-enclave
 ```
 
-Retain the PCR measurements printed by `build-enclave` for future attestation policy. Attestation
-exchange and the parent-side vsock client are intentionally outside this service.
+Convert the payload to an EIF with the repository's pinned Nitro CLI builder image, then build the
+host image:
+
+```console
+docker buildx bake \
+  --load \
+  --set tempo-zone-prover-eif-builder.tags=tempo-zone-prover-eif-builder:local \
+  tempo-zone-prover-eif-builder
+mkdir -p target/tempo-zone-prover-eif
+docker run --rm \
+  --platform linux/amd64 \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume "$PWD/target/tempo-zone-prover-eif:/output" \
+  tempo-zone-prover-eif-builder:local \
+  build-enclave \
+  --docker-uri tempo-zone-prover-enclave:local \
+  --output-file /output/tempo-zone-prover.eif \
+  | tee target/tempo-zone-prover-eif/measurements.json
+docker buildx bake \
+  --load \
+  --set tempo-zone-prover.tags=tempo-zone-prover:local \
+  tempo-zone-prover
+```
+
+The EIF and PCR measurements are written under `target/tempo-zone-prover-eif/`. CI embeds the EIF
+in the published image and uploads the measurements as a commit-specific workflow artifact.
+
+The host image launches the enclave in non-debug mode and exposes TCP port `5000`. It accepts
+`PROVER_EIF_PATH`, `ENCLAVE_NAME`, `ENCLAVE_CPU_COUNT`, `ENCLAVE_MEMORY_MIB`, `ENCLAVE_CID`,
+`PROVER_TCP_PORT`, `PROVER_VSOCK_PORT`, and `MONITOR_INTERVAL_SECONDS` as runtime configuration.

--- a/docker/Dockerfile.prover-host
+++ b/docker/Dockerfile.prover-host
@@ -27,11 +27,11 @@ RUN install -m 0664 -o root -g "${PROVER_GID}" /dev/null /var/log/nitro_enclaves
 
 WORKDIR /opt/tempo-zone-prover
 COPY --from=proxy-builder /build/target/release/tempo-vsock-proxy /usr/local/bin/tempo-vsock-proxy
-COPY artifacts/tempo-zone-prover.eif /opt/tempo-zone-prover/tempo-zone-prover.eif
-COPY scripts/run.sh /opt/tempo-zone-prover/run.sh
+COPY --from=prover-eif /tempo-zone-prover.eif /opt/tempo-zone-prover/tempo-zone-prover.eif
+COPY scripts/run-prover-host.sh /opt/tempo-zone-prover/run-prover-host.sh
 
 EXPOSE 5000
 
 USER ${PROVER_UID}:${PROVER_GID}
 
-ENTRYPOINT ["/opt/tempo-zone-prover/run.sh"]
+ENTRYPOINT ["/opt/tempo-zone-prover/run-prover-host.sh"]

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -6,8 +6,12 @@ variable "VERGEN_GIT_SHA_SHORT" {
   default = ""
 }
 
+variable "PROVER_EIF_CONTEXT" {
+  default = "./target/tempo-zone-prover-eif"
+}
+
 group "default" {
-  targets = ["tempo-zone", "tempo-zone-prover", "tempo-zone-xtask"]
+  targets = ["tempo-zone", "tempo-zone-xtask"]
 }
 
 target "docker-metadata" {}
@@ -53,8 +57,7 @@ target "tempo-zone" {
   target = "tempo-zone"
 }
 
-target "tempo-zone-prover" {
-  inherits = ["docker-metadata"]
+target "tempo-zone-prover-enclave" {
   dockerfile = "docker/Dockerfile.prover-enclave"
   context = "."
   contexts = {
@@ -63,6 +66,24 @@ target "tempo-zone-prover" {
   args = {
     CHEF_IMAGE = "chef"
     RUST_PROFILE = "release"
+  }
+  platforms = ["linux/amd64"]
+}
+
+target "tempo-zone-prover-eif-builder" {
+  dockerfile = "docker/Dockerfile.prover-eif-builder"
+  context = "."
+  platforms = ["linux/amd64"]
+}
+
+# The EIF is generated from tempo-zone-prover-enclave before this target is
+# built because Nitro CLI requires access to a local Docker image store.
+target "tempo-zone-prover" {
+  inherits = ["docker-metadata"]
+  dockerfile = "docker/Dockerfile.prover-host"
+  context = "."
+  contexts = {
+    prover-eif = "${PROVER_EIF_CONTEXT}"
   }
   platforms = ["linux/amd64"]
 }

--- a/scripts/run-prover-host.sh
+++ b/scripts/run-prover-host.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# Supervises the Nitro enclave and its TCP-to-vsock proxy.
+set -Eeuo pipefail
+
+EIF_PATH="${PROVER_EIF_PATH:-/opt/tempo-zone-prover/tempo-zone-prover.eif}"
+ENCLAVE_NAME="${ENCLAVE_NAME:-tempo-zone-prover}"
+ENCLAVE_CPU_COUNT="${ENCLAVE_CPU_COUNT:-2}"
+ENCLAVE_MEMORY_MIB="${ENCLAVE_MEMORY_MIB:-512}"
+ENCLAVE_CID="${ENCLAVE_CID:-16}"
+TCP_PORT="${PROVER_TCP_PORT:-5000}"
+VSOCK_PORT="${PROVER_VSOCK_PORT:-5000}"
+MONITOR_INTERVAL_SECONDS="${MONITOR_INTERVAL_SECONDS:-30}"
+
+enclave_id=""
+proxy_pid=""
+
+# Invoked by the EXIT trap below.
+# shellcheck disable=SC2329
+cleanup() {
+    local status=$?
+
+    trap - EXIT INT TERM
+
+    if [[ -n "${proxy_pid}" ]] && kill -0 "${proxy_pid}" 2>/dev/null; then
+        kill "${proxy_pid}" 2>/dev/null || true
+        wait "${proxy_pid}" 2>/dev/null || true
+    fi
+
+    if [[ -n "${enclave_id}" ]]; then
+        printf 'Terminating enclave %s\n' "${enclave_id}"
+        nitro-cli terminate-enclave --enclave-id "${enclave_id}" >/dev/null 2>&1 || true
+    fi
+
+    exit "${status}"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [[ ! -f "${EIF_PATH}" ]]; then
+    printf 'Prover EIF not found: %s\n' "${EIF_PATH}" >&2
+    exit 1
+fi
+
+if [[ ! "${MONITOR_INTERVAL_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'MONITOR_INTERVAL_SECONDS must be a positive integer\n' >&2
+    exit 1
+fi
+
+printf 'Launching the Tempo Zone prover as a non-debug Nitro Enclave\n'
+set +e
+run_output="$(nitro-cli run-enclave \
+    --enclave-name "${ENCLAVE_NAME}" \
+    --cpu-count "${ENCLAVE_CPU_COUNT}" \
+    --memory "${ENCLAVE_MEMORY_MIB}" \
+    --eif-path "${EIF_PATH}" \
+    --enclave-cid "${ENCLAVE_CID}" 2>&1)"
+nitro_status=$?
+set -e
+
+printf '%s\n' "${run_output}"
+if [[ "${nitro_status}" -ne 0 ]]; then
+    printf 'nitro-cli run-enclave failed\n' >&2
+    exit "${nitro_status}"
+fi
+
+if ! enclave_id="$(jq -Rser \
+    'capture("(?s)(?<json>\\{.*\\})").json | fromjson | .EnclaveID' \
+    <<<"${run_output}")"; then
+    printf 'nitro-cli returned no parseable EnclaveID\n' >&2
+    exit 1
+fi
+
+printf 'Tempo Zone prover enclave %s is running at CID %s on vsock port %s\n' \
+    "${enclave_id}" "${ENCLAVE_CID}" "${VSOCK_PORT}"
+
+/usr/local/bin/tempo-vsock-proxy "${TCP_PORT}" "${ENCLAVE_CID}" "${VSOCK_PORT}" &
+proxy_pid=$!
+printf 'Forwarding TCP port %s to enclave CID %s, vsock port %s with VMADDR_FLAG_TO_HOST\n' \
+    "${TCP_PORT}" "${ENCLAVE_CID}" "${VSOCK_PORT}"
+
+while kill -0 "${proxy_pid}" 2>/dev/null; do
+    if ! descriptions="$(nitro-cli describe-enclaves 2>&1)"; then
+        printf 'nitro-cli describe-enclaves failed:\n%s\n' "${descriptions}" >&2
+        exit 1
+    fi
+
+    if ! jq -e --arg enclave_id "${enclave_id}" \
+        'any(.[]; .EnclaveID == $enclave_id)' <<<"${descriptions}" >/dev/null; then
+        printf 'Enclave %s stopped unexpectedly\n' "${enclave_id}" >&2
+        exit 1
+    fi
+
+    sleep "${MONITOR_INTERVAL_SECONDS}"
+done
+
+wait "${proxy_pid}" || true
+printf 'TCP-to-vsock proxy exited unexpectedly\n' >&2
+exit 1


### PR DESCRIPTION
 ## Summary

Builds and publishes `ghcr.io/tempoxyz/tempo-zone-prover` as a deployable AWS Nitro host image.

The workflow now:
- builds the enclave payload as an internal image;
- converts it to an EIF using the pinned Nitro CLI builder;
- embeds the EIF and vsock proxy in the final prover image;
- uploads PCR measurements as a CI artifact.

The previous prover payload image is no longer published separately.