### PR TITLE
feat(prover): embed devnet genesis in CI image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,17 @@ on:
         description: "Tag nightly"
         type: boolean
         default: false
+      tempo_genesis_url:
+        description: "Tempo genesis JSON URL to embed in the prover image"
+        type: string
+        default: "https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json"
   workflow_call:
+    inputs:
+      tempo_genesis_url:
+        description: "Tempo genesis JSON URL to embed in the prover image"
+        required: false
+        type: string
+        default: "https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json"
   schedule:
     - cron: "5 9 * * *"
     - cron: "30 20 * * *"
@@ -24,6 +34,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io/tempoxyz
+  TEMPO_DEVNET_GENESIS_URL: ${{ inputs.tempo_genesis_url || 'https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json' }}
 
 jobs:
   build-and-push:
@@ -112,6 +123,22 @@ jobs:
       - id: shortsha
         run: echo "shortsha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+      - name: Download Tempo devnet genesis
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tempo-genesis
+          curl --proto '=https' --tlsv1.2 \
+            --fail-with-body --location \
+            --output .tempo-genesis/genesis.json \
+            "$TEMPO_DEVNET_GENESIS_URL"
+          jq -e '.config.chainId | type == "number"' \
+            .tempo-genesis/genesis.json >/dev/null
+
+          genesis_sha=$(sha256sum .tempo-genesis/genesis.json | cut -d' ' -f1)
+          echo "Embedding Tempo devnet genesis sha256:${genesis_sha}"
+
       - name: Build and push Docker images
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
         with:
@@ -137,7 +164,9 @@ jobs:
         with:
           files: docker/docker-bake.hcl
           targets: tempo-zone-prover-enclave
-          set: tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:eif-source
+          set: |
+            tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:eif-source
+            tempo-zone-prover-enclave.contexts.tempo-genesis=.tempo-genesis
           project: 0c6tg19qsp
           load: true
           no-cache: ${{ github.event_name == 'schedule' }}

--- a/bin/prover/enclave/README.md
+++ b/bin/prover/enclave/README.md
@@ -22,16 +22,16 @@ Requests use this envelope:
 ```
 
 `witness` is the serde representation of `zone_spf::BatchWitness`. The prover accepts chain IDs
-compiled into Tempo plus custom genesis files configured by the enclave operator through repeated
-`--tempo-genesis` arguments. A request cannot supply its own chain specification. Responses have
+compiled into Tempo plus custom genesis files configured by the enclave operator through a
+`--tempo-genesis` directory. A request cannot supply its own chain specification. Responses have
 `status: "ok"` with a `zone_spf::BatchOutput`, or `status: "error"` with a stable `code` and a
 diagnostic `message`.
 
 Set `SPF_VSOCK_PORT` or pass `--port` to change the port. The maximum request payload defaults to
 512 MiB and can be changed with `SPF_MAX_REQUEST_BYTES` or `--max-request-bytes`.
-Set `SPF_TEMPO_GENESIS` to a comma-separated list or pass `--tempo-genesis` repeatedly for trusted
-Tempo genesis JSON files. Each custom chain ID must be unique and cannot override a built-in Tempo
-network.
+Set `SPF_TEMPO_GENESIS` or pass `--tempo-genesis` with a directory containing trusted Tempo genesis
+JSON files. Files are loaded in filename order. Each custom chain ID must be unique and cannot
+override a built-in Tempo network.
 
 ## Images and EIF
 
@@ -47,6 +47,9 @@ docker buildx bake \
   --set tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:local \
   tempo-zone-prover-enclave
 ```
+
+CI supplies the downloaded devnet genesis as a named build context. The enclave payload stores it
+in `/etc/tempo/genesis/` and exposes that directory to the prover through `SPF_TEMPO_GENESIS`.
 
 Convert the payload to an EIF with the repository's pinned Nitro CLI builder image, then build the
 host image:

--- a/bin/prover/enclave/src/main.rs
+++ b/bin/prover/enclave/src/main.rs
@@ -7,8 +7,6 @@ use tempo_zone_prover_enclave::{DEFAULT_MAX_REQUEST_BYTES, DEFAULT_VSOCK_PORT, T
 use tracing::error;
 use tracing_subscriber::EnvFilter;
 
-const EMBEDDED_TEMPO_GENESIS: &str = "/etc/tempo/genesis/genesis.json";
-
 #[tokio::main]
 async fn main() -> ExitCode {
     tracing_subscriber::fmt()
@@ -47,14 +45,9 @@ struct Cli {
     )]
     max_request_bytes: usize,
 
-    /// Trusted custom Tempo genesis JSON file. May be specified more than once.
-    #[arg(
-        long,
-        env = "SPF_TEMPO_GENESIS",
-        value_name = "PATH",
-        value_delimiter = ','
-    )]
-    tempo_genesis: Vec<PathBuf>,
+    /// Directory containing trusted custom Tempo genesis JSON files.
+    #[arg(long, env = "SPF_TEMPO_GENESIS", value_name = "DIR")]
+    tempo_genesis: Option<PathBuf>,
 }
 
 impl Cli {
@@ -78,11 +71,17 @@ impl Cli {
 
     fn load_trusted_chain_specs(&self) -> io::Result<TrustedChainSpecs> {
         let mut specs = TrustedChainSpecs::default();
-        let mut paths = self.tempo_genesis.clone();
-        let embedded = PathBuf::from(EMBEDDED_TEMPO_GENESIS);
-        if embedded.is_file() && !paths.contains(&embedded) {
-            paths.push(embedded);
-        }
+        let Some(directory) = &self.tempo_genesis else {
+            return Ok(specs);
+        };
+        let mut paths = std::fs::read_dir(directory)?
+            .map(|entry| entry.map(|entry| entry.path()))
+            .collect::<io::Result<Vec<_>>>()?;
+        paths.retain(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "json")
+        });
+        paths.sort();
 
         for path in paths {
             let raw = std::fs::read(&path)?;

--- a/docker/Dockerfile.prover-enclave
+++ b/docker/Dockerfile.prover-enclave
@@ -19,6 +19,8 @@ FROM scratch AS tempo-genesis
 
 FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
 
+ENV SPF_TEMPO_GENESIS="/etc/tempo/genesis"
+
 COPY --from=tempo-genesis / /etc/tempo/genesis/
 
 WORKDIR /data


### PR DESCRIPTION
## Summary

Download the Tempo devnet genesis during CI image builds from a configurable URL, defaulting to `https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json`. The genesis is embedded in the prover image through the existing tempo-genesis build context.