### PR TITLE
fix: ensure header timestamp matches L1 anchor

### DIFF
--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -908,6 +908,7 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
             number: header.number(),
             parent_hash: header.parent_hash(),
             timestamp: header.timestamp(),
+            timestamp_millis_part: header.timestamp_millis_part,
             beneficiary: header.beneficiary(),
             tempo_header_rlp,
             deposits,

--- a/crates/contracts/src/precompiles/tempo_state.rs
+++ b/crates/contracts/src/precompiles/tempo_state.rs
@@ -9,6 +9,7 @@ crate::sol! {
 
         error InvalidParentHash();
         error InvalidBlockNumber();
+        error InvalidTimestamp();
         error InvalidRlpData();
         error OnlyZoneInbox();
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -679,7 +679,10 @@ mod tests {
         .unwrap();
 
         let factory = ZoneEvmFactory::new(reader.clone(), portal);
-        let mut evm = factory.create_evm(db, EvmEnv::default());
+        let mut env = EvmEnv::<TempoHardfork, TempoBlockEnv>::default();
+        env.block_env.inner.timestamp = U256::from(child.inner.timestamp);
+        env.block_env.timestamp_millis_part = child.timestamp_millis_part;
+        let mut evm = factory.create_evm(db, env);
         let calldata = IZoneInbox::advanceTempoCall {
             header: Bytes::from(child_rlp),
             deposits: Vec::new(),

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -10,6 +10,7 @@ use std::{net::TcpListener, time::Duration};
 use alloy::primitives::{Address, B256, Bytes, TxKind, U256, address};
 use alloy_consensus::Transaction;
 use alloy_eips::NumHash;
+use alloy_network::ReceiptResponse;
 use alloy_provider::{DynProvider, Provider};
 use alloy_rpc_types_eth::TransactionRequest;
 use alloy_sol_types::SolCall;

--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -10,6 +10,8 @@
 use std::time::Duration;
 
 use alloy::primitives::{U256, address};
+use alloy_consensus::BlockHeader;
+use alloy_network::ReceiptResponse;
 use alloy_provider::Provider;
 use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::ITIP20;
@@ -100,7 +102,7 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     let b_producer = cluster.sequencer_signers[replacement_index].address();
     for height in recovery_start_tempo_block..=optimistic_tip {
         assert_eq!(
-            cluster.assert_same_block(height).await?.beneficiary,
+            cluster.assert_same_block(height).await?.beneficiary(),
             b_producer,
             "replacement leader B did not optimistically produce recovery block {height}"
         );
@@ -138,7 +140,7 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
         cluster
             .assert_same_block(portal_activation_tempo_block)
             .await?
-            .beneficiary,
+            .beneficiary(),
         c_producer,
         "portal-selected leader C did not produce the transition block"
     );
@@ -154,7 +156,7 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     let next_height = portal_activation_tempo_block + 1;
     cluster.wait_all_at(next_height, HANDOFF_TIMEOUT).await?;
     assert_eq!(
-        cluster.assert_same_block(next_height).await?.beneficiary,
+        cluster.assert_same_block(next_height).await?.beneficiary(),
         c_producer
     );
     Ok(())
@@ -298,7 +300,8 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
             b_producer
         };
         assert_eq!(
-            header.beneficiary, expected,
+            header.beneficiary(),
+            expected,
             "block {height} has the wrong producer (boundary at {handoff_anchor})"
         );
     }
@@ -308,7 +311,7 @@ async fn test_planned_handoff_moves_production_at_exact_activation_boundary() ->
     let next = final_height + 1;
     cluster.wait_all_at(next, HANDOFF_TIMEOUT).await?;
     let header = cluster.assert_same_block(next).await?;
-    assert_eq!(header.beneficiary, b_producer);
+    assert_eq!(header.beneficiary(), b_producer);
 
     // Every node observes the included approval.
     for node in &cluster.nodes {
@@ -399,7 +402,8 @@ async fn test_lagged_follower_promotes_only_after_catching_up() -> eyre::Result<
             b_producer
         };
         assert_eq!(
-            header.beneficiary, expected,
+            header.beneficiary(),
+            expected,
             "block {height} has the wrong producer (boundary at {handoff_anchor})"
         );
     }
@@ -407,7 +411,10 @@ async fn test_lagged_follower_promotes_only_after_catching_up() -> eyre::Result<
     // B keeps producing; everyone follows.
     cluster.inject_block(vec![])?;
     cluster.wait_all_at(7, HANDOFF_TIMEOUT).await?;
-    assert_eq!(cluster.assert_same_block(7).await?.beneficiary, b_producer);
+    assert_eq!(
+        cluster.assert_same_block(7).await?.beneficiary(),
+        b_producer
+    );
     Ok(())
 }
 
@@ -526,7 +533,8 @@ async fn test_advance_scheduled_handoff_keeps_outgoing_leader_live() -> eyre::Re
             b_producer
         };
         assert_eq!(
-            header.beneficiary, expected,
+            header.beneficiary(),
+            expected,
             "block {height} has the wrong producer (boundary at {handoff_anchor})"
         );
     }

--- a/crates/node/tests/it/spf.rs
+++ b/crates/node/tests/it/spf.rs
@@ -100,7 +100,7 @@ async fn spf_batch_execute() -> eyre::Result<()> {
         .expect("second raw user transaction");
 
     let (state_root, zone_state_witness) = zone_state_witness(&genesis);
-    assert_eq!(state_root, genesis_block.header.state_root);
+    assert_eq!(state_root, genesis_block.header.state_root());
     let tempo_header = TempoHeader::default();
     let tempo_header_rlp = Bytes::from(alloy_rlp::encode(&tempo_header));
     let config = spf_config(&genesis);
@@ -121,10 +121,11 @@ async fn spf_batch_execute() -> eyre::Result<()> {
         },
         zone_blocks: vec![
             ZoneBlock {
-                number: first_built_block.header.number,
+                number: first_built_block.header.number(),
                 parent_hash,
-                timestamp: first_built_block.header.timestamp,
-                beneficiary: first_built_block.header.beneficiary,
+                timestamp: first_built_block.header.timestamp(),
+                timestamp_millis_part: first_built_block.header.timestamp_millis_part,
+                beneficiary: first_built_block.header.beneficiary(),
                 tempo_header_rlp: Bytes::from(alloy_rlp::encode(&first_tempo_block.header)),
                 deposits: vec![],
                 decryptions: vec![],
@@ -134,10 +135,11 @@ async fn spf_batch_execute() -> eyre::Result<()> {
                 transactions: vec![first_raw_transaction],
             },
             ZoneBlock {
-                number: second_built_block.header.number,
+                number: second_built_block.header.number(),
                 parent_hash: first_hash,
-                timestamp: second_built_block.header.timestamp,
-                beneficiary: second_built_block.header.beneficiary,
+                timestamp: second_built_block.header.timestamp(),
+                timestamp_millis_part: second_built_block.header.timestamp_millis_part,
+                beneficiary: second_built_block.header.beneficiary(),
                 tempo_header_rlp: Bytes::from(alloy_rlp::encode(&second_tempo_block.header)),
                 deposits: vec![],
                 decryptions: vec![],
@@ -268,6 +270,7 @@ struct BuiltTransactionBlock {
     genesis_state_root: B256,
     zone_number: u64,
     zone_timestamp: u64,
+    zone_timestamp_millis_part: u64,
     zone_beneficiary: Address,
     zone_hash: B256,
     tempo_header: TempoHeader,
@@ -299,6 +302,7 @@ impl BuiltTransactionBlock {
                 number: self.zone_number,
                 parent_hash,
                 timestamp: self.zone_timestamp,
+                timestamp_millis_part: self.zone_timestamp_millis_part,
                 beneficiary: self.zone_beneficiary,
                 tempo_header_rlp: Bytes::from(alloy_rlp::encode(&self.tempo_header)),
                 deposits: vec![],
@@ -374,10 +378,11 @@ async fn build_single_transaction_block(
         .await?;
 
     Ok(BuiltTransactionBlock {
-        genesis_state_root: genesis_block.header.state_root,
-        zone_number: built_block.header.number,
-        zone_timestamp: built_block.header.timestamp,
-        zone_beneficiary: built_block.header.beneficiary,
+        genesis_state_root: genesis_block.header.state_root(),
+        zone_number: built_block.header.number(),
+        zone_timestamp: built_block.header.timestamp(),
+        zone_timestamp_millis_part: built_block.header.timestamp_millis_part,
+        zone_beneficiary: built_block.header.beneficiary(),
         zone_hash: built_block.header.hash,
         tempo_header: l1_block.header,
         raw_user_transaction,

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -444,7 +444,7 @@ fn answer_portal_call(input: &[u8], enabled_tokens: &[Address]) -> Option<Vec<u8
 
 /// Helper to check TIP-403 authorization through the trusted operator RPC.
 pub(crate) struct Check403Registry {
-    pub(crate) provider: DynProvider,
+    pub(crate) provider: DynProvider<TempoNetwork>,
     pub(crate) token: Address,
 }
 
@@ -475,7 +475,8 @@ impl Check403Registry {
                 TransactionRequest::default()
                     .to(TIP403_REGISTRY_ADDRESS)
                     .from(Address::ZERO)
-                    .input(data.into()),
+                    .input(data.into())
+                    .into(),
             )
             .await
             .ok()
@@ -738,8 +739,8 @@ impl ZoneTestNode {
     }
 
     /// Returns an HTTP provider connected to this zone node.
-    pub(crate) fn provider(&self) -> alloy_provider::DynProvider {
-        ProviderBuilder::new()
+    pub(crate) fn provider(&self) -> alloy_provider::DynProvider<TempoNetwork> {
+        ProviderBuilder::new_with_network()
             .connect_http(self.http_url.clone())
             .erased()
     }
@@ -3685,11 +3686,8 @@ impl P2pCluster {
     }
 
     /// Assert every node holds the same block at `height` and return its header.
-    pub(crate) async fn assert_same_block(
-        &self,
-        height: u64,
-    ) -> eyre::Result<alloy_rpc_types_eth::Header> {
-        let mut reference: Option<alloy_rpc_types_eth::Header> = None;
+    pub(crate) async fn assert_same_block(&self, height: u64) -> eyre::Result<TempoHeaderResponse> {
+        let mut reference: Option<TempoHeaderResponse> = None;
         for (index, node) in self.nodes.iter().enumerate() {
             let block = node
                 .provider()
@@ -3730,11 +3728,8 @@ impl RealP2pCluster {
     }
 
     /// Assert all nodes have the same canonical block at `height`.
-    pub(crate) async fn assert_same_block(
-        &self,
-        height: u64,
-    ) -> eyre::Result<alloy_rpc_types_eth::Header> {
-        let mut reference: Option<alloy_rpc_types_eth::Header> = None;
+    pub(crate) async fn assert_same_block(&self, height: u64) -> eyre::Result<TempoHeaderResponse> {
+        let mut reference: Option<TempoHeaderResponse> = None;
         for (index, node) in self.nodes.iter().enumerate() {
             let block = node
                 .provider()

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -54,6 +54,16 @@ impl Harness {
         ctx.cfg.spec = TempoHardfork::T9;
         let genesis_rlp = encode_header(&TempoHeader::default());
         let genesis_hash = keccak256(&genesis_rlp);
+        let child_header = TempoHeader {
+            inner: alloy_consensus::Header {
+                parent_hash: genesis_hash,
+                number: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        ctx.block.inner.timestamp = U256::from(child_header.inner.timestamp);
+        ctx.block.timestamp_millis_part = child_header.timestamp_millis_part;
         {
             let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
             StorageCtx::enter(&mut storage, || -> eyre::Result<()> {

--- a/crates/precompiles/src/tempo_state.rs
+++ b/crates/precompiles/src/tempo_state.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_evm::precompiles::DynPrecompile;
-use alloy_primitives::{Address, B256, Bytes, keccak256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_rlp::Decodable as _;
 use alloy_sol_types::SolError;
 use revm::precompile::PrecompileResult;
@@ -86,8 +86,9 @@ impl TempoState {
 
     /// Validate and apply a finalized Tempo checkpoint transition.
     ///
-    /// IMPORTANT: this operation only enforces local continuity: the decoded block number must
-    /// increment by one and its parent hash must match the previously stored Tempo hash.
+    /// IMPORTANT: this operation only enforces local continuity and Zone-time alignment: the
+    /// decoded block number must increment by one, its parent hash must match the previously stored
+    /// Tempo hash, and its timestamp must exactly match the executing Zone block.
     ///
     /// Canonicality is a separate proof obligation: the batch proof must bind the imported header
     /// hash and state root to the canonical settlement anchor and authenticate every Tempo storage
@@ -108,6 +109,14 @@ impl TempoState {
         if !header_cursor.is_empty() {
             return Err(TempoStateError::invalid_rlp_data().into());
         }
+        self.storage.with_block_env(|zone_block| {
+            if zone_block.inner.timestamp != U256::from(header.timestamp())
+                || zone_block.timestamp_millis_part != header.timestamp_millis_part
+            {
+                return Err(TempoStateError::invalid_timestamp());
+            }
+            Ok(())
+        })?;
         if header.parent_hash() != prev_block_hash {
             return Err(TempoStateError::invalid_parent_hash().into());
         }
@@ -192,6 +201,7 @@ mod tests {
 
     struct TempoStateHarness {
         ctx: TestContext,
+        l1: L1State<MockL1Reader>,
         precompile: DynPrecompile,
     }
 
@@ -204,8 +214,17 @@ mod tests {
                 StorageCtx::enter(&mut storage, || TempoState::new().initialize(&encoded))?;
             }
             let l1 = L1State::new(MockL1Reader::default(), Address::ZERO);
-            let precompile = TempoState::create(l1, &test_env(&ctx));
-            Ok(Self { ctx, precompile })
+            let precompile = TempoState::create(l1.clone(), &test_env(&ctx));
+            Ok(Self {
+                ctx,
+                l1,
+                precompile,
+            })
+        }
+
+        fn set_block_timestamp(&mut self, header: &TempoHeader) {
+            self.ctx.block.inner.timestamp = U256::from(header.timestamp());
+            self.ctx.block.timestamp_millis_part = header.timestamp_millis_part;
         }
 
         fn call(
@@ -334,10 +353,49 @@ mod tests {
         let genesis_hash = keccak256(encode_header(&genesis));
         let mut harness = TempoStateHarness::new(&genesis)?;
         let child = child_header(genesis_hash, 1);
+        harness.set_block_timestamp(&child);
 
         let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
         assert!(output.is_success());
         harness.assert_checkpoint(keccak256(encode_header(&child)), 1)
+    }
+
+    #[test]
+    fn finalize_tempo_reverts_on_timestamp_seconds_mismatch() -> eyre::Result<()> {
+        let genesis = TempoHeader::default();
+        let genesis_hash = keccak256(encode_header(&genesis));
+        let mut harness = TempoStateHarness::new(&genesis)?;
+        let child = child_header(genesis_hash, 1);
+        harness.set_block_timestamp(&child);
+        harness.ctx.block.inner.timestamp += U256::ONE;
+
+        let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
+        assert!(output.is_revert());
+        assert_eq!(
+            output.bytes,
+            TempoStateAbi::InvalidTimestamp {}.abi_encode()
+        );
+        assert_eq!(harness.l1.get_anchor(), None);
+        harness.assert_checkpoint(genesis_hash, genesis.number())
+    }
+
+    #[test]
+    fn finalize_tempo_reverts_on_timestamp_millis_mismatch() -> eyre::Result<()> {
+        let genesis = TempoHeader::default();
+        let genesis_hash = keccak256(encode_header(&genesis));
+        let mut harness = TempoStateHarness::new(&genesis)?;
+        let child = child_header(genesis_hash, 1);
+        harness.set_block_timestamp(&child);
+        harness.ctx.block.timestamp_millis_part += 1;
+
+        let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
+        assert!(output.is_revert());
+        assert_eq!(
+            output.bytes,
+            TempoStateAbi::InvalidTimestamp {}.abi_encode()
+        );
+        assert_eq!(harness.l1.get_anchor(), None);
+        harness.assert_checkpoint(genesis_hash, genesis.number())
     }
 
     #[test]
@@ -418,11 +476,13 @@ mod tests {
         let genesis_hash = keccak256(encode_header(&genesis));
         let mut harness = TempoStateHarness::new(&genesis)?;
         let child = child_header(B256::ZERO, 1);
+        harness.set_block_timestamp(&child);
 
-        assert!(
-            harness
-                .finalize(ZONE_INBOX_ADDRESS, &child, false)?
-                .is_revert()
+        let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
+        assert!(output.is_revert());
+        assert_eq!(
+            output.bytes,
+            TempoStateAbi::InvalidParentHash {}.abi_encode()
         );
         harness.assert_checkpoint(genesis_hash, genesis.number())
     }
@@ -433,11 +493,13 @@ mod tests {
         let genesis_hash = keccak256(encode_header(&genesis));
         let mut harness = TempoStateHarness::new(&genesis)?;
         let child = child_header(genesis_hash, 2);
+        harness.set_block_timestamp(&child);
 
-        assert!(
-            harness
-                .finalize(ZONE_INBOX_ADDRESS, &child, false)?
-                .is_revert()
+        let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
+        assert!(output.is_revert());
+        assert_eq!(
+            output.bytes,
+            TempoStateAbi::InvalidBlockNumber {}.abi_encode()
         );
         harness.assert_checkpoint(genesis_hash, genesis.number())
     }

--- a/crates/sequencer/src/attestation.rs
+++ b/crates/sequencer/src/attestation.rs
@@ -305,7 +305,6 @@ impl AttestationStore {
 mod tests {
     use alloy_primitives::{Address, B256, U256, keccak256, uint};
     use alloy_signer_local::PrivateKeySigner;
-    use alloy_sol_types::{SolStruct as _, SolValue as _};
 
     use super::*;
 

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -503,6 +503,7 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
         number: header.number(),
         parent_hash: header.parent_hash(),
         timestamp: header.timestamp(),
+        timestamp_millis_part: header.timestamp_millis_part,
         beneficiary: header.beneficiary(),
         tempo_header_rlp,
         deposits,

--- a/crates/spf/src/execution/evm.rs
+++ b/crates/spf/src/execution/evm.rs
@@ -13,7 +13,6 @@ use alloy_evm::{
     eth::EthBlockExecutionCtx,
 };
 use alloy_primitives::{B256, Bytes, U256};
-use alloy_rlp::Decodable as _;
 use alloy_sol_types::{ContractError, SolCall as _, SolInterface as _};
 use reth_chainspec::EthereumHardforks as _;
 use reth_evm::{ConfigureEvm as _, NextBlockEnvAttributes};
@@ -171,13 +170,6 @@ pub(crate) fn next_block_env_attributes(
 ) -> Result<TempoNextBlockEnvAttributes, Error> {
     let block_gas_limit = parent.inner.gas_limit;
 
-    let mut encoded = block.tempo_header_rlp.as_ref();
-    let header = TempoHeader::decode(&mut encoded)
-        .map_err(|_| crate::WitnessDatabaseError::InvalidTempoHeader)?;
-    if !encoded.is_empty() {
-        return Err(crate::WitnessDatabaseError::InvalidTempoHeader.into());
-    }
-
     Ok(TempoNextBlockEnvAttributes {
         inner: NextBlockEnvAttributes {
             timestamp: block.timestamp,
@@ -195,7 +187,7 @@ pub(crate) fn next_block_env_attributes(
         },
         general_gas_limit: 0,
         shared_gas_limit: block_gas_limit,
-        timestamp_millis_part: header.timestamp_millis_part,
+        timestamp_millis_part: block.timestamp_millis_part,
         consensus_context: None,
         subblock_fee_recipients: HashMap::new(),
     })

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -727,6 +727,7 @@ mod tests {
             number: 1,
             parent_hash: witness.parent_header.hash_slow(),
             timestamp: 0,
+            timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
             tempo_header_rlp: Bytes::new(),
             deposits: Vec::new(),
@@ -1003,6 +1004,7 @@ mod tests {
             number: 1,
             parent_hash: witness.parent_header.hash_slow(),
             timestamp: 0,
+            timestamp_millis_part: 321,
             beneficiary: Address::ZERO,
             tempo_header_rlp: witness.tempo_state_witness.initial_tempo_header_rlp.clone(),
             deposits: Vec::new(),
@@ -1029,7 +1031,7 @@ mod tests {
             attributes.shared_gas_limit,
             witness.parent_header.inner.gas_limit
         );
-        assert_eq!(attributes.timestamp_millis_part, 0);
+        assert_eq!(attributes.timestamp_millis_part, 321);
 
         let tempo_database =
             TempoWitnessDatabase::from_tempo_state_witness(witness.tempo_state_witness.clone())
@@ -1061,6 +1063,7 @@ mod tests {
             number: 1,
             parent_hash: witness.parent_header.hash_slow(),
             timestamp: 0,
+            timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
             tempo_header_rlp: Bytes::from([0x01]),
             deposits: Vec::new(),
@@ -1081,6 +1084,7 @@ mod tests {
             number: 1,
             parent_hash: witness.parent_header.hash_slow(),
             timestamp: 0,
+            timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
             tempo_header_rlp: Bytes::from([0x01]),
             deposits: Vec::new(),
@@ -1109,6 +1113,7 @@ mod tests {
             number: 1,
             parent_hash: witness.parent_header.hash_slow(),
             timestamp: 0,
+            timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
             tempo_header_rlp: Bytes::from([0x01]),
             deposits: Vec::new(),

--- a/crates/spf/src/types.rs
+++ b/crates/spf/src/types.rs
@@ -98,6 +98,7 @@ pub struct ZoneBlock {
     pub number: u64,
     pub parent_hash: B256,
     pub timestamp: u64,
+    pub timestamp_millis_part: u64,
     pub beneficiary: Address,
     /// RLP-encoded Tempo header passed to `ZoneInbox.advanceTempo`.
     pub tempo_header_rlp: Bytes,

--- a/specs/ref-impls/src/interfaces/IZone.sol
+++ b/specs/ref-impls/src/interfaces/IZone.sol
@@ -1030,6 +1030,7 @@ interface ITempoState {
 
     error InvalidParentHash();
     error InvalidBlockNumber();
+    error InvalidTimestamp();
     error InvalidRlpData();
     error OnlyZoneInbox();
 
@@ -1040,7 +1041,7 @@ interface ITempoState {
     function tempoBlockNumber() external view returns (uint64);
 
     /// @notice Finalize a Tempo block header. Only callable by ZoneInbox.
-    /// @dev Validates chain continuity (parent hash must match, number must be +1).
+    /// @dev Validates chain continuity and exact timestamp alignment with the Zone block.
     ///      Called by ZoneInbox.advanceTempo(). Executor enforces ZoneInbox-only access.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external;

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -843,7 +843,7 @@ Sequencers MUST NOT use uncertified follow mode (`--follow.nocertify`) or a gene
 
 ### Header Finalization
 
-`ZoneInbox.advanceTempo()` calls `TempoState.finalizeTempo(header)` to advance the zone's view of Tempo. This function decodes the RLP header, validates chain continuity (parent hash must match the previous finalized header, block number must increment by one), stores the new checkpoint, and emits the decoded state root in `TempoBlockFinalized`.
+`ZoneInbox.advanceTempo()` calls `TempoState.finalizeTempo(header)` to advance the zone's view of Tempo. This function decodes the RLP header, requires its timestamp (seconds and millisecond component) to exactly match the executing zone block, validates chain continuity (parent hash must match the previous finalized header, block number must increment by one), stores the new checkpoint, and emits the decoded state root in `TempoBlockFinalized`.
 
 Canonical deployed Zones start with the nonzero pre-portal Tempo checkpoint recorded in genesis. Their first import begins with its immediate child—the portal-creation block—and ordinary parent-hash and consecutive-number validation applies from that block onward. The standalone zero-hash genesis template MUST be anchored before use and MUST NOT bootstrap a deployed portal from an arbitrary later snapshot.
 
@@ -1059,7 +1059,7 @@ The witness contains everything needed to re-execute the batch:
 
 - **PublicInputs**: `parent_chain_id`, `zone_id`, `prev_block_hash`, `tempo_block_number`, `anchor_block_number`, `anchor_block_hash`, `expected_withdrawal_batch_index`, `sequencer`. The verifier binds `parent_chain_id` to the L1 execution environment's chain ID; the portal supplies the remaining values, and the proof must be consistent with them.
 - **BatchWitness**: the public inputs, the parent header, the zone blocks to execute, the initial zone state, the Tempo state witness, and Tempo ancestry headers (for ancestry validation).
-- **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `beneficiary`, `protocol_version`, `tempo_header_rlp` (optional), `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
+- **ZoneBlock**: `number`, `parent_hash`, `timestamp`, `timestamp_millis_part`, `beneficiary`, `protocol_version`, `tempo_header_rlp` (optional), `deposits`, `decryptions`, `enabled_tokens`, `finalize_withdrawal_batch_count` (optional), `finalize_withdrawal_batch_encrypted_senders`, and user `transactions`.
 - **ZoneStateWitness**: a deduplicated pool of zone-state trie nodes and a bytecode pool. Account and storage values are decoded directly from trie leaves; the initial state root comes from the parent header. The witness includes EIP-2935 history-contract slots used by `BLOCKHASH`. Missing witness data must produce an error, not default to zero, to prevent the prover from omitting non-zero state.
 - **TempoStateWitness**: the RLP-encoded Tempo header for the checkpoint already bound in the parent zone state and a deduplicated pool of Tempo-state trie nodes. The header supplies the authenticated initial Tempo state root for L1 storage reads.
 
@@ -1078,7 +1078,7 @@ flowchart TB
 
         subgraph ZBL["zone_blocks"]
             direction TB
-            ZB["ZoneBlock[i]<br/>number<br/>parent_hash<br/>timestamp<br/>beneficiary<br/>tempo_header_rlp<br/>enabled_tokens<br/>finalize_withdrawal_batch_count<br/>finalize_withdrawal_batch_encrypted_senders<br/>transactions"]
+            ZB["ZoneBlock[i]<br/>number<br/>parent_hash<br/>timestamp<br/>timestamp_millis_part<br/>beneficiary<br/>tempo_header_rlp<br/>enabled_tokens<br/>finalize_withdrawal_batch_count<br/>finalize_withdrawal_batch_encrypted_senders<br/>transactions"]
 
             subgraph DEP["deposits"]
                 direction TB
@@ -1191,6 +1191,9 @@ pub struct ZoneBlock {
 
     /// Timestamp
     pub timestamp: u64,
+
+    /// Millisecond component of the timestamp
+    pub timestamp_millis_part: u64,
 
     /// Beneficiary (must match registered sequencer)
     pub beneficiary: Address,
@@ -1325,7 +1328,7 @@ The stateless execution function must reject the witness on any failed check, mi
    In the bootstrap proof, require at least two blocks. Require every field of `zone_blocks[0]` to equal the canonical genesis block derived from `(public_inputs.parent_chain_id, public_inputs.zone_id)`, including `chain_id = zone_chain_id(parent_chain_id, zone_id)` under the rules in [Chain ID](#chain-id); its parent hash is zero and it contains no user or system transactions. Apply the ordinary block rules to every remaining bootstrap block and to every block in an ordinary batch: require `block.parent_hash == prev_block_hash`, `block.number == prev_header.number + 1`, `block.timestamp >= prev_header.timestamp`, `block.beneficiary == public_inputs.sequencer`, and `tempo_header_rlp` to be present. Require `finalize_withdrawal_batch_count` to be absent in the genesis block and all intermediate blocks, and present in the final block of a batch. If `finalize_withdrawal_batch_count` is absent, require `finalize_withdrawal_batch_encrypted_senders` to be empty. If it is present, require the encrypted-sender array length to equal `count`.
 
 5. **Execute `advanceTempo` if the block imports a Tempo header.**
-   If `tempo_header_rlp` is present, call `TempoState.finalizeTempo(header)` in the modeled execution environment. This validates header continuity, updates the bound `tempoBlockNumber` and `tempoBlockHash`, and makes the imported header's state root available for subsequent `TempoState.readTempoStorageSlot` calls in this block. Require the finalized `tempoBlockHash` to equal `keccak256(tempo_header_rlp)`, then replace the active Tempo trie root with the `state_root` decoded from that header. If `tempo_header_rlp` is absent, retain the active root from the previous Tempo checkpoint.
+   If `tempo_header_rlp` is present, call `TempoState.finalizeTempo(header)` in the modeled execution environment. This requires the imported Tempo header's timestamp and millisecond component to exactly match the zone block, validates header continuity, updates the bound `tempoBlockNumber` and `tempoBlockHash`, and makes the imported header's state root available for subsequent `TempoState.readTempoStorageSlot` calls in this block. Require the finalized `tempoBlockHash` to equal `keccak256(tempo_header_rlp)`, then replace the active Tempo trie root with the `state_root` decoded from that header. If `tempo_header_rlp` is absent, retain the active root from the previous Tempo checkpoint.
 
 6. **Authenticate token enablements inside `advanceTempo`.**
    Using the now-bound Tempo root for this block, verify the portal's `tokenEnablementHash`. Execute `ZoneInbox.advanceTempo(header, deposits, decryptions, enabledTokens)` using `enabled_tokens` in the exact witness order. Starting from the pre-state `ZoneInbox.processedTokenEnablementHash`, apply the [token enablement commitment](#token-enablement-commitment) transition to each entry and require the result to equal the portal's `tokenEnablementHash` proven against the imported Tempo root. Reject omitted, extra, reordered, or modified entries. After equality is established, initialize each enabled token and its bridge roles, then update `processedTokenEnablementHash`. Token activation must complete before processing any deposit in the call.
@@ -1911,6 +1914,8 @@ Address: `0x1c00000000000000000000000000000000000000`
 ```solidity
 interface ITempoState {
     event TempoBlockFinalized(bytes32 indexed blockHash, uint64 indexed blockNumber, bytes32 stateRoot);
+
+    error InvalidTimestamp();
 
     function tempoBlockHash() external view returns (bytes32);
     function tempoBlockNumber() external view returns (uint64);


### PR DESCRIPTION
Changes `advanceTempo` to ensure that timestamp of zone block matches the L1 anchor timestamp.