### PR TITLE
fix(test): configure Earn policy at deployment

### DIFF
--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -372,6 +372,18 @@ impl EarnZoneFixture {
                 excessFeeRateBps: Default::default(),
             },
         };
+        let access_policy = if protected {
+            let whitelist_id = l1.create_whitelist_policy().await?;
+            let compound_id = l1
+                .create_compound_policy(1, whitelist_id, whitelist_id)
+                .await?;
+            Some(EarnAccessPolicy {
+                compound_id,
+                whitelist_id,
+            })
+        } else {
+            None
+        };
         let params = EarnDeployParams {
             deploymentId: keccak256("zones-earn-e2e-v1"),
             engine,
@@ -387,7 +399,7 @@ impl EarnZoneFixture {
                 updateDelay: Default::default(),
             },
             fees,
-            transferPolicyId: 0,
+            transferPolicyId: access_policy.map_or(0, |policy| policy.compound_id),
         };
 
         let provider = l1.dev_provider();
@@ -515,8 +527,7 @@ impl EarnZoneFixture {
         )
         .await?;
 
-        let access_policy = if protected {
-            let whitelist_id = l1.create_whitelist_policy().await?;
+        if let Some(policy) = access_policy {
             let outsider = l1.signer_at(3).address();
             for account in [
                 earn_vault,
@@ -528,20 +539,9 @@ impl EarnZoneFixture {
                 user_address,
                 outsider,
             ] {
-                l1.whitelist_address(whitelist_id, account).await?;
+                l1.whitelist_address(policy.whitelist_id, account).await?;
             }
-            let compound_id = l1
-                .create_compound_policy(1, whitelist_id, whitelist_id)
-                .await?;
-            l1.change_transfer_policy_id(earn_share, compound_id)
-                .await?;
-            Some(EarnAccessPolicy {
-                compound_id,
-                whitelist_id,
-            })
-        } else {
-            None
-        };
+        }
 
         l1.enable_token_on_portal(portal, vault_asset).await?;
         l1.enable_token_on_portal(portal, alternate_asset).await?;

--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -1244,6 +1244,39 @@ impl EarnZoneFixture {
         u256_to_u128(returned, "assets returned by Zone redemption")
     }
 
+    async fn simulate_zone_redeem_as(
+        &self,
+        account: &mut ZoneAccount,
+        shares: u128,
+        output_token: Address,
+        recipient: Address,
+    ) -> eyre::Result<()> {
+        let limits = self.redeem_limits(shares, output_token).await?;
+        let data = self
+            .callback_data(
+                EarnFlow::Redeem,
+                output_token,
+                recipient,
+                account.address(),
+                limits,
+            )
+            .await?;
+        account
+            .simulate_withdraw_token_with(
+                self.earn_share,
+                WithdrawalArgs {
+                    amount: shares,
+                    to: Some(self.router),
+                    memo: B256::ZERO,
+                    gas_limit: CALLBACK_GAS_LIMIT,
+                    zone_fallback_recipient: Some(account.address()),
+                    data,
+                    reveal_to: Bytes::new(),
+                },
+            )
+            .await
+    }
+
     async fn migrate_existing_vault_shares(&mut self) -> eyre::Result<u128> {
         let user = self.user.address();
         let provider = self.user.l1_provider();
@@ -1661,7 +1694,7 @@ async fn zone_removed_private_holder_is_blocked_until_reauthorized() -> eyre::Re
     );
     fixture.set_access_eligibility(outsider, false).await?;
     let redeem = fixture
-        .zone_redeem_as(
+        .simulate_zone_redeem_as(
             &mut outsider_account,
             outsider_shares,
             fixture.alternate_asset,

--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -265,8 +265,7 @@ impl Default for EarnLimits {
 
 #[derive(Clone, Copy)]
 struct EarnAccessPolicy {
-    compound_id: u64,
-    whitelist_id: u64,
+    policy_id: u64,
 }
 
 struct EarnZoneFixture {
@@ -373,13 +372,8 @@ impl EarnZoneFixture {
             },
         };
         let access_policy = if protected {
-            let whitelist_id = l1.create_whitelist_policy().await?;
-            let compound_id = l1
-                .create_compound_policy(1, whitelist_id, whitelist_id)
-                .await?;
             Some(EarnAccessPolicy {
-                compound_id,
-                whitelist_id,
+                policy_id: l1.create_whitelist_policy().await?,
             })
         } else {
             None
@@ -399,7 +393,7 @@ impl EarnZoneFixture {
                 updateDelay: Default::default(),
             },
             fees,
-            transferPolicyId: access_policy.map_or(0, |policy| policy.compound_id),
+            transferPolicyId: access_policy.map_or(0, |policy| policy.policy_id),
         };
 
         let provider = l1.dev_provider();
@@ -539,7 +533,7 @@ impl EarnZoneFixture {
                 user_address,
                 outsider,
             ] {
-                l1.whitelist_address(policy.whitelist_id, account).await?;
+                l1.whitelist_address(policy.policy_id, account).await?;
             }
         }
 
@@ -587,7 +581,7 @@ impl EarnZoneFixture {
             .ok_or_else(|| eyre::eyre!("Earn access policy is not configured"))?;
         let provider = self.l1.dev_provider();
         let receipt = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider)
-            .modifyPolicyWhitelist(policy.whitelist_id, account, eligible)
+            .modifyPolicyWhitelist(policy.policy_id, account, eligible)
             .send()
             .await?
             .get_receipt()
@@ -607,7 +601,7 @@ impl EarnZoneFixture {
         eyre::ensure!(
             recipient_authorized == eligible,
             "Zone did not mirror Earn recipient eligibility for policy {} and {account}: actual={recipient_authorized}, expected={eligible}",
-            policy.compound_id
+            policy.policy_id
         );
         Ok(())
     }

--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -1640,7 +1640,7 @@ async fn zone_ineligible_private_transfer_blocked() -> eyre::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn zone_removed_private_holder_can_exit() -> eyre::Result<()> {
+async fn zone_removed_private_holder_is_blocked_until_reauthorized() -> eyre::Result<()> {
     let mut fixture = EarnZoneFixture::start_protected().await?;
     let outsider_signer = fixture.l1.signer_at(3);
     let outsider = outsider_signer.address();
@@ -1660,6 +1660,28 @@ async fn zone_removed_private_holder_can_exit() -> eyre::Result<()> {
         "eligible private outsider received no EarnShare"
     );
     fixture.set_access_eligibility(outsider, false).await?;
+    let redeem = fixture
+        .zone_redeem_as(
+            &mut outsider_account,
+            outsider_shares,
+            fixture.alternate_asset,
+            outsider,
+        )
+        .await;
+    eyre::ensure!(
+        redeem.is_err(),
+        "removed private holder unexpectedly exited while ineligible"
+    );
+    assert_eq!(
+        fixture
+            .zone
+            .balance_of(fixture.earn_share, outsider)
+            .await?,
+        U256::from(outsider_shares),
+        "rejected exit changed the removed holder's EarnShare balance"
+    );
+
+    fixture.set_access_eligibility(outsider, true).await?;
     let outsider_output = fixture
         .zone_redeem_as(
             &mut outsider_account,
@@ -1670,7 +1692,7 @@ async fn zone_removed_private_holder_can_exit() -> eyre::Result<()> {
         .await?;
     assert_eq!(
         outsider_output, AMOUNT,
-        "removed private holder did not exit 1:1"
+        "re-authorized private holder did not exit 1:1"
     );
     assert_eq!(
         fixture

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3425,6 +3425,35 @@ impl ZoneAccount {
         Ok(())
     }
 
+    /// Approve the ZoneOutbox, then simulate a token withdrawal without submitting it.
+    pub(crate) async fn simulate_withdraw_token_with(
+        &mut self,
+        token: Address,
+        args: WithdrawalArgs,
+    ) -> eyre::Result<()> {
+        use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS};
+
+        self.approve_outbox(token).await?;
+
+        let to = args.to.unwrap_or(self.address);
+        let zone_fallback_recipient = args.zone_fallback_recipient.unwrap_or(self.address);
+        IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &self.l2_provider)
+            .requestWithdrawal(
+                token,
+                to,
+                args.amount,
+                args.memo,
+                args.gas_limit,
+                zone_fallback_recipient,
+                args.data,
+                args.reveal_to,
+            )
+            .from(self.address)
+            .call()
+            .await?;
+        Ok(())
+    }
+
     /// Approve the ZoneOutbox for a specific token, then request a withdrawal on L2.
     pub(crate) async fn withdraw_token(
         &mut self,


### PR DESCRIPTION
## Summary

- Create the protected Earn whitelist policy before deploying the Earn stack.
- Pass the supported simple-whitelist policy ID through `EarnDeployParams.transferPolicyId`.
- Populate whitelist membership after the remaining fixture addresses are available.
- Assert revoked private holders remain blocked until re-authorized, then verify their 1:1 exit.

This adapts the Zones fixture to [tempoxyz/earn#242](https://github.com/tempoxyz/earn/pull/242), which permanently relinquishes EarnShare administration during deployment.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test -p zone-node zone_removed_private_holder_is_blocked_until_reauthorized --no-run`
- Focused runtime verification runs in CI because the local Foundry build lacks Tempo T8 support.

Prompted by: @grandizzy
