### PR TITLE
feat: add `ZoneHardfork` plumbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13700,8 +13700,10 @@ dependencies = [
  "reth-chainspec",
  "reth-cli",
  "reth-network-peers",
+ "serde_json",
  "tempo-chainspec",
  "tempo-primitives",
+ "zone-hardfork",
 ]
 
 [[package]]
@@ -13710,6 +13712,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
@@ -13720,6 +13723,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-revm",
  "revm",
+ "serde_json",
  "tempo-alloy",
  "tempo-chainspec",
  "tempo-evm",
@@ -13731,9 +13735,18 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "zone-chainspec",
+ "zone-hardfork",
  "zone-l1",
  "zone-precompiles",
  "zone-primitives",
+]
+
+[[package]]
+name = "zone-hardfork"
+version = "0.1.0"
+dependencies = [
+ "alloy-hardforks",
+ "paste",
 ]
 
 [[package]]
@@ -13962,6 +13975,7 @@ dependencies = [
  "tempo-zone-contracts",
  "thiserror 2.0.18",
  "tracing",
+ "zone-hardfork",
  "zone-primitives",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/chainspec",
   "crates/contracts",
   "crates/evm",
+  "crates/hardfork",
   "crates/l1",
   "crates/node",
   "crates/p2p",
@@ -124,6 +125,7 @@ tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "495
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
 zone-chainspec = { path = "crates/chainspec" }
 zone-evm = { path = "crates/evm" }
+zone-hardfork = { path = "crates/hardfork", default-features = false }
 zone-l1 = { path = "crates/l1" }
 zone-node = { path = "crates/node" }
 zone-p2p = { path = "crates/p2p" }
@@ -182,6 +184,7 @@ revm = { version = "42.0.1", features = [
 # alloy
 alloy = { version = "2.3.0", default-features = false }
 alloy-chains = "0.2.36"
+alloy-hardforks = { version = "0.4.7", default-features = false }
 alloy-consensus = { version = "2.3.0", default-features = false }
 alloy-contract = { version = "2.3.0", default-features = false }
 alloy-eips = { version = "2.3.0", default-features = false }

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -11,8 +11,11 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+# zones
+zone-hardfork.workspace = true
+
 # tempo
-tempo-chainspec.workspace = true
+tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-primitives.workspace = true
 
 # reth
@@ -28,6 +31,7 @@ alloy-primitives.workspace = true
 
 # misc
 eyre = { workspace = true, optional = true }
+serde_json.workspace = true
 
 [features]
 default = []

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -17,21 +17,41 @@ use tempo_chainspec::{
     TempoChainSpec, TempoConsensusSpec, hardfork::TempoHardfork, spec::TempoHardforks,
 };
 use tempo_primitives::TempoHeader;
+pub use zone_hardfork::ZoneHardfork;
 
 /// Chain specification for a Tempo Zone.
 ///
+/// Zone, Tempo, and Ethereum activations all live in the underlying canonical hardfork schedule;
+/// the typed query traits keep the protocol axes independently addressable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZoneChainSpec {
-    /// Underlying Tempo chain specification.
+    /// Underlying Tempo chain specification, extended with Zone hardfork activations.
     pub inner: Arc<TempoChainSpec>,
+}
+
+/// Typed queries for Zone-owned hardfork activations.
+pub trait ZoneHardforks: TempoHardforks {
+    /// Returns the activation condition for a Zone-owned hardfork.
+    fn zone_fork_activation(&self, fork: ZoneHardfork) -> ForkCondition;
+
+    /// Returns the Zone-owned hardfork active at `timestamp`.
+    fn zone_hardfork_at(&self, timestamp: u64) -> ZoneHardfork {
+        ZoneHardfork::VARIANTS
+            .iter()
+            .rev()
+            .copied()
+            .find(|&fork| {
+                self.zone_fork_activation(fork)
+                    .active_at_timestamp(timestamp)
+            })
+            .unwrap_or(ZoneHardfork::Z0)
+    }
 }
 
 impl ZoneChainSpec {
     /// Converts a genesis configuration into a Zone chain specification.
     pub fn from_genesis(genesis: Genesis) -> Self {
-        Self {
-            inner: Arc::new(TempoChainSpec::from_genesis(genesis)),
-        }
+        Self::from(TempoChainSpec::from_genesis(genesis))
     }
 
     /// Applies Tempo hardfork activations from the parent chain.
@@ -45,19 +65,52 @@ impl ZoneChainSpec {
         }
         self
     }
-}
 
-impl From<TempoChainSpec> for ZoneChainSpec {
-    fn from(inner: TempoChainSpec) -> Self {
+    fn from_tempo(mut inner: TempoChainSpec) -> Self {
+        let z1_time = inner
+            .genesis()
+            .config
+            .extra_fields
+            .get("z1Time")
+            .and_then(parse_activation_timestamp);
+
+        inner
+            .inner
+            .hardforks
+            .insert(ZoneHardfork::Z0, ForkCondition::Timestamp(0));
+        if let Some(timestamp) = z1_time {
+            inner
+                .inner
+                .hardforks
+                .insert(ZoneHardfork::Z1, ForkCondition::Timestamp(timestamp));
+        }
+
         Self {
             inner: Arc::new(inner),
         }
     }
 }
 
+fn parse_activation_timestamp(value: &serde_json::Value) -> Option<u64> {
+    value.as_u64().or_else(|| {
+        value.as_str().and_then(|value| {
+            value.strip_prefix("0x").map_or_else(
+                || value.parse().ok(),
+                |hex| u64::from_str_radix(hex, 16).ok(),
+            )
+        })
+    })
+}
+
+impl From<TempoChainSpec> for ZoneChainSpec {
+    fn from(inner: TempoChainSpec) -> Self {
+        Self::from_tempo(inner)
+    }
+}
+
 impl From<Arc<TempoChainSpec>> for ZoneChainSpec {
     fn from(inner: Arc<TempoChainSpec>) -> Self {
-        Self { inner }
+        Self::from_tempo(inner.as_ref().clone())
     }
 }
 
@@ -153,6 +206,12 @@ impl TempoHardforks for ZoneChainSpec {
     }
 }
 
+impl ZoneHardforks for ZoneChainSpec {
+    fn zone_fork_activation(&self, fork: ZoneHardfork) -> ForkCondition {
+        self.fork(fork)
+    }
+}
+
 impl TempoConsensusSpec for ZoneChainSpec {
     fn shared_gas_limit_at(&self, _timestamp: u64, _gas_limit: u64) -> u64 {
         0
@@ -201,8 +260,8 @@ mod tests {
     fn delegates_tempo_chain_behavior() {
         let zone = ZoneChainSpec::from(DEV.clone());
 
-        assert!(Arc::ptr_eq(&zone.inner, &DEV));
         assert_eq!(zone.chain(), DEV.chain());
+        assert_eq!(zone.fork(ZoneHardfork::Z0), ForkCondition::Timestamp(0));
         assert_eq!(zone.genesis_hash(), DEV.genesis_hash());
         for &hardfork in TempoHardfork::VARIANTS {
             assert_eq!(
@@ -210,6 +269,34 @@ mod tests {
                 DEV.tempo_fork_activation(hardfork)
             );
         }
+    }
+
+    #[test]
+    fn zone_schedule_defaults_to_z0() {
+        let zone = ZoneChainSpec::from_genesis(Genesis::default());
+
+        assert_eq!(
+            zone.zone_fork_activation(ZoneHardfork::Z0),
+            ForkCondition::Timestamp(0)
+        );
+        assert_eq!(
+            zone.zone_fork_activation(ZoneHardfork::Z1),
+            ForkCondition::Never
+        );
+        assert_eq!(zone.zone_hardfork_at(u64::MAX), ZoneHardfork::Z0);
+    }
+
+    #[test]
+    fn parses_z1_timestamp_and_activates_at_boundary() {
+        let mut genesis = Genesis::default();
+        genesis
+            .config
+            .extra_fields
+            .insert("z1Time".into(), serde_json::json!(100));
+        let zone = ZoneChainSpec::from_genesis(genesis);
+
+        assert_eq!(zone.zone_hardfork_at(99), ZoneHardfork::Z0);
+        assert_eq!(zone.zone_hardfork_at(100), ZoneHardfork::Z1);
     }
 
     #[test]

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # zones
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
 zone-chainspec.workspace = true
+zone-hardfork.workspace = true
 zone-l1.workspace = true
 zone-primitives.workspace = true
 zone-precompiles = { workspace = true, features = ["std"] }
@@ -48,7 +49,9 @@ thiserror.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+alloy-genesis.workspace = true
 alloy-rlp.workspace = true
 eyre.workspace = true
+serde_json.workspace = true
 zone-precompiles = { workspace = true, features = ["std", "test-utils"] }
 tempo-precompiles = { workspace = true, features = ["test-utils"] }

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -483,7 +483,8 @@ mod tests {
 
     #[test]
     fn withdrawal_requests_require_same_block_finalization() {
-        let factory = ZoneEvmFactory::new(MockL1Reader::default(), Address::ZERO);
+        let spec = std::sync::Arc::new(ZoneChainSpec::from(tempo_chainspec::spec::DEV.clone()));
+        let factory = ZoneEvmFactory::new(spec, MockL1Reader::default(), Address::ZERO);
         let evm = factory.create_evm(CacheDB::new(EmptyDB::default()), EvmEnv::default());
         let chain_spec = ZoneChainSpec::from(DEV.clone());
         let ctx = TempoBlockExecutionCtx {
@@ -700,7 +701,8 @@ mod tests {
         .unwrap();
         db.insert_account_storage(TEMPO_STATE_ADDRESS, TEMPO_BLOCK_NUMBER_SLOT, U256::ZERO)
             .unwrap();
-        let factory = ZoneEvmFactory::new(MockL1Reader::default(), Address::ZERO);
+        let spec = std::sync::Arc::new(ZoneChainSpec::from(tempo_chainspec::spec::DEV.clone()));
+        let factory = ZoneEvmFactory::new(spec, MockL1Reader::default(), Address::ZERO);
         let evm = factory.create_evm(db, EvmEnv::default());
         let chain_spec = ZoneChainSpec::from(DEV.clone());
         let ctx = TempoBlockExecutionCtx {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -182,7 +182,7 @@ where
     ) -> Self::Evm<DB, NoOpInspector> {
         let zone_hardfork = self
             .chain_spec
-            .zone_hardfork_at(input.block_env.timestamp.to::<u64>());
+            .zone_hardfork_at(input.block_env.timestamp.saturating_to::<u64>());
         let db = L1OverlayDB::new(db, self.l1_reader.clone(), self.portal_address);
         let l1 = db.l1_state().clone();
         let evm = TempoEvm::new(db, input);
@@ -200,7 +200,7 @@ where
     ) -> Self::Evm<DB, I> {
         let zone_hardfork = self
             .chain_spec
-            .zone_hardfork_at(input.block_env.timestamp.to::<u64>());
+            .zone_hardfork_at(input.block_env.timestamp.saturating_to::<u64>());
         let db = L1OverlayDB::new(db, self.l1_reader.clone(), self.portal_address);
         let l1 = db.l1_state().clone();
         let evm = TempoEvm::new(db, input).with_inspector(inspector);

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -70,7 +70,7 @@ use tempo_revm::TempoTxEnv;
 use tempo_zone_contracts::{
     TEMPO_STATE_ADDRESS, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZONE_TX_CONTEXT_ADDRESS,
 };
-use zone_chainspec::ZoneChainSpec;
+use zone_chainspec::{ZoneChainSpec, ZoneHardforks};
 use zone_l1::state::{L1StateCache, L1StateProvider, L1StateProviderConfig};
 use zone_precompiles::create_outbox_precompile;
 
@@ -79,6 +79,7 @@ type TempoCtx<DB> = <TempoEvmFactory as EvmFactory>::Context<DB>;
 /// Zone EVM factory that adapts caller databases and registers the zone-native precompiles.
 #[derive(Debug, Clone)]
 pub struct ZoneEvmFactory<L1 = L1StateProvider> {
+    chain_spec: Arc<ZoneChainSpec>,
     l1_reader: L1,
     portal_address: Address,
 }
@@ -87,9 +88,10 @@ impl<L1> ZoneEvmFactory<L1>
 where
     L1: L1StorageReader,
 {
-    /// Create a new factory with the given L1 state reader and Zone portal address.
-    pub fn new(l1_reader: L1, portal_address: Address) -> Self {
+    /// Creates a factory with the canonical Zone chain spec, L1 reader, and portal address.
+    pub fn new(chain_spec: Arc<ZoneChainSpec>, l1_reader: L1, portal_address: Address) -> Self {
         Self {
+            chain_spec,
             l1_reader,
             portal_address,
         }
@@ -99,13 +101,14 @@ where
         &self,
         evm: TempoEvm<L1OverlayDB<DB, L1>, I>,
         l1: L1State<L1>,
+        zone_hardfork: zone_hardfork::ZoneHardfork,
     ) -> TempoEvm<L1OverlayDB<DB, L1>, I> {
         let mut evm = evm.with_fee_manager(ZoneProtocolFeeManager::new());
         let cfg = evm.ctx().cfg.clone();
         let actions = StorageActions::disabled();
         let non_creditable_slots = evm.non_creditable_slots();
         let (_, _, precompiles) = evm.components_mut();
-        let env = ZonePrecompileEnv::new(&cfg, actions, non_creditable_slots);
+        let env = ZonePrecompileEnv::new(&cfg, zone_hardfork, actions, non_creditable_slots);
         precompiles.apply_precompile(&TEMPO_STATE_ADDRESS, |_| {
             Some(TempoState::create(l1.clone(), &env))
         });
@@ -177,10 +180,16 @@ where
         db: DB,
         input: EvmEnv<Self::Spec, Self::BlockEnv>,
     ) -> Self::Evm<DB, NoOpInspector> {
+        let zone_hardfork = self
+            .chain_spec
+            .zone_hardfork_at(input.block_env.timestamp.to::<u64>());
         let db = L1OverlayDB::new(db, self.l1_reader.clone(), self.portal_address);
         let l1 = db.l1_state().clone();
         let evm = TempoEvm::new(db, input);
-        ZoneEvm::new(self.register_precompiles(evm, l1))
+        ZoneEvm::new(
+            self.register_precompiles(evm, l1, zone_hardfork),
+            zone_hardfork,
+        )
     }
 
     fn create_evm_with_inspector<DB: Database, I: Inspector<Self::Context<DB>>>(
@@ -189,10 +198,16 @@ where
         input: EvmEnv<Self::Spec, Self::BlockEnv>,
         inspector: I,
     ) -> Self::Evm<DB, I> {
+        let zone_hardfork = self
+            .chain_spec
+            .zone_hardfork_at(input.block_env.timestamp.to::<u64>());
         let db = L1OverlayDB::new(db, self.l1_reader.clone(), self.portal_address);
         let l1 = db.l1_state().clone();
         let evm = TempoEvm::new(db, input).with_inspector(inspector);
-        ZoneEvm::new(self.register_precompiles(evm, l1))
+        ZoneEvm::new(
+            self.register_precompiles(evm, l1, zone_hardfork),
+            zone_hardfork,
+        )
     }
 }
 
@@ -301,7 +316,7 @@ where
         l1_provider: L1,
         portal_address: Address,
     ) -> Self {
-        let zone_factory = ZoneEvmFactory::new(l1_provider, portal_address);
+        let zone_factory = ZoneEvmFactory::new(chain_spec.clone(), l1_provider, portal_address);
         let tempo_chain_spec = chain_spec.inner.clone();
         let inner = TempoEvmConfig::new(tempo_chain_spec);
         let block_assembler = ZoneBlockAssembler::new(chain_spec.clone());
@@ -668,7 +683,11 @@ mod tests {
         )
         .unwrap();
 
-        let factory = ZoneEvmFactory::new(reader.clone(), portal);
+        let factory = ZoneEvmFactory::new(
+            Arc::new(ZoneChainSpec::from(tempo_chainspec::spec::DEV.clone())),
+            reader.clone(),
+            portal,
+        );
         let mut env = EvmEnv::<TempoHardfork, TempoBlockEnv>::default();
         env.block_env.inner.timestamp = U256::from(child.inner.timestamp);
         env.block_env.timestamp_millis_part = child.timestamp_millis_part;

--- a/crates/evm/src/zone_evm/contract_creation.rs
+++ b/crates/evm/src/zone_evm/contract_creation.rs
@@ -106,7 +106,7 @@ mod tests {
         input: EvmEnv<tempo_chainspec::hardfork::TempoHardfork, TempoBlockEnv>,
     ) -> ZoneEvm<TestDb, NoOpInspector, TestL1> {
         let db = L1OverlayDB::new(db, TestL1::default(), Address::ZERO);
-        ZoneEvm::new(TempoEvm::new(db, input))
+        ZoneEvm::new(TempoEvm::new(db, input), zone_hardfork::ZoneHardfork::Z0)
     }
 
     fn evm_with_contract(addr: Address, code: &[u8]) -> ZoneEvm<TestDb, NoOpInspector, TestL1> {

--- a/crates/evm/src/zone_evm/mod.rs
+++ b/crates/evm/src/zone_evm/mod.rs
@@ -20,6 +20,7 @@ use tempo_evm::{
     evm::TempoEvm,
 };
 use tempo_revm::{ExecutionContext, TempoInvalidTransaction, TempoTxEnv};
+use zone_hardfork::ZoneHardfork;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{L1StorageReader, tx_context};
 use zone_primitives::constants::CONTRACT_DEPLOYER_ALLOWLIST;
@@ -35,13 +36,25 @@ type ZoneEvmError<E> = EVMError<E, TempoInvalidTransaction>;
 /// their state transitions can be committed through that public database.
 pub struct ZoneEvm<DB: Database, I, L1: L1StorageReader = L1StateProvider> {
     inner: TempoEvm<L1OverlayDB<DB, L1>, I>,
+    zone_hardfork: ZoneHardfork,
 }
 
 impl<DB: Database, I, L1: L1StorageReader> ZoneEvm<DB, I, L1> {
     /// Creates a new `ZoneEvm` with guarded `CREATE` and `CREATE2` opcodes.
-    pub(super) fn new(mut evm: TempoEvm<L1OverlayDB<DB, L1>, I>) -> Self {
+    pub(super) fn new(
+        mut evm: TempoEvm<L1OverlayDB<DB, L1>, I>,
+        zone_hardfork: ZoneHardfork,
+    ) -> Self {
         contract_creation::configure_runtime(&mut evm);
-        Self { inner: evm }
+        Self {
+            inner: evm,
+            zone_hardfork,
+        }
+    }
+
+    /// Returns the Zone-owned protocol revision selected for this block.
+    pub const fn zone_hardfork(&self) -> ZoneHardfork {
+        self.zone_hardfork
     }
 
     /// Provides a reference to the EVM context.
@@ -226,7 +239,7 @@ mod tests {
 
     fn test_evm() -> ZoneEvm<EmptyDB, NoOpInspector, MockL1Reader> {
         let db = L1OverlayDB::new(EmptyDB::default(), MockL1Reader::default(), Address::ZERO);
-        ZoneEvm::new(TempoEvm::new(db, EvmEnv::default()))
+        ZoneEvm::new(TempoEvm::new(db, EvmEnv::default()), ZoneHardfork::Z0)
     }
 
     fn registry_write() -> AddressMap<Account> {

--- a/crates/hardfork/Cargo.toml
+++ b/crates/hardfork/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "zone-hardfork"
+description = "Tempo Zone protocol hardfork definitions"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+alloy-hardforks.workspace = true
+paste = "1.0.15"
+
+[features]
+default = []

--- a/crates/hardfork/src/lib.rs
+++ b/crates/hardfork/src/lib.rs
@@ -1,0 +1,115 @@
+//! Zone-owned protocol hardfork definitions.
+//!
+//! This crate intentionally does not depend on `zone-chainspec` or Reth, so execution and SDK
+//! crates can use [`ZoneHardfork`] without pulling in node integration.
+
+#![no_std]
+
+use alloy_hardforks::hardfork;
+
+/// Defines the Zone hardfork enum and APIs from one ordered variant list.
+macro_rules! zone_hardfork {
+    (
+        $(#[$enum_meta:meta])*
+        ZoneHardfork {
+            $(#[$z0_meta:meta])* Z0,
+            $( $(#[$meta:meta])* $variant:ident ),* $(,)?
+        }
+    ) => {
+        hardfork!(
+            $(#[$enum_meta])*
+            ZoneHardfork {
+                $(#[$z0_meta])* Z0,
+                $( $(#[$meta])* $variant ),*
+            }
+        );
+
+        impl Default for ZoneHardfork {
+            fn default() -> Self {
+                Self::Z0
+            }
+        }
+
+        impl ZoneHardfork {
+            /// Returns whether Z0 behavior is available.
+            pub const fn is_z0(&self) -> bool {
+                *self as u8 >= Self::Z0 as u8
+            }
+
+            paste::paste! {
+                $(
+                    #[doc = concat!("Returns whether ", stringify!($variant), " behavior is available.")]
+                    pub const fn [<is_ $variant:lower>](&self) -> bool {
+                        *self as u8 >= Self::$variant as u8
+                    }
+                )*
+            }
+        }
+
+        /// Invokes a callback macro with every post-Z0 Zone hardfork variant.
+        ///
+        /// Downstream crates can use this to generate exhaustive hardfork-dependent APIs without
+        /// depending on Zone chainspec or node integration.
+        #[macro_export]
+        macro_rules! zone_post_z0_hardforks {
+            ($callback:ident) => {
+                $callback! { $($variant),* }
+            };
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+            use ZoneHardfork::*;
+            use alloy_hardforks::Hardfork;
+
+            #[test]
+            fn test_hardfork_name() {
+                assert_eq!(Z0.name(), "Z0");
+                $(assert_eq!($variant.name(), stringify!($variant));)*
+            }
+
+            #[test]
+            fn test_hardfork_trait_implementation() {
+                for fork in ZoneHardfork::VARIANTS {
+                    let _name: &str = Hardfork::name(fork);
+                }
+            }
+
+            #[test]
+            fn test_is_z0() {
+                for fork in ZoneHardfork::VARIANTS {
+                    assert!(fork.is_z0(), "{fork:?} should satisfy is_z0");
+                }
+            }
+
+            paste::paste! {
+                $(
+                    #[test]
+                    fn [<test_is_ $variant:lower>]() {
+                        let idx = ZoneHardfork::VARIANTS.iter().position(|fork| *fork == $variant)
+                            .expect(concat!(stringify!($variant), " missing from VARIANTS"));
+                        for (i, fork) in ZoneHardfork::VARIANTS.iter().enumerate() {
+                            let active = ZoneHardfork::[<is_ $variant:lower>](fork);
+                            if i >= idx {
+                                assert!(active, "{fork:?} should satisfy is_{}", stringify!([<$variant:lower>]));
+                            } else {
+                                assert!(!active, "{fork:?} should not satisfy is_{}", stringify!([<$variant:lower>]));
+                            }
+                        }
+                    }
+                )*
+            }
+        }
+    };
+}
+
+zone_hardfork!(
+    /// Zone protocol revisions, ordered by activation.
+    ZoneHardfork {
+        /// The original Zone state transition function.
+        Z0,
+        /// The first independently scheduled Zone transition.
+        Z1,
+    }
+);

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # zones
 tempo-zone-contracts = { workspace = true, default-features = false }
 zone-primitives = { workspace = true, default-features = false }
+zone-hardfork.workspace = true
 
 # tempo (workspace deps already have default-features = false)
 tempo-chainspec = { workspace = true, default-features = false }

--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -34,11 +34,13 @@ use tempo_precompiles::{
     },
     storage_credits::NonCreditableSlots,
 };
+use zone_hardfork::ZoneHardfork;
 
 /// Shared EVM configuration and accounting state installed for every Zone precompile wrapper.
 #[derive(Clone)]
 pub struct ZonePrecompileEnv {
     cfg: revm::context::CfgEnv<TempoHardfork>,
+    zone_hardfork: ZoneHardfork,
     actions: StorageActions,
     non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
 }
@@ -47,14 +49,21 @@ impl ZonePrecompileEnv {
     /// Captures the active EVM configuration and transaction-local storage accounting state.
     pub fn new(
         cfg: &revm::context::CfgEnv<TempoHardfork>,
+        zone_hardfork: ZoneHardfork,
         actions: StorageActions,
         non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
     ) -> Self {
         Self {
             cfg: cfg.clone(),
+            zone_hardfork,
             actions,
             non_creditable_slots,
         }
+    }
+
+    /// Returns the active Zone-owned protocol revision.
+    pub const fn zone_hardfork(&self) -> ZoneHardfork {
+        self.zone_hardfork
     }
 }
 
@@ -227,6 +236,7 @@ mod tests {
         let cfg = revm::context::CfgEnv::<TempoHardfork>::default();
         let env = ZonePrecompileEnv::new(
             &cfg,
+            zone_hardfork::ZoneHardfork::Z0,
             StorageActions::disabled(),
             Rc::new(RefCell::new(NonCreditableSlots::empty())),
         );
@@ -267,6 +277,7 @@ mod tests {
         cfg.spec = TempoHardfork::T8;
         let env = ZonePrecompileEnv::new(
             &cfg,
+            zone_hardfork::ZoneHardfork::Z0,
             StorageActions::disabled(),
             Rc::new(RefCell::new(NonCreditableSlots::empty())),
         );
@@ -312,6 +323,7 @@ mod tests {
         cfg.spec = TempoHardfork::T8;
         let env = ZonePrecompileEnv::new(
             &cfg,
+            zone_hardfork::ZoneHardfork::Z0,
             StorageActions::disabled(),
             Rc::new(RefCell::new(NonCreditableSlots::empty())),
         );
@@ -364,6 +376,7 @@ mod tests {
         let cfg = revm::context::CfgEnv::<TempoHardfork>::default();
         let env = ZonePrecompileEnv::new(
             &cfg,
+            zone_hardfork::ZoneHardfork::Z0,
             StorageActions::disabled(),
             Rc::new(RefCell::new(NonCreditableSlots::empty())),
         );

--- a/crates/precompiles/src/test_utils/local.rs
+++ b/crates/precompiles/src/test_utils/local.rs
@@ -60,6 +60,7 @@ pub(crate) fn test_storage_provider(
 pub(crate) fn test_env(ctx: &TestContext) -> ZonePrecompileEnv {
     ZonePrecompileEnv::new(
         &ctx.cfg,
+        zone_hardfork::ZoneHardfork::Z0,
         StorageActions::disabled(),
         Rc::new(RefCell::new(NonCreditableSlots::empty())),
     )


### PR DESCRIPTION
this PR introduces `ZoneHardfork` plumbing for independently scheduling zone-specific STF changes.

it preserves `TempoHardfork` as the execution spec used by `TempoEvm`, `CfgEnv`, and inherited tempo precompiles, while selecting a separate `ZoneHardfork` for zone-local behavior.

`ZoneChainSpec` remains the canonical source for both schedules. `ZoneEvmFactory` selects the active Zone fork from the executing block timestamp, and `ZoneEvm` propagates it to zone-native precompiles through `ZonePrecompileEnv`.

ownership model:
```
TempoEvm / CfgEnv / StorageCtx  → TempoHardfork
ZoneEvm / Zone precompiles      → ZoneHardfork
ZoneChainSpec                   → canonical schedule
```

this avoids introducing a combined hardfork type or changing inherited tempo execution semantics.