### PR TITLE
fix(prover): pass Tempo genesis to enclave explicitly

### DIFF
--- a/bin/prover/enclave/README.md
+++ b/bin/prover/enclave/README.md
@@ -51,7 +51,8 @@ docker buildx bake \
 ```
 
 CI supplies the downloaded devnet genesis as a named build context. The enclave payload stores it
-in `/etc/tempo/genesis/` and exposes that directory to the prover through `SPF_TEMPO_GENESIS`.
+in `/etc/tempo/genesis/` and passes that directory to the prover explicitly through the image
+entrypoint.
 
 Convert the payload to an EIF with the repository's pinned Nitro CLI builder image, then build the
 host image:

--- a/docker/Dockerfile.prover-enclave
+++ b/docker/Dockerfile.prover-enclave
@@ -27,4 +27,4 @@ WORKDIR /data
 COPY --from=builder /app/target/release/tempo-zone-prover-enclave /usr/local/bin/tempo-zone-prover-enclave
 
 USER 65532:65532
-ENTRYPOINT ["/usr/local/bin/tempo-zone-prover-enclave"]
+ENTRYPOINT ["/usr/local/bin/tempo-zone-prover-enclave", "--tempo-genesis", "/etc/tempo/genesis"]

--- a/docker/Dockerfile.prover-enclave
+++ b/docker/Dockerfile.prover-enclave
@@ -19,8 +19,6 @@ FROM scratch AS tempo-genesis
 
 FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
 
-ENV SPF_TEMPO_GENESIS="/etc/tempo/genesis"
-
 COPY --from=tempo-genesis / /etc/tempo/genesis/
 
 WORKDIR /data


### PR DESCRIPTION
## Summary

Pass `--tempo-genesis /etc/tempo/genesis` explicitly in the prover enclave entrypoint.